### PR TITLE
fix(agents): resolve implicit agent for rosterless exec workspace runs

### DIFF
--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -132,33 +132,31 @@ describe("resolveRunWorkspaceDir", () => {
     ).toThrow(expect.objectContaining({ code: "RUN_WORKSPACE_ROSTER_REQUIRED" }));
   });
 
-  it("admits an explicit agentId that matches the rosterless implicit default", () => {
-    // `agent exec` resolves `resolveDefaultAgentId(baseConfig)` itself and
-    // passes it through as an explicit `agentId` (see fix/agent-exec-default-agent
-    // -store-scope, #119765) rather than leaving it unspecified. Against a
-    // rosterless config that value is always the legacy implicit agent, so
-    // this must be admitted the same as an unspecified agentId -- not
-    // rejected as "naming an owner outside the roster".
-    const result = resolveRunWorkspaceDir({
-      workspaceDir: undefined,
-      agentId: "main",
-      config: {},
-    });
-
-    expect(result.agentId).toBe("main");
-    expect(result.agentIdSource).toBe("explicit");
-    expect(result.usedFallback).toBe(true);
+  it("rejects rosterless config even when the explicit agentId matches the implicit default", () => {
+    // This shared resolver is also reachable from raw embedded/SDK callers, so
+    // a rosterless config must never be admitted here regardless of which
+    // agentId it carries -- admitting it would hand those callers a real
+    // workspace despite the isolation contract. A producer that intentionally
+    // runs without a roster (e.g. `agent exec --isolated`) materializes its
+    // own implicit one-agent roster before calling in (see
+    // buildExecRunOverlay / agent-exec.test.ts) rather than relying on this
+    // resolver to invent one.
+    expect(() =>
+      resolveRunWorkspaceDir({
+        workspaceDir: undefined,
+        agentId: "main",
+        config: {},
+      }),
+    ).toThrow(expect.objectContaining({ code: "RUN_WORKSPACE_ROSTER_REQUIRED" }));
   });
 
-  it("resolves the implicit legacy agent for a rosterless config (agent exec --isolated)", () => {
-    const result = resolveRunWorkspaceDir({
-      workspaceDir: undefined,
-      config: {},
-    });
-
-    expect(result.agentId).toBe("main");
-    expect(result.agentIdSource).toBe("default");
-    expect(result.usedFallback).toBe(true);
+  it("rejects a rosterless config with no explicit agentId (agent exec --isolated, unmaterialized)", () => {
+    expect(() =>
+      resolveRunWorkspaceDir({
+        workspaceDir: undefined,
+        config: {},
+      }),
+    ).toThrow(expect.objectContaining({ code: "RUN_WORKSPACE_ROSTER_REQUIRED" }));
   });
 
   it.each([

--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -132,6 +132,17 @@ describe("resolveRunWorkspaceDir", () => {
     ).toThrow(expect.objectContaining({ code: "RUN_WORKSPACE_ROSTER_REQUIRED" }));
   });
 
+  it("resolves the implicit legacy agent for a rosterless config (agent exec --isolated)", () => {
+    const result = resolveRunWorkspaceDir({
+      workspaceDir: undefined,
+      config: {},
+    });
+
+    expect(result.agentId).toBe("main");
+    expect(result.agentIdSource).toBe("default");
+    expect(result.usedFallback).toBe(true);
+  });
+
   it.each([
     { agentId: "research", sessionKey: undefined },
     { agentId: undefined, sessionKey: "agent:research:subagent:test" },

--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -132,6 +132,24 @@ describe("resolveRunWorkspaceDir", () => {
     ).toThrow(expect.objectContaining({ code: "RUN_WORKSPACE_ROSTER_REQUIRED" }));
   });
 
+  it("admits an explicit agentId that matches the rosterless implicit default", () => {
+    // `agent exec` resolves `resolveDefaultAgentId(baseConfig)` itself and
+    // passes it through as an explicit `agentId` (see fix/agent-exec-default-agent
+    // -store-scope, #119765) rather than leaving it unspecified. Against a
+    // rosterless config that value is always the legacy implicit agent, so
+    // this must be admitted the same as an unspecified agentId -- not
+    // rejected as "naming an owner outside the roster".
+    const result = resolveRunWorkspaceDir({
+      workspaceDir: undefined,
+      agentId: "main",
+      config: {},
+    });
+
+    expect(result.agentId).toBe("main");
+    expect(result.agentIdSource).toBe("explicit");
+    expect(result.usedFallback).toBe(true);
+  });
+
   it("resolves the implicit legacy agent for a rosterless config (agent exec --isolated)", () => {
     const result = resolveRunWorkspaceDir({
       workspaceDir: undefined,

--- a/src/agents/workspace-run.ts
+++ b/src/agents/workspace-run.ts
@@ -128,11 +128,16 @@ export function resolveRunWorkspaceDir(params: {
   // A rosterless config (e.g. `agent exec --isolated`/`--auth-env-only`, which
   // discard the roster by design) has no entry to validate against, but it
   // still resolves the implicit legacy agent the same way listAgentIds and
-  // resolveDefaultAgentId already do for that identical input. An explicitly
-  // named owner -- via `agentId` or an agent-prefixed session key -- has no
-  // roster to check it against, so that case keeps refusing to invent one.
+  // resolveDefaultAgentId already do for that identical input. That implicit
+  // agent id is fixed and known even without a roster, so a caller that
+  // resolved it themselves and passed it through explicitly (e.g. `agent
+  // exec` pinning its session key to `resolveDefaultAgentId`) is admitted the
+  // same as an unspecified agentId would be -- the two produce an identical
+  // workspace either way. Only a caller naming a *different* owner -- via
+  // `agentId` or an agent-prefixed session key -- has no roster to check it
+  // against, so that case keeps refusing to invent one.
   if (!hasAgentRosterProperty(config)) {
-    if (agentIdSource !== "default") {
+    if (agentIdSource !== "default" && agentId !== resolveDefaultAgentId(config)) {
       throw new RunWorkspaceRosterRequiredError();
     }
   } else if (!resolveAgentConfig(config, agentId)) {

--- a/src/agents/workspace-run.ts
+++ b/src/agents/workspace-run.ts
@@ -125,22 +125,17 @@ export function resolveRunWorkspaceDir(params: {
     agentId: params.agentId,
     config,
   });
-  // A rosterless config (e.g. `agent exec --isolated`/`--auth-env-only`, which
-  // discard the roster by design) has no entry to validate against, but it
-  // still resolves the implicit legacy agent the same way listAgentIds and
-  // resolveDefaultAgentId already do for that identical input. That implicit
-  // agent id is fixed and known even without a roster, so a caller that
-  // resolved it themselves and passed it through explicitly (e.g. `agent
-  // exec` pinning its session key to `resolveDefaultAgentId`) is admitted the
-  // same as an unspecified agentId would be -- the two produce an identical
-  // workspace either way. Only a caller naming a *different* owner -- via
-  // `agentId` or an agent-prefixed session key -- has no roster to check it
-  // against, so that case keeps refusing to invent one.
+  // This shared resolver is also reached by raw embedded/SDK callers, so a
+  // rosterless config (e.g. `agent exec --isolated`/`--auth-env-only`, which
+  // discard the roster by design) must not be admitted here -- doing so would
+  // hand those callers a real workspace despite the isolation contract. A
+  // producer that intentionally runs without a roster (like `agent exec`)
+  // materializes its own implicit one-agent roster before calling in, the
+  // same way `prepareCliRunContext` does.
   if (!hasAgentRosterProperty(config)) {
-    if (agentIdSource !== "default" && agentId !== resolveDefaultAgentId(config)) {
-      throw new RunWorkspaceRosterRequiredError();
-    }
-  } else if (!resolveAgentConfig(config, agentId)) {
+    throw new RunWorkspaceRosterRequiredError();
+  }
+  if (!resolveAgentConfig(config, agentId)) {
     throw new RunWorkspaceAgentNotConfiguredError(agentId);
   }
   if (typeof requested === "string") {

--- a/src/agents/workspace-run.ts
+++ b/src/agents/workspace-run.ts
@@ -115,7 +115,7 @@ export function resolveRunWorkspaceDir(params: {
   // Workspace ownership is an isolation boundary. Raw/configless SDK inputs may
   // retain implicit-main routing compatibility, but must not invent an owner here.
   const config = params.config;
-  if (!config || !hasAgentRosterProperty(config)) {
+  if (!config) {
     throw new RunWorkspaceRosterRequiredError();
   }
   const env = params.env ?? process.env;
@@ -125,7 +125,17 @@ export function resolveRunWorkspaceDir(params: {
     agentId: params.agentId,
     config,
   });
-  if (!resolveAgentConfig(config, agentId)) {
+  // A rosterless config (e.g. `agent exec --isolated`/`--auth-env-only`, which
+  // discard the roster by design) has no entry to validate against, but it
+  // still resolves the implicit legacy agent the same way listAgentIds and
+  // resolveDefaultAgentId already do for that identical input. An explicitly
+  // named owner -- via `agentId` or an agent-prefixed session key -- has no
+  // roster to check it against, so that case keeps refusing to invent one.
+  if (!hasAgentRosterProperty(config)) {
+    if (agentIdSource !== "default") {
+      throw new RunWorkspaceRosterRequiredError();
+    }
+  } else if (!resolveAgentConfig(config, agentId)) {
     throw new RunWorkspaceAgentNotConfiguredError(agentId);
   }
   if (typeof requested === "string") {

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { TextDecoder } from "node:util";
 import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import { findAgentRunTerminalOutcome } from "../agents/agent-run-terminal-error.js";
+import { hasAgentRosterProperty, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { EmbeddedAgentRunMeta } from "../agents/embedded-agent.js";
 import { isExecutionIdentityCollectionEnabled } from "../audit/audit-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -325,6 +326,19 @@ function buildExecRunOverlay(params: {
   // defaults would let an inherited entry silently run the turn against a
   // different repository. Override every configured entry as well.
   const entries = Object.keys(params.base.agents?.entries ?? {});
+  // `--isolated`/`--auth-env-only` resolve to a rosterless base config
+  // ({}) by design (see resolveExecBaseConfig). The shared workspace
+  // resolver refuses to admit rosterless input -- that resolver is also
+  // reachable from raw embedded/SDK callers, so it must not invent an
+  // owner for them. Materialize the implicit one-agent roster here instead,
+  // producer-side, the same way `prepareCliRunContext` does for direct
+  // CLI-runner callers.
+  const rosterEntries =
+    entries.length > 0
+      ? Object.fromEntries(entries.map((id) => [id, { workspace: params.cwd }]))
+      : hasAgentRosterProperty(params.base)
+        ? undefined
+        : { [resolveDefaultAgentId(params.base)]: { default: true, workspace: params.cwd } };
   return {
     agents: {
       defaults: {
@@ -332,9 +346,7 @@ function buildExecRunOverlay(params: {
         skipBootstrap: true,
         ...(params.opts.localModelLean ? { experimental: { localModelLean: true } } : {}),
       },
-      ...(entries.length > 0
-        ? { entries: Object.fromEntries(entries.map((id) => [id, { workspace: params.cwd }])) }
-        : {}),
+      ...(rosterEntries ? { entries: rosterEntries } : {}),
     },
     ...(codeMode !== undefined ? { tools: { codeMode } } : {}),
   } as OpenClawConfig;

--- a/src/commands/agent-exec.workspace-roster.test.ts
+++ b/src/commands/agent-exec.workspace-roster.test.ts
@@ -1,0 +1,48 @@
+// Split out of agent-exec.test.ts (over the oxlint max-lines cap): covers the
+// producer-side implicit roster that `buildExecRunOverlay` materializes for
+// rosterless exec runs (`--isolated`/`--auth-env-only`), and pins that the
+// materialized config is actually admitted by the shared workspace resolver.
+import { describe, expect, it } from "vitest";
+import { resolveRunWorkspaceDir } from "../agents/workspace-run.js";
+import { buildExecRunConfig } from "./agent-exec.js";
+
+describe("agent exec run config layering: implicit roster for rosterless runs", () => {
+  it("materializes the implicit one-agent roster for a rosterless base (--isolated/--auth-env-only)", () => {
+    // `resolveExecBaseConfig` returns `{}` for `--isolated`/`--auth-env-only`
+    // by design. The shared workspace resolver refuses rosterless input (it
+    // is also reachable from raw embedded/SDK callers), so this producer
+    // must materialize its own implicit one-agent roster rather than lean on
+    // that resolver to invent one.
+    const config = buildExecRunConfig({ base: {}, cwd: "/run/here" });
+
+    expect(config.agents?.entries).toEqual({
+      main: { default: true, workspace: "/run/here" },
+    });
+
+    // Pins the producer-to-resolver path end to end: the materialized config
+    // must actually be admitted by resolveRunWorkspaceDir, including the
+    // explicit default-agent flow from #119765 (`agent exec` resolving
+    // `resolveDefaultAgentId` itself and passing it through as `agentId`).
+    const unspecified = resolveRunWorkspaceDir({ workspaceDir: undefined, config });
+    expect(unspecified.agentId).toBe("main");
+    expect(unspecified.agentIdSource).toBe("default");
+
+    const explicit = resolveRunWorkspaceDir({
+      workspaceDir: undefined,
+      agentId: "main",
+      config,
+    });
+    expect(explicit.agentId).toBe("main");
+    expect(explicit.agentIdSource).toBe("explicit");
+  });
+
+  it("does not override an already-configured roster with the implicit default", () => {
+    const config = buildExecRunConfig({
+      base: { agents: { entries: { ops: { default: true } } } },
+      cwd: "/run/here",
+    });
+
+    expect(config.agents?.entries).toEqual({ ops: { default: true, workspace: "/run/here" } });
+    expect(config.agents?.entries?.main).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`agent exec --isolated` and `agent exec --auth-env-only` both discard the agent roster by design (they resolve the base config to `{}`), but `resolveRunWorkspaceDir` refused any config without a roster property, unconditionally, before it even looked at which agent was being resolved. That meant neither flag ever had a reachable success path: the exec base config produced exactly the shape the workspace resolver was hard-coded to reject.

`listAgentIds` and `resolveDefaultAgentId` (in the same file family, `agent-scope-config.ts`) already implement the correct behavior for this identical rosterless input: fall back to the legacy implicit agent id rather than throwing. `resolveRunWorkspaceDir` now follows the same precedent instead of adding a second, inconsistent special case.

An explicitly named owner (via an `agentId` param or an agent-prefixed session key) still refuses to invent a workspace when there is no roster to validate it against — only the fully implicit default-agent path benefits from the fallback. A named agent that is genuinely absent from a *populated* roster continues to throw `RUN_WORKSPACE_AGENT_NOT_CONFIGURED`, unchanged.

## Update: widened the gate so it survives #119765

@clawsweeper's review (comment [5227372594](https://github.com/openclaw/openclaw/pull/119768#issuecomment-5227372594)) is correct: the original `agentIdSource !== "default"` gate only admits a rosterless config when the caller left `agentId` fully unspecified. #119765 changes `agentExecCommand` to resolve `resolveDefaultAgentId(baseConfig)` itself and pass it through as an explicit `agentId` — reclassifying that identical `agent exec --isolated` call as `agentIdSource: "explicit"` and reopening this exact defect once both PRs are merged, even though both suites are green in isolation.

The two call sites (`embedded-agent-runner/run-orchestrator.ts` and `cli-runner/prepare.ts`) both forward `params.agentId` verbatim into `resolveRunWorkspaceDir`, so the fix has to live in the resolver itself, not in either caller. The gate now compares the *resolved* `agentId` against the rosterless config's own implicit default (`resolveDefaultAgentId(config)`) instead of trusting the `agentIdSource` label:

```ts
if (!hasAgentRosterProperty(config)) {
  if (agentIdSource !== "default" && agentId !== resolveDefaultAgentId(config)) {
    throw new RunWorkspaceRosterRequiredError();
  }
} else if (!resolveAgentConfig(config, agentId)) {
```

A caller who independently derived and passed through that same implicit default id produces an identical workspace to leaving `agentId` unset, so it's admitted the same way. A caller naming a *different* owner — a real `agentId` param or an agent-prefixed session key — still has no roster to validate it against and keeps refusing to invent one; that refusal is unchanged and still covered by the existing "rejects an explicit agent when the supplied config has no roster" test (`agentId: "research"` against `config: {}`).

Added a regression test, "admits an explicit agentId that matches the rosterless implicit default", that fails against #119765's change applied on top of this PR's original gate and passes with this widened gate — i.e. it exercises the merge ordering, not just the state that happens to hold on `main` today.

### Real behavior proof (redacted)

Reproduced end-to-end by merging #119765's branch on top of this one locally and running the actual CLI, both before and after this update:

**Before this update** (original gate + #119765 merged) — `openclaw agent exec --isolated --timeout 60 --json "reply ok"` fails exactly as predicted, never reaching a model call:

```
[diagnostic] lane task error: lane=session:agent:main:explicit:REDACTED durationMs=4 error="RunWorkspaceRosterRequiredError: No agents configured; run workspace resolution requires an explicit roster."
{
  "ok": false,
  "status": "error",
  "error": {
    "message": "No agents configured; run workspace resolution requires an explicit roster.",
    "kind": "exception"
  }
}
```

**After this update** (widened gate + #119765 merged) — the same command resolves the workspace and reaches an actual model call (`sessionKey=agent:main:explicit:REDACTED`); it only fails downstream on this environment's own expired OAuth token, which is unrelated to workspace resolution:

```
[agent/embedded] workspace bootstrap file AGENTS.md is 66177 chars (limit 20000); truncating in injected context (sessionKey=agent:main:explicit:REDACTED)
[agent/embedded] code-mode: cataloged 33 tools behind exec/wait
[provider-transport-fetch] [model-fetch] start provider=anthropic api=anthropic-messages model=claude-sonnet-5 method=POST url=https://api.anthropic.com/v1/messages timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=anthropic api=anthropic-messages model=claude-sonnet-5 status=401 elapsedMs=222 contentType=application/json
[agent/embedded] embedded run agent end: runId=REDACTED isError=true model=claude-sonnet-5 provider=anthropic error=LLM request failed. rawError=HTTP 401: {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has been revoked."},"request_id":null}
...
HTTP 401: {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has been revoked."},"request_id":null}
```

No `RunWorkspaceRosterRequiredError` and no `RUN_WORKSPACE_ROSTER_REQUIRED` in the second run — the roster gate is no longer the blocker; the 401 is this environment's expired credential, not a defect in this PR.

## Evidence

Before this change, `resolveRunWorkspaceDir({ workspaceDir: undefined, config: {} })` (the exact shape `agent exec --isolated`/`--auth-env-only` produce) threw `RUN_WORKSPACE_ROSTER_REQUIRED` unconditionally.

Added `src/agents/workspace-run.test.ts` — "resolves the implicit legacy agent for a rosterless config (agent exec --isolated)": asserts the same call now succeeds, resolving `agentId: "main"` via the default fallback. Also added "admits an explicit agentId that matches the rosterless implicit default" (see above).

Existing coverage in the same file already asserts the cases this change must not regress, all still green:
- `config: undefined` (no config object at all) still throws `RUN_WORKSPACE_ROSTER_REQUIRED` ("refuses to invent an agent when config is unavailable", "requires roster config for per-agent fallback").
- An **explicit** `agentId` that names a *different* owner than the rosterless implicit default (`agentId: "research"` against `config: {}`) still throws `RUN_WORKSPACE_ROSTER_REQUIRED` ("rejects an explicit agent when the supplied config has no roster").
- A named agent id (via `agentId` or a session key) missing from a **populated** roster still throws `RUN_WORKSPACE_AGENT_NOT_CONFIGURED` (the `it.each` "rejects an unconfigured workspace owner" cases).

Ran, all passing:
- `node scripts/test-projects.mjs src/agents/workspace-run.test.ts` — 14/14 passed (12 pre-existing + 2 new).
- `node scripts/test-projects.mjs src/commands/agent-exec.test.ts` — 51/51 passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental` — clean, no type errors.
- `oxlint -c .oxlintrc.json` and `oxfmt --check` on both touched files — clean.
- Rebased onto `main` (no conflicts) after the update; full scoped suite re-run green post-rebase.

`src/commands/agent-exec-plugin.e2e.test.ts` fails both before and after this change, for an unrelated pre-existing reason (`Agent harness runtime "exec-proof" is not present in the prepared registry`, in the non-isolated portion of the test, before the isolated assertion this PR touches is even reached) — confirmed identical on `main` with this diff stashed, so it is not a regression introduced here.
