### PR TITLE
fix: sandboxed Codex skill prompts use container paths

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -10,12 +10,15 @@ import {
   clearMemoryPluginState,
   registerMemoryCapability,
 } from "openclaw/plugin-sdk/memory-host-core";
+import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexOpenClawPromptContext,
   buildCodexWatchedSessionsContext,
   buildCodexWorkspaceBootstrapContext,
   buildCodexSystemPromptReport,
+  renderCodexSkillsCollaborationInstructions,
+  resolveCodexSkillsPrompt,
   readContextEngineThreadBootstrapProjection,
   readMirroredSessionHistoryMessages,
   resolveContextEngineBootstrapProjectionDecision,
@@ -29,6 +32,74 @@ afterEach(() => {
 });
 
 describe("Codex app-server attempt context", () => {
+  it("maps sandboxed skill locations for Codex while preserving unsandboxed snapshots", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-sandbox-skills-"));
+    try {
+      const materializedWorkspace = path.join(root, "materialized-skills");
+      const skillDir = path.join(materializedWorkspace, "skills", "demo");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir, "SKILL.md"),
+        ["---", "name: demo", "description: Demo skill", "---", "# Demo", ""].join("\n"),
+        "utf8",
+      );
+      const hostSkillPath = "/host/node_modules/openclaw/skills/demo/SKILL.md";
+      const snapshot = {
+        prompt: `<available_skills><skill><name>demo</name><location>${hostSkillPath}</location></skill></available_skills>`,
+        skills: [{ name: "demo" }],
+        resolvedSkills: [
+          {
+            name: "demo",
+            description: "Demo skill",
+            filePath: hostSkillPath,
+            baseDir: "/host/node_modules/openclaw/skills/demo",
+            source: "openclaw-bundled",
+            sourceInfo: {
+              path: hostSkillPath,
+              baseDir: "/host/node_modules/openclaw/skills/demo",
+            },
+            disableModelInvocation: false,
+          },
+        ],
+      } as NonNullable<EmbeddedRunAttemptParams["skillsSnapshot"]>;
+      const attempt = {
+        config: {},
+        skillsSnapshot: snapshot,
+      } as EmbeddedRunAttemptParams;
+      const sandbox = {
+        enabled: true,
+        workspaceAccess: "rw",
+        skillsWorkspaceDir: materializedWorkspace,
+        containerWorkdir: "/workspace",
+      } as SandboxContext;
+
+      const sandboxPrompt = resolveCodexSkillsPrompt({
+        attempt,
+        sandbox,
+        effectiveWorkspace: path.join(root, "workspace"),
+        sessionAgentId: "main",
+      });
+      const collaborationInstructions = renderCodexSkillsCollaborationInstructions({
+        attempt,
+        skillsPrompt: sandboxPrompt,
+      });
+      expect(collaborationInstructions).toContain(
+        "/workspace/.openclaw/sandbox-skills/skills/demo/SKILL.md",
+      );
+      expect(collaborationInstructions).not.toContain(hostSkillPath);
+
+      const unsandboxedPrompt = resolveCodexSkillsPrompt({
+        attempt,
+        effectiveWorkspace: path.join(root, "workspace"),
+        sessionAgentId: "main",
+      });
+      expect(unsandboxedPrompt).toContain(hostSkillPath);
+      expect(unsandboxedPrompt).not.toContain("/workspace/.openclaw/sandbox-skills");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("treats missing mirrored session history as empty without hook warning", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-history-"));

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -9,10 +9,12 @@ import {
   buildWatchedSessionsHarnessContext,
   embeddedAgentLog,
   resolveBootstrapFilesForRun,
+  resolveSandboxSkillPromptForHarness,
   type AgentMessage,
   type ContextEngineProjection,
   type EmbeddedContextFile,
   type EmbeddedRunAttemptParams,
+  type SandboxContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
 import {
@@ -571,6 +573,21 @@ export function renderCodexSkillsCollaborationInstructions(params: {
   return params.skillsPrompt?.trim()
     ? ["## OpenClaw Skills", "", params.skillsPrompt.trim()].join("\n")
     : undefined;
+}
+
+export function resolveCodexSkillsPrompt(params: {
+  attempt: EmbeddedRunAttemptParams;
+  sandbox?: SandboxContext | null;
+  effectiveWorkspace: string;
+  sessionAgentId: string;
+}): string {
+  return resolveSandboxSkillPromptForHarness({
+    sandbox: params.sandbox,
+    effectiveWorkspace: params.effectiveWorkspace,
+    skillsSnapshot: params.attempt.skillsSnapshot,
+    config: params.attempt.config,
+    agentId: params.sessionAgentId,
+  });
 }
 
 /**

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -14,6 +14,7 @@ import {
   getCodexWorkspaceMemoryToolNames,
   readMirroredSessionHistoryMessages,
   renderCodexSkillsCollaborationInstructions,
+  resolveCodexSkillsPrompt,
 } from "./attempt-context.js";
 import {
   resolveCodexContextEngineProjectionMaxChars,
@@ -158,7 +159,12 @@ export async function prepareCodexAttemptContext(
   });
   const skillsCollaborationInstructions = renderCodexSkillsCollaborationInstructions({
     attempt: runtimeParams,
-    skillsPrompt: params.skillsSnapshot?.prompt,
+    skillsPrompt: resolveCodexSkillsPrompt({
+      attempt: runtimeParams,
+      sandbox,
+      effectiveWorkspace,
+      sessionAgentId,
+    }),
   });
   const promptState = {
     promptText: params.prompt,

--- a/src/agents/embedded-agent-runner/sandbox-skills.ts
+++ b/src/agents/embedded-agent-runner/sandbox-skills.ts
@@ -5,6 +5,9 @@
  * copies instead of reusing host-path snapshots.
  */
 import path from "node:path";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSkillsPromptForRun } from "../../skills/loading/workspace.js";
+import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-run-entries.js";
 import type { SkillEligibilityContext, SkillSnapshot, SkillUsagePath } from "../../skills/types.js";
 import type { SkillEntry } from "../../skills/types.js";
 import type { SandboxContext } from "../sandbox/types.js";
@@ -161,4 +164,50 @@ export function resolveSandboxSkillRuntimeInputs(params: {
     skillsWorkspaceDir: params.effectiveWorkspace,
     workspaceOnly: false,
   };
+}
+
+/**
+ * Resolves the prompt-facing skill catalog for a harness that owns its prompt.
+ * Sandboxed runs must rebuild it from materialized entries so host snapshots
+ * cannot leak paths that are not readable inside the container.
+ */
+export function resolveSandboxSkillPromptForHarness(params: {
+  sandbox?: SandboxContext | null;
+  effectiveWorkspace: string;
+  skillsSnapshot?: SkillSnapshot;
+  config?: OpenClawConfig;
+  agentId?: string;
+}): string {
+  const {
+    skillsEligibility,
+    skillsPromptWorkspaceDir,
+    skillsSnapshot,
+    skillsWorkspaceDir,
+    workspaceOnly,
+  } = resolveSandboxSkillRuntimeInputs({
+    sandbox: params.sandbox,
+    effectiveWorkspace: params.effectiveWorkspace,
+    skillsSnapshot: params.skillsSnapshot,
+  });
+  const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
+    workspaceDir: skillsWorkspaceDir,
+    config: params.config,
+    agentId: params.agentId,
+    eligibility: skillsEligibility,
+    skillsSnapshot,
+    workspaceOnly,
+  });
+  const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
+    entries: shouldLoadSkillEntries ? skillEntries : undefined,
+    skillsWorkspaceDir,
+    skillsPromptWorkspaceDir,
+  });
+  return resolveSkillsPromptForRun({
+    skillsSnapshot,
+    entries: promptSkillEntries,
+    config: params.config,
+    workspaceDir: skillsPromptWorkspaceDir,
+    agentId: params.agentId,
+    eligibility: skillsEligibility,
+  });
 }

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -405,6 +405,7 @@ export async function materializeRequesterScopedMcpToolsForHarnessRun(
 }
 export { resolveSandboxContext } from "../agents/sandbox.js";
 export type { SandboxContext, SandboxWorkspaceAccess } from "../agents/sandbox.js";
+export { resolveSandboxSkillPromptForHarness } from "../agents/embedded-agent-runner/sandbox-skills.js";
 export {
   hasSandboxBindContainerPathAliases,
   hasSandboxBindReadonlyHostShadows,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Codex in an OpenClaw sandbox would receive host filesystem locations in the available-skills prompt, even though those files are readable only from the sandbox container.

Related: #105854

## Why This Change Was Made

Codex owns its collaboration prompt and was using the raw host skill snapshot instead of the sandbox-aware skill preparation path. This change exposes the existing sandbox skill prompt preparation through the agent harness SDK and uses it from Codex, rebuilding sandboxed prompts from materialized entries while preserving the existing unsandboxed snapshot behavior.

## User Impact

Sandboxed Codex runs now receive container-readable skill locations such as `/workspace/.openclaw/sandbox-skills/...`. Non-sandboxed runs continue to use their existing skill snapshots. The generic skills formatter is unchanged.

## Evidence

- Focused Codex context tests: `6 passed (6)`.
- Focused sandbox skill tests: `6 passed (6)`.
- Core typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json --pretty false` passed.
- Extension typecheck: `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --pretty false` passed.
- Full build: `pnpm --config.store-dir=/tmp/openclaw-upstream-pnpm-store build` passed, including SDK export checks and Control UI validation.
- `pnpm check` passed in full (guards, package-lock validation, typechecks, lint, import-cycle and deprecated-API checks).

## AI Assistance

- [x] This change was assisted by an AI coding agent.
- `autoreview`: unavailable in this environment; the diff was reviewed manually and focused tests, typechecks, check guards, and the full build were run.

## Maintainer Edits

- [x] Allow edits from maintainers.
