### PR TITLE
fix(test): Gateway E2E no longer stalls on x64

### DIFF
--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -23,9 +23,7 @@ describe("e2e vitest config", () => {
       BUNDLED_PLUGIN_E2E_TEST_GLOB,
     ]);
     expect(e2eConfig.test?.exclude).toContain("src/tui/tui-pty-harness.e2e.test.ts");
-    const excludesTuiPtyLocal =
-      e2eConfig.test?.exclude?.includes("src/tui/tui-pty-local.e2e.test.ts") ?? false;
-    expect(excludesTuiPtyLocal).toBe(process.arch === "arm64");
+    expect(e2eConfig.test?.exclude).toContain("src/tui/tui-pty-local.e2e.test.ts");
     expect(e2eConfig.test?.pool).toBe("threads");
     expect(e2eConfig.test?.isolate).toBe(false);
     expect(normalizeConfigPath(e2eConfig.test?.runner)).toBe("test/non-isolated-runner.ts");

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -25,10 +25,9 @@ const { projects: _projects, ...baseTest } = baseTestWithProjects as {
   projects?: string[];
   setupFiles?: string[];
 };
-const tuiPtyExcludes = [
-  "src/tui/tui-pty-harness.e2e.test.ts",
-  ...(process.arch === "arm64" ? ["src/tui/tui-pty-local.e2e.test.ts"] : []),
-];
+// The dedicated TUI PTY config owns both terminal suites and emits per-test progress.
+// The local real-backend file can exceed the generic E2E silent-process watchdog.
+const tuiPtyExcludes = ["src/tui/tui-pty-harness.e2e.test.ts", "src/tui/tui-pty-local.e2e.test.ts"];
 const exclude = [
   ...(baseTest.exclude ?? []).filter((p) => p !== "**/*.e2e.test.ts"),
   ...tuiPtyExcludes,


### PR DESCRIPTION
Closes #119775

## What Problem This Solves

Fixes an issue where maintainers and agents running the Gateway E2E aggregate on x64 would get a false five-minute no-output failure instead of a terminal test verdict. The generic aggregate still scheduled the full real TUI PTY backend suite, which now takes about 15 minutes and reports progress only through its dedicated TUI configuration.

## Why This Change Was Made

The generic E2E configuration now excludes both TUI PTY suites on every architecture. The dedicated TUI PTY configuration remains their canonical owner and retains the local real-backend suite, its verbose per-test reporter, serial execution, and exact built-CLI coverage. The existing configuration regression test now enforces that architecture-independent boundary.

This removes the stale duplicate route instead of increasing the watchdog, retrying tests, or weakening assertions.

## User Impact

There is no product runtime change. Gateway E2E runs can now reach a truthful terminal result on x64, while the complete real TUI PTY suite remains covered in its purpose-built lane.

Production LOC: +0/-0. Test/tooling: +4/-7.

## Evidence

- Before: Blacksmith Testbox lease `tbx_01kza07mctzz4rcm0r089z9ghf`, run https://github.com/openclaw/openclaw/actions/runs/31052388184. `pnpm test:e2e:gateway` passed 514 assertions across four files, then the wrapper killed the silent process group after 300 seconds with exit 143.
- Owner control: on the same checkout and lease, `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 OPENCLAW_TUI_PTY_USE_BUILT_CLI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts` passed 24/24 in 887.90 seconds while reporting progress between long cases.
- Focused fix: `src/infra/vitest-e2e-config.test.ts` passed 2/2. Catalog probes proved the dedicated TUI config still lists `src/tui/tui-pty-local.e2e.test.ts` and the generic E2E config does not.
- Before/after aggregate: exact patched Testbox run https://github.com/openclaw/openclaw/actions/runs/31057032000 reached a terminal Vitest verdict after 34m56s instead of hitting the no-output watchdog. It exposed 45 unrelated current-main failures across 16 files; 1,371 tests passed and the original routing stall did not recur.
- Exact candidate changed gate: Blacksmith Testbox lease `tbx_01kza6zrj0txsv4tmwz86v1gbv`, run https://github.com/openclaw/openclaw/actions/runs/31059300043, passed formatting, typechecks, dependency/architecture guards, dead-code checks, script declarations, and core/scripts lint in 23m42s.
- Fresh AutoReview after formatting: clean, no accepted/actionable findings, 0.99.
- Public model identifier gate: PASS; the diff contains no model-bearing code, fixtures, generated metadata, or public proof identifiers.

Known gap: the current broad E2E baseline has unrelated failures outside these two files. This PR neither masks nor changes them; it restores the aggregate's ability to report them instead of dying silently first.
