### PR TITLE
docs: promote Release & CI to top-level navigation

### DIFF
--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -501,7 +501,12 @@
         {
           "group": "项目",
           "pages": ["zh-CN/reference/credits"]
-        },
+        }
+      ]
+    },
+    {
+      "tab": "发布与 CI",
+      "groups": [
         {
           "group": "发布策略",
           "pages": ["zh-CN/reference/RELEASING", "zh-CN/reference/test"]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2003,7 +2003,12 @@
                 "pages": [
                   "reference/pull-request-review-flow"
                 ]
-              },
+              }
+            ]
+          },
+          {
+            "tab": "Release & CI",
+            "groups": [
               {
                 "group": "Release and CI",
                 "pages": [

--- a/test/scripts/docs-sync-publish.test.ts
+++ b/test/scripts/docs-sync-publish.test.ts
@@ -116,7 +116,10 @@ describe("docs-sync-publish", () => {
       navigation: {
         languages: Array<{
           language: string;
-          tabs: Array<{ tab: string; groups?: Array<{ group: string }> }>;
+          tabs: Array<{
+            tab: string;
+            groups?: Array<{ group: string; pages?: unknown }>;
+          }>;
         }>;
       };
     };
@@ -129,6 +132,28 @@ describe("docs-sync-publish", () => {
     expect(english).toBeDefined();
     expect(simplifiedChinese).toBeDefined();
     expect(german).toBeDefined();
+    expect(english!.tabs.slice(-4).map((tab) => tab.tab)).toEqual([
+      "Gateway & Ops",
+      "Reference",
+      "Release & CI",
+      "Help",
+    ]);
+
+    const releaseRoutes = [
+      "releases/index",
+      "releases/2026.7.1",
+      "releases/2026.6.11",
+      "maturity/scorecard",
+      "maturity/taxonomy",
+      "reference/RELEASING",
+      "reference/full-release-validation",
+      "reference/release-performance-sweep",
+      "reference/test",
+      "ci",
+      "help/scripts",
+    ];
+    const releaseTab = english!.tabs.find((tab) => tab.tab === "Release & CI");
+    expect(collectPages(releaseTab)).toEqual(releaseRoutes);
 
     const englishWithoutClawHub = {
       ...english,
@@ -140,6 +165,13 @@ describe("docs-sync-publish", () => {
     expect(collectPages(simplifiedChinese).toSorted()).toEqual(expectedZhPages);
     expect(simplifiedChinese!.tabs[0]?.tab).toBe("快速开始");
     expect(simplifiedChinese!.tabs[0]?.groups?.[0]?.group).toBe("首页");
+    const simplifiedChineseReleaseTab = simplifiedChinese!.tabs.find(
+      (tab) => tab.tab === "发布与 CI",
+    );
+    expect(simplifiedChineseReleaseTab?.groups?.[0]?.group).toBe("发布策略");
+    expect(collectPages(simplifiedChineseReleaseTab)).toEqual(
+      releaseRoutes.map((page) => `zh-CN/${page}`),
+    );
 
     expect(collectPages(german)).toHaveLength(collectPages(englishWithoutClawHub).length);
     expect(german!.tabs[0]?.tab).toBe("Loslegen");


### PR DESCRIPTION
Closes #119769

## What Problem This Solves

The existing release, validation, testing, and CI documentation is grouped at the bottom of the broad Reference tab, which makes that operational area harder to discover as a unit.

## Why This Change Was Made

This PR proposes moving the complete existing **Release and CI** group into a top-level **Release & CI** tab between **Reference** and **Help**. It keeps `/releases` as the landing page and preserves every existing page and its order.

English navigation remains owned by `docs/docs.json` in this repository; `openclaw/docs` remains the generated publish mirror. The matching curated zh-Hans overlay moves with the routes so the localized tab and group labels remain attached after source-to-mirror composition.

The scope is navigation-only: no page content, release process, or generated mirror files change.

## User Impact

Readers would be able to reach release notes, maturity guidance, release policy, validation, tests, CI, and scripts from one visible top-level tab while Reference and Help remain in their existing relative order.

## Automation and Localization Impact

The existing source sync continues to clone English navigation into generated locale configurations. The only curated overlay adjustment moves the existing zh-Hans release labels to the new tab anchor; the route set and internal order are pinned by the focused sync test. No generated mirror files are edited in this PR.

## Evidence

Source checks on `41342b4df3df70cc383c4ee91a292a929f947232`:

- navigation JSON parse — passed
- `node scripts/run-vitest.mjs test/scripts/docs-sync-publish.test.ts` — 5 tests passed
- `node scripts/check-docs-mdx.mjs docs README.md` — 768 files passed
- `node scripts/docs-link-audit.mjs` — 6,399 internal links checked, 0 broken
- `git diff --check origin/main...HEAD` — passed
- independent exact-head diff review — no findings
- [ready-state CI run](https://github.com/openclaw/openclaw/actions/runs/31063338387) — passed, including `check-docs` and `openclaw/ci-gate`

[Exact-head generated-mirror proof](https://crabbox.openclaw.ai/portal/runs/run_cf8b6f6e8ec0) on the same SHA:

- baseline and proposed builds passed: 30,561 pages, 577/577 cards, 777 search entries, and 15,659 Pagefind pages across 21 languages
- standard docs smoke passed
- desktop showed `Gateway & Ops → Reference → Release & CI → Help`, with `Release & CI` selected at `/releases` and no horizontal overflow
- narrow navigation showed all 12 sections, the correct active section, no horizontal overflow, and working Reference/Help navigation

[Final-SHA desktop visual proof](https://github.com/openclaw/openclaw/pull/119802#issuecomment-5207678992) shows the proposed top-level order and the selected `Release & CI` state at `/releases`.

## Renderer Dependency

The mobile visibility contract is resolved by [openclaw/docs#124](https://github.com/openclaw/docs/pull/124), merged first as `fb05dd4a772592245ce83d72bd8c5110a57a6b8e` from exact companion head `66d56587232ce8cf6ab5d6244403a7509ca32906`.

Combined source and renderer validation passed:

- `npm test` — 4 tests passed
- `make docs-check` — full docs build and smoke passed
- `npm run docs:visual` — the 12-section list was fully visible at 390×980; the 390×700 fallback remained scrollable with Help reachable; desktop behavior remained unchanged
- script syntax check, Wrangler dry run, and diff check — passed

Renderer-first order is satisfied: the companion is on `openclaw/docs` main before this source navigation PR lands.

## Other Limitations

- The initial pre-PR remote source-gate paths were unavailable before source execution. Exact-head generated-mirror build and smoke proof later completed successfully on AWS, and required GitHub CI passed.
- `node --import tsx scripts/generate-config-doc-baseline.ts --check` reports current schema baseline drift (`core: current 2322 > budget 2321`). This PR does not touch config schemas or generated config baselines.
