### PR TITLE
fix(diagnostics): preserve OTEL startup failure during rollback

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1061,6 +1061,38 @@ describe("diagnostics-otel service", () => {
     });
   });
 
+  test("preserves SDK startup failure when rollback shutdown also fails", async () => {
+    const startupError = new Error("SDK startup failed");
+    const rollbackError = new Error("SDK rollback failed");
+    sdkStart.mockImplementationOnce(() => {
+      throw startupError;
+    });
+    sdkShutdown.mockRejectedValueOnce(rollbackError);
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+
+    const startError = await Promise.resolve(service.start(ctx)).catch((error: unknown) => error);
+
+    expect(startError).toBeInstanceOf(AggregateError);
+    expect(startError).toMatchObject({
+      message: "diagnostics-otel startup failed and rollback cleanup failed",
+      cause: startupError,
+      errors: [startupError, rollbackError],
+    });
+    expect(ctx.logger.error).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("diagnostics-otel: failed to start SDK: Error: SDK startup failed"),
+    );
+    expect(ctx.logger.error).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(
+        "diagnostics-otel: SDK startup rollback cleanup failed: Error: SDK rollback failed",
+      ),
+    );
+    expect(sdkShutdown).toHaveBeenCalledOnce();
+    await expect(service.stop?.(ctx)).resolves.toBeUndefined();
+  });
+
   test("registers and removes an OTLP exporter unhandled rejection handler", async () => {
     const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -75,6 +75,14 @@ function resolveSignalProtocol(
   );
 }
 
+function createStartupRollbackError(startupError: unknown, cleanupError: unknown) {
+  return new AggregateError(
+    [startupError, cleanupError],
+    "diagnostics-otel startup failed and rollback cleanup failed",
+    { cause: startupError },
+  );
+}
+
 export function createDiagnosticsOtelService(): OpenClawPluginService {
   let sdk: NodeSDK | null = null;
   let logProvider: LoggerProvider | null = null;
@@ -329,8 +337,15 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               errorCategory: errorCategory(err),
             },
           );
-          await stopStarted();
           ctx.logger.error(`diagnostics-otel: failed to start SDK: ${formatError(err)}`);
+          try {
+            await stopStarted();
+          } catch (cleanupError) {
+            ctx.logger.error(
+              `diagnostics-otel: SDK startup rollback cleanup failed: ${formatError(cleanupError)}`,
+            );
+            throw createStartupRollbackError(err, cleanupError);
+          }
           throw err;
         }
       } else if (sdkPreloaded && (tracesEnabled || metricsEnabled)) {

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -625,6 +625,41 @@ describe("startPluginServices", () => {
     expect(rollback).toHaveBeenCalledOnce();
   });
 
+  it("keeps diagnostics rollback detail visible beside the host startup failure", async () => {
+    const startupError = new Error("SDK startup failed");
+    const rollbackError = new Error("SDK rollback failed");
+
+    await startPluginServices({
+      registry: createRegistry(
+        [
+          {
+            id: "diagnostics-otel",
+            start: (ctx) => {
+              ctx.logger.error(
+                "diagnostics-otel: SDK startup rollback cleanup failed: Error: SDK rollback failed",
+              );
+              throw new AggregateError(
+                [startupError, rollbackError],
+                "diagnostics-otel startup failed and rollback cleanup failed",
+                { cause: startupError },
+              );
+            },
+          },
+        ],
+        "diagnostics-otel",
+        "bundled",
+      ),
+      config: createServiceConfig(),
+    });
+
+    expect(mockedLogger.error.mock.calls).toEqual([
+      ["diagnostics-otel: SDK startup rollback cleanup failed: Error: SDK rollback failed"],
+      [
+        "plugin service failed (diagnostics-otel, plugin=diagnostics-otel, root=/plugins/test-plugin): diagnostics-otel startup failed and rollback cleanup failed",
+      ],
+    ]);
+  });
+
   it("emits per-service startup trace spans and summary", async () => {
     const measured: string[] = [];
     const details: Array<{


### PR DESCRIPTION
Fixes #119746

Related context:

- https://github.com/openclaw/openclaw/pull/119705
- https://github.com/openclaw/openclaw/issues/119694
- https://github.com/openclaw/openclaw/pull/119708

## What Problem This Solves

Fixes an issue where operators starting diagnostics OTEL could receive only a rollback cleanup failure when the OpenTelemetry SDK had already failed to start. The secondary shutdown error masked the failure that actually prevented telemetry startup.

## Why This Change Was Made

The SDK startup owner now keeps the original startup error primary and preserves an owned rollback cleanup failure alongside it in an `AggregateError`, with the startup error retained as the cause. The diagnostics owner also logs the formatted rollback cleanup failure before rethrowing, so the host-visible service error retains both actionable failures. Cleanup still drains through the existing lifecycle order.

This follow-up does not change ordinary service-stop behavior, signal-specific protocol routing, gateway recovery, configuration, or exporter ownership. It preserves the protocol behavior landed in https://github.com/openclaw/openclaw/pull/119708.

Root cause: the SDK startup catch awaited the shared lifecycle cleanup before rethrowing the captured startup error. Because diagnostics-owned exporter cleanup may reject, that rejection could escape first and replace the already-captured startup failure. The initial aggregate preserved both errors structurally, but its static message left the nested cleanup detail invisible through the host logger, which records `error.message`.

Production LOC: `+16/-1`.
Test LOC: `+67/-0`.

## User Impact

Operators now retain the primary reason telemetry startup failed and receive the rollback cleanup failure needed to diagnose incomplete exporter shutdown.

## Evidence

- Focused diagnostics lifecycle and plugin-service tests: `173/173` passed across two Vitest shards.
- Added regression proof that SDK startup failure remains the cause and first aggregate error when rollback shutdown also fails.
- Added proof that rollback cleanup detail is logged at the diagnostics owner and remains visible beside the host startup failure.
- Added proof that the failed-start service is fully drained and a later stop resolves.
- `oxfmt --check`: clean on all three changed files.
- Targeted `oxlint`: clean on all three changed files.
- `git diff --check`: clean.
- Fresh P0-P2 autoreview: no findings; patch correct at `0.93` confidence.
- Direct dependency contract proof: installed `@opentelemetry/sdk-node@0.221.0` types declare `start(): void` and `shutdown(): Promise<void>`; its `build/src/sdk.js` shutdown implementation returns `Promise.all(...)`, confirming that provider cleanup rejection is an upstream-supported outcome.
- Exact-head hosted CI: passed at `6de8714e29e6a94806f28e81391b6eeb28f61366` in https://github.com/openclaw/openclaw/actions/runs/31053078525.
- Exact-head ClawSweeper: no code findings at `6de8714e29e6a94806f28e81391b6eeb28f61366` in https://github.com/openclaw/openclaw/pull/119747#issuecomment-5198194825.
- ClawSweeper dispositions: dependency proof completed; exact-head CI completed; latest rank-up moves confirmed against the current head.

Local note: the full repo oxlint wrapper was blocked before target linting by an unrelated current-main plugin-SDK boundary diagnostic in `packages/terminal-core/src/ansi.ts:194` (`TS2554`). The changed files pass isolated oxlint, and hosted CI remains the full-repo gate.
