### PR TITLE
fix(test): Doctor E2E follows current repair contracts

### DIFF
--- a/src/commands/doctor.fast-path-mocks.ts
+++ b/src/commands/doctor.fast-path-mocks.ts
@@ -88,7 +88,7 @@ vi.mock("./doctor-plugin-manifests.js", () => ({
 }));
 
 vi.mock("./doctor-plugin-registry.js", () => ({
-  maybeRepairPluginRegistryState: vi.fn(async ({ config }: { config: unknown }) => config),
+  maybeRepairPluginRegistryState: vi.fn(async ({ config }: { config: unknown }) => ({ config })),
 }));
 
 vi.mock("./doctor-platform-notes.js", () => ({
@@ -129,6 +129,7 @@ vi.mock("./doctor-skills.js", () => ({
 }));
 
 vi.mock("./doctor-state-integrity.js", () => ({
+  collectWorkspaceBackupTip: vi.fn(() => null),
   noteStateIntegrity: vi.fn().mockResolvedValue(undefined),
   noteWorkspaceBackupTip: vi.fn(),
 }));


### PR DESCRIPTION
Closes #119811

## What Problem This Solves

Resolves a problem where the broad Gateway E2E aggregate reported 29 Doctor failures after the contribution lifecycle began re-entering the current plugin-metadata snapshot around each check.

## Why This Change Was Made

The shared fast fixture now mirrors the real plugin-registry repair result and state-integrity export contracts. This keeps the fixture lightweight while allowing the complete Doctor contribution sequence to run; production code and behavior are unchanged.

## User Impact

No direct user-visible behavior changes. Maintainers regain trustworthy Doctor E2E coverage instead of a cleared config and a missing mocked export masking the intended assertions.

## Evidence

- Current-main reproduction: `doctor.warns-per-agent-sandbox-docker-browser-prune.e2e.test.ts` failed 2/2, and `doctor.warns-state-directory-is-missing.e2e.test.ts` failed 27/27.
- Diagnostic Testbox run [31063919573](https://github.com/openclaw/openclaw/actions/runs/31063919573) identified `doctor:plugin-registry` as the config-clearing contribution.
- Repaired Testbox run [31064077047](https://github.com/openclaw/openclaw/actions/runs/31064077047) passed 27/27 and exposed the connected missing export.
- Final focused Testbox run [31064271247](https://github.com/openclaw/openclaw/actions/runs/31064271247) passed 2/2.
- `oxfmt --check src/commands/doctor.fast-path-mocks.ts`
- `git diff --check`
- AutoReview: clean, no accepted/actionable findings, 0.99.

Production LOC: +0/-0. Test fixture: +2/-1.
