### PR TITLE
perf(agents): index subagent recovery ownership

### DIFF
--- a/scripts/bench-agent-concurrency-worker.ts
+++ b/scripts/bench-agent-concurrency-worker.ts
@@ -575,10 +575,15 @@ function sweepRow(child: number, generation: number, now: number): SubagentRunRe
 }
 
 async function runSweepSample(childCount: number): Promise<Sample> {
-  const { createSubagentRegistrySweeper } =
-    await import("../src/agents/subagent-registry-sweeper.js");
+  const [
+    { getSubagentRunsForChildSession, subagentRuns: runs },
+    { createSubagentRegistrySweeper },
+  ] = await Promise.all([
+    import("../src/agents/subagent-registry-memory.js"),
+    import("../src/agents/subagent-registry-sweeper.js"),
+  ]);
   const now = Date.now();
-  const runs = new Map<string, SubagentRunRecord>();
+  runs.clear();
   for (let child = 0; child < childCount; child += 1) {
     for (const generation of [3, 2, 1]) {
       const entry = sweepRow(child, generation, now);
@@ -632,8 +637,7 @@ async function runSweepSample(childCount: number): Promise<Sample> {
       sessionEffects += 1;
     },
     retireSupersededRun: async () => {},
-    getRunsForChildSession: (childSessionKey) =>
-      [...runs.values()].filter((entry) => entry.childSessionKey === childSessionKey),
+    getRunsForChildSession: getSubagentRunsForChildSession,
     getRunsForCollectorGroup: () => [],
     warn: () => {},
   });
@@ -668,6 +672,7 @@ async function runSweepSample(childCount: number): Promise<Sample> {
     };
   } finally {
     sweeper.reset();
+    runs.clear();
   }
 }
 

--- a/src/agents/subagent-registry-restart-recovery-coordinator.ts
+++ b/src/agents/subagent-registry-restart-recovery-coordinator.ts
@@ -19,6 +19,7 @@ type RecoveryRetry = {
 
 type RecoveryCoordinatorParams = {
   runs: Map<string, SubagentRunRecord>;
+  getRunsForChildSession: (childSessionKey: string) => Iterable<SubagentRunRecord>;
   getGatewayRuntime: () => GatewayRecoveryRuntime | undefined;
   abandonLaunch: ReturnType<
     typeof createSubagentRunManager
@@ -61,7 +62,10 @@ export function createInterruptedRecoveryCoordinator(params: RecoveryCoordinator
   const retries = new Map<string, RecoveryRetry>();
   const ownsCurrentGeneration = (runId: string, entry: SubagentRunRecord) =>
     params.runs.get(runId) === entry &&
-    getLatestSubagentRunByChildSessionKeyFromRuns(params.runs, entry.childSessionKey) === entry;
+    getLatestSubagentRunByChildSessionKeyFromRuns(
+      params.getRunsForChildSession(entry.childSessionKey),
+      entry.childSessionKey,
+    ) === entry;
 
   function defer(runId: string, retry: Omit<RecoveryRetry, "at">, delayMs: number) {
     retries.set(runId, { ...retry, at: Date.now() + delayMs });
@@ -119,7 +123,7 @@ export function createInterruptedRecoveryCoordinator(params: RecoveryCoordinator
       entry,
       now,
       gatewayRuntime: params.getGatewayRuntime(),
-      isCurrent: () => ownsCurrentGeneration(runId, entry),
+      isCurrent: ownsCurrentGeneration,
       abandonLaunch: params.abandonLaunch,
       clearAcceptedRecovery: params.clearAcceptedRecovery,
       getRun: (targetRunId) => params.runs.get(targetRunId),

--- a/src/agents/subagent-registry-restart-recovery.test.ts
+++ b/src/agents/subagent-registry-restart-recovery.test.ts
@@ -6,6 +6,7 @@ import {
   consumeSessionWorkAdmissionHandoff,
   type SessionWorkAdmissionLease,
 } from "../sessions/session-lifecycle-admission.js";
+import { getLatestSubagentRunByChildSessionKeyFromRuns } from "./subagent-registry-queries.js";
 import { recoverInterruptedSubagentRow } from "./subagent-registry-restart-recovery.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import {
@@ -788,6 +789,59 @@ describe("subagent registry restart recovery", () => {
     expect(mocks.patchSessionEntry).toHaveBeenCalledOnce();
     expect(mocks.entries[childSessionKey]!.abortedLastRun).toBe(false);
   });
+
+  it.each([
+    ["during settlement", true, true],
+    ["after settlement", false, false],
+  ])(
+    "preserves accepted recovery when a newer generation wins %s",
+    async (_name, beforeCommit, expectedAborted) => {
+      const entry = run();
+      const runs = new Map([[entry.runId, entry]]);
+      const isCurrent: RecoveryParams["isCurrent"] = (runId, candidate) =>
+        runs.get(runId) === candidate &&
+        getLatestSubagentRunByChildSessionKeyFromRuns(runs, candidate.childSessionKey) ===
+          candidate;
+      replaceRun.mockImplementationOnce((params: ReplaceRunParams) => {
+        runs.delete(params.previousRunId);
+        entry.runId = params.nextRunId;
+        entry.execution.restartRecovery = params.restartRecovery;
+        runs.set(entry.runId, entry);
+        return true;
+      });
+      mocks.patchSessionEntry.mockImplementationOnce(async ({ sessionKey }, update, options) => {
+        const next = update({ ...mocks.entries[sessionKey]! });
+        const advanceOwner = () => {
+          const newer = run({
+            runId: "newer-accepted-run",
+            generation: (entry.generation ?? 0) + 1,
+          });
+          runs.set(newer.runId, newer);
+        };
+        if (beforeCommit) {
+          advanceOwner();
+        }
+        options?.assertCommitAllowed?.();
+        mocks.entries[sessionKey] = next;
+        if (!beforeCommit) {
+          advanceOwner();
+        }
+        return next;
+      });
+
+      await expect(
+        recover(entry, {
+          getRun: (runId) => runs.get(runId),
+          isCurrent,
+        }),
+      ).resolves.toEqual({ status: "deferred" });
+
+      expect(mocks.entries[childSessionKey]!.abortedLastRun).toBe(expectedAborted);
+      expect(entry.execution.restartRecovery).toMatchObject({ phase: "accepted" });
+      expect(clearAcceptedRecovery).not.toHaveBeenCalled();
+      expect(resumeAcceptedRecovery).not.toHaveBeenCalled();
+    },
+  );
 
   it("terminalizes a retired accepted receipt without clearing newer restart evidence", async () => {
     const entry = run({

--- a/src/agents/subagent-registry-restart-recovery.ts
+++ b/src/agents/subagent-registry-restart-recovery.ts
@@ -36,6 +36,7 @@ import { getSubagentSessionStartedAt } from "./subagent-session-metrics.js";
 
 const MAX_RECOVERY_ATTEMPTS = 2;
 const RECOVERY_ATTEMPT_WINDOW_MS = 2 * 60_000;
+type SubagentRunManager = ReturnType<typeof createSubagentRunManager>;
 
 export type RestartRecoveryResult =
   | { status: "ignored" }
@@ -56,33 +57,17 @@ export type RestartRecoveryParams = {
   entry: SubagentRunRecord;
   now: number;
   gatewayRuntime: GatewayRecoveryRuntime | undefined;
-  isCurrent: () => boolean;
-  abandonLaunch: ReturnType<
-    typeof createSubagentRunManager
-  >["abandonSubagentRestartRecoveryLaunch"];
-  clearAcceptedRecovery: ReturnType<
-    typeof createSubagentRunManager
-  >["clearAcceptedSubagentRestartRecovery"];
+  isCurrent: (runId: string, entry: SubagentRunRecord) => boolean;
+  abandonLaunch: SubagentRunManager["abandonSubagentRestartRecoveryLaunch"];
+  clearAcceptedRecovery: SubagentRunManager["clearAcceptedSubagentRestartRecovery"];
   getRun: (runId: string) => SubagentRunRecord | undefined;
-  replaceRun: ReturnType<typeof createSubagentRunManager>["replaceSubagentRunAfterSteer"];
-  markLaunchAttempted: ReturnType<
-    typeof createSubagentRunManager
-  >["markSubagentRestartRecoveryLaunchAttempted"];
-  markLaunchAccepted: ReturnType<
-    typeof createSubagentRunManager
-  >["markSubagentRestartRecoveryLaunchAccepted"];
-  markLaunchConsumed: ReturnType<
-    typeof createSubagentRunManager
-  >["markSubagentRestartRecoveryLaunchConsumed"];
-  resetLaunchAttempt: ReturnType<
-    typeof createSubagentRunManager
-  >["resetSubagentRestartRecoveryLaunchAttempt"];
-  reserveLaunch: ReturnType<
-    typeof createSubagentRunManager
-  >["reserveSubagentRestartRecoveryLaunch"];
-  resumeAcceptedRecovery: ReturnType<
-    typeof createSubagentRunManager
-  >["resumeSettledSubagentRestartRecovery"];
+  replaceRun: SubagentRunManager["replaceSubagentRunAfterSteer"];
+  markLaunchAttempted: SubagentRunManager["markSubagentRestartRecoveryLaunchAttempted"];
+  markLaunchAccepted: SubagentRunManager["markSubagentRestartRecoveryLaunchAccepted"];
+  markLaunchConsumed: SubagentRunManager["markSubagentRestartRecoveryLaunchConsumed"];
+  resetLaunchAttempt: SubagentRunManager["resetSubagentRestartRecoveryLaunchAttempt"];
+  reserveLaunch: SubagentRunManager["reserveSubagentRestartRecoveryLaunch"];
+  resumeAcceptedRecovery: SubagentRunManager["resumeSettledSubagentRestartRecovery"];
   warn: (message: string, meta?: Record<string, unknown>) => void;
 };
 
@@ -95,7 +80,7 @@ async function reconcileAcceptedRecovery(params: {
   clearAcceptedRecovery: RestartRecoveryParams["clearAcceptedRecovery"];
   entry: SubagentRunRecord;
   getRun: RestartRecoveryParams["getRun"];
-  isCurrent: () => boolean;
+  isCurrent: RestartRecoveryParams["isCurrent"];
   now: number;
   receipt: SubagentRestartRecoveryReceipt;
   replaceRun: RestartRecoveryParams["replaceRun"];
@@ -117,7 +102,7 @@ async function reconcileAcceptedRecovery(params: {
     let remapped = false;
     try {
       remapped =
-        params.isCurrent() &&
+        params.isCurrent(params.runId, params.entry) &&
         params.replaceRun({
           previousRunId: params.runId,
           nextRunId: params.receipt.idempotencyKey,
@@ -143,7 +128,11 @@ async function reconcileAcceptedRecovery(params: {
       };
     }
     const successor = params.getRun(params.receipt.idempotencyKey);
-    if (!successor || successor.execution.restartRecovery !== params.receipt) {
+    if (
+      !successor ||
+      successor.execution.restartRecovery !== params.receipt ||
+      !params.isCurrent(successor.runId, successor)
+    ) {
       params.warn("accepted subagent restart recovery lost its remapped owner", {
         runId: params.runId,
         childSessionKey: params.childSessionKey,
@@ -152,6 +141,10 @@ async function reconcileAcceptedRecovery(params: {
     }
     owner = successor;
   }
+  const ownsAcceptedTarget = () =>
+    params.isCurrent(owner.runId, owner) &&
+    owner.execution.restartRecovery === params.receipt &&
+    isRestartRecoveryLifecycleCurrent(params.receipt);
 
   if (
     !params.currentSessionId ||
@@ -173,10 +166,7 @@ async function reconcileAcceptedRecovery(params: {
       !(await settleAcceptedRecoverySession({
         attempts: params.attempts,
         childSessionKey: params.childSessionKey,
-        isOwnerCurrent: () =>
-          params.getRun(owner.runId) === owner &&
-          owner.execution.restartRecovery === params.receipt &&
-          isRestartRecoveryLifecycleCurrent(params.receipt),
+        isOwnerCurrent: ownsAcceptedTarget,
         sessionId: params.receipt.sessionId,
         sessionLifecycleRevision: params.receipt.sessionLifecycleRevision,
         now: params.now,
@@ -222,9 +212,9 @@ async function reconcileAcceptedRecovery(params: {
       target: { runId: owner.runId, entry: owner },
     };
   }
-
   try {
     if (
+      !ownsAcceptedTarget() ||
       !params.clearAcceptedRecovery({
         runId: owner.runId,
         expected: owner,
@@ -247,6 +237,7 @@ async function reconcileAcceptedRecovery(params: {
     return { status: "deferred" };
   }
   if (
+    !params.isCurrent(owner.runId, owner) ||
     !params.resumeAcceptedRecovery({
       runId: owner.runId,
       expected: owner,
@@ -272,10 +263,10 @@ export async function recoverInterruptedSubagentRow(
     params.entry.execution.outcome?.status === "timeout" &&
     typeof params.entry.execution.endedAt === "number";
   const acceptedRecoveryCurrent =
-    initialRecoveryReceipt?.phase === "accepted" && params.isCurrent();
+    initialRecoveryReceipt?.phase === "accepted" && params.isCurrent(params.runId, params.entry);
   const isRecoverySourceCurrent = () =>
     isRecoveryAttemptLifecycleCurrent() &&
-    params.isCurrent() &&
+    params.isCurrent(params.runId, params.entry) &&
     params.entry.pauseReason !== "sessions_yield" &&
     params.entry.suppressAnnounceReason !== "steer-restart" &&
     params.entry.killReconciliation === undefined &&

--- a/src/agents/subagent-registry-sweep-kill.ts
+++ b/src/agents/subagent-registry-sweep-kill.ts
@@ -89,6 +89,7 @@ export async function reconcileDurableSubagentKillIntent(params: {
   runId: string;
   entry: SubagentRunRecord;
   runs: Map<string, SubagentRunRecord>;
+  getRunsForChildSession: (childSessionKey: string) => Iterable<SubagentRunRecord>;
   loadKillRuntime: () => Promise<typeof import("./subagent-control.runtime.js")>;
   completeSubagentRunWithRecovery: (
     completion: SubagentCompletionRequest,
@@ -104,13 +105,14 @@ export async function reconcileDurableSubagentKillIntent(params: {
   if (params.runs.get(params.runId) !== params.entry) {
     return false;
   }
+  const childRuns = () => params.getRunsForChildSession(params.entry.childSessionKey);
   const latest = getLatestSubagentRunByChildSessionKeyFromRuns(
-    params.runs,
+    childRuns(),
     params.entry.childSessionKey,
   );
   if (latest !== params.entry) {
     try {
-      const taskResolution = resolveSubagentTaskForRun(params.runs.values(), params.entry);
+      const taskResolution = resolveSubagentTaskForRun(childRuns(), params.entry);
       const task = taskResolution.task;
       if (taskResolution.lookup === "unavailable" || isUnstableTask(task)) {
         const finalized = finalizeTaskRunByRunId({
@@ -133,7 +135,7 @@ export async function reconcileDurableSubagentKillIntent(params: {
       }
       if (
         params.runs.get(params.runId) !== params.entry ||
-        getLatestSubagentRunByChildSessionKeyFromRuns(params.runs, params.entry.childSessionKey) ===
+        getLatestSubagentRunByChildSessionKeyFromRuns(childRuns(), params.entry.childSessionKey) ===
           params.entry
       ) {
         return false;
@@ -154,7 +156,7 @@ export async function reconcileDurableSubagentKillIntent(params: {
     params.entry.killIntent === killIntent &&
     killIntent.lifecycleGeneration !== undefined &&
     isAgentEventLifecycleGenerationCurrent(killIntent.lifecycleGeneration) &&
-    getLatestSubagentRunByChildSessionKeyFromRuns(params.runs, params.entry.childSessionKey) ===
+    getLatestSubagentRunByChildSessionKeyFromRuns(childRuns(), params.entry.childSessionKey) ===
       params.entry;
   const cfg = getRuntimeConfig();
   const storePath = resolveStorePath(cfg.session?.store, {

--- a/src/agents/subagent-registry-sweeper-recovery.test.ts
+++ b/src/agents/subagent-registry-sweeper-recovery.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { reconcileDurableSubagentKillIntent } from "./subagent-registry-sweep-kill.js";
 import { retireSupersededSubagentRun } from "./subagent-registry-sweeper-retire.js";
 import { createSubagentRegistrySweeper } from "./subagent-registry-sweeper.js";
@@ -62,6 +63,9 @@ function run(): SubagentRunRecord {
     startedAt: Date.now() - 55_000,
   });
 }
+
+const childRuns = (runs: Map<string, SubagentRunRecord>) => (childSessionKey: string) =>
+  [...runs.values()].filter((entry) => entry.childSessionKey === childSessionKey);
 
 function createHarness(runtime: { current?: GatewayRecoveryRuntime }) {
   const entry = run();
@@ -127,7 +131,7 @@ function createHarness(runtime: { current?: GatewayRecoveryRuntime }) {
     runContextEngineSubagentEnded: vi.fn(),
     notifyContextEngineSubagentEnded,
     retireSupersededRun: vi.fn(),
-    getRunsForChildSession: () => [],
+    getRunsForChildSession: childRuns(runs),
     getRunsForCollectorGroup: () => [],
     warn,
   });
@@ -193,6 +197,27 @@ describe("subagent registry recovery scheduling", () => {
     recoverRow.mockResolvedValue({ status: "handled" });
     await sweeper.runTick();
     expect(recoverRow).toHaveBeenCalledTimes(5);
+    sweeper.reset();
+  });
+
+  it("drops a stale terminal retry when a newer generation wins during finalization", async () => {
+    const runtime = { current: {} as GatewayRecoveryRuntime };
+    recoverRow.mockResolvedValue({ status: "terminal", error: "interrupted" });
+    const { entry, runs, finalizeInterruptedSubagentRun, sweeper } = createHarness(runtime);
+    const finalization = createDeferred<number>();
+    finalizeInterruptedSubagentRun.mockReturnValueOnce(finalization.promise);
+
+    const pending = sweeper.sweepOnce();
+    await vi.waitFor(() => expect(finalizeInterruptedSubagentRun).toHaveBeenCalledOnce());
+    const newer = run();
+    newer.runId = "newer-recovery-run";
+    newer.generation = (entry.generation ?? 0) + 1;
+    runs.set(newer.runId, newer);
+    finalization.resolve(0);
+    await pending;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(finalizeInterruptedSubagentRun).toHaveBeenCalledOnce();
     sweeper.reset();
   });
 
@@ -301,7 +326,22 @@ describe("subagent registry recovery scheduling", () => {
     sweeper.reset();
   });
 
-  it("does not apply a durable kill after runtime loading yields to a replacement row", async () => {
+  it.each([
+    [
+      "same run id",
+      (runs: Map<string, SubagentRunRecord>, entry: SubagentRunRecord) =>
+        runs.set(entry.runId, run()),
+    ],
+    [
+      "newer generation",
+      (runs: Map<string, SubagentRunRecord>, entry: SubagentRunRecord) => {
+        const newer = run();
+        newer.runId = "newer-kill-run";
+        newer.generation = (entry.generation ?? 0) + 1;
+        runs.set(newer.runId, newer);
+      },
+    ],
+  ])("does not apply a durable kill after %s wins during runtime loading", async (_name, win) => {
     const entry = run();
     entry.killIntent = {
       requestedAt: Date.now(),
@@ -311,35 +351,30 @@ describe("subagent registry recovery scheduling", () => {
       sessionLifecycleRevision: "session-revision",
     };
     const runs = new Map([[entry.runId, entry]]);
-    const replacement = run();
-    let releaseRuntime!: () => void;
-    const loadKillRuntime = vi.fn(
-      () =>
-        new Promise<typeof import("./subagent-control.runtime.js")>((resolve) => {
-          releaseRuntime = () =>
-            resolve(killRuntime as unknown as typeof import("./subagent-control.runtime.js"));
-        }),
-    );
+    const runtime = createDeferred<typeof import("./subagent-control.runtime.js")>();
+    const loadKillRuntime = vi.fn(() => runtime.promise);
     const completeSubagentRunWithRecovery = vi.fn();
-
+    const retireSupersededRun = vi.fn();
     const pending = reconcileDurableSubagentKillIntent({
       runId: entry.runId,
       entry,
       runs,
+      getRunsForChildSession: childRuns(runs),
       loadKillRuntime,
       completeSubagentRunWithRecovery,
-      retireSupersededRun: vi.fn(),
+      retireSupersededRun,
       warn: vi.fn(),
     });
+
     await vi.waitFor(() => expect(loadKillRuntime).toHaveBeenCalledOnce());
-    runs.set(entry.runId, replacement);
-    releaseRuntime();
+    win(runs, entry);
+    runtime.resolve(killRuntime as never);
 
     await expect(pending).resolves.toBe(false);
-    expect(killRuntime.isEmbeddedAgentRunActive).not.toHaveBeenCalled();
     expect(killRuntime.abortEmbeddedAgentRun).not.toHaveBeenCalled();
     expect(killRuntime.clearSessionQueues).not.toHaveBeenCalled();
     expect(completeSubagentRunWithRecovery).not.toHaveBeenCalled();
+    expect(retireSupersededRun).not.toHaveBeenCalled();
   });
 
   it("does not apply a durable kill after the same session id resets to a new revision", async () => {
@@ -366,6 +401,7 @@ describe("subagent registry recovery scheduling", () => {
       runId: entry.runId,
       entry,
       runs,
+      getRunsForChildSession: childRuns(runs),
       loadKillRuntime,
       completeSubagentRunWithRecovery,
       retireSupersededRun: vi.fn(),
@@ -444,6 +480,7 @@ describe("subagent registry recovery scheduling", () => {
         runId: entry.runId,
         entry,
         runs,
+        getRunsForChildSession: childRuns(runs),
         loadKillRuntime: async () =>
           killRuntime as unknown as typeof import("./subagent-control.runtime.js"),
         completeSubagentRunWithRecovery,
@@ -497,6 +534,7 @@ describe("subagent registry recovery scheduling", () => {
         runId: entry.runId,
         entry,
         runs,
+        getRunsForChildSession: childRuns(runs),
         loadKillRuntime: async () =>
           killRuntime as unknown as typeof import("./subagent-control.runtime.js"),
         completeSubagentRunWithRecovery: vi.fn(),

--- a/src/agents/subagent-registry-sweeper.ts
+++ b/src/agents/subagent-registry-sweeper.ts
@@ -168,6 +168,7 @@ export function createSubagentRegistrySweeper(params: {
 
   const recovery = createInterruptedRecoveryCoordinator({
     runs,
+    getRunsForChildSession: params.getRunsForChildSession,
     getGatewayRuntime: params.getGatewayRecoveryRuntime,
     abandonLaunch: params.abandonSubagentRestartRecoveryLaunch,
     clearAcceptedRecovery: params.clearAcceptedSubagentRestartRecovery,
@@ -321,6 +322,7 @@ export function createSubagentRegistrySweeper(params: {
               runId,
               entry,
               runs,
+              getRunsForChildSession: params.getRunsForChildSession,
               loadKillRuntime: () => killRuntimeLoader.load(),
               completeSubagentRunWithRecovery: params.completeSubagentRunWithRecovery,
               retireSupersededRun: params.retireSupersededRun,


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational performance problem where restart recovery sweeps repeatedly scanned the entire live subagent registry to determine ownership for each row. Large recovery sets therefore paid quadratic ownership-check cost while the registry already maintained a child-session index.

## Why This Change Was Made

Base SHA: `a20746e3abf7378462448c456eaa7098b85aab48`

The child-session index in `subagent-registry-memory.ts` is the architectural owner for live generations of one child session. This change threads that existing lookup into restart recovery and durable kill reconciliation, removing five full-registry scans: one in the recovery coordinator and four in durable kill ownership/task checks.

Ownership is re-read at the existing await boundaries. Recovery currency is target-aware across source rows, accepted remaps, settlement, receipt clearing, and resume, so a stale generation cannot mutate a newer owner.

Independent best-fix review compared the owner boundary and sibling recovery paths. It confirmed that reusing the canonical child-session index is preferable to adding a recovery-local cache or downstream guards.

There are no config, schema, persistence-format, scheduling, protocol, or public API changes.

### Complexity and size

- Per swept row, `K` ownership checks change from `O(K*N)` full-registry work to `O(K*G)`, where `G` is the live generation count for that child session and is normally 1.
- Across the full sweep, ownership work changes from worst-case `O(K*N^2)` to `O(K*N*G)`; the existing `O(N log N)` sweep ordering remains.
- Production: `+41/-42`, net `-1`.
- Tests: `+108/-16`, net `+92`.
- Benchmark fixture: `+10/-5`, net `+5`.

## User Impact

Operators with large retained subagent recovery sets get substantially lower restart-recovery sweep latency without changing recovery semantics, configuration, stored data, or required actions.

## Evidence

### Same-lease benchmark

Exact command:

```text
node --import tsx scripts/bench-agent-concurrency.ts --runs 20 --warmup 3 --fanout 1 --sweep-rows 32,128,512 --json
```

Environment: Node `v24.19.0`, AMD EPYC, 4 CPUs. Baseline and final ran sequentially on the same Testbox lease. Both invariant sets were green and identical.

| Recovery rows | p50 baseline -> final | p95 baseline -> final | p99 baseline -> final |
| ---: | ---: | ---: | ---: |
| 32 | 0.2557 -> 0.1868 ms (-27.0%) | 0.3419 -> 0.2823 ms (-17.4%) | 0.3843 -> 18.1853 ms (single scheduler outlier) |
| 128 | 0.9453 -> 0.5556 ms (-41.2%) | 1.2830 -> 0.7561 ms (-41.1%) | 4.4494 -> 0.9361 ms (-79.0%) |
| 512 | 8.5672 -> 1.8219 ms (-78.7%) | 11.4056 -> 5.1632 ms (-54.7%) | 13.2825 -> 11.2670 ms (-15.2%) |

The 32-row final p99 is one scheduler outlier; its p50 and p95 both improved. The post-benchmark lint amendment only introduced a type alias and test deferred helper; TypeScript emitted runtime JavaScript remained byte-identical.

### Race proofs

1. A newer recovery generation wins while terminal finalization is awaited: no stale retry or second finalization occurs.
2. Durable kill ownership changes while runtime loading is awaited: both same-run-ID replacement and a distinct newer generation avoid abort, queue clearing, completion, and retirement.
3. A newer accepted-recovery generation wins during settlement before commit: settlement defers and preserves the abort marker and receipt.
4. Settlement succeeds, then a newer generation wins before receipt retirement: recovery defers, retains the receipt, and does not clear or resume the stale owner.

### Verification

- Five focused suites passed at exact head: 65 tests total (`29 + 19 + 8 + 2 + 7`).
- Direct focused lint and `git diff --check` passed.
- Remote `check:changed` passed with lanes `core, coreTests, scripts, tooling`.
- Exact remote proof: https://github.com/openclaw/openclaw/actions/runs/31061063454
- Remote preflight verified the exact base, seven changed paths, and final production file hashes.

No changelog entry: this is an internal performance and ownership repair with no new user-visible surface or operator action, and `CONTRIBUTING.md` leaves changelog edits to the landing maintainers.

AI-assisted implementation; the code, race behavior, benchmark methodology, and final proof were reviewed directly.
