### PR TITLE
[AI-assisted] fix(skills): omit per-skill version rows from Codex skill catalogs

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -144,9 +144,9 @@ See [Timezones](/concepts/timezone) and [Date & Time](/date-time) for full behav
 
 ## Skills
 
-When eligible skills exist, OpenClaw injects a compact `<available_skills>` list (`formatSkillsForPrompt`) with the **file path** and a content-derived `<version>sha256:...</version>` marker per skill. The prompt instructs the model to use `read` to load the SKILL.md at the listed location (workspace, managed, or bundled), and to re-read a skill when its `<version>` differs from a previous turn. If no skills are eligible, the Skills section is omitted.
+When eligible skills exist, OpenClaw injects a compact `<available_skills>` list (`formatSkillsForPrompt`) with the **file path** and, on non-Codex harnesses, a content-derived `<version>sha256:...</version>` marker per skill. The prompt instructs the model to use `read` to load the SKILL.md at the listed location (workspace, managed, or bundled), and to re-read a skill when its `<version>` differs from a previous turn. If no skills are eligible, the Skills section is omitted.
 
-Native Codex turns receive this list as turn-scoped collaboration developer instructions instead of per-turn user input, except lightweight cron turns that preserve the exact scheduled prompt. Other harnesses keep the normal prompt section.
+Native Codex turns receive this list as turn-scoped collaboration developer instructions instead of per-turn user input, except lightweight cron turns that preserve the exact scheduled prompt. The Codex projection omits the per-skill `<version>` rows and the re-read reminder; other harnesses keep the normal prompt section.
 
 The location can point at a nested skill, such as `skills/personal/foo/SKILL.md`. Nesting is only organizational; the prompt uses the flat skill name from `SKILL.md` frontmatter.
 

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -563,13 +563,13 @@ function shouldInjectCodexOpenClawPromptContext(params: EmbeddedRunAttemptParams
 /** Renders loaded OpenClaw skill prompts as Codex collaboration instructions. */
 export function renderCodexSkillsCollaborationInstructions(params: {
   attempt: EmbeddedRunAttemptParams;
-  skillsPrompt?: string;
+  codexSkillsPrompt?: string;
 }): string | undefined {
   if (!shouldInjectCodexOpenClawPromptContext(params.attempt)) {
     return undefined;
   }
-  return params.skillsPrompt?.trim()
-    ? ["## OpenClaw Skills", "", params.skillsPrompt.trim()].join("\n")
+  return params.codexSkillsPrompt?.trim()
+    ? ["## OpenClaw Skills", "", params.codexSkillsPrompt.trim()].join("\n")
     : undefined;
 }
 

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -158,7 +158,7 @@ export async function prepareCodexAttemptContext(
   });
   const skillsCollaborationInstructions = renderCodexSkillsCollaborationInstructions({
     attempt: runtimeParams,
-    skillsPrompt: params.skillsSnapshot?.prompt,
+    codexSkillsPrompt: params.skillsSnapshot?.codexPrompt,
   });
   const promptState = {
     promptText: params.prompt,

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -470,7 +470,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     workspaceDir: effectiveWorkspace,
     developerInstructions: buildRenderedCodexDeveloperInstructions(),
     workspaceBootstrapContext,
-    skillsPrompt: skillsCollaborationInstructions ? (params.skillsSnapshot?.prompt ?? "") : "",
+    skillsPrompt: skillsCollaborationInstructions ? (params.skillsSnapshot?.codexPrompt ?? "") : "",
     tools: toolBridge.availableSpecs,
   });
   return {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1683,6 +1683,7 @@ describe("runCodexAppServerAttempt", () => {
     });
     params.skillsSnapshot = {
       prompt: "<available_skills><skill><name>demo</name></skill></available_skills>",
+      codexPrompt: "<available_skills><skill><name>demo</name></skill></available_skills>",
       skills: [],
     };
     const run = runCodexAppServerAttempt(params);
@@ -3597,6 +3598,7 @@ describe("runCodexAppServerAttempt", () => {
     params.bootstrapContextRunKind = "cron";
     params.skillsSnapshot = {
       prompt: "<available_skills><skill><name>demo</name></skill></available_skills>",
+      codexPrompt: "<available_skills><skill><name>demo</name></skill></available_skills>",
       skills: [],
     };
     const run = runCodexAppServerAttempt(params);
@@ -3639,6 +3641,7 @@ describe("runCodexAppServerAttempt", () => {
     params.bootstrapContextRunKind = "cron";
     params.skillsSnapshot = {
       prompt: "<available_skills><skill><name>demo</name></skill></available_skills>",
+      codexPrompt: "<available_skills><skill><name>demo</name></skill></available_skills>",
       skills: [],
     };
     const run = runCodexAppServerAttempt(params);

--- a/src/skills/loading/compact-format.test.ts
+++ b/src/skills/loading/compact-format.test.ts
@@ -149,6 +149,50 @@ describe("formatSkillsCompact", () => {
   });
 });
 
+describe("codex projection", () => {
+  it("omits version rows and reminder from the full catalog", () => {
+    const skills = [
+      { ...makeSkill("weather", "Get weather data"), promptVersion: "sha256:abc123" },
+      makeSkill("notes", "Summarize notes", "/tmp/notes/SKILL.md"),
+    ];
+    const out = formatSkillsForPrompt(skills, { projection: "codex" });
+    expect(out).toContain("<name>weather</name>");
+    expect(out).toContain("<description>Get weather data</description>");
+    expect(out).toContain("<location>/skills/weather/SKILL.md</location>");
+    expect(out).not.toContain("<version>");
+    expect(out).not.toContain("If a skill's <version> differs from a previous turn");
+    expect(formatSkillsForPrompt(skills)).toContain("<version>sha256:abc123</version>");
+    expect(formatSkillsForPrompt(skills)).toContain(
+      "If a skill's <version> differs from a previous turn",
+    );
+  });
+
+  it("omits version rows and reminder from the compact catalog", () => {
+    const skills = [
+      { ...makeSkill("weather", "Get weather data"), promptVersion: "sha256:abc123" },
+    ];
+    const out = formatSkillsCompact(skills, { projection: "codex" });
+    expect(out).toContain("<name>weather</name>");
+    expect(out).toContain("<description>Get weather data</description>");
+    expect(out).toContain("<location>/skills/weather/SKILL.md</location>");
+    expect(out).not.toContain("<version>");
+    expect(out).not.toContain("If a skill's <version> differs from a previous turn");
+    expect(formatSkillsCompact(skills)).toContain("<version>sha256:abc123</version>");
+    expect(formatSkillsCompact(skills)).toContain(
+      "If a skill's <version> differs from a previous turn",
+    );
+  });
+
+  it("preserves location notes in the codex projection", () => {
+    const out = formatSkillsForPrompt(
+      [{ ...makeSkill("remote", "Remote skill"), locationNote: "Load with exec host=node." }],
+      { projection: "codex" },
+    );
+    expect(out).toContain("<location_note>Load with exec host=node.</location_note>");
+    expect(out).not.toContain("<version>");
+  });
+});
+
 describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
   let envSnapshot: SkillsHomeEnvSnapshot;
 

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -9,7 +9,10 @@ import { addIgnoreRules, toPosixPath, type IgnoreMatcher } from "../../shared/ig
 import { expandTildePath } from "../../shared/tilde-path.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
 import { parseFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
-import { formatSkillsForPrompt as formatSkillContractForPrompt } from "./skill-contract.js";
+import {
+  formatSkillsForPrompt as formatSkillContractForPrompt,
+  type SkillPromptProjection,
+} from "./skill-contract.js";
 import { computeSkillPromptVersion } from "./skill-version.js";
 
 /** Max name length per spec */
@@ -268,9 +271,12 @@ function loadSkillFromFile(
  * Skills with disableModelInvocation=true are excluded from the prompt
  * (they can only be invoked explicitly via /skill:name commands).
  */
-export function formatSkillsForPrompt(skills: Skill[]): string {
+export function formatSkillsForPrompt(
+  skills: Skill[],
+  opts?: { projection?: SkillPromptProjection },
+): string {
   const visibleSkills = skills.filter((s) => !s.disableModelInvocation);
-  return formatSkillContractForPrompt(visibleSkills);
+  return formatSkillContractForPrompt(visibleSkills, opts);
 }
 
 interface LoadSkillsOptions {

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -1,6 +1,8 @@
 // Skill contract types describe loaded skill metadata, sources, and prompt surfaces.
 import type { SourceInfo } from "../../agents/sessions/source-info.js";
 
+export type SkillPromptProjection = "default" | "codex";
+
 export interface Skill {
   name: string;
   description: string;
@@ -35,14 +37,22 @@ function escapeXml(str: string): string {
  * package root on the cold skills path. Visibility policy is applied upstream
  * before calling this helper.
  */
-export function formatSkillsForPrompt(skills: Skill[]): string {
+export function formatSkillsForPrompt(
+  skills: Skill[],
+  opts?: { projection?: SkillPromptProjection },
+): string {
   if (skills.length === 0) {
     return "";
   }
+  const omitVersions = opts?.projection === "codex";
   const lines = [
     "\n\nThe following skills provide specialized instructions for specific tasks.",
     "Use the read tool to load a skill's file when the task matches its description.",
-    "If a skill's <version> differs from a previous turn, re-read its SKILL.md before using it.",
+    ...(omitVersions
+      ? []
+      : [
+          "If a skill's <version> differs from a previous turn, re-read its SKILL.md before using it.",
+        ]),
     "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
     "",
     "<available_skills>",
@@ -55,7 +65,7 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
     if (skill.locationNote) {
       lines.push(`    <location_note>${escapeXml(skill.locationNote)}</location_note>`);
     }
-    if (skill.promptVersion) {
+    if (!omitVersions && skill.promptVersion) {
       lines.push(`    <version>${escapeXml(skill.promptVersion)}</version>`);
     }
     lines.push("  </skill>");

--- a/src/skills/loading/workspace-snapshot.test.ts
+++ b/src/skills/loading/workspace-snapshot.test.ts
@@ -11,6 +11,7 @@ import {
   setMockSkillsHomeEnv,
   type SkillsHomeEnvSnapshot,
 } from "../test-support/home-env.test-support.js";
+import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
 import { buildWorkspaceSkillSnapshot, buildWorkspaceSkillsPrompt } from "./workspace.js";
 
 vi.mock("./plugin-skills.js", () => ({
@@ -242,6 +243,28 @@ describe("buildWorkspaceSkillSnapshot", () => {
     expect(afterVersion).toMatch(/^sha256:[a-f0-9]{16}$/);
     expect(afterVersion).not.toBe(beforeVersion);
     expect(after.prompt).toContain("If a skill's <version> differs from a previous turn");
+  });
+
+  it("produces a version-free codexPrompt while keeping the default prompt versioned", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "versioned"),
+      name: "versioned",
+      description: "Versioned skill",
+      body: "# versioned\nfirst body\n",
+    });
+
+    const snapshot = buildSnapshot(workspaceDir);
+
+    expect(snapshot.prompt).toContain("<version>");
+    expect(snapshot.prompt).toContain("If a skill's <version> differs from a previous turn");
+    expect(snapshot.prompt).toContain("<name>versioned</name>");
+    expect(snapshot.codexPrompt).toContain("<name>versioned</name>");
+    expect(snapshot.codexPrompt).not.toContain("<version>");
+    expect(snapshot.codexPrompt).not.toContain(
+      "If a skill's <version> differs from a previous turn",
+    );
+    expect(snapshot.promptFormatVersion).toBe(WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION);
   });
 
   it("truncates the skills prompt when it exceeds the configured char budget", async () => {

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -54,7 +54,7 @@ import {
 } from "./local-loader.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
-import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
+import { formatSkillsForPrompt, type Skill, type SkillPromptProjection } from "./skill-contract.js";
 import { resolveSkillTelemetrySource } from "./source.js";
 import { resolveAllowedSkillSymlinkTargetRealPaths, tryRealpath } from "./symlink-targets.js";
 
@@ -1352,7 +1352,7 @@ function truncateSkillDescription(description: string, maxChars: number): string
  */
 export function formatSkillsCompact(
   skills: Skill[],
-  opts?: { descriptionMaxChars?: number },
+  opts?: { descriptionMaxChars?: number; projection?: SkillPromptProjection },
 ): string {
   if (skills.length === 0) {
     return "";
@@ -1361,12 +1361,17 @@ export function formatSkillsCompact(
     0,
     Math.floor(opts?.descriptionMaxChars ?? COMPACT_DESCRIPTION_MAX_CHARS),
   );
+  const omitVersions = opts?.projection === "codex";
   const lines = [
     "\n\nThe following skills provide specialized instructions for specific tasks.",
     descriptionMaxChars > 0
       ? "Use the read tool to load a skill's file when the task matches its name or description."
       : "Use the read tool to load a skill's file when the task matches its name.",
-    "If a skill's <version> differs from a previous turn, re-read its SKILL.md before using it.",
+    ...(omitVersions
+      ? []
+      : [
+          "If a skill's <version> differs from a previous turn, re-read its SKILL.md before using it.",
+        ]),
     "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
     "",
     "<available_skills>",
@@ -1384,7 +1389,7 @@ export function formatSkillsCompact(
     if (skill.locationNote) {
       lines.push(`    <location_note>${escapeXml(skill.locationNote)}</location_note>`);
     }
-    if (skill.promptVersion) {
+    if (!omitVersions && skill.promptVersion) {
       lines.push(`    <version>${escapeXml(skill.promptVersion)}</version>`);
     }
     lines.push("  </skill>");
@@ -1422,6 +1427,7 @@ function buildRenderedSkillsPrompt(params: {
   total: number;
   format: SkillsPromptFormat;
   includeLimitNote?: boolean;
+  projection?: SkillPromptProjection;
 }): string {
   // resolveCodeModeSkills in src/agents/code-mode-skills.ts parses this exact format; update both together.
   // The production-renderer parity test in src/agents/code-mode.test.ts enforces this coupling.
@@ -1439,8 +1445,9 @@ function buildRenderedSkillsPrompt(params: {
     params.format.kind === "compact"
       ? formatSkillsCompact(params.skills, {
           descriptionMaxChars: params.format.descriptionMaxChars,
+          projection: params.projection,
         })
-      : formatSkillsForPrompt(params.skills);
+      : formatSkillsForPrompt(params.skills, { projection: params.projection });
   return [params.remoteNote, limitNote, catalog].filter(Boolean).join("\n");
 }
 
@@ -1449,6 +1456,7 @@ function applySkillsPromptLimits(params: {
   config?: OpenClawConfig;
   agentId?: string;
   remoteNote?: string;
+  projection?: SkillPromptProjection;
 }): string {
   const limits = resolveSkillsLimits(params.config, params.agentId);
   const total = params.skills.length;
@@ -1470,6 +1478,7 @@ function applySkillsPromptLimits(params: {
         total,
         format,
         includeLimitNote,
+        projection: params.projection,
       });
       if (prompt.length <= limits.maxSkillsPromptChars) {
         return prompt;
@@ -1564,9 +1573,18 @@ export function buildWorkspaceSkillSnapshot(
   opts?: WorkspaceSkillBuildOptions & { snapshotVersion?: number },
 ): SkillSnapshot {
   const { eligible, prompt, resolvedSkills } = resolveWorkspaceSkillPromptState(workspaceDir, opts);
+  const codexPrompt =
+    eligible.length === 0
+      ? ""
+      : resolveWorkspaceSkillPromptState(workspaceDir, {
+          ...opts,
+          entries: eligible,
+          projection: "codex",
+        }).prompt;
   const skillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
   return {
     prompt,
+    codexPrompt,
     skills: eligible.map((entry) => ({
       name: entry.skill.name,
       skillKey: resolveSkillKey(entry.skill, entry),
@@ -1605,6 +1623,7 @@ type WorkspaceSkillBuildOptions = {
   skillFilter?: string[];
   skillOverrides?: Record<string, boolean>;
   eligibility?: SkillEligibilityContext;
+  projection?: SkillPromptProjection;
 };
 
 function resolveEffectiveWorkspaceSkillFilter(
@@ -1656,6 +1675,7 @@ function resolveWorkspaceSkillPromptState(
     config: opts?.config,
     agentId: opts?.agentId,
     remoteNote,
+    projection: opts?.projection,
   });
   return { eligible, prompt, resolvedSkills };
 }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -117,10 +117,12 @@ export type SkillEligibilityContext = {
   };
 };
 
-export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 3;
+export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 4;
 
 export type SkillSnapshot = {
   prompt: string;
+  /** Version-free projection of this catalog for Codex, which re-reads skills on its own. */
+  codexPrompt?: string;
   skills: Array<{
     name: string;
     /** Config key can differ from the prompt-facing skill name. */


### PR DESCRIPTION
Closes #119738.

## What Problem This Solves

Fixes an issue where the OpenClaw skills catalog rendered for Codex included persistent per-skill `<version>sha256:...</version>` rows and a version-change reminder that consume about 1.15K tokens and 2,820 characters for a 60-skill catalog, while Codex's continuing-thread behavior does not reliably re-emit changed collaboration instructions in the same `default` mode. This made the signal weak for Codex while still costing persistent context.

## Why This Change Was Made

This change adds a typed `SkillPromptProjection` seam (`"default" | "codex"`) to the shared skills formatter so the Codex projection can omit per-skill version rows and the version-change reminder, while other harnesses keep the current version-bearing output unchanged. `buildWorkspaceSkillSnapshot` now builds both the default `prompt` and a version-free `codexPrompt`; the Codex app-server consumes the `codexPrompt` for collaboration instructions and the system prompt report. The bump to `WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 4` ensures existing snapshots are rebuilt with the new field.

## User Impact

- Codex-backed sessions receive a smaller skills catalog that drops the per-skill `<version>` rows and the re-read reminder.
- Non-Codex sessions, skill loading, and the `promptVersion` hash producers are unchanged.
- No new configuration option or parallel renderer is introduced.

## Evidence

- Preflight: `python3 scripts/preflight_ship.py --repo openclaw/openclaw --local openclaw-119738 --branch main --issue 119738 --file src/skills/loading/skill-contract.ts --must-contain "If a skill's <version> differs from a previous turn" --search '119738 in:body'` returned `PREFLIGHT CLEAR`.
- Typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json ...` and `node scripts/run-tsgo.mjs -p tsconfig.extensions.json ...` both pass.
- Format: `oxfmt --check` on all changed files passes.
- Targeted unit tests pass:
  - `src/skills/loading/compact-format.test.ts` (44 tests)
  - `src/skills/loading/workspace-snapshot.test.ts` (12 tests)
  - `extensions/codex/src/app-server/attempt-context.test.ts` (6 tests)
- Full `extensions/codex/src/app-server/run-attempt.test.ts` integration suite is blocked in this environment by an unrelated Node/SQLite runtime version check, not by the changed code.
- Direct Codex source cross-checks:
  - `../codex/codex-rs/skills/src/model.rs:7-19` — native skill metadata has no content-version field.
  - `../codex/codex-rs/core-skills/src/render.rs:518-534` — native catalog rows contain name, description, and path only.
  - `../codex/codex-rs/core/src/context/world_state/collaboration_mode.rs:30-57` — world-state diffing compares only `ModeKind`, so changed developer instructions under the same `default` mode may not re-emit.