### PR TITLE
fix(test): zalo lifecycle suites fail Windows teardown with EBUSY on agent state DB

### DIFF
--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   createRuntimeEnv,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedZaloAccount } from "./accounts.js";
@@ -98,9 +99,12 @@ describe("monitorZaloProvider lifecycle", () => {
     getUpdatesMock.mockReset();
     getUpdatesMock.mockImplementation(() => new Promise(() => {}));
     setActivePluginRegistry(createEmptyPluginRegistry());
+    // Agent close releases leases through shared state; closing shared state first
+    // can reopen it during teardown and leave Windows handles under the state dir.
+    closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     if (testStateDir) {
-      await fs.rm(testStateDir, { recursive: true, force: true });
+      await fs.rm(testStateDir, { recursive: true, force: true, maxRetries: 20, retryDelay: 25 });
       testStateDir = undefined;
     }
     if (previousStateDir === undefined) {

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.test.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.test.ts
@@ -1,0 +1,22 @@
+// Zalo tests cover lifecycle teardown release of per-agent state databases.
+import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetLifecycleTestState } from "./monitor-mocks-test-support.js";
+
+describe("resetLifecycleTestState", () => {
+  afterEach(async () => {
+    await resetLifecycleTestState();
+  });
+
+  it("closes per-agent state databases so teardown can remove the state dir", async () => {
+    // A processed inbound update opens the per-agent DB through the real session
+    // accessor inside the envelope builder; teardown must release that handle or
+    // Windows cannot remove the temp state dir (EBUSY, issue #119796).
+    const handle = openOpenClawAgentDatabase({ agentId: "main" });
+    expect(handle.db.isOpen).toBe(true);
+
+    await resetLifecycleTestState();
+
+    expect(handle.db.isOpen).toBe(false);
+  });
+});

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
@@ -12,6 +12,7 @@ import {
   createRuntimeEnv,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { vi, type Mock } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
@@ -114,9 +115,17 @@ const importCachedWebhookModule = createLazyRuntimeModule(
 );
 
 export async function resetLifecycleTestState() {
+  // Agent close releases leases through shared state; closing shared state first
+  // can reopen it during teardown and leave Windows handles under the state dir.
+  closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
   if (lifecycleStateDir) {
-    await fs.rm(lifecycleStateDir, { recursive: true, force: true });
+    await fs.rm(lifecycleStateDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 20,
+      retryDelay: 25,
+    });
     lifecycleStateDir = undefined;
   }
   if (previousLifecycleStateDir === undefined) {

--- a/extensions/zalouser/src/ingress.test-support.test.ts
+++ b/extensions/zalouser/src/ingress.test-support.test.ts
@@ -1,0 +1,35 @@
+// Teardown must close fixture-owned databases before restoring the parent state env.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { describe, expect, it } from "vitest";
+import { withZalouserIngressTestQueue } from "./ingress.test-support.js";
+
+describe("withZalouserIngressTestQueue", () => {
+  it("does not write through the parent state environment during teardown", async () => {
+    const parentDir = await fs.realpath(
+      await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-zalouser-parent-")),
+    );
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = parentDir;
+    try {
+      await withZalouserIngressTestQueue(async () => {
+        // A processed inbound message opens the per-agent DB under the child state
+        // dir; releasing its lease after env restoration would open a shared-state
+        // write transaction against this parent dir instead (PR #119809 review).
+        openOpenClawAgentDatabase({ agentId: "main" });
+      });
+      // With the correct close-before-restore order the parent state dir stays
+      // untouched; the old order created openclaw.sqlite* files here.
+      expect(await fs.readdir(parentDir)).toEqual([]);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(parentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/zalouser/src/ingress.test-support.ts
+++ b/extensions/zalouser/src/ingress.test-support.ts
@@ -76,16 +76,19 @@ export async function withZalouserIngressTestQueue<T>(
   try {
     return await fn(queue);
   } finally {
+    // Agent close releases leases through shared state; closing shared state first
+    // can reopen it during teardown and leave Windows handles under the state dir.
+    // Both closes must run before OPENCLAW_STATE_DIR is restored: cached agent
+    // databases captured the child env, and lease release after restoration would
+    // write through the parent fixture's shared state instead.
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 20, retryDelay: 25 });
     if (previousStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
     } else {
       process.env.OPENCLAW_STATE_DIR = previousStateDir;
     }
-    // Agent close releases leases through shared state; closing shared state first
-    // can reopen it during teardown and leave Windows handles under the state dir.
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-    await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 20, retryDelay: 25 });
   }
 }
 

--- a/extensions/zalouser/src/ingress.test-support.ts
+++ b/extensions/zalouser/src/ingress.test-support.ts
@@ -5,6 +5,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { expect, vi } from "vitest";
 import type { createZalouserIngressMonitor } from "./ingress.js";
@@ -80,8 +81,11 @@ export async function withZalouserIngressTestQueue<T>(
     } else {
       process.env.OPENCLAW_STATE_DIR = previousStateDir;
     }
+    // Agent close releases leases through shared state; closing shared state first
+    // can reopen it during teardown and leave Windows handles under the state dir.
+    closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
-    await fs.rm(stateDir, { recursive: true, force: true });
+    await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 20, retryDelay: 25 });
   }
 }
 


### PR DESCRIPTION
Related: #119796

This PR covers the lifecycle fixtures. The remaining credential, quote-metadata, and doctor fixtures are handled by #119964, so #119796 stays open until both land.

## What Problem This Solves

Fixes an issue where contributors running the Zalo extension test suites on a Windows checkout would see 9 of 26 `monitor.polling-lifecycle.test.ts` cases fail in teardown with `EBUSY: resource busy or locked, unlink '...\agents\main\agent\openclaw-agent.sqlite'`, cascading through every later hook in the file. Surfaced by @Yigtwxx while reviewing #110803 ([measurement](https://github.com/openclaw/openclaw/pull/110803#issuecomment-5195263841)); Linux CI never sees it because unlinking an open file succeeds there.

## Why This Change Was Made

A fully processed inbound update opens the per-agent state database through the real session accessor inside the inbound envelope builder (`resolveChannelInboundRouteEnvelope` → `readSessionUpdatedAt` → `openOpenClawAgentDatabase`), which caches the handle process-wide. The Zalo lifecycle teardown only closed the *shared* state database before `fs.rm`, leaving the agent DB handle (and WAL sidecars) live — a live handle, not a slow release, so `fs.rm` retries alone cannot help.

The fix mirrors the canonical fixture pattern from #113316 (`src/test-utils/openclaw-test-state.ts`): close cached agent databases via the existing `closeOpenClawAgentDatabasesForTest()` (already exported through `openclaw/plugin-sdk/sqlite-runtime-testing` and used by telegram/signal/whatsapp/matrix/slack tests) *before* closing shared state — agent close releases leases through shared state, so the reverse order can reopen it — and gives the temp-dir removal the same retry budget as the canonical fixture. Test-only change; no production code touched.

## User Impact

No end-user impact. Developers on Windows can now run the Zalo polling lifecycle/webhook suites to green locally; #110803's polling-ingress proof file (which amplifies the leak to 25/26 failures) becomes runnable on Windows once it lands on this base.

## Evidence

Reproduced the leak cross-platform and verified the fix, on `6e4d387fed` (current `main`), Node 24.18.0:

- New regression test `monitor-mocks-test-support.test.ts` opens the per-agent DB the same way the envelope builder does, then asserts `resetLifecycleTestState()` releases the handle. **Without the fix it fails** (`handle.db.isOpen` still `true` after teardown); **with the fix it passes** — the exact handle leak that Windows surfaces as EBUSY, observable on any OS.
- Focused run, all green (48/48):

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-zalo.config.ts --configLoader runner \
  extensions/zalo/src/monitor.polling-lifecycle.test.ts \
  extensions/zalo/src/monitor.lifecycle.test.ts \
  extensions/zalo/src/webhook-spool.test.ts \
  extensions/zalo/src/test-support/monitor-mocks-test-support.test.ts

Test Files  4 passed (4)
Tests  48 passed (48)
```

- Sibling check (corrected after Windows measurement by @Yigtwxx): `extensions/zalouser` uses the same close-shared-then-`rm` pattern. `ingress.test.ts` and `monitor.account-scope.test.ts` exercise queue mechanics only and are clean, but `monitor.group-gating.test.ts` asserts on fully built dispatch context (`ctx.WasMentioned`, `ctx.InboundHistory`) — the envelope-builder path — and leaks the same handle: 18/26 cases failed with EBUSY on both `6e4d387fed` and the previous head. The same three-line teardown fix in `extensions/zalouser/src/ingress.test-support.ts` turns all three files green (42/42) on Windows, and is included in this PR.
- Windows proof (exact head, native Windows 11, Node 24.15.0, run by @Yigtwxx): base `9 failed / 38 passed` → head `48 passed (48)`. A mutation run commenting out only the two `closeOpenClawAgentDatabasesForTest()` calls while keeping the retry budget reproduces the original stall, confirming the agent-DB close carries the fix and the `maxRetries`/`retryDelay` bump is hygiene matching the canonical fixture, not the repair.

Punchcard-Session: calm-willow-river-a9