### PR TITLE
fix(telegram): parse Mini App auth dates strictly

### DIFF
--- a/extensions/telegram/src/miniapp/init-data.test.ts
+++ b/extensions/telegram/src/miniapp/init-data.test.ts
@@ -51,6 +51,26 @@ describe("validateTelegramMiniAppInitData", () => {
       }),
     ).toBeNull();
   });
+
+  it("rejects non-canonical auth dates even when they are signed", () => {
+    for (const authDate of [
+      "1.8e9",
+      "0x6b49d200",
+      "1800000000.0",
+      "+1800000000",
+      " 1800000000 ",
+      "01800000000",
+      "0",
+    ]) {
+      expect(
+        validateTelegramMiniAppInitData({
+          initData: signedInitData({ auth_date: authDate }),
+          botToken: BOT_TOKEN,
+          nowMs: AUTH_DATE * 1000 + 10_000,
+        }),
+      ).toBeNull();
+    }
+  });
 });
 
 function signedInitData(overrides: Record<string, string>): string {

--- a/extensions/telegram/src/miniapp/init-data.ts
+++ b/extensions/telegram/src/miniapp/init-data.ts
@@ -1,5 +1,6 @@
 // Telegram Mini App init-data validation.
 import crypto from "node:crypto";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 
 const INIT_DATA_MAX_AGE_MS = 300_000;
@@ -23,14 +24,17 @@ export function validateTelegramMiniAppInitData(params: {
 
   const parsed = new URLSearchParams(initData);
   const receivedHash = parsed.get("hash")?.trim() ?? "";
-  const authDateRaw = parsed.get("auth_date")?.trim() ?? "";
+  const authDateRaw = parsed.get("auth_date") ?? "";
   const userRaw = parsed.get("user")?.trim() ?? "";
   if (!receivedHash || !authDateRaw || !userRaw) {
     return null;
   }
 
-  const authDateSeconds = Number(authDateRaw);
-  if (!Number.isInteger(authDateSeconds) || authDateSeconds <= 0) {
+  if (!/^[1-9]\d*$/.test(authDateRaw)) {
+    return null;
+  }
+  const authDateSeconds = parseStrictPositiveInteger(authDateRaw);
+  if (authDateSeconds === undefined) {
     return null;
   }
   const authDateMs = authDateSeconds * 1000;


### PR DESCRIPTION
## What Problem This Solves

Telegram Mini App authentication accepted signed `auth_date` values written in exponent, hexadecimal, fractional, explicit-plus, surrounding-whitespace, or leading-zero form, even though the validator's canonical format is a positive unsigned decimal.

## Why This Change Was Made

The validator now preserves the raw `auth_date` field and enforces `^[1-9]\d*$` before reusing `parseStrictPositiveInteger` for numeric conversion. This keeps the field-specific grammar local while retaining the shared parser's conversion and safety checks.

## User Impact

Canonical Telegram Mini App authentication continues to work, while signed non-canonical `auth_date` encodings are rejected consistently.

## Maintainer decision needed

The [Telegram Mini Apps documentation](https://core.telegram.org/bots/webapps) describes `auth_date` as an integer Unix timestamp and specifies the HMAC input, but does not define a lexical rule that forbids plus signs, leading zeroes, or surrounding whitespace. This change intentionally rejects those signed non-canonical forms. Please confirm from an owner decision or redacted canonical-client handoff that the stricter lexical contract is supported before merge.

## Evidence

- Real call-chain fallback at the production-module boundary, using the same HMAC-signed inputs on validation base `99bda3d8cda4fd1f0b30d17e911d6fbe0bdd60c7` and exact head `d7e7ba5c1e34cfd22c478c4fcf08076713c65877`:

```text
$ node --import tsx proof-live.mjs
base: canonical accepted; exponent, hexadecimal, fractional, plus-prefixed, surrounding-whitespace, and leading-zero accepted; zero and tampered hash rejected
head: canonical accepted; exponent, hexadecimal, fractional, plus-prefixed, surrounding-whitespace, leading-zero, zero, and tampered hash rejected
```

- This is a local HMAC-signed production-module fallback, not an authentic Telegram-generated Mini App handoff. It is supplemental evidence only; the authentic handoff and owner compatibility decision requested by review remain unresolved.
- negative-control: the exact-head signed tampered-hash case remains rejected.
- `node scripts/run-vitest.mjs extensions/telegram/src/miniapp/init-data.test.ts`: 3 tests passed.
- `node --import tsx scripts/check-extension-package-tsc-boundary.mts --mode=compile`: 123 plugin package boundaries passed.
- Canonical precedent: `parseStrictPositiveInteger` remains the numeric conversion helper, and `extensions/telegram/src/token.ts` already validates Telegram numeric fields locally before conversion.

<details>
<summary>Production-module proof source</summary>

```js
import crypto from "node:crypto";
import path from "node:path";

const { validateTelegramMiniAppInitData } = await import(
  path.resolve(process.cwd(), "extensions/telegram/src/miniapp/init-data.ts"),
);

const botToken = "fixture";
const nowMs = 1_800_000_000_000 + 10_000;
const cases = [
  ["canonical", "1800000000", false],
  ["exponent", "1.8e9", false],
  ["hexadecimal", "0x6b49d200", false],
  ["fractional", "1800000000.0", false],
  ["plus-prefixed", "+1800000000", false],
  ["surrounding-whitespace", " 1800000000 ", false],
  ["leading-zero", "01800000000", false],
  ["zero", "0", false],
  ["tampered-hash", "1800000000", true],
];

for (const [label, authDate, tampered] of cases) {
  const result = validateTelegramMiniAppInitData({
    initData: signedInitData(authDate, tampered),
    botToken,
    nowMs,
  });
  console.log(label + ": " + (result ? "accepted" : "rejected"));
}

function signedInitData(authDate, tampered) {
  const params = new URLSearchParams({
    auth_date: authDate,
    query_id: "AAE-test",
    user: JSON.stringify({ id: 123456, first_name: "Ayaan" }),
  });
  const entries = [...params.entries()]
    .map(([key, value]) => key + "=" + value)
    .toSorted();
  const secret = crypto.createHmac("sha256", "WebAppData").update(botToken).digest();
  const hash = crypto.createHmac("sha256", secret).update(entries.join("\\n")).digest("hex");
  params.set("hash", tampered ? "0" : hash);
  return params.toString();
}
```

</details>

AI-assisted: built with Codex
