### PR TITLE
refactor: share bounded terminal delivery evidence

### DIFF
--- a/src/agents/agent-command-restart-recovery.test.ts
+++ b/src/agents/agent-command-restart-recovery.test.ts
@@ -271,7 +271,10 @@ describe("buildRestartRecoveryTerminalDeliveryEvidence", () => {
   it("retains restart-unsafe committed side effects", () => {
     const evidence = buildRestartRecoveryTerminalDeliveryEvidence({ successfulCronAdds: 1 });
 
-    expect(evidence).toEqual({ captured: true, restartUnsafeSideEffectsDetected: true });
+    expect(evidence).toEqual({
+      captured: true,
+      restartUnsafeSideEffectsDetected: true,
+    });
   });
 
   it("preserves explicit negative messaging-target visibility", () => {

--- a/src/agents/agent-command-restart-recovery.ts
+++ b/src/agents/agent-command-restart-recovery.ts
@@ -2,16 +2,9 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../config/sessions/restart-recovery-types.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { DeliveryContext } from "../utils/delivery-context.shared.js";
-import {
-  collectDeliveredMediaUrls,
-  collectMessagingToolDeliveredMediaUrls,
-  hasCommittedOutboundDeliveryEvidence,
-  hasUnaccountedMessagingToolAggregateEvidence,
-  hasVisibleAgentPayload,
-  hasVisibleCommittedMessagingToolDeliveryEvidence,
-  type AgentDeliveryEvidence,
-} from "./embedded-agent-runner/delivery-evidence.js";
+import { hasVisibleAgentPayload } from "./embedded-agent-runner/delivery-evidence.js";
 import { mergeAttemptToolMediaPayloads } from "./embedded-agent-runner/run/tool-media-payloads.js";
+import { projectTerminalDeliveryEvidence } from "./terminal-delivery-evidence.js";
 
 function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -123,156 +116,15 @@ export function constrainRestartRecoveryDeliveryPayloads(
   return constrained;
 }
 
-function hasExplicitlyVisiblePayload(payload: unknown): boolean {
-  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
-    const visible = (payload as { visible?: unknown }).visible;
-    if (typeof visible === "boolean") {
-      return visible;
-    }
-  }
-  return hasVisibleAgentPayload(
-    { payloads: [payload] },
-    { includeErrorPayloads: false, includeReasoningPayloads: false },
-  );
-}
-
 /** Reduce a terminal result to bounded, route-checkable delivery evidence. */
 export function buildRestartRecoveryTerminalDeliveryEvidence(
-  result: AgentDeliveryEvidence,
+  result: Parameters<typeof projectTerminalDeliveryEvidence>[0],
 ): RestartRecoveryTerminalDeliveryEvidenceResult {
-  const rawPayloads = Array.isArray(result.payloads) ? result.payloads : undefined;
-  const payloads: RestartRecoveryTerminalDeliveryEvidenceResult["payloads"] = Array.isArray(
-    rawPayloads,
-  )
-    ? rawPayloads.slice(0, 64).map((payload) => {
-        const mediaUrls = collectDeliveredMediaUrls({ payloads: [payload] });
-        const visible = hasExplicitlyVisiblePayload(payload);
-        const evidence: { mediaUrls?: string[]; visible?: boolean } = { visible };
-        if (mediaUrls.length > 0) {
-          evidence.mediaUrls = mediaUrls;
-        }
-        return evidence;
-      })
-    : undefined;
-  const payloadsTruncated = rawPayloads && rawPayloads.length > 64 ? (true as const) : undefined;
-  const rawDeliveryStatus = result.deliveryStatus;
-  const status =
-    rawDeliveryStatus?.status === "failed" ||
-    rawDeliveryStatus?.status === "partial_failed" ||
-    rawDeliveryStatus?.status === "sent" ||
-    rawDeliveryStatus?.status === "suppressed"
-      ? rawDeliveryStatus.status
-      : undefined;
-  const rawPayloadOutcomes =
-    rawDeliveryStatus && typeof rawDeliveryStatus === "object"
-      ? (rawDeliveryStatus as { payloadOutcomes?: unknown }).payloadOutcomes
-      : undefined;
-  const payloadOutcomes: NonNullable<
-    RestartRecoveryTerminalDeliveryEvidenceResult["deliveryStatus"]
-  >["payloadOutcomes"] = Array.isArray(rawPayloadOutcomes)
-    ? rawPayloadOutcomes.flatMap((outcome) => {
-        if (!outcome || typeof outcome !== "object" || Array.isArray(outcome)) {
-          return [];
-        }
-        const record = outcome as Record<string, unknown>;
-        const outcomeStatus =
-          record.status === "failed" || record.status === "sent" || record.status === "suppressed"
-            ? record.status
-            : undefined;
-        if (!outcomeStatus || typeof record.index !== "number" || !Number.isInteger(record.index)) {
-          return [];
-        }
-        return [
-          {
-            index: record.index,
-            status: outcomeStatus,
-            ...(typeof record.sentBeforeError === "boolean"
-              ? { sentBeforeError: record.sentBeforeError }
-              : {}),
-          },
-        ];
-      })
-    : undefined;
-  const errorMessage = normalizeOptionalString(rawDeliveryStatus?.errorMessage);
-  const deliveryStatus: RestartRecoveryTerminalDeliveryEvidenceResult["deliveryStatus"] = status
-    ? {
-        status,
-        ...(errorMessage ? { errorMessage } : {}),
-        ...(payloadOutcomes?.length ? { payloadOutcomes } : {}),
-      }
-    : undefined;
-  const rawMessagingToolSentTargets = Array.isArray(result.messagingToolSentTargets)
-    ? result.messagingToolSentTargets
-    : undefined;
-  const messagingToolSentTargets: RestartRecoveryTerminalDeliveryEvidenceResult["messagingToolSentTargets"] =
-    rawMessagingToolSentTargets
-      ? rawMessagingToolSentTargets.slice(0, 64).flatMap((target) => {
-          if (!target || typeof target !== "object" || Array.isArray(target)) {
-            return [];
-          }
-          const record = target as Record<string, unknown>;
-          const mediaUrls = collectMessagingToolDeliveredMediaUrls({
-            messagingToolSentTargets: [record],
-          });
-          const visible = hasVisibleCommittedMessagingToolDeliveryEvidence({
-            messagingToolSentTargets: [record],
-          });
-          const evidence: NonNullable<
-            RestartRecoveryTerminalDeliveryEvidenceResult["messagingToolSentTargets"]
-          >[number] = { visible };
-          const provider = normalizeOptionalString(record.provider);
-          const accountId = normalizeOptionalString(record.accountId);
-          const to = normalizeOptionalString(record.to);
-          const threadId = normalizeOptionalThreadId(record.threadId);
-          if (provider) {
-            evidence.provider = provider;
-          }
-          if (accountId) {
-            evidence.accountId = accountId;
-          }
-          if (to) {
-            evidence.to = to;
-          }
-          if (threadId) {
-            evidence.threadId = threadId;
-          }
-          if (record.threadImplicit === true) {
-            evidence.threadImplicit = true;
-          }
-          if (record.threadSuppressed === true) {
-            evidence.threadSuppressed = true;
-          }
-          if (mediaUrls.length > 0) {
-            evidence.mediaUrls = mediaUrls;
-          }
-          return [evidence];
-        })
-      : undefined;
-  const messagingToolSentTargetsTruncated =
-    rawMessagingToolSentTargets && rawMessagingToolSentTargets.length > 64
-      ? (true as const)
-      : undefined;
-  const messagingToolAggregateEvidenceUnaccounted = hasUnaccountedMessagingToolAggregateEvidence(
-    result,
-  )
-    ? (true as const)
-    : undefined;
-  const restartUnsafeSideEffectsDetected =
-    hasCommittedOutboundDeliveryEvidence(result) ||
-    result.didSendDeterministicApprovalPrompt === true
-      ? (true as const)
-      : undefined;
+  const projected = projectTerminalDeliveryEvidence(result);
+  const { unsafeSideEffectsDetected, ...legacyEvidence } = projected;
   return {
-    captured: true,
-    ...(payloads?.length ? { payloads } : {}),
-    ...(payloadsTruncated ? { payloadsTruncated } : {}),
-    ...(deliveryStatus ? { deliveryStatus } : {}),
-    ...(messagingToolSentTargets?.length ? { messagingToolSentTargets } : {}),
-    ...(messagingToolSentTargetsTruncated ? { messagingToolSentTargetsTruncated } : {}),
-    ...(messagingToolAggregateEvidenceUnaccounted
-      ? { messagingToolAggregateEvidenceUnaccounted }
-      : {}),
-    ...(restartUnsafeSideEffectsDetected ? { restartUnsafeSideEffectsDetected } : {}),
+    ...legacyEvidence,
+    ...(unsafeSideEffectsDetected ? { restartUnsafeSideEffectsDetected: true as const } : {}),
   };
 }
 

--- a/src/agents/terminal-delivery-evidence.test.ts
+++ b/src/agents/terminal-delivery-evidence.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeTerminalDeliveryEvidenceResult,
+  projectTerminalDeliveryEvidence,
+} from "./terminal-delivery-evidence.js";
+
+describe("projectTerminalDeliveryEvidence", () => {
+  it("bounds payloads and targets to the shared cap and marks truncation", () => {
+    const evidence = projectTerminalDeliveryEvidence({
+      payloads: Array.from({ length: 65 }, (_, index) => ({
+        text: `payload ${index}`,
+        mediaUrls: [`/tmp/payload-${index}.png`],
+      })),
+      messagingToolSentTargets: Array.from({ length: 65 }, (_, index) => ({
+        provider: "discord",
+        to: `channel:${index}`,
+        text: `sent ${index}`,
+        mediaUrls: [`/tmp/target-${index}.png`],
+      })),
+    });
+
+    expect(evidence.payloads).toHaveLength(64);
+    expect(evidence.messagingToolSentTargets).toHaveLength(64);
+    expect(evidence.payloadsTruncated).toBe(true);
+    expect(evidence.messagingToolSentTargetsTruncated).toBe(true);
+  });
+
+  it("allows only bounded delivery statuses and payload outcomes", () => {
+    const evidence = projectTerminalDeliveryEvidence({
+      deliveryStatus: {
+        status: "partial_failed",
+        errorMessage: " delivery failed ",
+        payloadOutcomes: [
+          { index: 0, status: "sent", sentBeforeError: false },
+          { index: 1, status: "suppressed" },
+          { index: 2, status: "failed", sentBeforeError: true },
+          { index: 3, status: "weird", sentBeforeError: true },
+          { index: -1, status: "sent" },
+          { index: 1.5, status: "sent" },
+          { index: "4", status: "sent" },
+          null,
+        ],
+      },
+    } as never);
+
+    expect(evidence.deliveryStatus).toEqual({
+      status: "partial_failed",
+      errorMessage: "delivery failed",
+      payloadOutcomes: [
+        { index: 0, status: "sent", sentBeforeError: false },
+        { index: 1, status: "suppressed" },
+        { index: 2, status: "failed", sentBeforeError: true },
+      ],
+    });
+  });
+
+  it("projects visibility and media without leaking message text or channelData", () => {
+    const evidence = projectTerminalDeliveryEvidence({
+      payloads: [
+        {
+          text: "secret body",
+          mediaUrls: ["/tmp/proof.png"],
+          channelData: { token: "nope" },
+          metadata: { internal: true },
+        },
+        { isReasoning: true, text: "private reasoning", mediaUrls: ["/tmp/reasoning.png"] },
+      ],
+      messagingToolSentTargets: [
+        {
+          provider: "matrix",
+          accountId: "main",
+          to: "!room:example",
+          threadId: 42,
+          threadImplicit: true,
+          threadSuppressed: true,
+          text: "hello",
+          mediaUrls: ["/tmp/outbound.png"],
+          visible: false,
+          richContent: { html: "<b>secret</b>" },
+          channelData: { mxid: "@secret:example" },
+        },
+      ],
+    } as never);
+
+    expect(evidence).toEqual({
+      captured: true,
+      payloads: [
+        { mediaUrls: ["/tmp/proof.png"], visible: true },
+        { mediaUrls: ["/tmp/reasoning.png"], visible: false },
+      ],
+      messagingToolSentTargets: [
+        {
+          provider: "matrix",
+          accountId: "main",
+          to: "!room:example",
+          threadId: "42",
+          threadImplicit: true,
+          threadSuppressed: true,
+          mediaUrls: ["/tmp/outbound.png"],
+          visible: true,
+        },
+      ],
+      unsafeSideEffectsDetected: true,
+    });
+    expect(JSON.stringify(evidence)).not.toContain("secret body");
+    expect(JSON.stringify(evidence)).not.toContain("channelData");
+    expect(JSON.stringify(evidence)).not.toContain("richContent");
+  });
+
+  it("marks committed outbound evidence and deterministic approval prompts as unsafe side effects", () => {
+    expect(
+      projectTerminalDeliveryEvidence({
+        didSendDeterministicApprovalPrompt: true,
+      }),
+    ).toEqual({ captured: true, unsafeSideEffectsDetected: true });
+
+    expect(
+      projectTerminalDeliveryEvidence({
+        successfulCronAdds: 1,
+      }),
+    ).toEqual({ captured: true, unsafeSideEffectsDetected: true });
+  });
+
+  it("marks aggregate-only messaging sends as unaccounted and unsafe", () => {
+    expect(
+      projectTerminalDeliveryEvidence({
+        didSendViaMessagingTool: true,
+        messagingToolSentMediaUrls: ["/tmp/proof.png"],
+      }),
+    ).toEqual({
+      captured: true,
+      messagingToolAggregateEvidenceUnaccounted: true,
+      unsafeSideEffectsDetected: true,
+    });
+  });
+
+  it("excludes malformed and unrelated fields from normalized evidence", () => {
+    const normalized = normalizeTerminalDeliveryEvidenceResult({
+      captured: true,
+      payloads: [
+        {
+          mediaUrls: ["/tmp/proof.png", "", 5, "/tmp/proof.png"],
+          visible: true,
+          text: "leak",
+        },
+        "bad-payload",
+      ],
+      payloadsTruncated: true,
+      deliveryStatus: {
+        status: "failed",
+        errorMessage: " bad route ",
+        payloadOutcomes: [
+          { index: 0, status: "sent" },
+          { index: -1, status: "failed" },
+          { index: 1, status: "invalid" },
+        ],
+        body: "secret",
+      },
+      messagingToolSentTargets: [
+        {
+          provider: "discord",
+          accountId: "main",
+          to: "channel:123",
+          threadId: 7,
+          mediaUrls: ["/tmp/outbound.png", null, "/tmp/outbound.png"],
+          visible: false,
+          text: "leak me",
+          channelData: { nope: true },
+        },
+        { text: "missing route" },
+      ],
+      messagingToolSentTargetsTruncated: true,
+      messagingToolAggregateEvidenceUnaccounted: true,
+      unsafeSideEffectsDetected: true,
+      restartUnsafeSideEffectsDetected: true,
+      rawRunnerMetadata: { toolCalls: 5 },
+    } as never);
+
+    expect(normalized).toEqual({
+      captured: true,
+      payloads: [{ mediaUrls: ["/tmp/proof.png"], visible: true }, {}],
+      payloadsTruncated: true,
+      deliveryStatus: {
+        status: "failed",
+        errorMessage: "bad route",
+        payloadOutcomes: [{ index: 0, status: "sent" }],
+      },
+      messagingToolSentTargets: [
+        {
+          provider: "discord",
+          accountId: "main",
+          to: "channel:123",
+          threadId: "7",
+          mediaUrls: ["/tmp/outbound.png"],
+          visible: false,
+        },
+      ],
+      messagingToolSentTargetsTruncated: true,
+      messagingToolAggregateEvidenceUnaccounted: true,
+      unsafeSideEffectsDetected: true,
+    });
+    expect(JSON.stringify(normalized)).not.toContain("leak me");
+    expect(JSON.stringify(normalized)).not.toContain("rawRunnerMetadata");
+  });
+});

--- a/src/agents/terminal-delivery-evidence.test.ts
+++ b/src/agents/terminal-delivery-evidence.test.ts
@@ -172,7 +172,6 @@ describe("projectTerminalDeliveryEvidence", () => {
       messagingToolSentTargetsTruncated: true,
       messagingToolAggregateEvidenceUnaccounted: true,
       unsafeSideEffectsDetected: true,
-      restartUnsafeSideEffectsDetected: true,
       rawRunnerMetadata: { toolCalls: 5 },
     } as never);
 
@@ -201,5 +200,13 @@ describe("projectTerminalDeliveryEvidence", () => {
     });
     expect(JSON.stringify(normalized)).not.toContain("leak me");
     expect(JSON.stringify(normalized)).not.toContain("rawRunnerMetadata");
+  });
+
+  it("does not inherit restart-recovery persistence aliases", () => {
+    expect(
+      normalizeTerminalDeliveryEvidenceResult({
+        restartUnsafeSideEffectsDetected: true,
+      } as never),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/terminal-delivery-evidence.ts
+++ b/src/agents/terminal-delivery-evidence.ts
@@ -1,0 +1,401 @@
+import {
+  collectDeliveredMediaUrls,
+  collectMessagingToolDeliveredMediaUrls,
+  hasCommittedOutboundDeliveryEvidence,
+  hasUnaccountedMessagingToolAggregateEvidence,
+  hasVisibleAgentPayload,
+  hasVisibleCommittedMessagingToolDeliveryEvidence,
+  type AgentDeliveryEvidence,
+} from "./embedded-agent-runner/delivery-evidence.js";
+
+export const MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS = 64;
+
+export type TerminalDeliveryEvidenceResult = {
+  /** The terminal result was captured even when it contained no visible or delivery evidence. */
+  captured?: true;
+  payloads?: Array<{ mediaUrls?: string[]; visible?: boolean }>;
+  payloadsTruncated?: true;
+  deliveryStatus?: {
+    status: "failed" | "partial_failed" | "sent" | "suppressed";
+    errorMessage?: string;
+    payloadOutcomes?: Array<{
+      index: number;
+      status: "failed" | "sent" | "suppressed";
+      sentBeforeError?: boolean;
+    }>;
+  };
+  messagingToolSentTargets?: Array<{
+    provider?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string;
+    threadImplicit?: boolean;
+    threadSuppressed?: boolean;
+    mediaUrls?: string[];
+    visible?: boolean;
+  }>;
+  messagingToolSentTargetsTruncated?: true;
+  /** Aggregate committed sends were not all represented by route-checkable target records. */
+  messagingToolAggregateEvidenceUnaccounted?: true;
+  /** The terminal run reported a committed effect that makes fresh replay unsafe. */
+  unsafeSideEffectsDetected?: true;
+};
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeOptionalThreadId(value: unknown): string | undefined {
+  return (
+    normalizeOptionalString(value) ??
+    (typeof value === "number" && Number.isFinite(value) ? String(value) : undefined)
+  );
+}
+
+function hasExplicitlyVisiblePayload(payload: unknown): boolean {
+  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+    const visible = (payload as { visible?: unknown }).visible;
+    if (typeof visible === "boolean") {
+      return visible;
+    }
+  }
+  return hasVisibleAgentPayload(
+    { payloads: [payload] },
+    { includeErrorPayloads: false, includeReasoningPayloads: false },
+  );
+}
+
+/** Reduce a terminal result to bounded, route-checkable delivery evidence. */
+export function projectTerminalDeliveryEvidence(
+  result: AgentDeliveryEvidence & Pick<TerminalDeliveryEvidenceResult, "unsafeSideEffectsDetected">,
+): TerminalDeliveryEvidenceResult {
+  const rawPayloads = Array.isArray(result.payloads) ? result.payloads : undefined;
+  const payloads: TerminalDeliveryEvidenceResult["payloads"] = Array.isArray(rawPayloads)
+    ? rawPayloads.slice(0, MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS).map((payload) => {
+        const mediaUrls = collectDeliveredMediaUrls({ payloads: [payload] });
+        const visible = hasExplicitlyVisiblePayload(payload);
+        const evidence: { mediaUrls?: string[]; visible?: boolean } = { visible };
+        if (mediaUrls.length > 0) {
+          evidence.mediaUrls = mediaUrls;
+        }
+        return evidence;
+      })
+    : undefined;
+  const payloadsTruncated =
+    rawPayloads && rawPayloads.length > MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS
+      ? (true as const)
+      : undefined;
+  const rawDeliveryStatus = result.deliveryStatus;
+  const status =
+    rawDeliveryStatus?.status === "failed" ||
+    rawDeliveryStatus?.status === "partial_failed" ||
+    rawDeliveryStatus?.status === "sent" ||
+    rawDeliveryStatus?.status === "suppressed"
+      ? rawDeliveryStatus.status
+      : undefined;
+  const rawPayloadOutcomes =
+    rawDeliveryStatus && typeof rawDeliveryStatus === "object"
+      ? (rawDeliveryStatus as { payloadOutcomes?: unknown }).payloadOutcomes
+      : undefined;
+  const payloadOutcomes: NonNullable<
+    TerminalDeliveryEvidenceResult["deliveryStatus"]
+  >["payloadOutcomes"] = Array.isArray(rawPayloadOutcomes)
+    ? rawPayloadOutcomes.flatMap((outcome) => {
+        if (!outcome || typeof outcome !== "object" || Array.isArray(outcome)) {
+          return [];
+        }
+        const record = outcome as Record<string, unknown>;
+        const outcomeStatus =
+          record.status === "failed" || record.status === "sent" || record.status === "suppressed"
+            ? record.status
+            : undefined;
+        if (
+          !outcomeStatus ||
+          typeof record.index !== "number" ||
+          !Number.isInteger(record.index) ||
+          record.index < 0
+        ) {
+          return [];
+        }
+        return [
+          {
+            index: record.index,
+            status: outcomeStatus,
+            ...(typeof record.sentBeforeError === "boolean"
+              ? { sentBeforeError: record.sentBeforeError }
+              : {}),
+          },
+        ];
+      })
+    : undefined;
+  const errorMessage = normalizeOptionalString(rawDeliveryStatus?.errorMessage);
+  const deliveryStatus: TerminalDeliveryEvidenceResult["deliveryStatus"] = status
+    ? {
+        status,
+        ...(errorMessage ? { errorMessage } : {}),
+        ...(payloadOutcomes?.length ? { payloadOutcomes } : {}),
+      }
+    : undefined;
+  const rawMessagingToolSentTargets = Array.isArray(result.messagingToolSentTargets)
+    ? result.messagingToolSentTargets
+    : undefined;
+  const messagingToolSentTargets: TerminalDeliveryEvidenceResult["messagingToolSentTargets"] =
+    rawMessagingToolSentTargets
+      ? rawMessagingToolSentTargets
+          .slice(0, MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS)
+          .flatMap((target) => {
+            if (!target || typeof target !== "object" || Array.isArray(target)) {
+              return [];
+            }
+            const record = target as Record<string, unknown>;
+            const mediaUrls = collectMessagingToolDeliveredMediaUrls({
+              messagingToolSentTargets: [record],
+            });
+            const visible = hasVisibleCommittedMessagingToolDeliveryEvidence({
+              messagingToolSentTargets: [record],
+            });
+            const evidence: NonNullable<
+              TerminalDeliveryEvidenceResult["messagingToolSentTargets"]
+            >[number] = { visible };
+            const provider = normalizeOptionalString(record.provider);
+            const accountId = normalizeOptionalString(record.accountId);
+            const to = normalizeOptionalString(record.to);
+            const threadId = normalizeOptionalThreadId(record.threadId);
+            if (provider) {
+              evidence.provider = provider;
+            }
+            if (accountId) {
+              evidence.accountId = accountId;
+            }
+            if (to) {
+              evidence.to = to;
+            }
+            if (threadId) {
+              evidence.threadId = threadId;
+            }
+            if (record.threadImplicit === true) {
+              evidence.threadImplicit = true;
+            }
+            if (record.threadSuppressed === true) {
+              evidence.threadSuppressed = true;
+            }
+            if (mediaUrls.length > 0) {
+              evidence.mediaUrls = mediaUrls;
+            }
+            return [evidence];
+          })
+      : undefined;
+  const messagingToolSentTargetsTruncated =
+    rawMessagingToolSentTargets &&
+    rawMessagingToolSentTargets.length > MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS
+      ? (true as const)
+      : undefined;
+  const messagingToolAggregateEvidenceUnaccounted = hasUnaccountedMessagingToolAggregateEvidence(
+    result,
+  )
+    ? (true as const)
+    : undefined;
+  const unsafeSideEffectsDetected =
+    result.unsafeSideEffectsDetected === true ||
+    result.restartUnsafeSideEffectsDetected === true ||
+    hasCommittedOutboundDeliveryEvidence(result) ||
+    result.didSendDeterministicApprovalPrompt === true
+      ? (true as const)
+      : undefined;
+  return {
+    captured: true,
+    ...(payloads?.length ? { payloads } : {}),
+    ...(payloadsTruncated ? { payloadsTruncated } : {}),
+    ...(deliveryStatus ? { deliveryStatus } : {}),
+    ...(messagingToolSentTargets?.length ? { messagingToolSentTargets } : {}),
+    ...(messagingToolSentTargetsTruncated ? { messagingToolSentTargetsTruncated } : {}),
+    ...(messagingToolAggregateEvidenceUnaccounted
+      ? { messagingToolAggregateEvidenceUnaccounted }
+      : {}),
+    ...(unsafeSideEffectsDetected ? { unsafeSideEffectsDetected } : {}),
+  };
+}
+
+/** Normalizes bounded terminal delivery evidence without admitting raw delivery metadata. */
+export function normalizeTerminalDeliveryEvidenceResult(
+  value: unknown,
+): TerminalDeliveryEvidenceResult | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const captured = record.captured === true ? (true as const) : undefined;
+  const rawPayloads = Array.isArray(record.payloads) ? record.payloads : undefined;
+  const payloads: TerminalDeliveryEvidenceResult["payloads"] = rawPayloads
+    ? rawPayloads.slice(0, MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS).map((item) => {
+        if (!item || typeof item !== "object" || Array.isArray(item)) {
+          return {};
+        }
+        const payload = item as Record<string, unknown>;
+        const mediaUrls = Array.isArray(payload.mediaUrls)
+          ? Array.from(
+              new Set(
+                payload.mediaUrls.flatMap((mediaUrl) => {
+                  const normalized = normalizeOptionalString(mediaUrl);
+                  return normalized ? [normalized] : [];
+                }),
+              ),
+            )
+          : undefined;
+        const visible = typeof payload.visible === "boolean" ? payload.visible : undefined;
+        const evidence: { mediaUrls?: string[]; visible?: boolean } = {};
+        if (mediaUrls?.length) {
+          evidence.mediaUrls = mediaUrls;
+        }
+        if (visible !== undefined) {
+          evidence.visible = visible;
+        }
+        return evidence;
+      })
+    : undefined;
+  const payloadsTruncated =
+    record.payloadsTruncated === true ||
+    (rawPayloads?.length ?? 0) > MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS
+      ? (true as const)
+      : undefined;
+  const rawStatus =
+    record.deliveryStatus && typeof record.deliveryStatus === "object"
+      ? (record.deliveryStatus as Record<string, unknown>)
+      : undefined;
+  const status =
+    rawStatus?.status === "failed" ||
+    rawStatus?.status === "partial_failed" ||
+    rawStatus?.status === "sent" ||
+    rawStatus?.status === "suppressed"
+      ? rawStatus.status
+      : undefined;
+  const payloadOutcomes: NonNullable<
+    TerminalDeliveryEvidenceResult["deliveryStatus"]
+  >["payloadOutcomes"] = Array.isArray(rawStatus?.payloadOutcomes)
+    ? rawStatus.payloadOutcomes.slice(0, MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS).flatMap((item) => {
+        if (!item || typeof item !== "object" || Array.isArray(item)) {
+          return [];
+        }
+        const outcome = item as Record<string, unknown>;
+        const outcomeStatus =
+          outcome.status === "failed" ||
+          outcome.status === "sent" ||
+          outcome.status === "suppressed"
+            ? outcome.status
+            : undefined;
+        if (
+          !outcomeStatus ||
+          typeof outcome.index !== "number" ||
+          !Number.isInteger(outcome.index) ||
+          outcome.index < 0
+        ) {
+          return [];
+        }
+        return [
+          {
+            index: outcome.index,
+            status: outcomeStatus,
+            ...(typeof outcome.sentBeforeError === "boolean"
+              ? { sentBeforeError: outcome.sentBeforeError }
+              : {}),
+          },
+        ];
+      })
+    : undefined;
+  const errorMessage = normalizeOptionalString(rawStatus?.errorMessage);
+  const deliveryStatus: TerminalDeliveryEvidenceResult["deliveryStatus"] = status
+    ? {
+        status,
+        ...(errorMessage ? { errorMessage } : {}),
+        ...(payloadOutcomes?.length ? { payloadOutcomes } : {}),
+      }
+    : undefined;
+  const rawMessagingToolSentTargets = Array.isArray(record.messagingToolSentTargets)
+    ? record.messagingToolSentTargets
+    : undefined;
+  const messagingToolSentTargets: TerminalDeliveryEvidenceResult["messagingToolSentTargets"] =
+    rawMessagingToolSentTargets
+      ? rawMessagingToolSentTargets
+          .slice(0, MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS)
+          .flatMap((item) => {
+            if (!item || typeof item !== "object" || Array.isArray(item)) {
+              return [];
+            }
+            const target = item as Record<string, unknown>;
+            const provider = normalizeOptionalString(target.provider);
+            const accountId = normalizeOptionalString(target.accountId);
+            const to = normalizeOptionalString(target.to);
+            const threadId = normalizeOptionalThreadId(target.threadId);
+            const mediaUrls = Array.isArray(target.mediaUrls)
+              ? Array.from(
+                  new Set(
+                    target.mediaUrls.flatMap((mediaUrl) => {
+                      const normalized = normalizeOptionalString(mediaUrl);
+                      return normalized ? [normalized] : [];
+                    }),
+                  ),
+                )
+              : undefined;
+            const visible = typeof target.visible === "boolean" ? target.visible : undefined;
+            if (
+              !provider &&
+              !accountId &&
+              !to &&
+              !threadId &&
+              !mediaUrls?.length &&
+              visible === undefined &&
+              target.threadImplicit !== true &&
+              target.threadSuppressed !== true
+            ) {
+              return [];
+            }
+            return [
+              {
+                ...(provider ? { provider } : {}),
+                ...(accountId ? { accountId } : {}),
+                ...(to ? { to } : {}),
+                ...(threadId ? { threadId } : {}),
+                ...(target.threadImplicit === true ? { threadImplicit: true as const } : {}),
+                ...(target.threadSuppressed === true ? { threadSuppressed: true as const } : {}),
+                ...(mediaUrls?.length ? { mediaUrls } : {}),
+                ...(visible !== undefined ? { visible } : {}),
+              },
+            ];
+          })
+      : undefined;
+  const messagingToolSentTargetsTruncated =
+    record.messagingToolSentTargetsTruncated === true ||
+    (rawMessagingToolSentTargets?.length ?? 0) > MAX_TERMINAL_DELIVERY_EVIDENCE_ITEMS
+      ? (true as const)
+      : undefined;
+  const messagingToolAggregateEvidenceUnaccounted =
+    record.messagingToolAggregateEvidenceUnaccounted === true ? (true as const) : undefined;
+  const unsafeSideEffectsDetected =
+    record.unsafeSideEffectsDetected === true || record.restartUnsafeSideEffectsDetected === true
+      ? (true as const)
+      : undefined;
+  if (
+    !captured &&
+    !payloads?.length &&
+    !payloadsTruncated &&
+    !deliveryStatus &&
+    !messagingToolSentTargets?.length &&
+    !messagingToolSentTargetsTruncated &&
+    !messagingToolAggregateEvidenceUnaccounted &&
+    !unsafeSideEffectsDetected
+  ) {
+    return undefined;
+  }
+  return {
+    ...(captured ? { captured } : {}),
+    ...(payloads?.length ? { payloads } : {}),
+    ...(payloadsTruncated ? { payloadsTruncated } : {}),
+    ...(deliveryStatus ? { deliveryStatus } : {}),
+    ...(messagingToolSentTargets?.length ? { messagingToolSentTargets } : {}),
+    ...(messagingToolSentTargetsTruncated ? { messagingToolSentTargetsTruncated } : {}),
+    ...(messagingToolAggregateEvidenceUnaccounted
+      ? { messagingToolAggregateEvidenceUnaccounted }
+      : {}),
+    ...(unsafeSideEffectsDetected ? { unsafeSideEffectsDetected } : {}),
+  };
+}

--- a/src/agents/terminal-delivery-evidence.ts
+++ b/src/agents/terminal-delivery-evidence.ts
@@ -371,9 +371,7 @@ export function normalizeTerminalDeliveryEvidenceResult(
   const messagingToolAggregateEvidenceUnaccounted =
     record.messagingToolAggregateEvidenceUnaccounted === true ? (true as const) : undefined;
   const unsafeSideEffectsDetected =
-    record.unsafeSideEffectsDetected === true || record.restartUnsafeSideEffectsDetected === true
-      ? (true as const)
-      : undefined;
+    record.unsafeSideEffectsDetected === true ? (true as const) : undefined;
   if (
     !captured &&
     !payloads?.length &&

--- a/src/config/sessions/restart-recovery-state.ts
+++ b/src/config/sessions/restart-recovery-state.ts
@@ -70,18 +70,24 @@ function normalizePresentStringArray(value: unknown): string[] | undefined {
 function normalizeRestartRecoveryTerminalDeliveryEvidenceResult(
   value: unknown,
 ): RestartRecoveryTerminalDeliveryEvidenceResult | undefined {
-  const normalized = normalizeTerminalDeliveryEvidenceResult(value);
+  const record =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : undefined;
+  const restartUnsafeSideEffectsDetected =
+    record?.restartUnsafeSideEffectsDetected === true ? (true as const) : undefined;
+  const normalized = normalizeTerminalDeliveryEvidenceResult(
+    restartUnsafeSideEffectsDetected
+      ? { ...record, unsafeSideEffectsDetected: true as const }
+      : value,
+  );
   if (!normalized) {
     return undefined;
   }
   const { unsafeSideEffectsDetected, ...legacyEvidence } = normalized;
   return {
     ...legacyEvidence,
-    ...(unsafeSideEffectsDetected ||
-    (value &&
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      (value as Record<string, unknown>).restartUnsafeSideEffectsDetected === true)
+    ...(unsafeSideEffectsDetected || restartUnsafeSideEffectsDetected
       ? { restartUnsafeSideEffectsDetected: true as const }
       : {}),
   };

--- a/src/config/sessions/restart-recovery-state.ts
+++ b/src/config/sessions/restart-recovery-state.ts
@@ -1,4 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
+import { normalizeTerminalDeliveryEvidenceResult } from "../../agents/terminal-delivery-evidence.js";
 import {
   normalizeDeliveryContext,
   type DeliveryContext,
@@ -44,13 +45,6 @@ export function resolveRestartRecoveryChannelAuthority(
   };
 }
 
-function normalizeThreadId(value: unknown): string | undefined {
-  return (
-    normalizeRunId(value) ??
-    (typeof value === "number" && Number.isFinite(value) ? String(value) : undefined)
-  );
-}
-
 function normalizeStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -73,154 +67,23 @@ function normalizePresentStringArray(value: unknown): string[] | undefined {
   return normalizeStringArray(value) ?? [];
 }
 
-function normalizeTerminalDeliveryEvidenceResult(
+function normalizeRestartRecoveryTerminalDeliveryEvidenceResult(
   value: unknown,
 ): RestartRecoveryTerminalDeliveryEvidenceResult | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  const normalized = normalizeTerminalDeliveryEvidenceResult(value);
+  if (!normalized) {
     return undefined;
   }
-  const record = value as Record<string, unknown>;
-  const captured = record.captured === true ? (true as const) : undefined;
-  const rawPayloads = Array.isArray(record.payloads) ? record.payloads : undefined;
-  const payloads: RestartRecoveryTerminalDeliveryEvidenceResult["payloads"] = rawPayloads
-    ? rawPayloads.slice(0, 64).map((item) => {
-        if (!item || typeof item !== "object" || Array.isArray(item)) {
-          return {};
-        }
-        const payload = item as Record<string, unknown>;
-        const mediaUrls = normalizeStringArray(payload.mediaUrls);
-        const visible = typeof payload.visible === "boolean" ? payload.visible : undefined;
-        const evidence: { mediaUrls?: string[]; visible?: boolean } = {};
-        if (mediaUrls) {
-          evidence.mediaUrls = mediaUrls;
-        }
-        if (visible !== undefined) {
-          evidence.visible = visible;
-        }
-        return evidence;
-      })
-    : undefined;
-  const payloadsTruncated =
-    record.payloadsTruncated === true || (rawPayloads?.length ?? 0) > 64
-      ? (true as const)
-      : undefined;
-  const rawStatus =
-    record.deliveryStatus && typeof record.deliveryStatus === "object"
-      ? (record.deliveryStatus as Record<string, unknown>)
-      : undefined;
-  const status =
-    rawStatus?.status === "failed" ||
-    rawStatus?.status === "partial_failed" ||
-    rawStatus?.status === "sent" ||
-    rawStatus?.status === "suppressed"
-      ? rawStatus.status
-      : undefined;
-  const payloadOutcomes: NonNullable<
-    RestartRecoveryTerminalDeliveryEvidenceResult["deliveryStatus"]
-  >["payloadOutcomes"] = Array.isArray(rawStatus?.payloadOutcomes)
-    ? rawStatus.payloadOutcomes.slice(0, 64).flatMap((item) => {
-        if (!item || typeof item !== "object" || Array.isArray(item)) {
-          return [];
-        }
-        const outcome = item as Record<string, unknown>;
-        const outcomeStatus =
-          outcome.status === "failed" ||
-          outcome.status === "sent" ||
-          outcome.status === "suppressed"
-            ? outcome.status
-            : undefined;
-        if (
-          !outcomeStatus ||
-          typeof outcome.index !== "number" ||
-          !Number.isInteger(outcome.index) ||
-          outcome.index < 0
-        ) {
-          return [];
-        }
-        return [
-          {
-            index: outcome.index,
-            status: outcomeStatus,
-            ...(typeof outcome.sentBeforeError === "boolean"
-              ? { sentBeforeError: outcome.sentBeforeError }
-              : {}),
-          },
-        ];
-      })
-    : undefined;
-  const errorMessage = normalizeRunId(rawStatus?.errorMessage);
-  const deliveryStatus: RestartRecoveryTerminalDeliveryEvidenceResult["deliveryStatus"] = status
-    ? {
-        status,
-        ...(errorMessage ? { errorMessage } : {}),
-        ...(payloadOutcomes?.length ? { payloadOutcomes } : {}),
-      }
-    : undefined;
-  const rawMessagingToolSentTargets = Array.isArray(record.messagingToolSentTargets)
-    ? record.messagingToolSentTargets
-    : undefined;
-  const messagingToolSentTargets: RestartRecoveryTerminalDeliveryEvidenceResult["messagingToolSentTargets"] =
-    rawMessagingToolSentTargets
-      ? rawMessagingToolSentTargets.slice(0, 64).flatMap((item) => {
-          if (!item || typeof item !== "object" || Array.isArray(item)) {
-            return [];
-          }
-          const target = item as Record<string, unknown>;
-          const provider = normalizeRunId(target.provider);
-          const accountId = normalizeRunId(target.accountId);
-          const to = normalizeRunId(target.to);
-          const threadId = normalizeThreadId(target.threadId);
-          const mediaUrls = normalizeStringArray(target.mediaUrls);
-          const visible = typeof target.visible === "boolean" ? target.visible : undefined;
-          if (!provider && !accountId && !to && !threadId && !mediaUrls && visible === undefined) {
-            return [];
-          }
-          return [
-            {
-              ...(provider ? { provider } : {}),
-              ...(accountId ? { accountId } : {}),
-              ...(to ? { to } : {}),
-              ...(threadId ? { threadId } : {}),
-              ...(target.threadImplicit === true ? { threadImplicit: true as const } : {}),
-              ...(target.threadSuppressed === true ? { threadSuppressed: true as const } : {}),
-              ...(mediaUrls ? { mediaUrls } : {}),
-              ...(visible !== undefined ? { visible } : {}),
-            },
-          ];
-        })
-      : undefined;
-  const messagingToolSentTargetsTruncated =
-    record.messagingToolSentTargetsTruncated === true ||
-    (rawMessagingToolSentTargets?.length ?? 0) > 64
-      ? (true as const)
-      : undefined;
-  const messagingToolAggregateEvidenceUnaccounted =
-    record.messagingToolAggregateEvidenceUnaccounted === true ? (true as const) : undefined;
-  const restartUnsafeSideEffectsDetected =
-    record.restartUnsafeSideEffectsDetected === true ? (true as const) : undefined;
-  if (
-    !captured &&
-    !payloads?.length &&
-    !payloadsTruncated &&
-    !deliveryStatus &&
-    !messagingToolSentTargets?.length &&
-    !messagingToolSentTargetsTruncated &&
-    !messagingToolAggregateEvidenceUnaccounted &&
-    !restartUnsafeSideEffectsDetected
-  ) {
-    return undefined;
-  }
+  const { unsafeSideEffectsDetected, ...legacyEvidence } = normalized;
   return {
-    ...(captured ? { captured } : {}),
-    ...(payloads?.length ? { payloads } : {}),
-    ...(payloadsTruncated ? { payloadsTruncated } : {}),
-    ...(deliveryStatus ? { deliveryStatus } : {}),
-    ...(messagingToolSentTargets?.length ? { messagingToolSentTargets } : {}),
-    ...(messagingToolSentTargetsTruncated ? { messagingToolSentTargetsTruncated } : {}),
-    ...(messagingToolAggregateEvidenceUnaccounted
-      ? { messagingToolAggregateEvidenceUnaccounted }
+    ...legacyEvidence,
+    ...(unsafeSideEffectsDetected ||
+    (value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      (value as Record<string, unknown>).restartUnsafeSideEffectsDetected === true)
+      ? { restartUnsafeSideEffectsDetected: true as const }
       : {}),
-    ...(restartUnsafeSideEffectsDetected ? { restartUnsafeSideEffectsDetected } : {}),
   };
 }
 
@@ -236,7 +99,7 @@ function normalizeRestartRecoveryTerminalDeliveryEvidence(
       continue;
     }
     const runId = normalizeRunId((item as Record<string, unknown>).runId);
-    const result = normalizeTerminalDeliveryEvidenceResult(item);
+    const result = normalizeRestartRecoveryTerminalDeliveryEvidenceResult(item);
     if (!runId || !result) {
       continue;
     }

--- a/src/config/sessions/restart-recovery-types.ts
+++ b/src/config/sessions/restart-recovery-types.ts
@@ -1,3 +1,4 @@
+import type { TerminalDeliveryEvidenceResult } from "../../agents/terminal-delivery-evidence.js";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/source-reply-delivery-mode.types.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 
@@ -9,33 +10,10 @@ export type RestartRecoveryBeforeAgentReplyState =
   | "handled-reply"
   | "handled-unrecoverable";
 
-export type RestartRecoveryTerminalDeliveryEvidenceResult = {
-  /** The terminal result was captured even when it contained no visible or delivery evidence. */
-  captured?: true;
-  payloads?: Array<{ mediaUrls?: string[]; visible?: boolean }>;
-  payloadsTruncated?: true;
-  deliveryStatus?: {
-    status: "failed" | "partial_failed" | "sent" | "suppressed";
-    errorMessage?: string;
-    payloadOutcomes?: Array<{
-      index: number;
-      status: "failed" | "sent" | "suppressed";
-      sentBeforeError?: boolean;
-    }>;
-  };
-  messagingToolSentTargets?: Array<{
-    provider?: string;
-    accountId?: string;
-    to?: string;
-    threadId?: string;
-    threadImplicit?: boolean;
-    threadSuppressed?: boolean;
-    mediaUrls?: string[];
-    visible?: boolean;
-  }>;
-  messagingToolSentTargetsTruncated?: true;
-  /** Aggregate committed sends were not all represented by route-checkable target records. */
-  messagingToolAggregateEvidenceUnaccounted?: true;
+export type RestartRecoveryTerminalDeliveryEvidenceResult = Omit<
+  TerminalDeliveryEvidenceResult,
+  "unsafeSideEffectsDetected"
+> & {
   /** The terminal run reported a committed effect that makes fresh replay unsafe. */
   restartUnsafeSideEffectsDetected?: true;
 };

--- a/src/gateway/server-restart-sentinel-agent-delivery.restart-recovery.regression.test.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.restart-recovery.regression.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildRestartRecoveryTerminalDeliveryEvidence } from "../agents/agent-command-restart-recovery.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../config/sessions/restart-recovery-state.js";
 import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
@@ -17,18 +17,12 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { dispatchGatewayMethodInProcess } from "./server-plugins.js";
 import { deliverQueuedGeneratedMediaAgentTurn } from "./server-restart-sentinel-agent-delivery.js";
-
-vi.mock("./server-plugins.js", () => ({
-  dispatchGatewayMethodInProcess: vi.fn(),
-}));
 
 describe("restart-sentinel generated-media terminal evidence regression (#119736)", () => {
   let tempDir: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-terminal-evidence-"));
   });
 
@@ -259,7 +253,5 @@ describe("restart-sentinel generated-media terminal evidence regression (#119736
       "queued generated-media delivery dead-lettered after an unexpected committed side effect",
     );
     expect(readQueueStatus(unsafeQueueId)).toBe("pending");
-
-    expect(dispatchGatewayMethodInProcess).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-restart-sentinel-agent-delivery.restart-recovery.regression.test.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.restart-recovery.regression.test.ts
@@ -46,6 +46,7 @@ describe("restart-sentinel generated-media terminal evidence regression (#119736
     sessionId: string;
     messageId: string;
     unsafeSideEffectsDetected?: true;
+    legacyAliasOnly?: true;
   }): Promise<string> {
     await ensureSessionsDir(params.agentId);
     const entry = {
@@ -68,7 +69,20 @@ describe("restart-sentinel generated-media terminal evidence regression (#119736
     });
     await replaceSessionEntry(
       { sessionKey: params.sessionKey, storePath: storePath(params.agentId) },
-      { ...entry, ...cleanupPatch },
+      {
+        ...entry,
+        ...cleanupPatch,
+        ...(params.legacyAliasOnly
+          ? {
+              restartRecoveryTerminalDeliveryEvidence: [
+                {
+                  runId: params.messageId,
+                  restartUnsafeSideEffectsDetected: true as const,
+                },
+              ],
+            }
+          : {}),
+      },
     );
 
     return await enqueueSessionDelivery(
@@ -155,6 +169,7 @@ describe("restart-sentinel generated-media terminal evidence regression (#119736
       sessionId: unsafeSessionId,
       messageId: unsafeMessageId,
       unsafeSideEffectsDetected: true,
+      legacyAliasOnly: true,
     });
 
     const rawUnsafeEntry = readRawPersistedEntry(unsafeAgentId, unsafeSessionKey);
@@ -215,9 +230,6 @@ describe("restart-sentinel generated-media terminal evidence regression (#119736
     expect(reopenedUnsafeEntry.restartRecoveryTerminalDeliveryEvidence).toEqual([
       {
         runId: unsafeMessageId,
-        captured: true,
-        payloads: [{ visible: true }],
-        deliveryStatus: { status: "sent" },
         restartUnsafeSideEffectsDetected: true,
       },
     ]);

--- a/src/gateway/server-restart-sentinel-agent-delivery.restart-recovery.regression.test.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.restart-recovery.regression.test.ts
@@ -1,0 +1,265 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildRestartRecoveryTerminalDeliveryEvidence } from "../agents/agent-command-restart-recovery.js";
+import { buildRestartRecoveryClaimCleanupPatch } from "../config/sessions/restart-recovery-state.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import {
+  enqueueSessionDelivery,
+  loadPendingSessionDelivery,
+  type QueuedSessionDelivery,
+} from "../infra/session-delivery-queue.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { dispatchGatewayMethodInProcess } from "./server-plugins.js";
+import { deliverQueuedGeneratedMediaAgentTurn } from "./server-restart-sentinel-agent-delivery.js";
+
+vi.mock("./server-plugins.js", () => ({
+  dispatchGatewayMethodInProcess: vi.fn(),
+}));
+
+describe("restart-sentinel generated-media terminal evidence regression (#119736)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-terminal-evidence-"));
+  });
+
+  afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function storePath(agentId: string): string {
+    return path.join(tempDir, "agents", agentId, "sessions", "sessions.json");
+  }
+
+  async function ensureSessionsDir(agentId: string): Promise<void> {
+    await fs.mkdir(path.dirname(storePath(agentId)), { recursive: true });
+  }
+
+  async function seedPersistedRecoveryCase(params: {
+    agentId: string;
+    sessionKey: string;
+    sessionId: string;
+    messageId: string;
+    unsafeSideEffectsDetected?: true;
+  }): Promise<string> {
+    await ensureSessionsDir(params.agentId);
+    const entry = {
+      sessionId: params.sessionId,
+      status: "done" as const,
+      updatedAt: 1,
+      restartRecoveryDeliveryRunId: `${params.messageId}:internal`,
+      restartRecoveryDeliverySourceRunId: params.messageId,
+    };
+    const terminalDeliveryEvidence = buildRestartRecoveryTerminalDeliveryEvidence({
+      payloads: [{ visible: true }],
+      deliveryStatus: { status: "sent" },
+      ...(params.unsafeSideEffectsDetected ? { unsafeSideEffectsDetected: true as const } : {}),
+    });
+    const cleanupPatch = buildRestartRecoveryClaimCleanupPatch({
+      entry,
+      recordTerminalSource: true,
+      terminalDeliveryEvidence,
+      terminalRunId: params.messageId,
+    });
+    await replaceSessionEntry(
+      { sessionKey: params.sessionKey, storePath: storePath(params.agentId) },
+      { ...entry, ...cleanupPatch },
+    );
+
+    return await enqueueSessionDelivery(
+      {
+        kind: "agentTurn",
+        sessionKey: params.sessionKey,
+        message: `resume ${params.messageId}`,
+        messageId: params.messageId,
+        idempotencyKey: params.messageId,
+        route: {
+          channel: "discord",
+          to: "channel:123",
+          accountId: "default",
+          chatType: "channel",
+        },
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "image_generate",
+        },
+        sourceReplyDeliveryMode: "automatic",
+      },
+      tempDir,
+    );
+  }
+
+  function readRawPersistedEntry(agentId: string, sessionKey: string): Record<string, unknown> {
+    const sqliteTarget = resolveSqliteTargetFromSessionStorePath(storePath(agentId), {
+      agentId,
+    });
+    const database = openOpenClawAgentDatabase({
+      agentId,
+      path: sqliteTarget.path,
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDir },
+    });
+    const row = database.db
+      .prepare("SELECT entry_json FROM session_nodes WHERE session_key = ?")
+      .get(sessionKey) as { entry_json?: string } | undefined;
+    if (!row?.entry_json) {
+      throw new Error(`expected persisted session row for ${sessionKey}`);
+    }
+    return JSON.parse(row.entry_json) as Record<string, unknown>;
+  }
+
+  function readQueueStatus(id: string): string | undefined {
+    const { db } = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDir },
+    });
+    const row = db
+      .prepare("SELECT status FROM delivery_queue_entries WHERE queue_name = 'session' AND id = ?")
+      .get(id) as { status?: string } | undefined;
+    return row?.status;
+  }
+
+  function requireAgentTurn(
+    entry: QueuedSessionDelivery | null,
+    expectedId: string,
+  ): Extract<QueuedSessionDelivery, { kind: "agentTurn" }> {
+    if (!entry || entry.kind !== "agentTurn") {
+      throw new Error(`expected pending agentTurn delivery ${expectedId}`);
+    }
+    return entry;
+  }
+
+  it("reopens persisted terminal evidence without fresh redispatch and keeps the legacy unsafe field shape", async () => {
+    const safeAgentId = "safe";
+    const safeSessionKey = "agent:safe:terminal-safe";
+    const safeSessionId = "session-safe";
+    const safeMessageId = "image:task-terminal-safe:agent-loop";
+    const unsafeAgentId = "unsafe";
+    const unsafeSessionKey = "agent:unsafe:terminal-unsafe";
+    const unsafeSessionId = "session-unsafe";
+    const unsafeMessageId = "image:task-terminal-unsafe:agent-loop";
+
+    const safeQueueId = await seedPersistedRecoveryCase({
+      agentId: safeAgentId,
+      sessionKey: safeSessionKey,
+      sessionId: safeSessionId,
+      messageId: safeMessageId,
+    });
+    const unsafeQueueId = await seedPersistedRecoveryCase({
+      agentId: unsafeAgentId,
+      sessionKey: unsafeSessionKey,
+      sessionId: unsafeSessionId,
+      messageId: unsafeMessageId,
+      unsafeSideEffectsDetected: true,
+    });
+
+    const rawUnsafeEntry = readRawPersistedEntry(unsafeAgentId, unsafeSessionKey);
+    const rawUnsafeEvidence = (
+      rawUnsafeEntry.restartRecoveryTerminalDeliveryEvidence as Array<Record<string, unknown>>
+    )?.[0];
+    expect(rawUnsafeEvidence).toMatchObject({
+      runId: unsafeMessageId,
+      restartUnsafeSideEffectsDetected: true,
+    });
+    expect(rawUnsafeEvidence).not.toHaveProperty("unsafeSideEffectsDetected");
+
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const rawSafeEntry = readRawPersistedEntry(safeAgentId, safeSessionKey);
+    expect(
+      (rawSafeEntry.restartRecoveryTerminalDeliveryEvidence as Array<Record<string, unknown>>)?.[0],
+    ).toMatchObject({
+      runId: safeMessageId,
+      captured: true,
+      payloads: [{ visible: true }],
+      deliveryStatus: { status: "sent" },
+    });
+    const reopenedSafeEntry = loadSessionEntry({
+      agentId: safeAgentId,
+      sessionKey: safeSessionKey,
+      storePath: storePath(safeAgentId),
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDir },
+      readConsistency: "latest",
+    });
+    const reopenedUnsafeEntry = loadSessionEntry({
+      agentId: unsafeAgentId,
+      sessionKey: unsafeSessionKey,
+      storePath: storePath(unsafeAgentId),
+      env: { ...process.env, OPENCLAW_STATE_DIR: tempDir },
+      readConsistency: "latest",
+    });
+    expect(reopenedSafeEntry).toBeDefined();
+    expect(reopenedUnsafeEntry).toBeDefined();
+    const reopenedSafeQueue = requireAgentTurn(
+      await loadPendingSessionDelivery(safeQueueId, tempDir),
+      safeQueueId,
+    );
+    const reopenedUnsafeQueue = requireAgentTurn(
+      await loadPendingSessionDelivery(unsafeQueueId, tempDir),
+      unsafeQueueId,
+    );
+
+    expect(reopenedSafeEntry.restartRecoveryTerminalDeliveryEvidence).toEqual([
+      {
+        runId: safeMessageId,
+        captured: true,
+        payloads: [{ visible: true }],
+        deliveryStatus: { status: "sent" },
+      },
+    ]);
+    expect(reopenedUnsafeEntry.restartRecoveryTerminalDeliveryEvidence).toEqual([
+      {
+        runId: unsafeMessageId,
+        captured: true,
+        payloads: [{ visible: true }],
+        deliveryStatus: { status: "sent" },
+        restartUnsafeSideEffectsDetected: true,
+      },
+    ]);
+
+    await expect(
+      deliverQueuedGeneratedMediaAgentTurn({
+        entry: reopenedSafeQueue,
+        canonicalKey: safeSessionKey,
+        sessionEntry: reopenedSafeEntry,
+        stateDir: tempDir,
+      }),
+    ).resolves.toBe(true);
+    expect(readQueueStatus(safeQueueId)).toBe("pending");
+
+    await expect(
+      deliverQueuedGeneratedMediaAgentTurn({
+        entry: reopenedUnsafeQueue,
+        canonicalKey: unsafeSessionKey,
+        sessionEntry: reopenedUnsafeEntry,
+        stateDir: tempDir,
+      }),
+    ).rejects.toThrow(
+      "queued generated-media delivery dead-lettered after an unexpected committed side effect",
+    );
+    await expect(
+      deliverQueuedGeneratedMediaAgentTurn({
+        entry: reopenedUnsafeQueue,
+        canonicalKey: unsafeSessionKey,
+        sessionEntry: reopenedUnsafeEntry,
+        stateDir: tempDir,
+      }),
+    ).rejects.toThrow(
+      "queued generated-media delivery dead-lettered after an unexpected committed side effect",
+    );
+    expect(readQueueStatus(unsafeQueueId)).toBe("pending");
+
+    expect(dispatchGatewayMethodInProcess).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/state-migrations.legacy-session-store.test.ts
+++ b/src/infra/state-migrations.legacy-session-store.test.ts
@@ -141,7 +141,6 @@ it("preserves restart-recovery unsafe-side-effect aliases at the restart adapter
           restartRecoveryTerminalDeliveryEvidence: [
             {
               runId: "run-1",
-              captured: true,
               restartUnsafeSideEffectsDetected: true,
             },
           ],
@@ -154,7 +153,6 @@ it("preserves restart-recovery unsafe-side-effect aliases at the restart adapter
     expect(entry?.restartRecoveryTerminalDeliveryEvidence).toEqual([
       {
         runId: "run-1",
-        captured: true,
         restartUnsafeSideEffectsDetected: true,
       },
     ]);

--- a/src/infra/state-migrations.legacy-session-store.test.ts
+++ b/src/infra/state-migrations.legacy-session-store.test.ts
@@ -128,3 +128,35 @@ it("normalizes compatibility writes before persistence", async () => {
     expect(persisted["agent:main:main"]).not.toHaveProperty("pendingFinalDeliveryAttemptCount");
   });
 });
+
+it("preserves restart-recovery unsafe-side-effect aliases at the restart adapter", async () => {
+  await withTempDir({ prefix: "openclaw-legacy-restart-evidence-" }, async (root) => {
+    const storePath = path.join(root, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "session-1",
+          updatedAt: 1,
+          restartRecoveryTerminalDeliveryEvidence: [
+            {
+              runId: "run-1",
+              captured: true,
+              restartUnsafeSideEffectsDetected: true,
+            },
+          ],
+        },
+      }),
+    );
+
+    const entry = loadLegacySessionStore(storePath)["agent:main:main"];
+
+    expect(entry?.restartRecoveryTerminalDeliveryEvidence).toEqual([
+      {
+        runId: "run-1",
+        captured: true,
+        restartUnsafeSideEffectsDetected: true,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Restart recovery currently owns a useful privacy-bounded projection of terminal delivery evidence, but the contract is embedded in restart-specific code. Other lifecycle surfaces cannot reuse it without duplicating subtle bounding, normalization, visibility, and committed-side-effect logic.

## Why This Change Was Made

Extract the existing projection and normalization behavior into a neutral `terminal-delivery-evidence` module, then keep restart recovery as a thin compatibility wrapper. This deliberately does not broaden `agent.wait`, add a workflow store, or expose raw message bodies and arbitrary delivery metadata.

The shared contract:
- caps payload and target evidence at 64 items with explicit truncation flags
- allowlists delivery statuses and payload outcomes
- retains route-checkable visibility/media evidence without message text or arbitrary metadata
- marks committed outbound effects conservatively
- preserves the existing restart-recovery durable field shape

## User Impact

No direct user-visible behavior change. OpenClaw gains one reusable, privacy-bounded terminal evidence contract while restart recovery keeps its existing durable semantics.

## Evidence

- Focused Vitest slice: 8 files passed, 439 tests passed after rebasing onto current `upstream/main`
- Changed-file `oxlint`: 0 warnings, 0 errors
- Changed-file `oxfmt --check`: passed
- Runtime import-cycle check: 0 cycles
- `git diff --check`: passed
- Full TypeScript comparison completed with a 64 GiB Node heap: this branch adds no errors relative to a clean worktree at its base; the remaining failures are identical pre-existing repository baseline errors
- Independent review found two blockers before publication (projected-input idempotence and negative outcome indexes); both were fixed and the re-review approved the patch


### Restart-recovery production-boundary proof

A hermetic gateway regression now exercises the real boundary with synthetic identifiers and temporary on-disk state only:

1. project canonical terminal results through `buildRestartRecoveryTerminalDeliveryEvidence`
2. append the result through `buildRestartRecoveryClaimCleanupPatch`
3. persist the resulting session entry to the real SQLite session store
4. close and reopen database handles, then reload through the session accessor
5. pass the reopened evidence to the actual restart consumer, `deliverQueuedGeneratedMediaAgentTurn`

Redacted results:

- safe visible terminal evidence was recovered without invoking the fresh-dispatch sink
- canonical `unsafeSideEffectsDetected` persisted only as the legacy durable field `restartUnsafeSideEffectsDetected`
- unsafe committed-side-effect evidence failed closed without invoking the fresh-dispatch sink
- no prompt text, real route, user/session identifier, or delivery content was used or emitted

Verification at exact head `b08c52ddb535b7bf73c2d06c40539eb60f3114b9`:

- focused boundary and compatibility slice: 4 files passed, 30 tests passed
- changed-file `oxlint`: 0 warnings, 0 errors
- changed-file `oxfmt --check`: passed
- `git diff upstream/main...HEAD --check`: passed
- inspectable redacted alias-only runtime artifact: https://github.com/synapse-homeroot/openclaw/releases/download/pr119736-proof-b08c52ddb5/pr119736-runtime-proof-current.json
- artifact SHA-256: `9f08b491cdb94c5a6145d40f88ac10316d5a361d393ebcbdc822f1754ee34f6e`

The artifact was produced by a standalone `node --import tsx` runtime script, outside Vitest and without mocks. It persists an unsafe record containing only `runId` plus legacy `restartUnsafeSideEffectsDetected`, closes and reopens the real SQLite handles, and records the production restart consumer failing closed with `SessionDeliveryDeadLetteredError`; the safe control is consumed without redispatch. Identifiers are synthetic and output fields are allowlisted.
