### PR TITLE
fix(cli): report accurate filtered node totals

### DIFF
--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -560,7 +560,9 @@ export function registerNodesStatusCommands(nodes: Command) {
             return true;
           });
           const filteredLabel =
-            hasFilters && filteredPaired.length !== paired.length ? ` (of ${paired.length})` : "";
+            hasFilters && filteredPaired.length !== effectivePairedRows.length
+              ? ` (of ${effectivePairedRows.length})`
+              : "";
           if (opts.json) {
             defaultRuntime.writeJson({
               pending: pendingRows,

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -325,6 +325,39 @@ describe("cli program (nodes basics)", () => {
     expect(output).not.toContain("Two");
   });
 
+  it("counts catalog-only paired nodes in the filtered list total", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [{ nodeId: "paired-store", displayName: "Paired Store" }],
+        };
+      }
+      if (opts.method === "node.list") {
+        return {
+          nodes: [
+            { nodeId: "paired-store", connected: true },
+            {
+              nodeId: "catalog-only",
+              displayName: "Catalog Only",
+              paired: true,
+              connected: true,
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "list", "--connected"]);
+
+    const output = getRuntimeOutput();
+    expect(output).toMatch(/^Pending: 0 · Paired: 2$/m);
+    expect(output).toContain("Paired Store");
+    expect(output).toContain("Catalog Only");
+  });
+
   it("runs nodes status --last-connected and filters by age", async () => {
     const now = Date.now();
     callGateway.mockImplementation(async (...args: unknown[]) => {


### PR DESCRIPTION
Closes #119743

## What Problem This Solves

Fixes an issue where operators using a filtered `openclaw nodes list` could see an impossible inventory summary such as `Paired: 2 (of 1)` when the effective node catalog contributed a paired row that was absent from the raw pairing-store response.

## Why This Change Was Made

The CLI already filters and renders the merged effective paired-node rows, but its summary denominator still used the pre-merge pairing-store count. The fix makes the denominator use the same merged row owner as filtering and rendering. Pairing-scope fallback, older-Gateway compatibility, merge policy, filters, rows, and JSON output are unchanged.

The mismatch traces to the nodes list/status alignment work in https://github.com/openclaw/openclaw/pull/72619; its review identified this denominator case, but the landed code retained the stale raw count.

## User Impact

Filtered node inventory output now reports internally consistent totals. Operators can trust the summary to describe the same nodes shown in the table, including legacy/device-paired catalog rows.

## Evidence

- Pre-fix reproduction: Blacksmith Testbox `tbx_01kz9wsvj8eg52pq6tv37b0178`, [run 31048237291](https://github.com/openclaw/openclaw/actions/runs/31048237291). The full CLI program rendered `Pending: 0 · Paired: 2 (of 1)` above two paired rows.
- Focused fix: `pnpm test src/cli/program.nodes-basic.e2e.test.ts` — 29/29 passing.
- Stress: the full 29-test CLI file passed 30/30 fresh-process iterations (870 assertions).
- Sibling node CLI surface: 98/98 passing across basic/media/push Commander E2E, command coverage, plugin registration, pairing rendering, and approval transport timeout.
- Hosted changed gate: complete `core, coreTests` lanes green, including both typechecks, changed-file format/lint, import cycles, SDK/plugin contracts, dead exports, and storage/schema guards.
- Exact-head hosted CI: [run 31049483734](https://github.com/openclaw/openclaw/actions/runs/31049483734) green for `de68789cbb3ec4ac9eafa513d92b8e421e52a1a1`.
- Exact-head ClawSweeper: [run 31049593414](https://github.com/openclaw/clawsweeper/actions/runs/31049593414) reports no findings, security cleared, and patch correct at 0.96. Its only rank-up move was completed exact-head checks.
- AutoReview: clean, no accepted/actionable findings, correctness confidence 0.99.
- Production LOC: +3 / -1. Tests: +33 / -0. No config/default/API/data-model changes.
- Public model identifier audit: PASS; the diff contains no model identifiers.

Risk is low: this changes only the text summary denominator after the existing merge/filter decision and is covered through the full CLI registration path.

- [x] AI-assisted
- [x] I understand the code and verified the owner boundary
- [x] AutoReview completed with no actionable finding
