### PR TITLE
fix: grant administrator access through host-issued Control UI links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI owner handoff:** give browsers opened by host-issued dashboard and graphical onboarding links durable administrator access, including same-browser recovery from a limited credential, while keeping generic, Telegram, mobile, and ordinary scope-upgrade paths bounded. Thanks @shakkernerd.
 - **Control UI agent and skill permissions:** gate Agents, Skills, Skill Workshop, and delayed mutation dispatches by the current Gateway method catalog and operator scopes while preserving read-only browsing and legacy Gateway compatibility. Fixes #119176. Thanks @shakkernerd.
 - **Guided onboarding skip-UI routing:** keep `openclaw onboard --skip-ui` and `openclaw setup --skip-ui` on guided onboarding while skipping both browser and terminal handoffs, instead of silently switching to the classic wizard. Thanks @shakkernerd.
 - **Telegram durable ingress:** preserve pre-identity control-lane ownership during replay and attempt each drain snapshot row only once per pass, preventing targeted commands from spinning the spool and blocking polling shutdown.

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -8,9 +8,10 @@ title: "Dashboard"
 
 # `openclaw dashboard`
 
-Open the Control UI with a short-lived, one-time browser pairing link. A successful handoff leaves
-that browser with its own durable device credential, so reopening the dashboard does not depend on
-the shared Gateway token.
+Open the Control UI with a short-lived, one-time owner pairing link. A successful handoff gives that
+signed browser a durable administrator device credential, so reopening the dashboard does not depend
+on the shared Gateway token. Opening a fresh handoff in the same browser can also repair a previously
+limited device credential.
 
 ```bash
 openclaw dashboard
@@ -43,7 +44,7 @@ Notes:
 - Resolves configured `gateway.auth.token` SecretRefs when possible.
 - `browserUrl` carries a single-use, ten-minute bootstrap in the URL fragment. The Control UI strips
   it immediately, binds it to the browser's signed device identity, and stores only the resulting
-  per-device credential.
+  administrator per-device credential. Another browser profile cannot inherit or replay that grant.
 - Follows `gateway.tls.enabled`: TLS-enabled gateways print/open `https://` Control UI URLs and connect over `wss://`.
 - For `lan` or a wildcard `custom` bind, same-host launches always use loopback because a wildcard is not a browser destination. Plaintext `tailnet` and `custom` binds also use `127.0.0.1` so the browser has a secure context; TLS-enabled specific hosts keep the configured address so certificate names match.
 - Before delivering an authenticated loopback URL for a specific-interface bind, the command probes the configured interface and verifies that it and `127.0.0.1` are owned by the same Gateway process. Ambiguous listener ownership fails closed with status guidance.

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -145,11 +145,13 @@ are matched through your configured model and ClawHub search, and the step can
 be disabled with [`wizard.appRecommendations`](/gateway/configuration-reference#wizard).
 In a macOS, Linux, or Windows desktop session, it then opens the authenticated
 Control UI dashboard and waits up to 60 seconds for the browser client to
-connect. On headless Linux or over SSH, it prints a prominent copy-pasteable
-dashboard URL, including an SSH port-forward command for a loopback Gateway,
-and waits up to five minutes. A successful connection continues in the browser;
-an unreachable Gateway or a timeout falls back to the same terminal hatch as
-before. Pass `--tui` to skip the browser handoff and force that terminal hatch.
+connect. The short-lived handoff gives that exact signed browser a durable
+administrator credential. On headless Linux or over SSH, it prints a prominent
+copy-pasteable dashboard URL, including an SSH port-forward command for a
+loopback Gateway, and waits up to five minutes. A successful connection
+continues in the browser; an unreachable Gateway or a timeout falls back to the
+same terminal hatch as before. Pass `--tui` to skip the browser handoff and
+force that terminal hatch.
 If applying setup fails, onboarding falls back to the conversational OpenClaw
 chat to finish interactively. Channels, agents,
 plugins, and other optional features remain OpenClaw chat territory: run

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -92,6 +92,14 @@ An already-paired device does not get broader access silently: a reconnect
 that asks for a broader role or broader scopes creates a new pending upgrade
 request.
 
+The explicit exception is the administrator-capable Control UI owner profile
+issued directly on the Gateway host by `openclaw dashboard` or graphical
+onboarding. Its short-lived, single-use bootstrap can approve the exact closed
+scope set for a fresh browser or upgrade an existing limited credential only
+when it binds to that same signed browser keypair. Generic Control UI and
+Telegram handoffs, mobile setup profiles, shared credentials, locality, and
+caller-selected scopes do not receive this exception.
+
 Approving a device request:
 
 - A request with no operator role does not need operator scope approval.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -47,7 +47,7 @@ Onboarding usually configures a gateway token for shared-secret auth. If the Gat
 
 ## Device pairing (first connection)
 
-After gateway auth succeeds, connecting from a new browser or device usually requires a **one-time pairing approval**, shown as `disconnected (1008): pairing required`. On the Gateway host, `openclaw dashboard` is the preferred recovery path: it opens a short-lived, single-use pairing link and leaves the browser with a durable per-device credential.
+After gateway auth succeeds, connecting from a new browser or device usually requires a **one-time pairing approval**, shown as `disconnected (1008): pairing required`. On the Gateway host, `openclaw dashboard` is the preferred owner path: it opens a short-lived, single-use pairing link and leaves that exact signed browser with a durable administrator credential. Opening a fresh link in the same browser also repairs a previously limited credential; another browser profile cannot inherit or replay the grant.
 
 <Warning>
 When upgrading directly from a release that used the retired
@@ -78,7 +78,7 @@ silently discarding the old key.
 
 If the browser retries pairing with changed auth details (role/scopes/public key), the previous pending request is superseded and a new `requestId` is created; re-run `openclaw devices list` before approving.
 
-Switching an already-paired remote browser from read access to write/admin access is treated as an approval upgrade, not a silent reconnect: OpenClaw keeps the old approval active, blocks the broader reconnect, and asks you to approve the new scope set explicitly. A qualifying direct-loopback Control UI connection can silently approve the upgrade after it authenticates.
+Switching an already-paired browser from read access to write/admin access through ordinary stored or shared credentials is treated as an approval upgrade, not a silent reconnect: OpenClaw keeps the old approval active, blocks the broader reconnect, and asks you to approve the new scope set explicitly. The narrow exception is a fresh owner handoff issued on the Gateway host by `openclaw dashboard` or graphical onboarding; it can upgrade only the same signed browser that redeems that one-time handoff.
 
 Once approved, the device is remembered and won't require re-approval unless you revoke it with `openclaw devices revoke --device <id> --role <role>`. See [Devices CLI](/cli/devices) for token rotation, revocation, and the Paperclip / `openclaw_gateway` first-run approval flow.
 

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -87,7 +87,7 @@ Non-goals for v1:
 - Confirm the gateway is reachable: local `openclaw status`; remote, SSH tunnel `ssh -N -L 18789:127.0.0.1:18789 user@gateway-host` then open `http://127.0.0.1:18789/`.
 - For `AUTH_TOKEN_MISMATCH`, clients may do one trusted retry with a cached device token when the gateway returns retry hints; that retry reuses the token's cached approved scopes (explicit `deviceToken`/`scopes` callers keep their requested scope set). If auth still fails after that retry, resolve token drift manually.
 - For `AUTH_SCOPE_MISMATCH`, the device token was recognized but does not carry the requested scopes; re-pair or approve the new scope set instead of rotating the shared gateway token.
-- Outside that retry path, connect auth precedence is: explicit shared token/password, then explicit `deviceToken`, then stored device token, then bootstrap token.
+- Outside that retry path, the Control UI prefers a pending bootstrap token so a fresh host-issued handoff can create or upgrade the browser credential. Without a pending bootstrap, explicit shared token/password take precedence over the stored device token.
 - On the async Tailscale Serve path, failed attempts for the same `{scope, ip}` are serialized before the failed-auth limiter records them, so a second concurrent bad retry can already show `retry later`.
 - For token drift repair steps, see [Token drift recovery checklist](/cli/devices#token-drift-recovery-checklist).
 - Retrieve or supply the shared secret from the gateway host:

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -35,7 +35,8 @@ The Control UI is an **admin surface** (chat, config, exec approvals). Do not ex
 
 - After onboarding, the CLI auto-opens the dashboard and prints a clean link.
 - Re-open or repair a browser anytime: `openclaw dashboard`. It copies/opens a single-use pairing link
-  that replaces stale browser credentials without granting blanket remote auto-approval.
+  that grants administrator access to that exact signed browser, including recovery from a previously
+  limited credential, without granting blanket remote auto-approval.
 - If clipboard and browser delivery both fail, `openclaw dashboard` either gives a safe manual-token
   hint or tells you to run `openclaw dashboard --json` and open its short-lived `browserUrl`; it never
   prints the shared token value in interactive logs.
@@ -49,7 +50,8 @@ The Control UI is an **admin surface** (chat, config, exec approvals). Do not ex
   is kept in sessionStorage for the current tab and selected gateway URL, not localStorage.
 - **Host-authorized browser handoff**: `openclaw dashboard` issues a short-lived, single-use bootstrap
   instead of putting the shared Gateway token in the browser launch URL. The bootstrap is bound to
-  that browser's signed device identity and exchanged for a durable per-device credential.
+  that browser's signed device identity and exchanged for a durable administrator credential. A
+  different browser profile cannot redeem the same handoff or inherit the resulting access.
 - **Missing-config runtime token**: if startup says it generated a runtime token, that token is ephemeral and cannot be recovered. Loopback still requires auth. Run `openclaw doctor --generate-gateway-token`, restart the Gateway, then run `openclaw gateway auth-token --show` in an interactive terminal and paste the output into Control UI settings.
 - If `gateway.auth.token` is SecretRef-managed, the interactive dashboard handoff still works because
   it carries only the short-lived browser bootstrap; the external shared token is not placed in
@@ -69,7 +71,9 @@ Requirements:
 - Run `/dashboard` in a DM with the bot. Group invocations only tell you to open the command in DM and do not include a button.
 - Docker installs: Serve/Funnel modes require the gateway to bind loopback next to `tailscaled`, which bridge networking with published ports cannot satisfy. Run the gateway container with `network_mode: host` and mount the host `tailscaled` socket (`/var/run/tailscale`) plus the `tailscale` CLI into the container.
 
-The Mini App performs a one-time owner handoff and redirects to Control UI with a short-lived bootstrap token. It does not expose a shared gateway token in the URL.
+The Mini App performs a bounded one-time dashboard handoff and redirects to Control UI with a
+short-lived bootstrap token. It does not expose a shared gateway token in the URL, and it does not
+receive the administrator grant reserved for handoffs issued directly by the Gateway host.
 
 Non-goals for v1:
 

--- a/src/commands/control-ui-handoff.ts
+++ b/src/commands/control-ui-handoff.ts
@@ -7,6 +7,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveGatewayAuthToken } from "../gateway/auth-token-resolution.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
+import {
+  CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM,
+  CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT,
+} from "../gateway/control-ui-contract.js";
 import { CONTROL_UI_ASSETS_BUILD_TIMEOUT_MS } from "../infra/control-ui-assets.js";
 import { issueDeviceBootstrapToken } from "../infra/device-bootstrap.js";
 import { readResponseTextSnippet } from "../infra/http-body.js";
@@ -15,7 +19,7 @@ import { isSameProcessSpecificIpv4WithLoopbackListeners } from "../infra/ports-f
 import { inspectPortUsage } from "../infra/ports-inspect.js";
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
-import { BOOTSTRAP_HANDOFF_OPERATOR_SCOPES } from "../shared/device-bootstrap-profile.js";
+import { CONTROL_UI_OWNER_BOOTSTRAP_PROFILE } from "../shared/device-bootstrap-profile.js";
 import { sleep } from "../utils.js";
 import { resolveControlUiLinks } from "./onboard-helpers.js";
 
@@ -143,14 +147,14 @@ export async function issueControlUiBrowserHandoff(httpUrl: string): Promise<{
   expiresAtMs: number;
 }> {
   const issued = await issueDeviceBootstrapToken({
-    profile: {
-      roles: ["operator"],
-      scopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
-      purpose: "control-ui",
-    },
+    profile: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
+  });
+  const fragment = new URLSearchParams({
+    bootstrapToken: issued.token,
+    [CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM]: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT,
   });
   return {
-    browserUrl: `${httpUrl}#bootstrapToken=${encodeURIComponent(issued.token)}`,
+    browserUrl: `${httpUrl}#${fragment.toString()}`,
     expiresAtMs: issued.expiresAtMs,
   };
 }

--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -143,20 +143,22 @@ describe("dashboardCommand", () => {
       profile: {
         roles: ["operator"],
         scopes: [
+          "operator.admin",
           "operator.approvals",
+          "operator.pairing",
           "operator.questions",
           "operator.read",
           "operator.talk.secrets",
           "operator.write",
         ],
-        purpose: "control-ui",
+        purpose: "control-ui-owner",
       },
     });
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expect(runtime.log).toHaveBeenCalledWith(
       "Opened in your browser. Keep that tab to control OpenClaw.",
@@ -174,10 +176,10 @@ describe("dashboardCommand", () => {
 
     // Clipboard and browser receive only the short-lived browser bootstrap.
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
 
     // The logged output must never contain the token — it flows into
@@ -323,7 +325,7 @@ describe("dashboardCommand", () => {
     await dashboardCommand(runtime);
 
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expectNoLogWith("Token auto-auth unavailable");
     expectNoLogWith("missing env var");
@@ -344,10 +346,10 @@ describe("dashboardCommand", () => {
     await dashboardCommand(runtime);
 
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expectNoLogWith("Token auto-auth is disabled for SecretRef-managed");
     expectNoLogWith("Token auto-auth unavailable");
@@ -362,10 +364,10 @@ describe("dashboardCommand", () => {
     await dashboardCommand(runtime);
 
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
     expectNoLogWith("Token auto-auth unavailable");
     expectNoLogWith("Token auto-auth is disabled for SecretRef-managed");

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -205,7 +205,7 @@ describe("dashboardCommand bind selection", () => {
       tlsEnabled: false,
     });
     expect(mocks.copyToClipboard).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
     );
   });
 

--- a/src/commands/dashboard/json.test.ts
+++ b/src/commands/dashboard/json.test.ts
@@ -144,7 +144,8 @@ describe("dashboardCommand --json", () => {
         wsUrl: "ws://127.0.0.1:18789",
         port: 18789,
         tokenIncluded: true,
-        browserUrl: "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap",
+        browserUrl:
+          "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
         browserBootstrapExpiresAtMs: 123_456,
       },
       0,
@@ -159,13 +160,15 @@ describe("dashboardCommand --json", () => {
       profile: {
         roles: ["operator"],
         scopes: [
+          "operator.admin",
           "operator.approvals",
+          "operator.pairing",
           "operator.questions",
           "operator.read",
           "operator.talk.secrets",
           "operator.write",
         ],
-        purpose: "control-ui",
+        purpose: "control-ui-owner",
       },
     });
   });

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -3,6 +3,11 @@
 /** HTTP path for the Control UI bootstrap config payload. */
 export const CONTROL_UI_BOOTSTRAP_CONFIG_PATH = "/control-ui-config.json";
 
+/** Fragment marker selecting the host-authorized browser-owner bootstrap profile. */
+export const CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM = "bootstrapProfile";
+export const CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT = "owner";
+export type ControlUiBootstrapProfileHint = typeof CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT;
+
 /** Authenticated same-origin prefix for plugin manifest/catalog icon bytes. */
 export const CONTROL_UI_PLUGIN_ICON_PATH_PREFIX = "/__openclaw__/plugin-icon";
 

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1830,11 +1830,11 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
-  test("silently approves control ui operator bootstrap tokens with control-ui purpose", async () => {
+  test("silently approves host-authorized control ui owner bootstrap tokens", async () => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { getPairedDevice, listDevicePairing, verifyDeviceToken } =
       await import("../infra/device-pairing.js");
-    const { BOOTSTRAP_HANDOFF_OPERATOR_SCOPES } =
+    const { CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES, CONTROL_UI_OWNER_BOOTSTRAP_PROFILE } =
       await import("../shared/device-bootstrap-profile.js");
     const { resolveSharedGatewaySessionGeneration } =
       await import("./server/ws-shared-generation.js");
@@ -1847,11 +1847,7 @@ export function registerControlUiAndPairingSuite(): void {
 
     try {
       const issued = await issueDeviceBootstrapToken({
-        profile: {
-          roles: ["operator"],
-          scopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
-          purpose: "control-ui",
-        },
+        profile: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
       });
       const wsBootstrap = await openWs(port, {
         origin: "https://localhost",
@@ -1861,7 +1857,7 @@ export function registerControlUiAndPairingSuite(): void {
         skipDefaultAuth: true,
         bootstrapToken: issued.token,
         role: "operator",
-        scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+        scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
         client: CONTROL_UI_CLIENT,
         deviceIdentityPath: identityPath,
       });
@@ -1878,11 +1874,12 @@ export function registerControlUiAndPairingSuite(): void {
         | undefined;
       expect(payload?.type).toBe("hello-ok");
       expect(payload?.auth?.role).toBe("operator");
-      expect(payload?.auth?.scopes).toEqual([...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES]);
+      expect(payload?.auth?.scopes).toEqual([...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES]);
       const deviceToken = payload?.auth?.deviceToken;
       if (!deviceToken) {
-        throw new Error("expected control ui operator device token");
+        throw new Error("expected control ui owner device token");
       }
+      expect((await rpcReq(wsBootstrap, "set-heartbeats", { enabled: false })).ok).toBe(true);
       wsBootstrap.close();
 
       const pending = (await listDevicePairing()).pending.filter(
@@ -1891,7 +1888,7 @@ export function registerControlUiAndPairingSuite(): void {
       expect(pending).toEqual([]);
       const paired = await getPairedDevice(identity.deviceId);
       expect(paired?.roles).toEqual(["operator"]);
-      expect(paired?.approvedScopes).toEqual([...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES]);
+      expect(paired?.approvedScopes).toEqual([...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES]);
       const wsReload = await openWs(port, {
         origin: "https://localhost",
         "x-forwarded-for": "203.0.113.50",
@@ -1900,7 +1897,7 @@ export function registerControlUiAndPairingSuite(): void {
         skipDefaultAuth: true,
         deviceToken,
         role: "operator",
-        scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+        scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
         client: CONTROL_UI_CLIENT,
         deviceIdentityPath: identityPath,
       });
@@ -1920,7 +1917,7 @@ export function registerControlUiAndPairingSuite(): void {
           deviceId: identity.deviceId,
           token: deviceToken,
           role: "operator",
-          scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+          scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
           requiredSharedGatewaySessionGeneration: sharedGatewaySessionGeneration,
         }),
       ).resolves.toEqual({
@@ -1935,16 +1932,40 @@ export function registerControlUiAndPairingSuite(): void {
           deviceId: identity.deviceId,
           token: deviceToken,
           role: "operator",
-          scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+          scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
           requiredSharedGatewaySessionGeneration: "rotated-generation",
         }),
       ).resolves.toEqual({ ok: false, reason: "issuer-generation-stale" });
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
 
-      const wsReplay = await openWs(port, {
-        origin: "https://localhost",
-        "x-forwarded-for": "203.0.113.50",
+  test("keeps generic control ui bootstrap tokens on the bounded profile", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    const { BOOTSTRAP_HANDOFF_OPERATOR_SCOPES } =
+      await import("../shared/device-bootstrap-profile.js");
+    testState.gatewayControlUi = { allowedOrigins: ["https://localhost"] };
+    const { server, port, prevToken } = await startControlUiServer("secret");
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-control-ui-bounded-",
+    );
+
+    try {
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["operator"],
+          scopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+          purpose: "control-ui",
+        },
       });
-      const replay = await connectReq(wsReplay, {
+      const wsBootstrap = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.51",
+      });
+      const initial = await connectReq(wsBootstrap, {
         skipDefaultAuth: true,
         bootstrapToken: issued.token,
         role: "operator",
@@ -1952,11 +1973,135 @@ export function registerControlUiAndPairingSuite(): void {
         client: CONTROL_UI_CLIENT,
         deviceIdentityPath: identityPath,
       });
+      expect(initial.ok).toBe(true);
+      const auth = (
+        initial.payload as
+          | {
+              auth?: {
+                scopes?: string[];
+              };
+            }
+          | undefined
+      )?.auth;
+      expect(auth?.scopes).toEqual([...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES]);
+      expect(auth?.scopes).not.toContain("operator.admin");
+      expect(auth?.scopes).not.toContain("operator.pairing");
+      const adminMutation = await rpcReq(wsBootstrap, "set-heartbeats", { enabled: false });
+      expect(adminMutation.ok).toBe(false);
+      expect(adminMutation.error?.message ?? "").toContain("missing scope");
+      wsBootstrap.close();
+
+      expect(
+        (await listDevicePairing()).pending.filter((entry) => entry.deviceId === identity.deviceId),
+      ).toEqual([]);
+      expect((await getPairedDevice(identity.deviceId))?.approvedScopes).toEqual([
+        ...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+      ]);
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("silently upgrades the same control ui key with a host-authorized bootstrap", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    const { CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES, CONTROL_UI_OWNER_BOOTSTRAP_PROFILE } =
+      await import("../shared/device-bootstrap-profile.js");
+    const { identity, identityPath } = await seedApprovedOperatorReadPairing({
+      identityPrefix: "openclaw-control-ui-owner-upgrade-",
+      clientId: CONTROL_UI_CLIENT.id,
+      clientMode: CONTROL_UI_CLIENT.mode,
+      displayName: "control-ui-owner-upgrade",
+      platform: CONTROL_UI_CLIENT.platform,
+    });
+    const before = await getPairedDevice(identity.deviceId);
+    const previousToken = before?.tokens?.operator?.token;
+    if (!previousToken) {
+      throw new Error("expected limited operator token");
+    }
+
+    testState.gatewayControlUi = { allowedOrigins: ["https://localhost"] };
+    const { server, port, prevToken } = await startControlUiServer("secret");
+    const { identityPath: secondIdentityPath } = await createOperatorIdentityFixture(
+      "openclaw-control-ui-owner-upgrade-second-browser-",
+    );
+
+    try {
+      const issued = await issueDeviceBootstrapToken({
+        profile: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
+      });
+      const wsUpgrade = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.52",
+      });
+      const upgraded = await connectReq(wsUpgrade, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(upgraded.ok).toBe(true);
+      const auth = (
+        upgraded.payload as
+          | {
+              auth?: {
+                deviceToken?: string;
+                scopes?: string[];
+              };
+            }
+          | undefined
+      )?.auth;
+      const upgradedToken = auth?.deviceToken;
+      if (!upgradedToken) {
+        throw new Error("expected upgraded operator token");
+      }
+      expect(upgradedToken).not.toBe(previousToken);
+      expect(auth?.scopes).toEqual([...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES]);
+      expect((await rpcReq(wsUpgrade, "set-heartbeats", { enabled: false })).ok).toBe(true);
+      wsUpgrade.close();
+
+      expect(
+        (await listDevicePairing()).pending.filter((entry) => entry.deviceId === identity.deviceId),
+      ).toEqual([]);
+      const paired = await getPairedDevice(identity.deviceId);
+      expect(paired?.approvedScopes).toEqual([...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES]);
+      expect(paired?.tokens?.operator?.token).toBe(upgradedToken);
+
+      const wsReload = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.52",
+      });
+      const reload = await connectReq(wsReload, {
+        skipDefaultAuth: true,
+        deviceToken: upgradedToken,
+        role: "operator",
+        scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(reload.ok).toBe(true);
+      wsReload.close();
+
+      const wsSecondBrowser = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.53",
+      });
+      const replay = await connectReq(wsSecondBrowser, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: secondIdentityPath,
+      });
       expect(replay.ok).toBe(false);
       expect((replay.error?.details as { code?: string } | undefined)?.code).toBe(
         ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
       );
-      wsReplay.close();
+      wsSecondBrowser.close();
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);

--- a/src/gateway/server/ws-connection/connect-device-metadata.ts
+++ b/src/gateway/server/ws-connection/connect-device-metadata.ts
@@ -6,6 +6,8 @@ import {
 import { hasEffectivePairedDeviceRole, type PairedDevice } from "../../../infra/device-pairing.js";
 import {
   BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+  CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
+  deviceBootstrapProfilesEqual,
   isMobilePairingSetupBootstrapProfile,
   isVoiceNodePairingSetupBootstrapProfile,
   resolveBootstrapProfileScopesForRole,
@@ -69,11 +71,34 @@ export function isSetupCodeHandoffBootstrapClient(params: {
   );
 }
 
+/** Match the exact host-issued browser-owner profile and its closed requested scope set. */
+export function isControlUiOwnerBootstrapProfile(params: {
+  profile: DeviceBootstrapProfile | null;
+  requestedScopes: readonly string[];
+}): params is { profile: DeviceBootstrapProfile; requestedScopes: readonly string[] } {
+  const { profile, requestedScopes } = params;
+  return Boolean(
+    profile &&
+    deviceBootstrapProfilesEqual(profile, CONTROL_UI_OWNER_BOOTSTRAP_PROFILE) &&
+    deviceBootstrapProfilesEqual(
+      {
+        roles: ["operator"],
+        scopes: requestedScopes,
+        purpose: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE.purpose,
+      },
+      CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
+    ),
+  );
+}
+
 export function isControlUiOperatorBootstrapProfile(params: {
   profile: DeviceBootstrapProfile | null;
   requestedScopes: readonly string[];
 }): params is { profile: DeviceBootstrapProfile; requestedScopes: readonly string[] } {
   const { profile, requestedScopes } = params;
+  if (isControlUiOwnerBootstrapProfile(params)) {
+    return true;
+  }
   if (!profile || profile.purpose !== "control-ui") {
     return false;
   }

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -35,6 +35,7 @@ import { formatForLog } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { resolveTrustedProxyControlUiScopes } from "./connect-admission.js";
 import {
+  isControlUiOwnerBootstrapProfile,
   isControlUiOperatorBootstrapProfile,
   isMobileNodeBootstrapConnect,
   isSetupCodeHandoffBootstrapClient,
@@ -301,7 +302,7 @@ export async function authorizeGatewayConnectDevice(
           (isSetupCodeMobileNodeConnect || (isControlUi && role === "operator"))) ||
         (reason === "scope-upgrade" &&
           Boolean(existingPairedDevice) &&
-          isSetupCodeMobileNodeConnect);
+          (isSetupCodeMobileNodeConnect || (isControlUi && role === "operator")));
       const boundBootstrapProfile =
         authMethod === "bootstrap-token" &&
         bootstrapTokenCandidate &&
@@ -322,10 +323,19 @@ export async function authorizeGatewayConnectDevice(
       const setupCodeHandoffBootstrapProfile = allowSetupCodeHandoffBootstrapPairing
         ? boundBootstrapProfile
         : null;
-      const allowControlUiOperatorBootstrapPairing = isControlUiOperatorBootstrapProfile({
-        profile: boundBootstrapProfile,
-        requestedScopes: scopes,
-      });
+      const allowControlUiOwnerBootstrapPairing =
+        reason === "scope-upgrade" &&
+        isControlUiOwnerBootstrapProfile({
+          profile: boundBootstrapProfile,
+          requestedScopes: scopes,
+        });
+      const allowControlUiOperatorBootstrapPairing =
+        (reason === "not-paired" &&
+          isControlUiOperatorBootstrapProfile({
+            profile: boundBootstrapProfile,
+            requestedScopes: scopes,
+          })) ||
+        allowControlUiOwnerBootstrapPairing;
       const controlUiOperatorBootstrapProfile = allowControlUiOperatorBootstrapPairing
         ? boundBootstrapProfile
         : null;
@@ -373,7 +383,9 @@ export async function authorizeGatewayConnectDevice(
             }
           : {}),
         silent:
-          reason === "scope-upgrade" && !allowSetupCodeHandoffBootstrapPairing
+          reason === "scope-upgrade" &&
+          !allowSetupCodeHandoffBootstrapPairing &&
+          !allowControlUiOwnerBootstrapPairing
             ? false
             : allowSilentLocalPairing ||
               allowSilentTrustedCidrsNodePairing ||

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { flushLogger } from "../logging/logger.js";
+import {
+  CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES,
+  CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
+} from "../shared/device-bootstrap-profile.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
@@ -327,6 +331,27 @@ describe("device bootstrap tokens", () => {
       verifyBootstrapToken(baseDir, issued.token, {
         role: "operator",
         scopes: ["operator.read"],
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("requires the exact closed browser-owner profile before binding", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      profile: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
+    });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.admin"],
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
       }),
     ).resolves.toEqual({ ok: true });
   });

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
+  CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
   deviceBootstrapProfilesEqual,
   normalizeDeviceBootstrapHandoffProfile,
   normalizeDeviceBootstrapProfile,
@@ -404,10 +405,17 @@ export async function verifyDeviceBootstrapToken(params: {
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
     const allowedProfile = resolvePersistedBootstrapProfile(record);
+    const requestedProfile = resolveRequestedBootstrapProfile({
+      role,
+      scopes: params.scopes,
+      purpose: allowedProfile.purpose,
+    });
     // Fail closed for any attempt to redeem the token outside the issued
     // role/scope allowlist before binding it to a concrete device identity.
     if (
       allowedProfile.roles.length === 0 ||
+      (deviceBootstrapProfilesEqual(allowedProfile, CONTROL_UI_OWNER_BOOTSTRAP_PROFILE) &&
+        !deviceBootstrapProfilesEqual(requestedProfile, CONTROL_UI_OWNER_BOOTSTRAP_PROFILE)) ||
       !bootstrapProfileAllowsRequest({
         allowedProfile,
         requestedRole: role,
@@ -416,11 +424,6 @@ export async function verifyDeviceBootstrapToken(params: {
     ) {
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
-    const requestedProfile = resolveRequestedBootstrapProfile({
-      role,
-      scopes: params.scopes,
-      purpose: allowedProfile.purpose,
-    });
 
     const boundDeviceId = record.deviceId?.trim();
     const boundPublicKey =

--- a/src/shared/device-bootstrap-profile.test.ts
+++ b/src/shared/device-bootstrap-profile.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, test } from "vitest";
 import {
   BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+  CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES,
+  CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
   FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -77,7 +79,33 @@ describe("device bootstrap profile", () => {
     });
   });
 
-  test("allows admin only for the closed full-mobile purpose", () => {
+  test("allows admin only for closed full-access purposes", () => {
+    expect(
+      normalizeDeviceBootstrapHandoffProfile({
+        roles: ["operator"],
+        scopes: [
+          "operator.admin",
+          "operator.approvals",
+          "operator.pairing",
+          "operator.read",
+          "operator.talk.secrets",
+          "operator.write",
+        ],
+        purpose: "control-ui-owner",
+      }),
+    ).toEqual({
+      roles: ["operator"],
+      scopes: [
+        "operator.admin",
+        "operator.approvals",
+        "operator.pairing",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ],
+      purpose: "control-ui-owner",
+    });
+
     expect(
       normalizeDeviceBootstrapHandoffProfile({
         roles: ["node", "operator"],
@@ -115,6 +143,25 @@ describe("device bootstrap profile", () => {
       ],
       purpose: "mobile-full",
     });
+  });
+
+  test("browser-owner profile carries the exact full Control UI handoff", () => {
+    expect(CONTROL_UI_OWNER_BOOTSTRAP_PROFILE).toEqual({
+      roles: ["operator"],
+      scopes: [
+        "operator.admin",
+        "operator.approvals",
+        "operator.pairing",
+        "operator.questions",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ],
+      purpose: "control-ui-owner",
+    });
+    expect([...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES]).toEqual(
+      CONTROL_UI_OWNER_BOOTSTRAP_PROFILE.scopes,
+    );
   });
 
   test("existing setup profile preserves the bounded operator handoff", () => {

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -2,7 +2,11 @@
 import { normalizeDeviceAuthRole, normalizeDeviceAuthScopes } from "./device-auth.js";
 
 /** Closed purpose codes carried by specialized bootstrap tokens. */
-export type DeviceBootstrapPurpose = "control-ui" | "mobile-full" | "voice-node";
+export type DeviceBootstrapPurpose =
+  | "control-ui"
+  | "control-ui-owner"
+  | "mobile-full"
+  | "voice-node";
 
 /** Normalized roles/scopes carried by a bootstrap token during device handoff. */
 export type DeviceBootstrapProfile = {
@@ -29,6 +33,21 @@ export const BOOTSTRAP_HANDOFF_OPERATOR_SCOPES = [
 
 const BOOTSTRAP_HANDOFF_OPERATOR_SCOPE_SET = new Set<string>(BOOTSTRAP_HANDOFF_OPERATOR_SCOPES);
 
+/** Full browser-owner scopes allowed only by the host-issued Control UI profile. */
+export const CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES = [
+  "operator.admin",
+  "operator.approvals",
+  "operator.pairing",
+  "operator.questions",
+  "operator.read",
+  "operator.talk.secrets",
+  "operator.write",
+] as const;
+
+const CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPE_SET = new Set<string>(
+  CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES,
+);
+
 /** Full native-mobile operator scopes allowed only by the closed mobile setup profile. */
 const MOBILE_FULL_ACCESS_OPERATOR_SCOPES = [
   "operator.admin",
@@ -45,6 +64,13 @@ export const PAIRING_SETUP_BOOTSTRAP_PROFILE: DeviceBootstrapProfile = {
   // only start it after persisting this bounded operator token.
   roles: ["node", "operator"],
   scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+};
+
+/** Full browser-owner profile issued only by dashboard and graphical onboarding. */
+export const CONTROL_UI_OWNER_BOOTSTRAP_PROFILE: DeviceBootstrapProfile = {
+  roles: ["operator"],
+  scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
+  purpose: "control-ui-owner",
 };
 
 /** Full native-mobile setup profile for explicitly authorized setup surfaces. */
@@ -129,11 +155,13 @@ export function resolveBootstrapProfileScopesForRole(
   const normalizedScopes = normalizeDeviceAuthScopes(Array.from(scopes));
   if (normalizedRole === "operator") {
     const allowedScopes =
-      purpose === "mobile-full"
-        ? MOBILE_FULL_ACCESS_OPERATOR_SCOPE_SET
-        : purpose === "voice-node"
-          ? VOICE_NODE_OPERATOR_SCOPE_SET
-          : BOOTSTRAP_HANDOFF_OPERATOR_SCOPE_SET;
+      purpose === "control-ui-owner"
+        ? CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPE_SET
+        : purpose === "mobile-full"
+          ? MOBILE_FULL_ACCESS_OPERATOR_SCOPE_SET
+          : purpose === "voice-node"
+            ? VOICE_NODE_OPERATOR_SCOPE_SET
+            : BOOTSTRAP_HANDOFF_OPERATOR_SCOPE_SET;
     return normalizedScopes.filter((scope) => allowedScopes.has(scope));
   }
   return [];
@@ -201,6 +229,7 @@ export function normalizeDeviceBootstrapProfile(
 ): DeviceBootstrapProfile {
   const purpose =
     input?.purpose === "control-ui" ||
+    input?.purpose === "control-ui-owner" ||
     input?.purpose === "mobile-full" ||
     input?.purpose === "voice-node"
       ? input.purpose

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -39,6 +39,15 @@ const CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES = [
   "operator.talk.secrets",
   "operator.write",
 ] as const;
+const CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES = [
+  "operator.admin",
+  "operator.approvals",
+  "operator.pairing",
+  "operator.questions",
+  "operator.read",
+  "operator.talk.secrets",
+  "operator.write",
+] as const;
 const loadOrCreateDeviceIdentityMock = vi.hoisted(() =>
   vi.fn(
     async (): Promise<DeviceIdentity> => ({
@@ -525,6 +534,25 @@ describe("GatewayBrowserClient", () => {
     expectSignedPayloadFields(signedPayload, {
       scopes: [...CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES],
       token: "boot-1",
+      nonce: "nonce-1",
+    });
+  });
+
+  it("requests the exact owner profile for host-authorized bootstrap auth", async () => {
+    const client = new GatewayBrowserClient({
+      url: "wss://gateway.example",
+      bootstrapToken: "boot-owner",
+      bootstrapProfile: "owner",
+    });
+
+    const { connectFrame } = await startConnect(client);
+
+    expect(connectFrame.params?.auth?.bootstrapToken).toBe("boot-owner");
+    expect(connectFrame.params?.scopes).toEqual([...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES]);
+    const [, signedPayload] = requireFirstSignCall();
+    expectSignedPayloadFields(signedPayload, {
+      scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
+      token: "boot-owner",
       nonce: "nonce-1",
     });
   });

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -32,6 +32,14 @@ import {
 } from "@openclaw/gateway-client/browser";
 // Control UI module implements gateway behavior.
 import { formatErrorMessage } from "@openclaw/normalization-core";
+import {
+  CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT,
+  type ControlUiBootstrapProfileHint,
+} from "../../../src/gateway/control-ui-contract.js";
+import {
+  BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+  CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES,
+} from "../../../src/shared/device-bootstrap-profile.js";
 import { redactToolDetail } from "../lib/browser-redact.ts";
 import {
   clearDeviceAuthToken,
@@ -146,14 +154,6 @@ const CONTROL_UI_OPERATOR_SCOPES = [
   "operator.pairing",
 ] as const;
 
-const CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES = [
-  "operator.approvals",
-  "operator.questions",
-  "operator.read",
-  "operator.talk.secrets",
-  "operator.write",
-] as const;
-
 type GatewayConnectDevice = NonNullable<ConnectParams["device"]>;
 type GatewayConnectClientInfo = ConnectParams["client"];
 
@@ -170,6 +170,7 @@ export type GatewayBrowserClientOptions = {
   url: string;
   token?: string;
   bootstrapToken?: string;
+  bootstrapProfile?: ControlUiBootstrapProfileHint;
   password?: string;
   clientName?: GatewayClientName;
   clientVersion?: string;
@@ -458,7 +459,9 @@ export class GatewayBrowserClient {
     }
     const scopes = resolveGatewayConnectScopes({
       requestedScopes: selectedAuth.authBootstrapToken
-        ? [...CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES]
+        ? this.opts.bootstrapProfile === CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT
+          ? [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES]
+          : [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES]
         : undefined,
       usingStoredDeviceToken: selectedAuth.usingStoredDeviceToken,
       storedScopes: selectedAuth.storedScopes,
@@ -511,6 +514,7 @@ export class GatewayBrowserClient {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
     this.opts.bootstrapToken = undefined;
+    this.opts.bootstrapProfile = undefined;
     if (hello?.auth?.deviceToken && plan.deviceIdentity) {
       storeDeviceAuthToken({
         deviceId: plan.deviceIdentity.deviceId,

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -446,9 +446,10 @@ describe("normalizeInitialApplicationLocation", () => {
   it.each([
     {
       name: "bootstrap token on the deferred default landing",
-      initialUrl: "/?keep=yes#bootstrapToken=boot-default&tab=keep",
+      initialUrl: "/?keep=yes#bootstrapToken=boot-default&bootstrapProfile=owner&tab=keep",
       expectedUrl: "/?keep=yes#tab=keep",
       expectedBootstrapToken: "boot-default",
+      expectedBootstrapProfile: "owner",
       expectedToken: "",
       expectedDocumentMode: null,
     },
@@ -457,6 +458,7 @@ describe("normalizeInitialApplicationLocation", () => {
       initialUrl: "/operator/settings/appearance?keep=yes#tab=keep&bootstrapToken=boot-route",
       expectedUrl: "/operator/settings/appearance?keep=yes#tab=keep",
       expectedBootstrapToken: "boot-route",
+      expectedBootstrapProfile: undefined,
       expectedToken: "",
       expectedDocumentMode: null,
     },
@@ -465,6 +467,7 @@ describe("normalizeInitialApplicationLocation", () => {
       initialUrl: "/approve/exec%3A1?keep=yes#bootstrapToken=boot-approval&tab=keep",
       expectedUrl: "/approve/exec%3A1?keep=yes#tab=keep",
       expectedBootstrapToken: "boot-approval",
+      expectedBootstrapProfile: undefined,
       expectedToken: "",
       expectedDocumentMode: { kind: "approval", approvalId: "exec:1" },
     },
@@ -473,6 +476,7 @@ describe("normalizeInitialApplicationLocation", () => {
       initialUrl: "/settings/appearance?keep=yes&password=discard#token=shared-fragment&tab=keep",
       expectedUrl: "/settings/appearance?keep=yes#tab=keep",
       expectedBootstrapToken: "",
+      expectedBootstrapProfile: undefined,
       expectedToken: "shared-fragment",
       expectedDocumentMode: null,
     },
@@ -481,6 +485,7 @@ describe("normalizeInitialApplicationLocation", () => {
       initialUrl: "/settings/appearance?keep=yes&token=shared-query#password=discard&tab=keep",
       expectedUrl: "/settings/appearance?keep=yes#tab=keep",
       expectedBootstrapToken: "",
+      expectedBootstrapProfile: undefined,
       expectedToken: "shared-query",
       expectedDocumentMode: null,
     },
@@ -507,6 +512,9 @@ describe("normalizeInitialApplicationLocation", () => {
       expect(replaceState).toHaveBeenCalledExactlyOnceWith({}, "", testCase.expectedUrl);
       expect(runtime.context.gateway.connection.bootstrapToken).toBe(
         testCase.expectedBootstrapToken,
+      );
+      expect(runtime.context.gateway.connection.bootstrapProfile).toBe(
+        testCase.expectedBootstrapProfile,
       );
       expect(runtime.context.gateway.connection.token).toBe(testCase.expectedToken);
       expect(runtime.documentMode).toEqual(testCase.expectedDocumentMode);

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -276,7 +276,13 @@ export function bootstrapApplication(
     startup.password ?? "",
     startup.pendingBootstrapToken ?? "",
     undefined,
-    { persistDefaultConnectionSettings: documentMode === null, basePath },
+    {
+      persistDefaultConnectionSettings: documentMode === null,
+      basePath,
+      ...(startup.pendingBootstrapProfile
+        ? { bootstrapProfile: startup.pendingBootstrapProfile }
+        : {}),
+    },
   );
   const agents = createAgentCapability(gateway);
   const startupLifecycle = createStartupLifecycle();
@@ -358,6 +364,9 @@ export function bootstrapApplication(
           gatewayUrl: startup.pendingGatewayUrl,
           token: startup.pendingGatewayToken ?? "",
           bootstrapToken: startup.pendingBootstrapToken ?? "",
+          ...(startup.pendingBootstrapProfile
+            ? { bootstrapProfile: startup.pendingBootstrapProfile }
+            : {}),
         }
       : null;
   let lastPostConnectClient: GatewayBrowserClient | null = null;
@@ -413,6 +422,7 @@ export function bootstrapApplication(
       gatewayUrl: pending.gatewayUrl,
       token: pending.token,
       bootstrapToken: pending.bootstrapToken,
+      bootstrapProfile: pending.bootstrapProfile,
     });
   };
   const cancelPendingGatewayConnection = () => {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -1,3 +1,4 @@
+import type { ControlUiBootstrapProfileHint } from "../../../src/gateway/control-ui-contract.js";
 // Control UI module owns the application gateway store: the reactive
 // snapshot around GatewayBrowserClient consumed by the app shell.
 import type { EventLogEntry } from "../api/event-log.ts";
@@ -66,7 +67,11 @@ export function createApplicationGateway(
   initialPassword = "",
   initialBootstrapToken = "",
   createClient: GatewayClientFactory = defaultClientFactory,
-  options: { persistDefaultConnectionSettings?: boolean; basePath?: string } = {},
+  options: {
+    persistDefaultConnectionSettings?: boolean;
+    basePath?: string;
+    bootstrapProfile?: ControlUiBootstrapProfileHint;
+  } = {},
 ): ApplicationGateway {
   let settings = initialSettings;
   let persistConnectionSettings = options.persistDefaultConnectionSettings !== false;
@@ -74,6 +79,7 @@ export function createApplicationGateway(
     gatewayUrl: settings.gatewayUrl,
     token: settings.token,
     bootstrapToken: initialBootstrapToken,
+    ...(options.bootstrapProfile ? { bootstrapProfile: options.bootstrapProfile } : {}),
     password: initialPassword,
   };
   let snapshot: ApplicationGatewaySnapshot = {
@@ -263,7 +269,14 @@ export function createApplicationGateway(
   const connect = (overrides: ApplicationGatewayConnectOptions = {}) => {
     stopped = false;
     const { sessionKey: requestedSessionKey, ...connectionOverrides } = overrides;
-    const nextConnection = { ...connection, ...connectionOverrides };
+    const nextConnection = {
+      ...connection,
+      ...connectionOverrides,
+      ...(connectionOverrides.bootstrapToken !== undefined &&
+      connectionOverrides.bootstrapProfile === undefined
+        ? { bootstrapProfile: undefined }
+        : {}),
+    };
     const hasRequestedSessionKey = requestedSessionKey !== undefined;
     const nextSessionKey = hasRequestedSessionKey
       ? requestedSessionKey.trim()
@@ -312,6 +325,7 @@ export function createApplicationGateway(
       bootstrapToken: nextConnection.bootstrapToken.trim()
         ? nextConnection.bootstrapToken
         : undefined,
+      bootstrapProfile: nextConnection.bootstrapProfile,
       password: nextConnection.password.trim() ? nextConnection.password : undefined,
       clientName: "openclaw-control-ui",
       clientVersion: CONTROL_UI_BUILD_INFO.version ?? "dev",
@@ -330,7 +344,7 @@ export function createApplicationGateway(
           }),
           options.basePath,
         );
-        connection = { ...connection, bootstrapToken: "" };
+        connection = { ...connection, bootstrapToken: "", bootstrapProfile: undefined };
         if (persistConnectionSettings) {
           settings = loadSettings();
         }

--- a/ui/src/app/gateway.ts
+++ b/ui/src/app/gateway.ts
@@ -1,3 +1,4 @@
+import type { ControlUiBootstrapProfileHint } from "../../../src/gateway/control-ui-contract.js";
 import type { EventLogEntry } from "../api/event-log.ts";
 import type { GatewayBrowserClient, GatewayEventListener, GatewayHelloOk } from "../api/gateway.ts";
 import type { AuthenticatedUser } from "./user-profile.ts";
@@ -27,6 +28,7 @@ export type ApplicationGatewayConnection = {
   gatewayUrl: string;
   token: string;
   bootstrapToken: string;
+  bootstrapProfile?: ControlUiBootstrapProfileHint;
   password: string;
 };
 

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -80,12 +80,13 @@ describe("resolveApplicationStartupSettings", () => {
     const startup = resolveApplicationStartupSettings(makeSettings("wss://gateway.example"), {
       pathname: "/",
       search: "",
-      hash: "#gatewayUrl=wss%3A%2F%2Fgateway.example&bootstrapToken=boot-123",
+      hash: "#gatewayUrl=wss%3A%2F%2Fgateway.example&bootstrapToken=boot-123&bootstrapProfile=owner",
     });
 
     expect(startup.pendingGatewayUrl).toBeNull();
     expect(startup.pendingGatewayToken).toBeNull();
     expect(startup.pendingBootstrapToken).toBe("boot-123");
+    expect(startup.pendingBootstrapProfile).toBe("owner");
     expect(startup.settings.token).toBe("");
     expect(startup.location).toEqual({ pathname: "/", search: "", hash: "" });
   });
@@ -100,6 +101,7 @@ describe("resolveApplicationStartupSettings", () => {
     expect(startup.pendingGatewayUrl).toBe("wss://gateway-b.example");
     expect(startup.pendingGatewayToken).toBeNull();
     expect(startup.pendingBootstrapToken).toBe("boot-456");
+    expect(startup.pendingBootstrapProfile).toBeNull();
     expect(startup.location).toEqual({ pathname: "/dash", search: "", hash: "" });
   });
 });

--- a/ui/src/app/startup-settings.ts
+++ b/ui/src/app/startup-settings.ts
@@ -1,4 +1,9 @@
 // Control UI startup settings resolve native auth handoff and URL parameters.
+import {
+  CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM,
+  CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT,
+  type ControlUiBootstrapProfileHint,
+} from "../../../src/gateway/control-ui-contract.js";
 import { inferBasePathFromPathname, sessionRouteNamespaceFromPath } from "../app-route-paths.ts";
 import { normalizeOptionalString } from "../lib/string-coerce.ts";
 import type { UiSettings } from "./settings.ts";
@@ -21,6 +26,7 @@ type ApplicationStartupSettings = {
   pendingGatewayUrl: string | null;
   pendingGatewayToken: string | null;
   pendingBootstrapToken: string | null;
+  pendingBootstrapProfile: ControlUiBootstrapProfileHint | null;
   queryTokenUsed: boolean;
   location: ApplicationStartupLocation;
   changed: boolean;
@@ -42,6 +48,7 @@ export function resolveApplicationStartupSettings(
   let pendingGatewayUrl: string | null = null;
   let pendingGatewayToken: string | null = null;
   let pendingBootstrapToken: string | null = null;
+  let pendingBootstrapProfile: ControlUiBootstrapProfileHint | null = null;
   let queryTokenUsed = false;
 
   const updateSettings = (patch: Partial<UiSettings>) => {
@@ -83,6 +90,7 @@ export function resolveApplicationStartupSettings(
       pendingGatewayUrl,
       pendingGatewayToken,
       pendingBootstrapToken,
+      pendingBootstrapProfile,
       queryTokenUsed,
       location,
       changed,
@@ -104,6 +112,10 @@ export function resolveApplicationStartupSettings(
   const token = normalizeOptionalString(hashToken ?? queryToken);
   const hasBootstrapTokenParam = hashParams.has("bootstrapToken");
   const bootstrapToken = normalizeOptionalString(hashParams.get("bootstrapToken"));
+  const hasBootstrapProfileParam = hashParams.has(CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM);
+  const bootstrapProfile = normalizeOptionalString(
+    hashParams.get(CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM),
+  );
   const sessionPath = sessionRouteNamespaceFromPath(
     location.pathname,
     inferBasePathFromPathname(location.pathname),
@@ -134,7 +146,15 @@ export function resolveApplicationStartupSettings(
 
   if (hasBootstrapTokenParam) {
     pendingBootstrapToken = bootstrapToken ?? null;
+    pendingBootstrapProfile =
+      bootstrapToken && bootstrapProfile === CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT
+        ? CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT
+        : null;
     hashParams.delete("bootstrapToken");
+    shouldCleanUrl = true;
+  }
+  if (hasBootstrapProfileParam) {
+    hashParams.delete(CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM);
     shouldCleanUrl = true;
   }
 
@@ -175,6 +195,7 @@ export function resolveApplicationStartupSettings(
     pendingGatewayUrl,
     pendingGatewayToken,
     pendingBootstrapToken,
+    pendingBootstrapProfile,
     queryTokenUsed,
     location: shouldCleanUrl
       ? {


### PR DESCRIPTION
Fixes #119781

## What Problem This Solves

Fixes an issue where operators opening the Control UI through `openclaw dashboard` or graphical onboarding received a durable browser credential without `operator.admin`. Administrator-only settings and RPCs remained unavailable, and a browser with an existing limited credential could not recover administrator access through another fresh host-issued link.

## Why This Change Was Made

The host-issued entry points reused the generic bounded `control-ui` bootstrap profile. The resulting limited scopes were persisted and reused on reconnect and reload. Existing limited browsers also had no narrow host-authorized exception allowing a fresh handoff to upgrade the same signed key.

This change adds a dedicated `control-ui-owner` profile selected by the `bootstrapProfile=owner` URL-fragment hint. The Control UI accepts the hint only alongside a bootstrap token, removes both fragment fields immediately, and requests exactly:

- `operator.admin`
- `operator.approvals`
- `operator.pairing`
- `operator.questions`
- `operator.read`
- `operator.talk.secrets`
- `operator.write`

The Gateway verifies that exact closed profile before redemption. First redemption binds the handoff to the browser's signed device ID and public key. It supports fresh owner pairing and a same-key upgrade from an existing limited credential, then rotates to a durable device credential and clears the transient handoff state.

The exception remains narrowly bounded:

- Generic Control UI and Telegram Mini App handoffs retain their bounded profiles.
- Mobile Full and Limited profiles retain their existing scopes.
- Ordinary stored and shared credentials cannot silently widen access.
- Unrelated browser keys cannot inherit or replay the grant.
- Locality, proxy identity, and manual pairing behavior are unchanged.

The dashboard, onboarding, operator-scope, and Control UI documentation now describes the owner handoff and its boundaries. The dashboard troubleshooting text also correctly documents authentication precedence: a pending bootstrap token is preferred for its handoff; without one, an explicit shared token or password precedes the stored device credential. The changelog records the user-facing fix.

## User Impact

A fresh browser opened from `openclaw dashboard` or graphical onboarding now receives durable administrator access and retains it across reconnects, Gateway restarts, and reloads.

A previously limited browser can recover administrator access by redeeming a fresh host-issued handoff with the same signed key. Other browsers and ordinary authentication paths remain limited or require their existing approval flow.

## Evidence

Automated verification:

- Focused Testbox matrix: 209 tests passed across seven Vitest shards, covering exact profile validation, signed-key binding, fresh pairing, durable reload, same-key recovery, different-key and replay rejection, expiry, issuer-generation checks, generic bounded handoffs, ordinary upgrades, and mobile profiles.
- `pnpm check:changed`: passed.
- `pnpm docs:check-mdx`: 768 files passed.
- `pnpm docs:check-links`: 6,399 links checked, 0 broken.
- `pnpm ui:build`: production bundle, precompressed assets, and performance limits passed.

OCM-backed real-browser verification covered:

- A fresh owner handoff enabling an administrator-only setting, successfully issuing `config.patch`, surviving the resulting Gateway restart, reconnecting, and retaining the setting and administrator access after reload.
- A generic bounded credential remaining limited before and after reload.
- A fresh owner handoff upgrading that same signed limited browser to the exact seven-scope profile and retaining it after reload.
- A different clean browser replaying the consumed URL and being rejected with `bootstrap_token_invalid`, without creating a pending approval.

An independent review of the final patch before rebasing found no blocking runtime or security issue. The subsequent conflict-free rebase onto current `origin/main` mapped all three commits one-to-one with stable patch IDs and no relevant upstream contract changes, so the existing verification remains applicable.

Size:

- Production: `+166 -37` (net `+129`)
- Tests: `+295 -35` (net `+260`)
- Documentation and changelog: `+31 -15` (net `+16`)
- Total: 26 files, `+492 -87`

The positive production growth implements a concrete host-authorized security boundary and carries one closed profile from issuance through fragment handling, signed redemption, and the Gateway pairing decision. It adds no configuration surface, protocol-version change, schema migration, persistence path, or fallback authentication path.