### PR TITLE
fix(gateway): keep uncommitted generated media while its session run is live

### DIFF
--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -24,6 +24,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
+  attachManagedImageRecordToMessage,
   insertManagedImageRecord,
   MANAGED_OUTGOING_ORIGINALS_SUBDIR,
   readManagedImageRecord,
@@ -231,6 +232,8 @@ async function createFixture(
     filename?: string;
     contentType?: string;
     body?: Buffer;
+    messageId?: string | null;
+    createdAt?: string;
   },
 ) {
   const attachmentId = options?.attachmentId ?? "11111111-1111-4111-8111-111111111111";
@@ -245,8 +248,8 @@ async function createFixture(
       attachmentId,
       sessionKey,
       ...(options?.agentId ? { agentId: options.agentId } : {}),
-      messageId: "msg-1",
-      createdAt: new Date().toISOString(),
+      messageId: options?.messageId === undefined ? "msg-1" : options.messageId,
+      createdAt: options?.createdAt ?? new Date().toISOString(),
       alt: "Cat",
       original: {
         mediaRoot: path.join(stateDir, "media"),
@@ -1924,6 +1927,54 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     expect(result.deletedRecordCount).toBe(1);
     expect(result.deletedFileCount).toBe(1);
     expect(result.retainedCount).toBe(0);
+    await expectPathMissing(fixture.originalPath);
+  });
+
+  it("retains an aged transient record while its session still has an active run", async () => {
+    const fixture = await createFixture(stateDir, {
+      messageId: null,
+      createdAt: new Date(Date.now() - 16 * 60 * 1000).toISOString(),
+    });
+
+    const checkedSessionKeys: string[] = [];
+    const result = await cleanupManagedOutgoingImageRecords({
+      stateDir,
+      hasActiveSessionRun: (sessionKey) => {
+        checkedSessionKeys.push(sessionKey);
+        return sessionKey === fixture.sessionKey;
+      },
+    });
+
+    expect(result).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+    expect(checkedSessionKeys).toEqual([fixture.sessionKey]);
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+    expect(
+      attachManagedImageRecordToMessage({
+        attachmentId: fixture.attachmentId,
+        sessionKey: fixture.sessionKey,
+        messageId: "msg-late",
+        updatedAt: new Date().toISOString(),
+        stateDir,
+      }),
+    ).toBe(true);
+    const attached = readManagedImageRecord(fixture.attachmentId, stateDir);
+    expect(attached?.messageId).toBe("msg-late");
+    expect(attached?.retentionClass).toBe("history");
+  });
+
+  it("reaps an aged transient record once its session has no active run", async () => {
+    const fixture = await createFixture(stateDir, {
+      messageId: null,
+      createdAt: new Date(Date.now() - 16 * 60 * 1000).toISOString(),
+    });
+
+    const result = await cleanupManagedOutgoingImageRecords({
+      stateDir,
+      hasActiveSessionRun: () => false,
+    });
+
+    expect(result).toEqual({ deletedRecordCount: 1, deletedFileCount: 1, retainedCount: 0 });
+    expect(readManagedImageRecord(fixture.attachmentId, stateDir)).toBeNull();
     await expectPathMissing(fixture.originalPath);
   });
 

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -618,6 +618,7 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
   sessionKey?: string;
   agentId?: string;
   forceDeleteSessionRecords?: boolean;
+  hasActiveSessionRun?: (sessionKey: string, agentId: string | undefined) => boolean;
 }): Promise<CleanupManagedOutgoingMediaRecordsResult> {
   const stateDir = params?.stateDir ?? resolveStateDir();
   const nowMs = params?.nowMs ?? Date.now();
@@ -674,7 +675,11 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
       shouldDelete = transcriptMatch === "missing";
     } else if (!entry.cleanupPending) {
       const createdAtMs = Date.parse(record.createdAt);
-      shouldDelete = Number.isFinite(createdAtMs) && nowMs - createdAtMs >= transientMaxAgeMs;
+      shouldDelete =
+        Number.isFinite(createdAtMs) &&
+        nowMs - createdAtMs >= transientMaxAgeMs &&
+        params?.hasActiveSessionRun?.(record.sessionKey, record.agentId?.trim() || undefined) !==
+          true;
     }
 
     if (shouldDelete) {

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -39,6 +39,7 @@ import {
   waitForMediaCleanupDrains,
   waitForMediaCleanupDrainsToSettle,
 } from "./server-media-cleanup-lifecycle.js";
+import { hasRegisteredChatRunForSessionKey } from "./server-methods/session-active-runs.js";
 import { PENDING_CHAT_SEND_DEDUPE_PREFIX, type DedupeEntry } from "./server-shared.js";
 import { formatError } from "./server-utils.js";
 import { setBroadcastHealthUpdate } from "./server/health-state.js";
@@ -331,7 +332,14 @@ export function startGatewayMaintenanceTimers(params: {
     params.runManagedOutgoingMediaGc ??
     (async () => {
       const { cleanupManagedOutgoingMediaRecords } = await import("./managed-image-attachments.js");
-      return await cleanupManagedOutgoingMediaRecords();
+      return await cleanupManagedOutgoingMediaRecords({
+        hasActiveSessionRun: (sessionKey, agentId) =>
+          hasRegisteredChatRunForSessionKey({
+            context: { chatAbortControllers: params.chatAbortControllers },
+            sessionKey,
+            agentId,
+          }),
+      });
     });
   const managedOutgoingCleanupLoader = createLazyPromiseLoader(async () => {
     try {

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -13,6 +13,7 @@ import {
   createManagedOutgoingMediaBlocks,
 } from "../managed-image-attachments.js";
 import { formatForLog } from "../ws-log.js";
+import { hasRegisteredChatRunForSessionKey } from "./session-active-runs.js";
 import type { GatewayRequestContext } from "./types.js";
 
 const MANAGED_OUTGOING_MEDIA_PATH_PREFIX = "/api/chat/media/outgoing/";
@@ -426,7 +427,7 @@ export function hasManagedOutgoingAssistantContent(
 export function scheduleChatHistoryManagedMediaCleanup(params: {
   sessionKey: string;
   agentId?: string;
-  context: Pick<GatewayRequestContext, "logGateway">;
+  context: Pick<GatewayRequestContext, "chatAbortControllers" | "logGateway">;
 }) {
   const cleanupKey =
     params.sessionKey === "global" && params.agentId
@@ -438,6 +439,8 @@ export function scheduleChatHistoryManagedMediaCleanup(params: {
   const pending = cleanupManagedOutgoingMediaRecords({
     sessionKey: params.sessionKey,
     ...(params.sessionKey === "global" && params.agentId ? { agentId: params.agentId } : {}),
+    hasActiveSessionRun: (sessionKey, agentId) =>
+      hasRegisteredChatRunForSessionKey({ context: params.context, sessionKey, agentId }),
   })
     .then(() => undefined)
     .catch((error: unknown) => {

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../infra/agent-run-registry.js";
 import {
   collectTrackedActiveSessionRuns,
+  hasRegisteredChatRunForSessionKey,
   hasTrackedActiveSessionRun,
   hasVisibleActiveSessionRun,
   resolveVisibleActiveSessionRunState,
@@ -291,4 +292,52 @@ it("does not project an aborted embedded handle retained for cleanup as active",
   } finally {
     clearActiveEmbeddedRun(sessionId, handle, sessionKey);
   }
+});
+
+it("counts settled but still registered chat runs for a session key", () => {
+  const context = {
+    chatAbortControllers: new Map([
+      [
+        "run-finalizing",
+        {
+          sessionKey: "agent:main:main",
+          sessionId: "session-main",
+          projectSessionActive: false,
+          controlUiVisible: false,
+        },
+      ],
+      ["run-global-work", { sessionKey: "global", agentId: "work" }],
+    ]),
+  } as never;
+
+  expect(
+    hasRegisteredChatRunForSessionKey({
+      context,
+      sessionKey: "agent:main:main",
+      agentId: undefined,
+    }),
+  ).toBe(true);
+  expect(
+    hasRegisteredChatRunForSessionKey({
+      context,
+      sessionKey: "agent:other:other",
+      agentId: undefined,
+    }),
+  ).toBe(false);
+  expect(
+    hasRegisteredChatRunForSessionKey({ context, sessionKey: "global", agentId: "work" }),
+  ).toBe(true);
+  expect(
+    hasRegisteredChatRunForSessionKey({ context, sessionKey: "global", agentId: "other" }),
+  ).toBe(false);
+  expect(
+    hasRegisteredChatRunForSessionKey({ context, sessionKey: "global", agentId: undefined }),
+  ).toBe(true);
+  expect(
+    hasRegisteredChatRunForSessionKey({
+      context: {},
+      sessionKey: "agent:main:main",
+      agentId: undefined,
+    }),
+  ).toBe(false);
 });

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -61,6 +61,31 @@ function isTrackedActiveSessionRunForKey(
     : false;
 }
 
+export function hasRegisteredChatRunForSessionKey(params: {
+  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;
+  sessionKey: string;
+  agentId: string | undefined;
+}): boolean {
+  if (!(params.context.chatAbortControllers instanceof Map)) {
+    return false;
+  }
+  const requestedAgentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
+  for (const active of params.context.chatAbortControllers.values()) {
+    if (active.sessionKey?.trim() !== params.sessionKey) {
+      continue;
+    }
+    if (params.sessionKey !== "global") {
+      return true;
+    }
+    const activeAgentId =
+      typeof active.agentId === "string" ? normalizeAgentId(active.agentId) : undefined;
+    if (!requestedAgentId || !activeAgentId || requestedAgentId === activeAgentId) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Returns true when either requested or canonical session key has a visible active run. */
 export function hasTrackedActiveSessionRun(params: {
   context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;


### PR DESCRIPTION
## Summary
Generated assistant media (images, audio, video) in gateway chat replies is deleted by the managed outgoing media GC while the assistant turn that generated it is still running. The media record is created with `messageId: null` and `retentionClass: "transient"`, and only promoted when finalization commits the transcript message and attaches it. The GC reaps transient records purely by age with a 15 minute TTL, so any turn that stays in flight past the TTL (slow generation, queued turn, delayed provider response, blocked finalization) has its records and files deleted before the attach runs. The attach ignores the persistence result, so finalization succeeds anyway and the committed assistant message keeps a permanently dead media URL. Both GC entry points are automatic: the `chat.history` handler schedules a session-scoped sweep every time a client opens the chat, and the gateway maintenance lifecycle runs an unscoped sweep on a timer.

## Root cause
`src/gateway/managed-image-attachments.ts` (main `7b8bba26c9539eb631a56ea65c2ff22771b2d0db`): the transient branch of `cleanupManagedOutgoingMediaRecords` decides deletion from age alone.

```ts
} else if (!entry.cleanupPending) {
  const createdAtMs = Date.parse(record.createdAt);
  shouldDelete = Number.isFinite(createdAtMs) && nowMs - createdAtMs >= transientMaxAgeMs;
}
```

The transient state means "an in-flight turn has not committed its message yet", but the GC has no way to know whether that turn is still alive, so it treats every aged transient record as an orphan. `attachManagedOutgoingMediaToMessage` then discards the boolean from `attachManagedImageRecordToMessage`, so the reaped record surfaces as a dead URL instead of a failure.

## Fix
`cleanupManagedOutgoingMediaRecords` accepts a `hasActiveSessionRun` probe and skips the transient-age reap while the record's session still has a registered chat run.

```ts
} else if (!entry.cleanupPending) {
  const createdAtMs = Date.parse(record.createdAt);
  shouldDelete =
    Number.isFinite(createdAtMs) &&
    nowMs - createdAtMs >= transientMaxAgeMs &&
    params?.hasActiveSessionRun?.(record.sessionKey, record.agentId?.trim() || undefined) !==
      true;
}
```

Both GC entry points supply the probe from the gateway's registered chat-run map via a new `hasRegisteredChatRunForSessionKey` helper in `src/gateway/server-methods/session-active-runs.ts`: `scheduleChatHistoryManagedMediaCleanup` (chat.history sweep) and the maintenance sweep default in `src/gateway/server-maintenance.ts`. The helper deliberately counts every registered `chatAbortControllers` entry rather than the visible-run projection: `clearTrackedActiveRun` flips `projectSessionActive` to false as soon as the agent loop emits its terminal event, which is exactly when post-dispatch finalization (transcript append plus attach) is still running, while the registration itself spans admission through the post-dispatch `finally`. For `global` records it matches per agent and retains conservatively when either side has no explicit agent id.

## Why this is the right boundary
The retention rule ("a transient record may only be reaped once no live turn can still attach it") belongs to the cleanup owner, so it is expressed inside `cleanupManagedOutgoingMediaRecords`; the run registry is per-server request state the cleanup module cannot reach, so callers inject the one missing fact as a probe. Both production callers are wired in this change, so no GC path can reintroduce the reap. The short create-to-attach race was already safe (`claimManagedImageRecordCleanupIfCurrent` refuses to claim a row a concurrent attach updated); this change closes the long window the claim guard cannot see. Sessions without a live run keep the exact TTL behavior, including crashed-run orphans, which reap on the next sweep after the stale run entry expires out of the map (the maintenance loop already prunes expired entries). The aged-orphan file sweep is intentionally untouched: files gain a record in the same tick they are saved, so a live turn's files are never recordless long enough to age out. Sibling surfaces: open PR #117266 (mine) protects committed records referenced by inactive transcript branches in the same file but does not touch the transient branch or these lines; the generic attachment sweep entering `media/outgoing` was already fixed by #119127. Making the attach result fail finalization instead was rejected: at attach time the file is already gone, so the only correct fix is to not delete it while the turn is live.

Two accepted tradeoffs, named so they are decisions rather than oversights. First, transient records that will never be attached (finalization paths that build a second content set or fail before attach) are now retained for as long as their session stays continuously busy across sweeps; cleanup is deferred to the first sweep that finds the session idle, not lost, so a busy session accumulates only until its next quiet moment. Second, the probe compares the record's stored session key against registered run keys verbatim; a run re-registered under a different key form after a gateway restart is not matched and the record falls back to the pre-fix TTL, which is correct there because the interrupted finalization can no longer attach it.

## Verification
- `node scripts/run-vitest.mjs src/gateway/server-maintenance.test.ts src/gateway/server-methods/session-active-runs.test.ts src/gateway/managed-image-attachments.test.ts src/gateway/managed-image-record-store.test.ts` - 4 files, 137 tests passed.
- New regression tests: `retains an aged transient record while its session still has an active run` (also proves the later attach promotes the record) and `reaps an aged transient record once its session has no active run` in `src/gateway/managed-image-attachments.test.ts`; registered-run matching in `src/gateway/server-methods/session-active-runs.test.ts`. With the four production files reverted to pristine main the new tests fail (aged transient record reaped, helper export missing); with the patch they pass.
- `node scripts/run-oxlint.mjs <changed files>` clean; `oxfmt --check <changed files>` clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` clean.

## Real behavior proof
Behavior addressed: generated assistant media is deleted by the automatic managed-media GC while the assistant turn is still running, so the finalized message keeps a permanently dead media URL.
Real environment tested: the real gateway managed-media pipeline on pristine main 7b8bba26c9539eb631a56ea65c2ff22771b2d0db (all four production files byte-identical through the rebased base 6d2ba0d5622fa7aa21a4770cb4c6fd93cae44e04) and on the patched tree with identical inputs, in an isolated OPENCLAW_STATE_DIR: real createManagedOutgoingMediaBlocks persistence (shared SQLite state DB plus on-disk media store), a real chat run registered through registerChatAbortController, the real chat.history GC entry scheduleChatHistoryManagedMediaCleanup, and the real attachManagedOutgoingMediaToMessage finalization call. Nothing was stubbed; record creation ran under a clock shifted back 16 minutes so the records aged past the 15 minute transient TTL, exactly the state a 16 minute old generation leaves behind.
Exact steps or command run after this patch: `node --import tsx managed-media-live-run-proof.mjs` (script drives the production functions above for two sessions: one with a registered live run, one idle)
Evidence after fix:
```
# BEFORE (pristine main 7b8bba26c95)
{
  "liveRunSession": {
    "blockUrl": "/api/chat/media/outgoing/agent%3Amain%3Aproof-live-run/520bb03a-079b-421f-9ecd-ef81cc994083/full",
    "recordSurvivedGcDuringActiveRun": false,
    "fileSurvivedGcDuringActiveRun": false,
    "finalizeAttachEffective": false,
    "retentionClassAfterFinalize": null
  },
  "idleSession": {
    "agedTransientReapedWithNoRun": true
  }
}
# AFTER (this patch, identical inputs)
{
  "liveRunSession": {
    "blockUrl": "/api/chat/media/outgoing/agent%3Amain%3Aproof-live-run/3ad892bf-07c3-4b3f-aebe-ce5132973d2e/full",
    "recordSurvivedGcDuringActiveRun": true,
    "fileSurvivedGcDuringActiveRun": true,
    "finalizeAttachEffective": true,
    "retentionClassAfterFinalize": "history"
  },
  "idleSession": {
    "agedTransientReapedWithNoRun": true
  }
}
```
Observed result after fix: with a registered run the aged record and its file survive the sweep and the finalization attach promotes the record to history with the committed message id, while the idle session's aged transient record is still reaped on the unchanged TTL.
What was not tested: no end-to-end gateway server with a real provider holding a turn open past 15 minutes of wall clock; the maintenance-sweep wiring was exercised through the same probe rather than a live hourly timer.
