### PR TITLE
fix(health): report the SQLite session store instead of the legacy locator

### DIFF
--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -110,6 +110,8 @@ export function resolveHealthAgentOrder(cfg: OpenClawConfig) {
 export async function buildHealthSessionSummary(storePath: string, agentId?: string) {
   const { listSessionEntriesReadOnly } = await import("../../config/sessions/session-accessor.js");
   const { isTransientSqliteError } = await import("../../infra/unhandled-rejections.js");
+  const { resolveSqliteTargetFromSessionStorePath } =
+    await import("../../config/sessions/session-sqlite-target.js");
   let listed: ReturnType<typeof listSessionEntriesReadOnly>;
   try {
     listed = listSessionEntriesReadOnly({
@@ -132,8 +134,20 @@ export async function buildHealthSessionSummary(storePath: string, agentId?: str
     updatedAt: session.updatedAt || null,
     age: session.updatedAt ? Date.now() - session.updatedAt : null,
   }));
+  // storePath is the legacy JSON locator that still identifies a store; the rows
+  // above come from SQLite. Reporting the locator advertises a sessions.json that
+  // no longer exists, so report the database the entries were actually read from.
+  let resolvedPath = storePath;
+  try {
+    resolvedPath = resolveSqliteTargetFromSessionStorePath(
+      storePath,
+      agentId ? { agentId } : {},
+    ).path;
+  } catch {
+    // Health is best-effort: keep the locator rather than fail the whole summary.
+  }
   return {
-    path: storePath,
+    path: resolvedPath,
     count: sessions.length,
     recent,
   } satisfies HealthSummary["sessions"];

--- a/src/gateway/health/session-summary-path.test.ts
+++ b/src/gateway/health/session-summary-path.test.ts
@@ -1,0 +1,34 @@
+// Verifies health reports the SQLite database the session rows come from.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildHealthSessionSummary } from "./collector.js";
+
+describe("buildHealthSessionSummary store path", () => {
+  it("reports the SQLite database rather than the legacy sessions.json locator", async () => {
+    // resolveStorePath still yields this JSON locator for the default store, but
+    // no such file is written any more; entries are read from SQLite.
+    const storePath = path.join(
+      "/tmp",
+      "openclaw-health",
+      "agents",
+      "main",
+      "sessions",
+      "sessions.json",
+    );
+
+    const summary = await buildHealthSessionSummary(storePath, "main");
+
+    expect(summary.path.endsWith("sessions.json")).toBe(false);
+    expect(summary.path).toBe(
+      path.join("/tmp", "openclaw-health", "agents", "main", "agent", "openclaw-agent.sqlite"),
+    );
+  });
+
+  it("keeps an explicit .sqlite store path as given", async () => {
+    const storePath = path.join("/tmp", "openclaw-health", "custom", "store.sqlite");
+
+    const summary = await buildHealthSessionSummary(storePath, "main");
+
+    expect(summary.path).toBe(storePath);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes #119755.

`openclaw health` reports a session-store path that does not exist:

```text
Session store (main): ~/.openclaw/agents/main/sessions/sessions.json (35 entries)
```

The entry count is real and comes from SQLite. Only the path is wrong, and it names a legacy JSON file that is never written any more.

The cause is in `buildHealthSessionSummary` (`src/gateway/health/collector.ts`). It reads rows through `listSessionEntriesReadOnly`, which resolves the SQLite database, and then returns `path: storePath` unchanged. `storePath` comes from `resolveStorePath`, which still yields `<agent dir>/sessions/sessions.json` as the *logical locator* for the default store (`src/config/sessions/paths.ts:338`). So the summary pairs a SQLite row count with a JSON path from a different era.

Reproduced on current `main` before changing anything, by calling the collector directly and checking the file it names:

```
REPORTED_PATH=.../.openclaw/agents/main/sessions/sessions.json
REPORTED_EXISTS=false
REAL_SQLITE=.../.openclaw/agents/main/agent/openclaw-agent.sqlite
```

That matches the report exactly: the advertised file is absent, and the rows come from the SQLite database beside it.

## Why This Change Was Made

The issue offers two options, reporting the real store or omitting the path. I took the first, because the path is genuinely useful for operators doing backup or recovery work; it was only pointing at the wrong file.

The repo already owns the mapping, so this resolves rather than reconstructs. `resolveSqliteTargetFromSessionStorePath` turns the legacy locator into the database that actually backs it, including the suffixed and shared-store ownership rules, and it is the same helper the session accessor path uses. For the default layout it maps `agents/<id>/sessions/sessions.json` to `agents/<id>/agent/openclaw-agent.sqlite`; an explicit `.sqlite` store path is returned unchanged.

The resolution is wrapped in a `try`/`catch` that falls back to the original locator. Health is best-effort by design here, and the function already swallows transient SQLite errors for the same reason, so a surprising store layout should degrade the label rather than fail the whole health summary.

I did not touch `resolveStorePath` itself. That locator is load-bearing well beyond health, it is what the accessor and ownership code key on, and changing it would be a much wider change than this reporting bug needs.

## User Impact

`openclaw health` now names the SQLite database the session entries were read from, at both the single-agent and multi-agent output sites, and in the JSON payload. Operators and agents reading that output no longer plan recovery around a `sessions.json` that does not exist.

The `sessions.path` field keeps its type and meaning, so JSON consumers see a corrected value rather than a changed shape. No config, schema, or default surface changes.

## Evidence

Regression coverage in `src/gateway/health/session-summary-path.test.ts`: one case asserts the reported path is the SQLite database and explicitly that it does not end in `sessions.json`, one asserts an explicit `.sqlite` store path is passed through untouched.

I confirmed the test actually pins the fix by reverting the resolution to the old `storePath` passthrough and rerunning:

```
× reports the SQLite database rather than the legacy sessions.json locator
Tests  1 failed | 1 passed (2)
```

then restored it for 2/2.

Existing surfaces stay green: `src/commands/health` 4 files / 47 tests, `src/gateway/health` 3 files / 6 tests. `tsgo -p tsconfig.core.json` and `tsgo -p test/tsconfig/tsconfig.core.test.json` both clean, oxlint clean on the changed files, `git diff --check` clean.

Production delta is +15/-1 in one file, all of it the resolution plus the fallback comment.

One gap stated rather than buried: my pre-PR check runs lint, the full test suite, and build. Lint and build passed; the full local `pnpm run test` came back red after 115 minutes with its output truncated to the last shard, so I cannot attribute it. That truncation is why I am not claiming a green run.

What I can say about attribution: the change is one file in the health collector, and both suites that own it are green (`src/commands/health` 47 tests, `src/gateway/health` 6 tests). I also re-ran the offender I have seen dominate local full-suite runs, `src/commands/doctor/shared/open-policy-allowfrom.test.ts`, which passes 14/14 here in isolation and has previously timed out at 162s and 170s against a 120s cap under load on this machine. If CI here disagrees I will chase it rather than wave it off.

AI-assisted: written with AI assistance. I reproduced the bug on current `main`, read the collector, the store-path resolver, and the SQLite target resolver myself, and ran the tests and gates locally.
