### PR TITLE
fix(qa): attest realized profile executions

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -428,9 +428,11 @@ jobs:
           TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_revision }}
         run: |
           set -euo pipefail
-          node --input-type=module <<'NODE'
+          node --import tsx --input-type=module <<'NODE'
           import fs from "node:fs";
           import path from "node:path";
+          import { validateQaEvidenceSummaryJson } from "./extensions/qa-lab/src/evidence-summary.ts";
+          import { qaProfileEvidencePlan } from "./extensions/qa-lab/src/profile-evidence-plan.ts";
 
           const evidencePath = process.env.QA_EVIDENCE_PATH;
           const targetSha = process.env.TARGET_SHA;
@@ -441,9 +443,12 @@ jobs:
             throw new Error("TARGET_SHA is required");
           }
 
-          const evidence = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
+          const evidence = validateQaEvidenceSummaryJson(JSON.parse(fs.readFileSync(evidencePath, "utf8")));
           if (evidence.profile !== "all") {
             throw new Error(`qa-evidence.json profile must be all, got ${JSON.stringify(evidence.profile)}`);
+          }
+          if (!evidence.profilePlan) {
+            throw new Error("qa-evidence.json is missing profilePlan; rerun the QA Profile Evidence workflow with current code.");
           }
 
           const artifactDir = path.dirname(evidencePath);
@@ -465,6 +470,19 @@ jobs:
           }
           if (manifest.targetSha !== targetSha) {
             throw new Error(`QA evidence manifest targetSha ${manifest.targetSha} does not match selected ref ${targetSha}`);
+          }
+          if (typeof manifest.profilePlanSha256 !== "string") {
+            throw new Error("QA evidence manifest is missing profilePlanSha256; rerun the QA Profile Evidence workflow with current code.");
+          }
+          const { plan: profilePlan, sha256: profilePlanSha256 } = qaProfileEvidencePlan.attest(
+            evidence.profilePlan,
+            manifest.qaPassed === true,
+          );
+          if (profilePlan.profile !== "all") {
+            throw new Error(`qa-evidence.json profilePlan.profile must be all, got ${JSON.stringify(profilePlan.profile)}`);
+          }
+          if (profilePlanSha256 !== manifest.profilePlanSha256) {
+            throw new Error("QA evidence profilePlan digest does not match the manifest");
           }
           NODE
 

--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -415,6 +415,7 @@ jobs:
           import fs from "node:fs";
           import path from "node:path";
           import { validateQaEvidenceSummaryJson } from "./extensions/qa-lab/src/evidence-summary.ts";
+          import { qaProfileEvidencePlan } from "./extensions/qa-lab/src/profile-evidence-plan.ts";
 
           const outputDir = process.env.OUTPUT_DIR;
           if (!outputDir) {
@@ -437,6 +438,16 @@ jobs:
           if (payload.scorecard.categoryReports.length === 0) {
             throw new Error("QA profile qa-evidence.json scorecard has no category reports");
           }
+          if (!payload.profilePlan) {
+            throw new Error("QA profile qa-evidence.json is missing profilePlan; rerun the QA Profile Evidence workflow with current code.");
+          }
+          const { plan: profilePlan, sha256: profilePlanSha256 } = qaProfileEvidencePlan.attest(
+            payload.profilePlan,
+            process.env.QA_EXIT_CODE === "0",
+          );
+          if (profilePlan.profile !== process.env.QA_PROFILE) {
+            throw new Error(`qa-evidence.json profilePlan.profile must be ${process.env.QA_PROFILE}, got ${JSON.stringify(profilePlan.profile)}`);
+          }
 
           const manifest = {
             artifactName: process.env.ARTIFACT_NAME,
@@ -449,6 +460,7 @@ jobs:
             targetSha: process.env.TARGET_SHA,
             trustedReason: process.env.TRUSTED_REASON,
             evidenceMode: payload.evidenceMode,
+            profilePlanSha256,
             qaEvidencePath: "qa-evidence.json",
             scorecard: {
               categories: payload.scorecard.categories,

--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -132,6 +132,7 @@ async function makeSuiteResult(params: {
     summaryPath,
     report: "# report",
     watchUrl: "http://127.0.0.1:43124",
+    startedScenarioIds: ["character-vibes"],
     scenarios: [
       {
         name: "Character vibes",

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -1,10 +1,10 @@
-// Qa Lab tests cover cli plugin behavior.
+// QA Lab tests cover cli plugin behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { isCrablineServerChannel, OPENCLAW_CRABLINE_DEFAULT_CHANNEL } from "@openclaw/crabline";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { QaScenarioPack } from "./scenario-catalog.js";
+import { readQaScenarioById, type QaScenarioPack } from "./scenario-catalog.js";
 
 const {
   runQaManualLane,
@@ -106,7 +106,10 @@ import { QaSuiteInfraError } from "./errors.js";
 import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
 import { runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
+import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
 import type { QaProviderModeInput } from "./run-config.js";
+import { expandQaScenarioExecutionCells } from "./scenario-lane.js";
+import type { QaSuiteRunParams } from "./suite.js";
 
 const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
 const QA_PASSING_SUITE_SCENARIO = {
@@ -154,12 +157,24 @@ function makeQaEvidence(entries: unknown[] = []) {
 
 function flowSuiteRuntimeResult(params: {
   evidencePath?: string;
+  expectedCells?: Array<{
+    scenarioId: string;
+    executionKind: "flow" | "script" | "vitest" | "playwright";
+    channel: string | null;
+  }>;
+  observedCells?: Array<{
+    scenarioId: string;
+    executionKind: "flow" | "script" | "vitest" | "playwright";
+    channel: string | null;
+  }>;
   reportPath: string;
   summaryPath: string;
   scenarios?: unknown[];
 }) {
   return {
     executionKind: "flow",
+    expectedCells: params.expectedCells ?? params.observedCells ?? [],
+    observedCells: params.observedCells ?? [],
     result: {
       outputDir: path.dirname(params.reportPath),
       evidencePath:
@@ -175,6 +190,16 @@ function flowSuiteRuntimeResult(params: {
 
 function unifiedSuiteRuntimeResult(params: {
   evidencePath: string;
+  expectedCells?: Array<{
+    scenarioId: string;
+    executionKind: "flow" | "script" | "vitest" | "playwright";
+    channel: string | null;
+  }>;
+  observedCells?: Array<{
+    scenarioId: string;
+    executionKind: "flow" | "script" | "vitest" | "playwright";
+    channel: string | null;
+  }>;
   outputDir: string;
   reportPath: string;
   summaryPath: string;
@@ -182,6 +207,8 @@ function unifiedSuiteRuntimeResult(params: {
 }) {
   return {
     executionKind: "suite",
+    expectedCells: params.expectedCells ?? params.observedCells ?? [],
+    observedCells: params.observedCells ?? [],
     result: {
       outputDir: params.outputDir,
       reportPath: params.reportPath,
@@ -191,6 +218,31 @@ function unifiedSuiteRuntimeResult(params: {
       scenarios: params.scenarios ?? [QA_PASSING_SUITE_SCENARIO],
     },
   };
+}
+
+function executionCellsForSuiteParams(params?: QaSuiteRunParams) {
+  const scenarioIds = new Set(params?.scenarioIds ?? []);
+  const scenarios = readQaScenarioPack().scenarios.filter((scenario) =>
+    scenarioIds.has(scenario.id),
+  );
+  const adapterFactories: readonly QaTransportAdapterFactory[] = params?.adapterFactories ?? [];
+  return expandQaScenarioExecutionCells({
+    scenarios,
+    channelDriver: params?.channelDriver ?? "qa-channel",
+    channel: params?.channelId ?? params?.channelDriverSelection?.channel,
+    defaultChannel:
+      params?.channelDriver === "crabline" ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL : undefined,
+    supportsChannel:
+      params?.channelDriver === "crabline"
+        ? isCrablineServerChannel
+        : params?.channelDriver === "live"
+          ? (channel) =>
+              adapterFactories.some((factory) =>
+                factory.matches({ channelId: channel, driver: "live" }),
+              )
+          : undefined,
+    expandChannels: params?.expandScenarioChannels === true,
+  });
 }
 
 describe("qa cli runtime", () => {
@@ -289,12 +341,14 @@ describe("qa cli runtime", () => {
         defaultQaProviderModelForMode(mode as QaProviderModeInput, options),
     );
     readQaScenarioPack.mockClear();
-    runQaSuite.mockResolvedValue(
-      flowSuiteRuntimeResult({
+    runQaSuite.mockImplementation(async (params) => {
+      const observedCells = executionCellsForSuiteParams(params);
+      return flowSuiteRuntimeResult({
+        observedCells,
         reportPath: suiteReportPath,
         summaryPath: suiteSummaryPath,
-      }),
-    );
+      });
+    });
     runQaFlowSuiteFromRuntime.mockResolvedValue({
       outputDir: suiteArtifactsDir,
       evidencePath: suiteEvidencePath,
@@ -608,7 +662,7 @@ describe("qa cli runtime", () => {
     const previousProfile = process.env.OPENCLAW_QA_PROFILE;
     process.env.OPENCLAW_QA_PROFILE = "release";
     try {
-      runQaSuite.mockImplementationOnce(async () => {
+      runQaSuite.mockImplementationOnce(async (params) => {
         expect(process.env.OPENCLAW_QA_PROFILE).toBe("smoke-ci");
         await fs.writeFile(
           suiteEvidencePath,
@@ -663,6 +717,14 @@ describe("qa cli runtime", () => {
           "utf8",
         );
         return flowSuiteRuntimeResult({
+          observedCells: expandQaScenarioExecutionCells({
+            scenarios: [readQaScenarioById("telegram-commands-command")],
+            channelDriver: params?.channelDriver ?? "qa-channel",
+            channel: params?.channelId ?? params?.channelDriverSelection?.channel,
+            defaultChannel: OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
+            supportsChannel: isCrablineServerChannel,
+            expandChannels: true,
+          }),
           reportPath: suiteReportPath,
           summaryPath: suiteSummaryPath,
         });
@@ -701,6 +763,11 @@ describe("qa cli runtime", () => {
         evidenceMode?: unknown;
         entries?: unknown[];
         profile?: unknown;
+        profilePlan?: {
+          counts?: Record<string, unknown>;
+          expectedCells?: unknown[];
+          observedCells?: unknown[];
+        };
         scorecard?: {
           run?: { evidenceEntryCount?: unknown };
           coverageIds?: { fulfilled?: unknown };
@@ -712,6 +779,15 @@ describe("qa cli runtime", () => {
         };
       };
       expect(evidence.profile).toBe("smoke-ci");
+      expect(evidence.profilePlan?.counts).toMatchObject({
+        membership: 1,
+        selected: 1,
+        excluded: 0,
+        expectedCells: 1,
+        observedCells: 1,
+        missingCells: 0,
+      });
+      expect(evidence.profilePlan?.observedCells).toEqual(evidence.profilePlan?.expectedCells);
       expect(evidence.evidenceMode).toBe("slim");
       expect(evidence.scorecard).toMatchObject({
         run: {
@@ -818,13 +894,15 @@ describe("qa cli runtime", () => {
         }),
         "utf8",
       );
-      runQaSuite.mockResolvedValueOnce(
-        flowSuiteRuntimeResult({
+      runQaSuite.mockImplementationOnce(async (params) => {
+        const observedCells = executionCellsForSuiteParams(params);
+        return flowSuiteRuntimeResult({
+          observedCells,
           reportPath: suiteReportPath,
           summaryPath: suiteSummaryPath,
           scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
-        }),
-      );
+        });
+      });
 
       try {
         await runQaProfileCommand({
@@ -846,9 +924,11 @@ describe("qa cli runtime", () => {
   );
 
   it("filters QA-channel-pinned scenarios from an implicit Crabline smoke profile", async () => {
-    runQaSuite.mockImplementationOnce(async () => {
+    runQaSuite.mockImplementationOnce(async (params) => {
       await fs.writeFile(suiteEvidencePath, JSON.stringify(makeQaEvidence()), "utf8");
+      const observedCells = executionCellsForSuiteParams(params);
       return flowSuiteRuntimeResult({
+        observedCells,
         reportPath: suiteReportPath,
         summaryPath: suiteSummaryPath,
       });

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -1,4 +1,4 @@
-// Qa Lab plugin module implements cli behavior.
+// QA Lab plugin module implements cli behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -47,6 +47,7 @@ import { startQaLabServer } from "./lab-server.js";
 import { listLiveTransportQaAdapterFactories } from "./live-transports/cli.js";
 import { runQaManualLane } from "./manual-lane.runtime.js";
 import { runQaMultipass } from "./multipass.runtime.js";
+import { qaProfileEvidencePlan, type QaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import {
   resolveQaRunProfileExecutionSelection,
   resolveQaRunProfileMembership,
@@ -701,6 +702,8 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     `QA run profile: ${profile}; categories: ${categories.length}; scenarios: ${scenarios.length}\n`,
   );
   let evidencePath: string | undefined;
+  let expectedCells: QaProfileEvidencePlan["expectedCells"] = [];
+  let observedCells: QaProfileEvidencePlan["observedCells"] = [];
   await withTemporaryQaProfileEnv(profile, async () => {
     const suiteResult = await runQaSuiteCommand({
       repoRoot,
@@ -721,14 +724,25 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     });
     evidencePath =
       suiteResult && "evidencePath" in suiteResult ? suiteResult.evidencePath : undefined;
+    expectedCells = suiteResult && "expectedCells" in suiteResult ? suiteResult.expectedCells : [];
+    observedCells = suiteResult && "observedCells" in suiteResult ? suiteResult.observedCells : [];
   });
   if (!evidencePath) {
     throw new Error("qa run --qa-profile did not produce qa-evidence.json.");
   }
+  const profilePlan = qaProfileEvidencePlan.build({
+    profile,
+    membershipScenarios: taxonomyScenarios,
+    selectedScenarios: scenarios,
+    excludedScenarios: executionSelection.excludedScenarios,
+    expectedCells,
+    observedCells,
+  });
   await attachQaProfileScorecardEvidenceToFile({
     evidencePath,
     evidenceMode: opts.evidenceMode,
     profile,
+    profilePlan,
     filters: {
       surface: opts.surface,
       category: opts.category,
@@ -1055,7 +1069,11 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       if (!allowFailures && blockingScenarioCount > 0) {
         process.exitCode = 1;
       }
-      return result;
+      return {
+        ...result,
+        expectedCells: runtimeResult.expectedCells,
+        observedCells: runtimeResult.observedCells,
+      };
     }
     case "flow": {
       const result = runtimeResult.result;
@@ -1076,7 +1094,11 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       if (!allowFailures && blockingScenarioCount > 0) {
         process.exitCode = 1;
       }
-      return result;
+      return {
+        ...result,
+        expectedCells: runtimeResult.expectedCells,
+        observedCells: runtimeResult.observedCells,
+      };
     }
   }
   return undefined;

--- a/extensions/qa-lab/src/evidence-summary.test.ts
+++ b/extensions/qa-lab/src/evidence-summary.test.ts
@@ -34,6 +34,7 @@ describe("evidence summary", () => {
         },
       ],
       channelId: "qa-channel",
+      channelDriver: "local-shim",
       env: {
         OPENCLAW_QA_CHANNEL_DRIVER: "local-shim",
         OPENCLAW_QA_REF: "abc123",
@@ -154,23 +155,7 @@ describe("evidence summary", () => {
       false,
     ],
     [
-      "live driver selected through the QA environment",
-      "custom-live-transport",
-      undefined,
-      { OPENCLAW_QA_CHANNEL_DRIVER: "live" },
-      "live",
-      true,
-    ],
-    [
-      "live driver selected through the E2E environment",
-      "custom-live-transport",
-      undefined,
-      { OPENCLAW_E2E_CHANNEL_DRIVER: "live" },
-      "live",
-      true,
-    ],
-    [
-      "explicit synthetic driver overriding live environment",
+      "explicit synthetic driver ignores requested environment metadata",
       "telegram",
       "qa-channel",
       { OPENCLAW_QA_CHANNEL_DRIVER: "live" },

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -330,14 +330,6 @@ function resolveQaEvidenceRunner(params: { env?: NodeJS.ProcessEnv; fallback?: s
   return params.env?.OPENCLAW_QA_RUNNER?.trim() || params.fallback || "host";
 }
 
-function resolveQaEvidenceChannelDriver(params: { env?: NodeJS.ProcessEnv; fallback?: string }) {
-  const id =
-    params.fallback?.trim() ||
-    params.env?.OPENCLAW_QA_CHANNEL_DRIVER?.trim() ||
-    params.env?.OPENCLAW_E2E_CHANNEL_DRIVER?.trim();
-  return id ? { id } : undefined;
-}
-
 function resolveQaEvidencePackageSource(env: NodeJS.ProcessEnv | undefined) {
   const spec = env?.OPENCLAW_QA_PACKAGE_SOURCE?.trim() || undefined;
   const sha = env?.OPENCLAW_QA_PACKAGE_SOURCE_SHA?.trim() || undefined;
@@ -506,10 +498,7 @@ export function buildQaSuiteEvidenceSummary(
     env: params.env,
     explicit: params.profile,
   });
-  const channelDriver = resolveQaEvidenceChannelDriver({
-    env: params.env,
-    fallback: params.channelDriver,
-  });
+  const channelDriver = params.channelDriver?.trim() || undefined;
   const entries = params.scenarioResults.map((result, index): QaEvidenceSummaryEntry => {
     const scenario = params.scenarioDefinitions[index];
     const primaryCoverageIds = uniqueSortedStrings(scenario?.coverage?.primary ?? []);
@@ -545,8 +534,8 @@ export function buildQaSuiteEvidenceSummary(
         provider,
         channel: {
           id: params.channelId,
-          live: channelDriver?.id === "live",
-          driver: channelDriver?.id,
+          live: channelDriver === "live",
+          driver: channelDriver,
         },
         packageSource,
         artifacts: buildQaEvidenceArtifacts(params.artifactPaths, "qa-suite"),

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -1,8 +1,9 @@
-// Qa Lab plugin module implements QA evidence summary behavior.
+// QA Lab plugin module implements QA evidence summary behavior.
 import { z } from "zod";
 import { qaCoverageIdSchema } from "./coverage-id.js";
 import { resolveQaEvidenceEnvironment } from "./evidence-environment.js";
 import { splitQaModelRef } from "./model-selection.js";
+import { qaProfileEvidencePlan, type QaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import { getQaProvider, type QaProviderMode } from "./providers/index.js";
 import { qaRuntimePairLaneSchema, type QaRuntimePairLane } from "./scenario-catalog.js";
 import {
@@ -164,6 +165,7 @@ const qaEvidenceSummarySchema = z.strictObject({
   evidenceMode: qaScorecardEvidenceModeSchema,
   entries: z.array(qaEvidenceSummaryEntrySchema),
   profile: qaEvidenceProfileIdSchema.optional(),
+  profilePlan: qaProfileEvidencePlan.schema.optional(),
   scorecard: qaEvidenceScorecardSchema.optional(),
 });
 
@@ -441,6 +443,7 @@ function buildQaEvidenceSummary(params: {
   evidenceMode?: QaScorecardEvidenceMode;
   generatedAt: string;
   profile?: QaEvidenceProfile;
+  profilePlan?: QaProfileEvidencePlan;
   scorecard?: QaEvidenceScorecardJson;
 }): QaEvidenceSummaryJson {
   const profileOptions = readQaScorecardProfileOptions(params.profile);
@@ -459,6 +462,7 @@ function buildQaEvidenceSummary(params: {
     evidenceMode,
     entries,
     profile: params.profile,
+    profilePlan: params.profilePlan,
     scorecard: params.scorecard,
   });
 }
@@ -471,6 +475,7 @@ export function attachQaEvidenceScorecard(params: {
   evidenceMode?: QaScorecardEvidenceMode;
   summary: QaEvidenceSummaryJson;
   profile: QaEvidenceProfile;
+  profilePlan: QaProfileEvidencePlan;
   scorecard: QaEvidenceScorecardJson;
 }): QaEvidenceSummaryJson {
   return buildQaEvidenceSummary({
@@ -478,6 +483,7 @@ export function attachQaEvidenceScorecard(params: {
     evidenceMode: params.evidenceMode,
     generatedAt: params.summary.generatedAt,
     profile: params.profile,
+    profilePlan: params.profilePlan,
     scorecard: params.scorecard,
   });
 }

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -1,4 +1,4 @@
-// Qa Lab tests cover lab server plugin behavior.
+// QA Lab tests cover lab server plugin behavior.
 import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import os from "node:os";
@@ -407,6 +407,8 @@ describe("qa-lab server", () => {
     });
     suiteLaunchMock.runQaSuite.mockResolvedValue({
       executionKind: "suite",
+      expectedCells: [],
+      observedCells: [],
       result: await createQaLabSuiteResultFixture(),
     });
 
@@ -494,7 +496,12 @@ describe("qa-lab server", () => {
       const result = await createQaLabSuiteResultFixture({
         scenarios: [{ name: "Channel chat baseline", status, steps: [] }],
       });
-      suiteLaunchMock.runQaSuite.mockResolvedValue({ executionKind: "flow", result });
+      suiteLaunchMock.runQaSuite.mockResolvedValue({
+        executionKind: "flow",
+        expectedCells: [],
+        observedCells: [],
+        result,
+      });
 
       const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
         method: "POST",
@@ -561,7 +568,12 @@ describe("qa-lab server", () => {
       });
       const result = await createQaLabSuiteResultFixture();
       await writeFile(result.summaryPath, invalidResult.summary, "utf8");
-      suiteLaunchMock.runQaSuite.mockResolvedValue({ executionKind: "flow", result });
+      suiteLaunchMock.runQaSuite.mockResolvedValue({
+        executionKind: "flow",
+        expectedCells: [],
+        observedCells: [],
+        result,
+      });
 
       const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
         method: "POST",
@@ -601,7 +613,12 @@ describe("qa-lab server", () => {
         },
       ],
     });
-    suiteLaunchMock.runQaSuite.mockResolvedValue({ executionKind: "flow", result });
+    suiteLaunchMock.runQaSuite.mockResolvedValue({
+      executionKind: "flow",
+      expectedCells: [],
+      observedCells: [],
+      result,
+    });
 
     const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
       method: "POST",
@@ -630,6 +647,8 @@ describe("qa-lab server", () => {
     });
     suiteLaunchMock.runQaSuite.mockResolvedValue({
       executionKind: "flow",
+      expectedCells: [],
+      observedCells: [],
       result: await createQaLabSuiteResultFixture({ watchUrl: "http://runtime-watch.invalid" }),
     });
 
@@ -693,6 +712,8 @@ describe("qa-lab server", () => {
     expect(suiteLaunchMock.runQaSuite).toHaveBeenCalledTimes(1);
     finishSuite?.({
       executionKind: "flow",
+      expectedCells: [],
+      observedCells: [],
       result: await createQaLabSuiteResultFixture(),
     });
     await vi.waitFor(async () => {
@@ -727,6 +748,8 @@ describe("qa-lab server", () => {
     });
     suiteLaunchMock.runQaSuite.mockResolvedValue({
       executionKind: "flow",
+      expectedCells: [],
+      observedCells: [],
       result: await createQaLabSuiteResultFixture({ watchUrl: lab.baseUrl }),
     });
 

--- a/extensions/qa-lab/src/profile-evidence-plan.test.ts
+++ b/extensions/qa-lab/src/profile-evidence-plan.test.ts
@@ -1,0 +1,89 @@
+// QA Lab tests cover canonical profile scheduling evidence.
+import { describe, expect, it } from "vitest";
+import { qaProfileEvidencePlan } from "./profile-evidence-plan.js";
+import { readQaScenarioById } from "./scenario-catalog.js";
+import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
+
+describe("QA profile evidence plan", () => {
+  const portable = readQaScenarioById("thread-isolation");
+  const native = readQaScenarioById("control-ui-chat-flow-playwright");
+  const excluded = readQaScenarioById("matrix-room-block-streaming");
+
+  function buildPlan(observedCells: QaScenarioExecutionCell[]) {
+    return qaProfileEvidencePlan.build({
+      profile: "all",
+      membershipScenarios: [excluded, native, portable],
+      selectedScenarios: [portable, native],
+      excludedScenarios: [{ scenario: excluded, reasons: ["providerMode=mock-openai"] }],
+      expectedCells: expandQaScenarioExecutionCells({
+        scenarios: [portable, native],
+        channelDriver: "live",
+        supportsChannel: (channel) => channel === "matrix" || channel === "slack",
+        expandChannels: true,
+      }),
+      observedCells,
+    });
+  }
+
+  it("records a deterministic membership partition and exact execution cells", () => {
+    const plan = buildPlan([
+      { scenarioId: native.id, executionKind: "playwright", channel: null },
+      { scenarioId: portable.id, executionKind: "flow", channel: "slack" },
+    ]);
+
+    expect(plan.counts).toEqual({
+      membership: 3,
+      selected: 2,
+      excluded: 1,
+      expectedCells: 3,
+      observedCells: 2,
+      missingCells: 1,
+    });
+    expect(plan.expectedCells).toEqual([
+      { scenarioId: native.id, executionKind: "playwright", channel: null },
+      { scenarioId: portable.id, executionKind: "flow", channel: "matrix" },
+      { scenarioId: portable.id, executionKind: "flow", channel: "slack" },
+    ]);
+    expect(plan.missingCells).toEqual([
+      { scenarioId: portable.id, executionKind: "flow", channel: "matrix" },
+    ]);
+    expect(() => qaProfileEvidencePlan.attest(plan, true)).toThrow(
+      "successful QA profile evidence is missing 1 expected execution cell",
+    );
+  });
+
+  it("accepts complete plans and rejects unexpected or non-canonical cells", () => {
+    const complete = buildPlan([
+      { scenarioId: portable.id, executionKind: "flow", channel: "slack" },
+      { scenarioId: portable.id, executionKind: "flow", channel: "matrix" },
+      { scenarioId: native.id, executionKind: "playwright", channel: null },
+    ]);
+    expect(qaProfileEvidencePlan.attest(complete, true).plan).toEqual(complete);
+
+    expect(() =>
+      buildPlan([
+        ...complete.observedCells,
+        { scenarioId: portable.id, executionKind: "flow", channel: "telegram" },
+      ]),
+    ).toThrow("unexpected execution cells invalidate evidence");
+    expect(
+      qaProfileEvidencePlan.schema.safeParse({
+        ...complete,
+        expectedCells: complete.expectedCells.toReversed(),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("normalizes object key order before workflow hashing", () => {
+    const plan = buildPlan([
+      { scenarioId: native.id, executionKind: "playwright", channel: null },
+      { scenarioId: portable.id, executionKind: "flow", channel: "matrix" },
+      { scenarioId: portable.id, executionKind: "flow", channel: "slack" },
+    ]);
+    const reordered = Object.fromEntries(Object.entries(plan).toReversed());
+
+    expect(qaProfileEvidencePlan.attest(reordered, true)).toEqual(
+      qaProfileEvidencePlan.attest(plan, true),
+    );
+  });
+});

--- a/extensions/qa-lab/src/profile-evidence-plan.ts
+++ b/extensions/qa-lab/src/profile-evidence-plan.ts
@@ -1,0 +1,171 @@
+// QA Lab plugin module owns canonical profile scheduling evidence.
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
+import type { QaScenarioExecutionCell } from "./scenario-lane.js";
+
+const idSchema = z.string().trim().min(1);
+const cellSchema = z.strictObject({
+  scenarioId: idSchema,
+  executionKind: z.enum(["flow", "script", "vitest", "playwright"]),
+  channel: idSchema.nullable(),
+});
+const listNames = [
+  "membership",
+  "selected",
+  "excluded",
+  "expectedCells",
+  "observedCells",
+  "missingCells",
+] as const;
+type ListName = (typeof listNames)[number];
+const planShape = z.strictObject({
+  profile: idSchema,
+  membership: z.array(idSchema),
+  selected: z.array(idSchema),
+  excluded: z.array(
+    z.strictObject({
+      scenarioId: idSchema,
+      reasons: z.array(idSchema).min(1),
+    }),
+  ),
+  expectedCells: z.array(cellSchema),
+  observedCells: z.array(cellSchema),
+  missingCells: z.array(cellSchema),
+  counts: z.record(z.enum(listNames), z.number().int().nonnegative()),
+});
+
+type PlanShape = z.infer<typeof planShape>;
+
+function cellKey(cell: z.infer<typeof cellSchema>) {
+  return `${cell.scenarioId}\u0000${cell.executionKind}\u0000${cell.channel ?? ""}`;
+}
+
+function compareStrings(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function assertCanonical(name: string, values: readonly string[]) {
+  if (values.some((value, index) => index > 0 && values[index - 1]! >= value)) {
+    throw new Error(`${name} must be unique and sorted`);
+  }
+}
+
+function assertSame(message: string, left: readonly string[], right: readonly string[]) {
+  if (left.length !== right.length || left.some((value, index) => value !== right[index])) {
+    throw new Error(message);
+  }
+}
+
+function planLists(plan: PlanShape): Record<ListName, string[]> {
+  return {
+    membership: plan.membership,
+    selected: plan.selected,
+    excluded: plan.excluded.map((entry) => entry.scenarioId),
+    expectedCells: plan.expectedCells.map(cellKey),
+    observedCells: plan.observedCells.map(cellKey),
+    missingCells: plan.missingCells.map(cellKey),
+  };
+}
+
+function assertPlanInvariants(plan: PlanShape) {
+  const lists = planLists(plan);
+  for (const name of listNames) {
+    assertCanonical(name, lists[name]);
+    if (plan.counts[name] !== lists[name].length) {
+      throw new Error(`counts.${name} must equal ${lists[name].length}`);
+    }
+  }
+  for (const exclusion of plan.excluded) {
+    assertCanonical(`exclusion reasons for ${exclusion.scenarioId}`, exclusion.reasons);
+  }
+  assertSame(
+    "selected and excluded scenarios must exactly partition membership",
+    lists.membership,
+    [...lists.selected, ...lists.excluded].toSorted(),
+  );
+  assertSame(
+    "expected cells must exactly cover selected scenarios",
+    lists.selected,
+    [...new Set(plan.expectedCells.map((cell) => cell.scenarioId))].toSorted(),
+  );
+  const expected = new Set(lists.expectedCells);
+  const observed = new Set(lists.observedCells);
+  if (lists.observedCells.some((cell) => !expected.has(cell))) {
+    throw new Error("unexpected execution cells invalidate evidence");
+  }
+  assertSame(
+    "missing cells must equal expected minus observed",
+    lists.missingCells,
+    lists.expectedCells.filter((cell) => !observed.has(cell)),
+  );
+}
+
+const schema = planShape.superRefine((plan, context) => {
+  try {
+    assertPlanInvariants(plan);
+  } catch (error) {
+    context.addIssue({
+      code: "custom",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
+export type QaProfileEvidencePlan = z.infer<typeof schema>;
+
+function canonicalCells(cells: readonly QaScenarioExecutionCell[]) {
+  return cells
+    .map((cell) => ({ ...cell, channel: cell.channel ?? null }))
+    .toSorted((left, right) => compareStrings(cellKey(left), cellKey(right)));
+}
+
+function build(params: {
+  profile: string;
+  membershipScenarios: readonly QaSeedScenarioWithSource[];
+  selectedScenarios: readonly QaSeedScenarioWithSource[];
+  excludedScenarios: readonly {
+    scenario: QaSeedScenarioWithSource;
+    reasons: readonly string[];
+  }[];
+  expectedCells: readonly QaScenarioExecutionCell[];
+  observedCells: readonly QaScenarioExecutionCell[];
+}) {
+  const membership = params.membershipScenarios.map((scenario) => scenario.id).toSorted();
+  const selected = params.selectedScenarios.map((scenario) => scenario.id).toSorted();
+  const excluded = params.excludedScenarios
+    .map(({ scenario, reasons }) => ({
+      scenarioId: scenario.id,
+      reasons: [...new Set(reasons.map((reason) => reason.trim()).filter(Boolean))].toSorted(),
+    }))
+    .toSorted((left, right) => compareStrings(left.scenarioId, right.scenarioId));
+  const expectedCells = canonicalCells(params.expectedCells);
+  const observedCells = canonicalCells(params.observedCells);
+  const observedKeys = new Set(observedCells.map(cellKey));
+  const missingCells = expectedCells.filter((cell) => !observedKeys.has(cellKey(cell)));
+  const lists = { membership, selected, excluded, expectedCells, observedCells, missingCells };
+  return schema.parse({
+    profile: params.profile,
+    ...lists,
+    counts: Object.fromEntries(listNames.map((name) => [name, lists[name].length])),
+  });
+}
+
+function attest(value: unknown, successful = false) {
+  const plan = schema.parse(value);
+  if (successful && plan.missingCells.length > 0) {
+    throw new Error(
+      `successful QA profile evidence is missing ${plan.missingCells.length} expected execution cell(s)`,
+    );
+  }
+  return {
+    plan,
+    sha256: createHash("sha256").update(JSON.stringify(plan)).digest("hex"),
+  };
+}
+
+export const qaProfileEvidencePlan = {
+  attest,
+  build,
+  schema,
+};

--- a/extensions/qa-lab/src/qa-transport-registry.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.ts
@@ -169,6 +169,30 @@ export function normalizeQaTransportId(input?: string | null): QaTransportId {
   throw new Error(`unsupported QA transport: ${transportId}`);
 }
 
+export function selectQaTransportDriver(params: {
+  channelDriver?: QaTransportDriver | null;
+  channelDriverSelection?: { channelDriver: QaTransportDriver } | null;
+  channelId?: string;
+  transportId: QaTransportId;
+}): QaTransportDriver {
+  const setupDriver = params.channelDriverSelection?.channelDriver;
+  if (params.channelDriver && setupDriver && params.channelDriver !== setupDriver) {
+    throw new Error(
+      `channelDriver=${params.channelDriver} conflicts with adapter setup driver=${setupDriver}`,
+    );
+  }
+  if (setupDriver) {
+    return setupDriver;
+  }
+  if (params.channelDriver === "crabline") {
+    throw new Error("channelDriver=crabline requires Crabline adapter setup");
+  }
+  if (params.channelDriver === "live") {
+    return params.channelId ? "live" : params.transportId;
+  }
+  return params.channelDriver ?? params.transportId;
+}
+
 export async function createQaTransportAdapter(
   context: QaTransportFactoryContext,
   factories?: readonly QaTransportAdapterFactory[],

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -1,4 +1,4 @@
-// Qa Lab tests cover canonical scenario lane matching behavior.
+// QA Lab tests cover canonical scenario lane matching behavior.
 import { describe, expect, it } from "vitest";
 import type { QaProviderMode } from "./model-selection.js";
 import { resolveQaRunProfileExecutionSelection } from "./profile-planning.js";
@@ -6,7 +6,7 @@ import { readQaScenarioById, readQaScenarioPack } from "./scenario-catalog.js";
 import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
 import {
   describeQaProviderLaneMismatches,
-  resolveQaScenarioLaneChannels,
+  expandQaScenarioExecutionCells,
   scenarioMatchesQaProviderLane,
 } from "./scenario-lane.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
@@ -18,6 +18,28 @@ describe("QA scenario lane matching", () => {
       (coverageId) => planningCoverageIds.has(coverageId),
     ),
   );
+
+  it("expands scheduler cells deterministically across flow and native scenarios", () => {
+    const cells = expandQaScenarioExecutionCells({
+      scenarios: [
+        readQaScenarioById("thread-isolation"),
+        readQaScenarioById("control-ui-chat-flow-playwright"),
+      ],
+      channelDriver: "live",
+      supportsChannel: (channel) => channel === "matrix" || channel === "slack",
+      expandChannels: true,
+    });
+
+    expect(cells).toEqual([
+      { scenarioId: "thread-isolation", executionKind: "flow", channel: "slack" },
+      { scenarioId: "thread-isolation", executionKind: "flow", channel: "matrix" },
+      {
+        scenarioId: "control-ui-chat-flow-playwright",
+        executionKind: "playwright",
+        channel: null,
+      },
+    ]);
+  });
 
   it.each(planningScenarios)("selects $id for the GPT-5.6 Luna live lane", (scenario) => {
     expect(
@@ -157,12 +179,16 @@ describe("QA scenario lane matching", () => {
     const scenario = readQaScenarioById("thread-isolation");
 
     expect(
-      resolveQaScenarioLaneChannels({
-        scenario,
+      expandQaScenarioExecutionCells({
+        scenarios: [scenario],
         channelDriver: "live",
         supportsChannel: (channel) => channel === "slack" || channel === "matrix",
+        expandChannels: true,
       }),
-    ).toEqual(["slack", "matrix"]);
+    ).toEqual([
+      { scenarioId: scenario.id, executionKind: "flow", channel: "slack" },
+      { scenarioId: scenario.id, executionKind: "flow", channel: "matrix" },
+    ]);
   });
 
   it("reports every declared mismatch in one decision", () => {

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -6,6 +6,12 @@ import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
 
 type QaSeedScenario = ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"][number];
 
+export type QaScenarioExecutionCell = {
+  scenarioId: string;
+  executionKind: QaSeedScenario["execution"]["kind"];
+  channel: string | null;
+};
+
 function normalizeQaConfigString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
@@ -26,7 +32,7 @@ export function resolveQaScenarioRequiredProviderMode(scenario: QaSeedScenario) 
   return providerMode;
 }
 
-export function resolveQaScenarioLaneChannels(params: {
+function resolveQaScenarioLaneChannels(params: {
   scenario: QaSeedScenario;
   channelDriver: QaScorecardChannelDriver;
   channel?: string | null;
@@ -66,6 +72,27 @@ export function resolveQaScenarioLaneChannel(
   params: Parameters<typeof resolveQaScenarioLaneChannels>[0],
 ): string | undefined {
   return resolveQaScenarioLaneChannels(params)[0];
+}
+
+export function expandQaScenarioExecutionCells(
+  params: {
+    scenarios: readonly QaSeedScenario[];
+    expandChannels: boolean;
+  } & Omit<Parameters<typeof resolveQaScenarioLaneChannels>[0], "scenario">,
+): QaScenarioExecutionCell[] {
+  return params.scenarios.flatMap((scenario) => {
+    const channels =
+      scenario.execution.kind === "flow"
+        ? params.expandChannels
+          ? resolveQaScenarioLaneChannels({ ...params, scenario })
+          : [resolveQaScenarioLaneChannel({ ...params, scenario })]
+        : [undefined];
+    return channels.map((channel) => ({
+      scenarioId: scenario.id,
+      executionKind: scenario.execution.kind,
+      channel: channel ?? null,
+    }));
+  });
 }
 
 export function describeQaProviderLaneMismatches(params: {

--- a/extensions/qa-lab/src/scorecard-evidence.test.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.test.ts
@@ -1,4 +1,4 @@
-// Qa Lab tests cover profile scorecard evidence math.
+// QA Lab tests cover profile scorecard evidence math.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +8,7 @@ import {
   type QaEvidenceSummaryJson,
   type QaEvidenceSummaryEntry,
 } from "./evidence-summary.js";
+import type { QaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
 import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js";
 
@@ -69,12 +70,30 @@ async function buildQaProfileScorecardEvidence(params: {
     const scorecard = await attachQaProfileScorecardEvidenceToFile({
       evidencePath,
       profile: "release",
+      profilePlan: {
+        profile: "release",
+        membership: [],
+        selected: [],
+        excluded: [],
+        expectedCells: [],
+        observedCells: [],
+        missingCells: [],
+        counts: {
+          membership: 0,
+          selected: 0,
+          excluded: 0,
+          expectedCells: 0,
+          observedCells: 0,
+          missingCells: 0,
+        },
+      } satisfies QaProfileEvidencePlan,
       filters: params.filters,
       categories: params.categories,
     });
     const writtenEvidence = validateQaEvidenceSummaryJson(
       JSON.parse(await fs.readFile(evidencePath, "utf8")),
     );
+    expect(writtenEvidence.profilePlan?.profile).toBe("release");
     return { scorecard, writtenEvidence };
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });

--- a/extensions/qa-lab/src/scorecard-evidence.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.ts
@@ -1,4 +1,4 @@
-// Qa Lab plugin module embeds profile scorecard context into QA evidence.
+// QA Lab plugin module embeds profile scorecard context into QA evidence.
 import fs from "node:fs/promises";
 import {
   attachQaEvidenceScorecard,
@@ -7,6 +7,7 @@ import {
   type QaEvidenceSummaryEntry,
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
+import type { QaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import type {
   QaScorecardCategoryCoverageReport,
   QaScorecardEvidenceMode,
@@ -176,6 +177,7 @@ export async function attachQaProfileScorecardEvidenceToFile(params: {
   evidencePath: string;
   evidenceMode?: QaScorecardEvidenceMode;
   profile: string;
+  profilePlan: QaProfileEvidencePlan;
   filters: QaProfileScorecardFilters;
   categories: readonly QaScorecardCategoryCoverageReport[];
 }) {
@@ -191,6 +193,7 @@ export async function attachQaProfileScorecardEvidenceToFile(params: {
     summary: evidence,
     evidenceMode: params.evidenceMode,
     profile: params.profile,
+    profilePlan: params.profilePlan,
     scorecard,
   });
   await fs.writeFile(params.evidencePath, `${JSON.stringify(nextEvidence, null, 2)}\n`, "utf8");

--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -9,11 +9,12 @@ import {
 } from "./crabline-artifacts.js";
 import { buildQaSuiteEvidenceSummary, QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
 import type { QaProviderMode } from "./model-selection.js";
+import type { QaTransportDriver } from "./qa-transport-registry.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
 import type { RuntimeId } from "./runtime-parity.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
-import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
+import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
 import { splitModelRef } from "./suite-planning.js";
 import { countQaSuiteFailedScenarios, type QaSuiteSummaryJson } from "./suite-summary.js";
 import { createQaSuiteReportNotes } from "./suite-support.js";
@@ -35,7 +36,8 @@ export type QaSuiteSummaryJsonParams = {
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
-  channelDriver?: QaScorecardChannelDriver | null;
+  channel?: string | null;
+  channelDriver?: QaTransportDriver | null;
   channelDriverSelection?: QaSuiteChannelDriverSelection | null;
   scenarioIds?: readonly string[];
   runtimePair?: [RuntimeId, RuntimeId];
@@ -94,8 +96,8 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSui
       alternateModelName: alternateSplit?.model ?? null,
       fastMode: params.fastMode,
       concurrency: params.concurrency,
-      channelDriver: params.channelDriver ?? params.channelDriverSelection?.channelDriver ?? null,
-      channel: params.channelDriverSelection?.channel ?? null,
+      channelDriver: params.channelDriver ?? null,
+      channel: params.channel ?? params.channelDriverSelection?.channel ?? null,
       channelCapabilityMatrixPath: params.channelDriverSelection?.capabilityMatrixPath ?? null,
       channelDriverSmokePath: params.channelDriverSelection?.smokeArtifactPath ?? null,
       scenarioIds:
@@ -124,7 +126,8 @@ export async function writeQaSuiteArtifacts(params: {
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
-  channelDriver?: QaScorecardChannelDriver | null;
+  channel?: string | null;
+  channelDriver?: QaTransportDriver | null;
   channelDriverSelection?: OpenClawCrablineChannelDriverSelection | null;
   isolatedWorkers?: boolean;
   scenarioIds?: readonly string[];
@@ -204,8 +207,9 @@ export async function writeQaSuiteArtifacts(params: {
               : []),
           ],
           evidenceMode: params.evidenceMode,
-          channelId: params.channelDriverSelection?.channel ?? params.transport.id,
-          channelDriver: params.channelDriver ?? params.channelDriverSelection?.channelDriver,
+          channelId:
+            params.channel ?? params.channelDriverSelection?.channel ?? params.transport.id,
+          channelDriver: params.channelDriver ?? undefined,
           env: process.env,
           generatedAt: params.finishedAt.toISOString(),
           primaryModel: params.primaryModel,

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -127,6 +127,7 @@ describe("qa suite runtime launcher", () => {
             status: "pass",
             steps: [],
           })),
+          startedScenarioIds: scenarioIds,
           watchUrl: "http://127.0.0.1:43124",
         };
       },
@@ -698,9 +699,7 @@ describe("qa suite runtime launcher", () => {
     expect(evidence.entries).toMatchObject([
       { test: { id: "whatsapp-status-command" }, result: { status: "fail" } },
     ]);
-    expect(result.observedCells).toEqual([
-      { scenarioId: "whatsapp-status-command", executionKind: "flow", channel: "whatsapp" },
-    ]);
+    expect(result.observedCells).toEqual([]);
     await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
   });
 
@@ -2272,10 +2271,21 @@ describe("qa suite runtime launcher", () => {
     for (const scenarioId of ["whatsapp-status-command", "whatsapp-access-control-dm-open"]) {
       const blocked = evidence.entries?.find((entry) => entry.test?.id === scenarioId);
       expect(blocked).toMatchObject({
-        execution: { channel: { id: "whatsapp", driver: "live", live: true } },
+        execution: { channel: { id: "whatsapp", live: false } },
         result: { status: "blocked" },
       });
+      expect(blocked?.execution?.channel?.driver).toBeUndefined();
     }
+    expect(result.observedCells).not.toEqual(
+      expect.arrayContaining([
+        { scenarioId: "whatsapp-status-command", executionKind: "flow", channel: "whatsapp" },
+        {
+          scenarioId: "whatsapp-access-control-dm-open",
+          executionKind: "flow",
+          channel: "whatsapp",
+        },
+      ]),
+    );
   });
 
   it("omits later credential failures after the first failed flow scenario", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2263,7 +2263,7 @@ describe("qa suite runtime launcher", () => {
     ]);
     const evidence = JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")) as {
       entries?: Array<{
-        execution?: { channel?: { id?: string } };
+        execution?: { channel?: { driver?: string; id?: string; live?: boolean } };
         result?: { status?: string };
         test?: { id?: string };
       }>;

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -439,6 +439,15 @@ describe("qa suite runtime launcher", () => {
     expect(
       result.result.scenarios.find((scenario) => scenario.name === "thread-isolation [matrix]"),
     ).toMatchObject({ status: "fail" });
+    expect(result.observedCells).toEqual(
+      expect.arrayContaining([
+        { scenarioId: "channel-chat-baseline", executionKind: "flow", channel: null },
+        { scenarioId: "telegram-help-command", executionKind: "flow", channel: "telegram" },
+        { scenarioId: "matrix-restart-resume", executionKind: "flow", channel: "matrix" },
+        { scenarioId: "thread-isolation", executionKind: "flow", channel: "slack" },
+        { scenarioId: "thread-isolation", executionKind: "flow", channel: "matrix" },
+      ]),
+    );
   });
 
   it("uses one eligible channel outside profile execution", async () => {
@@ -688,6 +697,9 @@ describe("qa suite runtime launcher", () => {
     };
     expect(evidence.entries).toMatchObject([
       { test: { id: "whatsapp-status-command" }, result: { status: "fail" } },
+    ]);
+    expect(result.observedCells).toEqual([
+      { scenarioId: "whatsapp-status-command", executionKind: "flow", channel: "whatsapp" },
     ]);
     await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
   });

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -1,4 +1,4 @@
-// Qa Lab plugin module implements suite launch behavior.
+// QA Lab plugin module implements suite launch behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -25,9 +25,9 @@ import {
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
 import {
-  resolveQaScenarioLaneChannel,
-  resolveQaScenarioLaneChannels,
+  expandQaScenarioExecutionCells,
   resolveQaScenarioRequiredProviderMode,
+  type QaScenarioExecutionCell,
 } from "./scenario-lane.js";
 import {
   mapQaSuiteWithConcurrency,
@@ -54,7 +54,10 @@ import {
   type QaTestFileScenarioRunResult,
 } from "./test-file-scenario-runner.js";
 
-export type QaSuiteRuntimeResult =
+export type QaSuiteRuntimeResult = {
+  expectedCells: QaScenarioExecutionCell[];
+  observedCells: QaScenarioExecutionCell[];
+} & (
   | {
       executionKind: "flow";
       result: QaSuiteResult;
@@ -62,7 +65,8 @@ export type QaSuiteRuntimeResult =
   | {
       executionKind: "suite";
       result: QaUnifiedSuiteResult;
-    };
+    }
+);
 
 type QaUnifiedSuiteResult = {
   evidencePath: string;
@@ -73,16 +77,19 @@ type QaUnifiedSuiteResult = {
   summaryPath: string;
 };
 
-type QaSuiteExecutionPlan =
+type QaSuiteExecutionPlan = {
+  expectedCells: QaScenarioExecutionCell[];
+  scenarios: QaSeedScenarioWithSource[];
+} & (
   | {
       kind: "flow";
     }
   | {
       kind: "unified";
-      scenarios: QaSeedScenarioWithSource[];
-      flowScenarios: QaSeedScenarioWithSource[];
+      channelGroups: QaFlowChannelGroup[];
       testFileScenariosByKind: Map<QaTestFileExecutionKind, QaTestFileScenario[]>;
-    };
+    }
+);
 
 const MAX_SHARED_FLOW_PARTITIONS = 4;
 const MAX_ISOLATED_FLOW_CONCURRENCY = 8;
@@ -108,6 +115,7 @@ type QaUnifiedPartitionResult = {
 };
 
 type QaUnifiedPartitionTask = {
+  channel?: string;
   exclusiveKey?: string;
   run: () => Promise<QaUnifiedPartitionResult>;
   scenarios: readonly QaSeedScenarioWithSource[];
@@ -121,6 +129,21 @@ type QaFlowChannelGroup = {
   isolatesAdapterInstances?: boolean;
   scenarios: QaSeedScenarioWithSource[];
 };
+
+function groupQaScenariosByExecutionCell(
+  scenarios: readonly QaSeedScenarioWithSource[],
+  cells: readonly QaScenarioExecutionCell[],
+) {
+  const scenariosById = new Map(scenarios.map((scenario) => [scenario.id, scenario]));
+  const groups = new Map<string | undefined, QaSeedScenarioWithSource[]>();
+  for (const cell of cells) {
+    const channel = cell.channel ?? undefined;
+    const group = groups.get(channel) ?? [];
+    group.push(scenariosById.get(cell.scenarioId)!);
+    groups.set(channel, group);
+  }
+  return groups;
+}
 
 function hasQaSuiteRetryableNetworkCode(error: unknown) {
   let current: unknown = error;
@@ -212,37 +235,19 @@ async function resolveQaFlowChannelGroups(
         )?.isolatesInstances === true
       );
     };
-    const explicitChannel = runParams.channelId?.trim().toLowerCase();
-    if (explicitChannel) {
-      return [
-        {
-          channel: explicitChannel,
-          channelId: explicitChannel,
-          channelDriverSelection: runParams.channelDriverSelection,
-          isolatesAdapterInstances: isolatesInstances(explicitChannel),
-          scenarios: [...scenarios],
-        },
-      ];
-    }
-    const groups = new Map<string | undefined, QaSeedScenarioWithSource[]>();
-    for (const scenario of scenarios) {
-      const channelParams = {
-        scenario,
+    const groups = groupQaScenariosByExecutionCell(
+      scenarios,
+      expandQaScenarioExecutionCells({
+        scenarios,
         channelDriver: runParams.channelDriver ?? "qa-channel",
+        channel: runParams.channelId,
         supportsChannel: (channelId) =>
           runParams.adapterFactories?.some((factory) =>
             factory.matches({ channelId, driver: "live" }),
           ) === true,
-      } satisfies Parameters<typeof resolveQaScenarioLaneChannel>[0];
-      const channels = runParams.expandScenarioChannels
-        ? resolveQaScenarioLaneChannels(channelParams)
-        : [resolveQaScenarioLaneChannel(channelParams)];
-      for (const channel of channels) {
-        const group = groups.get(channel) ?? [];
-        group.push(scenario);
-        groups.set(channel, group);
-      }
-    }
+        expandChannels: runParams.expandScenarioChannels === true,
+      }),
+    );
     return [...groups].map(([channel, groupedScenarios]) => ({
       channel,
       channelId: channel,
@@ -263,8 +268,32 @@ async function resolveQaFlowChannelGroups(
   }
   // Package-only live lanes mount the QA harness without its dev tree. Load
   // Crabline only for Crabline-owned runs so unrelated transports stay isolated.
-  const { OPENCLAW_CRABLINE_DEFAULT_CHANNEL, resolveOpenClawCrablineChannelDriverSelection } =
-    await import("@openclaw/crabline");
+  const {
+    isCrablineServerChannel,
+    OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
+    resolveOpenClawCrablineChannelDriverSelection,
+  } = await import("@openclaw/crabline");
+  if (runParams.expandScenarioChannels) {
+    const groups = groupQaScenariosByExecutionCell(
+      scenarios,
+      expandQaScenarioExecutionCells({
+        scenarios,
+        channelDriver: "crabline",
+        channel: runParams.channelDriverSelection?.channel,
+        defaultChannel: OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
+        supportsChannel: isCrablineServerChannel,
+        expandChannels: true,
+      }),
+    );
+    return [...groups].map(([channel, groupedScenarios]) => ({
+      channel,
+      channelId: undefined,
+      channelDriverSelection: channel
+        ? resolveOpenClawCrablineChannelDriverSelection({ channel })
+        : undefined,
+      scenarios: groupedScenarios,
+    }));
+  }
   const channels = resolveQaSuiteScenarioChannels({
     defaultChannel: OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
     explicitChannel: runParams.channelDriverSelection?.channel,
@@ -302,7 +331,7 @@ async function resolveSuiteExecutionPlan(
 ): Promise<QaSuiteExecutionPlan> {
   const scenarioIds = params?.scenarioIds ?? [];
   if (scenarioIds.length === 0) {
-    return { kind: "flow" };
+    return { kind: "flow", expectedCells: [], scenarios: [] };
   }
   const selectedScenarios = resolveRequestedScenarios({
     scenarioIds,
@@ -321,6 +350,21 @@ async function resolveSuiteExecutionPlan(
   const channelGroups = (await resolveQaFlowChannelGroups(params, flowScenarios)).filter(
     (group) => group.scenarios.length > 0,
   );
+  const expectedCells = [
+    ...channelGroups.flatMap((group) =>
+      expandQaScenarioExecutionCells({
+        scenarios: group.scenarios,
+        channelDriver: params?.channelDriver ?? "qa-channel",
+        channel: group.channel,
+        expandChannels: false,
+      }),
+    ),
+    ...expandQaScenarioExecutionCells({
+      scenarios: [...testFileScenariosByKind.values()].flat(),
+      channelDriver: params?.channelDriver ?? "qa-channel",
+      expandChannels: false,
+    }),
+  ];
   const requiresFlowPartitions =
     channelGroups.length > 1 ||
     channelGroups.some(
@@ -331,12 +375,13 @@ async function resolveSuiteExecutionPlan(
     ) ||
     (flowScenarios.length > 1 && flowScenarios.some(scenarioRequiresIsolatedQaSuiteWorker));
   if (testFileScenariosByKind.size === 0 && !requiresFlowPartitions) {
-    return { kind: "flow" };
+    return { kind: "flow", expectedCells, scenarios: selectedScenarios };
   }
   return {
     kind: "unified",
+    channelGroups,
+    expectedCells,
     scenarios: selectedScenarios,
-    flowScenarios,
     testFileScenariosByKind,
   };
 }
@@ -672,7 +717,7 @@ async function writeUnifiedQaSuiteArtifacts(params: {
 async function runUnifiedQaSuite(params: {
   plan: Extract<QaSuiteExecutionPlan, { kind: "unified" }>;
   runParams: QaSuiteRunParams | undefined;
-}): Promise<QaUnifiedSuiteResult> {
+}): Promise<QaUnifiedSuiteResult & { observedCells: QaScenarioExecutionCell[] }> {
   if (params.plan.testFileScenariosByKind.size > 0) {
     rejectFlowOnlySuiteOptionsForUnifiedRun(params.runParams);
   }
@@ -722,15 +767,27 @@ async function runUnifiedQaSuite(params: {
       );
   const evidenceSummaries: QaEvidenceSummaryJson[] = [];
   const scenarioResultsById = new Map<string, QaSuiteScenarioResult[]>();
+  const observedCellsByKey = new Map<string, QaScenarioExecutionCell>();
+  const recordObservedScenarios = (
+    scenarios: readonly QaSeedScenarioWithSource[],
+    channel?: string,
+  ) => {
+    for (const cell of expandQaScenarioExecutionCells({
+      scenarios,
+      channelDriver: params.runParams?.channelDriver ?? "qa-channel",
+      channel,
+      expandChannels: false,
+    })) {
+      observedCellsByKey.set(JSON.stringify(cell), cell);
+    }
+  };
   const sharedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
   const isolatedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
   const testFilePartitionTasks: QaUnifiedPartitionTask[] = [];
   const scriptPartitionTasks: QaUnifiedPartitionTask[] = [];
   const unavailableChannelCredentialDetails = new Map<string, string>();
-  if (params.plan.flowScenarios.length > 0) {
-    const channelGroups = (
-      await resolveQaFlowChannelGroups(params.runParams, params.plan.flowScenarios)
-    ).filter((group) => group.scenarios.length > 0);
+  if (params.plan.channelGroups.length > 0) {
+    const channelGroups = params.plan.channelGroups;
     const runFlowSuite = await loadQaFlowSuiteRuntime();
     for (const channelGroup of channelGroups) {
       const sharedFlowScenarios = channelGroup.scenarios.filter(
@@ -863,6 +920,7 @@ async function runUnifiedQaSuite(params: {
           };
         };
         const task = {
+          channel: channelGroup.channel,
           // One channel's credential and Gateway state stay serial unless each adapter create()
           // owns an isolated runtime. Distinct channels may always run together.
           exclusiveKey: channelDriverFlowRequiresExclusiveWorkers
@@ -871,6 +929,7 @@ async function runUnifiedQaSuite(params: {
           scenarios: partition.scenarios,
           weight: partition.concurrency,
           run: async () => {
+            recordObservedScenarios(partition.scenarios, channelGroup.channel);
             const unavailableDetails = channelGroup.channelId
               ? unavailableChannelCredentialDetails.get(channelGroup.channelId)
               : undefined;
@@ -965,9 +1024,10 @@ async function runUnifiedQaSuite(params: {
   }
   const createTestFilePartitionTask = (
     scenariosByKind: ReadonlyMap<QaTestFileExecutionKind, QaTestFileScenario[]>,
-  ) =>
-    ({
-      scenarios: [...scenariosByKind.values()].flat(),
+  ) => {
+    const taskScenarios = [...scenariosByKind.values()].flat();
+    return {
+      scenarios: taskScenarios,
       weight: 1,
       run: async () => {
         const testFileEvidenceSummaries: QaEvidenceSummaryJson[] = [];
@@ -1020,6 +1080,9 @@ async function runUnifiedQaSuite(params: {
             break;
           }
         }
+        recordObservedScenarios(
+          taskScenarios.filter((scenario) => testFileStartedScenarioIds.includes(scenario.id)),
+        );
         return {
           evidenceSummaries: testFileEvidenceSummaries,
           scenarioResults: testFileScenarioResults,
@@ -1029,7 +1092,8 @@ async function runUnifiedQaSuite(params: {
           ),
         };
       },
-    }) satisfies QaUnifiedPartitionTask;
+    } satisfies QaUnifiedPartitionTask;
+  };
   const concurrentTestFileScenariosByKind = new Map(
     [...params.plan.testFileScenariosByKind].filter(([kind]) => kind !== "script"),
   );
@@ -1149,6 +1213,7 @@ async function runUnifiedQaSuite(params: {
     error: unknown,
   ): QaUnifiedPartitionResult => {
     const scenarios = task.scenarios;
+    recordObservedScenarios(scenarios, task.channel);
     const details = `suite partition failed: ${formatErrorMessage(error)}`;
     const scenarioResults = scenarios.map((scenario) => ({
       scenarioId: scenario.id,
@@ -1302,25 +1367,40 @@ async function runUnifiedQaSuite(params: {
     markdown: unifiedResult.report,
     generatedAt: finishedAt.toISOString(),
   });
-  return unifiedResult;
+  return {
+    ...unifiedResult,
+    observedCells: [...observedCellsByKey.values()].toSorted((left, right) =>
+      JSON.stringify(left).localeCompare(JSON.stringify(right)),
+    ),
+  };
 }
 
 export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteRuntimeResult> {
   const runParams = args[0];
   const plan = await resolveSuiteExecutionPlan(runParams);
   if (plan.kind === "unified") {
-    const result = await runUnifiedQaSuite({
+    const { observedCells, ...result } = await runUnifiedQaSuite({
       runParams,
       plan,
     });
     return {
       executionKind: "suite",
+      expectedCells: plan.expectedCells,
+      observedCells,
       result,
     };
   }
+  const result = await runQaSuiteWithInfraRetry(() => runQaFlowSuiteFromRuntime(...args));
+  if (plan.expectedCells.length > 0 && result.scenarios.length > plan.expectedCells.length) {
+    throw new Error(
+      `QA flow returned ${result.scenarios.length} results for ${plan.expectedCells.length} scheduled cells`,
+    );
+  }
   return {
     executionKind: "flow",
-    result: await runQaSuiteWithInfraRetry(() => runQaFlowSuiteFromRuntime(...args)),
+    expectedCells: plan.expectedCells,
+    observedCells: plan.expectedCells.slice(0, result.scenarios.length),
+    result,
   };
 }
 

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -17,6 +17,7 @@ import { DEFAULT_QA_PROVIDER_MODE } from "./providers/index.js";
 import {
   defaultQaSuiteConcurrencyForTransport,
   normalizeQaTransportId,
+  type QaTransportDriver,
 } from "./qa-transport-registry.js";
 import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
 import { defaultQaModelForMode, normalizeQaProviderMode } from "./run-config.js";
@@ -116,11 +117,32 @@ type QaUnifiedPartitionResult = {
 
 type QaUnifiedPartitionTask = {
   channel?: string;
+  channelId: string;
   exclusiveKey?: string;
   run: () => Promise<QaUnifiedPartitionResult>;
   scenarios: readonly QaSeedScenarioWithSource[];
   weight: number;
 };
+
+function summarizeQaEvidenceChannel(
+  summaries: readonly QaEvidenceSummaryJson[],
+): { id?: string; driver: QaTransportDriver } | undefined {
+  const channels = summaries.flatMap((summary) =>
+    summary.entries.map((entry) => entry.execution?.channel),
+  );
+  const first = channels[0];
+  if (
+    !first?.driver ||
+    !["qa-channel", "crabline", "live"].includes(first.driver) ||
+    channels.some((channel) => channel?.driver !== first.driver)
+  ) {
+    return undefined;
+  }
+  return {
+    ...(channels.every((channel) => channel?.id === first.id) ? { id: first.id } : {}),
+    driver: first.driver as QaTransportDriver,
+  };
+}
 
 type QaFlowChannelGroup = {
   channel: string | undefined;
@@ -665,7 +687,8 @@ function renderUnifiedQaSuiteReport(params: {
 
 async function writeUnifiedQaSuiteArtifacts(params: {
   alternateModel: string;
-  channelDriver: QaSuiteRunParams["channelDriver"];
+  channel?: string;
+  channelDriver?: QaTransportDriver;
   concurrency: number;
   evidence: QaEvidenceSummaryJson;
   fastMode: boolean;
@@ -689,6 +712,7 @@ async function writeUnifiedQaSuiteArtifacts(params: {
   });
   const summary = buildQaSuiteSummaryJson({
     alternateModel: params.alternateModel,
+    channel: params.channel,
     channelDriver: params.channelDriver,
     concurrency: params.concurrency,
     evidence: params.evidence,
@@ -876,6 +900,11 @@ async function runUnifiedQaSuite(params: {
         ]
           .filter((part): part is string => Boolean(part))
           .join("-");
+        const taskChannelId =
+          channelGroup.channelId ??
+          channelGroup.channelDriverSelection?.channel ??
+          channelGroup.channel ??
+          transportId;
         const buildCredentialUnavailableResult = (details: string): QaUnifiedPartitionResult => {
           const blockedResults = partition.scenarios.map((scenario) => ({
             name:
@@ -890,10 +919,7 @@ async function runUnifiedQaSuite(params: {
               buildQaSuiteEvidenceSummary({
                 artifactPaths: [],
                 evidenceMode: params.runParams?.evidenceMode,
-                channelId: channelGroup.channelId ?? transportId,
-                channelDriver:
-                  params.runParams?.channelDriver ??
-                  channelGroup.channelDriverSelection?.channelDriver,
+                channelId: taskChannelId,
                 env: process.env,
                 generatedAt: new Date().toISOString(),
                 primaryModel,
@@ -921,6 +947,7 @@ async function runUnifiedQaSuite(params: {
         };
         const task = {
           channel: channelGroup.channel,
+          channelId: taskChannelId,
           // One channel's credential and Gateway state stay serial unless each adapter create()
           // owns an isolated runtime. Distinct channels may always run together.
           exclusiveKey: channelDriverFlowRequiresExclusiveWorkers
@@ -929,7 +956,6 @@ async function runUnifiedQaSuite(params: {
           scenarios: partition.scenarios,
           weight: partition.concurrency,
           run: async () => {
-            recordObservedScenarios(partition.scenarios, channelGroup.channel);
             const unavailableDetails = channelGroup.channelId
               ? unavailableChannelCredentialDetails.get(channelGroup.channelId)
               : undefined;
@@ -985,6 +1011,11 @@ async function runUnifiedQaSuite(params: {
             if ("evidenceSummaries" in result) {
               return result;
             }
+            const startedScenarioIdSet = new Set(result.startedScenarioIds);
+            recordObservedScenarios(
+              partition.scenarios.filter((scenario) => startedScenarioIdSet.has(scenario.id)),
+              channelGroup.channel,
+            );
             const scenarioResults: QaUnifiedPartitionResult["scenarioResults"] = [];
             for (const [index, scenario] of partition.scenarios.entries()) {
               const scenarioResult = result.scenarios[index];
@@ -1009,7 +1040,7 @@ async function runUnifiedQaSuite(params: {
                 }),
               ],
               scenarioResults,
-              startedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
+              startedScenarioIds: result.startedScenarioIds,
               submittedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
             };
           },
@@ -1027,6 +1058,7 @@ async function runUnifiedQaSuite(params: {
   ) => {
     const taskScenarios = [...scenariosByKind.values()].flat();
     return {
+      channelId: transportId,
       scenarios: taskScenarios,
       weight: 1,
       run: async () => {
@@ -1158,25 +1190,28 @@ async function runUnifiedQaSuite(params: {
     });
     const missingScenarioEvidence =
       missingScenarioDefinitions.length > 0
-        ? [
-            buildQaSuiteEvidenceSummary({
-              artifactPaths: [],
-              evidenceMode: params.runParams?.evidenceMode,
-              channelDriver: params.runParams?.channelDriver,
-              channelId: transportId,
-              env: process.env,
-              generatedAt: new Date().toISOString(),
-              primaryModel,
-              providerMode,
-              repoRoot,
-              scenarioDefinitions: missingScenarioDefinitions,
-              scenarioResults: missingScenarioDefinitions.map((scenario) => ({
-                name: scenario.title,
-                status: "fail" as const,
-                details: "suite partition returned no scenario result",
-              })),
-            }),
-          ]
+        ? (() => {
+            const channel = summarizeQaEvidenceChannel(partition.evidenceSummaries);
+            return [
+              buildQaSuiteEvidenceSummary({
+                artifactPaths: [],
+                evidenceMode: params.runParams?.evidenceMode,
+                channelDriver: channel?.driver,
+                channelId: channel?.id ?? task.channelId,
+                env: process.env,
+                generatedAt: new Date().toISOString(),
+                primaryModel,
+                providerMode,
+                repoRoot,
+                scenarioDefinitions: missingScenarioDefinitions,
+                scenarioResults: missingScenarioDefinitions.map((scenario) => ({
+                  name: scenario.title,
+                  status: "fail" as const,
+                  details: "suite partition returned no scenario result",
+                })),
+              }),
+            ];
+          })()
         : [];
     return {
       ...partition,
@@ -1213,7 +1248,6 @@ async function runUnifiedQaSuite(params: {
     error: unknown,
   ): QaUnifiedPartitionResult => {
     const scenarios = task.scenarios;
-    recordObservedScenarios(scenarios, task.channel);
     const details = `suite partition failed: ${formatErrorMessage(error)}`;
     const scenarioResults = scenarios.map((scenario) => ({
       scenarioId: scenario.id,
@@ -1229,8 +1263,7 @@ async function runUnifiedQaSuite(params: {
         buildQaSuiteEvidenceSummary({
           artifactPaths: [],
           evidenceMode: params.runParams?.evidenceMode,
-          channelDriver: params.runParams?.channelDriver,
-          channelId: transportId,
+          channelId: task.channelId,
           env: process.env,
           generatedAt: new Date().toISOString(),
           primaryModel,
@@ -1287,6 +1320,7 @@ async function runUnifiedQaSuite(params: {
     evidenceSummaries,
     generatedAt: finishedAt.toISOString(),
   });
+  const channel = summarizeQaEvidenceChannel([evidence]);
   const scenarios = params.plan.scenarios.flatMap((scenario) => {
     const results = scenarioResultsById.get(scenario.id);
     if (results?.length) {
@@ -1312,7 +1346,8 @@ async function runUnifiedQaSuite(params: {
   });
   const unifiedResult = await writeUnifiedQaSuiteArtifacts({
     alternateModel,
-    channelDriver: params.runParams?.channelDriver,
+    channel: channel?.id,
+    channelDriver: channel?.driver,
     concurrency,
     evidence,
     fastMode,
@@ -1391,15 +1426,11 @@ export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteR
     };
   }
   const result = await runQaSuiteWithInfraRetry(() => runQaFlowSuiteFromRuntime(...args));
-  if (plan.expectedCells.length > 0 && result.scenarios.length > plan.expectedCells.length) {
-    throw new Error(
-      `QA flow returned ${result.scenarios.length} results for ${plan.expectedCells.length} scheduled cells`,
-    );
-  }
+  const startedScenarioIds = new Set(result.startedScenarioIds);
   return {
     executionKind: "flow",
     expectedCells: plan.expectedCells,
-    observedCells: plan.expectedCells.slice(0, result.scenarios.length),
+    observedCells: plan.expectedCells.filter((cell) => startedScenarioIds.has(cell.scenarioId)),
     result,
   };
 }

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -135,6 +135,7 @@ describe("isolated QA suite transport cleanup", () => {
       summaryPath: "/qa-child/qa-suite-summary.json",
       report: "",
       scenarios: [{ name: "leased-channel-scenario", status: "pass", steps: [] }],
+      startedScenarioIds: ["leased-channel-scenario"],
       watchUrl: lab.baseUrl,
     });
     const context = createCleanupTestContext();

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -80,6 +80,7 @@ export async function runQaFlowSuiteIsolated(
   const completedScenarioResults: Array<QaSuiteScenarioResult | undefined> = Array.from({
     length: selectedScenarios.length,
   });
+  const startedScenarioIds = new Set<string>();
   let artifactWriteQueue = Promise.resolve();
   const writePartialArtifacts = () => {
     const partialScenarios = completedScenarioResults.filter(
@@ -110,7 +111,8 @@ export async function runQaFlowSuiteIsolated(
           alternateModel,
           fastMode,
           concurrency,
-          channelDriver: params?.channelDriver,
+          channel: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
+          channelDriver: transportFactoryResult.driver,
           channelDriverSelection: params?.channelDriverSelection,
           isolatedWorkers: true,
           writeEvidenceFile: params?.writeEvidenceFile,
@@ -186,6 +188,9 @@ export async function runQaFlowSuiteIsolated(
               }),
             ),
           );
+          for (const scenarioId of childSuiteResult.startedScenarioIds) {
+            startedScenarioIds.add(scenarioId);
+          }
           const scenarioResult: QaSuiteScenarioResult =
             childSuiteResult.scenarios[0] ??
             ({
@@ -280,7 +285,8 @@ export async function runQaFlowSuiteIsolated(
         alternateModel,
         fastMode,
         concurrency,
-        channelDriver: params?.channelDriver,
+        channel: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
+        channelDriver: transportFactoryResult.driver,
         channelDriverSelection: params?.channelDriverSelection,
         isolatedWorkers: true,
         writeEvidenceFile: params?.writeEvidenceFile,
@@ -311,6 +317,7 @@ export async function runQaFlowSuiteIsolated(
       summaryPath,
       report,
       scenarios,
+      startedScenarioIds: [...startedScenarioIds],
       watchUrl: lab.baseUrl,
     } satisfies QaSuiteResult;
   } catch (error) {

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -111,6 +111,7 @@ export async function runQaFlowSuiteStandard(
   let result: QaSuiteResult | undefined;
   let completionProgress: string | undefined;
   let evidenceWritten = false;
+  const startedScenarioIds: string[] = [];
   try {
     writeQaSuiteProgress(progressEnabled, `provider start: ${providerMode}`);
     const activeMock = await startQaProviderServer(providerMode, {
@@ -237,6 +238,7 @@ export async function runQaFlowSuiteStandard(
     };
     await captureGatewayHeapCheckpoint("suite-start");
     for (const [index, scenario] of selectedScenarios.entries()) {
+      startedScenarioIds.push(scenario.id);
       const scenarioIdForLog = sanitizeQaSuiteProgressValue(scenario.id);
       writeQaSuiteProgress(
         progressEnabled,
@@ -393,7 +395,8 @@ export async function runQaFlowSuiteStandard(
         alternateModel,
         fastMode,
         concurrency,
-        channelDriver: params?.channelDriver,
+        channel: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
+        channelDriver: transportFactoryResult.driver,
         channelDriverSelection: params?.channelDriverSelection,
         isolatedWorkers: false,
         writeEvidenceFile: params?.writeEvidenceFile,
@@ -421,6 +424,7 @@ export async function runQaFlowSuiteStandard(
       summaryPath,
       report,
       scenarios,
+      startedScenarioIds,
       watchUrl: lab.baseUrl,
       ...(runtimeParityCell ? { runtimeParityCell } : {}),
     } satisfies QaSuiteResult;

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -183,6 +183,7 @@ describe("runtime parity suite transport cleanup", () => {
       summaryPath: "/qa-child/qa-suite-summary.json",
       report: "",
       scenarios: [{ name: "runtime-cleanup", status: "pass", steps: [] }],
+      startedScenarioIds: ["runtime-cleanup"],
       watchUrl: lab.baseUrl,
       runtimeParityCell: {
         runtime: params?.forcedRuntime ?? "openclaw",
@@ -224,6 +225,36 @@ describe("runtime parity suite transport cleanup", () => {
     } finally {
       stderrWrite.mockRestore();
     }
+  });
+
+  it("reports a parity scenario only after a nested producer starts it", async () => {
+    const lab = createCleanupTestLab();
+    const cleanup = vi.fn(async () => {});
+    const factory = createCleanupTestFactory(lab, () => ({ cleanup }));
+    const runChild = vi.fn<QaSuiteRunner>().mockImplementation(async (params) => ({
+      outputDir: "/qa-child",
+      evidencePath: "/qa-child/qa-evidence.json",
+      reportPath: "/qa-child/qa-suite-report.md",
+      summaryPath: "/qa-child/qa-suite-summary.json",
+      report: "",
+      scenarios: [{ name: "runtime-cleanup", status: "pass", steps: [] }],
+      startedScenarioIds: [],
+      watchUrl: lab.baseUrl,
+      runtimeParityCell: {
+        runtime: params?.forcedRuntime ?? "openclaw",
+        transcriptBytes: "",
+        toolCalls: [],
+        finalText: "ok",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        wallClockMs: 1,
+        bootStateLines: [],
+      },
+    }));
+
+    const result = await runCleanupTestSuite({ factory, lab, runChild });
+
+    expect(result.startedScenarioIds).toEqual([]);
+    expect(runChild).toHaveBeenCalledTimes(2);
   });
 
   it("prints one generic completion after real nested standard cells and parent cleanup", async () => {

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -110,6 +110,7 @@ export async function runQaRuntimeParitySuite(params: {
   let parentTransportCleaned = false;
   let result: QaSuiteResult | undefined;
   let evidenceWritten = false;
+  const startedScenarioIds = new Set<string>();
   try {
     if (params.channelDriver === "live") {
       // The parent only contributes aggregate metadata; release its exclusive
@@ -183,6 +184,9 @@ export async function runQaRuntimeParitySuite(params: {
               captureRuntimeParityCell: true,
               writeEvidenceFile: params.writeEvidenceFile,
             });
+            for (const startedScenarioId of cellResult.startedScenarioIds) {
+              startedScenarioIds.add(startedScenarioId);
+            }
             const scenarioResult =
               cellResult.scenarios[0] ??
               ({
@@ -265,7 +269,8 @@ export async function runQaRuntimeParitySuite(params: {
         alternateModel: params.alternateModel,
         fastMode: params.fastMode,
         concurrency: params.concurrency,
-        channelDriver: params.channelDriver,
+        channel: params.channelId ?? params.channelDriverSelection?.channel ?? transport.id,
+        channelDriver: transportFactoryResult.driver,
         channelDriverSelection: params.channelDriverSelection,
         scenarioIds:
           params.scenarioIds && params.scenarioIds.length > 0
@@ -296,6 +301,9 @@ export async function runQaRuntimeParitySuite(params: {
       summaryPath,
       report,
       scenarios,
+      startedScenarioIds: params.selectedScenarios
+        .map((scenario) => scenario.id)
+        .filter((scenarioId) => startedScenarioIds.has(scenarioId)),
       watchUrl: lab.baseUrl,
     } satisfies QaSuiteResult;
   } catch (error) {

--- a/extensions/qa-lab/src/suite-types.ts
+++ b/extensions/qa-lab/src/suite-types.ts
@@ -75,6 +75,7 @@ export type QaSuiteResult = {
   summaryPath: string;
   report: string;
   scenarios: QaSuiteScenarioResult[];
+  startedScenarioIds: string[];
   watchUrl: string;
   runtimeParityCell?: RuntimeParityCell;
 };

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -1,4 +1,4 @@
-// Qa Lab tests cover suite.summary json plugin behavior.
+// QA Lab tests cover suite.summary json plugin behavior.
 import { describe, expect, it } from "vitest";
 import { buildQaSuiteEvidenceSummary } from "./evidence-summary.js";
 import { buildQaSuiteSummaryJson } from "./suite.js";
@@ -44,6 +44,7 @@ describe("buildQaSuiteSummaryJson", () => {
   it("records Crabline channel-driver metadata when selected", () => {
     const json = buildQaSuiteSummaryJson({
       ...baseParams,
+      channelDriver: "crabline",
       channelDriverSelection: {
         capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
         channel: "telegram",
@@ -58,14 +59,15 @@ describe("buildQaSuiteSummaryJson", () => {
     expect(json.run.channelDriverSmokePath).toBe("crabline-fake-provider-smoke.json");
   });
 
-  it("records declarative non-Crabline channel-driver metadata", () => {
+  it("records realized non-Crabline channel metadata", () => {
     const json = buildQaSuiteSummaryJson({
       ...baseParams,
+      channel: "telegram",
       channelDriver: "live",
     });
 
     expect(json.run.channelDriver).toBe("live");
-    expect(json.run.channel).toBeNull();
+    expect(json.run.channel).toBe("telegram");
     expect(json.run.channelCapabilityMatrixPath).toBeNull();
     expect(json.run.channelDriverSmokePath).toBeNull();
   });

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -130,6 +130,7 @@ describe("qa suite", () => {
         { name: "fail", status: "fail", steps: [] },
         { name: "skip", status: "skip", steps: [] },
       ],
+      startedScenarioIds: ["pass", "fail", "skip"],
       watchUrl: "http://127.0.0.1:43123",
     } satisfies QaSuiteResult;
 
@@ -207,7 +208,7 @@ describe("qa suite", () => {
         state: {} as QaLabServerHandle["state"],
         transportId: "qa-channel",
       }),
-    ).resolves.toMatchObject({ adapter: { id: "qa-channel" } });
+    ).resolves.toMatchObject({ adapter: { id: "qa-channel" }, driver: "qa-channel" });
 
     expect(create).not.toHaveBeenCalled();
   });
@@ -267,7 +268,7 @@ describe("qa suite", () => {
         state: {} as QaLabServerHandle["state"],
         transportId: "qa-channel",
       }),
-    ).resolves.toMatchObject({ adapter });
+    ).resolves.toMatchObject({ adapter, driver: "live" });
 
     expect(create).toHaveBeenCalledTimes(1);
     expect(create).toHaveBeenCalledWith(
@@ -690,6 +691,8 @@ describe("qa suite", () => {
         alternateModel: "mock-openai/gpt-5.6-luna-alt",
         fastMode: true,
         concurrency: 1,
+        channel: "telegram",
+        channelDriver: "crabline",
         channelDriverSelection: {
           capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
           channel: "telegram",

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -20,6 +20,7 @@ import {
 import type { QaThinkingLevel } from "./qa-gateway-config.js";
 import {
   createQaTransportAdapter,
+  selectQaTransportDriver,
   type QaTransportAdapterFactory,
   type QaTransportFactoryContext,
   type QaTransportId,
@@ -93,18 +94,16 @@ export async function createQaSuiteTransportAdapter(params: {
   transportId: QaTransportId;
 }) {
   try {
-    const usesLiveAdapter =
-      params.channelDriver === "live" &&
-      params.channelId !== undefined &&
-      params.adapterFactories !== undefined;
-    return await createQaTransportAdapter(
+    const driver = selectQaTransportDriver({
+      channelDriver: params.channelDriver,
+      channelDriverSelection: params.channelDriverSelection,
+      channelId: params.channelId,
+      transportId: params.transportId,
+    });
+    const result = await createQaTransportAdapter(
       {
         channelId: params.channelId ?? params.channelDriverSelection?.channel ?? params.transportId,
-        driver: usesLiveAdapter
-          ? "live"
-          : params.channelDriverSelection
-            ? "crabline"
-            : params.transportId,
+        driver,
         outputDir: params.outputDir,
         adapterOptions: {
           ...params.adapterOptions,
@@ -119,8 +118,9 @@ export async function createQaSuiteTransportAdapter(params: {
         },
         state: params.state,
       },
-      usesLiveAdapter ? params.adapterFactories : undefined,
+      driver === "live" ? params.adapterFactories : undefined,
     );
+    return { ...result, driver };
   } catch (error) {
     await params.cleanupOnFailure?.().catch(() => undefined);
     throw error;
@@ -429,6 +429,7 @@ export type QaSuiteResult = {
   summaryPath: string;
   report: string;
   scenarios: QaSuiteScenarioResult[];
+  startedScenarioIds: string[];
   watchUrl: string;
   runtimeParityCell?: RuntimeParityCell;
 };

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -15,11 +15,12 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { createNodeTestShards } from "../../scripts/lib/ci-node-test-plan.mjs";
 import { NATIVE_I18N_LOCALES } from "../../scripts/native-app-i18n.ts";
 import { SUPPORTED_LOCALES } from "../../ui/src/i18n/lib/registry.ts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const CHECKOUT_V6 = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
 const CACHE_V5 = "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae";
@@ -41,6 +42,7 @@ const MATURITY_SCORECARD_WORKFLOW = ".github/workflows/maturity-scorecard.yml";
 const MATURITY_SCORECARD_WORKFLOW_REF =
   "openclaw/openclaw/.github/workflows/maturity-scorecard.yml@refs/heads/main";
 const OIDC_BOUND_MAIN_REUSABLE_WORKFLOWS = new Set<string>();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const MATURITY_GENERATED_PR_PATHS = [
   "qa/maturity-scores.yaml",
   "docs/maturity/scorecard.md",
@@ -5860,7 +5862,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       );
       const producerScript = expectDefined(producerStep?.run, "QA evidence producer script");
       const consumerScript = expectDefined(consumerStep?.run, "QA evidence consumer script");
-      const root = mkdtempSync(path.join(tmpdir(), "openclaw-qa-profile-artifact-"));
+      const root = tempDirs.make("openclaw-qa-profile-artifact-");
       const evidencePath = path.join(root, "qa-evidence.json");
       const manifestPath = path.join(root, "qa-profile-evidence-manifest.json");
       const targetSha = "a".repeat(40);

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5848,6 +5848,168 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
   });
 
   it.skipIf(process.platform === "win32")(
+    "round-trips complete and incomplete profile evidence and rejects digest drift",
+    () => {
+      const qaWorkflow = readQaProfileEvidenceWorkflow();
+      const maturityWorkflow = readMaturityScorecardWorkflow();
+      const producerStep = qaWorkflow.jobs.run_qa_profile.steps.find(
+        (step: WorkflowStep) => step.name === "Validate QA profile evidence",
+      );
+      const consumerStep = maturityWorkflow.jobs.publish.steps.find(
+        (step: WorkflowStep) => step.name === "Validate QA evidence manifest",
+      );
+      const producerScript = expectDefined(producerStep?.run, "QA evidence producer script");
+      const consumerScript = expectDefined(consumerStep?.run, "QA evidence consumer script");
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-qa-profile-artifact-"));
+      const evidencePath = path.join(root, "qa-evidence.json");
+      const manifestPath = path.join(root, "qa-profile-evidence-manifest.json");
+      const targetSha = "a".repeat(40);
+      const expectedCell = {
+        scenarioId: "scenario-one",
+        executionKind: "flow",
+        channel: null,
+      };
+      const scorecard = {
+        filters: { surface: null, category: null },
+        run: { evidenceEntryCount: 0 },
+        categories: { total: 1, fulfilled: 1, partial: 0, missing: 0, fulfillmentPercent: 100 },
+        features: { total: 1, fulfilled: 1, partial: 0, missing: 0, fulfillmentPercent: 100 },
+        coverageIds: {
+          total: 1,
+          fulfilled: 1,
+          missing: 0,
+          fulfillmentPercent: 100,
+        },
+        categoryReports: [
+          {
+            id: "surface.category",
+            surfaceId: "surface",
+            name: "Category",
+            status: "fulfilled",
+            features: {
+              total: 1,
+              fulfilled: 1,
+              partial: 0,
+              missing: 0,
+              fulfillmentPercent: 100,
+            },
+            coverageIds: {
+              total: 1,
+              fulfilled: 1,
+              missing: 0,
+              fulfillmentPercent: 100,
+              secondaryOnly: 0,
+            },
+            missingCoverageIds: [],
+          },
+        ],
+      };
+
+      const writeEvidence = (complete: boolean) => {
+        const observedCells = complete ? [expectedCell] : [];
+        const missingCells = complete ? [] : [expectedCell];
+        writeFileSync(
+          evidencePath,
+          `${JSON.stringify({
+            kind: "openclaw.qa.evidence-summary",
+            schemaVersion: 2,
+            generatedAt: "2026-08-05T00:00:00.000Z",
+            evidenceMode: "full",
+            entries: [],
+            profile: "all",
+            profilePlan: {
+              profile: "all",
+              membership: ["scenario-one"],
+              selected: ["scenario-one"],
+              excluded: [],
+              expectedCells: [expectedCell],
+              observedCells,
+              missingCells,
+              counts: {
+                membership: 1,
+                selected: 1,
+                excluded: 0,
+                expectedCells: 1,
+                observedCells: observedCells.length,
+                missingCells: missingCells.length,
+              },
+            },
+            scorecard,
+          })}\n`,
+          "utf8",
+        );
+      };
+      const runProducer = (qaExitCode: string) =>
+        runWorkflowShellScript(producerScript, {
+          env: {
+            ...process.env,
+            ALLOW_FAILURES: "true",
+            ARTIFACT_NAME: `qa-profile-evidence-all-${targetSha}`,
+            GITHUB_OUTPUT: path.join(root, "github-output"),
+            GITHUB_STEP_SUMMARY: path.join(root, "github-summary"),
+            OUTPUT_DIR: root,
+            QA_EXIT_CODE: qaExitCode,
+            QA_PROFILE: "all",
+            REQUESTED_REF: targetSha,
+            TARGET_SHA: targetSha,
+            TRUSTED_REASON: "fixture",
+          },
+        });
+      const runConsumer = () =>
+        runWorkflowShellScript(consumerScript, {
+          env: {
+            ...process.env,
+            QA_EVIDENCE_PATH: evidencePath,
+            TARGET_SHA: targetSha,
+          },
+        });
+
+      try {
+        writeEvidence(true);
+        const completeProducer = runProducer("0");
+        expect(
+          completeProducer.status,
+          `${completeProducer.stdout}${completeProducer.stderr}`,
+        ).toBe(0);
+        const completeConsumer = runConsumer();
+        expect(
+          completeConsumer.status,
+          `${completeConsumer.stdout}${completeConsumer.stderr}`,
+        ).toBe(0);
+
+        writeEvidence(false);
+        const incompleteProducer = runProducer("7");
+        expect(
+          incompleteProducer.status,
+          `${incompleteProducer.stdout}${incompleteProducer.stderr}`,
+        ).toBe(0);
+        const incompleteConsumer = runConsumer();
+        expect(
+          incompleteConsumer.status,
+          `${incompleteConsumer.stdout}${incompleteConsumer.stderr}`,
+        ).toBe(0);
+
+        writeEvidence(true);
+        const mismatchProducer = runProducer("0");
+        expect(
+          mismatchProducer.status,
+          `${mismatchProducer.stdout}${mismatchProducer.stderr}`,
+        ).toBe(0);
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+        manifest.profilePlanSha256 = "0".repeat(64);
+        writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+        const mismatched = runConsumer();
+        expect(mismatched.status).toBe(1);
+        expect(`${mismatched.stdout}${mismatched.stderr}`).toContain(
+          "QA evidence profilePlan digest does not match the manifest",
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
     "suppresses only reported QA result failures when explicitly allowed",
     () => {
       expect(runQaProfileFailureGate({ allowFailures: false, qaExitCode: "7" }).status).toBe(7);

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5698,6 +5698,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(validateManifestStep.run).toContain("qa-evidence.json profile must be all");
     expect(validateManifestStep.run).toContain("QA evidence manifest profile must be all");
     expect(validateManifestStep.run).toContain("manifest.targetSha !== targetSha");
+    expect(validateManifestStep.run).toContain("qaProfileEvidencePlan.attest");
+    expect(validateManifestStep.run).toContain("profilePlanSha256");
+    expect(validateManifestStep.run).toContain("rerun the QA Profile Evidence workflow");
 
     expect(qaRunJob.outputs.artifact_name).toBe("${{ steps.evidence.outputs.artifact_name }}");
     const qaEvidenceStep = qaRunJob.steps.find(
@@ -5708,6 +5711,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(qaEvidenceStep.run).toContain("qa-profile-evidence-manifest.json");
     expect(qaEvidenceStep.run).toContain("validateQaEvidenceSummaryJson");
+    expect(qaEvidenceStep.run).toContain("qaProfileEvidencePlan.attest");
+    expect(qaEvidenceStep.run).toContain("profilePlanSha256");
+    expect(qaEvidenceStep.run).toContain("rerun the QA Profile Evidence workflow");
     expect(qaEvidenceStep.env.ALLOW_FAILURES).toBe("${{ inputs.allow_failures }}");
     expect(qaEvidenceStep.run).toContain("qaExitCode: Number(process.env.QA_EXIT_CODE)");
     expect(qaEvidenceStep.run).toContain('qaPassed: process.env.QA_EXIT_CODE === "0"');


### PR DESCRIPTION
## What Problem This Solves

QA profile evidence could prove neither the canonical membership partition nor the exact execution cells actually started. Worse, the suite launcher recorded cells before credential checks and adapter creation, so a blocked partition could appear fully observed.

## Why This Change Was Made

QA Lab now owns one schema-v2 profile plan containing canonical membership, selected scenarios, reasoned exclusions, expected scheduler cells, producer-observed cells, explicit missing cells, matching counts, and a stable SHA-256 digest.

The scheduler and runtime share one execution-cell expansion helper. Observed cells now come only from the suite producer after adapter creation and scenario start:

- standard runs record scenario-loop entry;
- isolated runs aggregate child producer results;
- runtime parity aggregates nested runtime-cell producer results;
- credential-unavailable, adapter-failure, and synthetic partition-failure paths record no observed cell and infer no realized driver.

Generic schema-v2 evidence may omit `profilePlan`. QA profile and maturity workflows require and validate it, with an explicit rerun-required error for old artifacts.

Fixes #115753.

Related history:

- #95947 established the `all` taxonomy profile.
- #96595 made `all` the default maturity evidence profile.
- #115446 validated maturity profiles against scenario inventory.
- #117975 allowed scorecard generation from incomplete evidence.
- #115540 expanded profile scenarios across every eligible channel.
- #115777 carries the canonical producer-owned realized-driver direction, but is conflicting and `maintainerCanModify=false`. This PR direct-lands the coherent owner-boundary pieces because it also owns the combined profile-plan scheduling invariant. Dallin Romney is credited as co-author.
- #116262 was the narrower closed attempt. Its blocked-path realization informed this combined repair; ruel225 is credited as co-author.

## User Impact

Operators and maturity automation can verify that selected and excluded scenarios exactly partition profile membership, successful evidence observed every required execution cell, allowed failures name missing cells, and unexpected cells invalidate evidence. Blocked credentials can no longer manufacture successful scheduling evidence.

## Evidence

- Exact head: `7f28c951cddd15e1d7ac88d0f4606aea6fa8b028`
- Branch base: `397a60582a109489d7dd4f1be1136251c10dc1b9`
- Focused QA Lab tests: 137 passed.
- Post-CI-fix owner test: 47 passed.
- Workflow guards: 101 passed, 2 skipped by platform contract.
- Artifact round trip: the actual workflow producer and consumer accept complete and allowed-incomplete serialized plans, and reject a digest-mismatched plan.
- Credential-unavailable regression: blocked live partitions omit observed cells and realized live-driver evidence.
- Runtime parity regression: the parent reports a scenario only after a nested producer starts it.
- Extension typecheck: passed.
- Extension test typecheck: passed; this directly reproduces and clears the prior hosted `check-test-types` failure.
- Formatting, `git diff --check`, dependency/plugin/dead-export/declaration guards: passed.
- Autoreview: clean, no accepted/actionable findings.
- Remote changed-file proof did not start: Blacksmith Testbox was unauthenticated and the routed fallback failed during sync-manifest creation. Trusted local fallback and exact-head hosted CI cover the branch before landing.
- Codex contract inspected directly at `openai/codex@bb1af235ea2822d7a40f75ef52e4d6a2cde84da2`: `codex-rs/app-server/src/message_processor.rs`, `codex-rs/app-server-protocol/src/protocol/v2/turn.rs`, and `codex-rs/app-server/src/thread_state.rs`. Codex records a turn only after `turn/start` reaches `TurnStarted`; QA parity therefore consumes nested producer-start facts rather than parent scheduling.

LOC:

- Production TypeScript: `+500/-122`, net `+378`.
- Tests: `+499/-47`, net `+452`.
- Workflow YAML: `+32/-2`, net `+30`.
- The final repair commit itself is production net `+69` and tests net `+35`.

The production growth is the persisted schema and validator, scheduler-owned expected-cell expansion, producer-owned realized execution/driver facts, CLI evidence attachment, and shared digest/success semantics imported by both workflows. The LOC audit reduced `profile-evidence-plan.ts` from 223 to 171 lines and removed environment-derived driver inference instead of duplicating policy in workflow JavaScript.

No changelog entry: this is QA evidence and CI attestation infrastructure.

Punchcard-Session: silver-meadow-lantern-vx
