### PR TITLE
fix: agent exec runs the configured default agent, not a hardwired main

### DIFF
--- a/src/commands/agent-exec.default-agent.test.ts
+++ b/src/commands/agent-exec.default-agent.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import { agentExecCommand } from "./agent-exec.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+}
+
+function createRuntime(): RuntimeEnv {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+}
+
+function successResult(text = "done") {
+  return {
+    payloads: [{ text }],
+    meta: {
+      durationMs: 25,
+      finalAssistantVisibleText: text,
+      agentMeta: { sessionId: "session-result", provider: "openai", model: "gpt-5.6-sol" },
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+  vi.restoreAllMocks();
+});
+
+describe("agent exec default agent scoping", () => {
+  // Regression: exec left `agentId` unset, so the session key it built
+  // normalized to the legacy `main` lane while the SQLite store target
+  // resolved ownership through the configured default agent, and any
+  // non-`main` default threw before the model was ever reached.
+  it("resolves a store scope that does not throw when the default agent is not main", async () => {
+    const configPath = path.join(
+      await makeTempRoot("openclaw-agent-exec-default-agent-"),
+      "openclaw.json",
+    );
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ agents: { entries: { alpha: { default: true } } } }),
+    );
+    const runAgent = vi.fn(async () => successResult());
+
+    const result = await agentExecCommand("inspect", { config: configPath }, createRuntime(), {
+      runAgent,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "alpha" }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -606,7 +606,8 @@ export async function agentExecCommand(
     const pluginInstallRoots = pluginInstallContext?.resolvePluginInstallRoots();
     const timeout = normalizeTimeoutSeconds(opts.timeout);
     const fallbacks = normalizeFallbacks(opts.model, opts.fallback);
-    const { resolveDefaultAgentDir } = await import("../agents/agent-scope-config.js");
+    const { resolveDefaultAgentDir, resolveDefaultAgentId } =
+      await import("../agents/agent-scope-config.js");
     // Resolve from the inherited config, not `{}`: the default agent may declare
     // its own `agentDir`, and that is where its stored auth profiles live. This
     // reads `baseConfig` rather than `runConfig` because the run config
@@ -615,6 +616,12 @@ export async function agentExecCommand(
     // Computed before the environment repoints the state dir so the unconfigured
     // case still resolves against the real one.
     const storedAuthAgentDir = resolveDefaultAgentDir(baseConfig);
+    // The run must carry the same agent id the SQLite session-store target
+    // resolves its owner to (`resolveSqliteTargetFromSessionStorePath`'s
+    // fallback is this same configured default), or the ownership guard
+    // compares a hardwired `main` against a store legitimately owned by the
+    // configured default and throws before the model is ever reached.
+    const execAgentId = resolveDefaultAgentId(baseConfig);
     restoreEnvironment = setAgentExecEnvironment({ stateDir, cwd });
     runtimePaths = await import("../config/paths.js");
     runtimePaths.pinRuntimePaths();
@@ -659,6 +666,7 @@ export async function agentExecCommand(
         {
           message: prompt,
           sessionId,
+          agentId: execAgentId,
           workspaceDir: cwd,
           cwd,
           model: opts.model,


### PR DESCRIPTION
## What Problem This Solves

`openclaw agent exec` always ran the turn as agent id `main`, but the SQLite
session-store target it opens resolves ownership through the **configured
default agent**. On any install where `agents.entries.<id>.default === true`
for an entry other than `main`, those two disagree and the ownership guard in
the session-store scope resolver throws before the model is ever called —
`agent exec` cannot complete a single turn.

Root cause: `agentExecCommand`'s call into `runAgent` never set `agentId`, so
the session key it built for the run (`agent:<agentId>:explicit:<uuid>`)
normalized the missing id to the legacy `main` fallback. The SQLite store
path it then opened, however, was already selected using the resolved
default agent (`resolveDefaultAgentId`), because that store target's own
fallback owner is the configured default, not `main`. Two different
resolutions of "which agent is this run" that must agree, and only did by
coincidence on installs where the default happened to be named `main`.

Fix: resolve the default agent id the same way the store target does
(`resolveDefaultAgentId(baseConfig)`) and pass it through as `agentId` on the
run, so the session key and the store scope are derived from the same
input.

## Evidence

Added a regression test (`src/commands/agent-exec.default-agent.test.ts`)
that pins a config with a non-`main` default agent entry and asserts
`agent exec` completes (`exitCode: 0`) with the run carrying that agent id,
covering the exact case from the reproduction in #119750: "default agent is
not main -> exec resolves a store scope that does not throw."

Ran scoped:
- `node scripts/test-projects.mjs src/commands/agent-exec.test.ts src/commands/agent-exec.default-agent.test.ts` — 52 passed (51 existing + 1 new), no regressions in the untouched suite.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — no type errors.
- `oxlint -c .oxlintrc.json` and `oxfmt --check` on both changed files — clean.

## Trade-offs / Residual risks

- New test lives in its own file (`agent-exec.default-agent.test.ts`)
  rather than in `agent-exec.test.ts`, because that file already sits at
  the repo's `max-lines` cap for `src/commands/**`; splitting follows the
  existing sibling-file convention in this directory (`agent.acp.test.ts`,
  `agent.delivery.test.ts`, …).
- Scoped the fix to `agent exec`'s own agent-id resolution rather than
  changing `normalizeAgentId`'s undefined-input fallback, since that
  fallback is relied on elsewhere for legitimate "run in the main lane"
  semantics; changing it globally would be a much larger, riskier surface
  than this call site needs.
- Did not add an `--agent` flag to `agent exec`; the issue's documented
  alternative (scope the store to its own ephemeral state dir and never
  consult the configured default) was not pursued, since aligning the run's
  agent id with the already-resolved store owner is the smaller, more
  consistent fix and matches the issue's preferred resolution.
