### PR TITLE
fix(sessions): prevent memory spikes during large transcript cleanup

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"db186d810ff456142338c36af49cf272d4d58063d341a9d2f93885acc1c0a168","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"fb754397315ac037d664accc011ca80acf3b422bd58ff9eab5912e1fa0d05f52","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"30bff907731a9c485e5ebf857d2bccb22f64733d6db696f65630ed24ffb0ab9d","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"bd923c5df5b125258a47b98e03ca1a902b6c811825a25046b6f60de87b83b91c","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"354bdde4f8741dc12786458920d1c1f251d6771f86e1b35455388fcffad7412e","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"83b3d0e3a1756c4c3532718fcc638f9ca20a22defde55bd08890398a9058d21c","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"e758c281a2468ed7b6692d7aac41532aa392199205d34c21425885650fe5002a","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"b5839e29169e83c4b721aaeae8cff09dcfcf8c10706d19d4339c38bc744eed47","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"ffdbd5eee1c1d4c3e3a906e9ef11cac1b67594c3f28698fbb91c9b4e9cefef01","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"56f7b992a9a1b84ae0a6c2bfde096ef1e55ef1cc6bc641f470a0c87cdfa9c2e2","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"e32f1483f2008c9ba937a6190e632ed3d47c59f9403770cad5ec4079c66f6e67","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"060731fb1411ba85f7f3cab6b73a9483a4bc6d19ebe450fdd75e460ac6b717eb","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"4b024e2a19bf93fbe9c910d84d9960751b89c287e69f7d56fc85ccae4e39e3ba","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"1e32b8e62f270664a32eed52da257c2966748828820815b92a20b473d2873235","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"a12c5a0cb965b393e90521aeb1ce23d9939d9468935a33d8c7c3e717f822d10a","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"1caada1285a476c8ebd23dd290da55a0c4601eabf71a8de9d346fb5015185417","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"18eac1e06d9ac32918f30178967692e13a47d7272b30c4386d12b74366192a47","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"15028d1d4fd784d0bdb5d9926e52bea5a1d8f891eba7dc8fff5c662aaa05bad3","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"6949fac4c91bb514789686bf0808d4255c1c9af27e0b880c65be2f25e20a4ec1","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"b77ef4a3390e45e51ee64bccb79e5d8047e287ffb87002f12212fefa8c8372ee","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"57a1b7494090393e3c88294bf717a91ce894a059af4ef940cffe110ed4567a47","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"11d22bcc55611535bf5d5d831abd1ef51d6b406200b2df8a4403bf49c168e775","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"606c0eefefe6c30667c337de3a7222bbd1f03ab2c87703445407aa48e651895a","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"75abd9e0a0da8d8f5ce380f2ad1d3736ed73bcdadbd7e8a47915a73bcfca95f7","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"ef25098b086e8959a75cd35962a000ab2e564aa4c57d0987cb991532e623b509","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"607a262154dd4fe8d8da9ba82b444a4875578e977ae1cd30710eec91c0e883a0","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"d2642457b2c68f9a0c7b4b46da3ad1f960b1358f235e07da83ec2b121c4897f3","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"37db932353f65b673a64a591d1749239b4ecfcb61db1e67ac2ccea4c1c7ac598","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"56b152bbedcc3c35b9f8ab1e2d44d999931aa24f88b1b902948803f08c8899fe","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"2c1ce8873f9f472ce1423bc1d73fa3e3ef092ccbb7b7ee4c7bac13e8258e949c","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"1e5dfd14f428c5181b3f59a6d793d3688cefa04ed4fbde992fdfd7ee9c2bb84c","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"14bdda53d1ec1456f2856fed6061353b2d881dd336b3c5384c0eb389a807f46e","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/src/commands/doctor-session-canonical-keys.ts
+++ b/src/commands/doctor-session-canonical-keys.ts
@@ -559,7 +559,7 @@ async function repairCanonicalSessionGroup(
         env: params.env,
         path: destination.sqlitePath,
       });
-      writeTranscriptArchive({
+      await writeTranscriptArchive({
         archiveDirectory,
         content: destinationContent,
         reason: "deleted",

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -4,6 +4,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import type { Transform } from "node:stream";
 import zlib from "node:zlib";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 
@@ -12,6 +13,11 @@ export const SESSION_ARCHIVE_ZSTD_SUFFIX = ".zst";
 type ZstdCodec = {
   compress: (data: Buffer) => Buffer;
   decompress: (data: Buffer) => Buffer;
+};
+
+type ZstdStreamCodec = {
+  createCompress: () => Transform;
+  createDecompress: () => Transform;
 };
 
 // node:zlib ships zstd since Node 22.15/23.8; Bun may not implement it yet.
@@ -36,6 +42,25 @@ function resolveZstdCodec(): ZstdCodec | null {
 
 const zstdCodec = resolveZstdCodec();
 
+function resolveZstdStreamCodec(): ZstdStreamCodec | null {
+  const candidate = zlib as Partial<{
+    createZstdCompress: () => Transform;
+    createZstdDecompress: () => Transform;
+  }>;
+  if (
+    typeof candidate.createZstdCompress !== "function" ||
+    typeof candidate.createZstdDecompress !== "function"
+  ) {
+    return null;
+  }
+  return {
+    createCompress: candidate.createZstdCompress.bind(zlib),
+    createDecompress: candidate.createZstdDecompress.bind(zlib),
+  };
+}
+
+const zstdStreamCodec = resolveZstdStreamCodec();
+
 /** Strips the optional zstd suffix so archive name parsers see one shape. */
 export function stripSessionArchiveCompressionSuffix(fileName: string): string {
   return fileName.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX)
@@ -55,6 +80,28 @@ export function encodeSessionArchiveContent(content: string): {
   // Default zstd level (3) matches the ratio/speed point Codex uses for cold
   // rollouts; archives are write-once so speed matters less than footprint.
   return { bytes: zstdCodec.compress(plain), suffix: SESSION_ARCHIVE_ZSTD_SUFFIX };
+}
+
+/** Creates a bounded-memory archive encoder when streaming zstd is available. */
+export function createSessionArchiveCompressionStream(): {
+  stream: Transform | null;
+  suffix: "" | typeof SESSION_ARCHIVE_ZSTD_SUFFIX;
+} {
+  if (!zstdStreamCodec) {
+    return { stream: null, suffix: "" };
+  }
+  return {
+    stream: zstdStreamCodec.createCompress(),
+    suffix: SESSION_ARCHIVE_ZSTD_SUFFIX,
+  };
+}
+
+/** Creates the decoder required to compare a compressed archive as a byte stream. */
+export function createSessionArchiveDecompressionStream(): Transform {
+  if (!zstdStreamCodec) {
+    throw new Error("Cannot stream compressed transcript archive: this runtime lacks zstd support");
+  }
+  return zstdStreamCodec.createDecompress();
 }
 
 /** Reads an archived transcript, transparently decompressing zstd artifacts. */

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -88,6 +88,8 @@ export function createSessionArchiveCompressionStream(): {
   suffix: "" | typeof SESSION_ARCHIVE_ZSTD_SUFFIX;
 } {
   if (!zstdStreamCodec) {
+    // A sync-only fallback would materialize the entire transcript and defeat
+    // this writer's bounded-memory contract. Keep partial runtimes on plain JSONL.
     return { stream: null, suffix: "" };
   }
   return {

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -20,6 +20,8 @@ type ZstdStreamCodec = {
   createDecompress: () => Transform;
 };
 
+type ZstdTransformConstructor = new () => Transform;
+
 // node:zlib ships zstd since Node 22.15/23.8; Bun may not implement it yet.
 // Feature-detect so the Bun path writes plain JSONL archives instead of
 // crashing, and mixed plain/compressed archives always stay readable.
@@ -46,17 +48,27 @@ function resolveZstdStreamCodec(): ZstdStreamCodec | null {
   const candidate = zlib as Partial<{
     createZstdCompress: () => Transform;
     createZstdDecompress: () => Transform;
+    ZstdCompress: ZstdTransformConstructor;
+    ZstdDecompress: ZstdTransformConstructor;
   }>;
-  if (
-    typeof candidate.createZstdCompress !== "function" ||
-    typeof candidate.createZstdDecompress !== "function"
-  ) {
+  const ZstdCompress = candidate.ZstdCompress;
+  const ZstdDecompress = candidate.ZstdDecompress;
+  const createCompress =
+    typeof candidate.createZstdCompress === "function"
+      ? candidate.createZstdCompress.bind(zlib)
+      : typeof ZstdCompress === "function"
+        ? () => new ZstdCompress()
+        : null;
+  const createDecompress =
+    typeof candidate.createZstdDecompress === "function"
+      ? candidate.createZstdDecompress.bind(zlib)
+      : typeof ZstdDecompress === "function"
+        ? () => new ZstdDecompress()
+        : null;
+  if (!createCompress || !createDecompress) {
     return null;
   }
-  return {
-    createCompress: candidate.createZstdCompress.bind(zlib),
-    createDecompress: candidate.createZstdDecompress.bind(zlib),
-  };
+  return { createCompress, createDecompress };
 }
 
 const zstdStreamCodec = resolveZstdStreamCodec();
@@ -88,8 +100,9 @@ export function createSessionArchiveCompressionStream(): {
   suffix: "" | typeof SESSION_ARCHIVE_ZSTD_SUFFIX;
 } {
   if (!zstdStreamCodec) {
-    // A sync-only fallback would materialize the entire transcript and defeat
-    // this writer's bounded-memory contract. Keep partial runtimes on plain JSONL.
+    // Supported Node releases expose zstd transforms alongside sync helpers.
+    // A truly sync-only compatibility runtime stays on plain JSONL because a
+    // sync fallback would materialize the transcript and defeat this contract.
     return { stream: null, suffix: "" };
   }
   return {

--- a/src/config/sessions/session-accessor.sqlite-archive.stream.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.stream.test.ts
@@ -1,23 +1,23 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { readSessionArchiveContentSync } from "./archive-compression.js";
 import { writeSqliteTranscriptArchive } from "./session-accessor.sqlite-archive.js";
 
 describe("SQLite transcript archive stream writer", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let archiveDirectory: string;
 
   beforeEach(() => {
-    archiveDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-archive-stream-"));
+    archiveDirectory = tempDirs.make("openclaw-archive-stream-");
   });
 
   afterEach(() => {
     __setFsSafeTestHooksForTest();
     vi.restoreAllMocks();
-    fs.rmSync(archiveDirectory, { force: true, recursive: true });
   });
 
   it("routes existing whole-content callers through the canonical publisher", async () => {
@@ -178,6 +178,74 @@ describe("SQLite transcript archive stream writer", () => {
     ).rejects.toThrow(`SQLite transcript archive verification failed for ${sessionId}`);
 
     expect(findArchiveEntries(archiveDirectory, sessionId)).toEqual([]);
+  });
+
+  it("removes its published archive when final content verification fails", async () => {
+    const sessionId = "corrupt-after-publication-session";
+    __setFsSafeTestHooksForTest({
+      beforePublishDirectorySync: (_method, targetPath) => {
+        fs.writeFileSync(targetPath, "corrupt after publication\n", "utf8");
+      },
+    });
+
+    await expect(
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from("verified before publication\n", "utf8")],
+        reason: "deleted",
+        sessionId,
+      }),
+    ).rejects.toThrow(`SQLite transcript archive verification failed for ${sessionId}`);
+
+    expect(findArchiveEntries(archiveDirectory, sessionId)).toEqual([]);
+  });
+
+  it("preserves a replacement at the archive path after final verification fails", async () => {
+    const sessionId = "replaced-after-publication-session";
+    let publishedPath: string | undefined;
+    const displacedPath = path.join(archiveDirectory, "displaced-publication");
+    __setFsSafeTestHooksForTest({
+      beforePublishDirectorySync: (_method, targetPath) => {
+        publishedPath = targetPath;
+        fs.renameSync(targetPath, displacedPath);
+        fs.writeFileSync(targetPath, "replacement owner\n", "utf8");
+      },
+    });
+
+    await expect(
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from("original publication\n", "utf8")],
+        reason: "deleted",
+        sessionId,
+      }),
+    ).rejects.toThrow(`SQLite transcript archive verification failed for ${sessionId}`);
+
+    expect(publishedPath).toBeDefined();
+    expect(fs.readFileSync(publishedPath!, "utf8")).toBe("replacement owner\n");
+  });
+
+  it("preserves the verification error when published archive cleanup fails", async () => {
+    const sessionId = "busy-after-publication-session";
+    __setFsSafeTestHooksForTest({
+      beforePublishDirectorySync: (_method, targetPath) => {
+        fs.writeFileSync(targetPath, "corrupt after publication\n", "utf8");
+      },
+    });
+    vi.spyOn(fs, "unlinkSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("injected busy published archive cleanup"), { code: "EBUSY" });
+    });
+
+    await expect(
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from("verified before publication\n", "utf8")],
+        reason: "deleted",
+        sessionId,
+      }),
+    ).rejects.toThrow(`SQLite transcript archive verification failed for ${sessionId}`);
+
+    expect(findArchiveEntries(archiveDirectory, sessionId)).toHaveLength(1);
   });
 });
 

--- a/src/config/sessions/session-accessor.sqlite-archive.stream.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.stream.test.ts
@@ -1,0 +1,198 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readSessionArchiveContentSync } from "./archive-compression.js";
+import { writeSqliteTranscriptArchive } from "./session-accessor.sqlite-archive.js";
+
+describe("SQLite transcript archive stream writer", () => {
+  let archiveDirectory: string;
+
+  beforeEach(() => {
+    archiveDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-archive-stream-"));
+  });
+
+  afterEach(() => {
+    __setFsSafeTestHooksForTest();
+    vi.restoreAllMocks();
+    fs.rmSync(archiveDirectory, { force: true, recursive: true });
+  });
+
+  it("routes existing whole-content callers through the canonical publisher", async () => {
+    const sessionId = "whole-content-archive-session";
+    const content = `${createTranscriptEventLine(sessionId, "existing caller")}\n`;
+
+    const archivedPath = await writeSqliteTranscriptArchive({
+      archiveDirectory,
+      content,
+      reason: "bak",
+      sessionId,
+    });
+
+    expect(readSessionArchiveContentSync(archivedPath)).toBe(content);
+  });
+
+  it("reuses matching content across arbitrary source chunk boundaries", async () => {
+    const sessionId = "streamed-duplicate-archive-session";
+    const content = `${JSON.stringify({
+      id: sessionId,
+      text: "\u4f60\u597d\ud83e\udd9e".repeat(32_768),
+    })}\n`;
+    const contentBytes = Buffer.from(content, "utf8");
+    const first = await writeSqliteTranscriptArchive({
+      archiveDirectory,
+      contentChunks: splitBuffer(contentBytes, 7),
+      reason: "deleted",
+      sessionId,
+    });
+    const second = await writeSqliteTranscriptArchive({
+      archiveDirectory,
+      contentChunks: splitBuffer(contentBytes, 4093),
+      reason: "deleted",
+      sessionId,
+    });
+
+    expect(second).toBe(first);
+    expect(readSessionArchiveContentSync(second)).toBe(content);
+  });
+
+  it("ignores a corrupt compressed candidate and publishes an exact archive", async () => {
+    const sessionId = "corrupt-candidate-archive-session";
+    const content = `${createTranscriptEventLine(sessionId, "valid replacement")}\n`;
+    const corruptPath = path.join(
+      archiveDirectory,
+      `${sessionId}.jsonl.deleted.2026-01-01T00-00-00.000Z.zst`,
+    );
+    fs.writeFileSync(corruptPath, randomBytes(128));
+
+    const archivedPath = await writeSqliteTranscriptArchive({
+      archiveDirectory,
+      contentChunks: [Buffer.from(content, "utf8")],
+      reason: "deleted",
+      sessionId,
+    });
+
+    expect(archivedPath).not.toBe(corruptPath);
+    expect(readSessionArchiveContentSync(archivedPath)).toBe(content);
+    expect(fs.readFileSync(corruptPath)).toHaveLength(128);
+  });
+
+  it("cleans staged output when exact stream verification fails", async () => {
+    const sessionId = "failed-stream-verification-session";
+
+    await expect(
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from("original\n", "utf8")],
+        reason: "deleted",
+        sessionId,
+        validateSource: () => {
+          const staged = fs
+            .readdirSync(archiveDirectory)
+            .find((entry) => entry.startsWith(`${sessionId}.jsonl.deleted.`));
+          if (!staged) {
+            throw new Error("expected staged archive");
+          }
+          fs.writeFileSync(path.join(archiveDirectory, staged), "changed\n", "utf8");
+        },
+      }),
+    ).rejects.toThrow(`SQLite transcript archive verification failed for ${sessionId}`);
+
+    expect(findArchiveEntries(archiveDirectory, sessionId)).toEqual([]);
+  });
+
+  it("cleans staged output when archive durability fails", async () => {
+    const sessionId = "failed-stream-fsync-session";
+    vi.spyOn(fs, "fsyncSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("injected archive fsync failure"), { code: "EIO" });
+    });
+
+    await expect(
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from("durability required\n", "utf8")],
+        reason: "deleted",
+        sessionId,
+      }),
+    ).rejects.toThrow("injected archive fsync failure");
+    expect(findArchiveEntries(archiveDirectory, sessionId)).toEqual([]);
+  });
+
+  it("preserves the archive failure when Windows-style temp cleanup also fails", async () => {
+    const sessionId = "failed-stream-cleanup-session";
+    vi.spyOn(fs, "fsyncSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("primary archive failure"), { code: "EIO" });
+    });
+    vi.spyOn(fs, "rmSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("injected busy cleanup"), { code: "EBUSY" });
+    });
+
+    await expect(
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from("preserve the primary failure\n", "utf8")],
+        reason: "deleted",
+        sessionId,
+      }),
+    ).rejects.toThrow("primary archive failure");
+  });
+
+  it("reuses an identical archive after a no-clobber publication race", async () => {
+    const sessionId = "concurrent-stream-archive-session";
+    const content = `${createTranscriptEventLine(sessionId, "concurrent publication")}\n`;
+    vi.spyOn(Date, "now").mockReturnValue(1_788_000_000_000);
+    const writeArchive = () =>
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from(content, "utf8")],
+        reason: "deleted",
+        sessionId,
+      });
+
+    const [first, second] = await Promise.all([writeArchive(), writeArchive()]);
+
+    expect(second).toBe(first);
+    expect(readSessionArchiveContentSync(first)).toBe(content);
+    expect(
+      findArchiveEntries(archiveDirectory, sessionId).filter((entry) => !entry.endsWith(".tmp")),
+    ).toHaveLength(1);
+  });
+
+  it("rejects an archive pathname pruned during the publication durability boundary", async () => {
+    const sessionId = "pruned-during-publication-session";
+    __setFsSafeTestHooksForTest({
+      beforePublishDirectorySync: (_method, targetPath) => {
+        fs.rmSync(targetPath);
+      },
+    });
+
+    await expect(
+      writeSqliteTranscriptArchive({
+        archiveDirectory,
+        contentChunks: [Buffer.from("must remain durable\n", "utf8")],
+        reason: "deleted",
+        sessionId,
+      }),
+    ).rejects.toThrow(`SQLite transcript archive verification failed for ${sessionId}`);
+
+    expect(findArchiveEntries(archiveDirectory, sessionId)).toEqual([]);
+  });
+});
+
+function createTranscriptEventLine(sessionId: string, content: string): string {
+  return JSON.stringify({ type: "session", id: sessionId, content });
+}
+
+function findArchiveEntries(archiveDirectory: string, sessionId: string): string[] {
+  return fs
+    .readdirSync(archiveDirectory)
+    .filter((entry) => entry.startsWith(`${sessionId}.jsonl.deleted.`));
+}
+
+function* splitBuffer(content: Buffer, chunkSize: number): IterableIterator<Buffer> {
+  for (let offset = 0; offset < content.length; offset += chunkSize) {
+    yield content.subarray(offset, Math.min(offset + chunkSize, content.length));
+  }
+}

--- a/src/config/sessions/session-accessor.sqlite-archive.stream.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.stream.test.ts
@@ -5,7 +5,7 @@ import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { readSessionArchiveContentSync } from "./archive-compression.js";
-import { writeSqliteTranscriptArchive } from "./session-accessor.sqlite-archive.js";
+import { writeTranscriptArchive } from "./session-accessor.sqlite-archive.js";
 
 describe("SQLite transcript archive stream writer", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -24,7 +24,7 @@ describe("SQLite transcript archive stream writer", () => {
     const sessionId = "whole-content-archive-session";
     const content = `${createTranscriptEventLine(sessionId, "existing caller")}\n`;
 
-    const archivedPath = await writeSqliteTranscriptArchive({
+    const archivedPath = await writeTranscriptArchive({
       archiveDirectory,
       content,
       reason: "bak",
@@ -41,13 +41,13 @@ describe("SQLite transcript archive stream writer", () => {
       text: "\u4f60\u597d\ud83e\udd9e".repeat(32_768),
     })}\n`;
     const contentBytes = Buffer.from(content, "utf8");
-    const first = await writeSqliteTranscriptArchive({
+    const first = await writeTranscriptArchive({
       archiveDirectory,
       contentChunks: splitBuffer(contentBytes, 7),
       reason: "deleted",
       sessionId,
     });
-    const second = await writeSqliteTranscriptArchive({
+    const second = await writeTranscriptArchive({
       archiveDirectory,
       contentChunks: splitBuffer(contentBytes, 4093),
       reason: "deleted",
@@ -67,7 +67,7 @@ describe("SQLite transcript archive stream writer", () => {
     );
     fs.writeFileSync(corruptPath, randomBytes(128));
 
-    const archivedPath = await writeSqliteTranscriptArchive({
+    const archivedPath = await writeTranscriptArchive({
       archiveDirectory,
       contentChunks: [Buffer.from(content, "utf8")],
       reason: "deleted",
@@ -83,7 +83,7 @@ describe("SQLite transcript archive stream writer", () => {
     const sessionId = "failed-stream-verification-session";
 
     await expect(
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from("original\n", "utf8")],
         reason: "deleted",
@@ -110,7 +110,7 @@ describe("SQLite transcript archive stream writer", () => {
     });
 
     await expect(
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from("durability required\n", "utf8")],
         reason: "deleted",
@@ -130,7 +130,7 @@ describe("SQLite transcript archive stream writer", () => {
     });
 
     await expect(
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from("preserve the primary failure\n", "utf8")],
         reason: "deleted",
@@ -144,7 +144,7 @@ describe("SQLite transcript archive stream writer", () => {
     const content = `${createTranscriptEventLine(sessionId, "concurrent publication")}\n`;
     vi.spyOn(Date, "now").mockReturnValue(1_788_000_000_000);
     const writeArchive = () =>
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from(content, "utf8")],
         reason: "deleted",
@@ -169,7 +169,7 @@ describe("SQLite transcript archive stream writer", () => {
     });
 
     await expect(
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from("must remain durable\n", "utf8")],
         reason: "deleted",
@@ -189,7 +189,7 @@ describe("SQLite transcript archive stream writer", () => {
     });
 
     await expect(
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from("verified before publication\n", "utf8")],
         reason: "deleted",
@@ -213,7 +213,7 @@ describe("SQLite transcript archive stream writer", () => {
     });
 
     await expect(
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from("original publication\n", "utf8")],
         reason: "deleted",
@@ -237,7 +237,7 @@ describe("SQLite transcript archive stream writer", () => {
     });
 
     await expect(
-      writeSqliteTranscriptArchive({
+      writeTranscriptArchive({
         archiveDirectory,
         contentChunks: [Buffer.from("verified before publication\n", "utf8")],
         reason: "deleted",

--- a/src/config/sessions/session-accessor.sqlite-archive.sync-zstd.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.sync-zstd.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+
+let readSessionArchiveContentSync: typeof import("./archive-compression.js").readSessionArchiveContentSync;
+let writeSqliteTranscriptArchive: typeof import("./session-accessor.sqlite-archive.js").writeSqliteTranscriptArchive;
+
+describe("SQLite transcript archive sync-only zstd fallback", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let archiveDirectory: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock("node:zlib", async () => {
+      const actual = await vi.importActual<typeof import("node:zlib")>("node:zlib");
+      return {
+        ...actual,
+        default: {
+          ...actual,
+          createZstdCompress: undefined,
+          createZstdDecompress: undefined,
+        },
+      };
+    });
+    ({ readSessionArchiveContentSync } = await import("./archive-compression.js"));
+    ({ writeSqliteTranscriptArchive } = await import("./session-accessor.sqlite-archive.js"));
+    archiveDirectory = tempDirs.make("openclaw-archive-sync-zstd-");
+  });
+
+  afterEach(() => {
+    vi.doUnmock("node:zlib");
+    vi.resetModules();
+  });
+
+  it("keeps multi-chunk archives complete and reusable without buffering for zstd", async () => {
+    const sessionId = "sync-only-zstd-session";
+    const content = `${JSON.stringify({ id: sessionId, text: "compressible".repeat(8192) })}\n`;
+    const bytes = Buffer.from(content, "utf8");
+
+    const first = await writeSqliteTranscriptArchive({
+      archiveDirectory,
+      contentChunks: splitBuffer(bytes, 97),
+      reason: "deleted",
+      sessionId,
+    });
+    const second = await writeSqliteTranscriptArchive({
+      archiveDirectory,
+      contentChunks: splitBuffer(bytes, 4093),
+      reason: "deleted",
+      sessionId,
+    });
+
+    expect(first.endsWith(".zst")).toBe(false);
+    expect(second).toBe(first);
+    expect(readSessionArchiveContentSync(first)).toBe(content);
+    expect(
+      fs
+        .readdirSync(archiveDirectory)
+        .filter((entry) => entry.startsWith(`${sessionId}.jsonl.deleted.`)),
+    ).toHaveLength(1);
+  });
+});
+
+function* splitBuffer(content: Buffer, chunkSize: number): IterableIterator<Buffer> {
+  for (let offset = 0; offset < content.length; offset += chunkSize) {
+    yield content.subarray(offset, Math.min(offset + chunkSize, content.length));
+  }
+}

--- a/src/config/sessions/session-accessor.sqlite-archive.sync-zstd.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.sync-zstd.test.ts
@@ -1,49 +1,69 @@
 import fs from "node:fs";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import zlib from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 
-let readSessionArchiveContentSync: typeof import("./archive-compression.js").readSessionArchiveContentSync;
-let writeSqliteTranscriptArchive: typeof import("./session-accessor.sqlite-archive.js").writeSqliteTranscriptArchive;
-
-describe("SQLite transcript archive sync-only zstd fallback", () => {
+describe("SQLite transcript archive partial zstd capabilities", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-  let archiveDirectory: string;
-
-  beforeEach(async () => {
-    vi.resetModules();
-    vi.doMock("node:zlib", async () => {
-      const actual = await vi.importActual<typeof import("node:zlib")>("node:zlib");
-      return {
-        ...actual,
-        default: {
-          ...actual,
-          createZstdCompress: undefined,
-          createZstdDecompress: undefined,
-        },
-      };
-    });
-    ({ readSessionArchiveContentSync } = await import("./archive-compression.js"));
-    ({ writeSqliteTranscriptArchive } = await import("./session-accessor.sqlite-archive.js"));
-    archiveDirectory = tempDirs.make("openclaw-archive-sync-zstd-");
-  });
 
   afterEach(() => {
     vi.doUnmock("node:zlib");
     vi.resetModules();
   });
 
-  it("keeps multi-chunk archives complete and reusable without buffering for zstd", async () => {
-    const sessionId = "sync-only-zstd-session";
+  it("reuses a sync-created legacy zstd archive through transform constructors", async () => {
+    const { readSessionArchiveContentSync, writeTranscriptArchive } = await loadArchiveModules({
+      hideFactories: true,
+    });
+    const archiveDirectory = tempDirs.make("openclaw-archive-zstd-constructors-");
+    const sessionId = "constructor-zstd-session";
     const content = `${JSON.stringify({ id: sessionId, text: "compressible".repeat(8192) })}\n`;
     const bytes = Buffer.from(content, "utf8");
+    const legacyPath = path.join(
+      archiveDirectory,
+      `${sessionId}.jsonl.deleted.2026-01-01T00-00-00.000Z.zst`,
+    );
+    fs.writeFileSync(legacyPath, zlib.zstdCompressSync(bytes));
 
-    const first = await writeSqliteTranscriptArchive({
+    const archivedPath = await writeTranscriptArchive({
       archiveDirectory,
       contentChunks: splitBuffer(bytes, 97),
       reason: "deleted",
       sessionId,
     });
-    const second = await writeSqliteTranscriptArchive({
+
+    expect(archivedPath).toBe(legacyPath);
+    expect(readSessionArchiveContentSync(archivedPath)).toBe(content);
+    expect(
+      fs
+        .readdirSync(archiveDirectory)
+        .filter((entry) => entry.startsWith(`${sessionId}.jsonl.deleted.`)),
+    ).toEqual([path.basename(legacyPath)]);
+  });
+
+  it("keeps a reusable plain fallback when no zstd transforms exist", async () => {
+    const { readSessionArchiveContentSync, writeTranscriptArchive } = await loadArchiveModules({
+      hideConstructors: true,
+      hideFactories: true,
+    });
+    const archiveDirectory = tempDirs.make("openclaw-archive-true-sync-zstd-");
+    const sessionId = "true-sync-only-zstd-session";
+    const content = `${JSON.stringify({ id: sessionId, text: "compressible".repeat(8192) })}\n`;
+    const bytes = Buffer.from(content, "utf8");
+    const legacyPath = path.join(
+      archiveDirectory,
+      `${sessionId}.jsonl.deleted.2026-01-01T00-00-00.000Z.zst`,
+    );
+    fs.writeFileSync(legacyPath, zlib.zstdCompressSync(bytes));
+
+    const first = await writeTranscriptArchive({
+      archiveDirectory,
+      contentChunks: splitBuffer(bytes, 97),
+      reason: "deleted",
+      sessionId,
+    });
+    const second = await writeTranscriptArchive({
       archiveDirectory,
       contentChunks: splitBuffer(bytes, 4093),
       reason: "deleted",
@@ -52,14 +72,44 @@ describe("SQLite transcript archive sync-only zstd fallback", () => {
 
     expect(first.endsWith(".zst")).toBe(false);
     expect(second).toBe(first);
+    expect(readSessionArchiveContentSync(legacyPath)).toBe(content);
     expect(readSessionArchiveContentSync(first)).toBe(content);
     expect(
       fs
         .readdirSync(archiveDirectory)
         .filter((entry) => entry.startsWith(`${sessionId}.jsonl.deleted.`)),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
   });
 });
+
+async function loadArchiveModules(options: {
+  hideConstructors?: boolean;
+  hideFactories?: boolean;
+}): Promise<{
+  readSessionArchiveContentSync: typeof import("./archive-compression.js").readSessionArchiveContentSync;
+  writeTranscriptArchive: typeof import("./session-accessor.sqlite-archive.js").writeTranscriptArchive;
+}> {
+  vi.resetModules();
+  vi.doMock("node:zlib", async () => {
+    const actual = await vi.importActual<typeof import("node:zlib")>("node:zlib");
+    return {
+      ...actual,
+      default: {
+        ...actual,
+        createZstdCompress: options.hideFactories ? undefined : actual.createZstdCompress,
+        createZstdDecompress: options.hideFactories ? undefined : actual.createZstdDecompress,
+        ZstdCompress: options.hideConstructors ? undefined : actual.ZstdCompress,
+        ZstdDecompress: options.hideConstructors ? undefined : actual.ZstdDecompress,
+      },
+    };
+  });
+  const archiveCompression = await import("./archive-compression.js");
+  const sqliteArchive = await import("./session-accessor.sqlite-archive.js");
+  return {
+    readSessionArchiveContentSync: archiveCompression.readSessionArchiveContentSync,
+    writeTranscriptArchive: sqliteArchive.writeTranscriptArchive,
+  };
+}
 
 function* splitBuffer(content: Buffer, chunkSize: number): IterableIterator<Buffer> {
   for (let offset = 0; offset < content.length; offset += chunkSize) {

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -1,14 +1,17 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
-import { syncDirectoryBestEffortSync } from "../../infra/directory-durability.js";
+import { publishFileNoClobber } from "../../infra/directory-durability.js";
+import { FsSafeError } from "../../infra/fs-safe.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import {
-  encodeSessionArchiveContent,
-  readSessionArchiveContentSync,
+  createSessionArchiveCompressionStream,
+  createSessionArchiveDecompressionStream,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "./archive-compression.js";
 import { formatSessionArchiveTimestamp, type SessionArchiveReason } from "./artifacts.js";
@@ -83,12 +86,64 @@ function resolveSqliteTranscriptArchivePath(params: {
   return archivePath;
 }
 
-function findMatchingSqliteTranscriptArchive(params: {
+type TranscriptArchiveDigest = {
+  byteLength: number;
+  sha256: string;
+};
+
+type SqliteTranscriptArchiveContent =
+  | { content: string; contentChunks?: never }
+  | { content?: never; contentChunks: Iterable<Buffer> };
+
+function transcriptArchiveDigestsEqual(
+  left: TranscriptArchiveDigest | null,
+  right: TranscriptArchiveDigest,
+): boolean {
+  return left?.byteLength === right.byteLength && left.sha256 === right.sha256;
+}
+
+async function readTranscriptArchiveDigest(params: {
+  archivePath: string;
+  compressed?: boolean;
+}): Promise<TranscriptArchiveDigest | null> {
+  const hash = createHash("sha256");
+  let byteLength = 0;
+  let decoder: ReturnType<typeof createSessionArchiveDecompressionStream> | null = null;
+  let fileHandle: fs.promises.FileHandle | undefined;
+  let file: fs.ReadStream | undefined;
+  try {
+    decoder =
+      (params.compressed ?? params.archivePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX))
+        ? createSessionArchiveDecompressionStream()
+        : null;
+    fileHandle = await fs.promises.open(params.archivePath, "r");
+    file = fileHandle.createReadStream({ autoClose: false });
+    const decoded = decoder ?? file;
+    if (decoder) {
+      file.once("error", (error) => decoder?.destroy(error));
+      file.pipe(decoder);
+    }
+    for await (const value of decoded) {
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      byteLength += chunk.length;
+      hash.update(chunk);
+    }
+    return { byteLength, sha256: hash.digest("hex") };
+  } catch {
+    return null;
+  } finally {
+    file?.destroy();
+    decoder?.destroy();
+    await fileHandle?.close().catch(() => undefined);
+  }
+}
+
+async function findMatchingSqliteTranscriptArchiveStream(params: {
   archiveDirectory: string;
-  content: string;
+  expected: TranscriptArchiveDigest;
   reason: SessionArchiveReason;
   sessionId: string;
-}): string | null {
+}): Promise<string | null> {
   let entries: string[];
   try {
     entries = fs.readdirSync(params.archiveDirectory);
@@ -101,16 +156,16 @@ function findMatchingSqliteTranscriptArchive(params: {
       continue;
     }
     const archivePath = path.join(params.archiveDirectory, entry);
-    const compressed = entry.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX);
     try {
-      const stat = fs.statSync(archivePath);
-      if (!stat.isFile()) {
+      if (!fs.statSync(archivePath).isFile()) {
         continue;
       }
-      if (!compressed && stat.size !== Buffer.byteLength(params.content, "utf8")) {
-        continue;
-      }
-      if (readSessionArchiveContentSync(archivePath) === params.content) {
+      if (
+        transcriptArchiveDigestsEqual(
+          await readTranscriptArchiveDigest({ archivePath }),
+          params.expected,
+        )
+      ) {
         return archivePath;
       }
     } catch {
@@ -120,64 +175,179 @@ function findMatchingSqliteTranscriptArchive(params: {
   return null;
 }
 
-/** Writes or reuses a transcript archive and returns its durable path. */
-export function writeTranscriptArchive(params: {
-  archiveDirectory: string;
-  content: string;
-  reason: SessionArchiveReason;
-  sessionId: string;
-}): string {
-  fs.mkdirSync(params.archiveDirectory, { recursive: true });
-  const existing = findMatchingSqliteTranscriptArchive(params);
-  if (existing) {
-    return existing;
-  }
-  // Archives are the long-lived cold tier; compress when the runtime can so
-  // keep-forever retention stays cheap. Plain JSONL is the Bun/older fallback.
-  const encoded = encodeSessionArchiveContent(params.content);
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    const archivePath = `${resolveSqliteTranscriptArchivePath({
-      archiveDirectory: params.archiveDirectory,
-      reason: params.reason,
-      sessionId: params.sessionId,
-      nowMs: Date.now() + attempt,
-    })}${encoded.suffix}`;
-    if (fs.existsSync(archivePath)) {
-      continue;
+async function writeDurableArchiveStreamExclusive(params: {
+  compressor: NodeJS.ReadWriteStream | null;
+  contentChunks: Iterable<Buffer>;
+  filePath: string;
+}): Promise<TranscriptArchiveDigest> {
+  const fd = fs.openSync(params.filePath, "wx", 0o600);
+  const output = fs.createWriteStream(params.filePath, {
+    autoClose: false,
+    emitClose: false,
+    fd,
+  });
+  const hash = createHash("sha256");
+  let byteLength = 0;
+  const measure = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      byteLength += bytes.length;
+      hash.update(bytes);
+      callback(null, bytes);
+    },
+  });
+  let result: TranscriptArchiveDigest | undefined;
+  let operationError: Error | undefined;
+  try {
+    const input = Readable.from(params.contentChunks, {
+      highWaterMark: 1,
+      objectMode: false,
+    });
+    if (params.compressor) {
+      await pipeline(input, measure, params.compressor, output);
+    } else {
+      await pipeline(input, measure, output);
     }
-    const tempPath = `${archivePath}.${randomUUID()}.tmp`;
-    try {
-      writeDurableFileExclusive(tempPath, encoded.bytes);
-      fs.renameSync(tempPath, archivePath);
-      syncDirectoryBestEffortSync(params.archiveDirectory);
-      // Full readback is bounded by the same single-generation content held by
-      // this Worker (Node string limits cap both); a partial
-      // or corrupt archive must fail here, before any rows are reclaimed.
-      if (readSessionArchiveContentSync(archivePath) !== params.content) {
-        fs.rmSync(archivePath, { force: true });
-        throw new Error(`SQLite transcript archive verification failed for ${params.sessionId}`);
-      }
-      return archivePath;
-    } catch (error) {
-      fs.rmSync(tempPath, { force: true });
-      if ((error as { code?: unknown })?.code === "EEXIST") {
-        continue;
-      }
-      throw error;
+    fs.fsyncSync(fd);
+    result = { byteLength, sha256: hash.digest("hex") };
+  } catch (error) {
+    operationError =
+      error instanceof Error
+        ? error
+        : new Error("SQLite transcript archive write failed", { cause: error });
+  }
+  let closeError: Error | undefined;
+  try {
+    fs.closeSync(fd);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EBADF") {
+      closeError =
+        error instanceof Error
+          ? error
+          : new Error("SQLite transcript archive close failed", { cause: error });
     }
   }
-  throw new Error(`Could not create SQLite transcript archive for ${params.sessionId}`);
+  if (operationError !== undefined) {
+    throw operationError;
+  }
+  if (closeError !== undefined) {
+    throw closeError;
+  }
+  if (!result) {
+    throw new Error(`SQLite transcript archive write produced no result for ${params.filePath}`);
+  }
+  return result;
 }
 
-// Windows rejects fsync on read-only handles, so keep the exclusive writable
-// descriptor open through both the write and durability boundary.
-function writeDurableFileExclusive(filePath: string, content: Buffer): void {
-  const fd = fs.openSync(filePath, "wx", 0o600);
+function removeArchiveTempBestEffort(tempPath: string): void {
   try {
-    fs.writeFileSync(fd, content);
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
+    fs.rmSync(tempPath, { force: true });
+  } catch {
+    // Preserve the archive or snapshot failure; abandoned temps are never retained archives.
+  }
+}
+
+function isArchivePublicationCollision(error: unknown): boolean {
+  return (
+    (error instanceof FsSafeError && error.code === "already-exists") ||
+    (error as NodeJS.ErrnoException)?.code === "EEXIST"
+  );
+}
+
+/** Writes or reuses a transcript archive through one bounded-memory publication path. */
+export async function writeTranscriptArchive(
+  params: {
+    archiveDirectory: string;
+    reason: SessionArchiveReason;
+    sessionId: string;
+    validateSource?: () => Promise<void> | void;
+  } & SqliteTranscriptArchiveContent,
+): Promise<string> {
+  if ((params.content === undefined) === (params.contentChunks === undefined)) {
+    throw new Error("SQLite transcript archive requires exactly one content source");
+  }
+  fs.mkdirSync(params.archiveDirectory, { recursive: true });
+  const encoding = createSessionArchiveCompressionStream();
+  const nowMs = Date.now();
+  const tempPath = `${resolveSqliteTranscriptArchivePath({
+    archiveDirectory: params.archiveDirectory,
+    reason: params.reason,
+    sessionId: params.sessionId,
+    nowMs,
+  })}${encoding.suffix}.${randomUUID()}.tmp`;
+  try {
+    const expected = await writeDurableArchiveStreamExclusive({
+      compressor: encoding.stream,
+      contentChunks: params.contentChunks ?? [Buffer.from(params.content ?? "", "utf8")],
+      filePath: tempPath,
+    });
+    await params.validateSource?.();
+    const existing = await findMatchingSqliteTranscriptArchiveStream({
+      archiveDirectory: params.archiveDirectory,
+      expected,
+      reason: params.reason,
+      sessionId: params.sessionId,
+    });
+    if (existing) {
+      removeArchiveTempBestEffort(tempPath);
+      return existing;
+    }
+    if (
+      !transcriptArchiveDigestsEqual(
+        await readTranscriptArchiveDigest({
+          archivePath: tempPath,
+          compressed: encoding.suffix === SESSION_ARCHIVE_ZSTD_SUFFIX,
+        }),
+        expected,
+      )
+    ) {
+      throw new Error(`SQLite transcript archive verification failed for ${params.sessionId}`);
+    }
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const archivePath = `${resolveSqliteTranscriptArchivePath({
+        archiveDirectory: params.archiveDirectory,
+        reason: params.reason,
+        sessionId: params.sessionId,
+        nowMs: nowMs + attempt,
+      })}${encoding.suffix}`;
+      try {
+        await publishFileNoClobber(tempPath, archivePath, {
+          durability: "degrade",
+          moveSource: true,
+          strategy: "link-or-copy",
+        });
+        // Publication fences the bytes, but archive pruning can still unlink the
+        // pathname after the helper's identity check. Preserve the lifecycle's
+        // post-publication existence and content fence before rows may be deleted.
+        if (
+          !transcriptArchiveDigestsEqual(
+            await readTranscriptArchiveDigest({ archivePath }),
+            expected,
+          )
+        ) {
+          throw new Error(`SQLite transcript archive verification failed for ${params.sessionId}`);
+        }
+        return archivePath;
+      } catch (error) {
+        if (isArchivePublicationCollision(error)) {
+          if (
+            transcriptArchiveDigestsEqual(
+              await readTranscriptArchiveDigest({ archivePath }),
+              expected,
+            )
+          ) {
+            removeArchiveTempBestEffort(tempPath);
+            return archivePath;
+          }
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error(`Could not create SQLite transcript archive for ${params.sessionId}`);
+  } catch (error) {
+    removeArchiveTempBestEffort(tempPath);
+    throw error;
   }
 }
 

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -6,7 +6,12 @@ import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
-import { publishFileNoClobber } from "../../infra/directory-durability.js";
+import {
+  getPublishFileExclusiveFailureDetails,
+  publishFileNoClobber,
+  syncDirectory,
+} from "../../infra/directory-durability.js";
+import { sameFileIdentity, type FileIdentityStat } from "../../infra/fs-safe-advanced.js";
 import { FsSafeError } from "../../infra/fs-safe.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import {
@@ -247,6 +252,34 @@ function removeArchiveTempBestEffort(tempPath: string): void {
   }
 }
 
+function removePublishedArchiveIfOwnedBestEffort(
+  archivePath: string,
+  expectedIdentity: FileIdentityStat,
+): boolean {
+  let currentIdentity: fs.Stats;
+  try {
+    currentIdentity = fs.lstatSync(archivePath);
+  } catch {
+    return false;
+  }
+  if (
+    currentIdentity.isSymbolicLink() ||
+    !currentIdentity.isFile() ||
+    !sameFileIdentity(currentIdentity, expectedIdentity)
+  ) {
+    return false;
+  }
+  // Node has no cross-platform unlink-by-identity primitive. Keep the owner
+  // check and unlink synchronous so no in-process task can replace the path.
+  try {
+    fs.unlinkSync(archivePath);
+    return true;
+  } catch {
+    // Preserve the verification failure; a later retention sweep can retry cleanup.
+    return false;
+  }
+}
+
 function isArchivePublicationCollision(error: unknown): boolean {
   return (
     (error instanceof FsSafeError && error.code === "already-exists") ||
@@ -310,12 +343,14 @@ export async function writeTranscriptArchive(
         sessionId: params.sessionId,
         nowMs: nowMs + attempt,
       })}${encoding.suffix}`;
+      let publishedIdentity: FileIdentityStat | undefined;
       try {
-        await publishFileNoClobber(tempPath, archivePath, {
+        const publication = await publishFileNoClobber(tempPath, archivePath, {
           durability: "degrade",
           moveSource: true,
           strategy: "link-or-copy",
         });
+        publishedIdentity = publication.identity;
         // Publication fences the bytes, but archive pruning can still unlink the
         // pathname after the helper's identity check. Preserve the lifecycle's
         // post-publication existence and content fence before rows may be deleted.
@@ -329,6 +364,18 @@ export async function writeTranscriptArchive(
         }
         return archivePath;
       } catch (error) {
+        const publicationFailure = getPublishFileExclusiveFailureDetails(error);
+        const cleanupIdentity =
+          publishedIdentity ??
+          (publicationFailure?.targetCreated && publicationFailure.cleanup !== "removed"
+            ? publicationFailure.targetIdentity
+            : undefined);
+        if (cleanupIdentity) {
+          const removed = removePublishedArchiveIfOwnedBestEffort(archivePath, cleanupIdentity);
+          if (removed) {
+            await syncDirectory(path.dirname(archivePath)).catch(() => undefined);
+          }
+        }
         if (isArchivePublicationCollision(error)) {
           if (
             transcriptArchiveDigestsEqual(

--- a/src/config/sessions/session-accessor.sqlite-archive.worker-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker-concurrency.test.ts
@@ -11,10 +11,10 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { replaceSessionEntry } from "./session-accessor.js";
-import { materializeSqliteTranscriptArchiveInWorker } from "./session-accessor.sqlite-archive.worker.js";
-import { planSqliteSessionStateDeleteIfUnreferenced } from "./session-accessor.sqlite-lifecycle-state.js";
+import { materializeTranscriptArchiveInWorker } from "./session-accessor.sqlite-archive.worker.js";
+import { planSessionStateDeleteIfUnreferenced } from "./session-accessor.sqlite-lifecycle-state.js";
 import { touchTranscriptMutationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
-import { replaceSqliteTranscriptEvents } from "./session-accessor.sqlite.js";
+import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
 const BATCHED_TRANSCRIPT_EVENT_COUNT = 33;
@@ -51,7 +51,7 @@ describe("SQLite transcript archive worker concurrency", () => {
     let batchesRead = 0;
     let concurrentWriteCompleted = false;
 
-    const result = await materializeSqliteTranscriptArchiveInWorker(
+    const result = await materializeTranscriptArchiveInWorker(
       planArchiveWorker(database, path.dirname(storePath), sessionId),
       {
         afterBatchRead: (batchIndex) => {
@@ -96,7 +96,7 @@ describe("SQLite transcript archive worker concurrency", () => {
     database.db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
     let checkpoint: Record<string, unknown> | undefined;
 
-    const result = await materializeSqliteTranscriptArchiveInWorker(
+    const result = await materializeTranscriptArchiveInWorker(
       planArchiveWorker(database, path.dirname(storePath), sessionId),
       {
         afterBatchRead: (batchIndex) => {
@@ -131,7 +131,7 @@ describe("SQLite transcript archive worker concurrency", () => {
     let mutationCount = 0;
 
     await expect(
-      materializeSqliteTranscriptArchiveInWorker(
+      materializeTranscriptArchiveInWorker(
         planArchiveWorker(database, archiveDirectory, sessionId),
         {
           afterBatchRead: (batchIndex) => {
@@ -185,7 +185,7 @@ async function createBatchedTranscript(params: {
     { sessionKey: params.sessionKey, storePath: params.storePath },
     { sessionId: params.sessionId, updatedAt: Date.now() },
   );
-  await replaceSqliteTranscriptEvents(
+  await replaceTranscriptEvents(
     { sessionId: params.sessionId, sessionKey: params.sessionKey, storePath: params.storePath },
     Array.from({ length: BATCHED_TRANSCRIPT_EVENT_COUNT }, (_, index) => ({
       content: `event-${index}`,
@@ -221,7 +221,7 @@ function planArchiveWorker(
   archiveDirectory: string,
   sessionId: string,
 ) {
-  const plan = planSqliteSessionStateDeleteIfUnreferenced({
+  const plan = planSessionStateDeleteIfUnreferenced({
     archiveDirectory,
     database,
     referencedSessionIds: new Set(),

--- a/src/config/sessions/session-accessor.sqlite-archive.worker-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker-concurrency.test.ts
@@ -1,0 +1,234 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import { replaceSessionEntry } from "./session-accessor.js";
+import { materializeSqliteTranscriptArchiveInWorker } from "./session-accessor.sqlite-archive.worker.js";
+import { planSqliteSessionStateDeleteIfUnreferenced } from "./session-accessor.sqlite-lifecycle-state.js";
+import { touchTranscriptMutationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
+import { replaceSqliteTranscriptEvents } from "./session-accessor.sqlite.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+const BATCHED_TRANSCRIPT_EVENT_COUNT = 33;
+
+describe("SQLite transcript archive worker concurrency", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-archive-concurrency-"));
+    storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("allows a rollback-journal writer between bounded archive batches", async () => {
+    const sessionId = "rollback-reader-session";
+    const sessionKey = "agent:main:rollback-reader";
+    const concurrentSessionKey = "agent:main:rollback-writer";
+    await createBatchedTranscript({ sessionId, sessionKey, storePath });
+    await replaceSessionEntry(
+      { sessionKey: concurrentSessionKey, storePath },
+      { sessionId: "rollback-writer-session", updatedAt: Date.now() },
+    );
+
+    const database = openLifecycleTestDatabase(storePath);
+    database.db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+    expect(database.db.prepare("PRAGMA journal_mode = DELETE;").get()).toEqual({
+      journal_mode: "delete",
+    });
+    let batchesRead = 0;
+    let concurrentWriteCompleted = false;
+
+    const result = await materializeSqliteTranscriptArchiveInWorker(
+      planArchiveWorker(database, path.dirname(storePath), sessionId),
+      {
+        afterBatchRead: (batchIndex) => {
+          batchesRead += 1;
+          if (batchIndex !== 0) {
+            return;
+          }
+          const writer = new DatabaseSync(database.path);
+          try {
+            writer.exec("PRAGMA busy_timeout = 250;");
+            const writeResult = writer
+              .prepare("UPDATE session_nodes SET updated_at = updated_at + 1 WHERE session_key = ?")
+              .run(concurrentSessionKey);
+            expect(writeResult.changes).toBe(1);
+            concurrentWriteCompleted = true;
+          } finally {
+            writer.close();
+          }
+        },
+      },
+    );
+
+    expect(result.archivedPath).not.toBeNull();
+    expect(batchesRead).toBe(3);
+    expect(concurrentWriteCompleted).toBe(true);
+  });
+
+  it("does not pin a WAL read snapshot between bounded archive batches", async () => {
+    const sessionId = "wal-reader-session";
+    const sessionKey = "agent:main:wal-reader";
+    const concurrentSessionKey = "agent:main:wal-writer";
+    await createBatchedTranscript({ sessionId, sessionKey, storePath });
+    await replaceSessionEntry(
+      { sessionKey: concurrentSessionKey, storePath },
+      { sessionId: "wal-writer-session", updatedAt: Date.now() },
+    );
+
+    const database = openLifecycleTestDatabase(storePath);
+    expect(database.db.prepare("PRAGMA journal_mode = WAL;").get()).toEqual({
+      journal_mode: "wal",
+    });
+    database.db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+    let checkpoint: Record<string, unknown> | undefined;
+
+    const result = await materializeSqliteTranscriptArchiveInWorker(
+      planArchiveWorker(database, path.dirname(storePath), sessionId),
+      {
+        afterBatchRead: (batchIndex) => {
+          if (batchIndex !== 0) {
+            return;
+          }
+          const writer = new DatabaseSync(database.path);
+          try {
+            writer.exec("PRAGMA busy_timeout = 250;");
+            const writeResult = writer
+              .prepare("UPDATE session_nodes SET updated_at = updated_at + 1 WHERE session_key = ?")
+              .run(concurrentSessionKey);
+            expect(writeResult.changes).toBe(1);
+            checkpoint = writer.prepare("PRAGMA wal_checkpoint(TRUNCATE);").get();
+          } finally {
+            writer.close();
+          }
+        },
+      },
+    );
+
+    expect(result.archivedPath).not.toBeNull();
+    expect(checkpoint).toEqual({ busy: 0, checkpointed: 0, log: 0 });
+  });
+
+  it("rejects transcript mutation between archive batches before publication", async () => {
+    const sessionId = "changed-between-batches-session";
+    const sessionKey = "agent:main:changed-between-batches";
+    await createBatchedTranscript({ sessionId, sessionKey, storePath });
+    const database = openLifecycleTestDatabase(storePath);
+    const archiveDirectory = path.dirname(storePath);
+    let mutationCount = 0;
+
+    await expect(
+      materializeSqliteTranscriptArchiveInWorker(
+        planArchiveWorker(database, archiveDirectory, sessionId),
+        {
+          afterBatchRead: (batchIndex) => {
+            if (batchIndex !== 0) {
+              return;
+            }
+            mutationCount += 1;
+            runOpenClawAgentWriteTransaction(
+              (transactionDb) => {
+                const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(transactionDb.db);
+                executeSqliteQuerySync(
+                  transactionDb.db,
+                  db
+                    .updateTable("transcript_events")
+                    .set({ event_json: createTranscriptEventLine(sessionId, "changed after read") })
+                    .where("session_id", "=", sessionId)
+                    .where("seq", "=", 0),
+                );
+                touchTranscriptMutationInTransaction(transactionDb, sessionId);
+              },
+              { agentId: database.agentId, path: database.path },
+            );
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      `SQLite session state changed during archive materialization for ${sessionId}`,
+    );
+
+    expect(mutationCount).toBe(1);
+    expect(findArchiveEntries(archiveDirectory, sessionId)).toEqual([]);
+    const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+    const retained = executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("transcript_events")
+        .select("event_json")
+        .where("session_id", "=", sessionId)
+        .where("seq", "=", 0),
+    ).rows[0];
+    expect(retained?.event_json).toBe(createTranscriptEventLine(sessionId, "changed after read"));
+  });
+});
+
+async function createBatchedTranscript(params: {
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+}): Promise<void> {
+  await replaceSessionEntry(
+    { sessionKey: params.sessionKey, storePath: params.storePath },
+    { sessionId: params.sessionId, updatedAt: Date.now() },
+  );
+  await replaceSqliteTranscriptEvents(
+    { sessionId: params.sessionId, sessionKey: params.sessionKey, storePath: params.storePath },
+    Array.from({ length: BATCHED_TRANSCRIPT_EVENT_COUNT }, (_, index) => ({
+      content: `event-${index}`,
+      id: `${params.sessionId}-${index}`,
+      type: "session",
+    })),
+  );
+}
+
+function createTranscriptEventLine(sessionId: string, content: string): string {
+  return JSON.stringify({ type: "session", id: sessionId, content });
+}
+
+function findArchiveEntries(archiveDirectory: string, sessionId: string): string[] {
+  return fs
+    .readdirSync(archiveDirectory)
+    .filter((entry) => entry.startsWith(`${sessionId}.jsonl.deleted.`));
+}
+
+function openLifecycleTestDatabase(storePath: string) {
+  const target = resolveSqliteTargetFromSessionStorePath(storePath);
+  if (!target.path) {
+    throw new Error(`Could not resolve SQLite database path for ${storePath}`);
+  }
+  return openOpenClawAgentDatabase({
+    agentId: target.agentId ?? "main",
+    path: target.path,
+  });
+}
+
+function planArchiveWorker(
+  database: ReturnType<typeof openLifecycleTestDatabase>,
+  archiveDirectory: string,
+  sessionId: string,
+) {
+  const plan = planSqliteSessionStateDeleteIfUnreferenced({
+    archiveDirectory,
+    database,
+    referencedSessionIds: new Set(),
+    sessionId,
+  });
+  if (!plan) {
+    throw new Error(`expected an archive plan for ${sessionId}`);
+  }
+  return plan;
+}

--- a/src/config/sessions/session-accessor.sqlite-archive.worker-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker-concurrency.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -20,17 +20,17 @@ import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target
 const BATCHED_TRANSCRIPT_EVENT_COUNT = 33;
 
 describe("SQLite transcript archive worker concurrency", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let tempDir: string;
   let storePath: string;
 
   beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-archive-concurrency-"));
+    tempDir = tempDirs.make("openclaw-sqlite-archive-concurrency-");
     storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
   });
 
   afterEach(() => {
     closeOpenClawAgentDatabasesForTest();
-    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
   it("allows a rollback-journal writer between bounded archive batches", async () => {

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -445,7 +445,7 @@ describe("SQLite transcript archive worker", () => {
     const sessionKey = "agent:main:missing-archive-result";
     const scope = { sessionKey, sessionId, storePath };
     const event = createTranscriptEvent(sessionId, "must survive a missing archive result");
-    await replaceSqliteTranscriptEvents(scope, [event]);
+    await replaceTranscriptEvents(scope, [event]);
     const database = openLifecycleTestDatabase(storePath);
     const plan = planArchiveWorker(database, path.dirname(storePath), sessionId);
 
@@ -669,7 +669,7 @@ describe("SQLite transcript archive worker", () => {
     const archiveDirectory = path.dirname(storePath);
     const database = openLifecycleTestDatabase(storePath);
 
-    const result = await materializeSqliteTranscriptArchiveInWorker(
+    const result = await materializeTranscriptArchiveInWorker(
       planArchiveWorker(database, archiveDirectory, sessionId),
     );
 
@@ -742,7 +742,7 @@ describe("SQLite transcript archive worker", () => {
     const sessionKey = "agent:main:changed-during-archive-verification";
     const scope = { sessionKey, sessionId, storePath };
     const original = createTranscriptEvent(sessionId, "stable read snapshot");
-    await replaceSqliteTranscriptEvents(scope, [original]);
+    await replaceTranscriptEvents(scope, [original]);
     const database = openLifecycleTestDatabase(storePath);
     const plan = planArchiveWorker(database, path.dirname(storePath), sessionId);
     let mutationCount = 0;
@@ -753,9 +753,9 @@ describe("SQLite transcript archive worker", () => {
       },
     });
 
-    let workerResult: Awaited<ReturnType<typeof materializeSqliteTranscriptArchiveInWorker>>;
+    let workerResult: Awaited<ReturnType<typeof materializeTranscriptArchiveInWorker>>;
     try {
-      workerResult = await materializeSqliteTranscriptArchiveInWorker(plan);
+      workerResult = await materializeTranscriptArchiveInWorker(plan);
     } finally {
       __setFsSafeTestHooksForTest();
     }

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -1,9 +1,10 @@
-// SQLite transcript archive worker tests cover off-main execution and snapshot fencing.
 import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+// SQLite transcript archive worker tests cover off-main execution and snapshot fencing.
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { recordAcpParentStreamEvents } from "../../agents/subagents/spawn/acp-parent-stream-store.sqlite.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
@@ -47,6 +48,7 @@ describe("SQLite transcript archive worker", () => {
   });
 
   afterEach(() => {
+    __setFsSafeTestHooksForTest();
     closeOpenClawAgentDatabasesForTest();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
@@ -119,36 +121,26 @@ describe("SQLite transcript archive worker", () => {
       createTranscriptEvent(sessionId, "durable archive first"),
     ]);
 
-    const originalLinkSync = fs.linkSync;
-    const originalRenameSync = fs.renameSync;
-    const entryObservedDuringArchivePublish: boolean[] = [];
-    const observeArchivePublish = (archivePath: unknown) => {
-      if (String(archivePath).includes(`${sessionId}.jsonl.deleted.`)) {
-        entryObservedDuringArchivePublish.push(
-          loadSessionEntry({ sessionKey, storePath })?.sessionId === sessionId,
-        );
-      }
-    };
     const openSpy = vi.spyOn(fs, "openSync");
     const fsyncSpy = vi.spyOn(fs, "fsyncSync");
-    const linkSpy = vi.spyOn(fs, "linkSync").mockImplementation((...args) => {
-      observeArchivePublish(args[1]);
-      return originalLinkSync(...args);
-    });
-    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((...args) => {
-      observeArchivePublish(args[1]);
-      return originalRenameSync(...args);
+    const publishedWhileEntryPresent: string[] = [];
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated: (_method, targetPath) => {
+        publishedWhileEntryPresent.push(targetPath);
+        expect(loadSessionEntry({ sessionKey, storePath })?.sessionId).toBe(sessionId);
+      },
     });
 
     let archivedPath: string | null = null;
     try {
       const database = openLifecycleTestDatabase(storePath);
-      const workerResult = materializeTranscriptArchiveInWorker(
+      const workerResult = await materializeTranscriptArchiveInWorker(
         planArchiveWorker(database, path.dirname(storePath), sessionId),
       );
       archivedPath = workerResult.archivedPath;
       expect(archivedPath).not.toBeNull();
-      expect(entryObservedDuringArchivePublish).toEqual([true]);
+      expect(publishedWhileEntryPresent).toEqual([archivedPath]);
+      expect(loadSessionEntry({ sessionKey, storePath })?.sessionId).toBe(sessionId);
       const archiveTempOpenIndexes = openSpy.mock.calls.flatMap((args, index) =>
         String(args[0]).includes(`${sessionId}.jsonl.deleted.`) && args[1] === "wx" ? [index] : [],
       );
@@ -156,8 +148,7 @@ describe("SQLite transcript archive worker", () => {
       const archiveTempOpenIndex = archiveTempOpenIndexes[0] ?? -1;
       expect(fsyncSpy).toHaveBeenCalledWith(openSpy.mock.results[archiveTempOpenIndex]?.value);
     } finally {
-      renameSpy.mockRestore();
-      linkSpy.mockRestore();
+      __setFsSafeTestHooksForTest();
       fsyncSpy.mockRestore();
       openSpy.mockRestore();
     }
@@ -449,6 +440,21 @@ describe("SQLite transcript archive worker", () => {
     });
   });
 
+  it("keeps transcript rows when an archive result is missing", async () => {
+    const sessionId = "missing-archive-result-session";
+    const sessionKey = "agent:main:missing-archive-result";
+    const scope = { sessionKey, sessionId, storePath };
+    const event = createTranscriptEvent(sessionId, "must survive a missing archive result");
+    await replaceSqliteTranscriptEvents(scope, [event]);
+    const database = openLifecycleTestDatabase(storePath);
+    const plan = planArchiveWorker(database, path.dirname(storePath), sessionId);
+
+    expect(() =>
+      deleteMaterializedPlans(database, [{ ...plan, archivedTranscript: null }], sessionKey),
+    ).toThrow(`SQLite transcript archive missing before deletion for ${sessionId}`);
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
   it("keeps rows when a transcript changes after its archive snapshot", async () => {
     const sessionId = "stale-archive-snapshot-session";
     const sessionKey = "agent:main:stale-archive-snapshot";
@@ -647,13 +653,34 @@ describe("SQLite transcript archive worker", () => {
     fs.writeFileSync(tempPath, `${line}\n`, "utf8");
 
     const database = openLifecycleTestDatabase(storePath);
-    const result = materializeTranscriptArchiveInWorker(
+    const result = await materializeTranscriptArchiveInWorker(
       planArchiveWorker(database, archiveDirectory, sessionId),
     );
 
     expect(result.archivedPath).not.toBe(tempPath);
     expect(fs.existsSync(tempPath)).toBe(true);
     expect(readArchiveLines(result.archivedPath ?? undefined)).toEqual([line]);
+  });
+
+  it("does not create an archive for an empty transcript snapshot", async () => {
+    const sessionId = "empty-transcript-archive-session";
+    const sessionKey = "agent:main:empty-transcript-archive";
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: Date.now() });
+    const archiveDirectory = path.dirname(storePath);
+    const database = openLifecycleTestDatabase(storePath);
+
+    const result = await materializeSqliteTranscriptArchiveInWorker(
+      planArchiveWorker(database, archiveDirectory, sessionId),
+    );
+
+    expect(result).toEqual({ archivedPath: null, sessionId });
+    expect(
+      fs.existsSync(archiveDirectory)
+        ? fs
+            .readdirSync(archiveDirectory)
+            .filter((entry) => entry.startsWith(`${sessionId}.jsonl.deleted.`))
+        : [],
+    ).toEqual([]);
   });
 
   it("reuses a matching archive before deleting entry rows", async () => {
@@ -687,7 +714,7 @@ describe("SQLite transcript archive worker", () => {
 
     try {
       const database = openLifecycleTestDatabase(storePath);
-      const workerResult = materializeTranscriptArchiveInWorker(
+      const workerResult = await materializeTranscriptArchiveInWorker(
         planArchiveWorker(database, path.dirname(storePath), sessionId),
       );
       expect(workerResult.archivedPath).toBe(archivePath);
@@ -708,6 +735,50 @@ describe("SQLite transcript archive worker", () => {
         sourcePath: path.join(path.dirname(storePath), `${sessionId}.jsonl`),
       },
     ]);
+  });
+
+  it("keeps rows changed while a published archive is being verified", async () => {
+    const sessionId = "changed-during-archive-verification";
+    const sessionKey = "agent:main:changed-during-archive-verification";
+    const scope = { sessionKey, sessionId, storePath };
+    const original = createTranscriptEvent(sessionId, "stable read snapshot");
+    await replaceSqliteTranscriptEvents(scope, [original]);
+    const database = openLifecycleTestDatabase(storePath);
+    const plan = planArchiveWorker(database, path.dirname(storePath), sessionId);
+    let mutationCount = 0;
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated: () => {
+        mutationCount += 1;
+        appendTranscriptEvent(database, sessionId);
+      },
+    });
+
+    let workerResult: Awaited<ReturnType<typeof materializeSqliteTranscriptArchiveInWorker>>;
+    try {
+      workerResult = await materializeSqliteTranscriptArchiveInWorker(plan);
+    } finally {
+      __setFsSafeTestHooksForTest();
+    }
+    expect(mutationCount).toBe(1);
+    expect(readArchiveLines(workerResult.archivedPath ?? undefined)).toEqual([
+      JSON.stringify(original),
+    ]);
+    const materialized = [
+      {
+        ...plan,
+        archivedTranscript: workerResult.archivedPath
+          ? {
+              archivedPath: workerResult.archivedPath,
+              sourcePath: path.join(path.dirname(storePath), `${sessionId}.jsonl`),
+            }
+          : null,
+      },
+    ];
+
+    expect(() => deleteMaterializedPlans(database, materialized, sessionKey)).toThrow(
+      `SQLite session state changed before deletion for ${sessionId}`,
+    );
+    await expect(loadTranscriptEvents(scope)).resolves.toHaveLength(2);
   });
 });
 

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.ts
@@ -1,7 +1,7 @@
 /** Worker entrypoint for SQLite transcript archive materialization off the gateway event loop. */
 import { parentPort, workerData } from "node:worker_threads";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
-import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
+import { withOpenClawAgentDatabaseReadOnlyAsync } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   sqliteSessionStateDeleteSnapshotsEqual,
@@ -12,9 +12,14 @@ import {
   writeTranscriptArchive,
 } from "./session-accessor.sqlite-archive.js";
 import { readSessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.js";
-import { serializeJsonlLines } from "./transcript-jsonl.js";
 
 type TranscriptArchiveDatabase = Pick<OpenClawAgentKyselyDatabase, "transcript_events">;
+
+const TRANSCRIPT_ARCHIVE_ROW_BATCH_SIZE = 16;
+
+type TranscriptArchiveWorkerHooks = {
+  afterBatchRead?: (batchIndex: number) => void;
+};
 
 function isSqliteTranscriptArchiveWorkerData(value: unknown): boolean {
   return (
@@ -87,48 +92,83 @@ function parseWorkerPlans(value: unknown): TranscriptArchiveWorkerPlan[] | undef
   return parsed;
 }
 
-function readTranscriptArchiveContent(
+const TRANSCRIPT_ARCHIVE_NEWLINE = Buffer.from("\n");
+
+function* iterateTranscriptArchiveContent(
   database: import("node:sqlite").DatabaseSync,
   sessionId: string,
-): string {
+  snapshotLastSeq: number,
+  hooks?: TranscriptArchiveWorkerHooks,
+): IterableIterator<Buffer> {
   const db = getNodeSqliteKysely<TranscriptArchiveDatabase>(database);
-  const lines = executeSqliteQuerySync(
-    database,
-    db
+  let afterSeq: number | null = null;
+  let batchIndex = 0;
+  for (;;) {
+    let query = db
       .selectFrom("transcript_events")
-      .select("event_json")
+      .select(["event_json", "seq"])
       .where("session_id", "=", sessionId)
-      .orderBy("seq", "asc"),
-  ).rows.map((row) => row.event_json);
-  return serializeJsonlLines(lines);
+      .where("seq", "<=", snapshotLastSeq)
+      .orderBy("seq", "asc")
+      .limit(TRANSCRIPT_ARCHIVE_ROW_BATCH_SIZE);
+    if (afterSeq !== null) {
+      query = query.where("seq", ">", afterSeq);
+    }
+    // Materialize one bounded batch so no SQLite statement remains open while
+    // compression or filesystem backpressure suspends this generator.
+    const rows = executeSqliteQuerySync(database, query).rows;
+    if (rows.length === 0) {
+      return;
+    }
+    hooks?.afterBatchRead?.(batchIndex);
+    for (const row of rows) {
+      yield Buffer.from(row.event_json, "utf8");
+      yield TRANSCRIPT_ARCHIVE_NEWLINE;
+    }
+    afterSeq = rows.at(-1)?.seq ?? null;
+    batchIndex += 1;
+    if (rows.length < TRANSCRIPT_ARCHIVE_ROW_BATCH_SIZE) {
+      return;
+    }
+  }
 }
 
-export function materializeTranscriptArchiveInWorker(
+function assertArchiveSnapshotCurrent(
+  database: import("node:sqlite").DatabaseSync,
   plan: TranscriptArchiveWorkerPlan,
-): TranscriptArchiveWorkerResult {
-  const opened = withOpenClawAgentDatabaseReadOnly(
-    (database) => {
-      let transactionOpen = false;
-      try {
-        // sqlite-allow-raw: metadata and transcript rows must come from one read snapshot.
-        database.db.exec("BEGIN");
-        transactionOpen = true;
-        const snapshot = readSessionStateDeleteSnapshot(database.db, plan.sessionId);
-        if (!sqliteSessionStateDeleteSnapshotsEqual(snapshot, plan.snapshot)) {
-          throw new Error(
-            `SQLite session state changed before archive materialization for ${plan.sessionId}`,
-          );
-        }
-        const content = readTranscriptArchiveContent(database.db, plan.sessionId);
-        database.db.exec("COMMIT"); // sqlite-allow-raw: closes the consistent read snapshot.
-        transactionOpen = false;
-        return { content, snapshot };
-      } catch (error) {
-        if (transactionOpen) {
-          database.db.exec("ROLLBACK"); // sqlite-allow-raw: releases a failed read snapshot.
-        }
-        throw error;
+  phase: "before" | "during",
+): void {
+  const snapshot = readSessionStateDeleteSnapshot(database, plan.sessionId);
+  if (!sqliteSessionStateDeleteSnapshotsEqual(snapshot, plan.snapshot)) {
+    throw new Error(
+      `SQLite session state changed ${phase} archive materialization for ${plan.sessionId}`,
+    );
+  }
+}
+
+export async function materializeTranscriptArchiveInWorker(
+  plan: TranscriptArchiveWorkerPlan,
+  hooks?: TranscriptArchiveWorkerHooks,
+): Promise<TranscriptArchiveWorkerResult> {
+  const opened = await withOpenClawAgentDatabaseReadOnlyAsync(
+    async (database) => {
+      assertArchiveSnapshotCurrent(database.db, plan, "before");
+      const snapshotLastSeq = plan.snapshot.lastSeq;
+      if (snapshotLastSeq === null) {
+        return null;
       }
+      return await writeTranscriptArchive({
+        archiveDirectory: plan.archiveDirectory,
+        contentChunks: iterateTranscriptArchiveContent(
+          database.db,
+          plan.sessionId,
+          snapshotLastSeq,
+          hooks,
+        ),
+        reason: plan.reason,
+        sessionId: plan.sessionId,
+        validateSource: () => assertArchiveSnapshotCurrent(database.db, plan, "during"),
+      });
     },
     { agentId: plan.agentId, path: plan.databasePath },
   );
@@ -137,24 +177,17 @@ export function materializeTranscriptArchiveInWorker(
       `Cannot archive SQLite transcript ${plan.sessionId}: ${opened.reason.replaceAll("-", " ")}`,
     );
   }
-  const { content } = opened.value;
-  const archivedPath =
-    content.length > 0
-      ? writeTranscriptArchive({
-          archiveDirectory: plan.archiveDirectory,
-          content,
-          reason: plan.reason,
-          sessionId: plan.sessionId,
-        })
-      : null;
-  return { archivedPath, sessionId: plan.sessionId };
+  return { archivedPath: opened.value, sessionId: plan.sessionId };
 }
 
-function runWorkerPort(
+async function runWorkerPort(
   port: NonNullable<typeof parentPort>,
   plans: readonly TranscriptArchiveWorkerPlan[],
-): void {
-  const results = plans.map((plan) => materializeTranscriptArchiveInWorker(plan));
+): Promise<void> {
+  const results: TranscriptArchiveWorkerResult[] = [];
+  for (const plan of plans) {
+    results.push(await materializeTranscriptArchiveInWorker(plan));
+  }
   port.postMessage({ type: "done", results } satisfies TranscriptArchiveWorkerMessage);
   port.close();
 }
@@ -167,5 +200,5 @@ if (isSqliteTranscriptArchiveWorkerData(workerData)) {
   if (!plans) {
     throw new Error("SQLite transcript archive worker requires valid worker data");
   }
-  runWorkerPort(parentPort, plans);
+  await runWorkerPort(parentPort, plans);
 }

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -244,6 +244,9 @@ export function deleteMaterializedSessionStatePlans(
     if (!sqliteSessionStateDeleteSnapshotsEqual(currentSnapshot, plan.snapshot)) {
       throw new Error(`SQLite session state changed before deletion for ${plan.sessionId}`);
     }
+    if (plan.archiveTranscript && plan.snapshot.lastSeq !== null && !plan.archivedTranscript) {
+      throw new Error(`SQLite transcript archive missing before deletion for ${plan.sessionId}`);
+    }
     deleteSqliteSessionStateRows(database, plan.sessionId);
     if (plan.snapshot.lastSeq !== null && plan.archivedTranscript) {
       archivedTranscripts.push(plan.archivedTranscript);

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -206,7 +206,7 @@ export async function trimTranscriptForManualCompact(
       );
     }
     const retainedEvents = retainedLines.map((line) => JSON.parse(line) as TranscriptEvent);
-    const archivedPath = writeTranscriptArchive({
+    const archivedPath = await writeTranscriptArchive({
       archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
       content: serializeJsonlLines(lines),
       reason: "bak",

--- a/src/infra/directory-durability.ts
+++ b/src/infra/directory-durability.ts
@@ -17,7 +17,6 @@ export {
   publishFileExclusive,
   sha256File,
   syncDirectory,
-  syncDirectoryBestEffortSync,
   type DirectorySyncOutcome,
   type DirectoryReceipt,
   type DurableDirectoryReceipt,

--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -114,3 +114,47 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
     db.close();
   }
 }
+
+/**
+ * Run an asynchronous read against a connection that remains open until the
+ * operation settles. File-backed reads use a private handle so suspension can
+ * never retain or borrow the process writer handle.
+ */
+export async function withOpenClawAgentDatabaseReadOnlyAsync<T>(
+  operation: (database: OpenClawAgentReadOnlyDatabase) => Promise<T>,
+  options: OpenClawAgentDatabaseOptions,
+): Promise<OpenClawAgentDatabaseReadOnlyResult<T>> {
+  const agentId = normalizeAgentId(options.agentId);
+  const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
+  if (isIncognitoOpenClawAgentSqlitePath(pathname, { agentId, env: options.env })) {
+    throw new Error("Asynchronous read-only operations are not supported for incognito databases");
+  }
+  if (!fs.existsSync(pathname)) {
+    return { found: false, reason: "database-missing" };
+  }
+  const db = openNodeSqliteDatabase(pathname, { readOnly: true });
+  try {
+    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    assertSupportedAgentSchemaVersion(db, pathname);
+    assertCanonicalAgentMediaPersistenceVersion(db, pathname);
+    const schemaMeta = readExistingAgentSchemaMeta(db);
+    if (!schemaMeta) {
+      return { found: false, reason: "schema-missing" };
+    }
+    assertExistingAgentSchemaOwner(schemaMeta, agentId, pathname);
+    try {
+      return {
+        found: true,
+        value: await operation({ agentId, db, path: pathname }),
+      };
+    } catch (error) {
+      if (isMissingTableError(error)) {
+        return { found: false, reason: "table-missing" };
+      }
+      throw error;
+    }
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(db);
+    db.close();
+  }
+}

--- a/src/state/openclaw-agent-db.incognito.test.ts
+++ b/src/state/openclaw-agent-db.incognito.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import {
   withOpenClawAgentDatabaseReadOnly,
@@ -15,21 +16,17 @@ import {
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "./openclaw-agent-db.js";
 
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
-  for (const tempDir of tempDirs.splice(0)) {
-    fs.rmSync(tempDir, { force: true, recursive: true });
-  }
 });
 
 describe("incognito agent database", () => {
   it("does not allocate an in-memory database for a read-only miss", () => {
     const stateDir = fs.realpathSync(
-      fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "openclaw-incognito-read-miss-")),
+      tempDirs.make("openclaw-incognito-read-miss-", fs.realpathSync(os.tmpdir())),
     );
-    tempDirs.push(stateDir);
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
     const before = listOpenIncognitoAgentDatabases();
@@ -47,9 +44,8 @@ describe("incognito agent database", () => {
 
   it("rejects async reads that would retain the shared in-memory writer handle", async () => {
     const stateDir = fs.realpathSync(
-      fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "openclaw-incognito-async-read-")),
+      tempDirs.make("openclaw-incognito-async-read-", fs.realpathSync(os.tmpdir())),
     );
-    tempDirs.push(stateDir);
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
     openOpenClawAgentDatabase({ agentId: "main", env, path: sentinel });
@@ -67,9 +63,8 @@ describe("incognito agent database", () => {
 
   it("refuses a file at the reserved sentinel path before opening in memory", () => {
     const stateDir = fs.realpathSync(
-      fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "openclaw-incognito-collision-")),
+      tempDirs.make("openclaw-incognito-collision-", fs.realpathSync(os.tmpdir())),
     );
-    tempDirs.push(stateDir);
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
     fs.mkdirSync(path.dirname(sentinel), { recursive: true });
@@ -98,9 +93,8 @@ describe("incognito agent database", () => {
 
   it("boots the canonical schema in one cached memory handle without touching its sentinel path", () => {
     const stateDir = fs.realpathSync(
-      fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "openclaw-incognito-db-")),
+      tempDirs.make("openclaw-incognito-db-", fs.realpathSync(os.tmpdir())),
     );
-    tempDirs.push(stateDir);
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
 

--- a/src/state/openclaw-agent-db.incognito.test.ts
+++ b/src/state/openclaw-agent-db.incognito.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
-import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.js";
+import {
+  withOpenClawAgentDatabaseReadOnly,
+  withOpenClawAgentDatabaseReadOnlyAsync,
+} from "./openclaw-agent-db-readonly.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   IncognitoAgentDatabasePathCollisionError,
@@ -40,6 +43,26 @@ describe("incognito agent database", () => {
     ).toEqual({ found: false, reason: "database-missing" });
     expect(listOpenIncognitoAgentDatabases()).toEqual(before);
     expect(fs.existsSync(sentinel)).toBe(false);
+  });
+
+  it("rejects async reads that would retain the shared in-memory writer handle", async () => {
+    const stateDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "openclaw-incognito-async-read-")),
+    );
+    tempDirs.push(stateDir);
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
+    openOpenClawAgentDatabase({ agentId: "main", env, path: sentinel });
+
+    await expect(
+      withOpenClawAgentDatabaseReadOnlyAsync(async () => "unreachable", {
+        agentId: "main",
+        env,
+        path: sentinel,
+      }),
+    ).rejects.toThrow(
+      "Asynchronous read-only operations are not supported for incognito databases",
+    );
   });
 
   it("refuses a file at the reserved sentinel path before opening in memory", () => {


### PR DESCRIPTION
Related: #112423

## What Problem This Solves

Fixes an issue where users deleting or resetting a session with a large SQLite transcript could cause archive memory usage to grow far beyond the transcript size and eventually fail with `RangeError: Invalid string length` before cleanup completed.

On the unpatched path, a 256 MiB logical transcript used a median additional sampled RSS of 1437.79 MiB, and a 520 MiB transcript deterministically failed before publishing an archive.

## Why This Change Was Made

The lifecycle archive Worker now reads ordered `event_json` rows with keyset pagination, materializes one fixed 16-row batch at a time, and streams the exact JSONL bytes through the existing plain/zstd archive format with backpressure. The canonical archive writer hashes logical bytes while writing and verifies staged and published content with streaming digests, preserving no-clobber publication, durability, matching-archive reuse, and archive-before-delete behavior.

The Worker does not hold one long SQLite read transaction. It validates the source snapshot before and after streaming, so rollback-journal and WAL writers can proceed between bounded batches while any transcript mutation causes publication or deletion to fail closed. Existing whole-content callers now use the same canonical publication policy, and lifecycle deletion also refuses to remove a non-empty transcript when its archive result is missing.

## User Impact

Large SQLite transcript cleanup no longer requires one giant JSONL string or multiple full-content buffers. Memory is bounded by the largest event row, one 16-row batch, and stream buffers rather than total transcript size, while the existing archive bytes, compression compatibility, durability, deduplication, and lifecycle safety checks remain intact.

There is no schema, configuration, archive-format, or public API change.

## Evidence

### Reproducible before/after benchmark

The benchmark uses an isolated real OpenClaw SQLite database, writes deterministic high-entropy events through the production persistence API, invokes the production lifecycle materializer and archive Worker in a controlled child process, and stream-verifies the published archive's logical byte length and SHA-256.

- Before-fix reproduction commit: [`0cd475b729e4067d0af54baf1aec8adffc0278e5`](https://github.com/HermanZeng/openclaw/commit/0cd475b729e4067d0af54baf1aec8adffc0278e5)
- After-fix evidence commit: [`d4c6228c4e73a70c53183b5cd55011bea7dc279c`](https://github.com/HermanZeng/openclaw/commit/d4c6228c4e73a70c53183b5cd55011bea7dc279c)
- Production implementation commit under the after-fix evidence: [`c270cddd78bc8dc07c99a5cc35b268fc0f6f13e8`](https://github.com/HermanZeng/openclaw/commit/c270cddd78bc8dc07c99a5cc35b268fc0f6f13e8)
- Current validated PR head: [b4895579527](https://github.com/HermanZeng/openclaw/commit/b4895579527), based on [c2d8b3be4dd](https://github.com/openclaw/openclaw/commit/c2d8b3be4dd)

Commands:

```powershell
node --import tsx scripts/bench-sqlite-transcript-archive-memory.ts 256
node --import tsx scripts/bench-sqlite-transcript-archive-memory.ts 520
```

256 MiB logical transcript (`268,451,986` bytes, identical SHA-256 on every run):

| State | Operation RSS delta | Result |
|---|---:|---|
| Before, median of 3 | `1437.79 MiB` sampled | archive verified |
| After, median of 3 | `198.25 MiB` process high-water (`187.37 MiB` sampled) | archive verified |

520 MiB target (`545,293,210` logical bytes):

| State | Operation RSS delta | Result |
|---|---:|---|
| Before | n/a | `RangeError: Invalid string length`; no archive |
| After | `151.62 MiB` process high-water (`148.33 MiB` sampled) | archive published and exact byte length/SHA-256 verified |

All after-fix benchmark runs reported `publishableEvidence: true`, stable source hashes, normal child exit, successful cleanup, and `archiveMatchesExpected: true`.

### Tests and checks

Passed on the rebased PR commit:

- `oxfmt --check` for all 12 changed files
- `node scripts/run-oxlint.mjs <changed files>`
- `pnpm deadcode:dependencies`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- Current-head archive/compression and Worker validation: 36/36 tests passed across 4 focused files
- `git diff --check upstream/main...HEAD`
- Post-review coverage proves legacy sync-produced zstd reuse through public Transform constructors, bounded-memory plain JSONL fallback when no streaming zstd API exists, and identity-safe cleanup after final verification failure.
- `node scripts/check-sqlite-transaction-boundary.mjs`
- `node scripts/check-kysely-guardrails.mjs`
- `pnpm build`
- Built Gateway large-transcript responsiveness E2E: 1/1 targeted test passed in 21.29 s
- `codex review --commit HEAD`: no actionable regressions identified

Concurrency coverage proves that a rollback-journal writer can commit between archive batches, a WAL writer is not pinned behind a long read snapshot, and transcript mutation between batches is rejected before publication.

### Legacy zstd compatibility

The remaining compatibility concern was tested against every runtime family OpenClaw currently admits instead of adding an unbounded synchronous decode path.

#### Supported Node releases

- OpenClaw requires Node `>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0`. These supported release lines expose the public zstd sync helpers and streaming Transform APIs together.
- The codec resolver accepts either the public `createZstdCompress` / `createZstdDecompress` factories or the public `ZstdCompress` / `ZstdDecompress` Transform constructors. A runtime with factory helpers hidden therefore still streams and reuses legacy `.zst` archives.
- A regression test seeds a legacy archive with `zstdCompressSync`, hides only the factories, then verifies that the exact existing `.zst` path is reused through the constructors with identical logical bytes and no duplicate archive.
- A separate adversarial test hides both factories and constructors while leaving sync helpers visible. That synthetic capability shape stays bounded and data-safe by publishing and reusing one plain JSONL fallback rather than invoking an unbounded sync decoder.

Cross-version Node proof used the oldest supported Node 22 release as the legacy writer and a current Node 24 stream decoder:

```text
Node v22.22.3, zstdCompressSync:
{"plainBytes":852009,"compressedBytes":148}

Node v24.18.0, new ZstdDecompress():
{"decodedBytes":852009,"sha256":"bb47fcf7e7cc31336e3894be2021c3dfa9d0688750e987ce1816f61bfcdd92ce","expectedSha256":"bb47fcf7e7cc31336e3894be2021c3dfa9d0688750e987ce1816f61bfcdd92ce","match":true}
```

#### Experimentally admitted Bun 1.4 builds

OpenClaw also experimentally admits Bun builds that provide `node:sqlite` ([#114256](https://github.com/openclaw/openclaw/pull/114256)), so that path was checked directly rather than assumed to have Node's capability shape.

- The exact Bun revision used to establish OpenClaw's admission path, `1.4.0-canary.1+43d60f69c`, defines both zstd Transform classes and both stream factories in its immutable source: [`ZstdCompress` / `ZstdDecompress`](https://github.com/oven-sh/bun/blob/43d60f69c/src/js/node/zlib.ts#L816-L826) and [`createZstdCompress` / `createZstdDecompress`](https://github.com/oven-sh/bun/blob/43d60f69c/src/js/node/zlib.ts#L854-L911).
- The current official Windows x64 Bun canary archive (`sha256:7de042c49ef20ccfd683c88903b0aba286a154e11d0eb71868e8acb6ce7e7dae`) was also exercised at runtime.

Capability probe:

```text
$ bun --revision
1.4.0-canary.1+45ee9556a

{
  "sqliteDatabaseSync": "function",
  "zstdCompressSync": "function",
  "zstdDecompressSync": "function",
  "createZstdCompress": "function",
  "createZstdDecompress": "function",
  "ZstdCompress": "function",
  "ZstdDecompress": "function"
}
```

Directly importing this PR's codec resolver under that Bun binary selected the streaming path:

```text
{"bun":"1.4.0","compressionSuffix":".zst","compressionStream":"ZstdCompress","decompressionStream":"ZstdDecompress"}
```

Finally, Node `v22.22.3` synchronously produced a 1,235,025-byte legacy zstd frame from 3,757,780 logical bytes. Bun 1.4 streamed that same file through `createZstdDecompress()` in 230 output chunks; the logical SHA-256 matched exactly:

```text
writer: v22.22.3
plainBytes: 3757780
compressedBytes: 1235025
sha256: 3ea691c1431bb86dbedeb1dae336ae95158c290f86b64419f4f6515f4c953f56

reader: Bun 1.4.0
chunks: 230
maxChunkBytes: 16384
decodedBytes: 3757780
sha256: 3ea691c1431bb86dbedeb1dae336ae95158c290f86b64419f4f6515f4c953f56
```

Therefore, no official Node or Bun build currently admitted by OpenClaw was found with the modeled "sync zstd but no streaming zstd" shape. Standard legacy zstd frames remain stream-decodable across runtime versions. The synthetic partial-runtime test remains intentionally defensive: it preserves data and bounded memory without claiming exact compressed-archive reuse for an unofficial, partially implemented runtime.

See the [Node zlib API](https://nodejs.org/api/zlib.html), [Bun node:zlib API](https://bun.sh/reference/node/zlib), and the [zstd compatibility guarantee](https://github.com/facebook/zstd/blob/dev/programs/README.md).
## Scope

- The bounded source-materialization guarantee applies to the lifecycle archive Worker. Manual compact and doctor repair now share the same canonical streaming publication and verification policy, but those callers still arrive with source content already materialized.
- The bound is `O(max event row + fixed batch + stream buffers)`, not strict constant memory.
- This change does not attempt to solve the independent pre-existing race between published archives and concurrent history-budget pruning; it retains post-publication readback plus the existing lifecycle snapshot fences.

## AI Assistance

This PR was developed with assistance from OpenAI Codex for codebase navigation, implementation, test generation, adversarial review, and evidence preparation. I reviewed the final implementation, tests, benchmark methodology, commands, and outputs and understand the behavior and compatibility boundaries.
