### PR TITLE
fix(diagnostics): prevent duplicate and leaked lifecycle spans

### DIFF
--- a/extensions/diagnostics-otel/src/service-recorders-tools.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-tools.ts
@@ -57,6 +57,8 @@ export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime
     ...(evt.toolOwner ? { "openclaw.tool.owner": normalizeDiagnosticValue(evt.toolOwner) } : {}),
     ...paramsSummaryAttrs(evt.paramsSummary),
   });
+  const toolTimestampMs = (evt: { sourceTimestampMs?: number; ts: number }) =>
+    evt.sourceTimestampMs ?? evt.ts;
 
   const skillUsedAttrs = (
     evt: Extract<DiagnosticEventPayload, { type: "skill.used" }>,
@@ -110,7 +112,7 @@ export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime
       metadata,
       spanWithDuration("openclaw.tool.execution", spanAttrs, undefined, {
         parentContext: activeTrustedParentContext(evt, metadata),
-        startTimeMs: evt.ts,
+        startTimeMs: toolTimestampMs(evt),
       }),
     ).spanContext();
   };
@@ -133,10 +135,10 @@ export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime
       takeTrackedTrustedSpan(evt, metadata) ??
       spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
         parentContext: activeTrustedParentContext(evt, metadata),
-        endTimeMs: evt.ts,
+        endTimeMs: toolTimestampMs(evt),
       });
     setSpanAttrs(span, spanAttrs);
-    span.end(evt.ts);
+    span.end(toolTimestampMs(evt));
   };
 
   const recordToolExecutionError = (
@@ -163,14 +165,14 @@ export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime
       takeTrackedTrustedSpan(evt, metadata) ??
       spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
         parentContext: activeTrustedParentContext(evt, metadata),
-        endTimeMs: evt.ts,
+        endTimeMs: toolTimestampMs(evt),
       });
     setSpanAttrs(span, spanAttrs);
     span.setStatus({
       code: SpanStatusCode.ERROR,
       message: redactSensitiveText(evt.errorCategory),
     });
-    span.end(evt.ts);
+    span.end(toolTimestampMs(evt));
   };
 
   const recordToolExecutionBlocked = (
@@ -191,12 +193,14 @@ export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime
     };
     addRunAttrs(spanAttrs, evt);
     assignOtelToolIdentityAttributes(spanAttrs, evt);
-    const span = spanWithDuration("openclaw.tool.execution", spanAttrs, 0, {
-      parentContext: activeTrustedParentContext(evt, metadata),
-      endTimeMs: evt.ts,
-    });
+    const span =
+      takeTrackedTrustedSpan(evt, metadata) ??
+      spanWithDuration("openclaw.tool.execution", spanAttrs, 0, {
+        parentContext: activeTrustedParentContext(evt, metadata),
+        endTimeMs: toolTimestampMs(evt),
+      });
     setSpanAttrs(span, spanAttrs);
-    span.end(evt.ts);
+    span.end(toolTimestampMs(evt));
   };
 
   const recordPayloadLarge = (evt: Extract<DiagnosticEventPayload, { type: "payload.large" }>) => {

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -3525,6 +3525,71 @@ describe("diagnostics-otel service", () => {
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
   });
 
+  test("closes a tracked blocked tool span once without creating a duplicate", async () => {
+    await startOtelService({ traces: true, metrics: true });
+
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.started",
+      runId: "run-blocked",
+      toolName: "exec",
+      toolCallId: "call-blocked",
+      sourceTimestampMs: 1_000,
+      trace: createTestTrace(TOOL_SPAN_ID, CHILD_SPAN_ID),
+    });
+    await emitTrustedAndFlush({
+      type: "tool.execution.blocked",
+      runId: "run-blocked",
+      toolName: "exec",
+      toolCallId: "call-blocked",
+      deniedReason: "tools.deny",
+      reason: "policy denied",
+      sourceTimestampMs: 1_250,
+      trace: createTestTrace(TOOL_SPAN_ID, CHILD_SPAN_ID),
+    });
+
+    const toolSpans = telemetryState.spans.filter(
+      (span) => span.name === "openclaw.tool.execution",
+    );
+    expect(toolSpans).toHaveLength(1);
+    expect(startedSpanOptions("openclaw.tool.execution")?.startTime).toBe(1_000);
+    expect(toolSpans[0]?.end).toHaveBeenCalledTimes(1);
+    expect(toolSpans[0]?.end).toHaveBeenCalledWith(1_250);
+  });
+
+  test("uses authoritative source timestamps for terminal-only tool spans", async () => {
+    await startOtelService({ traces: true, metrics: true });
+
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.completed",
+      runId: "run-completed",
+      toolName: "read",
+      toolCallId: "call-completed",
+      durationMs: 250,
+      sourceTimestampMs: 5_000,
+    });
+    await emitTrustedAndFlush({
+      type: "tool.execution.error",
+      runId: "run-error",
+      toolName: "write",
+      toolCallId: "call-error",
+      durationMs: 500,
+      errorCategory: "test",
+      sourceTimestampMs: 7_000,
+    });
+
+    const toolSpanCalls = telemetryState.tracer.startSpan.mock.calls.filter(
+      (call) => call[0] === "openclaw.tool.execution",
+    );
+    const toolSpans = telemetryState.spans.filter(
+      (span) => span.name === "openclaw.tool.execution",
+    );
+    expect(toolSpanCalls).toHaveLength(2);
+    expect((toolSpanCalls[0]?.[1] as { startTime?: number } | undefined)?.startTime).toBe(4_750);
+    expect((toolSpanCalls[1]?.[1] as { startTime?: number } | undefined)?.startTime).toBe(6_500);
+    expect(toolSpans[0]?.end).toHaveBeenCalledWith(5_000);
+    expect(toolSpans[1]?.end).toHaveBeenCalledWith(7_000);
+  });
+
   test("exports model failover spans", async () => {
     await startOtelService({ traces: true });
 

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -864,19 +864,34 @@ describe("diagnostic-events", () => {
     ).toBe(true);
   });
 
-  it("preserves trusted terminal tool diagnostics when the async queue is full", async () => {
+  it("preserves trusted lifecycle terminals when the async queue is full", async () => {
     const events: DiagnosticEventPayload[] = [];
     onInternalDiagnosticEvent((event) => {
       events.push(event);
     });
+    const model = {
+      runId: "run-model",
+      callId: "call-model",
+      provider: "openai",
+      model: "gpt-5.4",
+    };
+    const harness = { runId: "run-harness", harnessId: "harness" };
+    const terminalEvents: Array<Parameters<typeof emitTrustedDiagnosticEvent>[0]> = [
+      { type: "tool.execution.completed", toolName: "exec", durationMs: 1 },
+      { type: "tool.execution.error", toolName: "exec", durationMs: 1, errorCategory: "test" },
+      { type: "model.call.completed", ...model, durationMs: 1 },
+      { type: "model.call.error", ...model, durationMs: 1, errorCategory: "test" },
+      { type: "harness.run.completed", ...harness, durationMs: 1, outcome: "completed" },
+      {
+        type: "harness.run.error",
+        ...harness,
+        durationMs: 1,
+        phase: "resolve",
+        errorCategory: "test",
+      },
+    ];
 
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.completed",
-      runId: "run-saturation-first",
-      toolName: "exec",
-      toolCallId: "call-saturation-first",
-      durationMs: 1,
-    });
+    emitTrustedDiagnosticEvent(terminalEvents[0]!);
 
     for (let index = 0; index < 9_999; index += 1) {
       emitDiagnosticEvent({
@@ -887,52 +902,26 @@ describe("diagnostic-events", () => {
         model: "gpt-5.4",
       });
     }
-
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.error",
-      runId: "run-saturation-second",
-      toolName: "exec",
-      toolCallId: "call-saturation-second",
-      durationMs: 1,
-      errorCategory: "test",
-    });
+    for (const terminalEvent of terminalEvents.slice(1)) {
+      emitTrustedDiagnosticEvent(terminalEvent);
+    }
 
     expect(
       hasPendingInternalDiagnosticEvent(
-        (event, metadata) =>
-          metadata.trusted &&
-          event.type === "tool.execution.error" &&
-          event.toolCallId === "call-saturation-second",
+        (event, metadata) => metadata.trusted && event.type === "harness.run.error",
       ),
     ).toBe(true);
 
     await waitForDiagnosticEventsDrained();
 
+    for (const terminalEvent of terminalEvents) {
+      expect(events).toContainEqual(expect.objectContaining(terminalEvent));
+    }
     expect(
-      events
-        .filter(
-          (
-            event,
-          ): event is Extract<
-            DiagnosticEventPayload,
-            { type: "tool.execution.completed" | "tool.execution.error" }
-          > => event.type === "tool.execution.completed" || event.type === "tool.execution.error",
-        )
-        .map((event) => ({
-          type: event.type,
-          toolCallId: event.toolCallId,
-        })),
-    ).toEqual([
-      {
-        type: "tool.execution.completed",
-        toolCallId: "call-saturation-first",
-      },
-      {
-        type: "tool.execution.error",
-        toolCallId: "call-saturation-second",
-      },
-    ]);
-    expect(events.filter((event) => event.type === "model.call.started")).toHaveLength(9_998);
+      events.filter(
+        (event) => event.type === "model.call.started" && event.runId.startsWith("saturation-run-"),
+      ),
+    ).toHaveLength(9_994);
   });
 
   it("emits a bounded summary when async diagnostics are dropped at saturation", async () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -958,9 +958,15 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "log.record",
 ]);
 const PRIORITY_ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
+  // Trusted lifecycle terminals must displace best-effort diagnostics; dropping one
+  // can strand the recorder's active span after its producer already finished.
   "tool.execution.completed",
   "tool.execution.error",
   "tool.execution.blocked",
+  "model.call.completed",
+  "model.call.error",
+  "harness.run.completed",
+  "harness.run.error",
 ]);
 
 function createDiagnosticEventsState(): DiagnosticEventsGlobalState {


### PR DESCRIPTION
Fixes #119790

Related: https://github.com/openclaw/openclaw/pull/114480

## What Problem This Solves

Fixes an issue where OTEL lifecycle spans could be duplicated, use delayed dispatcher timestamps, or remain active after their producer had already finished.

The affected paths were blocked tool executions and trusted model/harness terminal diagnostics emitted while the async diagnostics queue was full.

## Why This Change Was Made

The diagnostics recorder now consumes the span tracked by `tool.execution.started` for every tool terminal variant, including `tool.execution.blocked`, and uses `sourceTimestampMs` for tool start/end boundaries when the producer supplies it.

The diagnostics bus now protects trusted model and harness terminals alongside tool terminals, allowing them to displace best-effort events at queue capacity. The existing exported-context behavior from #112283 and snapshot-based drain behavior from #119705 remain unchanged.

This intentionally does not change endpoint routing, exporter shutdown/health, token metrics, semantic conventions, or unrelated producers.

## User Impact

Operators receive one correctly timed tool span per lifecycle, including blocked executions. Queue pressure no longer silently strands active model or harness spans when best-effort diagnostics consume the queue.

## Evidence

- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts`
  - 1 file passed, 159 tests passed.
- `node scripts/run-vitest.mjs src/infra/diagnostic-events.test.ts`
  - 1 file passed, 36 tests passed.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.otlp-export.test.ts`
  - 1 file passed, 82 tests passed using the real OpenTelemetry SDK and local OTLP receiver paths.
- Targeted `oxfmt --check` and type-aware `oxlint` passed for all four changed files.
- `check-max-lines-ratchet`, conflict-marker scan, environment-variable count, and `git diff --check` passed.
- P0-P2 structured autoreview against `origin/main` completed cleanly with no accepted/actionable findings.

Upstream contract verified at `openai/codex@f141dc77f05b91aa758b3f27178329ced79d87a1`:

- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1245` requires the item start timestamp.
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1319` requires the item completion timestamp.
- `codex-rs/core/src/session/mod.rs:2086` records the start timestamp at lifecycle start.
- `codex-rs/core/src/session/mod.rs:2103` records the completion timestamp before terminal emission.
- `codex-rs/app-server/README.md:1519` defines the start-to-terminal item lifecycle.
- `codex-rs/app-server/README.md:1558` defines `item/completed` as authoritative.
