### PR TITLE
fix(agents): fence restart recovery to gateway lifecycle

### DIFF
--- a/src/agents/subagent-registry-restart-recovery.test.ts
+++ b/src/agents/subagent-registry-restart-recovery.test.ts
@@ -506,6 +506,20 @@ describe("subagent registry restart recovery", () => {
     expect(dispatchAgent).not.toHaveBeenCalled();
   });
 
+  it("does not reserve when the Gateway lifecycle rotates during transcript recovery", async () => {
+    const entry = run();
+    mocks.readSessionMessages.mockImplementationOnce(async () => {
+      rotateAgentEventLifecycleGeneration();
+      return [];
+    });
+
+    await expect(recover(entry)).resolves.toEqual({ status: "handled" });
+
+    expect(reserveLaunch).not.toHaveBeenCalled();
+    expect(markLaunchAttempted).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
+  });
+
   it("never overwrites a consumed attempt when the mutable session marker advances", async () => {
     const entry = run({
       execution: {

--- a/src/agents/subagent-registry-restart-recovery.ts
+++ b/src/agents/subagent-registry-restart-recovery.ts
@@ -274,6 +274,7 @@ export async function recoverInterruptedSubagentRow(
   const acceptedRecoveryCurrent =
     initialRecoveryReceipt?.phase === "accepted" && params.isCurrent();
   const isRecoverySourceCurrent = () =>
+    isRecoveryAttemptLifecycleCurrent() &&
     params.isCurrent() &&
     params.entry.pauseReason !== "sessions_yield" &&
     params.entry.suppressAnnounceReason !== "steer-restart" &&
@@ -542,7 +543,7 @@ export async function recoverInterruptedSubagentRow(
           expected: params.entry,
           sessionMarker: marker,
           idempotencyKey,
-          lifecycleGeneration: agentEvents.getAgentEventLifecycleGeneration(),
+          lifecycleGeneration: recoveryLifecycleGeneration,
         });
         if (!attempted || attempted.phase === "accepted") {
           earlyResult = { status: "handled" };

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -931,6 +931,7 @@ export function createSubagentRunManager(params: {
       entry !== markParams.expected ||
       receipt?.sessionMarker !== markParams.sessionMarker ||
       receipt.idempotencyKey !== markParams.idempotencyKey ||
+      !isAgentEventLifecycleGenerationCurrent(markParams.lifecycleGeneration) ||
       typeof entry.execution.endedAt === "number" ||
       entry.killReconciliation !== undefined ||
       entry.killIntent !== undefined ||

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -45,6 +45,7 @@ import {
   SUBAGENT_ENDED_REASON_ERROR,
   SUBAGENT_ENDED_REASON_KILLED,
 } from "./subagent-lifecycle-events.js";
+import { createSubagentRunManager } from "./subagent-registry-run-manager.js";
 import type {
   ContextEngineSubagentEndedParams,
   SubagentRunRecord,
@@ -1993,6 +1994,77 @@ describe("subagent registry seam flow", () => {
     await vi.advanceTimersByTimeAsync(1);
 
     expect(mocks.dispatchRecoveryAgent).not.toHaveBeenCalled();
+  });
+
+  it("keeps a reserved recovery receipt reusable when its lifecycle retires", () => {
+    const runId = "run-recovery-lifecycle-fence";
+    const entry = createSubagentRunRecord({
+      runId,
+      task: "resume only in the owning Gateway lifecycle",
+      execution: { status: "interrupted", startedAt: Date.now() - 25_000 },
+    });
+    const runs = new Map([[runId, entry]]);
+    const persistOrThrow = vi.fn();
+    const manager = createSubagentRunManager({
+      runs,
+      getRunsForChildSession: () => runs.values(),
+      resumedRuns: new Set(),
+      persist: vi.fn(),
+      persistOrThrow,
+      callGateway: mocks.callGateway as typeof import("../gateway/call.js").callGateway,
+      getRuntimeConfig: mocks.getRuntimeConfig,
+      ensureListener: noop,
+      startSweeper: noop,
+      stopSweeper: noop,
+      resumeSubagentRun: noop,
+      clearPendingLifecycleError: noop,
+      clearPendingLifecycleTimeout: noop,
+      resolveSubagentWaitTimeoutMs: () => 1_000,
+      scheduleSweep: noop,
+      resolveSubagentSessionCompletion: () => null,
+      resolveSubagentSessionStartedAt: () => undefined,
+      notifyContextEngineSubagentEnded: async () => {},
+      completeCleanupBookkeeping: noop,
+      completeSubagentRun: async () => {},
+      resolveSubagentTask: () => ({ lookup: "unavailable" }),
+    });
+    const idempotencyKey = "subagent-recovery:lifecycle-fence";
+    expect(
+      manager.reserveSubagentRestartRecoveryLaunch({
+        runId,
+        expected: entry,
+        sessionId: "session-id",
+        sessionMarker: "session-id:333",
+        idempotencyKey,
+      }),
+    ).toBe(idempotencyKey);
+    const reserved = entry.execution.restartRecovery;
+    expect(reserved).toMatchObject({ phase: "reserved" });
+    expect(reserved).not.toHaveProperty("lifecycleGeneration");
+
+    mocks.lifecycleGeneration = "retired-generation";
+    expect(
+      manager.markSubagentRestartRecoveryLaunchAttempted({
+        runId,
+        expected: entry,
+        sessionMarker: "session-id:333",
+        idempotencyKey,
+        lifecycleGeneration: "test-generation",
+      }),
+    ).toBeUndefined();
+    expect(entry.execution.restartRecovery).toBe(reserved);
+    expect(persistOrThrow).toHaveBeenCalledOnce();
+
+    expect(
+      manager.markSubagentRestartRecoveryLaunchAttempted({
+        runId,
+        expected: entry,
+        sessionMarker: "session-id:333",
+        idempotencyKey,
+        lifecycleGeneration: "retired-generation",
+      }),
+    ).toMatchObject({ phase: "attempted", idempotencyKey });
+    expect(persistOrThrow).toHaveBeenCalledTimes(2);
   });
 
   it("keeps parent run active when agent.wait times out before child session settles", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where interrupted subagent recovery could continue after the Gateway lifecycle that started it had retired, allowing stale restart work to dispatch through the replacement lifecycle.

Release note: Fixes a race where interrupted subagent recovery could dispatch through a retired Gateway lifecycle after restart.

## Why This Change Was Made

The root cause was split across the restart-recovery and run-manager owner boundary: recovery's source-current predicate checked row and session identity but omitted its captured Gateway lifecycle generation, while the durable `reserved -> attempted` transition accepted a supplied stale generation. That let stale recovery work stamp the replacement generation after an await.

The canonical fix carries the captured lifecycle through recovery admission and into `markLaunchAttempted`, while the run manager rejects a stale supplied generation before mutating or persisting the at-most-once receipt.

## User Impact

When the Gateway lifecycle rotates during transcript recovery, the stale recovery returns as handled without reserving a launch, marking an attempt, or dispatching. The active lifecycle remains responsible for any subsequent recovery.

There are no config, schema, dependency, performance, index, or scheduling changes.

## Evidence

- Exact commit: `67beead1b7f205d6f63ae387c1f6b2bc6a7c8d60`
- Production delta: `+3/-1`, net `+2`; tests: `+86`
- Restart-recovery focused suite: `27/27`
- Direct run-manager stale-generation contract: `1/1`
- Orphan restart integration suite: `8/8`
- Sibling proof covers both the durable run-manager transition and cold-restart orphan recovery behavior.
- Exact-head Blacksmith `core, coreTests` check passed: https://github.com/openclaw/openclaw/actions/runs/31056517970
- Structured branch autoreview: no P0/P1 findings

- [x] This PR is AI-assisted.
- [x] I understand what the code does.
- [x] I ran autoreview and addressed all actionable findings.
