### PR TITLE
fix(codex): show endpoint probe failure details

### DIFF
--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -1105,12 +1105,16 @@ export function redactCodexAppServerDiagnostic(value: string): string {
   const redacted = compact
     .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]+/gi, "$1<redacted>")
     .replace(
-      /("[a-z0-9_-]*(?:api_?key|authorization|token|access_token|refresh_token|client_secret|secret|password|cookie)"\s*:\s*")([^"]+)(")/gi,
+      /("[a-z0-9_-]*(?:api[-_]?key|authorization|token|access_token|refresh_token|client_secret|secret|password|cookie)"\s*:\s*")([^"]+)(")/gi,
       "$1<redacted>$3",
     )
     .replace(
-      /\b([a-z0-9_-]*(?:api_?key|authorization|access_token|refresh_token|client_secret|token|secret|password|cookie))(\s*=\s*)(["']?)[^\s"']+(\3)/gi,
+      /\b([a-z0-9_-]*(?:api[-_]?key|authorization|access_token|refresh_token|client_secret|token|secret|password|cookie))(\s*=\s*)(["']?)[^\s"']+(\3)/gi,
       "$1$2$3<redacted>$4",
+    )
+    .replace(
+      /\b([a-z0-9_-]*(?:api[-_]?key|authorization|access_token|refresh_token|client_secret|token|secret|password|cookie))(\s*:\s*)[^\r\n]+/gi,
+      "$1$2<redacted>",
     );
   return redacted.length > CODEX_APP_SERVER_DIAGNOSTIC_MAX
     ? `${truncateUtf16Safe(redacted, CODEX_APP_SERVER_DIAGNOSTIC_MAX)}...`

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -29,7 +29,7 @@ import {
 } from "./transport.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
-const CODEX_APP_SERVER_PARSE_LOG_MAX = 500;
+const CODEX_APP_SERVER_DIAGNOSTIC_MAX = 500;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX = 8 * 1024 * 1024;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX_LINES = 1_000;
 // agents_wait can use a 600s inner budget plus 30s handler grace. Keep the
@@ -355,7 +355,7 @@ export class CodexAppServerClient {
 
   /** Returns a bounded, redacted stderr diagnostic from the app-server process. */
   getStderrDiagnostic(): string | undefined {
-    return redactCodexAppServerLinePreview(this.stderrTail) || undefined;
+    return redactCodexAppServerDiagnostic(this.stderrTail) || undefined;
   }
 
   /** Returns the terminal transport error that closed this physical client. */
@@ -1095,20 +1095,25 @@ function readCodexVersionFromUserAgent(userAgent: string | undefined): string | 
   return match?.[1];
 }
 
-function redactCodexAppServerLinePreview(value: string): string {
+/**
+ * Makes app-server supplied diagnostics safe for logs and owner-visible tool
+ * results. App-server RPC errors can include server-controlled text, so keep
+ * the preview small and remove common credential encodings before it escapes.
+ */
+export function redactCodexAppServerDiagnostic(value: string): string {
   const compact = value.replace(/\s+/g, " ").trim();
   const redacted = compact
     .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]+/gi, "$1<redacted>")
     .replace(
-      /("(?:api_?key|authorization|token|access_token|refresh_token)"\s*:\s*")([^"]+)(")/gi,
+      /("[a-z0-9_-]*(?:api_?key|authorization|token|access_token|refresh_token|client_secret|secret|password|cookie)"\s*:\s*")([^"]+)(")/gi,
       "$1<redacted>$3",
     )
     .replace(
-      /\b([a-z0-9_]*(?:api_?key|authorization|access_token|refresh_token|token))(\s*=\s*)(["']?)[^\s"']+(\3)/gi,
+      /\b([a-z0-9_-]*(?:api_?key|authorization|access_token|refresh_token|client_secret|token|secret|password|cookie))(\s*=\s*)(["']?)[^\s"']+(\3)/gi,
       "$1$2$3<redacted>$4",
     );
-  return redacted.length > CODEX_APP_SERVER_PARSE_LOG_MAX
-    ? `${truncateUtf16Safe(redacted, CODEX_APP_SERVER_PARSE_LOG_MAX)}...`
+  return redacted.length > CODEX_APP_SERVER_DIAGNOSTIC_MAX
+    ? `${truncateUtf16Safe(redacted, CODEX_APP_SERVER_DIAGNOSTIC_MAX)}...`
     : redacted;
 }
 
@@ -1118,7 +1123,7 @@ function appendBoundedTail(current: string, next: string, maxLength: number): st
 }
 
 function buildCodexAppServerExitError(code: unknown, signal: unknown, stderrTail: string): Error {
-  const stderrPreview = redactCodexAppServerLinePreview(stderrTail);
+  const stderrPreview = redactCodexAppServerDiagnostic(stderrTail);
   const suffix = stderrPreview ? ` stderr=${JSON.stringify(stderrPreview)}` : "";
   return new Error(
     `codex app-server exited: code=${formatExitValue(code)} signal=${formatExitValue(
@@ -1141,7 +1146,7 @@ function shouldBufferCodexAppServerParseFailure(value: string, error: unknown): 
 }
 
 function logCodexAppServerParseFailure(value: string, error: unknown, fragmentCount: number): void {
-  const linePreview = redactCodexAppServerLinePreview(value);
+  const linePreview = redactCodexAppServerDiagnostic(value);
   const suffix = fragmentCount > 1 ? ` fragments=${fragmentCount}` : "";
   embeddedAgentLog.warn("failed to parse codex app-server message", {
     error,

--- a/extensions/codex/src/supervision-tools.endpoint-probe.test.ts
+++ b/extensions/codex/src/supervision-tools.endpoint-probe.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createCodexSupervisionTools } from "./supervision-tools.js";
+
+type Options = Parameters<typeof createCodexSupervisionTools>[0];
+type EndpointRequest = NonNullable<Options["request"]>;
+
+function toolByName(tools: ReturnType<typeof createCodexSupervisionTools>, name: string) {
+  const tool = tools.find((entry) => entry.name === name);
+  if (!tool) {
+    throw new Error(`missing tool: ${name}`);
+  }
+  return tool;
+}
+
+describe("Codex endpoint probe diagnostics", () => {
+  it("bounds and redacts bearer and named credentials", async () => {
+    const bearerToken = "super-secret-bearer-token-0123456789";
+    const accessToken = "super-secret-access-token-0123456789";
+    const trailingDiagnostic = "x".repeat(600);
+    const request: EndpointRequest = async () => {
+      throw new Error(
+        `Codex app-server rejected Bearer ${bearerToken}; access_token=${accessToken} ${trailingDiagnostic}`,
+      );
+    };
+    const tools = createCodexSupervisionTools({
+      getPluginConfig: () => ({
+        supervision: {
+          enabled: true,
+          endpoints: [{ id: "broken", transport: "stdio-proxy" }],
+        },
+      }),
+      senderIsOwner: true,
+      request,
+    });
+
+    const result = await toolByName(tools, "codex_endpoint_probe").execute("probe", {});
+    const output = JSON.stringify(result);
+    const parsed = JSON.parse(output) as { details: { health: Array<{ detail?: string }> } };
+    const detail = parsed.details.health[0]?.detail;
+
+    if (typeof detail !== "string") {
+      throw new Error("endpoint probe did not return a failure detail");
+    }
+
+    expect(detail).toContain("Bearer <redacted>");
+    expect(detail).toContain("access_token=<redacted>");
+    expect(detail).toMatch(/\.\.\.$/);
+    expect(detail.length).toBe(503);
+    expect(output).not.toContain(bearerToken);
+    expect(output).not.toContain(accessToken);
+    expect(output).not.toContain(trailingDiagnostic);
+  });
+});

--- a/extensions/codex/src/supervision-tools.endpoint-probe.test.ts
+++ b/extensions/codex/src/supervision-tools.endpoint-probe.test.ts
@@ -50,4 +50,28 @@ describe("Codex endpoint probe diagnostics", () => {
     expect(output).not.toContain(accessToken);
     expect(output).not.toContain(trailingDiagnostic);
   });
+
+  it("redacts colon-delimited credentials", async () => {
+    const apiKey = "super-secret-api-key-0123456789";
+    const request: EndpointRequest = async () => {
+      throw new Error(`Codex app-server rejected X-Api-Key: ${apiKey}`);
+    };
+    const tools = createCodexSupervisionTools({
+      getPluginConfig: () => ({
+        supervision: {
+          enabled: true,
+          endpoints: [{ id: "broken", transport: "stdio-proxy" }],
+        },
+      }),
+      senderIsOwner: true,
+      request,
+    });
+
+    const output = JSON.stringify(
+      await toolByName(tools, "codex_endpoint_probe").execute("probe", {}),
+    );
+
+    expect(output).toContain("X-Api-Key: <redacted>");
+    expect(output).not.toContain(apiKey);
+  });
 });

--- a/extensions/codex/src/supervision-tools.test.ts
+++ b/extensions/codex/src/supervision-tools.test.ts
@@ -209,6 +209,38 @@ describe("Codex supervision compatibility tools", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  it("reports redacted endpoint probe failure details", async () => {
+    const token = "super-secret-token-0123456789";
+    const request = createEndpointRequest(async () => {
+      throw new Error(`Codex app-server rejected Bearer ${token}`);
+    });
+    const tools = createCodexSupervisionTools({
+      getPluginConfig: () => ({
+        supervision: {
+          enabled: true,
+          endpoints: [{ id: "broken", transport: "stdio-proxy" }],
+        },
+      }),
+      senderIsOwner: true,
+      request,
+    });
+
+    const result = await toolByName(tools, "codex_endpoint_probe").execute("probe", {});
+
+    expect(result).toMatchObject({
+      details: {
+        health: [
+          {
+            endpointId: "broken",
+            ok: false,
+            detail: "Codex app-server rejected Bearer [redacted]",
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(token);
+  });
+
   it("omits stored transcript metadata and endpoint errors when raw reads are disabled", async () => {
     const privatePreview = "private stored transcript preview";
     const privateName = "private stored thread name";

--- a/extensions/codex/src/supervision-tools.test.ts
+++ b/extensions/codex/src/supervision-tools.test.ts
@@ -233,12 +233,39 @@ describe("Codex supervision compatibility tools", () => {
           {
             endpointId: "broken",
             ok: false,
-            detail: "Codex app-server rejected Bearer [redacted]",
+            detail: "Codex app-server rejected Bearer <redacted>",
           },
         ],
       },
     });
     expect(JSON.stringify(result)).not.toContain(token);
+  });
+
+  it("bounds and redacts non-Bearer endpoint probe failure details", async () => {
+    const token = "super-secret-access-token-0123456789";
+    const trailingDiagnostic = "x".repeat(600);
+    const request = createEndpointRequest(async () => {
+      throw new Error(`Codex app-server rejected access_token=${token} ${trailingDiagnostic}`);
+    });
+    const tools = createCodexSupervisionTools({
+      getPluginConfig: () => ({
+        supervision: {
+          enabled: true,
+          endpoints: [{ id: "broken", transport: "stdio-proxy" }],
+        },
+      }),
+      senderIsOwner: true,
+      request,
+    });
+
+    const result = await toolByName(tools, "codex_endpoint_probe").execute("probe", {});
+    const detail = (result.details?.health as Array<{ detail?: string }>)[0]?.detail;
+
+    expect(detail).toContain("access_token=<redacted>");
+    expect(detail).toMatch(/\.\.\.$/);
+    expect(detail?.length).toBe(503);
+    expect(JSON.stringify(result)).not.toContain(token);
+    expect(JSON.stringify(result)).not.toContain(trailingDiagnostic);
   });
 
   it("omits stored transcript metadata and endpoint errors when raw reads are disabled", async () => {

--- a/extensions/codex/src/supervision-tools.test.ts
+++ b/extensions/codex/src/supervision-tools.test.ts
@@ -209,65 +209,6 @@ describe("Codex supervision compatibility tools", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
-  it("reports redacted endpoint probe failure details", async () => {
-    const token = "super-secret-token-0123456789";
-    const request = createEndpointRequest(async () => {
-      throw new Error(`Codex app-server rejected Bearer ${token}`);
-    });
-    const tools = createCodexSupervisionTools({
-      getPluginConfig: () => ({
-        supervision: {
-          enabled: true,
-          endpoints: [{ id: "broken", transport: "stdio-proxy" }],
-        },
-      }),
-      senderIsOwner: true,
-      request,
-    });
-
-    const result = await toolByName(tools, "codex_endpoint_probe").execute("probe", {});
-
-    expect(result).toMatchObject({
-      details: {
-        health: [
-          {
-            endpointId: "broken",
-            ok: false,
-            detail: "Codex app-server rejected Bearer <redacted>",
-          },
-        ],
-      },
-    });
-    expect(JSON.stringify(result)).not.toContain(token);
-  });
-
-  it("bounds and redacts non-Bearer endpoint probe failure details", async () => {
-    const token = "super-secret-access-token-0123456789";
-    const trailingDiagnostic = "x".repeat(600);
-    const request = createEndpointRequest(async () => {
-      throw new Error(`Codex app-server rejected access_token=${token} ${trailingDiagnostic}`);
-    });
-    const tools = createCodexSupervisionTools({
-      getPluginConfig: () => ({
-        supervision: {
-          enabled: true,
-          endpoints: [{ id: "broken", transport: "stdio-proxy" }],
-        },
-      }),
-      senderIsOwner: true,
-      request,
-    });
-
-    const result = await toolByName(tools, "codex_endpoint_probe").execute("probe", {});
-    const detail = (result.details?.health as Array<{ detail?: string }>)[0]?.detail;
-
-    expect(detail).toContain("access_token=<redacted>");
-    expect(detail).toMatch(/\.\.\.$/);
-    expect(detail?.length).toBe(503);
-    expect(JSON.stringify(result)).not.toContain(token);
-    expect(JSON.stringify(result)).not.toContain(trailingDiagnostic);
-  });
-
   it("omits stored transcript metadata and endpoint errors when raw reads are disabled", async () => {
     const privatePreview = "private stored transcript preview";
     const privateName = "private stored thread name";

--- a/extensions/codex/src/supervision-tools.ts
+++ b/extensions/codex/src/supervision-tools.ts
@@ -16,6 +16,7 @@ import {
   resolveCodexAppServerAuthProfileIdForAgent,
   resolveCodexAppServerFallbackApiKeyCacheKey,
 } from "./app-server/auth-bridge.js";
+import { redactCodexAppServerDiagnostic } from "./app-server/client.js";
 import {
   assertCodexAppServerConnectionSecurity,
   codexAppServerStartOptionsKey,
@@ -24,7 +25,6 @@ import {
   type CodexAppServerStartOptions,
   type CodexSupervisionEndpoint,
 } from "./app-server/config.js";
-import { redactCodexAppServerDiagnostic } from "./app-server/client.js";
 import { requestCodexAppServerJson } from "./app-server/request.js";
 
 /** Legacy endpoint env retained for the shipped Supervisor tool contract. */

--- a/extensions/codex/src/supervision-tools.ts
+++ b/extensions/codex/src/supervision-tools.ts
@@ -24,6 +24,7 @@ import {
   type CodexAppServerStartOptions,
   type CodexSupervisionEndpoint,
 } from "./app-server/config.js";
+import { redactCodexAppServerDiagnostic } from "./app-server/client.js";
 import { requestCodexAppServerJson } from "./app-server/request.js";
 
 /** Legacy endpoint env retained for the shipped Supervisor tool contract. */
@@ -1065,7 +1066,9 @@ export function createCodexSupervisionTools(options: CodexSupervisionToolsOption
             health.push({
               endpointId: endpoint.id,
               ok: false,
-              detail: error instanceof Error ? error.message : String(error),
+              detail: redactCodexAppServerDiagnostic(
+                error instanceof Error ? error.message : String(error),
+              ),
             });
           }
         }

--- a/extensions/codex/src/supervision-tools.ts
+++ b/extensions/codex/src/supervision-tools.ts
@@ -1062,7 +1062,11 @@ export function createCodexSupervisionTools(options: CodexSupervisionToolsOption
             if (error instanceof CodexSupervisionPolicyError) {
               throw error;
             }
-            health.push({ endpointId: endpoint.id, ok: false });
+            health.push({
+              endpointId: endpoint.id,
+              ok: false,
+              detail: error instanceof Error ? error.message : String(error),
+            });
           }
         }
         requireCurrentEndpointSet(options, endpoints);
@@ -1071,7 +1075,7 @@ export function createCodexSupervisionTools(options: CodexSupervisionToolsOption
           endpoints: endpoints.map((endpoint) =>
             endpointResult(endpoint, pluginConfig, options.env ?? process.env),
           ),
-          health,
+          health: redactCodexSupervisionValue(health),
         });
       },
     },


### PR DESCRIPTION
Related: #118482

## What Problem This Solves

Fixes a problem where operators using the owner-authorized Codex endpoint probe could see that an app-server endpoint was unhealthy but not why the request failed. The Unix-socket compression workaround described in the issue is already present on current `main`; this addresses the remaining diagnostic gap.

## Why This Change Was Made

The probe now preserves an endpoint request failure in its existing health result shape only after it has passed through the shared app-server diagnostic sanitizer. Diagnostics are compacted, redact common bearer and named credential encodings, and are capped at 500 UTF-16 code units. No configuration or transport behavior changes.

## User Impact

Owners can diagnose a failed Codex endpoint probe without exposing credentials or receiving unbounded server-controlled text in the tool result.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/supervision-tools.test.ts` and `node scripts/run-vitest.mjs extensions/codex/src/supervision-tools.endpoint-probe.test.ts` — 33 passing tests total; the dedicated probe suite covers bearer-token, `access_token`, and oversized diagnostics without growing the existing large test file.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/client.test.ts` — 36 passing tests.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/transport-websocket.test.ts` — 8 passing tests.
- Extension test TypeScript check, targeted lint, formatting, and `git diff --check` — clean.
- `autoreview --mode uncommitted` — clean; TruffleHog clean; no accepted/actionable findings.
- Runtime proof, using the canonical `codex_endpoint_probe` request path with no injected request mock against a configured but unavailable local WebSocket endpoint:

  ```text
  summary: codex endpoints: 0/1 ok
  endpoint: unavailable-local (websocket)
  health: ok=false; detail="initialize transport failed after request write: connect ECONNREFUSED 127.0.0.1:9"
  ```

- Upstream protocol check: [Codex app-server documents Unix socket WebSocket control connections using the standard HTTP Upgrade handshake](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#L24-L44).

AI-assisted with Codex.
