### PR TITLE
fix(backup): skip ephemeral coordinator lock databases

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1976,6 +1976,53 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("omits ephemeral coordinator lock databases held open by a running gateway", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-coordinator-lock-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        // Shapes a running gateway leaves behind: gateway-lock.ts appends
+        // `.sqlite` to `gateway.<hash>.lock`, and the device-identity
+        // coordinator uses the same `.lock.sqlite` convention.
+        const lockPaths = [
+          state.statePath("tmp", "openclaw-502", "gateway.a1b2c3d4.lock.sqlite"),
+          state.statePath("tmp", "openclaw-502", "gateway.state.e5f6a7b8.lock.sqlite"),
+          state.statePath("tmp", "device-identity.9c8d7e6f.lock.sqlite"),
+        ];
+        await fs.mkdir(outputDir, { recursive: true });
+        for (const lockPath of lockPaths) {
+          await fs.mkdir(path.dirname(lockPath), { recursive: true });
+          for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+            await fs.writeFile(`${lockPath}${suffix}`, "");
+          }
+        }
+
+        const result = await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: Date.UTC(2026, 4, 9, 8, 34, 0),
+        });
+        const entries = await listArchiveEntries(result.archivePath);
+        for (const lockPath of lockPaths) {
+          const relativeLockPath = path
+            .relative(state.stateDir, lockPath)
+            .split(path.sep)
+            .join("/");
+          for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+            expect(
+              entries.some((entry) => entry.endsWith(`/state/${relativeLockPath}${suffix}`)),
+              `${relativeLockPath}${suffix}`,
+            ).toBe(false);
+          }
+        }
+      },
+    );
+  });
+
   it("omits transient memory reindex databases and sidecars", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -376,7 +376,10 @@ type StateSqliteBackupPlan = {
 };
 
 const SQLITE_BACKUP_SOURCE_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
-const SQLITE_BACKUP_EXCLUDED_SUFFIXES = [".reindex-lock.sqlite"] as const;
+// Exclusive-coordinator lock databases are process-lifetime scratch, not backup
+// material, and a running gateway holds them open so compaction cannot succeed.
+// `.reindex-lock.sqlite` stays listed separately: it ends in `-lock.sqlite`.
+const SQLITE_BACKUP_EXCLUDED_SUFFIXES = [".reindex-lock.sqlite", ".lock.sqlite"] as const;
 const SQLITE_BACKUP_REINDEX_TRANSIENT_PATTERN =
   /\.sqlite\.(?:backup|memory-reindex|tmp)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #119757.

`openclaw backup create --output <dir> --verify` cannot back up a running gateway. It fails on a zero-byte ephemeral lock database the gateway holds open:

```text
Error: SQLite database cannot be compacted safely for backup:
 ~/.openclaw/tmp/openclaw-502/gateway.<id>.lock.sqlite
 ... database is locked | ERR_SQLITE_ERROR
```

No archive is produced, so the documented pre-upgrade backup step cannot run without stopping the gateway first, which the docs never say.

Refusing an unsafe raw copy is correct, and I did not touch that. The bug is that the file is in the backup set at all. It is a process-lifetime coordination lock, not user data: `src/infra/gateway-lock.ts:491` acquires the coordinator as `` `${lockPath}.sqlite` `` over `gateway.<hash>.lock`, producing exactly the `gateway.<hash>.lock.sqlite` in the report. `src/infra/device-identity-coordinator.ts:48` builds `device-identity.<hash>.lock.sqlite` the same way.

## Why This Change Was Made

The repo already has the right mechanism, and this class of file was already understood to be non-backup material. `SQLITE_BACKUP_EXCLUDED_SUFFIXES` in `src/infra/backup-create.ts` is a suffix list consulted both when classifying a source path and when walking directories. It listed `.reindex-lock.sqlite` and nothing else, so reindex locks were skipped while coordinator locks were not.

So this adds one entry rather than inventing an exclusion path:

```ts
const SQLITE_BACKUP_EXCLUDED_SUFFIXES = [".reindex-lock.sqlite", ".lock.sqlite"] as const;
```

That covers the gateway config and state locks and the device-identity lock. The existing entry has to stay, because `.reindex-lock.sqlite` ends in `-lock.sqlite` with a hyphen and would not match the new suffix.

I chose the suffix over excluding `tmp/` wholesale. The suffix targets the actual property that makes these files unbackupable, which is that they are exclusive coordinators held for the life of a process, and it keeps working if a coordinator is ever placed outside `tmp/`, as the device-identity one already is.

## User Impact

`backup create` works against a running gateway again, which is the documented pre-upgrade path. Nothing that belongs in a backup is dropped: these files carry no durable state, are zero-byte in the reported case, and are recreated on demand by whichever process next takes the lock.

No config, schema, or default surface changes. Production delta is +5/-1 in one file, four of which are the comment explaining why the entry exists.

## Evidence

Regression coverage in `src/infra/backup-create.test.ts`, added as a sibling to the existing transient-reindex exclusion test so both live in the same place. It writes the real path shapes a running gateway leaves behind, including the sidecars:

```
tmp/openclaw-502/gateway.a1b2c3d4.lock.sqlite
tmp/openclaw-502/gateway.state.e5f6a7b8.lock.sqlite
tmp/device-identity.9c8d7e6f.lock.sqlite
```

each with `""`, `-wal`, `-shm`, and `-journal`, then asserts none appear in the produced archive.

I confirmed the test pins the fix by reverting the suffix list to its previous value and rerunning:

```
× omits ephemeral coordinator lock databases held open by a running gateway
Tests  1 failed | 69 passed (70)
```

then restored it for 70/70.

Verification: `src/infra/backup-create.test.ts` 70 tests, `src/commands/backup` 3 files / 16 tests, `tsgo -p tsconfig.core.json` and `tsgo -p test/tsconfig/tsconfig.core.test.json` both clean, `git diff --check` clean.

I did not reproduce the original failure end to end against a live gateway, since that means holding the operator's running service open, which the repo rules put off limits without explicit approval. The test reproduces the file shape and the archive assertion instead, and the lock-path construction is cited above rather than assumed.

AI-assisted: written with AI assistance. I read the backup classifier, the directory walk, the gateway lock acquisition, and the device-identity coordinator myself before changing anything.
