### PR TITLE
fix(diagnostics): report exporter health in doctor and status

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -14,6 +14,11 @@ When Gateway status reports degraded SecretRef owners, doctor prints a **Secret 
 
 When channel ingress events are dead-lettered, doctor names each affected channel account and points to [`openclaw channels dead-letters list`](/cli/channels#inbound-dead-letters) for inspection and recovery.
 
+When the Gateway has exporter health facts, doctor reports the latest trusted
+per-signal state and transport under **Telemetry exporters**. The summary is
+redacted and does not include endpoint values, headers, certificates, payloads,
+or raw errors.
+
 Related:
 
 - Troubleshooting: [Troubleshooting](/gateway/troubleshooting)

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -74,6 +74,9 @@ and `openclaw memory status --deep`.
 - Overview includes update channel + git SHA (for source checkouts).
 - Update info surfaces in the Overview; if an update is available, status
   prints a hint to run `openclaw update` (see [Updating](/install/updating)).
+- `status --all` includes a **Telemetry exporters** diagnosis with the latest
+  trusted per-signal exporter state and transport. Endpoint values, headers,
+  certificates, payloads, and raw errors are not shown.
 
 ## Secrets
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -126,6 +126,31 @@ paths.
   through the Gateway, or use `openclaw agent --local`, when you need traces
   from a headless run.
 
+## Exporter health
+
+`openclaw doctor` and `openclaw status --all` show a bounded, redacted snapshot
+of the running Gateway's latest trusted exporter state for each signal and
+transport. For `diagnostics-otel`, the snapshot distinguishes:
+
+- OTLP/HTTP protobuf with an endpoint supplied by config or an `OTEL_*`
+  environment fallback.
+- OTLP/HTTP protobuf using the exporter dependency's default endpoint because
+  no endpoint was supplied.
+- Stdout log export.
+- Trace or metric export owned by an externally preloaded OpenTelemetry SDK.
+
+OTLP export failure and recovery transitions are recorded from the exporter's
+final result callback, after dependency-owned retries finish. A retryable
+response that later succeeds is therefore not reported as a failure. Startup,
+log preparation or emit, export, and shutdown failures use fixed reason
+categories rather than raw errors.
+
+The snapshot never includes endpoint values, headers, certificates, payloads,
+or raw error messages. Transport is retained only in this local health
+projection. It is not added to the existing
+`openclaw.telemetry.exporter.events` metric attributes, and existing Prometheus
+label sets are unchanged.
+
 ## Configuration reference
 
 ```json5

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/api-logs": "0.221.0",
+    "@opentelemetry/core": "2.10.0",
     "@opentelemetry/exporter-logs-otlp-proto": "0.221.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "0.221.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",

--- a/extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts
@@ -1,0 +1,325 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { context, diag, DiagLogLevel, metrics, propagation, trace } from "@opentelemetry/api";
+import { logs } from "@opentelemetry/api-logs";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import type { DiagnosticEventPayload } from "../api.js";
+import { startOtelService, stopStartedOtelServices } from "./service.test-helpers.js";
+
+const PRELOAD_ENV = "OPENCLAW_OTEL_PRELOADED";
+const IMMEDIATE_RETRY_AFTER = "Thu, 01 Jan 1970 00:00:00 GMT";
+const OTEL_ENV_KEYS = [
+  "OTEL_SDK_DISABLED",
+  "OTEL_TRACES_EXPORTER",
+  "OTEL_METRICS_EXPORTER",
+  "OTEL_LOGS_EXPORTER",
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_PROTOCOL",
+  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+  "OTEL_EXPORTER_OTLP_TIMEOUT",
+  "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+  "OTEL_EXPORTER_OTLP_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_CLIENT_KEY",
+  "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY",
+] as const;
+const OTEL_GLOBAL_API_KEY = Symbol.for("opentelemetry.js.api.1");
+const OTEL_GLOBAL_LOGS_KEY = Symbol.for("io.opentelemetry.js.api.logs");
+
+type OtelGlobalRegistrations = {
+  context?: Parameters<typeof context.setGlobalContextManager>[0];
+  diag?: Parameters<typeof diag.setLogger>[0];
+  metrics?: Parameters<typeof metrics.setGlobalMeterProvider>[0];
+  propagation?: Parameters<typeof propagation.setGlobalPropagator>[0];
+  trace?: Parameters<typeof trace.setGlobalTracerProvider>[0];
+};
+type ExporterEvent = Extract<DiagnosticEventPayload, { type: "telemetry.exporter" }>;
+
+let originalPreloaded: string | undefined;
+let originalEnv: Record<(typeof OTEL_ENV_KEYS)[number], string | undefined>;
+let originalGlobals: OtelGlobalRegistrations;
+let originalLogsProvider: ReturnType<typeof logs.getLoggerProvider> | undefined;
+
+function registeredOtelGlobals(): OtelGlobalRegistrations | undefined {
+  return (globalThis as unknown as Record<symbol, OtelGlobalRegistrations | undefined>)[
+    OTEL_GLOBAL_API_KEY
+  ];
+}
+
+beforeEach(() => {
+  originalPreloaded = process.env[PRELOAD_ENV];
+  originalEnv = Object.fromEntries(OTEL_ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
+    (typeof OTEL_ENV_KEYS)[number],
+    string | undefined
+  >;
+  for (const key of OTEL_ENV_KEYS) {
+    delete process.env[key];
+  }
+  originalGlobals = { ...registeredOtelGlobals() };
+  originalLogsProvider = Object.hasOwn(globalThis, OTEL_GLOBAL_LOGS_KEY)
+    ? logs.getLoggerProvider()
+    : undefined;
+  context.disable();
+  logs.disable();
+  metrics.disable();
+  propagation.disable();
+  trace.disable();
+  process.env[PRELOAD_ENV] = "0";
+});
+
+afterEach(async () => {
+  await stopStartedOtelServices();
+  context.disable();
+  propagation.disable();
+  metrics.disable();
+  trace.disable();
+  logs.disable();
+  if (originalGlobals.context) {
+    context.setGlobalContextManager(originalGlobals.context);
+  }
+  if (originalGlobals.propagation) {
+    propagation.setGlobalPropagator(originalGlobals.propagation);
+  }
+  if (originalGlobals.metrics) {
+    metrics.setGlobalMeterProvider(originalGlobals.metrics);
+  }
+  if (originalGlobals.trace) {
+    trace.setGlobalTracerProvider(originalGlobals.trace);
+  }
+  if (originalLogsProvider) {
+    logs.setGlobalLoggerProvider(originalLogsProvider);
+  }
+  if (originalPreloaded === undefined) {
+    delete process.env[PRELOAD_ENV];
+  } else {
+    process.env[PRELOAD_ENV] = originalPreloaded;
+  }
+  for (const key of OTEL_ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  diag.disable();
+  if (originalGlobals.diag) {
+    diag.setLogger(originalGlobals.diag, {
+      logLevel: DiagLogLevel.ALL,
+      suppressOverrideMessage: true,
+    });
+  }
+  resetDiagnosticEventsForTest();
+});
+
+async function startExporterHealthReceiver(
+  handleRequest: (request: IncomingMessage, response: ServerResponse, requestCount: number) => void,
+) {
+  let requestCount = 0;
+  const server = createServer((request, response) => {
+    requestCount += 1;
+    request.resume();
+    handleRequest(request, response, requestCount);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    get requestCount() {
+      return requestCount;
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    },
+  };
+}
+
+function captureExporterEvents() {
+  const events: ExporterEvent[] = [];
+  const unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
+    if (metadata.trusted && event.type === "telemetry.exporter") {
+      events.push(event);
+    }
+  });
+  return { events, unsubscribe };
+}
+
+async function waitForExporterStatus(events: ExporterEvent[], status: ExporterEvent["status"]) {
+  const deadline = Date.now() + 4_000;
+  while (Date.now() < deadline) {
+    if (events.some((event) => event.status === status)) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+  throw new Error(`timed out waiting for exporter status ${status}`);
+}
+
+function emitExporterHealthSpan(name: string) {
+  trace.getTracer("openclaw-otel-exporter-health-test").startSpan(name).end();
+}
+
+function startTraceExporterHealthService(
+  endpoint: string,
+  timeout: string,
+  flushIntervalMs?: number,
+) {
+  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = timeout;
+  return startOtelService({
+    endpoint,
+    traces: true,
+    metrics: false,
+    logs: false,
+    ...(flushIntervalMs === undefined
+      ? {}
+      : {
+          configure: (ctx) => {
+            ctx.config.diagnostics!.otel!.flushIntervalMs = flushIntervalMs;
+          },
+        }),
+  });
+}
+
+test("retries a real OTLP 503 then succeeds without an intermediate failure fact", async () => {
+  const receiver = await startExporterHealthReceiver((_request, response, requestCount) => {
+    response.writeHead(requestCount === 1 ? 503 : 200, {
+      ...(requestCount === 1 ? { "retry-after": IMMEDIATE_RETRY_AFTER } : {}),
+      "content-type": "application/x-protobuf",
+    });
+    response.end();
+  });
+  const capture = captureExporterEvents();
+  const { service, ctx } = await startTraceExporterHealthService(receiver.endpoint, "1000");
+
+  try {
+    emitExporterHealthSpan("retry-then-success");
+    await service.stop?.(ctx);
+    await waitForDiagnosticEventsDrained();
+    expect(receiver.requestCount).toBe(2);
+    expect(capture.events.some((event) => event.status === "failure")).toBe(false);
+    expect(capture.events.some((event) => event.status === "recovered")).toBe(false);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records a final failure after persistent real OTLP 503 responses", async () => {
+  const receiver = await startExporterHealthReceiver((_request, response) => {
+    response.writeHead(503, { "retry-after": IMMEDIATE_RETRY_AFTER });
+    response.end();
+  });
+  const capture = captureExporterEvents();
+  const { service, ctx } = await startTraceExporterHealthService(receiver.endpoint, "1000");
+
+  try {
+    emitExporterHealthSpan("persistent-503");
+    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
+    await waitForDiagnosticEventsDrained();
+    expect(receiver.requestCount).toBe(6);
+    expect(
+      capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "export_failed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records a final failure for a real OTLP connection reset", async () => {
+  const receiver = await startExporterHealthReceiver((request) => {
+    request.socket.destroy();
+  });
+  const capture = captureExporterEvents();
+  const { service, ctx } = await startTraceExporterHealthService(receiver.endpoint, "200");
+
+  try {
+    emitExporterHealthSpan("connection-reset");
+    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
+    await waitForDiagnosticEventsDrained();
+    expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
+    expect(
+      capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "export_failed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records a final failure for a real OTLP request timeout", async () => {
+  const receiver = await startExporterHealthReceiver(() => {
+    // Keep the request open until the exporter-owned timeout settles.
+  });
+  const capture = captureExporterEvents();
+  const { service, ctx } = await startTraceExporterHealthService(receiver.endpoint, "150");
+
+  try {
+    emitExporterHealthSpan("request-timeout");
+    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
+    await waitForDiagnosticEventsDrained();
+    expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
+    expect(
+      capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "export_failed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records recovery after a later real OTLP export succeeds", async () => {
+  let failExports = true;
+  const receiver = await startExporterHealthReceiver((_request, response) => {
+    response.writeHead(failExports ? 503 : 200, {
+      "content-type": "application/x-protobuf",
+      ...(failExports ? { "retry-after": IMMEDIATE_RETRY_AFTER } : {}),
+    });
+    response.end();
+  });
+  const capture = captureExporterEvents();
+  const { service, ctx } = await startTraceExporterHealthService(receiver.endpoint, "1000", 1000);
+
+  try {
+    emitExporterHealthSpan("failure-before-recovery");
+    await waitForExporterStatus(capture.events, "failure");
+    failExports = false;
+    emitExporterHealthSpan("successful-recovery");
+    await waitForExporterStatus(capture.events, "recovered");
+    expect(
+      capture.events
+        .filter((event) => event.reason === "export_failed")
+        .map((event) => event.status),
+    ).toEqual(["failure", "recovered"]);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);

--- a/extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts
@@ -9,7 +9,12 @@ import {
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { afterEach, beforeEach, expect, test } from "vitest";
 import type { DiagnosticEventPayload } from "../api.js";
-import { startOtelService, stopStartedOtelServices } from "./service.test-helpers.js";
+import {
+  getReportedExporterHealth,
+  startOtelService,
+  stopStartedOtelServices,
+  type ReportedExporterHealth,
+} from "./service.test-helpers.js";
 
 const PRELOAD_ENV = "OPENCLAW_OTEL_PRELOADED";
 const IMMEDIATE_RETRY_AFTER = "Thu, 01 Jan 1970 00:00:00 GMT";
@@ -158,7 +163,10 @@ function captureExporterEvents() {
   return { events, unsubscribe };
 }
 
-async function waitForExporterStatus(events: ExporterEvent[], status: ExporterEvent["status"]) {
+async function waitForExporterStatus(
+  events: Array<Pick<ReportedExporterHealth, "status">>,
+  status: ReportedExporterHealth["status"],
+) {
   const deadline = Date.now() + 4_000;
   while (Date.now() < deadline) {
     if (events.some((event) => event.status === status)) {
@@ -196,6 +204,25 @@ function startTraceExporterHealthService(
   });
 }
 
+test("does not report disabled real NodeSDK trace or metric routes as started", async () => {
+  process.env.OTEL_SDK_DISABLED = " TRUE ";
+
+  const { ctx } = await startOtelService({
+    traces: true,
+    metrics: true,
+    logs: true,
+    logsExporter: "stdout",
+  });
+
+  expect(
+    getReportedExporterHealth(ctx).map(({ signal, transport, status }) => ({
+      signal,
+      transport,
+      status,
+    })),
+  ).toEqual([{ signal: "logs", transport: "stdout", status: "started" }]);
+});
+
 test("retries a real OTLP 503 then succeeds without an intermediate failure fact", async () => {
   const receiver = await startExporterHealthReceiver((_request, response, requestCount) => {
     response.writeHead(requestCount === 1 ? 503 : 200, {
@@ -213,7 +240,11 @@ test("retries a real OTLP 503 then succeeds without an intermediate failure fact
     await waitForDiagnosticEventsDrained();
     expect(receiver.requestCount).toBe(2);
     expect(capture.events.some((event) => event.status === "failure")).toBe(false);
-    expect(capture.events.some((event) => event.status === "recovered")).toBe(false);
+    expect(
+      getReportedExporterHealth(ctx).some(
+        (event) => event.status === "failure" || event.status === "recovered",
+      ),
+    ).toBe(false);
   } finally {
     capture.unsubscribe();
     await service.stop?.(ctx);
@@ -236,6 +267,11 @@ test("records a final failure after persistent real OTLP 503 responses", async (
     expect(receiver.requestCount).toBe(6);
     expect(
       capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "emit_failed",
+      ),
+    ).toHaveLength(1);
+    expect(
+      getReportedExporterHealth(ctx).filter(
         (event) => event.status === "failure" && event.reason === "export_failed",
       ),
     ).toHaveLength(1);
@@ -260,6 +296,11 @@ test("records a final failure for a real OTLP connection reset", async () => {
     expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
     expect(
       capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "emit_failed",
+      ),
+    ).toHaveLength(1);
+    expect(
+      getReportedExporterHealth(ctx).filter(
         (event) => event.status === "failure" && event.reason === "export_failed",
       ),
     ).toHaveLength(1);
@@ -284,6 +325,11 @@ test("records a final failure for a real OTLP request timeout", async () => {
     expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
     expect(
       capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "emit_failed",
+      ),
+    ).toHaveLength(1);
+    expect(
+      getReportedExporterHealth(ctx).filter(
         (event) => event.status === "failure" && event.reason === "export_failed",
       ),
     ).toHaveLength(1);
@@ -305,18 +351,18 @@ test("records recovery after a later real OTLP export succeeds", async () => {
   });
   const capture = captureExporterEvents();
   const { service, ctx } = await startTraceExporterHealthService(receiver.endpoint, "1000", 1000);
+  const health = getReportedExporterHealth(ctx);
 
   try {
     emitExporterHealthSpan("failure-before-recovery");
-    await waitForExporterStatus(capture.events, "failure");
+    await waitForExporterStatus(health, "failure");
     failExports = false;
     emitExporterHealthSpan("successful-recovery");
-    await waitForExporterStatus(capture.events, "recovered");
+    await waitForExporterStatus(health, "recovered");
     expect(
-      capture.events
-        .filter((event) => event.reason === "export_failed")
-        .map((event) => event.status),
+      health.filter((event) => event.reason === "export_failed").map((event) => event.status),
     ).toEqual(["failure", "recovered"]);
+    expect(capture.events.map((event) => event.status)).not.toContain("recovered");
   } finally {
     capture.unsubscribe();
     await service.stop?.(ctx);

--- a/extensions/diagnostics-otel/src/service-exporter-health.test.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.test.ts
@@ -1,0 +1,142 @@
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
+import { describe, expect, it, vi } from "vitest";
+import type { DiagnosticEventPayload } from "../api.js";
+import { observeOtlpExporterHealth } from "./service-exporter-health.js";
+
+type ExporterEvent = Extract<DiagnosticEventPayload, { type: "telemetry.exporter" }>;
+
+function createObservedExporter(events: ExporterEvent[]) {
+  let resultCallback: ((result: ExportResult) => void) | undefined;
+  const shutdown = vi.fn(async () => {});
+  const exporter = {
+    export: vi.fn((_items: unknown, callback: (result: ExportResult) => void) => {
+      resultCallback = callback;
+    }),
+    shutdown,
+  };
+  observeOtlpExporterHealth(exporter, {
+    signal: "traces",
+    emitExporterEvent: (event) => {
+      events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+    },
+  });
+  return {
+    exporter,
+    shutdown,
+    complete(result: ExportResult) {
+      if (!resultCallback) {
+        throw new Error("export callback was not registered");
+      }
+      resultCallback(result);
+    },
+  };
+}
+
+describe("observeOtlpExporterHealth", () => {
+  it("emits one final failure transition and one recovery transition", () => {
+    const events: ExporterEvent[] = [];
+    const observed = createObservedExporter(events);
+    const consumerCallback = vi.fn();
+
+    observed.exporter.export([], consumerCallback);
+    observed.complete({
+      code: ExportResultCode.FAILED,
+      error: new Error("collector unavailable"),
+    });
+    observed.exporter.export([], consumerCallback);
+    observed.complete({
+      code: ExportResultCode.FAILED,
+      error: new Error("collector still unavailable"),
+    });
+    observed.exporter.export([], consumerCallback);
+    observed.complete({ code: ExportResultCode.SUCCESS });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        signal: "traces",
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "export_failed",
+        errorCategory: "Error",
+      }),
+      expect.objectContaining({
+        signal: "traces",
+        transport: "otlp-http-protobuf",
+        status: "recovered",
+        reason: "export_failed",
+      }),
+    ]);
+    expect(consumerCallback).toHaveBeenCalledTimes(3);
+  });
+
+  it("records a shutdown rejection without exposing its message", async () => {
+    const events: ExporterEvent[] = [];
+    const observed = createObservedExporter(events);
+    observed.shutdown.mockRejectedValueOnce(new TypeError("private collector details"));
+
+    await expect(observed.exporter.shutdown()).rejects.toThrow("private collector details");
+    expect(events).toEqual([
+      expect.objectContaining({
+        signal: "traces",
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "shutdown_failed",
+        errorCategory: "TypeError",
+      }),
+    ]);
+    expect(JSON.stringify(events)).not.toContain("private collector details");
+  });
+
+  it("records and rethrows a synchronous dependency export failure once", () => {
+    const events: ExporterEvent[] = [];
+    const exportItems = vi.fn(() => {
+      throw new TypeError("private serialization details");
+    });
+    const exporter = {
+      export: exportItems,
+      shutdown: vi.fn(async () => {}),
+    };
+    observeOtlpExporterHealth(exporter, {
+      signal: "logs",
+      emitExporterEvent: (event) => {
+        events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+      },
+    });
+
+    expect(() => exporter.export([], vi.fn())).toThrow("private serialization details");
+    expect(() => exporter.export([], vi.fn())).toThrow("private serialization details");
+    expect(events).toEqual([
+      expect.objectContaining({
+        signal: "logs",
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "export_failed",
+        errorCategory: "TypeError",
+      }),
+    ]);
+    expect(JSON.stringify(events)).not.toContain("private serialization details");
+  });
+
+  it("does not misclassify a synchronous consumer callback failure", () => {
+    const events: ExporterEvent[] = [];
+    const exporter = {
+      export: vi.fn((_items: unknown, callback: (result: ExportResult) => void) => {
+        callback({ code: ExportResultCode.SUCCESS });
+      }),
+      shutdown: vi.fn(async () => {}),
+    };
+    observeOtlpExporterHealth(exporter, {
+      signal: "metrics",
+      emitExporterEvent: (event) => {
+        events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+      },
+    });
+
+    expect(() =>
+      exporter.export([], () => {
+        throw new Error("consumer callback failed");
+      }),
+    ).toThrow("consumer callback failed");
+    expect(events).toEqual([]);
+  });
+});

--- a/extensions/diagnostics-otel/src/service-exporter-health.test.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.test.ts
@@ -1,7 +1,10 @@
 import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import { describe, expect, it, vi } from "vitest";
 import type { DiagnosticEventPayload } from "../api.js";
-import { observeOtlpExporterHealth } from "./service-exporter-health.js";
+import {
+  createExporterHealthEventEmitter,
+  observeOtlpExporterHealth,
+} from "./service-exporter-health.js";
 
 type ExporterEvent = Extract<DiagnosticEventPayload, { type: "telemetry.exporter" }>;
 
@@ -16,9 +19,9 @@ function createObservedExporter(events: ExporterEvent[]) {
   };
   observeOtlpExporterHealth(exporter, {
     signal: "traces",
-    emitExporterEvent: (event) => {
+    emitExporterEvent: createExporterHealthEventEmitter((event) => {
       events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
-    },
+    }),
   });
   return {
     exporter,
@@ -98,9 +101,9 @@ describe("observeOtlpExporterHealth", () => {
     };
     observeOtlpExporterHealth(exporter, {
       signal: "logs",
-      emitExporterEvent: (event) => {
+      emitExporterEvent: createExporterHealthEventEmitter((event) => {
         events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
-      },
+      }),
     });
 
     expect(() => exporter.export([], vi.fn())).toThrow("private serialization details");
@@ -127,9 +130,9 @@ describe("observeOtlpExporterHealth", () => {
     };
     observeOtlpExporterHealth(exporter, {
       signal: "metrics",
-      emitExporterEvent: (event) => {
+      emitExporterEvent: createExporterHealthEventEmitter((event) => {
         events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
-      },
+      }),
     });
 
     expect(() =>

--- a/extensions/diagnostics-otel/src/service-exporter-health.test.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.test.ts
@@ -1,14 +1,13 @@
 import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import { describe, expect, it, vi } from "vitest";
-import type { DiagnosticEventPayload } from "../api.js";
 import {
   createExporterHealthEventEmitter,
+  createPublicExporterHealthEventEmitter,
   observeOtlpExporterHealth,
+  type ExporterHealthUpdate,
 } from "./service-exporter-health.js";
 
-type ExporterEvent = Extract<DiagnosticEventPayload, { type: "telemetry.exporter" }>;
-
-function createObservedExporter(events: ExporterEvent[]) {
+function createObservedExporter(events: ExporterHealthUpdate[]) {
   let resultCallback: ((result: ExportResult) => void) | undefined;
   const shutdown = vi.fn(async () => {});
   const exporter = {
@@ -20,7 +19,7 @@ function createObservedExporter(events: ExporterEvent[]) {
   observeOtlpExporterHealth(exporter, {
     signal: "traces",
     emitExporterEvent: createExporterHealthEventEmitter((event) => {
-      events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+      events.push(event);
     }),
   });
   return {
@@ -35,9 +34,76 @@ function createObservedExporter(events: ExporterEvent[]) {
   };
 }
 
+describe("createPublicExporterHealthEventEmitter", () => {
+  it("emits one public lifecycle for a signal with multiple transports", () => {
+    const events: ExporterHealthUpdate[] = [];
+    const emit = createPublicExporterHealthEventEmitter((event) => events.push(event));
+
+    emit({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "otlp-http-protobuf",
+      status: "started",
+      reason: "configured",
+    });
+    emit({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "started",
+      reason: "configured",
+    });
+    emit({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "otlp-http-protobuf",
+      status: "dropped",
+    });
+    emit({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "dropped",
+    });
+
+    expect(events.map(({ status, transport }) => ({ status, transport }))).toEqual([
+      { status: "started", transport: "otlp-http-protobuf" },
+      { status: "dropped", transport: "stdout" },
+    ]);
+  });
+
+  it("coalesces matching failures without publishing recovery", () => {
+    const events: ExporterHealthUpdate[] = [];
+    const emit = createPublicExporterHealthEventEmitter((event) => events.push(event));
+    const base = {
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      reason: "emit_failed",
+      errorCategory: "TypeError",
+    } as const;
+
+    emit({ ...base, transport: "otlp-http-protobuf", status: "failure" });
+    emit({ ...base, transport: "stdout", status: "failure" });
+    emit({ ...base, transport: "otlp-http-protobuf", status: "recovered" });
+    emit({ ...base, transport: "stdout", status: "recovered" });
+    emit({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "failure",
+      reason: "queue_full",
+    });
+
+    expect(events.map(({ status, reason }) => ({ status, reason }))).toEqual([
+      { status: "failure", reason: "emit_failed" },
+      { status: "failure", reason: "queue_full" },
+    ]);
+  });
+});
+
 describe("observeOtlpExporterHealth", () => {
   it("emits one final failure transition and one recovery transition", () => {
-    const events: ExporterEvent[] = [];
+    const events: ExporterHealthUpdate[] = [];
     const observed = createObservedExporter(events);
     const consumerCallback = vi.fn();
 
@@ -73,7 +139,7 @@ describe("observeOtlpExporterHealth", () => {
   });
 
   it("records a shutdown rejection without exposing its message", async () => {
-    const events: ExporterEvent[] = [];
+    const events: ExporterHealthUpdate[] = [];
     const observed = createObservedExporter(events);
     observed.shutdown.mockRejectedValueOnce(new TypeError("private collector details"));
 
@@ -91,7 +157,7 @@ describe("observeOtlpExporterHealth", () => {
   });
 
   it("records and rethrows a synchronous dependency export failure once", () => {
-    const events: ExporterEvent[] = [];
+    const events: ExporterHealthUpdate[] = [];
     const exportItems = vi.fn((_items: unknown, _callback: (result: ExportResult) => void) => {
       throw new TypeError("private serialization details");
     });
@@ -102,7 +168,7 @@ describe("observeOtlpExporterHealth", () => {
     observeOtlpExporterHealth(exporter, {
       signal: "logs",
       emitExporterEvent: createExporterHealthEventEmitter((event) => {
-        events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+        events.push(event);
       }),
     });
 
@@ -121,7 +187,7 @@ describe("observeOtlpExporterHealth", () => {
   });
 
   it("does not misclassify a synchronous consumer callback failure", () => {
-    const events: ExporterEvent[] = [];
+    const events: ExporterHealthUpdate[] = [];
     const exporter = {
       export: vi.fn((_items: unknown, callback: (result: ExportResult) => void) => {
         callback({ code: ExportResultCode.SUCCESS });
@@ -131,7 +197,7 @@ describe("observeOtlpExporterHealth", () => {
     observeOtlpExporterHealth(exporter, {
       signal: "metrics",
       emitExporterEvent: createExporterHealthEventEmitter((event) => {
-        events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+        events.push(event);
       }),
     });
 

--- a/extensions/diagnostics-otel/src/service-exporter-health.test.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.test.ts
@@ -89,7 +89,7 @@ describe("observeOtlpExporterHealth", () => {
 
   it("records and rethrows a synchronous dependency export failure once", () => {
     const events: ExporterEvent[] = [];
-    const exportItems = vi.fn(() => {
+    const exportItems = vi.fn((_items: unknown, _callback: (result: ExportResult) => void) => {
       throw new TypeError("private serialization details");
     });
     const exporter = {

--- a/extensions/diagnostics-otel/src/service-exporter-health.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.ts
@@ -1,0 +1,83 @@
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
+import { errorCategory } from "./service-exporter.js";
+import type { TelemetryExporterDiagnosticEvent } from "./service-types.js";
+
+type ObservableOtlpExporter = {
+  export(items: unknown, resultCallback: (result: ExportResult) => void): void;
+  shutdown(): Promise<void>;
+};
+
+/**
+ * Observes the exporter result callback, which runs only after the OTLP
+ * transport has exhausted dependency-owned retries.
+ */
+export function observeOtlpExporterHealth<TExporter extends object>(
+  exporter: TExporter,
+  params: {
+    emitExporterEvent: (
+      event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">,
+    ) => void;
+    signal: TelemetryExporterDiagnosticEvent["signal"];
+  },
+): TExporter {
+  const observed = exporter as unknown as ObservableOtlpExporter;
+  const exportItems = observed.export.bind(observed);
+  const shutdown = observed.shutdown.bind(observed);
+  let exportFailed = false;
+
+  const emit = (
+    status: TelemetryExporterDiagnosticEvent["status"],
+    reason: "export_failed" | "shutdown_failed",
+    error?: unknown,
+  ) => {
+    params.emitExporterEvent({
+      exporter: "diagnostics-otel",
+      signal: params.signal,
+      transport: "otlp-http-protobuf",
+      status,
+      reason,
+      ...(error ? { errorCategory: errorCategory(error) } : {}),
+    });
+  };
+  const noteExportFailure = (error: unknown) => {
+    if (exportFailed) {
+      return;
+    }
+    exportFailed = true;
+    emit("failure", "export_failed", error);
+  };
+
+  observed.export = (items, resultCallback) => {
+    let dependencyCallbackInvoked = false;
+    try {
+      exportItems(items, (result) => {
+        dependencyCallbackInvoked = true;
+        if (result.code === ExportResultCode.FAILED) {
+          noteExportFailure(result.error);
+        } else if (result.code === ExportResultCode.SUCCESS && exportFailed) {
+          exportFailed = false;
+          emit("recovered", "export_failed");
+        }
+        resultCallback(result);
+      });
+    } catch (error) {
+      // The delegate serializes before creating its transport promise, so that
+      // path can throw without invoking the result callback.
+      if (!dependencyCallbackInvoked) {
+        noteExportFailure(error);
+      }
+      throw error;
+    }
+  };
+
+  observed.shutdown = async () => {
+    try {
+      await shutdown();
+    } catch (error) {
+      emit("failure", "shutdown_failed", error);
+      throw error;
+    }
+  };
+
+  return exporter;
+}

--- a/extensions/diagnostics-otel/src/service-exporter-health.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.ts
@@ -1,23 +1,54 @@
 import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import { errorCategory } from "./service-exporter.js";
-import type { TelemetryExporterDiagnosticEvent } from "./service-types.js";
 
 type ObservableOtlpExporter = {
   export(items: unknown, resultCallback: (result: ExportResult) => void): void;
   shutdown(): Promise<void>;
 };
 
-type ExporterEvent = Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">;
-type FailureReason = NonNullable<ExporterEvent["reason"]> | "unspecified";
+type ExporterHealthReason =
+  | "configured"
+  | "default_endpoint"
+  | "emit_failed"
+  | "export_failed"
+  | "handler_failed"
+  | "queue_full"
+  | "shutdown_failed"
+  | "start_failed"
+  | "unsupported_protocol";
+
+export type ExporterHealthUpdate = {
+  exporter: string;
+  signal: "traces" | "metrics" | "logs";
+  transport: "otlp-http-protobuf" | "stdout" | "external-sdk";
+  endpointMode?: "configured" | "default_endpoint";
+  status: "started" | "failure" | "recovered" | "dropped";
+  reason?: ExporterHealthReason;
+  errorCategory?: string;
+};
+
+type FailureReason = ExporterHealthReason | "unspecified";
+type PublicExporterHealthUpdate = Omit<ExporterHealthUpdate, "status"> & {
+  status: Exclude<ExporterHealthUpdate["status"], "recovered">;
+};
+type PublicSignalState = {
+  routes: Set<ExporterHealthUpdate["transport"]>;
+  started: boolean;
+  routeFailures: Map<ExporterHealthUpdate["transport"], string>;
+};
+
+function publicFailureKey(event: ExporterHealthUpdate): string {
+  return `${event.reason ?? "unspecified"}\u0000${event.errorCategory ?? "unknown"}`;
+}
 
 /** Owns route transitions so one producer cannot recover another producer's failure. */
-export function createExporterHealthEventEmitter(publish: (event: ExporterEvent) => void) {
+export function createExporterHealthEventEmitter(publish: (event: ExporterHealthUpdate) => void) {
   const failures = new Map<
     string,
-    { active: Map<FailureReason, ExporterEvent>; reported?: FailureReason }
+    { active: Map<FailureReason, ExporterHealthUpdate>; reported?: FailureReason }
   >();
-  return (event: ExporterEvent) => {
-    const key = `${event.exporter}\u0000${event.signal}\u0000${event.transport ?? "unknown"}`;
+  return (event: ExporterHealthUpdate) => {
+    const key = `${event.exporter}\u0000${event.signal}\u0000${event.transport}`;
     if (event.status === "started" || event.status === "dropped") {
       failures.delete(key);
       publish(event);
@@ -25,7 +56,9 @@ export function createExporterHealthEventEmitter(publish: (event: ExporterEvent)
     }
     const reason = event.reason ?? "unspecified";
     if (event.status === "failure") {
-      const route = failures.get(key) ?? { active: new Map<FailureReason, ExporterEvent>() };
+      const route = failures.get(key) ?? {
+        active: new Map<FailureReason, ExporterHealthUpdate>(),
+      };
       failures.set(key, route);
       if (route.active.has(reason)) {
         return;
@@ -52,6 +85,67 @@ export function createExporterHealthEventEmitter(publish: (event: ExporterEvent)
   };
 }
 
+/** Coalesces private transport transitions into the shipped signal-level public stream. */
+export function createPublicExporterHealthEventEmitter(
+  publish: (event: PublicExporterHealthUpdate) => void,
+) {
+  const signals = new Map<string, PublicSignalState>();
+  return (event: ExporterHealthUpdate) => {
+    const signalKey = `${event.exporter}\u0000${event.signal}`;
+    let state = signals.get(signalKey);
+    if (!state) {
+      if (event.status === "dropped") {
+        return;
+      }
+      state = {
+        routes: new Set(),
+        started: false,
+        routeFailures: new Map(),
+      };
+      signals.set(signalKey, state);
+    }
+
+    const routeKey = event.transport;
+    if (event.status === "dropped") {
+      const removed = state.routes.delete(routeKey);
+      state.routeFailures.delete(routeKey);
+      if (!removed || state.routes.size > 0) {
+        return;
+      }
+      signals.delete(signalKey);
+      publish({ ...event, status: "dropped" });
+      return;
+    }
+
+    state.routes.add(routeKey);
+    if (event.status === "started") {
+      state.routeFailures.delete(routeKey);
+      if (state.started) {
+        return;
+      }
+      state.started = true;
+      publish({ ...event, status: "started" });
+      return;
+    }
+    if (event.status === "recovered") {
+      state.routeFailures.delete(routeKey);
+      return;
+    }
+
+    const failureKey = publicFailureKey(event);
+    if (state.routeFailures.get(routeKey) === failureKey) {
+      return;
+    }
+    const duplicate = [...state.routeFailures.entries()].some(
+      ([transport, activeFailure]) => transport !== routeKey && activeFailure === failureKey,
+    );
+    state.routeFailures.set(routeKey, failureKey);
+    if (!duplicate) {
+      publish({ ...event, status: "failure" });
+    }
+  };
+}
+
 /**
  * Observes the exporter result callback, which runs only after the OTLP
  * transport has exhausted dependency-owned retries.
@@ -59,8 +153,8 @@ export function createExporterHealthEventEmitter(publish: (event: ExporterEvent)
 export function observeOtlpExporterHealth<TExporter extends object>(
   exporter: TExporter,
   params: {
-    emitExporterEvent: (event: ExporterEvent) => void;
-    signal: TelemetryExporterDiagnosticEvent["signal"];
+    emitExporterEvent: (event: ExporterHealthUpdate) => void;
+    signal: ExporterHealthUpdate["signal"];
   },
 ): TExporter {
   const observed = exporter as unknown as ObservableOtlpExporter;
@@ -68,7 +162,7 @@ export function observeOtlpExporterHealth<TExporter extends object>(
   const shutdown = observed.shutdown.bind(observed);
 
   const emit = (
-    status: TelemetryExporterDiagnosticEvent["status"],
+    status: ExporterHealthUpdate["status"],
     reason: "export_failed" | "shutdown_failed",
     error?: unknown,
   ) => {

--- a/extensions/diagnostics-otel/src/service-exporter-health.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.ts
@@ -7,6 +7,51 @@ type ObservableOtlpExporter = {
   shutdown(): Promise<void>;
 };
 
+type ExporterEvent = Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">;
+type FailureReason = NonNullable<ExporterEvent["reason"]> | "unspecified";
+
+/** Owns route transitions so one producer cannot recover another producer's failure. */
+export function createExporterHealthEventEmitter(publish: (event: ExporterEvent) => void) {
+  const failures = new Map<
+    string,
+    { active: Map<FailureReason, ExporterEvent>; reported?: FailureReason }
+  >();
+  return (event: ExporterEvent) => {
+    const key = `${event.exporter}\u0000${event.signal}\u0000${event.transport ?? "unknown"}`;
+    if (event.status === "started" || event.status === "dropped") {
+      failures.delete(key);
+      publish(event);
+      return;
+    }
+    const reason = event.reason ?? "unspecified";
+    if (event.status === "failure") {
+      const route = failures.get(key) ?? { active: new Map<FailureReason, ExporterEvent>() };
+      failures.set(key, route);
+      if (route.active.has(reason)) {
+        return;
+      }
+      route.active.set(reason, event);
+      if (route.reported === undefined) {
+        route.reported = reason;
+        publish(event);
+      }
+      return;
+    }
+    const route = failures.get(key);
+    if (!route?.active.delete(reason) || route.reported !== reason) {
+      return;
+    }
+    const next = route.active.entries().next().value;
+    if (next) {
+      route.reported = next[0];
+      publish(next[1]);
+      return;
+    }
+    failures.delete(key);
+    publish(event);
+  };
+}
+
 /**
  * Observes the exporter result callback, which runs only after the OTLP
  * transport has exhausted dependency-owned retries.
@@ -14,16 +59,13 @@ type ObservableOtlpExporter = {
 export function observeOtlpExporterHealth<TExporter extends object>(
   exporter: TExporter,
   params: {
-    emitExporterEvent: (
-      event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">,
-    ) => void;
+    emitExporterEvent: (event: ExporterEvent) => void;
     signal: TelemetryExporterDiagnosticEvent["signal"];
   },
 ): TExporter {
   const observed = exporter as unknown as ObservableOtlpExporter;
   const exportItems = observed.export.bind(observed);
   const shutdown = observed.shutdown.bind(observed);
-  let exportFailed = false;
 
   const emit = (
     status: TelemetryExporterDiagnosticEvent["status"],
@@ -39,13 +81,6 @@ export function observeOtlpExporterHealth<TExporter extends object>(
       ...(error ? { errorCategory: errorCategory(error) } : {}),
     });
   };
-  const noteExportFailure = (error: unknown) => {
-    if (exportFailed) {
-      return;
-    }
-    exportFailed = true;
-    emit("failure", "export_failed", error);
-  };
 
   observed.export = (items, resultCallback) => {
     let dependencyCallbackInvoked = false;
@@ -53,9 +88,8 @@ export function observeOtlpExporterHealth<TExporter extends object>(
       exportItems(items, (result) => {
         dependencyCallbackInvoked = true;
         if (result.code === ExportResultCode.FAILED) {
-          noteExportFailure(result.error);
-        } else if (result.code === ExportResultCode.SUCCESS && exportFailed) {
-          exportFailed = false;
+          emit("failure", "export_failed", result.error);
+        } else if (result.code === ExportResultCode.SUCCESS) {
           emit("recovered", "export_failed");
         }
         resultCallback(result);
@@ -64,7 +98,7 @@ export function observeOtlpExporterHealth<TExporter extends object>(
       // The delegate serializes before creating its transport promise, so that
       // path can throw without invoking the result callback.
       if (!dependencyCallbackInvoked) {
-        noteExportFailure(error);
+        emit("failure", "export_failed", error);
       }
       throw error;
     }

--- a/extensions/diagnostics-otel/src/service-logs.ts
+++ b/extensions/diagnostics-otel/src/service-logs.ts
@@ -20,6 +20,7 @@ import {
   normalizeOtelLogString,
   type OtelContentCapturePolicy,
 } from "./service-content-normalization.js";
+import { observeOtlpExporterHealth } from "./service-exporter-health.js";
 import { errorCategory, formatError } from "./service-exporter.js";
 import {
   addTraceAttributes,
@@ -87,14 +88,18 @@ export function createDiagnosticsLogExporter(params: {
     | undefined;
   if (logsEnabled) {
     let logRecordExportFailureLastReportedAt = Number.NEGATIVE_INFINITY;
+    const failedEmits = new Set<"otlp-http-protobuf" | "stdout" | undefined>();
 
     let otelLogger: { emit: (logRecord: LogRecord) => void } | undefined;
     if (logsToOtlp) {
-      const logExporter = new OTLPLogExporter({
-        ...(logUrl ? { url: logUrl } : {}),
-        ...(headers ? { headers } : {}),
-        ...(logHttpAgentOptions ? { httpAgentOptions: logHttpAgentOptions } : {}),
-      });
+      const logExporter = observeOtlpExporterHealth(
+        new OTLPLogExporter({
+          ...(logUrl ? { url: logUrl } : {}),
+          ...(headers ? { headers } : {}),
+          ...(logHttpAgentOptions ? { httpAgentOptions: logHttpAgentOptions } : {}),
+        }),
+        { emitExporterEvent, signal: "logs" },
+      );
       const logProcessor = new BatchLogRecordProcessor({
         exporter: logExporter,
         ...(typeof flushIntervalMs === "number"
@@ -108,14 +113,22 @@ export function createDiagnosticsLogExporter(params: {
       otelLogger = logProvider.getLogger("openclaw");
     }
 
-    const reportLogExportFailure = (err: unknown, label: "log record" | "security event") => {
-      emitExporterEvent({
-        exporter: "diagnostics-otel",
-        signal: "logs",
-        status: "failure",
-        reason: "emit_failed",
-        errorCategory: errorCategory(err),
-      });
+    const reportLogExportFailure = (
+      err: unknown,
+      label: "log record" | "security event",
+      transport?: "otlp-http-protobuf" | "stdout",
+    ) => {
+      if (!failedEmits.has(transport)) {
+        failedEmits.add(transport);
+        emitExporterEvent({
+          exporter: "diagnostics-otel",
+          signal: "logs",
+          ...(transport ? { transport } : {}),
+          status: "failure",
+          reason: "emit_failed",
+          errorCategory: errorCategory(err),
+        });
+      }
       const now = Date.now();
       if (
         now - logRecordExportFailureLastReportedAt >=
@@ -125,17 +138,42 @@ export function createDiagnosticsLogExporter(params: {
         logger.error(`diagnostics-otel: ${label} export failed: ${formatError(err)}`);
       }
     };
+    const reportLogExportRecovery = (transport?: "otlp-http-protobuf" | "stdout") => {
+      if (!failedEmits.delete(transport)) {
+        return;
+      }
+      emitExporterEvent({
+        exporter: "diagnostics-otel",
+        signal: "logs",
+        ...(transport ? { transport } : {}),
+        status: "recovered",
+        reason: "emit_failed",
+      });
+    };
 
-    const emitLogRecord = ({ logRecord, traceContext }: BuiltOtelLogRecord) => {
+    const emitLogRecord = (
+      { logRecord, traceContext }: BuiltOtelLogRecord,
+      label: "log record" | "security event",
+    ) => {
       if (logsToOtlp) {
-        otelLogger?.emit(logRecord);
+        try {
+          otelLogger?.emit(logRecord);
+          reportLogExportRecovery("otlp-http-protobuf");
+        } catch (error) {
+          reportLogExportFailure(error, label, "otlp-http-protobuf");
+        }
       }
       if (logsToStdout) {
-        writeStdoutDiagnosticLogRecord({
-          logRecord,
-          serviceName,
-          ...(traceContext ? { traceContext } : {}),
-        });
+        try {
+          writeStdoutDiagnosticLogRecord({
+            logRecord,
+            serviceName,
+            ...(traceContext ? { traceContext } : {}),
+          });
+          reportLogExportRecovery("stdout");
+        } catch (error) {
+          reportLogExportFailure(error, label, "stdout");
+        }
       }
     };
 
@@ -205,7 +243,9 @@ export function createDiagnosticsLogExporter(params: {
 
     recordLogRecord = (evt, metadata) => {
       try {
-        emitLogRecord(buildDiagnosticLogRecord(evt, metadata));
+        const record = buildDiagnosticLogRecord(evt, metadata);
+        reportLogExportRecovery();
+        emitLogRecord(record, "log record");
       } catch (err) {
         reportLogExportFailure(err, "log record");
       }
@@ -215,7 +255,9 @@ export function createDiagnosticsLogExporter(params: {
         return;
       }
       try {
-        emitLogRecord(buildSecurityLogRecord(evt, metadata));
+        const record = buildSecurityLogRecord(evt, metadata);
+        reportLogExportRecovery();
+        emitLogRecord(record, "security event");
       } catch (err) {
         reportLogExportFailure(err, "security event");
       }

--- a/extensions/diagnostics-otel/src/service-logs.ts
+++ b/extensions/diagnostics-otel/src/service-logs.ts
@@ -88,8 +88,6 @@ export function createDiagnosticsLogExporter(params: {
     | undefined;
   if (logsEnabled) {
     let logRecordExportFailureLastReportedAt = Number.NEGATIVE_INFINITY;
-    const failedEmits = new Set<"otlp-http-protobuf" | "stdout" | undefined>();
-
     let otelLogger: { emit: (logRecord: LogRecord) => void } | undefined;
     if (logsToOtlp) {
       const logExporter = observeOtlpExporterHealth(
@@ -118,17 +116,14 @@ export function createDiagnosticsLogExporter(params: {
       label: "log record" | "security event",
       transport?: "otlp-http-protobuf" | "stdout",
     ) => {
-      if (!failedEmits.has(transport)) {
-        failedEmits.add(transport);
-        emitExporterEvent({
-          exporter: "diagnostics-otel",
-          signal: "logs",
-          ...(transport ? { transport } : {}),
-          status: "failure",
-          reason: "emit_failed",
-          errorCategory: errorCategory(err),
-        });
-      }
+      emitExporterEvent({
+        exporter: "diagnostics-otel",
+        signal: "logs",
+        ...(transport ? { transport } : {}),
+        status: "failure",
+        reason: "emit_failed",
+        errorCategory: errorCategory(err),
+      });
       const now = Date.now();
       if (
         now - logRecordExportFailureLastReportedAt >=
@@ -139,9 +134,6 @@ export function createDiagnosticsLogExporter(params: {
       }
     };
     const reportLogExportRecovery = (transport?: "otlp-http-protobuf" | "stdout") => {
-      if (!failedEmits.delete(transport)) {
-        return;
-      }
       emitExporterEvent({
         exporter: "diagnostics-otel",
         signal: "logs",

--- a/extensions/diagnostics-otel/src/service-logs.ts
+++ b/extensions/diagnostics-otel/src/service-logs.ts
@@ -20,7 +20,7 @@ import {
   normalizeOtelLogString,
   type OtelContentCapturePolicy,
 } from "./service-content-normalization.js";
-import { observeOtlpExporterHealth } from "./service-exporter-health.js";
+import { observeOtlpExporterHealth, type ExporterHealthUpdate } from "./service-exporter-health.js";
 import { errorCategory, formatError } from "./service-exporter.js";
 import {
   addTraceAttributes,
@@ -32,7 +32,6 @@ import type {
   OtelHttpAgentFactory,
   OtelHttpAgentOptions,
   OtelLogger,
-  TelemetryExporterDiagnosticEvent,
 } from "./service-types.js";
 
 const LOG_SEVERITY_MAP: Record<string, SeverityNumber> = {
@@ -46,7 +45,7 @@ const LOG_SEVERITY_MAP: Record<string, SeverityNumber> = {
 
 export function createDiagnosticsLogExporter(params: {
   contentCapturePolicy: OtelContentCapturePolicy;
-  emitExporterEvent: (event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">) => void;
+  emitExporterEvent: (event: ExporterHealthUpdate) => void;
   flushIntervalMs?: number;
   headers?: Record<string, string>;
   logger: OtelLogger;
@@ -89,6 +88,10 @@ export function createDiagnosticsLogExporter(params: {
   if (logsEnabled) {
     let logRecordExportFailureLastReportedAt = Number.NEGATIVE_INFINITY;
     let otelLogger: { emit: (logRecord: LogRecord) => void } | undefined;
+    const activeTransports: ExporterHealthUpdate["transport"][] = [
+      ...(logsToOtlp ? (["otlp-http-protobuf"] as const) : []),
+      ...(logsToStdout ? (["stdout"] as const) : []),
+    ];
     if (logsToOtlp) {
       const logExporter = observeOtlpExporterHealth(
         new OTLPLogExporter({
@@ -114,12 +117,12 @@ export function createDiagnosticsLogExporter(params: {
     const reportLogExportFailure = (
       err: unknown,
       label: "log record" | "security event",
-      transport?: "otlp-http-protobuf" | "stdout",
+      transport: ExporterHealthUpdate["transport"],
     ) => {
       emitExporterEvent({
         exporter: "diagnostics-otel",
         signal: "logs",
-        ...(transport ? { transport } : {}),
+        transport,
         status: "failure",
         reason: "emit_failed",
         errorCategory: errorCategory(err),
@@ -133,14 +136,19 @@ export function createDiagnosticsLogExporter(params: {
         logger.error(`diagnostics-otel: ${label} export failed: ${formatError(err)}`);
       }
     };
-    const reportLogExportRecovery = (transport?: "otlp-http-protobuf" | "stdout") => {
+    const reportLogExportRecovery = (transport: ExporterHealthUpdate["transport"]) => {
       emitExporterEvent({
         exporter: "diagnostics-otel",
         signal: "logs",
-        ...(transport ? { transport } : {}),
+        transport,
         status: "recovered",
         reason: "emit_failed",
       });
+    };
+    const reportLogPreparationFailure = (err: unknown, label: "log record" | "security event") => {
+      for (const transport of activeTransports) {
+        reportLogExportFailure(err, label, transport);
+      }
     };
 
     const emitLogRecord = (
@@ -236,10 +244,9 @@ export function createDiagnosticsLogExporter(params: {
     recordLogRecord = (evt, metadata) => {
       try {
         const record = buildDiagnosticLogRecord(evt, metadata);
-        reportLogExportRecovery();
         emitLogRecord(record, "log record");
       } catch (err) {
-        reportLogExportFailure(err, "log record");
+        reportLogPreparationFailure(err, "log record");
       }
     };
     recordSecurityEvent = (evt, metadata) => {
@@ -248,10 +255,9 @@ export function createDiagnosticsLogExporter(params: {
       }
       try {
         const record = buildSecurityLogRecord(evt, metadata);
-        reportLogExportRecovery();
         emitLogRecord(record, "security event");
       } catch (err) {
-        reportLogExportFailure(err, "security event");
+        reportLogPreparationFailure(err, "security event");
       }
     };
   }

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -9,7 +9,7 @@
 // Collector-boundary cases start the real NodeSDK, so teardown restores every global SDK
 // registration; otherwise a shutdown provider would poison later real-SDK cases.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -28,6 +28,7 @@ import {
   createChildDiagnosticTraceContext,
   createDiagnosticTraceContext,
   emitTrustedDiagnosticEventWithPrivateData,
+  onInternalDiagnosticEvent,
   parseDiagnosticTraceparent,
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
@@ -37,6 +38,7 @@ import {
   runModelCallAndCaptureTraceparent,
   startLocalOtlpReceiver,
 } from "../../../test/e2e/qa-lab/runtime/otel-test-support.js";
+import type { DiagnosticEventPayload } from "../api.js";
 import { createDiagnosticsOtelService } from "./service.js";
 import {
   createOtelContext,
@@ -45,6 +47,7 @@ import {
 } from "./service.test-helpers.js";
 
 const PRELOAD_ENV = "OPENCLAW_OTEL_PRELOADED";
+const IMMEDIATE_RETRY_AFTER = "Thu, 01 Jan 1970 00:00:00 GMT";
 const ENDPOINT_ENV_KEYS = [
   "OTEL_SDK_DISABLED",
   "OTEL_TRACES_EXPORTER",
@@ -58,6 +61,8 @@ const ENDPOINT_ENV_KEYS = [
   "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
   "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
   "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+  "OTEL_EXPORTER_OTLP_TIMEOUT",
+  "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
   "OTEL_EXPORTER_OTLP_CERTIFICATE",
   "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
   "OTEL_EXPORTER_OTLP_CLIENT_KEY",
@@ -82,6 +87,8 @@ type OtelGlobalRegistrations = {
   propagation?: Parameters<typeof propagation.setGlobalPropagator>[0];
   trace?: Parameters<typeof trace.setGlobalTracerProvider>[0];
 };
+
+type ExporterEvent = Extract<DiagnosticEventPayload, { type: "telemetry.exporter" }>;
 
 let exporter: InMemorySpanExporter;
 let provider: BasicTracerProvider;
@@ -232,6 +239,59 @@ async function startOtlpReceiver() {
   };
 }
 
+async function startExporterHealthReceiver(
+  handleRequest: (request: IncomingMessage, response: ServerResponse, requestCount: number) => void,
+) {
+  let requestCount = 0;
+  const server = createServer((request, response) => {
+    requestCount += 1;
+    request.resume();
+    handleRequest(request, response, requestCount);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    get requestCount() {
+      return requestCount;
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    },
+  };
+}
+
+function captureExporterEvents() {
+  const events: ExporterEvent[] = [];
+  const unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
+    if (metadata.trusted && event.type === "telemetry.exporter") {
+      events.push(event);
+    }
+  });
+  return { events, unsubscribe };
+}
+
+async function waitForExporterStatus(events: ExporterEvent[], status: ExporterEvent["status"]) {
+  const deadline = Date.now() + 4_000;
+  while (Date.now() < deadline) {
+    if (events.some((event) => event.status === status)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for exporter status ${status}`);
+}
+
+function emitExporterHealthSpan(name: string) {
+  trace.getTracer("openclaw-otel-exporter-health-test").startSpan(name).end();
+}
+
 function releasePreloadedOtelGlobals() {
   context.disable();
   logs.disable();
@@ -282,6 +342,178 @@ const SHARED_ENDPOINT_ROUTING_CASES = [
     ],
   },
 ] as const;
+
+test("retries a real OTLP 503 then succeeds without an intermediate failure fact", async () => {
+  const receiver = await startExporterHealthReceiver((_request, response, requestCount) => {
+    if (requestCount === 1) {
+      response.writeHead(503, { "retry-after": IMMEDIATE_RETRY_AFTER });
+    } else {
+      response.writeHead(200, { "content-type": "application/x-protobuf" });
+    }
+    response.end();
+  });
+  const capture = captureExporterEvents();
+  releasePreloadedOtelGlobals();
+  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "1000";
+  const { service, ctx } = await startOtelService({
+    endpoint: receiver.endpoint,
+    traces: true,
+    metrics: false,
+    logs: false,
+  });
+
+  try {
+    emitExporterHealthSpan("retry-then-success");
+    await service.stop?.(ctx);
+    await waitForDiagnosticEventsDrained();
+
+    expect(receiver.requestCount).toBe(2);
+    expect(capture.events.some((event) => event.status === "failure")).toBe(false);
+    expect(capture.events.some((event) => event.status === "recovered")).toBe(false);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records a final failure after persistent real OTLP 503 responses", async () => {
+  const receiver = await startExporterHealthReceiver((_request, response) => {
+    response.writeHead(503, { "retry-after": IMMEDIATE_RETRY_AFTER });
+    response.end();
+  });
+  const capture = captureExporterEvents();
+  releasePreloadedOtelGlobals();
+  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "1000";
+  const { service, ctx } = await startOtelService({
+    endpoint: receiver.endpoint,
+    traces: true,
+    metrics: false,
+    logs: false,
+  });
+
+  try {
+    emitExporterHealthSpan("persistent-503");
+    await service.stop?.(ctx).catch(() => {});
+    await waitForDiagnosticEventsDrained();
+
+    expect(receiver.requestCount).toBe(6);
+    expect(
+      capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "export_failed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records a final failure for a real OTLP connection reset", async () => {
+  const receiver = await startExporterHealthReceiver((request) => {
+    request.socket.destroy();
+  });
+  const capture = captureExporterEvents();
+  releasePreloadedOtelGlobals();
+  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "200";
+  const { service, ctx } = await startOtelService({
+    endpoint: receiver.endpoint,
+    traces: true,
+    metrics: false,
+    logs: false,
+  });
+
+  try {
+    emitExporterHealthSpan("connection-reset");
+    await service.stop?.(ctx).catch(() => {});
+    await waitForDiagnosticEventsDrained();
+
+    expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
+    expect(
+      capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "export_failed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records a final failure for a real OTLP request timeout", async () => {
+  const receiver = await startExporterHealthReceiver(() => {
+    // Keep the request open until the exporter-owned timeout settles.
+  });
+  const capture = captureExporterEvents();
+  releasePreloadedOtelGlobals();
+  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "150";
+  const { service, ctx } = await startOtelService({
+    endpoint: receiver.endpoint,
+    traces: true,
+    metrics: false,
+    logs: false,
+  });
+
+  try {
+    emitExporterHealthSpan("request-timeout");
+    await service.stop?.(ctx).catch(() => {});
+    await waitForDiagnosticEventsDrained();
+
+    expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
+    expect(
+      capture.events.filter(
+        (event) => event.status === "failure" && event.reason === "export_failed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
+
+test("records recovery after a later real OTLP export succeeds", async () => {
+  let failExports = true;
+  const receiver = await startExporterHealthReceiver((_request, response) => {
+    response.writeHead(failExports ? 503 : 200, {
+      "content-type": "application/x-protobuf",
+      ...(failExports ? { "retry-after": IMMEDIATE_RETRY_AFTER } : {}),
+    });
+    response.end();
+  });
+  const capture = captureExporterEvents();
+  releasePreloadedOtelGlobals();
+  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "1000";
+  const { service, ctx } = await startOtelService({
+    endpoint: receiver.endpoint,
+    traces: true,
+    metrics: false,
+    logs: false,
+    configure: (serviceContext) => {
+      serviceContext.config.diagnostics!.otel!.flushIntervalMs = 1000;
+    },
+  });
+
+  try {
+    emitExporterHealthSpan("failure-before-recovery");
+    await waitForExporterStatus(capture.events, "failure");
+    failExports = false;
+    emitExporterHealthSpan("successful-recovery");
+    await waitForExporterStatus(capture.events, "recovered");
+
+    expect(
+      capture.events
+        .filter((event) => event.reason === "export_failed")
+        .map((event) => event.status),
+    ).toEqual(["failure", "recovered"]);
+  } finally {
+    capture.unsubscribe();
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 15_000);
 
 test.each(SHARED_ENDPOINT_ROUTING_CASES)(
   "routes real exporters from a shared $label endpoint",

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -9,7 +9,7 @@
 // Collector-boundary cases start the real NodeSDK, so teardown restores every global SDK
 // registration; otherwise a shutdown provider would poison later real-SDK cases.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -28,7 +28,6 @@ import {
   createChildDiagnosticTraceContext,
   createDiagnosticTraceContext,
   emitTrustedDiagnosticEventWithPrivateData,
-  onInternalDiagnosticEvent,
   parseDiagnosticTraceparent,
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
@@ -38,7 +37,6 @@ import {
   runModelCallAndCaptureTraceparent,
   startLocalOtlpReceiver,
 } from "../../../test/e2e/qa-lab/runtime/otel-test-support.js";
-import type { DiagnosticEventPayload } from "../api.js";
 import { createDiagnosticsOtelService } from "./service.js";
 import {
   createOtelContext,
@@ -47,7 +45,6 @@ import {
 } from "./service.test-helpers.js";
 
 const PRELOAD_ENV = "OPENCLAW_OTEL_PRELOADED";
-const IMMEDIATE_RETRY_AFTER = "Thu, 01 Jan 1970 00:00:00 GMT";
 const ENDPOINT_ENV_KEYS = [
   "OTEL_SDK_DISABLED",
   "OTEL_TRACES_EXPORTER",
@@ -87,8 +84,6 @@ type OtelGlobalRegistrations = {
   propagation?: Parameters<typeof propagation.setGlobalPropagator>[0];
   trace?: Parameters<typeof trace.setGlobalTracerProvider>[0];
 };
-
-type ExporterEvent = Extract<DiagnosticEventPayload, { type: "telemetry.exporter" }>;
 
 let exporter: InMemorySpanExporter;
 let provider: BasicTracerProvider;
@@ -239,59 +234,6 @@ async function startOtlpReceiver() {
   };
 }
 
-async function startExporterHealthReceiver(
-  handleRequest: (request: IncomingMessage, response: ServerResponse, requestCount: number) => void,
-) {
-  let requestCount = 0;
-  const server = createServer((request, response) => {
-    requestCount += 1;
-    request.resume();
-    handleRequest(request, response, requestCount);
-  });
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const { port } = server.address() as AddressInfo;
-  return {
-    endpoint: `http://127.0.0.1:${port}`,
-    get requestCount() {
-      return requestCount;
-    },
-    async close() {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-        server.closeAllConnections();
-      });
-    },
-  };
-}
-
-function captureExporterEvents() {
-  const events: ExporterEvent[] = [];
-  const unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
-    if (metadata.trusted && event.type === "telemetry.exporter") {
-      events.push(event);
-    }
-  });
-  return { events, unsubscribe };
-}
-
-async function waitForExporterStatus(events: ExporterEvent[], status: ExporterEvent["status"]) {
-  const deadline = Date.now() + 4_000;
-  while (Date.now() < deadline) {
-    if (events.some((event) => event.status === status)) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  throw new Error(`timed out waiting for exporter status ${status}`);
-}
-
-function emitExporterHealthSpan(name: string) {
-  trace.getTracer("openclaw-otel-exporter-health-test").startSpan(name).end();
-}
-
 function releasePreloadedOtelGlobals() {
   context.disable();
   logs.disable();
@@ -342,178 +284,6 @@ const SHARED_ENDPOINT_ROUTING_CASES = [
     ],
   },
 ] as const;
-
-test("retries a real OTLP 503 then succeeds without an intermediate failure fact", async () => {
-  const receiver = await startExporterHealthReceiver((_request, response, requestCount) => {
-    if (requestCount === 1) {
-      response.writeHead(503, { "retry-after": IMMEDIATE_RETRY_AFTER });
-    } else {
-      response.writeHead(200, { "content-type": "application/x-protobuf" });
-    }
-    response.end();
-  });
-  const capture = captureExporterEvents();
-  releasePreloadedOtelGlobals();
-  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "1000";
-  const { service, ctx } = await startOtelService({
-    endpoint: receiver.endpoint,
-    traces: true,
-    metrics: false,
-    logs: false,
-  });
-
-  try {
-    emitExporterHealthSpan("retry-then-success");
-    await service.stop?.(ctx);
-    await waitForDiagnosticEventsDrained();
-
-    expect(receiver.requestCount).toBe(2);
-    expect(capture.events.some((event) => event.status === "failure")).toBe(false);
-    expect(capture.events.some((event) => event.status === "recovered")).toBe(false);
-  } finally {
-    capture.unsubscribe();
-    await service.stop?.(ctx);
-    await receiver.close();
-  }
-}, 15_000);
-
-test("records a final failure after persistent real OTLP 503 responses", async () => {
-  const receiver = await startExporterHealthReceiver((_request, response) => {
-    response.writeHead(503, { "retry-after": IMMEDIATE_RETRY_AFTER });
-    response.end();
-  });
-  const capture = captureExporterEvents();
-  releasePreloadedOtelGlobals();
-  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "1000";
-  const { service, ctx } = await startOtelService({
-    endpoint: receiver.endpoint,
-    traces: true,
-    metrics: false,
-    logs: false,
-  });
-
-  try {
-    emitExporterHealthSpan("persistent-503");
-    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
-    await waitForDiagnosticEventsDrained();
-
-    expect(receiver.requestCount).toBe(6);
-    expect(
-      capture.events.filter(
-        (event) => event.status === "failure" && event.reason === "export_failed",
-      ),
-    ).toHaveLength(1);
-  } finally {
-    capture.unsubscribe();
-    await service.stop?.(ctx);
-    await receiver.close();
-  }
-}, 15_000);
-
-test("records a final failure for a real OTLP connection reset", async () => {
-  const receiver = await startExporterHealthReceiver((request) => {
-    request.socket.destroy();
-  });
-  const capture = captureExporterEvents();
-  releasePreloadedOtelGlobals();
-  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "200";
-  const { service, ctx } = await startOtelService({
-    endpoint: receiver.endpoint,
-    traces: true,
-    metrics: false,
-    logs: false,
-  });
-
-  try {
-    emitExporterHealthSpan("connection-reset");
-    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
-    await waitForDiagnosticEventsDrained();
-
-    expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
-    expect(
-      capture.events.filter(
-        (event) => event.status === "failure" && event.reason === "export_failed",
-      ),
-    ).toHaveLength(1);
-  } finally {
-    capture.unsubscribe();
-    await service.stop?.(ctx);
-    await receiver.close();
-  }
-}, 15_000);
-
-test("records a final failure for a real OTLP request timeout", async () => {
-  const receiver = await startExporterHealthReceiver(() => {
-    // Keep the request open until the exporter-owned timeout settles.
-  });
-  const capture = captureExporterEvents();
-  releasePreloadedOtelGlobals();
-  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "150";
-  const { service, ctx } = await startOtelService({
-    endpoint: receiver.endpoint,
-    traces: true,
-    metrics: false,
-    logs: false,
-  });
-
-  try {
-    emitExporterHealthSpan("request-timeout");
-    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
-    await waitForDiagnosticEventsDrained();
-
-    expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
-    expect(
-      capture.events.filter(
-        (event) => event.status === "failure" && event.reason === "export_failed",
-      ),
-    ).toHaveLength(1);
-  } finally {
-    capture.unsubscribe();
-    await service.stop?.(ctx);
-    await receiver.close();
-  }
-}, 15_000);
-
-test("records recovery after a later real OTLP export succeeds", async () => {
-  let failExports = true;
-  const receiver = await startExporterHealthReceiver((_request, response) => {
-    response.writeHead(failExports ? 503 : 200, {
-      "content-type": "application/x-protobuf",
-      ...(failExports ? { "retry-after": IMMEDIATE_RETRY_AFTER } : {}),
-    });
-    response.end();
-  });
-  const capture = captureExporterEvents();
-  releasePreloadedOtelGlobals();
-  process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "1000";
-  const { service, ctx } = await startOtelService({
-    endpoint: receiver.endpoint,
-    traces: true,
-    metrics: false,
-    logs: false,
-    configure: (serviceContext) => {
-      serviceContext.config.diagnostics!.otel!.flushIntervalMs = 1000;
-    },
-  });
-
-  try {
-    emitExporterHealthSpan("failure-before-recovery");
-    await waitForExporterStatus(capture.events, "failure");
-    failExports = false;
-    emitExporterHealthSpan("successful-recovery");
-    await waitForExporterStatus(capture.events, "recovered");
-
-    expect(
-      capture.events
-        .filter((event) => event.reason === "export_failed")
-        .map((event) => event.status),
-    ).toEqual(["failure", "recovered"]);
-  } finally {
-    capture.unsubscribe();
-    await service.stop?.(ctx);
-    await receiver.close();
-  }
-}, 15_000);
 
 test.each(SHARED_ENDPOINT_ROUTING_CASES)(
   "routes real exporters from a shared $label endpoint",

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -394,7 +394,7 @@ test("records a final failure after persistent real OTLP 503 responses", async (
 
   try {
     emitExporterHealthSpan("persistent-503");
-    await service.stop?.(ctx).catch(() => {});
+    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
     await waitForDiagnosticEventsDrained();
 
     expect(receiver.requestCount).toBe(6);
@@ -426,7 +426,7 @@ test("records a final failure for a real OTLP connection reset", async () => {
 
   try {
     emitExporterHealthSpan("connection-reset");
-    await service.stop?.(ctx).catch(() => {});
+    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
     await waitForDiagnosticEventsDrained();
 
     expect(receiver.requestCount).toBeGreaterThanOrEqual(1);
@@ -458,7 +458,7 @@ test("records a final failure for a real OTLP request timeout", async () => {
 
   try {
     emitExporterHealthSpan("request-timeout");
-    await service.stop?.(ctx).catch(() => {});
+    await Promise.resolve(service.stop?.(ctx)).catch(() => {});
     await waitForDiagnosticEventsDrained();
 
     expect(receiver.requestCount).toBeGreaterThanOrEqual(1);

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -546,6 +546,39 @@ test.each(SHARED_ENDPOINT_ROUTING_CASES)(
   30_000,
 );
 
+test("keeps the required protobuf content type over a colliding custom header", async () => {
+  const receiver = await startOtlpReceiver();
+  releasePreloadedOtelGlobals();
+  const { service, ctx } = await startOtelService({
+    endpoint: receiver.endpoint,
+    traces: true,
+    metrics: true,
+    logs: true,
+    configure: (serviceContext) => {
+      serviceContext.config.diagnostics!.otel!.headers = {
+        "content-type": "text/plain",
+      };
+    },
+  });
+
+  try {
+    await emitRealSdkSignals();
+    await service.stop?.(ctx);
+
+    expect(new Set(receiver.requests.map((request) => request.url))).toEqual(
+      new Set(["/v1/traces", "/v1/metrics", "/v1/logs"]),
+    );
+    expect(
+      receiver.requests.every(
+        (request) => request.method === "POST" && request.contentType === "application/x-protobuf",
+      ),
+    ).toBe(true);
+  } finally {
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 30_000);
+
 test("uses real signal-specific exporter endpoints verbatim", async () => {
   const receiver = await startOtlpReceiver();
   releasePreloadedOtelGlobals();

--- a/extensions/diagnostics-otel/src/service.test-helpers.ts
+++ b/extensions/diagnostics-otel/src/service.test-helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
 import type { OpenClawPluginServiceContext } from "../api.js";
+import type { ExporterHealthUpdate } from "./service-exporter-health.js";
 import { createDiagnosticsOtelService } from "./service.js";
 
 const OTEL_TEST_STATE_DIR = "/tmp/openclaw-diagnostics-otel-test";
@@ -42,6 +43,12 @@ type StartOtelServiceOptions = OtelContextFlags & {
 type InternalDiagnosticListener = Parameters<
   NonNullable<OpenClawPluginServiceContext["internalDiagnostics"]>["onEvent"]
 >[0];
+export type ReportedExporterHealth = Omit<ExporterHealthUpdate, "exporter">;
+type TrustedExporterInternalDiagnostics = NonNullable<
+  OpenClawPluginServiceContext["internalDiagnostics"]
+> & {
+  reportExporterHealth?: (update: ReportedExporterHealth) => void;
+};
 type ModelUsageEventInput = Omit<
   Extract<DiagnosticEventPayload, { type: "model.usage" }>,
   "seq" | "ts"
@@ -53,6 +60,7 @@ type StartedService = {
 };
 
 const startedServices = new Set<StartedService>();
+const exporterHealthReports = new WeakMap<OpenClawPluginServiceContext, ReportedExporterHealth[]>();
 
 export function createOtelContext(
   endpoint: string,
@@ -65,7 +73,14 @@ export function createOtelContext(
     captureContent,
   }: OtelContextFlags = {},
 ): OpenClawPluginServiceContext {
-  return {
+  const reports: ReportedExporterHealth[] = [];
+  const internalDiagnostics: TrustedExporterInternalDiagnostics = {
+    emit: emitTrustedDiagnosticEventWithPrivateData,
+    onEvent: onTrustedInternalDiagnosticEvent,
+    registerTracePropagationBridge: registerDiagnosticTracePropagationBridge,
+    reportExporterHealth: (update) => reports.push(update),
+  };
+  const ctx: OpenClawPluginServiceContext = {
     config: {
       diagnostics: {
         enabled: true,
@@ -88,12 +103,16 @@ export function createOtelContext(
       debug: vi.fn(),
     },
     stateDir: OTEL_TEST_STATE_DIR,
-    internalDiagnostics: {
-      emit: emitTrustedDiagnosticEventWithPrivateData,
-      onEvent: onTrustedInternalDiagnosticEvent,
-      registerTracePropagationBridge: registerDiagnosticTracePropagationBridge,
-    },
+    internalDiagnostics,
   };
+  exporterHealthReports.set(ctx, reports);
+  return ctx;
+}
+
+export function getReportedExporterHealth(
+  ctx: OpenClawPluginServiceContext,
+): ReportedExporterHealth[] {
+  return exporterHealthReports.get(ctx) ?? [];
 }
 
 export async function startOtelService({

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -63,6 +63,13 @@ const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const traceExporterCtor = vi.hoisted(() => vi.fn());
 const metricExporterCtor = vi.hoisted(() => vi.fn());
 const logExporterCtor = vi.hoisted(() => vi.fn());
+const traceExporterExport = vi.hoisted(() => vi.fn());
+const metricExporterExport = vi.hoisted(() => vi.fn());
+const logExporterExport = vi.hoisted(() => vi.fn());
+const traceExporterShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const metricExporterShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const logExporterShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const exporterForceFlush = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const logProcessorCtor = vi.hoisted(() => vi.fn());
 const spanProcessorCtor = vi.hoisted(() => vi.fn());
 const nodeProxyAgent = vi.hoisted(() => ({ kind: "node-proxy-agent" }));
@@ -121,18 +128,33 @@ vi.mock("@opentelemetry/sdk-node", () => ({
 vi.mock("@opentelemetry/exporter-metrics-otlp-proto", () => ({
   OTLPMetricExporter: function OTLPMetricExporter(options?: unknown) {
     metricExporterCtor(options);
+    return {
+      export: metricExporterExport,
+      forceFlush: exporterForceFlush,
+      shutdown: metricExporterShutdown,
+    };
   },
 }));
 
 vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
   OTLPTraceExporter: function OTLPTraceExporter(options?: unknown) {
     traceExporterCtor(options);
+    return {
+      export: traceExporterExport,
+      forceFlush: exporterForceFlush,
+      shutdown: traceExporterShutdown,
+    };
   },
 }));
 
 vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
   OTLPLogExporter: function OTLPLogExporter(options?: unknown) {
     logExporterCtor(options);
+    return {
+      export: logExporterExport,
+      forceFlush: exporterForceFlush,
+      shutdown: logExporterShutdown,
+    };
   },
 }));
 
@@ -199,6 +221,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { emitDiagnosticEvent, type DiagnosticEventPayload } from "../api.js";
 import { MAX_RETAINED_TRUSTED_SPAN_CONTEXTS } from "./service-constants.js";
+import { createDiagnosticsLogExporter } from "./service-logs.js";
 import { createDiagnosticsOtelService } from "./service.js";
 import {
   CHILD_SPAN_ID,
@@ -612,6 +635,17 @@ describe("diagnostics-otel service", () => {
     traceExporterCtor.mockClear();
     metricExporterCtor.mockClear();
     logExporterCtor.mockClear();
+    traceExporterExport.mockReset();
+    metricExporterExport.mockReset();
+    logExporterExport.mockReset();
+    traceExporterShutdown.mockReset();
+    traceExporterShutdown.mockResolvedValue(undefined);
+    metricExporterShutdown.mockReset();
+    metricExporterShutdown.mockResolvedValue(undefined);
+    logExporterShutdown.mockReset();
+    logExporterShutdown.mockResolvedValue(undefined);
+    exporterForceFlush.mockReset();
+    exporterForceFlush.mockResolvedValue(undefined);
     logProcessorCtor.mockClear();
     spanProcessorCtor.mockClear();
     createNodeProxyAgentMock.mockReset();
@@ -1132,7 +1166,51 @@ describe("diagnostics-otel service", () => {
     });
   });
 
+  test("retires an exporter failure retained after shutdown rejects", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    const { service, ctx } = await startOtelService({
+      traces: true,
+      metrics: false,
+      logs: false,
+    });
+    const options = sdkCtor.mock.calls.at(-1)?.[0] as
+      | { traceExporter?: { shutdown(): Promise<void> } }
+      | undefined;
+    if (!options?.traceExporter) {
+      throw new Error("expected trace exporter");
+    }
+    traceExporterShutdown.mockRejectedValueOnce(new TypeError("private shutdown details"));
+    sdkShutdown.mockImplementationOnce(() => options.traceExporter!.shutdown());
+
+    await expect(service.stop?.(ctx)).rejects.toThrow("private shutdown details");
+    await waitForDiagnosticEventsDrained();
+    expect(events.map(({ status, reason }) => ({ status, reason }))).toEqual([
+      { status: "started", reason: "configured" },
+      { status: "failure", reason: "shutdown_failed" },
+    ]);
+
+    await expect(service.stop?.(ctx)).resolves.toBeUndefined();
+    await waitForDiagnosticEventsDrained();
+    expect(events.at(-1)).toMatchObject({
+      transport: "otlp-http-protobuf",
+      status: "dropped",
+    });
+    expect(JSON.stringify(events)).not.toContain("private shutdown details");
+    unsubscribe();
+  });
+
   test("preserves SDK startup failure when rollback shutdown also fails", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
     const startupError = new Error("SDK startup failed");
     const rollbackError = new Error("SDK rollback failed");
     sdkStart.mockImplementationOnce(() => {
@@ -1161,8 +1239,91 @@ describe("diagnostics-otel service", () => {
       ),
     );
     expect(sdkShutdown).toHaveBeenCalledOnce();
+    await waitForDiagnosticEventsDrained();
+    expect(
+      events.map(({ transport, endpointMode, status, reason }) => ({
+        transport,
+        endpointMode,
+        status,
+        reason,
+      })),
+    ).toEqual([
+      {
+        transport: "otlp-http-protobuf",
+        endpointMode: "configured",
+        status: "failure",
+        reason: "start_failed",
+      },
+    ]);
     await expect(service.stop?.(ctx)).resolves.toBeUndefined();
+    await waitForDiagnosticEventsDrained();
+    expect(events.at(-1)).toMatchObject({
+      transport: "otlp-http-protobuf",
+      status: "dropped",
+    });
+    unsubscribe();
   });
+
+  test.each([
+    {
+      label: "explicit",
+      endpoint: OTEL_TEST_ENDPOINT,
+      endpointMode: "configured" as const,
+    },
+    {
+      label: "dependency-default",
+      endpoint: undefined,
+      endpointMode: "default_endpoint" as const,
+    },
+  ])(
+    "records $label endpoint ownership when SDK startup fails",
+    async ({ endpoint, endpointMode }) => {
+      const events: TelemetryExporterEvent[] = [];
+      const unsubscribe = onInternalDiagnosticEvent((event) => {
+        if (event.type === "telemetry.exporter") {
+          events.push(event);
+        }
+      });
+      sdkStart.mockImplementationOnce(() => {
+        throw new TypeError("private startup details");
+      });
+      const service = createDiagnosticsOtelService();
+      const ctx = createOtelContext(endpoint ?? "", {
+        traces: true,
+        metrics: false,
+        logs: false,
+      });
+      if (endpoint === undefined) {
+        delete ctx.config.diagnostics?.otel?.endpoint;
+      }
+
+      await expect(service.start(ctx)).rejects.toThrow("private startup details");
+      await waitForDiagnosticEventsDrained();
+
+      expect(
+        events.map(({ signal, transport, endpointMode: eventMode, status, reason }) => ({
+          signal,
+          transport,
+          endpointMode: eventMode,
+          status,
+          reason,
+        })),
+      ).toEqual([
+        {
+          signal: "traces",
+          transport: "otlp-http-protobuf",
+          endpointMode,
+          status: "failure",
+          reason: "start_failed",
+        },
+      ]);
+      expect(JSON.stringify(events)).not.toContain(OTEL_TEST_ENDPOINT);
+      expect(JSON.stringify(events)).not.toContain("private startup details");
+
+      await service.stop?.(ctx);
+      unsubscribe();
+    },
+  );
 
   test("registers and removes an OTLP exporter unhandled rejection handler", async () => {
     const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
@@ -1291,6 +1452,7 @@ describe("diagnostics-otel service", () => {
       const event = exporterEvents.find((entry) => entry.signal === signal);
       expect(event?.type).toBe("telemetry.exporter");
       expect(event?.exporter).toBe("diagnostics-otel");
+      expect(event?.transport).toBe("otlp-http-protobuf");
       expect(event?.status).toBe("started");
       expect(event?.reason).toBe("configured");
     }
@@ -1304,6 +1466,240 @@ describe("diagnostics-otel service", () => {
     });
 
     unsubscribe();
+  });
+
+  test("records dependency-default, stdout, and external SDK ownership facts", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+
+    const defaultEndpoint = await startOtelService({
+      traces: true,
+      configure: (context) => {
+        delete context.config.diagnostics?.otel?.endpoint;
+      },
+    });
+    await defaultEndpoint.service.stop?.(defaultEndpoint.ctx);
+
+    process.env.OPENCLAW_OTEL_PRELOADED = "1";
+    await startOtelService({
+      traces: true,
+      metrics: true,
+      logs: true,
+      logsExporter: "stdout",
+    });
+
+    expect(
+      events
+        .filter((event) => event.status === "started")
+        .map(({ signal, transport, endpointMode, status, reason }) => ({
+          signal,
+          transport,
+          endpointMode,
+          status,
+          reason,
+        })),
+    ).toEqual([
+      {
+        signal: "traces",
+        transport: "otlp-http-protobuf",
+        endpointMode: "default_endpoint",
+        status: "started",
+        reason: "default_endpoint",
+      },
+      {
+        signal: "traces",
+        transport: "external-sdk",
+        endpointMode: undefined,
+        status: "started",
+        reason: "configured",
+      },
+      {
+        signal: "metrics",
+        transport: "external-sdk",
+        endpointMode: undefined,
+        status: "started",
+        reason: "configured",
+      },
+      {
+        signal: "logs",
+        transport: "stdout",
+        endpointMode: undefined,
+        status: "started",
+        reason: "configured",
+      },
+    ]);
+
+    unsubscribe();
+  });
+
+  test("retires trace ownership across external, unsupported, and supported restarts", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+
+    try {
+      await service.start(ctx);
+      process.env.OPENCLAW_OTEL_PRELOADED = "1";
+      await service.start(ctx);
+      process.env.OPENCLAW_OTEL_PRELOADED = "0";
+      ctx.config.diagnostics!.otel!.protocol = "grpc";
+      await service.start(ctx);
+      ctx.config.diagnostics!.otel!.protocol = "http/protobuf";
+      await service.start(ctx);
+      await waitForDiagnosticEventsDrained();
+
+      expect(
+        events.map(({ signal, transport, status, reason }) => ({
+          signal,
+          transport,
+          status,
+          reason,
+        })),
+      ).toEqual([
+        {
+          signal: "traces",
+          transport: "otlp-http-protobuf",
+          status: "started",
+          reason: "configured",
+        },
+        {
+          signal: "traces",
+          transport: "otlp-http-protobuf",
+          status: "dropped",
+          reason: undefined,
+        },
+        {
+          signal: "traces",
+          transport: "external-sdk",
+          status: "started",
+          reason: "configured",
+        },
+        {
+          signal: "traces",
+          transport: "external-sdk",
+          status: "dropped",
+          reason: undefined,
+        },
+        {
+          signal: "traces",
+          transport: "otlp-http-protobuf",
+          status: "failure",
+          reason: "unsupported_protocol",
+        },
+        {
+          signal: "traces",
+          transport: "otlp-http-protobuf",
+          status: "dropped",
+          reason: undefined,
+        },
+        {
+          signal: "traces",
+          transport: "otlp-http-protobuf",
+          status: "started",
+          reason: "configured",
+        },
+      ]);
+    } finally {
+      unsubscribe();
+      await service.stop?.(ctx);
+    }
+  });
+
+  test("retires unsupported OTLP failures on disabled restart and stop", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+    ctx.config.diagnostics!.otel!.protocol = "grpc";
+
+    try {
+      await service.start(ctx);
+      ctx.config.diagnostics!.enabled = false;
+      await service.start(ctx);
+      ctx.config.diagnostics!.enabled = true;
+      await service.start(ctx);
+      await service.stop?.(ctx);
+      await waitForDiagnosticEventsDrained();
+
+      expect(
+        events.map(({ transport, status, reason }) => ({
+          transport,
+          status,
+          reason,
+        })),
+      ).toEqual([
+        {
+          transport: "otlp-http-protobuf",
+          status: "failure",
+          reason: "unsupported_protocol",
+        },
+        { transport: "otlp-http-protobuf", status: "dropped", reason: undefined },
+        {
+          transport: "otlp-http-protobuf",
+          status: "failure",
+          reason: "unsupported_protocol",
+        },
+        { transport: "otlp-http-protobuf", status: "dropped", reason: undefined },
+      ]);
+    } finally {
+      unsubscribe();
+      await service.stop?.(ctx);
+    }
+  });
+
+  test("rebuilds the current log route set while preserving logs both", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      logs: true,
+      logsExporter: "both",
+    });
+
+    try {
+      await service.start(ctx);
+      ctx.config.diagnostics!.otel!.logsExporter = "stdout";
+      await service.start(ctx);
+      ctx.config.diagnostics!.otel!.logsExporter = "both";
+      await service.start(ctx);
+      await waitForDiagnosticEventsDrained();
+
+      expect(
+        events.map(({ transport, status }) => ({
+          transport,
+          status,
+        })),
+      ).toEqual([
+        { transport: "otlp-http-protobuf", status: "started" },
+        { transport: "stdout", status: "started" },
+        { transport: "otlp-http-protobuf", status: "dropped" },
+        { transport: "stdout", status: "dropped" },
+        { transport: "stdout", status: "started" },
+        { transport: "stdout", status: "dropped" },
+        { transport: "otlp-http-protobuf", status: "started" },
+        { transport: "stdout", status: "started" },
+      ]);
+    } finally {
+      unsubscribe();
+      await service.stop?.(ctx);
+    }
   });
 
   test("exports trusted security events as bounded OTLP logs", async () => {
@@ -1463,13 +1859,29 @@ describe("diagnostics-otel service", () => {
     expect(
       events.map((event) => ({
         signal: event.signal,
+        transport: event.transport,
         status: event.status,
         reason: event.reason,
       })),
     ).toEqual([
-      { signal: "traces", status: "failure", reason: "unsupported_protocol" },
-      { signal: "metrics", status: "failure", reason: "unsupported_protocol" },
-      { signal: "logs", status: "failure", reason: "unsupported_protocol" },
+      {
+        signal: "traces",
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "unsupported_protocol",
+      },
+      {
+        signal: "metrics",
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "unsupported_protocol",
+      },
+      {
+        signal: "logs",
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "unsupported_protocol",
+      },
     ]);
     expect(vi.mocked(ctx.logger.warn).mock.calls).toEqual(
       ["traces", "metrics", "logs"].map((signal) => [
@@ -1869,22 +2281,29 @@ describe("diagnostics-otel service", () => {
         events.push(event);
       }
     });
-    logEmit.mockImplementationOnce(() => {
-      throw new TypeError("token sk-test-secret should not leave as telemetry");
-    });
+    logEmit
+      .mockImplementationOnce(() => {
+        throw new TypeError("token sk-test-secret should not leave as telemetry");
+      })
+      .mockImplementationOnce(() => {
+        throw new TypeError("repeated private failure");
+      });
 
     await startOtelService({ logs: true });
-    await emitAndFlush({
-      type: "log.record",
-      level: "INFO",
-      message: "export me",
-    });
+    for (const message of ["first failure", "second failure", "recovery"]) {
+      await emitAndFlush({
+        type: "log.record",
+        level: "INFO",
+        message,
+      });
+    }
 
     const exporterEvents = events.filter((event) => event.type === "telemetry.exporter");
     const failureEvent = exporterEvents.find((event) => event.status === "failure");
     expect(failureEvent?.type).toBe("telemetry.exporter");
     expect(failureEvent?.exporter).toBe("diagnostics-otel");
     expect(failureEvent?.signal).toBe("logs");
+    expect(failureEvent?.transport).toBe("otlp-http-protobuf");
     expect(failureEvent?.status).toBe("failure");
     expect(failureEvent?.reason).toBe("emit_failed");
     expect(failureEvent?.errorCategory).toBe("TypeError");
@@ -1897,8 +2316,139 @@ describe("diagnostics-otel service", () => {
       "openclaw.reason": "emit_failed",
       "openclaw.errorCategory": "TypeError",
     });
+    expect(
+      exporterEvents
+        .filter(
+          (event) => event.transport === "otlp-http-protobuf" && event.reason === "emit_failed",
+        )
+        .map((event) => event.status),
+    ).toEqual(["failure", "recovered"]);
 
     unsubscribe();
+  });
+
+  test("recovers stdout emit health after repeated failures", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    const stdout = captureStdoutWrites();
+    const failWrite = (() => {
+      throw new TypeError("private stdout failure");
+    }) as typeof process.stdout.write;
+    stdout.spy.mockImplementationOnce(failWrite).mockImplementationOnce(failWrite);
+
+    try {
+      await startOtelService({
+        traces: false,
+        metrics: false,
+        logs: true,
+        logsExporter: "stdout",
+      });
+      for (const message of ["first failure", "second failure", "recovery"]) {
+        await emitAndFlush({ type: "log.record", level: "INFO", message });
+      }
+
+      expect(
+        events
+          .filter((event) => event.transport === "stdout" && event.reason === "emit_failed")
+          .map(({ status, errorCategory }) => ({ status, errorCategory })),
+      ).toEqual([
+        { status: "failure", errorCategory: "TypeError" },
+        { status: "recovered", errorCategory: undefined },
+      ]);
+      expect(stdout.writes).toHaveLength(1);
+      expect(JSON.stringify(events)).not.toContain("private stdout failure");
+    } finally {
+      stdout.spy.mockRestore();
+      unsubscribe();
+    }
+  });
+
+  test("preserves and recovers bounded exporter facts for log preparation failures", () => {
+    const events: TelemetryExporterEvent[] = [];
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const diagnosticsLogs = createDiagnosticsLogExporter({
+      contentCapturePolicy: {
+        inputMessages: false,
+        outputMessages: false,
+        toolInputs: false,
+        toolOutputs: false,
+        systemPrompt: false,
+        toolDefinitions: false,
+        logBodies: false,
+      },
+      emitExporterEvent: (event) => {
+        events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+      },
+      logger,
+      logsEnabled: true,
+      logsToOtlp: true,
+      logsToStdout: false,
+      resource: {} as never,
+      serviceName: "openclaw-test",
+    });
+    const attributes = new Proxy<Record<string, string | number | boolean>>(
+      {},
+      {
+        ownKeys() {
+          throw new TypeError("private preparation details");
+        },
+      },
+    );
+
+    const recordLog = (
+      seq: number,
+      recordAttributes: Record<string, string | number | boolean>,
+    ) => {
+      diagnosticsLogs.recordLogRecord?.(
+        {
+          type: "log.record",
+          seq,
+          ts: seq,
+          level: "INFO",
+          message: "prepare me",
+          attributes: recordAttributes,
+        },
+        { trusted: false },
+      );
+    };
+    recordLog(1, attributes);
+    recordLog(2, attributes);
+    recordLog(3, {});
+
+    expect(
+      events.map(({ transport, status, reason, errorCategory }) => ({
+        transport,
+        status,
+        reason,
+        errorCategory,
+      })),
+    ).toEqual([
+      {
+        transport: undefined,
+        status: "failure",
+        reason: "emit_failed",
+        errorCategory: "TypeError",
+      },
+      {
+        transport: undefined,
+        status: "recovered",
+        reason: "emit_failed",
+        errorCategory: undefined,
+      },
+    ]);
+    expect(JSON.stringify(events)).not.toContain("private preparation details");
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("diagnostics-otel: log record export failed"),
+    );
   });
 
   test("ignores untrusted telemetry exporter events for OTEL metrics", async () => {

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1551,9 +1551,10 @@ describe("diagnostics-otel service", () => {
       process.env.OPENCLAW_OTEL_PRELOADED = "1";
       await service.start(ctx);
       process.env.OPENCLAW_OTEL_PRELOADED = "0";
-      ctx.config.diagnostics!.otel!.protocol = "grpc";
+      delete ctx.config.diagnostics!.otel!.protocol;
+      process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
       await service.start(ctx);
-      ctx.config.diagnostics!.otel!.protocol = "http/protobuf";
+      process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf";
       await service.start(ctx);
       await waitForDiagnosticEventsDrained();
 
@@ -1623,7 +1624,8 @@ describe("diagnostics-otel service", () => {
     });
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
-    ctx.config.diagnostics!.otel!.protocol = "grpc";
+    delete ctx.config.diagnostics!.otel!.protocol;
+    process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
 
     try {
       await service.start(ctx);

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2,6 +2,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const telemetryState = vi.hoisted(() => {
@@ -221,6 +222,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { emitDiagnosticEvent, type DiagnosticEventPayload } from "../api.js";
 import { MAX_RETAINED_TRUSTED_SPAN_CONTEXTS } from "./service-constants.js";
+import { createExporterHealthEventEmitter } from "./service-exporter-health.js";
 import { createDiagnosticsLogExporter } from "./service-logs.js";
 import { createDiagnosticsOtelService } from "./service.js";
 import {
@@ -2329,6 +2331,74 @@ describe("diagnostics-otel service", () => {
     unsubscribe();
   });
 
+  test("does not recover log OTLP health while an export failure remains active", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    let completeExport: ((result: ExportResult) => void) | undefined;
+    logExporterExport.mockImplementation(
+      (_items: unknown, callback: (result: ExportResult) => void) => {
+        completeExport = callback;
+      },
+    );
+    logEmit
+      .mockImplementationOnce(() => {
+        throw new TypeError("private enqueue failure");
+      })
+      .mockImplementationOnce(() => {});
+    await startOtelService({ traces: false, metrics: false, logs: true });
+    const exporter = firstLogProcessorOptions().exporter as
+      | {
+          export(items: unknown, callback: (result: ExportResult) => void): void;
+        }
+      | undefined;
+    if (!exporter) {
+      throw new Error("expected log exporter");
+    }
+
+    exporter.export([], vi.fn());
+    completeExport?.({
+      code: ExportResultCode.FAILED,
+      error: new Error("private collector failure"),
+    });
+    await emitAndFlush({ type: "log.record", level: "INFO", message: "enqueue failure" });
+    await emitAndFlush({ type: "log.record", level: "INFO", message: "enqueue recovery" });
+    exporter.export([], vi.fn());
+    completeExport?.({
+      code: ExportResultCode.FAILED,
+      error: new Error("repeated private collector failure"),
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(
+      events
+        .filter((event) => event.transport === "otlp-http-protobuf")
+        .map(({ status, reason }) => ({ status, reason })),
+    ).toEqual([
+      { status: "started", reason: "configured" },
+      { status: "failure", reason: "export_failed" },
+    ]);
+
+    exporter.export([], vi.fn());
+    completeExport?.({ code: ExportResultCode.SUCCESS });
+    await waitForDiagnosticEventsDrained();
+    expect(
+      events
+        .filter((event) => event.transport === "otlp-http-protobuf")
+        .map(({ status, reason }) => ({ status, reason })),
+    ).toEqual([
+      { status: "started", reason: "configured" },
+      { status: "failure", reason: "export_failed" },
+      { status: "recovered", reason: "export_failed" },
+    ]);
+    expect(JSON.stringify(events)).not.toContain("private");
+
+    unsubscribe();
+  });
+
   test("recovers stdout emit health after repeated failures", async () => {
     const events: TelemetryExporterEvent[] = [];
     const unsubscribe = onInternalDiagnosticEvent((event) => {
@@ -2387,9 +2457,9 @@ describe("diagnostics-otel service", () => {
         toolDefinitions: false,
         logBodies: false,
       },
-      emitExporterEvent: (event) => {
+      emitExporterEvent: createExporterHealthEventEmitter((event) => {
         events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
-      },
+      }),
       logger,
       logsEnabled: true,
       logsToOtlp: true,

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -222,13 +222,17 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { emitDiagnosticEvent, type DiagnosticEventPayload } from "../api.js";
 import { MAX_RETAINED_TRUSTED_SPAN_CONTEXTS } from "./service-constants.js";
-import { createExporterHealthEventEmitter } from "./service-exporter-health.js";
+import {
+  createExporterHealthEventEmitter,
+  type ExporterHealthUpdate,
+} from "./service-exporter-health.js";
 import { createDiagnosticsLogExporter } from "./service-logs.js";
 import { createDiagnosticsOtelService } from "./service.js";
 import {
   CHILD_SPAN_ID,
   createOtelContext,
   createTestTrace,
+  getReportedExporterHealth,
   GRANDCHILD_SPAN_ID,
   MODEL_CALL_SPAN_ID,
   MODEL_CALL_FIXTURE,
@@ -261,6 +265,7 @@ const ORIGINAL_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT =
   process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
 const ORIGINAL_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
 const ORIGINAL_OTEL_SEMCONV_STABILITY_OPT_IN = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+const ORIGINAL_OTEL_SDK_DISABLED = process.env.OTEL_SDK_DISABLED;
 const OTEL_PROTOCOL_ENV_KEYS = [
   "OTEL_EXPORTER_OTLP_PROTOCOL",
   "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
@@ -622,6 +627,7 @@ describe("diagnostics-otel service", () => {
       delete process.env[key];
     }
     delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    delete process.env.OTEL_SDK_DISABLED;
     telemetryState.counters.clear();
     telemetryState.histograms.clear();
     telemetryState.spans.length = 0;
@@ -688,6 +694,11 @@ describe("diagnostics-otel service", () => {
       delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
     } else {
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN = ORIGINAL_OTEL_SEMCONV_STABILITY_OPT_IN;
+    }
+    if (ORIGINAL_OTEL_SDK_DISABLED === undefined) {
+      delete process.env.OTEL_SDK_DISABLED;
+    } else {
+      process.env.OTEL_SDK_DISABLED = ORIGINAL_OTEL_SDK_DISABLED;
     }
     if (ORIGINAL_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT === undefined) {
       delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
@@ -1195,18 +1206,39 @@ describe("diagnostics-otel service", () => {
       { status: "started", reason: "configured" },
       { status: "failure", reason: "shutdown_failed" },
     ]);
+    expect(
+      getReportedExporterHealth(ctx).map(({ transport, status, reason }) => ({
+        transport,
+        status,
+        reason,
+      })),
+    ).toEqual([
+      {
+        transport: "otlp-http-protobuf",
+        status: "started",
+        reason: "configured",
+      },
+      {
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "shutdown_failed",
+      },
+    ]);
 
     await expect(service.stop?.(ctx)).resolves.toBeUndefined();
     await waitForDiagnosticEventsDrained();
-    expect(events.at(-1)).toMatchObject({
+    expect(events.at(-1)).toMatchObject({ status: "dropped" });
+    expect(getReportedExporterHealth(ctx).at(-1)).toMatchObject({
       transport: "otlp-http-protobuf",
       status: "dropped",
     });
-    expect(JSON.stringify(events)).not.toContain("private shutdown details");
+    expect(JSON.stringify({ events, health: getReportedExporterHealth(ctx) })).not.toContain(
+      "private shutdown details",
+    );
     unsubscribe();
   });
 
-  test("preserves SDK startup failure when rollback shutdown also fails", async () => {
+  test("preserves SDK startup failure through host rollback when shutdown also fails", async () => {
     const events: TelemetryExporterEvent[] = [];
     const unsubscribe = onInternalDiagnosticEvent((event) => {
       if (event.type === "telemetry.exporter") {
@@ -1242,8 +1274,14 @@ describe("diagnostics-otel service", () => {
     );
     expect(sdkShutdown).toHaveBeenCalledOnce();
     await waitForDiagnosticEventsDrained();
+    expect(events.map(({ status, reason }) => ({ status, reason }))).toEqual([
+      {
+        status: "failure",
+        reason: "start_failed",
+      },
+    ]);
     expect(
-      events.map(({ transport, endpointMode, status, reason }) => ({
+      getReportedExporterHealth(ctx).map(({ transport, endpointMode, status, reason }) => ({
         transport,
         endpointMode,
         status,
@@ -1259,7 +1297,22 @@ describe("diagnostics-otel service", () => {
     ]);
     await expect(service.stop?.(ctx)).resolves.toBeUndefined();
     await waitForDiagnosticEventsDrained();
-    expect(events.at(-1)).toMatchObject({
+    expect(events.map(({ status, reason }) => ({ status, reason }))).toEqual([
+      {
+        status: "failure",
+        reason: "start_failed",
+      },
+    ]);
+    expect(getReportedExporterHealth(ctx).at(-1)).toMatchObject({
+      transport: "otlp-http-protobuf",
+      status: "failure",
+      reason: "start_failed",
+    });
+
+    await expect(service.stop?.(ctx)).resolves.toBeUndefined();
+    await waitForDiagnosticEventsDrained();
+    expect(events.at(-1)).toMatchObject({ status: "dropped" });
+    expect(getReportedExporterHealth(ctx).at(-1)).toMatchObject({
       transport: "otlp-http-protobuf",
       status: "dropped",
     });
@@ -1302,14 +1355,23 @@ describe("diagnostics-otel service", () => {
       await expect(service.start(ctx)).rejects.toThrow("private startup details");
       await waitForDiagnosticEventsDrained();
 
+      expect(events.map(({ signal, status, reason }) => ({ signal, status, reason }))).toEqual([
+        {
+          signal: "traces",
+          status: "failure",
+          reason: "start_failed",
+        },
+      ]);
       expect(
-        events.map(({ signal, transport, endpointMode: eventMode, status, reason }) => ({
-          signal,
-          transport,
-          endpointMode: eventMode,
-          status,
-          reason,
-        })),
+        getReportedExporterHealth(ctx).map(
+          ({ signal, transport, endpointMode: eventMode, status, reason }) => ({
+            signal,
+            transport,
+            endpointMode: eventMode,
+            status,
+            reason,
+          }),
+        ),
       ).toEqual([
         {
           signal: "traces",
@@ -1319,9 +1381,14 @@ describe("diagnostics-otel service", () => {
           reason: "start_failed",
         },
       ]);
-      expect(JSON.stringify(events)).not.toContain(OTEL_TEST_ENDPOINT);
-      expect(JSON.stringify(events)).not.toContain("private startup details");
+      expect(JSON.stringify({ events, health: getReportedExporterHealth(ctx) })).not.toContain(
+        OTEL_TEST_ENDPOINT,
+      );
+      expect(JSON.stringify({ events, health: getReportedExporterHealth(ctx) })).not.toContain(
+        "private startup details",
+      );
 
+      await service.stop?.(ctx);
       await service.stop?.(ctx);
       unsubscribe();
     },
@@ -1447,16 +1514,22 @@ describe("diagnostics-otel service", () => {
         events.push(event);
       }
     });
-    await startOtelService({ traces: true, metrics: true, logs: true });
+    const { ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
 
-    const exporterEvents = events.filter((event) => event.type === "telemetry.exporter");
     for (const signal of ["traces", "metrics", "logs"]) {
-      const event = exporterEvents.find((entry) => entry.signal === signal);
+      const event = events.find((entry) => entry.signal === signal);
       expect(event?.type).toBe("telemetry.exporter");
       expect(event?.exporter).toBe("diagnostics-otel");
-      expect(event?.transport).toBe("otlp-http-protobuf");
       expect(event?.status).toBe("started");
       expect(event?.reason).toBe("configured");
+      expect(getReportedExporterHealth(ctx).find((entry) => entry.signal === signal)).toMatchObject(
+        {
+          transport: "otlp-http-protobuf",
+          endpointMode: "configured",
+          status: "started",
+          reason: "configured",
+        },
+      );
     }
     expect(
       telemetryState.counters.get("openclaw.telemetry.exporter.events")?.add,
@@ -1467,6 +1540,183 @@ describe("diagnostics-otel service", () => {
       "openclaw.reason": "configured",
     });
 
+    unsubscribe();
+  });
+
+  test("coalesces multi-transport logs into one public lifecycle", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    const { service, ctx } = await startOtelService({
+      traces: false,
+      metrics: false,
+      logs: true,
+      logsExporter: "both",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(events.map(({ signal, status, reason }) => ({ signal, status, reason }))).toEqual([
+      { signal: "logs", status: "started", reason: "configured" },
+    ]);
+    expect(
+      getReportedExporterHealth(ctx).map(({ transport, status }) => ({ transport, status })),
+    ).toEqual([
+      { transport: "otlp-http-protobuf", status: "started" },
+      { transport: "stdout", status: "started" },
+    ]);
+    expect(
+      telemetryState.counters.get("openclaw.telemetry.exporter.events")?.add,
+    ).toHaveBeenCalledTimes(1);
+
+    await service.stop?.(ctx);
+    await waitForDiagnosticEventsDrained();
+    expect(events.map((event) => event.status)).toEqual(["started", "dropped"]);
+    expect(
+      telemetryState.counters.get("openclaw.telemetry.exporter.events")?.add,
+    ).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  test("keeps disabled owned SDK signals out of the operator health projection", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    process.env.OTEL_SDK_DISABLED = " TRUE ";
+
+    const { ctx } = await startOtelService({
+      traces: true,
+      metrics: true,
+      logs: true,
+      logsExporter: "stdout",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(events.map(({ signal, status, reason }) => ({ signal, status, reason }))).toEqual([
+      { signal: "logs", status: "started", reason: "configured" },
+    ]);
+    expect(
+      getReportedExporterHealth(ctx).map(({ signal, transport, status, reason }) => ({
+        signal,
+        transport,
+        status,
+        reason,
+      })),
+    ).toEqual([
+      {
+        signal: "logs",
+        transport: "stdout",
+        status: "started",
+        reason: "configured",
+      },
+    ]);
+    expect(sdkStart).toHaveBeenCalledOnce();
+
+    unsubscribe();
+  });
+
+  test("keeps disabled owned SDK protocol failures out of operator health", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    process.env.OTEL_SDK_DISABLED = "true";
+    process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "grpc";
+    process.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "http/json";
+
+    const { ctx } = await startOtelService({
+      traces: true,
+      metrics: true,
+      logs: true,
+      logsExporter: "stdout",
+      configure: (context) => {
+        delete context.config.diagnostics?.otel?.protocol;
+      },
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(events.map(({ signal, status, reason }) => ({ signal, status, reason }))).toEqual([
+      { signal: "logs", status: "started", reason: "configured" },
+    ]);
+    expect(
+      getReportedExporterHealth(ctx).map(({ signal, transport, status, reason }) => ({
+        signal,
+        transport,
+        status,
+        reason,
+      })),
+    ).toEqual([
+      {
+        signal: "logs",
+        transport: "stdout",
+        status: "started",
+        reason: "configured",
+      },
+    ]);
+    expect(sdkStart).not.toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  test("keeps disabled malformed owned SDK routes out of operator health", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    process.env.OTEL_SDK_DISABLED = "true";
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      metrics: false,
+      logs: false,
+    });
+    ctx.config.diagnostics!.otel!.tracesEndpoint = "not a collector URL";
+
+    await expect(service.start(ctx)).rejects.toThrow(
+      "Configured OpenTelemetry collector endpoint is invalid",
+    );
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toEqual([]);
+    expect(getReportedExporterHealth(ctx)).toEqual([]);
+    await service.stop?.(ctx);
+    unsubscribe();
+  });
+
+  test("keeps disabled owned SDK start failures out of operator health", async () => {
+    const events: TelemetryExporterEvent[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "telemetry.exporter") {
+        events.push(event);
+      }
+    });
+    process.env.OTEL_SDK_DISABLED = "true";
+    sdkStart.mockImplementationOnce(() => {
+      throw new TypeError("mocked disabled SDK start failure");
+    });
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      metrics: true,
+      logs: false,
+    });
+
+    await expect(service.start(ctx)).rejects.toThrow("mocked disabled SDK start failure");
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toEqual([]);
+    expect(getReportedExporterHealth(ctx)).toEqual([]);
+    await service.stop?.(ctx);
+    await service.stop?.(ctx);
     unsubscribe();
   });
 
@@ -1487,7 +1737,7 @@ describe("diagnostics-otel service", () => {
     await defaultEndpoint.service.stop?.(defaultEndpoint.ctx);
 
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
-    await startOtelService({
+    const externalSdk = await startOtelService({
       traces: true,
       metrics: true,
       logs: true,
@@ -1496,6 +1746,40 @@ describe("diagnostics-otel service", () => {
 
     expect(
       events
+        .filter((event) => event.status === "started")
+        .map(({ signal, status, reason }) => ({
+          signal,
+          status,
+          reason,
+        })),
+    ).toEqual([
+      {
+        signal: "traces",
+        status: "started",
+        reason: "configured",
+      },
+      {
+        signal: "traces",
+        status: "started",
+        reason: "configured",
+      },
+      {
+        signal: "metrics",
+        status: "started",
+        reason: "configured",
+      },
+      {
+        signal: "logs",
+        status: "started",
+        reason: "configured",
+      },
+    ]);
+    const healthReports = [
+      ...getReportedExporterHealth(defaultEndpoint.ctx),
+      ...getReportedExporterHealth(externalSdk.ctx),
+    ];
+    expect(
+      healthReports
         .filter((event) => event.status === "started")
         .map(({ signal, transport, endpointMode, status, reason }) => ({
           signal,
@@ -1539,12 +1823,6 @@ describe("diagnostics-otel service", () => {
   });
 
   test("retires trace ownership across external, unsupported, and supported restarts", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
 
@@ -1561,7 +1839,7 @@ describe("diagnostics-otel service", () => {
       await waitForDiagnosticEventsDrained();
 
       expect(
-        events.map(({ signal, transport, status, reason }) => ({
+        getReportedExporterHealth(ctx).map(({ signal, transport, status, reason }) => ({
           signal,
           transport,
           status,
@@ -1612,18 +1890,11 @@ describe("diagnostics-otel service", () => {
         },
       ]);
     } finally {
-      unsubscribe();
       await service.stop?.(ctx);
     }
   });
 
   test("retires unsupported OTLP failures on disabled restart and stop", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
     delete ctx.config.diagnostics!.otel!.protocol;
@@ -1639,7 +1910,7 @@ describe("diagnostics-otel service", () => {
       await waitForDiagnosticEventsDrained();
 
       expect(
-        events.map(({ transport, status, reason }) => ({
+        getReportedExporterHealth(ctx).map(({ transport, status, reason }) => ({
           transport,
           status,
           reason,
@@ -1659,18 +1930,11 @@ describe("diagnostics-otel service", () => {
         { transport: "otlp-http-protobuf", status: "dropped", reason: undefined },
       ]);
     } finally {
-      unsubscribe();
       await service.stop?.(ctx);
     }
   });
 
   test("rebuilds the current log route set while preserving logs both", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
       logs: true,
@@ -1686,7 +1950,7 @@ describe("diagnostics-otel service", () => {
       await waitForDiagnosticEventsDrained();
 
       expect(
-        events.map(({ transport, status }) => ({
+        getReportedExporterHealth(ctx).map(({ transport, status }) => ({
           transport,
           status,
         })),
@@ -1701,7 +1965,6 @@ describe("diagnostics-otel service", () => {
         { transport: "stdout", status: "started" },
       ]);
     } finally {
-      unsubscribe();
       await service.stop?.(ctx);
     }
   });
@@ -1863,30 +2126,41 @@ describe("diagnostics-otel service", () => {
     expect(
       events.map((event) => ({
         signal: event.signal,
-        transport: event.transport,
         status: event.status,
         reason: event.reason,
       })),
     ).toEqual([
       {
         signal: "traces",
-        transport: "otlp-http-protobuf",
         status: "failure",
         reason: "unsupported_protocol",
       },
       {
         signal: "metrics",
-        transport: "otlp-http-protobuf",
         status: "failure",
         reason: "unsupported_protocol",
       },
       {
         signal: "logs",
-        transport: "otlp-http-protobuf",
         status: "failure",
         reason: "unsupported_protocol",
       },
     ]);
+    expect(
+      getReportedExporterHealth(ctx).map(({ signal, transport, status, reason }) => ({
+        signal,
+        transport,
+        status,
+        reason,
+      })),
+    ).toEqual(
+      ["traces", "metrics", "logs"].map((signal) => ({
+        signal,
+        transport: "otlp-http-protobuf",
+        status: "failure",
+        reason: "unsupported_protocol",
+      })),
+    );
     expect(vi.mocked(ctx.logger.warn).mock.calls).toEqual(
       ["traces", "metrics", "logs"].map((signal) => [
         `diagnostics-otel: unsupported ${signal} protocol grpc; OTLP export disabled`,
@@ -2293,7 +2567,7 @@ describe("diagnostics-otel service", () => {
         throw new TypeError("repeated private failure");
       });
 
-    await startOtelService({ logs: true });
+    const { ctx } = await startOtelService({ logs: true });
     for (const message of ["first failure", "second failure", "recovery"]) {
       await emitAndFlush({
         type: "log.record",
@@ -2302,12 +2576,10 @@ describe("diagnostics-otel service", () => {
       });
     }
 
-    const exporterEvents = events.filter((event) => event.type === "telemetry.exporter");
-    const failureEvent = exporterEvents.find((event) => event.status === "failure");
+    const failureEvent = events.find((event) => event.status === "failure");
     expect(failureEvent?.type).toBe("telemetry.exporter");
     expect(failureEvent?.exporter).toBe("diagnostics-otel");
     expect(failureEvent?.signal).toBe("logs");
-    expect(failureEvent?.transport).toBe("otlp-http-protobuf");
     expect(failureEvent?.status).toBe("failure");
     expect(failureEvent?.reason).toBe("emit_failed");
     expect(failureEvent?.errorCategory).toBe("TypeError");
@@ -2321,12 +2593,18 @@ describe("diagnostics-otel service", () => {
       "openclaw.errorCategory": "TypeError",
     });
     expect(
-      exporterEvents
+      events.filter((event) => event.reason === "emit_failed").map((event) => event.status),
+    ).toEqual(["failure"]);
+    expect(
+      getReportedExporterHealth(ctx)
         .filter(
           (event) => event.transport === "otlp-http-protobuf" && event.reason === "emit_failed",
         )
         .map((event) => event.status),
     ).toEqual(["failure", "recovered"]);
+    expect(JSON.stringify({ events, health: getReportedExporterHealth(ctx) })).not.toContain(
+      "sk-test-secret",
+    );
 
     unsubscribe();
   });
@@ -2349,7 +2627,7 @@ describe("diagnostics-otel service", () => {
         throw new TypeError("private enqueue failure");
       })
       .mockImplementationOnce(() => {});
-    await startOtelService({ traces: false, metrics: false, logs: true });
+    const { ctx } = await startOtelService({ traces: false, metrics: false, logs: true });
     const exporter = firstLogProcessorOptions().exporter as
       | {
           export(items: unknown, callback: (result: ExportResult) => void): void;
@@ -2374,7 +2652,7 @@ describe("diagnostics-otel service", () => {
     await waitForDiagnosticEventsDrained();
 
     expect(
-      events
+      getReportedExporterHealth(ctx)
         .filter((event) => event.transport === "otlp-http-protobuf")
         .map(({ status, reason }) => ({ status, reason })),
     ).toEqual([
@@ -2386,7 +2664,7 @@ describe("diagnostics-otel service", () => {
     completeExport?.({ code: ExportResultCode.SUCCESS });
     await waitForDiagnosticEventsDrained();
     expect(
-      events
+      getReportedExporterHealth(ctx)
         .filter((event) => event.transport === "otlp-http-protobuf")
         .map(({ status, reason }) => ({ status, reason })),
     ).toEqual([
@@ -2394,7 +2672,10 @@ describe("diagnostics-otel service", () => {
       { status: "failure", reason: "export_failed" },
       { status: "recovered", reason: "export_failed" },
     ]);
-    expect(JSON.stringify(events)).not.toContain("private");
+    expect(events.map((event) => event.status)).not.toContain("recovered");
+    expect(JSON.stringify({ events, health: getReportedExporterHealth(ctx) })).not.toContain(
+      "private",
+    );
 
     unsubscribe();
   });
@@ -2413,7 +2694,7 @@ describe("diagnostics-otel service", () => {
     stdout.spy.mockImplementationOnce(failWrite).mockImplementationOnce(failWrite);
 
     try {
-      await startOtelService({
+      const { ctx } = await startOtelService({
         traces: false,
         metrics: false,
         logs: true,
@@ -2424,15 +2705,18 @@ describe("diagnostics-otel service", () => {
       }
 
       expect(
-        events
+        getReportedExporterHealth(ctx)
           .filter((event) => event.transport === "stdout" && event.reason === "emit_failed")
           .map(({ status, errorCategory }) => ({ status, errorCategory })),
       ).toEqual([
         { status: "failure", errorCategory: "TypeError" },
         { status: "recovered", errorCategory: undefined },
       ]);
+      expect(events.map((event) => event.status)).not.toContain("recovered");
       expect(stdout.writes).toHaveLength(1);
-      expect(JSON.stringify(events)).not.toContain("private stdout failure");
+      expect(JSON.stringify({ events, health: getReportedExporterHealth(ctx) })).not.toContain(
+        "private stdout failure",
+      );
     } finally {
       stdout.spy.mockRestore();
       unsubscribe();
@@ -2440,7 +2724,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("preserves and recovers bounded exporter facts for log preparation failures", () => {
-    const events: TelemetryExporterEvent[] = [];
+    const events: ExporterHealthUpdate[] = [];
     const logger = {
       info: vi.fn(),
       warn: vi.fn(),
@@ -2458,7 +2742,7 @@ describe("diagnostics-otel service", () => {
         logBodies: false,
       },
       emitExporterEvent: createExporterHealthEventEmitter((event) => {
-        events.push({ type: "telemetry.exporter", seq: 1, ts: 1, ...event });
+        events.push(event);
       }),
       logger,
       logsEnabled: true,
@@ -2505,13 +2789,13 @@ describe("diagnostics-otel service", () => {
       })),
     ).toEqual([
       {
-        transport: undefined,
+        transport: "otlp-http-protobuf",
         status: "failure",
         reason: "emit_failed",
         errorCategory: "TypeError",
       },
       {
-        transport: undefined,
+        transport: "otlp-http-protobuf",
         status: "recovered",
         reason: "emit_failed",
         errorCategory: undefined,

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -30,6 +30,7 @@ import {
   resolveContentCapturePolicy,
 } from "./service-content-normalization.js";
 import { createDiagnosticsEventHandler } from "./service-events.js";
+import { observeOtlpExporterHealth } from "./service-exporter-health.js";
 import {
   errorCategory,
   findOtlpExporterError,
@@ -52,6 +53,9 @@ import { createDiagnosticsTraceRuntime } from "./service-traces.js";
 import type { OtelLogsExporter, TelemetryExporterDiagnosticEvent } from "./service-types.js";
 
 const OTLP_HTTP_PROTOBUF_PROTOCOL = "http/protobuf";
+type ExporterTransport = "otlp-http-protobuf" | "stdout" | "external-sdk";
+type ExporterEndpointMode = "configured" | "default_endpoint";
+type ExporterRouteState = Pick<TelemetryExporterDiagnosticEvent, "signal" | "status" | "transport">;
 const OTEL_SIGNAL_PROTOCOL_ENV = {
   traces: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL_ENV,
   metrics: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL_ENV,
@@ -98,14 +102,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   let unregisterTracePropagationBridge: (() => void) | null = null;
   let stopActiveTrustedSpans: (() => void) | null = null;
   let unregisterUnhandledRejectionHandler: (() => void) | null = null;
+  let retireExporterRoutes: ((preserveFailures?: boolean) => void) | null = null;
 
-  const stopStarted = async () => {
+  const stopStarted = async (options?: { preserveExporterRoutes?: boolean }) => {
     const currentUnsubscribe = unsubscribe;
     const currentUnregisterTracePropagationBridge = unregisterTracePropagationBridge;
     const currentLogProvider = logProvider;
     const currentSdk = sdk;
     const currentStopActiveTrustedSpans = stopActiveTrustedSpans;
     const currentUnregisterUnhandledRejectionHandler = unregisterUnhandledRejectionHandler;
+    const currentRetireExporterRoutes = retireExporterRoutes;
 
     unsubscribe = null;
     unregisterTracePropagationBridge = null;
@@ -113,6 +119,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
     sdk = null;
     stopActiveTrustedSpans = null;
     unregisterUnhandledRejectionHandler = null;
+    retireExporterRoutes = options?.preserveExporterRoutes ? currentRetireExporterRoutes : null;
 
     const settle = async (...stops: Array<(() => void | Promise<void>) | null>) =>
       (
@@ -124,13 +131,19 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       currentUnsubscribe,
       currentStopActiveTrustedSpans,
     );
-    failures.push(
-      ...(await settle(
-        currentLogProvider ? () => currentLogProvider.shutdown() : null,
-        currentSdk ? () => currentSdk.shutdown() : null,
-      )),
-      ...(await settle(currentUnregisterUnhandledRejectionHandler)),
+    const providerFailures = await settle(
+      currentLogProvider ? () => currentLogProvider.shutdown() : null,
+      currentSdk ? () => currentSdk.shutdown() : null,
     );
+    failures.push(...providerFailures);
+    if (!options?.preserveExporterRoutes) {
+      currentRetireExporterRoutes?.(providerFailures.length > 0);
+    }
+    if (providerFailures.length > 0) {
+      // Keep final callback failures visible until the next lifecycle call retires them.
+      retireExporterRoutes = currentRetireExporterRoutes;
+    }
+    failures.push(...(await settle(currentUnregisterUnhandledRejectionHandler)));
 
     if (failures.length === 1) {
       throw failures[0];
@@ -154,9 +167,20 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
+      const exporterRoutes = new Map<string, ExporterRouteState>();
       const emitExporterEvent = (
         event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">,
       ) => {
+        const key = `${event.signal}\u0000${event.transport ?? "unknown"}`;
+        if (event.status === "dropped") {
+          exporterRoutes.delete(key);
+        } else {
+          exporterRoutes.set(key, {
+            signal: event.signal,
+            status: event.status,
+            ...(event.transport ? { transport: event.transport } : {}),
+          });
+        }
         try {
           ctx.internalDiagnostics?.emit({
             type: "telemetry.exporter",
@@ -164,14 +188,6 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           });
         } catch {
           // Exporter health must never affect the exporter lifecycle.
-        }
-      };
-      const emitForSignals = (
-        signals: TelemetryExporterDiagnosticEvent["signal"][],
-        event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts" | "signal">,
-      ) => {
-        for (const signal of signals) {
-          emitExporterEvent({ signal, ...event });
         }
       };
       const tracesEnabled = otel.traces !== false;
@@ -197,6 +213,19 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       }
 
       const sdkPreloaded = hasPreloadedOtelSdk();
+      retireExporterRoutes = (preserveFailures = false) => {
+        for (const route of [...exporterRoutes.values()]) {
+          if (preserveFailures && route.status === "failure") {
+            continue;
+          }
+          emitExporterEvent({
+            exporter: "diagnostics-otel",
+            signal: route.signal,
+            ...(route.transport ? { transport: route.transport } : {}),
+            status: "dropped",
+          });
+        }
+      };
       const ownedOtlpSignals: TelemetryExporterDiagnosticEvent["signal"][] = [
         ...(!sdkPreloaded && tracesEnabled ? (["traces"] as const) : []),
         ...(!sdkPreloaded && metricsEnabled ? (["metrics"] as const) : []),
@@ -212,6 +241,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         emitExporterEvent({
           signal,
           exporter: "diagnostics-otel",
+          transport: "otlp-http-protobuf",
           status: "failure",
           reason: "unsupported_protocol",
         });
@@ -225,12 +255,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const tracesActive = sdkPreloaded ? tracesEnabled : tracesToOtlp;
       const metricsActive = sdkPreloaded ? metricsEnabled : metricsToOtlp;
       const logsActive = logsToStdout || logsToOtlp;
-      const startedSignals: TelemetryExporterDiagnosticEvent["signal"][] = [
-        ...(tracesActive ? (["traces"] as const) : []),
-        ...(metricsActive ? (["metrics"] as const) : []),
-        ...(logsActive ? (["logs"] as const) : []),
-      ];
-      if (startedSignals.length === 0) {
+      if (!tracesActive && !metricsActive && !logsActive) {
         return;
       }
 
@@ -285,11 +310,14 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         : undefined;
       if (tracesToOtlp || metricsToOtlp) {
         const traceExporter = tracesToOtlp
-          ? new OTLPTraceExporter({
-              ...(traceUrl ? { url: traceUrl } : {}),
-              ...(headers ? { headers } : {}),
-              ...(traceHttpAgentOptions ? { httpAgentOptions: traceHttpAgentOptions } : {}),
-            })
+          ? observeOtlpExporterHealth(
+              new OTLPTraceExporter({
+                ...(traceUrl ? { url: traceUrl } : {}),
+                ...(headers ? { headers } : {}),
+                ...(traceHttpAgentOptions ? { httpAgentOptions: traceHttpAgentOptions } : {}),
+              }),
+              { emitExporterEvent, signal: "traces" },
+            )
           : undefined;
         const spanProcessors =
           traceExporter && typeof otel.flushIntervalMs === "number"
@@ -301,11 +329,14 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             : undefined;
 
         const metricExporter = metricsToOtlp
-          ? new OTLPMetricExporter({
-              ...(metricUrl ? { url: metricUrl } : {}),
-              ...(headers ? { headers } : {}),
-              ...(metricHttpAgentOptions ? { httpAgentOptions: metricHttpAgentOptions } : {}),
-            })
+          ? observeOtlpExporterHealth(
+              new OTLPMetricExporter({
+                ...(metricUrl ? { url: metricUrl } : {}),
+                ...(headers ? { headers } : {}),
+                ...(metricHttpAgentOptions ? { httpAgentOptions: metricHttpAgentOptions } : {}),
+              }),
+              { emitExporterEvent, signal: "metrics" },
+            )
           : undefined;
 
         const metricReader = metricExporter
@@ -340,21 +371,23 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         try {
           sdk.start();
         } catch (err) {
-          emitForSignals(
-            [
-              ...(tracesToOtlp ? (["traces"] as const) : []),
-              ...(metricsToOtlp ? (["metrics"] as const) : []),
-            ],
-            {
+          for (const [signal, url] of [
+            ...(tracesToOtlp ? ([["traces", traceUrl]] as const) : []),
+            ...(metricsToOtlp ? ([["metrics", metricUrl]] as const) : []),
+          ]) {
+            emitExporterEvent({
               exporter: "diagnostics-otel",
+              signal,
+              transport: "otlp-http-protobuf",
+              endpointMode: url ? "configured" : "default_endpoint",
               status: "failure",
               reason: "start_failed",
               errorCategory: errorCategory(err),
-            },
-          );
+            });
+          }
           ctx.logger.error(`diagnostics-otel: failed to start SDK: ${formatError(err)}`);
           try {
-            await stopStarted();
+            await stopStarted({ preserveExporterRoutes: true });
           } catch (cleanupError) {
             ctx.logger.error(
               `diagnostics-otel: SDK startup rollback cleanup failed: ${formatError(cleanupError)}`,
@@ -448,11 +481,36 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return true;
       });
 
-      emitForSignals(startedSignals, {
-        exporter: "diagnostics-otel",
-        status: "started",
-        reason: "configured",
-      });
+      const emitStarted = (
+        signal: TelemetryExporterDiagnosticEvent["signal"],
+        transport: ExporterTransport,
+        endpointMode?: ExporterEndpointMode,
+      ) => {
+        emitExporterEvent({
+          exporter: "diagnostics-otel",
+          signal,
+          transport,
+          ...(endpointMode ? { endpointMode } : {}),
+          status: "started",
+          reason: endpointMode ?? "configured",
+        });
+      };
+      if (sdkPreloaded && tracesEnabled) {
+        emitStarted("traces", "external-sdk");
+      } else if (tracesToOtlp) {
+        emitStarted("traces", "otlp-http-protobuf", traceUrl ? "configured" : "default_endpoint");
+      }
+      if (sdkPreloaded && metricsEnabled) {
+        emitStarted("metrics", "external-sdk");
+      } else if (metricsToOtlp) {
+        emitStarted("metrics", "otlp-http-protobuf", metricUrl ? "configured" : "default_endpoint");
+      }
+      if (logsToOtlp) {
+        emitStarted("logs", "otlp-http-protobuf", logUrl ? "configured" : "default_endpoint");
+      }
+      if (logsToStdout) {
+        emitStarted("logs", "stdout");
+      }
 
       if (logsActive) {
         const label =

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -217,7 +217,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const sdkPreloaded = hasPreloadedOtelSdk();
       retireExporterRoutes = (preserveFailures = false) => {
-        for (const route of [...exporterRoutes.values()]) {
+        for (const route of exporterRoutes.values()) {
           if (preserveFailures && route.status === "failure") {
             continue;
           }

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1,5 +1,6 @@
 // Diagnostics Otel plugin module implements service behavior.
 import { metrics, trace, type SpanContext } from "@opentelemetry/api";
+import { getBooleanFromEnv } from "@opentelemetry/core";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { resourceFromAttributes } from "@opentelemetry/resources";
@@ -32,7 +33,9 @@ import {
 import { createDiagnosticsEventHandler } from "./service-events.js";
 import {
   createExporterHealthEventEmitter,
+  createPublicExporterHealthEventEmitter,
   observeOtlpExporterHealth,
+  type ExporterHealthUpdate,
 } from "./service-exporter-health.js";
 import {
   errorCategory,
@@ -58,7 +61,11 @@ import type { OtelLogsExporter, TelemetryExporterDiagnosticEvent } from "./servi
 const OTLP_HTTP_PROTOBUF_PROTOCOL = "http/protobuf";
 type ExporterTransport = "otlp-http-protobuf" | "stdout" | "external-sdk";
 type ExporterEndpointMode = "configured" | "default_endpoint";
-type ExporterRouteState = Pick<TelemetryExporterDiagnosticEvent, "signal" | "status" | "transport">;
+type ExporterRouteState = Pick<ExporterHealthUpdate, "signal" | "status" | "transport">;
+type ExporterHealthReporter = {
+  reportExporterHealth?: (update: Omit<ExporterHealthUpdate, "exporter">) => void;
+};
+type PublicExporterEvent = Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">;
 const OTEL_SIGNAL_PROTOCOL_ENV = {
   traces: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL_ENV,
   metrics: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL_ENV,
@@ -90,6 +97,31 @@ function createStartupRollbackError(startupError: unknown, cleanupError: unknown
   );
 }
 
+function publicExporterEventForHealth(
+  event: ExporterHealthUpdate,
+): PublicExporterEvent | undefined {
+  const base = {
+    exporter: event.exporter,
+    signal: event.signal,
+  };
+  if (event.status === "recovered") {
+    return undefined;
+  }
+  if (event.status === "started") {
+    return { ...base, status: "started", reason: "configured" };
+  }
+  if (event.status === "dropped") {
+    return { ...base, status: "dropped" };
+  }
+  const reason = event.reason === "export_failed" ? "emit_failed" : event.reason;
+  return {
+    ...base,
+    status: "failure",
+    ...(reason && reason !== "default_endpoint" ? { reason } : {}),
+    ...(event.errorCategory ? { errorCategory: event.errorCategory } : {}),
+  };
+}
+
 function diagnosticTraceContextFromSpanContext(spanContext: SpanContext): DiagnosticTraceContext {
   return {
     traceId: spanContext.traceId,
@@ -106,6 +138,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   let stopActiveTrustedSpans: (() => void) | null = null;
   let unregisterUnhandledRejectionHandler: (() => void) | null = null;
   let retireExporterRoutes: ((preserveFailures?: boolean) => void) | null = null;
+  let preserveExporterRoutesOnNextStop = false;
 
   const stopStarted = async (options?: { preserveExporterRoutes?: boolean }) => {
     const currentUnsubscribe = unsubscribe;
@@ -162,6 +195,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
   return {
     id: "diagnostics-otel",
     async start(ctx) {
+      preserveExporterRoutesOnNextStop = false;
       await stopStarted();
 
       const cfg = ctx.config.diagnostics;
@@ -170,29 +204,53 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
+      const sdkPreloaded = hasPreloadedOtelSdk();
+      const ownedNodeSdkDisabled = !sdkPreloaded && getBooleanFromEnv("OTEL_SDK_DISABLED");
       const exporterRoutes = new Map<string, ExporterRouteState>();
-      const emitExporterEvent = createExporterHealthEventEmitter(
-        (event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">) => {
-          const key = `${event.signal}\u0000${event.transport ?? "unknown"}`;
-          if (event.status === "dropped") {
-            exporterRoutes.delete(key);
-          } else {
-            exporterRoutes.set(key, {
-              signal: event.signal,
-              status: event.status,
-              ...(event.transport ? { transport: event.transport } : {}),
-            });
-          }
-          try {
-            ctx.internalDiagnostics?.emit({
-              type: "telemetry.exporter",
-              ...event,
-            });
-          } catch {
-            // Exporter health must never affect the exporter lifecycle.
-          }
-        },
-      );
+      const internalDiagnostics = ctx.internalDiagnostics;
+      const exporterHealthReporter = internalDiagnostics as unknown as
+        | ExporterHealthReporter
+        | undefined;
+      const emitPublicExporterEvent = createPublicExporterHealthEventEmitter((event) => {
+        const publicEvent = publicExporterEventForHealth(event);
+        if (!publicEvent) {
+          return;
+        }
+        try {
+          internalDiagnostics?.emit({
+            type: "telemetry.exporter",
+            ...publicEvent,
+          });
+        } catch {
+          // Public lifecycle telemetry is best effort.
+        }
+      });
+      const emitExporterEvent = createExporterHealthEventEmitter((event) => {
+        if (
+          ownedNodeSdkDisabled &&
+          event.transport === "otlp-http-protobuf" &&
+          (event.signal === "traces" || event.signal === "metrics")
+        ) {
+          return;
+        }
+        const key = `${event.signal}\u0000${event.transport}`;
+        if (event.status === "dropped") {
+          exporterRoutes.delete(key);
+        } else {
+          exporterRoutes.set(key, {
+            signal: event.signal,
+            status: event.status,
+            transport: event.transport,
+          });
+        }
+        try {
+          const { exporter: _exporter, ...update } = event;
+          exporterHealthReporter?.reportExporterHealth?.(update);
+        } catch {
+          // Exporter health must never affect the exporter lifecycle.
+        }
+        emitPublicExporterEvent(event);
+      });
       const tracesEnabled = otel.traces !== false;
       const metricsEnabled = otel.metrics !== false;
       const logsEnabled = otel.logs === true;
@@ -215,7 +273,6 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      const sdkPreloaded = hasPreloadedOtelSdk();
       retireExporterRoutes = (preserveFailures = false) => {
         for (const route of exporterRoutes.values()) {
           if (preserveFailures && route.status === "failure") {
@@ -224,7 +281,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           emitExporterEvent({
             exporter: "diagnostics-otel",
             signal: route.signal,
-            ...(route.transport ? { transport: route.transport } : {}),
+            transport: route.transport,
             status: "dropped",
           });
         }
@@ -389,6 +446,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             });
           }
           ctx.logger.error(`diagnostics-otel: failed to start SDK: ${formatError(err)}`);
+          // startPluginServices performs one mandatory cleanup call after a rejected start.
+          // It belongs to this rollback and must not retire the failure it is reporting.
+          preserveExporterRoutesOnNextStop = true;
           try {
             await stopStarted({ preserveExporterRoutes: true });
           } catch (cleanupError) {
@@ -526,7 +586,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       }
     },
     async stop() {
-      await stopStarted();
+      const preserveExporterRoutes = preserveExporterRoutesOnNextStop;
+      preserveExporterRoutesOnNextStop = false;
+      await stopStarted(preserveExporterRoutes ? { preserveExporterRoutes: true } : undefined);
     },
   } satisfies OpenClawPluginService;
 }

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -30,7 +30,10 @@ import {
   resolveContentCapturePolicy,
 } from "./service-content-normalization.js";
 import { createDiagnosticsEventHandler } from "./service-events.js";
-import { observeOtlpExporterHealth } from "./service-exporter-health.js";
+import {
+  createExporterHealthEventEmitter,
+  observeOtlpExporterHealth,
+} from "./service-exporter-health.js";
 import {
   errorCategory,
   findOtlpExporterError,
@@ -168,28 +171,28 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       }
 
       const exporterRoutes = new Map<string, ExporterRouteState>();
-      const emitExporterEvent = (
-        event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">,
-      ) => {
-        const key = `${event.signal}\u0000${event.transport ?? "unknown"}`;
-        if (event.status === "dropped") {
-          exporterRoutes.delete(key);
-        } else {
-          exporterRoutes.set(key, {
-            signal: event.signal,
-            status: event.status,
-            ...(event.transport ? { transport: event.transport } : {}),
-          });
-        }
-        try {
-          ctx.internalDiagnostics?.emit({
-            type: "telemetry.exporter",
-            ...event,
-          });
-        } catch {
-          // Exporter health must never affect the exporter lifecycle.
-        }
-      };
+      const emitExporterEvent = createExporterHealthEventEmitter(
+        (event: Omit<TelemetryExporterDiagnosticEvent, "type" | "seq" | "ts">) => {
+          const key = `${event.signal}\u0000${event.transport ?? "unknown"}`;
+          if (event.status === "dropped") {
+            exporterRoutes.delete(key);
+          } else {
+            exporterRoutes.set(key, {
+              signal: event.signal,
+              status: event.status,
+              ...(event.transport ? { transport: event.transport } : {}),
+            });
+          }
+          try {
+            ctx.internalDiagnostics?.emit({
+              type: "telemetry.exporter",
+              ...event,
+            });
+          } catch {
+            // Exporter health must never affect the exporter lifecycle.
+          }
+        },
+      );
       const tracesEnabled = otel.traces !== false;
       const metricsEnabled = otel.metrics !== false;
       const logsEnabled = otel.logs === true;

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -799,6 +799,7 @@ describe("diagnostics-prometheus service", () => {
         type: "telemetry.exporter",
         exporter: "diagnostics-prometheus",
         signal: "metrics",
+        transport: "prometheus-scrape",
         status: "started",
         reason: "configured",
       },
@@ -832,6 +833,13 @@ describe("diagnostics-prometheus service", () => {
     exporter.service.stop?.();
 
     expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(emitted.at(-1)).toStrictEqual({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-prometheus",
+      signal: "metrics",
+      transport: "prometheus-scrape",
+      status: "dropped",
+    });
     expect(exporter.render()).toBe("");
   });
 });

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -4,10 +4,22 @@ import type { DiagnosticEventPrivateData } from "openclaw/plugin-sdk/diagnostic-
 // Diagnostics Prometheus tests cover service plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { DiagnosticEventMetadata, DiagnosticEventPayload } from "../api.js";
+import type { OpenClawPluginServiceContext } from "../api.js";
 import { createDiagnosticsPrometheusExporter } from "./service.js";
 
 const trusted: DiagnosticEventMetadata = Object.freeze({ trusted: true });
 const untrusted: DiagnosticEventMetadata = Object.freeze({ trusted: false });
+type ExporterHealthReport = {
+  signal: "metrics";
+  transport: "prometheus-scrape";
+  status: "started" | "dropped";
+  reason?: "configured";
+};
+type TrustedExporterInternalDiagnostics = NonNullable<
+  OpenClawPluginServiceContext["internalDiagnostics"]
+> & {
+  reportExporterHealth?: (update: ExporterHealthReport) => void;
+};
 
 function baseEvent(): Pick<DiagnosticEventPayload, "seq" | "ts"> {
   return { seq: 1, ts: 1700000000000 };
@@ -39,7 +51,8 @@ function createMetricsHarness() {
           listener = undefined;
         };
       },
-    },
+      reportExporterHealth() {},
+    } as TrustedExporterInternalDiagnostics,
   });
   return {
     record(event: DiagnosticEventPayload, metadata: DiagnosticEventMetadata) {
@@ -233,6 +246,30 @@ describe("diagnostics-prometheus service", () => {
       'openclaw_diagnostic_async_queue_dropped_total{drop_class="untrusted"} 2',
     );
     expect(rendered).toContain("openclaw_diagnostic_async_queue_length 0");
+  });
+
+  it("records one metric for one signal-level exporter lifecycle fact", () => {
+    const metrics = createMetricsHarness();
+
+    metrics.record(
+      {
+        ...baseEvent(),
+        type: "telemetry.exporter",
+        exporter: "diagnostics-otel",
+        signal: "logs",
+        status: "started",
+        reason: "configured",
+      },
+      trusted,
+    );
+
+    const rendered = metrics.render();
+    expect(rendered).toContain(
+      'openclaw_telemetry_exporter_total{exporter="diagnostics-otel",reason="configured",signal="logs",status="started"} 1',
+    );
+    expect(rendered).not.toContain(
+      'openclaw_telemetry_exporter_total{exporter="diagnostics-otel",reason="configured",signal="logs",status="started"} 2',
+    );
   });
 
   it("redacts and bounds label values", () => {
@@ -759,6 +796,7 @@ describe("diagnostics-prometheus service", () => {
       ) => void
     > = [];
     const emitted: unknown[] = [];
+    const healthReports: ExporterHealthReport[] = [];
     const error = vi.fn();
     const exporter = createDiagnosticsPrometheusExporter();
     const unsubscribe = vi.fn();
@@ -778,7 +816,11 @@ describe("diagnostics-prometheus service", () => {
           listeners.push(listener);
           return unsubscribe;
         },
-      },
+        reportExporterHealth: (update) => {
+          healthReports.push(update);
+          throw new Error("private exporter health callback failure");
+        },
+      } as TrustedExporterInternalDiagnostics,
     });
 
     expect(listeners).toHaveLength(1);
@@ -798,6 +840,13 @@ describe("diagnostics-prometheus service", () => {
       {
         type: "telemetry.exporter",
         exporter: "diagnostics-prometheus",
+        signal: "metrics",
+        status: "started",
+        reason: "configured",
+      },
+    ]);
+    expect(healthReports).toStrictEqual([
+      {
         signal: "metrics",
         transport: "prometheus-scrape",
         status: "started",
@@ -836,6 +885,10 @@ describe("diagnostics-prometheus service", () => {
     expect(emitted.at(-1)).toStrictEqual({
       type: "telemetry.exporter",
       exporter: "diagnostics-prometheus",
+      signal: "metrics",
+      status: "dropped",
+    });
+    expect(healthReports.at(-1)).toStrictEqual({
       signal: "metrics",
       transport: "prometheus-scrape",
       status: "dropped",

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -10,6 +10,7 @@ import type {
   DiagnosticEventPayload,
   OpenClawPluginHttpRouteHandler,
   OpenClawPluginService,
+  OpenClawPluginServiceContext,
 } from "../api.js";
 import { isInternalDiagnosticEventMetadata, redactSensitiveText } from "../api.js";
 
@@ -1004,6 +1005,9 @@ function createMetricsHandler(store: PrometheusMetricStore): OpenClawPluginHttpR
 export function createDiagnosticsPrometheusExporter() {
   const store = createPrometheusMetricStore();
   let unsubscribe: (() => void) | undefined;
+  let emitExporterEvent:
+    | NonNullable<OpenClawPluginServiceContext["internalDiagnostics"]>["emit"]
+    | undefined;
 
   const service = {
     id: "diagnostics-prometheus",
@@ -1022,10 +1026,12 @@ export function createDiagnosticsPrometheusExporter() {
           );
         }
       });
-      ctx.internalDiagnostics?.emit({
+      emitExporterEvent = ctx.internalDiagnostics?.emit;
+      emitExporterEvent?.({
         type: "telemetry.exporter",
         exporter: "diagnostics-prometheus",
         signal: "metrics",
+        transport: "prometheus-scrape",
         status: "started",
         reason: "configured",
       });
@@ -1033,6 +1039,14 @@ export function createDiagnosticsPrometheusExporter() {
     stop() {
       unsubscribe?.();
       unsubscribe = undefined;
+      emitExporterEvent?.({
+        type: "telemetry.exporter",
+        exporter: "diagnostics-prometheus",
+        signal: "metrics",
+        transport: "prometheus-scrape",
+        status: "dropped",
+      });
+      emitExporterEvent = undefined;
       store.reset();
     },
   } satisfies OpenClawPluginService;

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -10,7 +10,6 @@ import type {
   DiagnosticEventPayload,
   OpenClawPluginHttpRouteHandler,
   OpenClawPluginService,
-  OpenClawPluginServiceContext,
 } from "../api.js";
 import { isInternalDiagnosticEventMetadata, redactSensitiveText } from "../api.js";
 
@@ -1002,12 +1001,34 @@ function createMetricsHandler(store: PrometheusMetricStore): OpenClawPluginHttpR
   };
 }
 
+type PrometheusExporterHealthUpdate = {
+  signal: "metrics";
+  transport: "prometheus-scrape";
+  status: "started" | "dropped";
+  reason?: "configured";
+};
+type TrustedExporterDiagnosticsBridge = {
+  emit: (event: {
+    type: "telemetry.exporter";
+    exporter: "diagnostics-prometheus";
+    signal: "metrics";
+    status: "started" | "dropped";
+    reason?: "configured";
+  }) => void;
+  reportExporterHealth?: (update: PrometheusExporterHealthUpdate) => void;
+};
+
 export function createDiagnosticsPrometheusExporter() {
   const store = createPrometheusMetricStore();
   let unsubscribe: (() => void) | undefined;
-  let emitExporterEvent:
-    | NonNullable<OpenClawPluginServiceContext["internalDiagnostics"]>["emit"]
-    | undefined;
+  let internalDiagnostics: TrustedExporterDiagnosticsBridge | undefined;
+  const reportExporterHealth = (update: PrometheusExporterHealthUpdate) => {
+    try {
+      internalDiagnostics?.reportExporterHealth?.(update);
+    } catch {
+      // Exporter health must never affect the exporter lifecycle.
+    }
+  };
 
   const service = {
     id: "diagnostics-prometheus",
@@ -1026,12 +1047,17 @@ export function createDiagnosticsPrometheusExporter() {
           );
         }
       });
-      emitExporterEvent = ctx.internalDiagnostics?.emit;
-      emitExporterEvent?.({
+      internalDiagnostics = ctx.internalDiagnostics as unknown as TrustedExporterDiagnosticsBridge;
+      reportExporterHealth({
+        signal: "metrics",
+        transport: "prometheus-scrape",
+        status: "started",
+        reason: "configured",
+      });
+      internalDiagnostics.emit({
         type: "telemetry.exporter",
         exporter: "diagnostics-prometheus",
         signal: "metrics",
-        transport: "prometheus-scrape",
         status: "started",
         reason: "configured",
       });
@@ -1039,14 +1065,18 @@ export function createDiagnosticsPrometheusExporter() {
     stop() {
       unsubscribe?.();
       unsubscribe = undefined;
-      emitExporterEvent?.({
-        type: "telemetry.exporter",
-        exporter: "diagnostics-prometheus",
+      reportExporterHealth({
         signal: "metrics",
         transport: "prometheus-scrape",
         status: "dropped",
       });
-      emitExporterEvent = undefined;
+      internalDiagnostics?.emit({
+        type: "telemetry.exporter",
+        exporter: "diagnostics-prometheus",
+        signal: "metrics",
+        status: "dropped",
+      });
+      internalDiagnostics = undefined;
       store.reset();
     },
   } satisfies OpenClawPluginService;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,6 +732,9 @@ importers:
       '@opentelemetry/api-logs':
         specifier: 0.221.0
         version: 0.221.0
+      '@opentelemetry/core':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-logs-otlp-proto':
         specifier: 0.221.0
         version: 0.221.0(@opentelemetry/api@1.9.1)

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -84,8 +84,43 @@ describe("checkGatewayHealth", () => {
       timeoutMs: 6000,
       config: cfg,
     });
+    expect(callGateway).toHaveBeenNthCalledWith(3, {
+      method: "diagnostics.stability",
+      params: { type: "telemetry.exporter", limit: 1000 },
+      timeoutMs: 3000,
+      config: cfg,
+    });
     expect(runtime.error).not.toHaveBeenCalled();
     expect(note.mock.calls.map(([, title]) => title)).not.toContain("OpenClaw version mismatch");
+  });
+
+  it("renders the shared redacted telemetry exporter summary", async () => {
+    callGateway
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        events: [
+          {
+            seq: 1,
+            type: "telemetry.exporter",
+            source: "diagnostics-otel",
+            target: "logs",
+            transport: "stdout",
+            outcome: "started",
+            reason: "configured",
+            payload: "private log payload",
+          },
+        ],
+      });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 });
+
+    expect(note).toHaveBeenCalledWith(
+      "diagnostics-otel · logs · started · stdout",
+      "Telemetry exporters",
+    );
+    expect(JSON.stringify(note.mock.calls)).not.toContain("private log payload");
   });
 
   it("reports failed channel diagnostics without marking a reachable gateway unhealthy", async () => {

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -27,6 +27,7 @@ import {
   gatewayProbeResultSawGateway,
 } from "./gateway-health-auth-diagnostic.js";
 import { formatGatewayClosedDiagnostic, formatHealthCheckFailure } from "./health-format.js";
+import { formatTelemetryExporterSummary } from "./telemetry-exporter-summary.js";
 
 type GatewayMemoryProbe = {
   checked: boolean;
@@ -112,14 +113,22 @@ export async function checkGatewayHealth(params: {
         "Plugins configured unavailable",
       );
     }
-    try {
-      const statusLocal = await callGateway({
+    const [channelsResult, exporterResult] = await Promise.allSettled([
+      callGateway({
         method: "channels.status",
         params: { probe: true, timeoutMs: 5000 },
         timeoutMs: 6000,
         config: params.cfg,
-      });
-      const issues = collectChannelStatusIssues(statusLocal);
+      }),
+      callGateway({
+        method: "diagnostics.stability",
+        params: { type: "telemetry.exporter", limit: 1000 },
+        timeoutMs: Math.min(timeoutMs, 6000),
+        config: params.cfg,
+      }),
+    ]);
+    if (channelsResult.status === "fulfilled") {
+      const issues = collectChannelStatusIssues(channelsResult.value);
       if (issues.length > 0) {
         note(
           issues
@@ -133,14 +142,20 @@ export async function checkGatewayHealth(params: {
           "Channel warnings",
         );
       }
-    } catch (error) {
+    } else {
       note(
         [
-          `Channel status probe failed: ${sanitizeTerminalText(formatErrorMessage(error))}`,
+          `Channel status probe failed: ${sanitizeTerminalText(formatErrorMessage(channelsResult.reason))}`,
           `Retry: ${formatCliCommand("openclaw channels status --probe")}`,
         ].join("\n"),
         "Channel warnings",
       );
+    }
+    if (exporterResult.status === "fulfilled") {
+      const exporterSummary = formatTelemetryExporterSummary(exporterResult.value);
+      if (exporterSummary) {
+        note(exporterSummary.lines.join("\n"), exporterSummary.title);
+      }
     }
     return { healthOk, authenticated: true, status };
   } catch (err) {

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -82,6 +82,7 @@ function createBaseParams(
     channelsStatus: null,
     channelIssues: [],
     deliveryDiagnostics: null,
+    exporterDiagnostics: null,
     gatewayReachable: false,
     health: null,
     nodeOnlyGateway: null,
@@ -264,6 +265,38 @@ describe("status-all diagnosis port checks", () => {
       "✓ Inbound delivery telemetry: received 2 · dispatch 2/2 · turns 2 · processed 2",
     );
     expect(output).toContain("latest delivery event:");
+  });
+
+  it("renders the shared redacted telemetry exporter summary", async () => {
+    const params = createBaseParams([]);
+    params.exporterDiagnostics = {
+      events: [
+        {
+          seq: 1,
+          type: "telemetry.exporter",
+          source: "diagnostics-otel",
+          target: "traces",
+          transport: "otlp-http-protobuf",
+          outcome: "failure",
+          reason: "export_failed",
+          mode: "configured",
+          url: "https://collector.example/private",
+          headers: { authorization: "secret" },
+          error: "raw failure",
+        },
+      ],
+    };
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Telemetry exporters");
+    expect(output).toContain(
+      "diagnostics-otel · traces · failed · OTLP/HTTP protobuf (explicit endpoint) · export failed",
+    );
+    expect(output).not.toContain("collector.example");
+    expect(output).not.toContain("secret");
+    expect(output).not.toContain("raw failure");
   });
 
   it("keeps handled terminal delivery paths healthy without dispatch starts", async () => {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -29,6 +29,7 @@ import {
   formatUpdateRestartStatusValue,
 } from "../status-update-restart.ts";
 import type { NodeOnlyGatewayInfo } from "../status.node-mode.js";
+import { formatTelemetryExporterSummary } from "../telemetry-exporter-summary.js";
 import { formatTimeAgo, redactSecrets } from "./format.js";
 import { readFileTailLines, summarizeLogTail } from "./gateway.js";
 
@@ -157,6 +158,7 @@ export async function appendStatusAllDiagnosis(params: {
   channelsStatus: unknown;
   channelIssues: ChannelIssueLike[];
   deliveryDiagnostics: unknown;
+  exporterDiagnostics: unknown;
   agentStatus?: AgentStatusLike;
   gatewayReachable: boolean;
   health: unknown;
@@ -332,6 +334,14 @@ export async function appendStatusAllDiagnosis(params: {
       lines.push(
         `  ${muted("No agent session was updated in the last 30m; if channels received messages, verify inbound dispatch and turn creation.")}`,
       );
+    }
+  }
+
+  const exporterSummary = formatTelemetryExporterSummary(params.exporterDiagnostics);
+  if (exporterSummary) {
+    emitCheck(exporterSummary.title, exporterSummary.status);
+    for (const line of exporterSummary.lines) {
+      lines.push(`  ${muted(line)}`);
     }
   }
 

--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(async () => ({ path: "/tmp/openclaw.json" })),
   inspectPortUsage: vi.fn(async () => null),
   resolveGatewayBindHost: vi.fn(async () => "127.0.0.1"),
+  resolveStatusGatewayDiagnosticsSafe: vi.fn(async () => null),
+  resolveStatusGatewayHealthSafe: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../agents/exec-defaults.js", () => ({
@@ -32,8 +34,8 @@ vi.mock("../status-overview-surface.ts", () => ({
   buildStatusOverviewSurfaceFromOverview: () => ({}),
 }));
 vi.mock("../status-runtime-shared.ts", () => ({
-  resolveStatusGatewayDiagnosticsSafe: async () => null,
-  resolveStatusGatewayHealthSafe: async () => undefined,
+  resolveStatusGatewayDiagnosticsSafe: mocks.resolveStatusGatewayDiagnosticsSafe,
+  resolveStatusGatewayHealthSafe: mocks.resolveStatusGatewayHealthSafe,
 }));
 vi.mock("../status-update-restart.ts", () => ({
   formatUpdateRestartStatusValue: () => null,
@@ -47,6 +49,8 @@ import { buildStatusAllReportData } from "./report-data.js";
 describe("buildStatusAllReportData", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveStatusGatewayDiagnosticsSafe.mockResolvedValue(null);
+    mocks.resolveStatusGatewayHealthSafe.mockResolvedValue(undefined);
   });
 
   it("keeps local config diagnosis non-observing", async () => {
@@ -80,5 +84,45 @@ describe("buildStatusAllReportData", () => {
     expect(mocks.inspectPortUsage).toHaveBeenCalledWith(18789, {
       probeHosts: ["127.0.0.1"],
     });
+  });
+
+  it("collects delivery and exporter stability projections in parallel", async () => {
+    await buildStatusAllReportData({
+      overview: {
+        cfg: {},
+        gatewaySnapshot: {
+          gatewayReachable: true,
+          gatewayProbe: { error: null },
+          gatewayCallOverrides: undefined,
+          gatewayConnection: {},
+          remoteUrlMissing: false,
+        },
+        secretDiagnostics: [],
+        tailscaleMode: "off",
+        tailscaleDns: null,
+        agentStatus: { agents: [], defaultId: null },
+        channels: { rows: [], details: [] },
+        channelIssues: [],
+        osSummary: { label: "test" },
+      } as never,
+      daemon: {} as never,
+      nodeService: {} as never,
+      nodeOnlyGateway: null,
+      progress: { setLabel: vi.fn(), tick: vi.fn() },
+    });
+
+    expect(mocks.resolveStatusGatewayDiagnosticsSafe.mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          gatewayReachable: true,
+        }),
+      ],
+      [
+        expect.objectContaining({
+          gatewayReachable: true,
+          type: "telemetry.exporter",
+        }),
+      ],
+    ]);
   });
 });

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -77,30 +77,36 @@ async function resolveStatusAllLocalDiagnosis(params: {
     gatewayReachable: boolean;
     health: StatusGatewayHealthSafe | undefined;
     deliveryDiagnostics: unknown;
+    exporterDiagnostics: unknown;
     nodeOnlyGateway: NodeOnlyGatewayInfo | null;
   };
 }> {
   const { overview } = params;
   const snap = await readConfigFileSnapshot({ observe: false }).catch(() => null);
   const configPath = resolveStatusAllConfigPath(snap?.path);
+  const diagnosticsParams = {
+    config: overview.cfg,
+    timeoutMs: Math.min(5000, params.timeoutMs ?? 10_000),
+    gatewayReachable: params.gatewayReachable,
+    ...(params.gatewayCallOverrides ? { callOverrides: params.gatewayCallOverrides } : {}),
+  };
 
-  const health = params.nodeOnlyGateway
-    ? undefined
-    : await resolveStatusGatewayHealthSafe({
-        config: overview.cfg,
-        timeoutMs: Math.min(8000, params.timeoutMs ?? 10_000),
-        gatewayReachable: params.gatewayReachable,
-        gatewayProbeError: params.gatewayProbe?.error ?? null,
-        ...(params.gatewayCallOverrides ? { callOverrides: params.gatewayCallOverrides } : {}),
-      });
-  const diagnostics = params.nodeOnlyGateway
-    ? null
-    : await resolveStatusGatewayDiagnosticsSafe({
-        config: overview.cfg,
-        timeoutMs: Math.min(5000, params.timeoutMs ?? 10_000),
-        gatewayReachable: params.gatewayReachable,
-        ...(params.gatewayCallOverrides ? { callOverrides: params.gatewayCallOverrides } : {}),
-      });
+  const [health, deliveryDiagnostics, exporterDiagnostics] = params.nodeOnlyGateway
+    ? [undefined, null, null]
+    : await Promise.all([
+        resolveStatusGatewayHealthSafe({
+          config: overview.cfg,
+          timeoutMs: Math.min(8000, params.timeoutMs ?? 10_000),
+          gatewayReachable: params.gatewayReachable,
+          gatewayProbeError: params.gatewayProbe?.error ?? null,
+          ...(params.gatewayCallOverrides ? { callOverrides: params.gatewayCallOverrides } : {}),
+        }),
+        resolveStatusGatewayDiagnosticsSafe(diagnosticsParams),
+        resolveStatusGatewayDiagnosticsSafe({
+          ...diagnosticsParams,
+          type: "telemetry.exporter",
+        }),
+      ]);
 
   params.progress.setLabel("Checking local state…");
   // These probes are intentionally best-effort so status-all can still print a partial report.
@@ -172,7 +178,8 @@ async function resolveStatusAllLocalDiagnosis(params: {
       agentStatus: overview.agentStatus,
       gatewayReachable: params.gatewayReachable,
       health,
-      deliveryDiagnostics: diagnostics,
+      deliveryDiagnostics,
+      exporterDiagnostics,
       nodeOnlyGateway: params.nodeOnlyGateway,
     },
   };

--- a/src/commands/status-all/report-lines.test.ts
+++ b/src/commands/status-all/report-lines.test.ts
@@ -73,6 +73,7 @@ describe("buildStatusAllReportLines", () => {
         channelsStatus: null,
         channelIssues: [],
         deliveryDiagnostics: null,
+        exporterDiagnostics: null,
         gatewayReachable: false,
         health: null,
         nodeOnlyGateway: null,

--- a/src/commands/status-runtime-shared.test.ts
+++ b/src/commands/status-runtime-shared.test.ts
@@ -1,6 +1,7 @@
 // Status runtime shared tests cover gateway health, runtime details, and safe status probe fallbacks.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  resolveStatusGatewayDiagnosticsSafe,
   resolveStatusGatewayHealth,
   resolveStatusGatewayHealthSafe,
   resolveStatusRuntimeSnapshot,
@@ -369,6 +370,22 @@ describe("status-runtime-shared", () => {
       config: { gateway: {} },
       url: "ws://127.0.0.1:18789",
       token: "tok",
+    });
+  });
+
+  it("requests the typed exporter stability projection", async () => {
+    await resolveStatusGatewayDiagnosticsSafe({
+      config: { gateway: {} },
+      timeoutMs: 4321,
+      gatewayReachable: true,
+      type: "telemetry.exporter",
+    });
+
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "diagnostics.stability",
+      params: { limit: 1000, type: "telemetry.exporter" },
+      timeoutMs: 4321,
+      config: { gateway: {} },
     });
   });
 

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -183,6 +183,7 @@ export async function resolveStatusGatewayDiagnosticsSafe(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
   gatewayReachable: boolean;
+  type?: string;
   callOverrides?: {
     url: string;
     token?: string;
@@ -195,7 +196,7 @@ export async function resolveStatusGatewayDiagnosticsSafe(params: {
   const { callGateway } = await loadGatewayCallModule();
   return await callGateway<unknown>({
     method: "diagnostics.stability",
-    params: { limit: 1000 },
+    params: { limit: 1000, ...(params.type ? { type: params.type } : {}) },
     timeoutMs: params.timeoutMs,
     config: params.config,
     ...params.callOverrides,

--- a/src/commands/telemetry-exporter-summary.test.ts
+++ b/src/commands/telemetry-exporter-summary.test.ts
@@ -32,6 +32,7 @@ describe("formatTelemetryExporterSummary", () => {
           type: "telemetry.exporter",
           source: "diagnostics-prometheus",
           target: "metrics",
+          transport: "prometheus-scrape",
           outcome: "failure",
           reason: "handler_failed",
         },
@@ -63,7 +64,7 @@ describe("formatTelemetryExporterSummary", () => {
         "custom_exporter · metrics · started · external SDK ownership",
         "diagnostics-otel · traces · recovered · OTLP/HTTP protobuf (dependency default endpoint) · after export failure",
         "diagnostics-otel · logs · started · stdout",
-        "diagnostics-prometheus · metrics · failed · exporter · handler failed",
+        "diagnostics-prometheus · metrics · failed · prometheus-scrape · handler failed",
       ],
     });
     expect(JSON.stringify(summary)).not.toContain("collector.example");

--- a/src/commands/telemetry-exporter-summary.test.ts
+++ b/src/commands/telemetry-exporter-summary.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { formatTelemetryExporterSummary } from "./telemetry-exporter-summary.js";
+
+describe("formatTelemetryExporterSummary", () => {
+  it("renders bounded redacted exporter facts without misattribution", () => {
+    const summary = formatTelemetryExporterSummary({
+      events: [
+        {
+          seq: 1,
+          type: "telemetry.exporter",
+          source: "https://spoofed.example",
+          target: "traces",
+          transport: "otlp-http-protobuf",
+          outcome: "failure",
+          reason: "export_failed",
+        },
+        {
+          seq: 2,
+          type: "telemetry.exporter",
+          source: "diagnostics-otel",
+          target: "traces",
+          transport: "otlp-http-protobuf",
+          outcome: "recovered",
+          reason: "export_failed",
+          mode: "default_endpoint",
+          url: "https://collector.example/private",
+          headers: { authorization: "secret" },
+          error: "raw collector failure",
+        },
+        {
+          seq: 3,
+          type: "telemetry.exporter",
+          source: "diagnostics-prometheus",
+          target: "metrics",
+          outcome: "failure",
+          reason: "handler_failed",
+        },
+        {
+          seq: 4,
+          type: "telemetry.exporter",
+          source: "custom_exporter",
+          target: "metrics",
+          transport: "external-sdk",
+          outcome: "started",
+          reason: "configured",
+        },
+        {
+          seq: 5,
+          type: "telemetry.exporter",
+          source: "diagnostics-otel",
+          target: "logs",
+          transport: "stdout",
+          outcome: "started",
+          reason: "configured",
+        },
+      ],
+    });
+
+    expect(summary).toEqual({
+      title: "Telemetry exporters",
+      status: "warn",
+      lines: [
+        "custom_exporter · metrics · started · external SDK ownership",
+        "diagnostics-otel · traces · recovered · OTLP/HTTP protobuf (dependency default endpoint) · after export failure",
+        "diagnostics-otel · logs · started · stdout",
+        "diagnostics-prometheus · metrics · failed · exporter · handler failed",
+      ],
+    });
+    expect(JSON.stringify(summary)).not.toContain("collector.example");
+    expect(JSON.stringify(summary)).not.toContain("secret");
+    expect(JSON.stringify(summary)).not.toContain("raw collector failure");
+    expect(JSON.stringify(summary)).not.toContain("spoofed.example");
+  });
+
+  it("warns for a final exporter failure", () => {
+    expect(
+      formatTelemetryExporterSummary({
+        events: [
+          {
+            seq: 1,
+            type: "telemetry.exporter",
+            source: "diagnostics-otel",
+            target: "logs",
+            transport: "otlp-http-protobuf",
+            outcome: "failure",
+            reason: "shutdown_failed",
+            mode: "configured",
+          },
+        ],
+      }),
+    ).toEqual({
+      title: "Telemetry exporters",
+      status: "warn",
+      lines: [
+        "diagnostics-otel · logs · failed · OTLP/HTTP protobuf (explicit endpoint) · shutdown failed",
+      ],
+    });
+  });
+
+  it("renders startup failures with explicit and dependency-default ownership", () => {
+    expect(
+      formatTelemetryExporterSummary({
+        events: [
+          {
+            seq: 1,
+            type: "telemetry.exporter",
+            source: "diagnostics-otel",
+            target: "traces",
+            transport: "otlp-http-protobuf",
+            outcome: "failure",
+            reason: "start_failed",
+            mode: "default_endpoint",
+          },
+          {
+            seq: 2,
+            type: "telemetry.exporter",
+            source: "diagnostics-otel",
+            target: "metrics",
+            transport: "otlp-http-protobuf",
+            outcome: "failure",
+            reason: "start_failed",
+            mode: "configured",
+          },
+        ],
+      }),
+    ).toEqual({
+      title: "Telemetry exporters",
+      status: "warn",
+      lines: [
+        "diagnostics-otel · traces · failed · OTLP/HTTP protobuf (dependency default endpoint) · start failed",
+        "diagnostics-otel · metrics · failed · OTLP/HTTP protobuf (explicit endpoint) · start failed",
+      ],
+    });
+  });
+
+  it("renders stdout recovery without exposing failure details", () => {
+    expect(
+      formatTelemetryExporterSummary({
+        events: [
+          {
+            seq: 1,
+            type: "telemetry.exporter",
+            source: "diagnostics-otel",
+            target: "logs",
+            transport: "stdout",
+            outcome: "recovered",
+            reason: "emit_failed",
+            error: "private stdout details",
+          },
+        ],
+      }),
+    ).toEqual({
+      title: "Telemetry exporters",
+      status: "ok",
+      lines: ["diagnostics-otel · logs · recovered · stdout · after emit failure"],
+    });
+  });
+
+  it("renders safe unknown transports and redacts unsafe ones", () => {
+    const summary = formatTelemetryExporterSummary({
+      events: [
+        {
+          seq: 1,
+          type: "telemetry.exporter",
+          source: "custom_exporter",
+          target: "logs",
+          transport: "vendor-proto",
+          outcome: "started",
+          reason: "configured",
+        },
+        {
+          seq: 2,
+          type: "telemetry.exporter",
+          source: "second_exporter",
+          target: "metrics",
+          transport: "https://private.example/transport",
+          outcome: "failure",
+          reason: "queue_full",
+        },
+      ],
+    });
+
+    expect(summary).toEqual({
+      title: "Telemetry exporters",
+      status: "warn",
+      lines: [
+        "custom_exporter · logs · started · vendor-proto",
+        "second_exporter · metrics · failed · exporter · queue full",
+      ],
+    });
+    expect(JSON.stringify(summary)).not.toContain("private.example");
+  });
+});

--- a/src/commands/telemetry-exporter-summary.test.ts
+++ b/src/commands/telemetry-exporter-summary.test.ts
@@ -174,7 +174,7 @@ describe("formatTelemetryExporterSummary", () => {
           type: "telemetry.exporter",
           source: "second_exporter",
           target: "metrics",
-          transport: "https://private.example/transport",
+          transport: "collector.internal:4318",
           outcome: "failure",
           reason: "queue_full",
         },
@@ -189,6 +189,6 @@ describe("formatTelemetryExporterSummary", () => {
         "second_exporter · metrics · failed · exporter · queue full",
       ],
     });
-    expect(JSON.stringify(summary)).not.toContain("private.example");
+    expect(JSON.stringify(summary)).not.toContain("collector.internal");
   });
 });

--- a/src/commands/telemetry-exporter-summary.ts
+++ b/src/commands/telemetry-exporter-summary.ts
@@ -1,0 +1,150 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+const SIGNALS = ["traces", "metrics", "logs"] as const;
+const STATUSES = ["started", "failure", "recovered", "dropped"] as const;
+const SAFE_CODE = /^[A-Za-z0-9_.:-]{1,120}$/u;
+const REASON_LABELS = {
+  unsupported_protocol: "unsupported protocol",
+  start_failed: "start failed",
+  export_failed: "export failed",
+  handler_failed: "handler failed",
+  emit_failed: "emit failed",
+  queue_full: "queue full",
+  shutdown_failed: "shutdown failed",
+} as const;
+
+type ExporterSignal = (typeof SIGNALS)[number];
+type ExporterStatus = (typeof STATUSES)[number];
+type ExporterReason = keyof typeof REASON_LABELS | "configured" | "default_endpoint";
+
+type ExporterHealthRecord = {
+  seq: number;
+  source: string;
+  signal: ExporterSignal;
+  status: ExporterStatus;
+  transport?: string;
+  reason?: ExporterReason;
+  ownership?: "configured" | "default_endpoint";
+};
+
+function oneOf<const T extends readonly string[]>(value: unknown, choices: T): value is T[number] {
+  return typeof value === "string" && (choices as readonly string[]).includes(value);
+}
+
+function parseExporterHealthRecord(value: unknown): ExporterHealthRecord | undefined {
+  if (
+    !isRecord(value) ||
+    value.type !== "telemetry.exporter" ||
+    typeof value.source !== "string" ||
+    !SAFE_CODE.test(value.source) ||
+    !oneOf(value.target, SIGNALS) ||
+    !oneOf(value.outcome, STATUSES)
+  ) {
+    return undefined;
+  }
+  const seq = typeof value.seq === "number" && Number.isFinite(value.seq) ? value.seq : 0;
+  const transport =
+    typeof value.transport === "string" && SAFE_CODE.test(value.transport)
+      ? value.transport
+      : undefined;
+  const reason =
+    typeof value.reason === "string" &&
+    (value.reason === "configured" ||
+      value.reason === "default_endpoint" ||
+      Object.hasOwn(REASON_LABELS, value.reason))
+      ? (value.reason as ExporterReason)
+      : undefined;
+  const ownership =
+    value.mode === "configured" || value.mode === "default_endpoint" ? value.mode : undefined;
+  return {
+    seq,
+    source: value.source,
+    signal: value.target,
+    status: value.outcome,
+    ...(transport ? { transport } : {}),
+    ...(reason ? { reason } : {}),
+    ...(ownership ? { ownership } : {}),
+  };
+}
+
+function formatTransport(record: ExporterHealthRecord): string {
+  switch (record.transport) {
+    case "otlp-http-protobuf":
+      return record.ownership === "default_endpoint" || record.reason === "default_endpoint"
+        ? "OTLP/HTTP protobuf (dependency default endpoint)"
+        : record.ownership === "configured" || record.reason === "configured"
+          ? "OTLP/HTTP protobuf (explicit endpoint)"
+          : "OTLP/HTTP protobuf";
+    case "stdout":
+      return "stdout";
+    case "external-sdk":
+      return "external SDK ownership";
+    default:
+      return record.transport ?? "exporter";
+  }
+}
+
+function formatReason(record: ExporterHealthRecord): string | undefined {
+  if (record.status === "started") {
+    return undefined;
+  }
+  if (record.status === "recovered" && record.reason === "export_failed") {
+    return "after export failure";
+  }
+  if (record.status === "recovered" && record.reason === "emit_failed") {
+    return "after emit failure";
+  }
+  return record.reason && Object.hasOwn(REASON_LABELS, record.reason)
+    ? REASON_LABELS[record.reason as keyof typeof REASON_LABELS]
+    : undefined;
+}
+
+/** Builds the redacted exporter-health text shared by Doctor and status --all. */
+export function formatTelemetryExporterSummary(snapshot: unknown) {
+  if (!isRecord(snapshot) || !Array.isArray(snapshot.events)) {
+    return null;
+  }
+  const latest = new Map<string, ExporterHealthRecord>();
+  for (const value of snapshot.events) {
+    const record = parseExporterHealthRecord(value);
+    if (!record) {
+      continue;
+    }
+    const key = `${record.source}\u0000${record.signal}\u0000${record.transport ?? "unknown"}`;
+    const previous = latest.get(key);
+    if (!previous || record.seq >= previous.seq) {
+      latest.set(key, record);
+    }
+  }
+  const records = [...latest.values()].toSorted((left, right) => {
+    const sourceOrder = left.source.localeCompare(right.source);
+    if (sourceOrder !== 0) {
+      return sourceOrder;
+    }
+    const signalOrder = SIGNALS.indexOf(left.signal) - SIGNALS.indexOf(right.signal);
+    if (signalOrder !== 0) {
+      return signalOrder;
+    }
+    return (left.transport ?? "").localeCompare(right.transport ?? "");
+  });
+  if (records.length === 0) {
+    return null;
+  }
+  return {
+    title: "Telemetry exporters",
+    status: records.some((record) => record.status === "failure" || record.status === "dropped")
+      ? "warn"
+      : "ok",
+    lines: records.map((record) =>
+      [
+        record.source,
+        record.signal,
+        record.status === "failure" ? "failed" : record.status,
+        formatTransport(record),
+        formatReason(record),
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(" · "),
+    ),
+  };
+}

--- a/src/commands/telemetry-exporter-summary.ts
+++ b/src/commands/telemetry-exporter-summary.ts
@@ -27,6 +27,12 @@ type ExporterHealthRecord = {
   ownership?: "configured" | "default_endpoint";
 };
 
+type TelemetryExporterSummary = {
+  title: string;
+  status: "ok" | "warn";
+  lines: string[];
+};
+
 function oneOf<const T extends readonly string[]>(value: unknown, choices: T): value is T[number] {
   return typeof value === "string" && (choices as readonly string[]).includes(value);
 }
@@ -100,7 +106,7 @@ function formatReason(record: ExporterHealthRecord): string | undefined {
 }
 
 /** Builds the redacted exporter-health text shared by Doctor and status --all. */
-export function formatTelemetryExporterSummary(snapshot: unknown) {
+export function formatTelemetryExporterSummary(snapshot: unknown): TelemetryExporterSummary | null {
   if (!isRecord(snapshot) || !Array.isArray(snapshot.events)) {
     return null;
   }

--- a/src/commands/telemetry-exporter-summary.ts
+++ b/src/commands/telemetry-exporter-summary.ts
@@ -2,7 +2,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
 const SIGNALS = ["traces", "metrics", "logs"] as const;
 const STATUSES = ["started", "failure", "recovered", "dropped"] as const;
-const SAFE_CODE = /^[A-Za-z0-9_.:-]{1,120}$/u;
+const SAFE_EXPORTER_CODE = /^[A-Za-z0-9_-]{1,120}$/u;
 const REASON_LABELS = {
   unsupported_protocol: "unsupported protocol",
   start_failed: "start failed",
@@ -42,7 +42,7 @@ function parseExporterHealthRecord(value: unknown): ExporterHealthRecord | undef
     !isRecord(value) ||
     value.type !== "telemetry.exporter" ||
     typeof value.source !== "string" ||
-    !SAFE_CODE.test(value.source) ||
+    !SAFE_EXPORTER_CODE.test(value.source) ||
     !oneOf(value.target, SIGNALS) ||
     !oneOf(value.outcome, STATUSES)
   ) {
@@ -50,7 +50,7 @@ function parseExporterHealthRecord(value: unknown): ExporterHealthRecord | undef
   }
   const seq = typeof value.seq === "number" && Number.isFinite(value.seq) ? value.seq : 0;
   const transport =
-    typeof value.transport === "string" && SAFE_CODE.test(value.transport)
+    typeof value.transport === "string" && SAFE_EXPORTER_CODE.test(value.transport)
       ? value.transport
       : undefined;
   const reason =

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -761,15 +761,11 @@ export type DiagnosticTelemetryExporterEvent = DiagnosticBaseEvent & {
   type: "telemetry.exporter";
   exporter: string;
   signal: "traces" | "metrics" | "logs";
-  transport?: string;
-  endpointMode?: "configured" | "default_endpoint";
-  status: "started" | "failure" | "recovered" | "dropped";
+  status: "started" | "failure" | "dropped";
   reason?:
     | "configured"
-    | "default_endpoint"
-    | "export_failed"
-    | "handler_failed"
     | "emit_failed"
+    | "handler_failed"
     | "queue_full"
     | "shutdown_failed"
     | "start_failed"

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -761,11 +761,15 @@ export type DiagnosticTelemetryExporterEvent = DiagnosticBaseEvent & {
   type: "telemetry.exporter";
   exporter: string;
   signal: "traces" | "metrics" | "logs";
-  status: "started" | "failure" | "dropped";
+  transport?: string;
+  endpointMode?: "configured" | "default_endpoint";
+  status: "started" | "failure" | "recovered" | "dropped";
   reason?:
     | "configured"
-    | "emit_failed"
+    | "default_endpoint"
+    | "export_failed"
     | "handler_failed"
+    | "emit_failed"
     | "queue_full"
     | "shutdown_failed"
     | "start_failed"

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   emitDiagnosticEvent,
+  emitTrustedDiagnosticEvent,
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
@@ -449,6 +450,390 @@ describe("diagnostic stability recorder", () => {
     expect(snapshot.firstSeq).toBe(6);
     expect(snapshot.lastSeq).toBe(1005);
     expectFields(snapshot.events[0], { seq: 6, queueDepth: 5 });
+  });
+
+  it("keeps trusted exporter state sticky and rejects spoofed untrusted facts", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "failure",
+      reason: "export_failed",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "started",
+      reason: "default_endpoint",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "failure",
+      reason: "export_failed",
+      errorCategory: "collector-secret-message",
+    });
+    for (let index = 0; index < 1005; index += 1) {
+      emitDiagnosticEvent({
+        type: "message.queued",
+        source: "test",
+        queueDepth: index,
+      });
+    }
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({
+      type: "telemetry.exporter",
+      limit: 1000,
+    });
+    const defaultSnapshot = getDiagnosticStabilitySnapshot({ limit: 1000 });
+
+    expect(snapshot.capacity).toBe(16);
+    expect(snapshot.count).toBe(1);
+    expect(snapshot.events).toEqual([
+      expect.objectContaining({
+        type: "telemetry.exporter",
+        source: "diagnostics-otel",
+        target: "traces",
+        transport: "otlp-http-protobuf",
+        outcome: "failure",
+        reason: "export_failed",
+        mode: "default_endpoint",
+      }),
+    ]);
+    expect(JSON.stringify(snapshot)).not.toContain("collector-secret-message");
+    expect(defaultSnapshot.count).toBe(1000);
+    expect(defaultSnapshot.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "message.queued",
+          source: "test",
+        }),
+      ]),
+    );
+    expect(defaultSnapshot.events).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "telemetry.exporter" })]),
+    );
+  });
+
+  it("retains exporter ownership through recovery", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "metrics",
+      transport: "otlp-http-protobuf",
+      status: "started",
+      reason: "configured",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "metrics",
+      transport: "otlp-http-protobuf",
+      status: "failure",
+      reason: "export_failed",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "metrics",
+      transport: "otlp-http-protobuf",
+      status: "recovered",
+      reason: "export_failed",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(
+      getDiagnosticStabilitySnapshot({
+        type: "telemetry.exporter",
+        limit: 1000,
+      }).events,
+    ).toEqual([
+      expect.objectContaining({
+        target: "metrics",
+        outcome: "recovered",
+        reason: "export_failed",
+        mode: "configured",
+      }),
+    ]);
+  });
+
+  it("preserves explicit and dependency-default ownership on startup failures", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      endpointMode: "default_endpoint",
+      status: "failure",
+      reason: "start_failed",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-otel",
+      signal: "metrics",
+      transport: "otlp-http-protobuf",
+      endpointMode: "configured",
+      status: "failure",
+      reason: "start_failed",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(
+      getDiagnosticStabilitySnapshot({
+        type: "telemetry.exporter",
+        limit: 1000,
+      }).events,
+    ).toEqual([
+      expect.objectContaining({
+        target: "traces",
+        transport: "otlp-http-protobuf",
+        outcome: "failure",
+        reason: "start_failed",
+        mode: "default_endpoint",
+      }),
+      expect.objectContaining({
+        target: "metrics",
+        transport: "otlp-http-protobuf",
+        outcome: "failure",
+        reason: "start_failed",
+        mode: "configured",
+      }),
+    ]);
+  });
+
+  it("keeps safe generic codes while dropping unsafe sources and redacting transports", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "diagnostics-prometheus",
+      signal: "metrics",
+      transport: "prometheus-scrape",
+      status: "started",
+      reason: "configured",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "custom-exporter",
+      signal: "logs",
+      transport: "https://private.example/transport",
+      status: "failure",
+      reason: "queue_full",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "telemetry.exporter",
+      exporter: "https://private.example/exporter",
+      signal: "traces",
+      transport: "vendor-proto",
+      status: "failure",
+      reason: "export_failed",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({
+      type: "telemetry.exporter",
+      limit: 1000,
+    });
+    expect(snapshot.events).toEqual([
+      expect.objectContaining({
+        source: "diagnostics-prometheus",
+        transport: "prometheus-scrape",
+      }),
+      expect.objectContaining({
+        source: "custom-exporter",
+        outcome: "failure",
+        reason: "queue_full",
+      }),
+    ]);
+    expect(snapshot.events[1]).not.toHaveProperty("transport");
+    expect(JSON.stringify(snapshot)).not.toContain("private.example");
+  });
+
+  it("replaces retired routes while retaining every current logs both route", async () => {
+    startDiagnosticStabilityRecorder();
+    const emitExporter = (
+      event: Omit<
+        Extract<Parameters<typeof emitTrustedDiagnosticEvent>[0], { type: "telemetry.exporter" }>,
+        "type"
+      >,
+    ) => {
+      emitTrustedDiagnosticEvent({ type: "telemetry.exporter", ...event });
+    };
+
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "started",
+      reason: "configured",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "dropped",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "external-sdk",
+      status: "started",
+      reason: "configured",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(
+      getDiagnosticStabilitySnapshot({ type: "telemetry.exporter", limit: 1000 }).events,
+    ).toEqual([
+      expect.objectContaining({
+        target: "traces",
+        transport: "external-sdk",
+        outcome: "started",
+      }),
+    ]);
+
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "external-sdk",
+      status: "dropped",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "failure",
+      reason: "unsupported_protocol",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "otlp-http-protobuf",
+      status: "started",
+      reason: "configured",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "started",
+      reason: "configured",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    let events = getDiagnosticStabilitySnapshot({
+      type: "telemetry.exporter",
+      limit: 1000,
+    }).events;
+    expect(events.filter((event) => event.target === "traces")).toEqual([
+      expect.objectContaining({
+        transport: "otlp-http-protobuf",
+        outcome: "failure",
+        reason: "unsupported_protocol",
+      }),
+    ]);
+    expect(events.filter((event) => event.target === "logs")).toEqual([
+      expect.objectContaining({ transport: "otlp-http-protobuf", outcome: "started" }),
+      expect.objectContaining({ transport: "stdout", outcome: "started" }),
+    ]);
+
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "dropped",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "started",
+      reason: "configured",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(
+      getDiagnosticStabilitySnapshot({ type: "telemetry.exporter", limit: 1000 }).events.filter(
+        (event) => event.target === "traces",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        transport: "otlp-http-protobuf",
+        outcome: "started",
+      }),
+    ]);
+
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "otlp-http-protobuf",
+      status: "dropped",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "dropped",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "started",
+      reason: "configured",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    events = getDiagnosticStabilitySnapshot({
+      type: "telemetry.exporter",
+      limit: 1000,
+    }).events;
+    expect(events.filter((event) => event.target === "logs")).toEqual([
+      expect.objectContaining({ transport: "stdout", outcome: "started" }),
+    ]);
+
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "dropped",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "otlp-http-protobuf",
+      status: "started",
+      reason: "configured",
+    });
+    emitExporter({
+      exporter: "diagnostics-otel",
+      signal: "logs",
+      transport: "stdout",
+      status: "started",
+      reason: "configured",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    events = getDiagnosticStabilitySnapshot({
+      type: "telemetry.exporter",
+      limit: 1000,
+    }).events;
+    expect(events.filter((event) => event.target === "logs")).toEqual([
+      expect.objectContaining({ transport: "otlp-http-protobuf", outcome: "started" }),
+      expect.objectContaining({ transport: "stdout", outcome: "started" }),
+    ]);
   });
 
   it("filters snapshots by type, sequence, and limit", () => {

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -2,17 +2,18 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   emitDiagnosticEvent,
-  emitTrustedDiagnosticEvent,
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
 import {
   getDiagnosticStabilitySnapshot,
   normalizeDiagnosticStabilityQuery,
+  recordDiagnosticExporterHealth,
   resetDiagnosticStabilityRecorderForTest,
   selectDiagnosticStabilitySnapshot,
   startDiagnosticStabilityRecorder,
   stopDiagnosticStabilityRecorder,
+  type DiagnosticExporterHealthUpdate,
   type DiagnosticStabilitySnapshot,
 } from "./diagnostic-stability.js";
 
@@ -459,26 +460,23 @@ describe("diagnostic stability recorder", () => {
       type: "telemetry.exporter",
       exporter: "diagnostics-otel",
       signal: "traces",
-      transport: "otlp-http-protobuf",
       status: "failure",
-      reason: "export_failed",
+      reason: "emit_failed",
     });
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-otel",
+    recordDiagnosticExporterHealth("diagnostics-otel", {
       signal: "traces",
       transport: "otlp-http-protobuf",
+      endpointMode: "default_endpoint",
       status: "started",
-      reason: "default_endpoint",
+      reason: "configured",
     });
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-otel",
+    recordDiagnosticExporterHealth("diagnostics-otel", {
       signal: "traces",
       transport: "otlp-http-protobuf",
+      endpointMode: "default_endpoint",
       status: "failure",
       reason: "export_failed",
-      errorCategory: "collector-secret-message",
+      errorCategory: "https://collector.example/private",
     });
     for (let index = 0; index < 1005; index += 1) {
       emitDiagnosticEvent({
@@ -508,7 +506,7 @@ describe("diagnostic stability recorder", () => {
         mode: "default_endpoint",
       }),
     ]);
-    expect(JSON.stringify(snapshot)).not.toContain("collector-secret-message");
+    expect(JSON.stringify(snapshot)).not.toContain("collector.example");
     expect(defaultSnapshot.count).toBe(1000);
     expect(defaultSnapshot.events).toEqual(
       expect.arrayContaining([
@@ -526,25 +524,20 @@ describe("diagnostic stability recorder", () => {
   it("retains exporter ownership through recovery", async () => {
     startDiagnosticStabilityRecorder();
 
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-otel",
+    recordDiagnosticExporterHealth("diagnostics-otel", {
       signal: "metrics",
       transport: "otlp-http-protobuf",
+      endpointMode: "configured",
       status: "started",
       reason: "configured",
     });
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-otel",
+    recordDiagnosticExporterHealth("diagnostics-otel", {
       signal: "metrics",
       transport: "otlp-http-protobuf",
       status: "failure",
       reason: "export_failed",
     });
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-otel",
+    recordDiagnosticExporterHealth("diagnostics-otel", {
       signal: "metrics",
       transport: "otlp-http-protobuf",
       status: "recovered",
@@ -570,18 +563,14 @@ describe("diagnostic stability recorder", () => {
   it("preserves explicit and dependency-default ownership on startup failures", async () => {
     startDiagnosticStabilityRecorder();
 
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-otel",
+    recordDiagnosticExporterHealth("diagnostics-otel", {
       signal: "traces",
       transport: "otlp-http-protobuf",
       endpointMode: "default_endpoint",
       status: "failure",
       reason: "start_failed",
     });
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-otel",
+    recordDiagnosticExporterHealth("diagnostics-otel", {
       signal: "metrics",
       transport: "otlp-http-protobuf",
       endpointMode: "configured",
@@ -616,30 +605,39 @@ describe("diagnostic stability recorder", () => {
   it("keeps safe generic codes while dropping unsafe sources and redacting transports", async () => {
     startDiagnosticStabilityRecorder();
 
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "diagnostics-prometheus",
+    recordDiagnosticExporterHealth("diagnostics-prometheus", {
       signal: "metrics",
       transport: "prometheus-scrape",
       status: "started",
       reason: "configured",
     });
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "custom-exporter",
+    recordDiagnosticExporterHealth("custom-exporter", {
       signal: "logs",
       transport: "collector.internal:4318",
+      endpointMode:
+        "https://private.example/mode" as DiagnosticExporterHealthUpdate["endpointMode"],
       status: "failure",
       reason: "queue_full",
+      errorCategory: "TypeError",
     });
-    emitTrustedDiagnosticEvent({
-      type: "telemetry.exporter",
-      exporter: "https://private.example/exporter",
+    recordDiagnosticExporterHealth("https://private.example/exporter", {
       signal: "traces",
       transport: "vendor-proto",
       status: "failure",
       reason: "export_failed",
     });
+    recordDiagnosticExporterHealth("diagnostics-otel", {
+      signal: "private-signal",
+      transport: "otlp-http-protobuf",
+      status: "failure",
+      reason: "export_failed",
+    } as unknown as DiagnosticExporterHealthUpdate);
+    recordDiagnosticExporterHealth("diagnostics-otel", {
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "private-status",
+      reason: "export_failed",
+    } as unknown as DiagnosticExporterHealthUpdate);
     await waitForDiagnosticEventsDrained();
 
     const snapshot = getDiagnosticStabilitySnapshot({
@@ -655,22 +653,22 @@ describe("diagnostic stability recorder", () => {
         source: "custom-exporter",
         outcome: "failure",
         reason: "queue_full",
+        errorCategory: "TypeError",
       }),
     ]);
     expect(snapshot.events[1]).not.toHaveProperty("transport");
+    expect(snapshot.events[1]).not.toHaveProperty("mode");
     expect(JSON.stringify(snapshot)).not.toContain("collector.internal");
     expect(JSON.stringify(snapshot)).not.toContain("private.example");
+    expect(JSON.stringify(snapshot)).not.toContain("private-signal");
+    expect(JSON.stringify(snapshot)).not.toContain("private-status");
   });
 
   it("replaces retired routes while retaining every current logs both route", async () => {
     startDiagnosticStabilityRecorder();
-    const emitExporter = (
-      event: Omit<
-        Extract<Parameters<typeof emitTrustedDiagnosticEvent>[0], { type: "telemetry.exporter" }>,
-        "type"
-      >,
-    ) => {
-      emitTrustedDiagnosticEvent({ type: "telemetry.exporter", ...event });
+    const emitExporter = (event: DiagnosticExporterHealthUpdate & { exporter: string }) => {
+      const { exporter, ...update } = event;
+      recordDiagnosticExporterHealth(exporter, update);
     };
 
     emitExporter({

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -628,7 +628,7 @@ describe("diagnostic stability recorder", () => {
       type: "telemetry.exporter",
       exporter: "custom-exporter",
       signal: "logs",
-      transport: "https://private.example/transport",
+      transport: "collector.internal:4318",
       status: "failure",
       reason: "queue_full",
     });
@@ -658,6 +658,7 @@ describe("diagnostic stability recorder", () => {
       }),
     ]);
     expect(snapshot.events[1]).not.toHaveProperty("transport");
+    expect(JSON.stringify(snapshot)).not.toContain("collector.internal");
     expect(JSON.stringify(snapshot)).not.toContain("private.example");
   });
 

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -1,6 +1,6 @@
 // Diagnostic stability helpers compare diagnostic outputs across runs.
 import {
-  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
   type DiagnosticMemoryUsage,
 } from "../infra/diagnostic-events.js";
@@ -9,6 +9,7 @@ import {
 const DEFAULT_DIAGNOSTIC_STABILITY_CAPACITY = 1000;
 const DEFAULT_DIAGNOSTIC_STABILITY_LIMIT = 50;
 export const MAX_DIAGNOSTIC_STABILITY_LIMIT = DEFAULT_DIAGNOSTIC_STABILITY_CAPACITY;
+const MAX_DIAGNOSTIC_EXPORTER_STATES = 16;
 const LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 
 const SAFE_REASON_CODE = /^[A-Za-z0-9_.:-]{1,120}$/u;
@@ -140,6 +141,8 @@ type DiagnosticStabilityState = {
   nextIndex: number;
   count: number;
   dropped: number;
+  exporterRecords: Map<string, DiagnosticStabilityEventRecord>;
+  exporterDropped: number;
   unsubscribe: (() => void) | null;
 };
 
@@ -150,6 +153,8 @@ function createState(capacity = DEFAULT_DIAGNOSTIC_STABILITY_CAPACITY): Diagnost
     nextIndex: 0,
     count: 0,
     dropped: 0,
+    exporterRecords: new Map(),
+    exporterDropped: 0,
     unsubscribe: null,
   };
 }
@@ -542,9 +547,21 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       assignReasonCode(record, event.reason);
       break;
     case "telemetry.exporter":
-      record.source = event.exporter;
+      record.source = copyReasonCode(event.exporter);
       record.target = event.signal;
       record.outcome = event.status;
+      const transport = copyReasonCode(event.transport);
+      if (transport) {
+        record.transport = transport;
+      }
+      if (event.endpointMode === "configured" || event.endpointMode === "default_endpoint") {
+        record.mode = event.endpointMode;
+      } else if (
+        event.status === "started" &&
+        (event.reason === "configured" || event.reason === "default_endpoint")
+      ) {
+        record.mode = event.reason;
+      }
       assignReasonCode(record, event.reason ?? event.errorCategory);
       break;
     case "diagnostic.async_queue.dropped":
@@ -577,6 +594,34 @@ function appendRecord(record: DiagnosticStabilityEventRecord): void {
   state.dropped += 1;
 }
 
+function upsertExporterRecord(record: DiagnosticStabilityEventRecord): void {
+  if (!record.source) {
+    return;
+  }
+  const state = getDiagnosticStabilityState();
+  const key = `${record.source}\u0000${record.target ?? "unknown"}\u0000${record.transport ?? "unknown"}`;
+  if (record.outcome === "dropped") {
+    state.exporterRecords.delete(key);
+    return;
+  }
+  const previous = state.exporterRecords.get(key);
+  if (!record.mode && previous?.mode) {
+    record.mode = previous.mode;
+  }
+  if (
+    !state.exporterRecords.has(key) &&
+    state.exporterRecords.size >= MAX_DIAGNOSTIC_EXPORTER_STATES
+  ) {
+    const oldestKey = state.exporterRecords.keys().next().value;
+    if (oldestKey !== undefined) {
+      state.exporterRecords.delete(oldestKey);
+      state.exporterDropped += 1;
+    }
+  }
+  state.exporterRecords.delete(key);
+  state.exporterRecords.set(key, record);
+}
+
 function listRecords(): DiagnosticStabilityEventRecord[] {
   const state = getDiagnosticStabilityState();
   if (state.count === 0) {
@@ -591,6 +636,12 @@ function listRecords(): DiagnosticStabilityEventRecord[] {
     ...state.records.slice(state.nextIndex),
     ...state.records.slice(0, state.nextIndex),
   ].filter((record): record is DiagnosticStabilityEventRecord => record !== undefined);
+}
+
+function listExporterRecords(): DiagnosticStabilityEventRecord[] {
+  return [...getDiagnosticStabilityState().exporterRecords.values()].toSorted(
+    (left, right) => left.seq - right.seq,
+  );
 }
 
 function summarizeRecords(
@@ -733,7 +784,16 @@ export function startDiagnosticStabilityRecorder(): void {
   if (state.unsubscribe) {
     return;
   }
-  state.unsubscribe = onDiagnosticEvent((event) => {
+  state.unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
+    if (event.type === "telemetry.exporter") {
+      if (metadata.trusted) {
+        upsertExporterRecord(sanitizeDiagnosticEvent(event));
+      }
+      return;
+    }
+    if (metadata.trusted || event.type === "log.record") {
+      return;
+    }
     appendRecord(sanitizeDiagnosticEvent(event));
   });
 }
@@ -752,12 +812,16 @@ export function getDiagnosticStabilitySnapshot(options?: {
   sinceSeq?: number;
 }): DiagnosticStabilitySnapshot {
   const state = getDiagnosticStabilityState();
-  const { filtered, events } = selectRecords(listRecords(), options);
+  const exporterQuery = options?.type === "telemetry.exporter";
+  const { filtered, events } = selectRecords(
+    exporterQuery ? listExporterRecords() : listRecords(),
+    options,
+  );
   return {
     generatedAt: new Date().toISOString(),
-    capacity: state.capacity,
+    capacity: exporterQuery ? MAX_DIAGNOSTIC_EXPORTER_STATES : state.capacity,
     count: filtered.length,
-    dropped: state.dropped,
+    dropped: exporterQuery ? state.exporterDropped : state.dropped,
     firstSeq: filtered[0]?.seq,
     lastSeq: filtered.at(-1)?.seq,
     events,

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -13,6 +13,7 @@ const MAX_DIAGNOSTIC_EXPORTER_STATES = 16;
 const LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 
 const SAFE_REASON_CODE = /^[A-Za-z0-9_.:-]{1,120}$/u;
+const SAFE_EXPORTER_CODE = /^[A-Za-z0-9_-]{1,120}$/u;
 
 /** Sanitized diagnostic event record retained in the stability ring buffer. */
 export type DiagnosticStabilityEventRecord = {
@@ -176,6 +177,10 @@ function copyReasonCode(reason: string | undefined): string | undefined {
     return undefined;
   }
   return reason;
+}
+
+function copyExporterCode(value: string | undefined): string | undefined {
+  return value && SAFE_EXPORTER_CODE.test(value) ? value : undefined;
 }
 
 function assignReasonCode(
@@ -547,10 +552,10 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       assignReasonCode(record, event.reason);
       break;
     case "telemetry.exporter":
-      record.source = copyReasonCode(event.exporter);
+      record.source = copyExporterCode(event.exporter);
       record.target = event.signal;
       record.outcome = event.status;
-      const transport = copyReasonCode(event.transport);
+      const transport = copyExporterCode(event.transport);
       if (transport) {
         record.transport = transport;
       }

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -27,6 +27,7 @@ export type DiagnosticStabilityEventRecord = {
   surface?: string;
   action?: string;
   reason?: string;
+  errorCategory?: string;
   outcome?: string;
   mode?: string;
   level?: string;
@@ -142,9 +143,28 @@ type DiagnosticStabilityState = {
   nextIndex: number;
   count: number;
   dropped: number;
+  exporterSeq: number;
   exporterRecords: Map<string, DiagnosticStabilityEventRecord>;
   exporterDropped: number;
   unsubscribe: (() => void) | null;
+};
+
+export type DiagnosticExporterHealthUpdate = {
+  signal: "traces" | "metrics" | "logs";
+  transport: string;
+  endpointMode?: "configured" | "default_endpoint";
+  status: "started" | "failure" | "recovered" | "dropped";
+  reason?:
+    | "configured"
+    | "default_endpoint"
+    | "export_failed"
+    | "handler_failed"
+    | "emit_failed"
+    | "queue_full"
+    | "shutdown_failed"
+    | "start_failed"
+    | "unsupported_protocol";
+  errorCategory?: string;
 };
 
 function createState(capacity = DEFAULT_DIAGNOSTIC_STABILITY_CAPACITY): DiagnosticStabilityState {
@@ -154,6 +174,7 @@ function createState(capacity = DEFAULT_DIAGNOSTIC_STABILITY_CAPACITY): Diagnost
     nextIndex: 0,
     count: 0,
     dropped: 0,
+    exporterSeq: 0,
     exporterRecords: new Map(),
     exporterDropped: 0,
     unsubscribe: null,
@@ -172,15 +193,27 @@ function copyMemory(memory: DiagnosticMemoryUsage): DiagnosticMemoryUsage {
   return { ...memory };
 }
 
-function copyReasonCode(reason: string | undefined): string | undefined {
-  if (!reason || !SAFE_REASON_CODE.test(reason)) {
+function copyReasonCode(reason: unknown): string | undefined {
+  if (typeof reason !== "string" || !SAFE_REASON_CODE.test(reason)) {
     return undefined;
   }
   return reason;
 }
 
-function copyExporterCode(value: string | undefined): string | undefined {
-  return value && SAFE_EXPORTER_CODE.test(value) ? value : undefined;
+function copyExporterCode(value: unknown): string | undefined {
+  return typeof value === "string" && SAFE_EXPORTER_CODE.test(value) ? value : undefined;
+}
+
+function isDiagnosticExporterSignal(
+  value: unknown,
+): value is DiagnosticExporterHealthUpdate["signal"] {
+  return value === "traces" || value === "metrics" || value === "logs";
+}
+
+function isDiagnosticExporterStatus(
+  value: unknown,
+): value is DiagnosticExporterHealthUpdate["status"] {
+  return value === "started" || value === "failure" || value === "recovered" || value === "dropped";
 }
 
 function assignReasonCode(
@@ -551,25 +584,12 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.pluginId = event.pluginId;
       assignReasonCode(record, event.reason);
       break;
-    case "telemetry.exporter": {
+    case "telemetry.exporter":
       record.source = copyExporterCode(event.exporter);
       record.target = event.signal;
       record.outcome = event.status;
-      const transport = copyExporterCode(event.transport);
-      if (transport) {
-        record.transport = transport;
-      }
-      if (event.endpointMode === "configured" || event.endpointMode === "default_endpoint") {
-        record.mode = event.endpointMode;
-      } else if (
-        event.status === "started" &&
-        (event.reason === "configured" || event.reason === "default_endpoint")
-      ) {
-        record.mode = event.reason;
-      }
       assignReasonCode(record, event.reason ?? event.errorCategory);
       break;
-    }
     case "diagnostic.async_queue.dropped":
       record.droppedEvents = event.droppedEvents;
       record.droppedTrustedEvents = event.droppedTrustedEvents;
@@ -626,6 +646,44 @@ function upsertExporterRecord(record: DiagnosticStabilityEventRecord): void {
   }
   state.exporterRecords.delete(key);
   state.exporterRecords.set(key, record);
+}
+
+/** Records a trusted diagnostics-exporter health transition outside the public event contract. */
+export function recordDiagnosticExporterHealth(
+  exporter: string,
+  update: DiagnosticExporterHealthUpdate,
+): void {
+  const source = copyExporterCode(exporter);
+  if (
+    !source ||
+    !isDiagnosticExporterSignal(update.signal) ||
+    !isDiagnosticExporterStatus(update.status)
+  ) {
+    return;
+  }
+  const state = getDiagnosticStabilityState();
+  state.exporterSeq += 1;
+  const record: DiagnosticStabilityEventRecord = {
+    seq: state.exporterSeq,
+    ts: Date.now(),
+    type: "telemetry.exporter",
+    source,
+    target: update.signal,
+    outcome: update.status,
+  };
+  const transport = copyExporterCode(update.transport);
+  if (transport) {
+    record.transport = transport;
+  }
+  if (update.endpointMode === "configured" || update.endpointMode === "default_endpoint") {
+    record.mode = update.endpointMode;
+  }
+  const errorCategory = copyReasonCode(update.errorCategory);
+  if (errorCategory) {
+    record.errorCategory = errorCategory;
+  }
+  assignReasonCode(record, update.reason ?? update.errorCategory);
+  upsertExporterRecord(record);
 }
 
 function listRecords(): DiagnosticStabilityEventRecord[] {
@@ -792,9 +850,6 @@ export function startDiagnosticStabilityRecorder(): void {
   }
   state.unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
     if (event.type === "telemetry.exporter") {
-      if (metadata.trusted) {
-        upsertExporterRecord(sanitizeDiagnosticEvent(event));
-      }
       return;
     }
     if (metadata.trusted || event.type === "log.record") {

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -551,7 +551,7 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.pluginId = event.pluginId;
       assignReasonCode(record, event.reason);
       break;
-    case "telemetry.exporter":
+    case "telemetry.exporter": {
       record.source = copyExporterCode(event.exporter);
       record.target = event.signal;
       record.outcome = event.status;
@@ -569,6 +569,7 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       }
       assignReasonCode(record, event.reason ?? event.errorCategory);
       break;
+    }
     case "diagnostic.async_queue.dropped":
       record.droppedEvents = event.droppedEvents;
       record.droppedTrustedEvents = event.droppedTrustedEvents;

--- a/src/plugin-sdk/plugin-service-context.test.ts
+++ b/src/plugin-sdk/plugin-service-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest";
 import type { OpenClawPluginServiceContext as CoreServiceContext } from "./core.js";
-import type { DiagnosticEventPrivateData } from "./diagnostic-runtime.js";
+import type { DiagnosticEventPayload, DiagnosticEventPrivateData } from "./diagnostic-runtime.js";
 import type { OpenClawPluginServiceContext as PluginEntryServiceContext } from "./plugin-entry.js";
 
 type ListenerArgs<T extends { internalDiagnostics?: unknown }> =
@@ -13,6 +13,10 @@ type ListenerArgs<T extends { internalDiagnostics?: unknown }> =
     : never;
 
 type ListenerPrivateData<T extends { internalDiagnostics?: unknown }> = ListenerArgs<T>[2];
+type InternalDiagnostics<T extends { internalDiagnostics?: unknown }> = NonNullable<
+  T["internalDiagnostics"]
+>;
+type TelemetryExporterEvent = Extract<DiagnosticEventPayload, { type: "telemetry.exporter" }>;
 
 describe("plugin service diagnostics contract", () => {
   it("keeps host attribution out of public SDK listener declarations", () => {
@@ -26,6 +30,35 @@ describe("plugin service diagnostics contract", () => {
     expectTypeOf<ListenerArgs<CoreServiceContext>["length"]>().toEqualTypeOf<3>();
     expectTypeOf<
       "hostPluginId" extends keyof ListenerPrivateData<PluginEntryServiceContext> ? true : false
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      "reportExporterHealth" extends keyof InternalDiagnostics<PluginEntryServiceContext>
+        ? true
+        : false
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      "reportExporterHealth" extends keyof InternalDiagnostics<CoreServiceContext> ? true : false
+    >().toEqualTypeOf<false>();
+  });
+
+  it("keeps the shipped telemetry exporter event union unchanged", () => {
+    expectTypeOf<TelemetryExporterEvent["status"]>().toEqualTypeOf<
+      "started" | "failure" | "dropped"
+    >();
+    expectTypeOf<NonNullable<TelemetryExporterEvent["reason"]>>().toEqualTypeOf<
+      | "configured"
+      | "emit_failed"
+      | "handler_failed"
+      | "queue_full"
+      | "shutdown_failed"
+      | "start_failed"
+      | "unsupported_protocol"
+    >();
+    expectTypeOf<
+      "transport" extends keyof TelemetryExporterEvent ? true : false
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      "endpointMode" extends keyof TelemetryExporterEvent ? true : false
     >().toEqualTypeOf<false>();
   });
 });

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -23,10 +23,21 @@ import {
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
 import { markHostPluginUsageDiagnosticEvent } from "../infra/diagnostic-plugin-usage-provenance.js";
+import {
+  getDiagnosticStabilitySnapshot,
+  resetDiagnosticStabilityRecorderForTest,
+  type DiagnosticExporterHealthUpdate,
+} from "../logging/diagnostic-stability.js";
 import { queuePluginSessionsChanged, subscribePluginSessionsChanged } from "./gateway-events.js";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 import { startPluginServices } from "./services.js";
+
+type TrustedExporterInternalDiagnostics = NonNullable<
+  OpenClawPluginServiceContext["internalDiagnostics"]
+> & {
+  reportExporterHealth?: (update: DiagnosticExporterHealthUpdate) => void;
+};
 
 function createRegistry(
   services: OpenClawPluginService[],
@@ -149,6 +160,7 @@ describe("startPluginServices", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetDiagnosticEventsForTest();
+    resetDiagnosticStabilityRecorderForTest();
     resetPluginRuntimeStateForTest();
   });
 
@@ -661,6 +673,59 @@ describe("startPluginServices", () => {
     ]);
   });
 
+  it("retains trusted exporter startup health after host rollback", async () => {
+    const rollback = vi.fn();
+    const handle = await startPluginServices({
+      registry: createRegistry(
+        [
+          {
+            id: "diagnostics-otel",
+            start: (ctx) => {
+              const reportExporterHealth = (
+                ctx.internalDiagnostics as TrustedExporterInternalDiagnostics | undefined
+              )?.reportExporterHealth;
+              if (!reportExporterHealth) {
+                throw new Error("expected trusted exporter health reporter");
+              }
+              reportExporterHealth({
+                signal: "traces",
+                transport: "otlp-http-protobuf",
+                endpointMode: "configured",
+                status: "failure",
+                reason: "start_failed",
+                errorCategory: "TypeError",
+              });
+              throw new TypeError("SDK startup failed");
+            },
+            stop: rollback,
+          },
+        ],
+        "diagnostics-otel",
+        "bundled",
+      ),
+      config: createServiceConfig(),
+    });
+
+    expect(rollback).toHaveBeenCalledOnce();
+    await handle.stop();
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(
+      getDiagnosticStabilitySnapshot({
+        type: "telemetry.exporter",
+        limit: 1000,
+      }).events,
+    ).toEqual([
+      expect.objectContaining({
+        source: "diagnostics-otel",
+        target: "traces",
+        transport: "otlp-http-protobuf",
+        outcome: "failure",
+        reason: "start_failed",
+        errorCategory: "TypeError",
+      }),
+    ]);
+  });
+
   it("emits per-service startup trace spans and summary", async () => {
     const measured: string[] = [];
     const details: Array<{
@@ -789,6 +854,10 @@ describe("startPluginServices", () => {
     expect(contexts[0]?.internalDiagnostics?.onEvent).toBeTypeOf("function");
     expect(contexts[0]?.internalDiagnostics?.emit).toBeTypeOf("function");
     expect(contexts[0]?.internalDiagnostics?.registerTracePropagationBridge).toBeTypeOf("function");
+    expect(
+      (contexts[0]?.internalDiagnostics as TrustedExporterInternalDiagnostics | undefined)
+        ?.reportExporterHealth,
+    ).toBeTypeOf("function");
 
     const prometheusContexts: OpenClawPluginServiceContext[] = [];
     const prometheusService = createTrackingService("diagnostics-prometheus", {
@@ -804,6 +873,10 @@ describe("startPluginServices", () => {
     expect(prometheusContexts[0]?.internalDiagnostics?.registerTracePropagationBridge).toBeTypeOf(
       "function",
     );
+    expect(
+      (prometheusContexts[0]?.internalDiagnostics as TrustedExporterInternalDiagnostics | undefined)
+        ?.reportExporterHealth,
+    ).toBeTypeOf("function");
 
     const officialDiagnosticsOtelContexts: OpenClawPluginServiceContext[] = [];
     const officialDiagnosticsOtelService = createTrackingService("diagnostics-otel", {
@@ -824,6 +897,13 @@ describe("startPluginServices", () => {
     expect(
       officialDiagnosticsOtelContexts[0]?.internalDiagnostics?.registerTracePropagationBridge,
     ).toBeTypeOf("function");
+    expect(
+      (
+        officialDiagnosticsOtelContexts[0]?.internalDiagnostics as
+          | TrustedExporterInternalDiagnostics
+          | undefined
+      )?.reportExporterHealth,
+    ).toBeTypeOf("function");
 
     const officialInstallContexts: OpenClawPluginServiceContext[] = [];
     const officialInstallService = createTrackingService("diagnostics-prometheus", {
@@ -838,6 +918,13 @@ describe("startPluginServices", () => {
     expect(officialInstallContexts[0]?.internalDiagnostics?.emit).toBeTypeOf("function");
     expect(
       officialInstallContexts[0]?.internalDiagnostics?.registerTracePropagationBridge,
+    ).toBeTypeOf("function");
+    expect(
+      (
+        officialInstallContexts[0]?.internalDiagnostics as
+          | TrustedExporterInternalDiagnostics
+          | undefined
+      )?.reportExporterHealth,
     ).toBeTypeOf("function");
 
     const untrustedContexts: OpenClawPluginServiceContext[] = [];
@@ -861,6 +948,26 @@ describe("startPluginServices", () => {
     });
 
     expect(spoofedContexts[0]?.internalDiagnostics).toBeUndefined();
+
+    (
+      contexts[0]?.internalDiagnostics as TrustedExporterInternalDiagnostics | undefined
+    )?.reportExporterHealth?.({
+      signal: "traces",
+      transport: "otlp-http-protobuf",
+      status: "recovered",
+      reason: "export_failed",
+    });
+    expect(
+      getDiagnosticStabilitySnapshot({ type: "telemetry.exporter", limit: 1000 }).events,
+    ).toEqual([
+      expect.objectContaining({
+        source: "diagnostics-otel",
+        target: "traces",
+        transport: "otlp-http-protobuf",
+        outcome: "recovered",
+        reason: "export_failed",
+      }),
+    ]);
   });
 
   it("delivers host plugin attribution only to the trusted OTel listener lane", async () => {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -9,6 +9,10 @@ import {
 } from "../infra/diagnostic-events.js";
 import { markTrustedOtelDiagnosticListener } from "../infra/diagnostic-otel-listener-provenance.js";
 import { registerDiagnosticTracePropagationBridge } from "../infra/diagnostic-trace-propagation.js";
+import {
+  recordDiagnosticExporterHealth,
+  type DiagnosticExporterHealthUpdate,
+} from "../logging/diagnostic-stability.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { subscribePluginSessionsChanged } from "./gateway-events.js";
 import { isPluginJsonValue, type PluginJsonValue } from "./host-hook-json.js";
@@ -19,6 +23,12 @@ import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
 import type { OpenClawPluginServiceContext, PluginLogger } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
+type TrustedExporterInternalDiagnostics = NonNullable<
+  OpenClawPluginServiceContext["internalDiagnostics"]
+> & {
+  reportExporterHealth: (update: DiagnosticExporterHealthUpdate) => void;
+};
+
 function createPluginLogger(): PluginLogger {
   return {
     info: (msg) => log.info(msg),
@@ -43,6 +53,19 @@ function createServiceContext(params: {
   const grantsInternalDiagnostics =
     isDiagnosticsExporter &&
     (params.service?.origin === "bundled" || params.service?.trustedOfficialInstall === true);
+  const internalDiagnostics: TrustedExporterInternalDiagnostics | undefined =
+    grantsInternalDiagnostics
+      ? {
+          emit: emitTrustedDiagnosticEventWithPrivateData,
+          onEvent: isOtelExporter
+            ? (listener) =>
+                onTrustedInternalDiagnosticEvent(markTrustedOtelDiagnosticListener(listener))
+            : onTrustedInternalDiagnosticEvent,
+          registerTracePropagationBridge: registerDiagnosticTracePropagationBridge,
+          reportExporterHealth: (update) =>
+            recordDiagnosticExporterHealth(params.service.service.id, update),
+        }
+      : undefined;
 
   return {
     config: params.config,
@@ -58,18 +81,7 @@ function createServiceContext(params: {
           ),
         }
       : {}),
-    ...(grantsInternalDiagnostics
-      ? {
-          internalDiagnostics: {
-            emit: emitTrustedDiagnosticEventWithPrivateData,
-            onEvent: isOtelExporter
-              ? (listener) =>
-                  onTrustedInternalDiagnosticEvent(markTrustedOtelDiagnosticListener(listener))
-              : onTrustedInternalDiagnosticEvent,
-            registerTracePropagationBridge: registerDiagnosticTracePropagationBridge,
-          },
-        }
-      : {}),
+    ...(internalDiagnostics ? { internalDiagnostics } : {}),
   };
 }
 


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/93070

Related follow-up: https://github.com/openclaw/openclaw/issues/119927

## What Problem This Solves

Operators could enable OpenTelemetry export and receive no telemetry while
`openclaw doctor` and `openclaw status --all` had no durable, per-signal
explanation of exporter state.

## Architecture

Final exporter outcomes come from the diagnostics exporters after
dependency-owned retries settle. `service-exporter-health.ts` is the sole route
state machine. A private, feature-detected
`internalDiagnostics.reportExporterHealth` callback admits trusted exporter
facts into one bounded, redacted Gateway projection.

The shipped public `DiagnosticEventPayload` and public plugin SDK exports remain
unchanged:

- public exporter statuses remain `started`, `failure`, and `dropped`;
- public reason literals and fields remain unchanged;
- recovery emits no public event;
- transport, endpoint mode, redacted final failure, and recovery stay private;
- public lifecycle facts are coalesced per signal, so multi-transport logs do
  not double-count events or metrics;
- only bundled or trusted official diagnostics exporters receive the callback.

Prometheus metric names and labels are unchanged. No config, gateway protocol,
SQLite, public plugin SDK, or gateway-status surface is added.

## Correctness Repairs

- `OTEL_SDK_DISABLED=true` suppresses all operator health for plugin-owned trace
  and metric OTLP routes, including malformed endpoints, unsupported protocols,
  startup failures, and false `started` claims.
- A failed diagnostics exporter start remains visible through
  `startPluginServices` mandatory rollback instead of being erased by `stop`.
- Private per-transport transitions project to one existing signal-level public
  lifecycle and one Prometheus/OTel counter increment.

## Evidence

Exact head: `c194a9bd433e54424f08c02d47a4228507230069`.

- Exact-head ownership-fix rerun: 196 passed, 0 failed across two Vitest shards
  (`src/plugins/services.test.ts` and the diagnostics-otel service suite).
- Production-equivalent focused P1 matrix: 228 passed, 0 failed across three
  Vitest shards.
- Production-equivalent broader matrix: 371 passed, 0 failed across six Vitest
  shards.
- Real OTLP receiver coverage includes retry-then-success without a false
  failure, persistent 503, connection reset, timeout, and later recovery.
- Disabled-mode coverage includes supported, unsupported, malformed, and
  mocked startup-failure paths; plugin-owned logs remain covered as active.
- Host integration starts through `startPluginServices` and verifies the
  Gateway snapshot retains `start_failed` after rollback.
- Public event and metric cardinality tests cover `logsExporter: "both"`.
- Public-surface type coverage locks the shipped exporter status/reason union,
  rejects transport/endpoint fields, and confirms the private callback is absent
  from both public service-context exports.
- Trust, redaction, bounded-state, route ordering, recovery, retirement, and
  Prometheus lifecycle coverage passed.
- `git diff --check`, targeted oxfmt/oxlint, max-lines, Plugin SDK API/export
  baselines, plugin boundaries, dependency pins, dead-export checks, and
  TruffleHog passed.
- The exact `check-tsgo-core-boundary.mjs` gate passed after replacing the core
  test's extension import with a generic trusted fake service.
- Knip no longer reports the task's former unlisted
  `@opentelemetry/sdk-node` dependency. The local full scan reaches unrelated
  sparse-checkout omissions instead.
- `node scripts/check-changed.mjs` passed every changed-file guard before the
  unchanged `packages/terminal-core/src/ansi.ts:194` type baseline and sparse
  package-resolution baseline.
- Final local P1 autoreview reported no accepted/actionable finding and rated
  the test-ownership repair correct at 0.94.

Exact-head GitHub CI completed with 137 checks, 0 pending, and 0 failed.
ClawSweeper reviewed the same head with no correctness finding.

## Dependency Contract Inspection

Installed dependency source was inspected directly:

- `@opentelemetry/core@2.10.0`
  - `build/src/platform/node/environment.js:55-72` trims and lowercases boolean
    environment values, accepting only `true` and `false`.
- `@opentelemetry/otlp-exporter-base@0.221.0`
  - `build/src/OTLPExporterBase.js:18-20` delegates the exporter callback.
  - `build/src/retrying-transport.js:32-61` completes dependency-owned retries
    before returning the final transport result.
  - `build/src/otlp-export-delegate.js:31-96` invokes the result callback after
    that transport promise settles; request serialization can fail
    synchronously before the promise exists.
- `@opentelemetry/sdk-node@0.221.0`
  - `build/src/sdk.js:90-95` reads `OTEL_SDK_DISABLED`.
  - `build/src/sdk.js:156-166` returns before context-manager and propagator
    setup when disabled.

## Repair Boundary

- Root cause: final exporter state lived in transient callbacks while the
  public diagnostic event union was being used as an internal health transport.
- Architectural owner: exporter plugins detect final outcomes; the private host
  callback admits trusted facts; `service-exporter-health.ts` owns route
  transitions; shared diagnostics owns bounded projection and CLI rendering.
- Canonical fix: preserve the public event contract and carry private
  transport/endpoint/failure/recovery facts directly to the projection.
- Removed path: public recovery/transport/endpoint expansion and public-event
  ingestion as the authoritative health source.
- Recovery correction delta against inherited head `281c94da3cb2`: production
  `+377/-103`; tests `+716/-129`.
- ClawSweeper's full PR surface against its current-main review base:
  production `+925/-125`; tests `+2,455/-23`.
- Positive production growth adds the operator-health capability, canonical
  multi-cause route ownership, trust gating, redaction, shared rendering,
  disabled-route claim suppression, and rollback preservation.

## Explicit Non-Goal

This PR only prevents false operator-health claims for disabled plugin-owned
trace and metric routes. It does **not** implement full
`OTEL_SDK_DISABLED` conformance: plugin-owned logs can still initialize, and the
dependency returns before propagator setup.

The canonical full suppression and propagation repair remains
https://github.com/openclaw/openclaw/issues/119927.
