### PR TITLE
fix(doctor): refresh planner statistics (ANALYZE) after SQLite compaction

### DIFF
--- a/src/commands/doctor-sqlite-compact.test.ts
+++ b/src/commands/doctor-sqlite-compact.test.ts
@@ -1,0 +1,48 @@
+// Compaction must refresh SQLite planner statistics: VACUUM alone preserves
+// stale sqlite_stat* rows, which leaves the query planner tuned for a data
+// volume that no longer exists after mass deletion (#119720).
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { compactDoctorSqliteFile } from "./doctor-sqlite-compact.js";
+
+describe("compactDoctorSqliteFile", () => {
+  it("runs ANALYZE so planner statistics reflect the compacted data", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-compact-test-"));
+    const sqlitePath = join(dir, "store.sqlite");
+    try {
+      const seed = openNodeSqliteDatabase(sqlitePath);
+      seed.exec("PRAGMA journal_mode = WAL;");
+      seed.exec("CREATE TABLE entries (id INTEGER PRIMARY KEY, body TEXT);");
+      seed.exec("CREATE INDEX entries_body ON entries (body);");
+      const insert = seed.prepare("INSERT INTO entries (body) VALUES (?)");
+      for (let i = 0; i < 2000; i += 1) {
+        insert.run(`row-${i}`);
+      }
+      // Simulate a mass prune: keep planner-relevant skew by deleting 95%.
+      seed.exec("DELETE FROM entries WHERE id % 20 != 0;");
+      seed.close();
+
+      const result = compactDoctorSqliteFile({ sqlitePath });
+      expect(result.integrityCheck).toBe("ok");
+
+      const verify = openNodeSqliteDatabase(sqlitePath);
+      try {
+        const statTable = verify
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat1'")
+          .get() as { name?: string } | undefined;
+        expect(statTable?.name).toBe("sqlite_stat1");
+        const statRows = verify.prepare("SELECT COUNT(*) AS rows FROM sqlite_stat1").get() as {
+          rows: number;
+        };
+        expect(statRows.rows).toBeGreaterThan(0);
+      } finally {
+        verify.close();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/doctor-sqlite-compact.ts
+++ b/src/commands/doctor-sqlite-compact.ts
@@ -51,6 +51,12 @@ export function compactDoctorSqliteFile(
     checkpointTruncate(database, options.sqlitePath);
     database.exec("PRAGMA auto_vacuum = INCREMENTAL;");
     database.exec("VACUUM;");
+    // Refresh planner statistics after compaction. VACUUM rewrites the file but
+    // leaves sqlite_stat* untouched, so a store that just shed most of its rows
+    // keeps plans shaped for the old data volume (observed in production as a
+    // 36.7s -> 809ms session-catalog scan difference after a 16.7GB -> 970MB
+    // prune; see #119720).
+    database.exec("ANALYZE;");
     checkpointTruncate(database, options.sqlitePath);
     const { integrityCheck } = assertSqliteIntegrity(database, options.sqlitePath);
     const after = readCompactSnapshot(database, options.sqlitePath);


### PR DESCRIPTION
## Summary

- **Problem:** `compactDoctorSqliteFile` runs `checkpoint → VACUUM → checkpoint → integrity` but never refreshes planner statistics. VACUUM preserves stale `sqlite_stat*` rows, so a store that just shed most of its rows keeps query plans shaped for data that no longer exists.
- **Production impact (from #119720):** after a 16.7GB → 970MB session-store prune, the gateway's `session-catalog` boot phase ran **36,704ms**; a single manual `ANALYZE` dropped it to **809ms (45×)** and ended a repeating boot→seizure loop (event loop pegged 110–120%, HTTP timeouts, dropped provider streams).
- **Fix:** run `ANALYZE` after `VACUUM` (before the final checkpoint so the statistics land in the same offline window). One call site covers both the session-store and state-store doctor compact paths.
- **Test:** new `doctor-sqlite-compact.test.ts` seeds a store, mass-deletes 95% of rows, compacts, and asserts `sqlite_stat1` exists and is populated.

## Scope boundary / follow-ups (deliberately not in this PR)
- `PRAGMA optimize` on connection close for all runtime DBs (SQLite's own guidance; cheap, self-gating) — happy to follow up if wanted.
- Automatic `ANALYZE` after *runtime* mass deletions (session maintenance / disk-budget enforcement), not just the offline doctor path.
- The larger ask in #119720 — moving synchronous `agent.write` transactions off the event loop — is architectural and untouched here.

Refs #119720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)