### PR TITLE
fix(hooks): target hook-triggered heartbeat wakes at the hook agent/session (#119808)

### DIFF
--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -461,6 +461,7 @@ async function expectNotifyOnExitWake(tool: ExecToolInstance, expected: Record<s
 async function drainNotifyEvents(sessionKey = DEFAULT_NOTIFY_SESSION_KEY) {
   return await drainFormattedSystemEvents({
     cfg: notifyCfg,
+    agentId: "main",
     sessionKey,
     isMainSession: false,
     isNewSession: false,

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -135,6 +135,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     if (!useFastReplyRuntime && heartbeatRunScope !== "commitment-only") {
       const eventsBlock = await drainFormattedSystemEvents({
         cfg,
+        agentId,
         sessionKey,
         isMainSession,
         isNewSession,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -10,6 +10,12 @@ import {
 } from "../../agents/embedded-agent-runner/runs.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { HEARTBEAT_RUN_SCOPE } from "../../infra/heartbeat-run-scope.js";
+import { withSystemEventOwner } from "../../infra/system-event-ownership.js";
+import {
+  enqueueSystemEvent,
+  peekSystemEventEntries,
+  resetSystemEventsForTest,
+} from "../../infra/system-events.js";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { hasControlCommand } from "../command-detection.js";
@@ -352,6 +358,7 @@ describe("runPreparedReply media-only handling", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    resetSystemEventsForTest();
     const paths = cleanupPaths.splice(0);
     return Promise.all(paths.map((entry) => rm(entry, { recursive: true, force: true })));
   });
@@ -3702,6 +3709,40 @@ describe("runPreparedReply media-only handling", () => {
 
     const call = requireRunReplyAgentCall();
     expect(call.followupRun.prompt).toContain("System: [t] Node connected.");
+  });
+
+  it("admits only system events visible to the prepared agent", async () => {
+    const actualSystemEvents = await vi.importActual<typeof import("./session-system-events.js")>(
+      "./session-system-events.js",
+    );
+    vi.mocked(drainFormattedSystemEvents).mockImplementationOnce(
+      actualSystemEvents.drainFormattedSystemEvents,
+    );
+    enqueueSystemEvent(
+      "Alpha hook finished",
+      withSystemEventOwner({ sessionKey: "global" }, "alpha"),
+    );
+    enqueueSystemEvent(
+      "Beta hook finished",
+      withSystemEventOwner({ sessionKey: "global" }, "beta"),
+    );
+    enqueueSystemEvent("Legacy unowned event", { sessionKey: "global" });
+
+    await runPreparedReply(
+      baseParams({
+        agentId: "alpha",
+        sessionKey: "global",
+        opts: { isHeartbeat: true },
+      }),
+    );
+
+    const call = requireRunReplyAgentCall();
+    expect(call.followupRun.prompt).toContain("Alpha hook finished");
+    expect(call.followupRun.prompt).toContain("Legacy unowned event");
+    expect(call.followupRun.prompt).not.toContain("Beta hook finished");
+    expect(peekSystemEventEntries("global").map((event) => event.text)).toEqual([
+      "Beta hook finished",
+    ]);
   });
 
   it("does not strip think-hint token from deferred queue body", async () => {

--- a/src/auto-reply/reply/session-reset-cleanup.test.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.test.ts
@@ -4,6 +4,7 @@ import {
   clearEmbeddedSessionPromptStates,
   getEmbeddedSessionPromptState,
 } from "../../agents/embedded-agent-runner/session-prompt-state.js";
+import { withSystemEventOwner } from "../../infra/system-event-ownership.js";
 import {
   enqueueSystemEvent,
   peekSystemEvents,
@@ -26,7 +27,7 @@ describe("clearSessionResetRuntimeState", () => {
     const state = getEmbeddedSessionPromptState("old-session");
     state.sentUserTurnIds.add("sent-user-turn");
 
-    clearSessionResetRuntimeState(["old-session"]);
+    clearSessionResetRuntimeState(["old-session"], { agentId: "main" });
 
     expect(getEmbeddedSessionPromptState("old-session")).not.toBe(state);
   });
@@ -36,13 +37,26 @@ describe("clearSessionResetRuntimeState", () => {
     enqueueSystemEvent("stale beta", { sessionKey: "beta" });
     enqueueSystemEvent("fresh gamma", { sessionKey: "gamma" });
 
-    const result = clearSessionResetRuntimeState([" alpha ", undefined, " ", "alpha", "beta"]);
+    const result = clearSessionResetRuntimeState([" alpha ", undefined, " ", "alpha", "beta"], {
+      agentId: "main",
+    });
 
     expect(result.keys).toEqual(["alpha", "beta"]);
     expect(result.systemEventsCleared).toBe(2);
     expect(peekSystemEvents("alpha")).toStrictEqual([]);
     expect(peekSystemEvents("beta")).toStrictEqual([]);
     expect(peekSystemEvents("gamma")).toEqual(["fresh gamma"]);
+  });
+
+  it("preserves events owned by other agents during an agent-scoped reset", () => {
+    enqueueSystemEvent("unowned", { sessionKey: "global" });
+    enqueueSystemEvent("alpha", withSystemEventOwner({ sessionKey: "global" }, "alpha"));
+    enqueueSystemEvent("beta", withSystemEventOwner({ sessionKey: "global" }, "beta"));
+
+    const result = clearSessionResetRuntimeState(["global"], { agentId: " Alpha " });
+
+    expect(result.systemEventsCleared).toBe(2);
+    expect(peekSystemEvents("global")).toEqual(["beta"]);
   });
 
   it("releases active reply work owned by the archived reset session id", () => {
@@ -60,6 +74,7 @@ describe("clearSessionResetRuntimeState", () => {
     operation.setPhase("running");
 
     clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      agentId: "main",
       activeReplySessionId: "old-session",
     });
 
@@ -82,6 +97,7 @@ describe("clearSessionResetRuntimeState", () => {
     operation.setPhase("running");
 
     clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      agentId: "main",
       activeReplySessionId: "old-session",
     });
 
@@ -111,6 +127,7 @@ describe("clearSessionResetRuntimeState", () => {
     operation.setPhase("running");
 
     clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      agentId: "main",
       activeReplySessionId: "old-session",
     });
 
@@ -126,6 +143,7 @@ describe("clearSessionResetRuntimeState", () => {
     });
 
     clearSessionResetRuntimeState(["agent:main:slack:room:1", "old-session"], {
+      agentId: "main",
       activeReplySessionId: "old-session",
     });
 

--- a/src/auto-reply/reply/session-reset-cleanup.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.ts
@@ -1,6 +1,10 @@
 /** Clears reset-related queues and system events for session keys. */
 import { clearEmbeddedSessionPromptStates } from "../../agents/embedded-agent-runner/session-prompt-state.js";
-import { drainSystemEventEntries } from "../../infra/system-events.js";
+import { selectAgentSystemEvents } from "../../infra/system-event-ownership.js";
+import {
+  consumeSelectedSystemEventEntries,
+  peekSystemEventEntries,
+} from "../../infra/system-events.js";
 import { clearSessionQueues, type ClearSessionQueueResult } from "./queue/cleanup.js";
 import { clearReplyRunForResetBySessionId } from "./reply-run-registry.js";
 
@@ -9,20 +13,26 @@ type ClearSessionResetRuntimeStateResult = ClearSessionQueueResult & {
   systemEventsCleared: number;
 };
 
-/** Clears queued follow-ups and pending system events for reset session keys. */
+/** Clears queued follow-ups and pending system events visible to the resetting agent. */
 export function clearSessionResetRuntimeState(
   keys: Array<string | undefined>,
-  opts?: { activeReplySessionId?: string },
+  opts: { agentId: string; activeReplySessionId?: string },
 ): ClearSessionResetRuntimeStateResult {
   clearEmbeddedSessionPromptStates(keys);
   const cleared = clearSessionQueues(keys);
   let systemEventsCleared = 0;
 
   for (const key of cleared.keys) {
-    systemEventsCleared += drainSystemEventEntries(key).length;
+    // Global session rows may share one transient queue across agents. An
+    // agent-scoped reset must not discard another agent's pending work.
+    const removed = consumeSelectedSystemEventEntries(
+      key,
+      selectAgentSystemEvents(peekSystemEventEntries(key), opts.agentId),
+    );
+    systemEventsCleared += removed.length;
   }
 
-  if (opts?.activeReplySessionId) {
+  if (opts.activeReplySessionId) {
     clearReplyRunForResetBySessionId(opts.activeReplySessionId);
   }
 

--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -1,4 +1,3 @@
-// Records system-level session events for restarts, forks, and resets.
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -12,6 +11,8 @@ import {
   resolveTimezone,
 } from "../../infra/format-time/format-datetime.ts";
 import { isExecCompletionEvent } from "../../infra/heartbeat-events-filter.js";
+// Records system-level session events for restarts, forks, and resets.
+import { selectAgentSystemEvents } from "../../infra/system-event-ownership.js";
 import {
   consumeSelectedSystemEventEntries,
   peekSystemEventEntries,
@@ -104,6 +105,7 @@ function formatSystemEventTimestamp(ts: number, cfg: OpenClawConfig) {
 /** Drain queued system events, format as `System:` lines, return the block text (or undefined). */
 export async function drainFormattedSystemEvents(params: {
   cfg: OpenClawConfig;
+  agentId: string;
   sessionKey: string;
   isMainSession: boolean;
   isNewSession: boolean;
@@ -115,9 +117,10 @@ export async function drainFormattedSystemEvents(params: {
   // so the heartbeat path can consume and deliver them.
   const queued = consumeSelectedSystemEventEntries(
     params.sessionKey,
-    selectGenericSystemEvents(peekSystemEventEntries(params.sessionKey), {
-      suppressHeartbeatOwnedEvents: params.suppressHeartbeatOwnedEvents,
-    }),
+    selectGenericSystemEvents(
+      selectAgentSystemEvents(peekSystemEventEntries(params.sessionKey), params.agentId),
+      { suppressHeartbeatOwnedEvents: params.suppressHeartbeatOwnedEvents },
+    ),
   );
   const sessionStateTargets = queued
     .map((event) =>

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1291,6 +1291,7 @@ describe("initSessionState RawBody", () => {
     await expect(
       drainFormattedSystemEvents({
         cfg,
+        agentId: "main",
         sessionKey,
         isMainSession: false,
         isNewSession: true,
@@ -2141,6 +2142,7 @@ describe("initSessionState reset policy", () => {
     await expect(
       drainFormattedSystemEvents({
         cfg,
+        agentId: "main",
         sessionKey,
         isMainSession: false,
         isNewSession: true,
@@ -4326,6 +4328,7 @@ describe("drainFormattedSystemEvents", () => {
 
       const result = await drainFormattedSystemEvents({
         cfg: {} as OpenClawConfig,
+        agentId: "main",
         sessionKey: "agent:main:main",
         isMainSession: true,
         isNewSession: false,
@@ -4346,6 +4349,7 @@ describe("drainFormattedSystemEvents", () => {
 
     const result = await drainFormattedSystemEvents({
       cfg: { channels: {} } as OpenClawConfig,
+      agentId: "main",
       sessionKey: "agent:main:main",
       isMainSession: true,
       isNewSession: true,
@@ -4371,6 +4375,7 @@ describe("drainFormattedSystemEvents", () => {
 
       const result = await drainFormattedSystemEvents({
         cfg: {} as OpenClawConfig,
+        agentId: "main",
         sessionKey: "agent:main:main",
         isMainSession: true,
         isNewSession: false,
@@ -4395,6 +4400,7 @@ describe("drainFormattedSystemEvents", () => {
 
       const result = await drainFormattedSystemEvents({
         cfg: {} as OpenClawConfig,
+        agentId: "main",
         sessionKey: "agent:main:main",
         isMainSession: true,
         isNewSession: false,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -741,6 +741,7 @@ async function initSessionStateAttemptLocked(
   if (previousSessionEntry) {
     clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId], {
       activeReplySessionId: previousSessionEntry.sessionId,
+      agentId,
     });
   }
 

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -911,4 +911,55 @@ describe("dispatchAgentHook trust handling", () => {
     });
     expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
+
+  it("carries the fresh default agent on the global-scope announce wake", async () => {
+    // Global session scope resolves the event key to the unscoped "global"
+    // sentinel, which carries no agent identity; the scheduler cannot resolve
+    // a target from it, so the wake must carry the fresh default agent or the
+    // announced event sits unread.
+    loadConfigMock.mockImplementation(() => ({
+      agents: { entries: { main: { default: true } } },
+      session: { scope: "global" },
+    }));
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "done",
+      delivered: false,
+      deliveryAttempted: false,
+    });
+
+    dispatchAgentHook({
+      ...buildAgentPayload("Email"),
+      deliver: true,
+    });
+
+    await waitForFast(() => expect(enqueueSystemEventMock).toHaveBeenCalled());
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+$/),
+      agentId: "main",
+      sessionKey: "global",
+    });
+  });
+
+  it("carries the fresh default agent on the global-scope failure wake", async () => {
+    loadConfigMock.mockImplementation(() => ({
+      agents: { entries: { main: { default: true } } },
+      session: { scope: "global" },
+    }));
+    runCronIsolatedAgentTurnMock.mockRejectedValueOnce(new Error("agent exploded"));
+
+    dispatchAgentHook(buildAgentPayload("Email"));
+
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
+      agentId: "main",
+      sessionKey: "global",
+    });
+  });
 });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -859,6 +859,34 @@ describe("dispatchAgentHook trust handling", () => {
     expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
 
+  it("omits the default agentId from the announce wake when no agent is named", async () => {
+    // An unnamed hook resolves its event session from fresh config at announce
+    // time; pairing the dispatch-time default agent with that session could
+    // wake a stale agent after a default-agent reload.
+    runCronIsolatedAgentTurnMock.mockResolvedValueOnce({
+      status: "ok",
+      summary: "done",
+      delivered: false,
+      deliveryAttempted: false,
+    });
+
+    dispatchAgentHook({
+      ...buildAgentPayload("Email"),
+      deliver: true,
+    });
+
+    await waitForFast(() => expect(enqueueSystemEventMock).toHaveBeenCalled());
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    const wake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(wake).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+$/),
+      sessionKey: "agent:main:main",
+    });
+    expect(wake.agentId).toBeUndefined();
+  });
+
   it("keeps global-scope error events and wakes on the selected agent", async () => {
     loadConfigMock.mockReturnValue({
       agents: { entries: { main: { default: true }, hooks: {} } },

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -962,4 +962,56 @@ describe("dispatchAgentHook trust handling", () => {
       sessionKey: "global",
     });
   });
+
+  it("carries the explicit agent on the recovered global failure wake when the initial key is absent", async () => {
+    // Early config resolution fails before the event key resolves, so
+    // hookEventSessionKey is absent; recovery still yields the unscoped
+    // "global" sentinel. The failure wake must reuse the recovered key and
+    // attach the explicit agent so the queued failure event is consumed.
+    loadConfigMock.mockImplementationOnce(() => {
+      throw new Error("config exploded");
+    });
+    resolveMainSessionKeyMock.mockReturnValueOnce("global").mockReturnValueOnce("global");
+
+    const result = await dispatchAgentHook(buildAgentPayload("Config", "hooks"));
+
+    expect(result).toMatchObject({
+      ok: false,
+      statusCode: 502,
+      error: "hook agent run failed before entering the agent runner",
+      runId: expect.any(String),
+    });
+    await waitForFast(() =>
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+        "Hook Config (error): Error: config exploded",
+        { sessionKey: "global" },
+      ),
+    );
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
+      agentId: "hooks",
+    });
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
+  });
+
+  it("carries the fresh default agent on the recovered global failure wake when no agent is named", async () => {
+    loadConfigMock.mockImplementationOnce(() => {
+      throw new Error("config exploded");
+    });
+    resolveMainSessionKeyMock.mockReturnValueOnce("global").mockReturnValueOnce("global");
+
+    dispatchAgentHook(buildAgentPayload("Config"));
+
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
+      agentId: "main",
+    });
+    expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
+  });
 });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -3,6 +3,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSystemEventOptionsOwnerAgentId } from "../../infra/system-event-ownership.js";
 import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -59,10 +60,12 @@ vi.mock("../../config/io.js", () => ({
 }));
 
 let capturedDispatchAgentHook: ((...args: unknown[]) => unknown) | undefined;
+let capturedDispatchWakeHook: ((...args: unknown[]) => unknown) | undefined;
 
 vi.mock("./hooks-request-handler.js", () => ({
   createHooksRequestHandler: vi.fn((opts: Record<string, unknown>) => {
     capturedDispatchAgentHook = opts.dispatchAgentHook as typeof capturedDispatchAgentHook;
+    capturedDispatchWakeHook = opts.dispatchWakeHook as typeof capturedDispatchWakeHook;
     return vi.fn();
   }),
 }));
@@ -74,6 +77,12 @@ function waitForFast<T>(
   options: { timeout?: number; interval?: number } = {},
 ) {
   return vi.waitFor(callback, { interval: 1, ...options });
+}
+
+function expectOwnedSystemEvent(text: string, ownerAgentId: string): void {
+  const call = enqueueSystemEventMock.mock.calls.find(([queuedText]) => queuedText === text);
+  expect(call?.[1]).toEqual({ sessionKey: "global" });
+  expect(resolveSystemEventOptionsOwnerAgentId(call?.[1] as object)).toBe(ownerAgentId);
 }
 
 function buildMinimalParams(overrides: { agentStartAdmissionTimeoutMs?: number } = {}) {
@@ -116,6 +125,13 @@ function buildAgentPayload(name: string, agentId?: string) {
 
 function dispatchAgentHook(payload: unknown): unknown {
   return resolveDispatchAgentHook()(payload);
+}
+
+function dispatchWakeHook(payload: unknown): unknown {
+  if (!capturedDispatchWakeHook) {
+    throw new Error("dispatchWakeHook missing");
+  }
+  return capturedDispatchWakeHook(payload);
 }
 
 function resolveDispatchAgentHook(): (...args: unknown[]) => unknown {
@@ -178,12 +194,35 @@ describe("dispatchAgentHook trust handling", () => {
     resolveOutboundChannelPluginMock.mockReturnValue({ id: "telegram" });
     resolveChannelDefaultAccountIdMock.mockReturnValue("default");
     capturedDispatchAgentHook = undefined;
+    capturedDispatchWakeHook = undefined;
     createGatewayHooksRequestHandler(buildMinimalParams());
   });
 
   afterEach(() => {
     resetGatewayWorkAdmission();
     vi.restoreAllMocks();
+  });
+
+  it("queues and targets a mapped global wake for the same agent", () => {
+    loadConfigMock.mockReturnValue({
+      agents: { entries: { main: { default: true }, hooks: {} } },
+      session: { scope: "global" },
+    });
+
+    dispatchWakeHook({
+      text: "Mapped wake",
+      mode: "now",
+      agentId: "hooks",
+      sessionKey: "hook:mapped",
+    });
+
+    expectOwnedSystemEvent("Mapped wake", "hooks");
+    expect(requestHeartbeatMock).toHaveBeenCalledWith({
+      source: "hook",
+      intent: "immediate",
+      reason: "hook:wake",
+      agentId: "hooks",
+    });
   });
 
   it("passes normalized delivery through to the isolated CronJob", async () => {
@@ -844,12 +883,7 @@ describe("dispatchAgentHook trust handling", () => {
       delivery: { mode: "announce" as const },
     });
 
-    await waitForFast(() =>
-      expect(enqueueSystemEventMock).toHaveBeenCalledWith("Hook Global announce: done", {
-        sessionKey: "global",
-        ownerAgentId: "hooks",
-      }),
-    );
+    await waitForFast(() => expectOwnedSystemEvent("Hook Global announce: done", "hooks"));
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
     expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
       source: "hook",
@@ -898,10 +932,7 @@ describe("dispatchAgentHook trust handling", () => {
     dispatchAgentHook(buildAgentPayload("Global error", "hooks"));
 
     await waitForFast(() =>
-      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
-        "Hook Global error (error): Error: agent exploded",
-        { sessionKey: "global", ownerAgentId: "hooks" },
-      ),
+      expectOwnedSystemEvent("Hook Global error (error): Error: agent exploded", "hooks"),
     );
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
     expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
@@ -913,10 +944,10 @@ describe("dispatchAgentHook trust handling", () => {
     expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
 
-  it("carries the fresh default agent on the global-scope announce wake", async () => {
+  it("carries the accepted default agent on the global-scope announce wake", async () => {
     // Global session scope resolves the event key to the unscoped "global"
     // sentinel, which carries no agent identity; the scheduler cannot resolve
-    // a target from it, so the wake must carry the fresh default agent or the
+    // a target from it, so the wake must carry the accepted agent or the
     // announced event sits unread.
     loadConfigMock.mockImplementation(() => ({
       agents: { entries: { main: { default: true } } },
@@ -946,7 +977,7 @@ describe("dispatchAgentHook trust handling", () => {
     expect(announceWake.sessionKey).toBeUndefined();
   });
 
-  it("carries the fresh default agent on the global-scope failure wake", async () => {
+  it("carries the accepted default agent on the global-scope failure wake", async () => {
     loadConfigMock.mockImplementation(() => ({
       agents: { entries: { main: { default: true } } },
       session: { scope: "global" },
@@ -985,10 +1016,7 @@ describe("dispatchAgentHook trust handling", () => {
       runId: expect.any(String),
     });
     await waitForFast(() =>
-      expect(enqueueSystemEventMock).toHaveBeenCalledWith(
-        "Hook Config (error): Error: config exploded",
-        { sessionKey: "global", ownerAgentId: "hooks" },
-      ),
+      expectOwnedSystemEvent("Hook Config (error): Error: config exploded", "hooks"),
     );
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
     expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
@@ -1016,75 +1044,5 @@ describe("dispatchAgentHook trust handling", () => {
       agentId: "main",
     });
     expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
-  });
-
-  it("keeps the global announce wake on the dispatch-time agent after a default-agent reload", async () => {
-    // Dispatch accepts "main" as the default; while the run is queued the
-    // config reloads so "work" becomes default. The announce wake must still
-    // target the accepted agent — the one the isolated run actually used —
-    // not the freshly resolved default.
-    const dispatch = resolveDispatchAgentHook();
-    let currentConfig: OpenClawConfig = {
-      agents: { entries: { main: { default: true }, work: { default: false } } },
-      session: { scope: "global" },
-    };
-    loadConfigMock.mockImplementation(() => currentConfig);
-    const firstGate = createDeferred();
-    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
-      await firstGate.promise;
-      return { status: "ok", summary: "done", delivered: false, deliveryAttempted: false };
-    });
-
-    dispatch({ ...buildAgentPayload("Email"), deliver: true });
-    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
-
-    currentConfig = {
-      agents: { entries: { work: { default: true } } },
-      session: { scope: "global" },
-    };
-    firstGate.resolve();
-
-    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
-    const wake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(wake).toMatchObject({
-      source: "hook",
-      intent: "immediate",
-      reason: expect.stringMatching(/^hook:[0-9a-f-]+$/),
-      agentId: "main",
-    });
-    expect(wake.sessionKey).toBeUndefined();
-  });
-
-  it("keeps the global failure wake on the dispatch-time agent after a default-agent reload", async () => {
-    const dispatch = resolveDispatchAgentHook();
-    let currentConfig: OpenClawConfig = {
-      agents: { entries: { main: { default: true }, work: { default: false } } },
-      session: { scope: "global" },
-    };
-    loadConfigMock.mockImplementation(() => currentConfig);
-    const firstGate = createDeferred();
-    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
-      await firstGate.promise;
-      throw new Error("agent exploded");
-    });
-
-    dispatch(buildAgentPayload("Email"));
-    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
-
-    currentConfig = {
-      agents: { entries: { work: { default: true } } },
-      session: { scope: "global" },
-    };
-    firstGate.resolve();
-
-    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
-    const wake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(wake).toMatchObject({
-      source: "hook",
-      intent: "immediate",
-      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
-      agentId: "main",
-    });
-    expect(wake.sessionKey).toBeUndefined();
   });
 });

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -847,6 +847,7 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() =>
       expect(enqueueSystemEventMock).toHaveBeenCalledWith("Hook Global announce: done", {
         sessionKey: "global",
+        ownerAgentId: "hooks",
       }),
     );
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
@@ -899,7 +900,7 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() =>
       expect(enqueueSystemEventMock).toHaveBeenCalledWith(
         "Hook Global error (error): Error: agent exploded",
-        { sessionKey: "global" },
+        { sessionKey: "global", ownerAgentId: "hooks" },
       ),
     );
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
@@ -935,13 +936,14 @@ describe("dispatchAgentHook trust handling", () => {
 
     await waitForFast(() => expect(enqueueSystemEventMock).toHaveBeenCalled());
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
-    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+    const announceWake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(announceWake).toMatchObject({
       source: "hook",
       intent: "immediate",
       reason: expect.stringMatching(/^hook:[0-9a-f-]+$/),
       agentId: "main",
-      sessionKey: "global",
     });
+    expect(announceWake.sessionKey).toBeUndefined();
   });
 
   it("carries the fresh default agent on the global-scope failure wake", async () => {
@@ -954,13 +956,14 @@ describe("dispatchAgentHook trust handling", () => {
     dispatchAgentHook(buildAgentPayload("Email"));
 
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
-    expect(requestHeartbeatMock.mock.calls[0]?.[0]).toMatchObject({
+    const failureWake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(failureWake).toMatchObject({
       source: "hook",
       intent: "immediate",
       reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
       agentId: "main",
-      sessionKey: "global",
     });
+    expect(failureWake.sessionKey).toBeUndefined();
   });
 
   it("carries the explicit agent on the recovered global failure wake when the initial key is absent", async () => {
@@ -984,7 +987,7 @@ describe("dispatchAgentHook trust handling", () => {
     await waitForFast(() =>
       expect(enqueueSystemEventMock).toHaveBeenCalledWith(
         "Hook Config (error): Error: config exploded",
-        { sessionKey: "global" },
+        { sessionKey: "global", ownerAgentId: "hooks" },
       ),
     );
     await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -1021,7 +1021,7 @@ describe("dispatchAgentHook trust handling", () => {
     // target the accepted agent — the one the isolated run actually used —
     // not the freshly resolved default.
     const dispatch = resolveDispatchAgentHook();
-    let currentConfig = {
+    let currentConfig: OpenClawConfig = {
       agents: { entries: { main: { default: true }, work: { default: false } } },
       session: { scope: "global" },
     };
@@ -1054,7 +1054,7 @@ describe("dispatchAgentHook trust handling", () => {
 
   it("keeps the global failure wake on the dispatch-time agent after a default-agent reload", async () => {
     const dispatch = resolveDispatchAgentHook();
-    let currentConfig = {
+    let currentConfig: OpenClawConfig = {
       agents: { entries: { main: { default: true }, work: { default: false } } },
       session: { scope: "global" },
     };

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -1014,4 +1014,74 @@ describe("dispatchAgentHook trust handling", () => {
     });
     expect(requestHeartbeatMock.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
+
+  it("keeps the global announce wake on the dispatch-time agent after a default-agent reload", async () => {
+    // Dispatch accepts "main" as the default; while the run is queued the
+    // config reloads so "work" becomes default. The announce wake must still
+    // target the accepted agent — the one the isolated run actually used —
+    // not the freshly resolved default.
+    const dispatch = resolveDispatchAgentHook();
+    let currentConfig = {
+      agents: { entries: { main: { default: true }, work: { default: false } } },
+      session: { scope: "global" },
+    };
+    loadConfigMock.mockImplementation(() => currentConfig);
+    const firstGate = createDeferred();
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+      await firstGate.promise;
+      return { status: "ok", summary: "done", delivered: false, deliveryAttempted: false };
+    });
+
+    dispatch({ ...buildAgentPayload("Email"), deliver: true });
+    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
+
+    currentConfig = {
+      agents: { entries: { work: { default: true } } },
+      session: { scope: "global" },
+    };
+    firstGate.resolve();
+
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    const wake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(wake).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+$/),
+      agentId: "main",
+    });
+    expect(wake.sessionKey).toBeUndefined();
+  });
+
+  it("keeps the global failure wake on the dispatch-time agent after a default-agent reload", async () => {
+    const dispatch = resolveDispatchAgentHook();
+    let currentConfig = {
+      agents: { entries: { main: { default: true }, work: { default: false } } },
+      session: { scope: "global" },
+    };
+    loadConfigMock.mockImplementation(() => currentConfig);
+    const firstGate = createDeferred();
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+      await firstGate.promise;
+      throw new Error("agent exploded");
+    });
+
+    dispatch(buildAgentPayload("Email"));
+    await waitForFast(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
+
+    currentConfig = {
+      agents: { entries: { work: { default: true } } },
+      session: { scope: "global" },
+    };
+    firstGate.resolve();
+
+    await waitForFast(() => expect(requestHeartbeatMock).toHaveBeenCalledTimes(1));
+    const wake = requestHeartbeatMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(wake).toMatchObject({
+      source: "hook",
+      intent: "immediate",
+      reason: expect.stringMatching(/^hook:[0-9a-f-]+:error$/),
+      agentId: "main",
+    });
+    expect(wake.sessionKey).toBeUndefined();
+  });
 });

--- a/src/gateway/server/hooks.terminal-target.test.ts
+++ b/src/gateway/server/hooks.terminal-target.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSystemEventOptionsOwnerAgentId } from "../../infra/system-event-ownership.js";
+import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
+
+const enqueueSystemEventMock = vi.fn();
+const requestHeartbeatMock = vi.fn();
+const runCronIsolatedAgentTurnMock = vi.fn();
+const loadConfigMock = vi.fn<() => OpenClawConfig>();
+const logHooksWarnMock = vi.fn();
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeat: requestHeartbeatMock,
+}));
+vi.mock("../../cron/isolated-agent.js", () => ({
+  runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
+}));
+vi.mock("../../config/io.js", () => ({
+  getRuntimeConfig: loadConfigMock,
+}));
+
+let capturedDispatchAgentHook: ((value: HookPayload) => Promise<unknown>) | undefined;
+
+vi.mock("./hooks-request-handler.js", () => ({
+  createHooksRequestHandler: vi.fn((opts: Record<string, unknown>) => {
+    capturedDispatchAgentHook = opts.dispatchAgentHook as typeof capturedDispatchAgentHook;
+    return vi.fn();
+  }),
+}));
+
+const { createGatewayHooksRequestHandler } = await import("./hooks.js");
+
+type HookPayload = {
+  message: string;
+  name: string;
+  agentId?: string;
+  wakeMode: "now" | "next-heartbeat";
+  sessionKey: string;
+  sourcePath: string;
+  deliver: boolean;
+  channel: "last";
+  delivery: { mode: "none" };
+};
+
+function payload(overrides: Partial<HookPayload> = {}): HookPayload {
+  return {
+    message: "test message",
+    name: "Email",
+    wakeMode: "now",
+    sessionKey: "session-1",
+    sourcePath: "/hooks/agent",
+    deliver: true,
+    channel: "last",
+    delivery: { mode: "none" },
+    ...overrides,
+  };
+}
+
+function globalConfig(defaultAgentId: "main" | "work", includeMain = true): OpenClawConfig {
+  return {
+    agents: {
+      entries: {
+        ...(includeMain ? { main: { default: defaultAgentId === "main" } } : {}),
+        work: { default: defaultAgentId === "work" },
+      },
+    },
+    session: { scope: "global" },
+  };
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function dispatch(value: HookPayload): Promise<unknown> {
+  if (!capturedDispatchAgentHook) {
+    throw new Error("dispatchAgentHook missing");
+  }
+  return capturedDispatchAgentHook(value);
+}
+
+function expectOwnedEvent(text: string, agentId: string): void {
+  const call = enqueueSystemEventMock.mock.calls.find(([actual]) => actual === text);
+  expect(call?.[1]).toEqual({ sessionKey: "global" });
+  expect(resolveSystemEventOptionsOwnerAgentId(call?.[1] as object)).toBe(agentId);
+}
+
+async function startGatedRun(
+  result: "success" | "failure",
+  wakeMode: "now" | "next-heartbeat" = "now",
+) {
+  const gate = createDeferred();
+  runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+    await gate.promise;
+    if (result === "failure") {
+      throw new Error("agent exploded");
+    }
+    return { status: "ok", summary: "done", delivered: false, deliveryAttempted: false };
+  });
+  void dispatch(payload({ wakeMode }));
+  await vi.waitFor(() => expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1));
+  return gate;
+}
+
+describe("global hook terminal target resolution", () => {
+  beforeEach(() => {
+    resetGatewayWorkAdmission();
+    vi.clearAllMocks();
+    loadConfigMock.mockReturnValue(globalConfig("main"));
+    capturedDispatchAgentHook = undefined;
+    createGatewayHooksRequestHandler({
+      deps: {} as never,
+      getHooksConfig: () => null,
+      getClientIpConfig: () => ({ trustedProxies: undefined, allowRealIpFallback: false }),
+      bindHost: "127.0.0.1",
+      port: 18789,
+      logHooks: {
+        warn: logHooksWarnMock,
+        debug: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+  });
+
+  afterEach(() => {
+    resetGatewayWorkAdmission();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the accepted agent when hooks are disabled and the default changes", async () => {
+    const gate = await startGatedRun("success");
+    loadConfigMock.mockReturnValue({
+      ...globalConfig("work"),
+      hooks: { enabled: false },
+    });
+    gate.resolve();
+
+    await vi.waitFor(() => expectOwnedEvent("Hook Email: done", "main"));
+    expect(requestHeartbeatMock).toHaveBeenCalledWith(expect.objectContaining({ agentId: "main" }));
+  });
+
+  it.each([
+    {
+      name: "the accepted agent is removed after success",
+      outcome: "success" as const,
+      wakeMode: "now" as const,
+      status: "ok",
+      reason: "accepted-agent-removed",
+    },
+    {
+      name: "the accepted agent is removed after failure",
+      outcome: "failure" as const,
+      wakeMode: "now" as const,
+      status: "error",
+      reason: "accepted-agent-removed",
+    },
+    {
+      name: "the accepted agent is removed before next-heartbeat completion",
+      outcome: "success" as const,
+      wakeMode: "next-heartbeat" as const,
+      status: "ok",
+      reason: "accepted-agent-removed",
+    },
+  ])("suppresses the terminal event when $name", async (testCase) => {
+    const gate = await startGatedRun(testCase.outcome, testCase.wakeMode);
+    loadConfigMock.mockReturnValue({
+      ...globalConfig("work", false),
+      hooks: { enabled: true, token: "test-token", allowedAgentIds: ["*"] },
+    });
+    gate.resolve();
+
+    await vi.waitFor(() =>
+      expect(logHooksWarnMock).toHaveBeenCalledWith(
+        "hook agent terminal event suppressed",
+        expect.objectContaining({
+          acceptedAgentId: "main",
+          status: testCase.status,
+          reason: testCase.reason,
+          runId: expect.any(String),
+          jobId: expect.any(String),
+        }),
+      ),
+    );
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,5 +1,6 @@
 // Gateway hook server wiring translates external hook requests into wake events or isolated agent runs.
 import { randomUUID } from "node:crypto";
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import {
   resolveDateTimestampMs,
   resolveTimestampMsToIsoString,
@@ -279,6 +280,9 @@ export function createGatewayHooksRequestHandler(params: {
     const sessionKey = target?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(value.text, {
       sessionKey,
+      ...(isUnscopedSessionKeySentinel(sessionKey) && target?.heartbeatTarget.agentId
+        ? { ownerAgentId: normalizeAgentId(target.heartbeatTarget.agentId) }
+        : {}),
     });
     if (value.mode === "now") {
       requestHeartbeat({
@@ -327,25 +331,25 @@ export function createGatewayHooksRequestHandler(params: {
     const reportHookFailure = (err: unknown) => {
       logHooks.warn(`hook agent failed: ${String(err)}`);
       const eventSessionKey = hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
+      const fallbackHeartbeatTarget = isUnscopedSessionKeySentinel(eventSessionKey)
+        ? {
+            agentId:
+              normalizeOptionalString(value.agentId) ?? resolveDefaultAgentId(getRuntimeConfig()),
+          }
+        : { sessionKey: eventSessionKey };
+      const heartbeatTarget = hookEventTarget?.heartbeatTarget ?? fallbackHeartbeatTarget;
       enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
         sessionKey: eventSessionKey,
+        ...(isUnscopedSessionKeySentinel(eventSessionKey) && heartbeatTarget.agentId
+          ? { ownerAgentId: normalizeAgentId(heartbeatTarget.agentId) }
+          : {}),
       });
       if (value.wakeMode === "now") {
-        // Before config resolves, the error belongs to the fallback main session.
-        // Global scope has no session-owned target, so carry the explicit or
-        // current default agent without the shared sentinel session key.
-        const fallbackHeartbeatTarget = isUnscopedSessionKeySentinel(eventSessionKey)
-          ? {
-              agentId:
-                normalizeOptionalString(value.agentId) ??
-                resolveDefaultAgentId(getRuntimeConfig()),
-            }
-          : { sessionKey: eventSessionKey };
         requestHeartbeat({
           source: "hook",
           intent: "immediate",
           reason: `hook:${jobId}:error`,
-          ...(hookEventTarget?.heartbeatTarget ?? fallbackHeartbeatTarget),
+          ...heartbeatTarget,
         });
       }
     };
@@ -503,6 +507,10 @@ export function createGatewayHooksRequestHandler(params: {
               hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
             enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
               sessionKey: eventSessionKey,
+              ...(isUnscopedSessionKeySentinel(eventSessionKey) &&
+              hookEventTarget?.heartbeatTarget.agentId
+                ? { ownerAgentId: normalizeAgentId(hookEventTarget.heartbeatTarget.agentId) }
+                : {}),
             });
             if (value.wakeMode === "now") {
               requestHeartbeat({

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,13 +1,12 @@
 // Gateway hook server wiring translates external hook requests into wake events or isolated agent runs.
 import { randomUUID } from "node:crypto";
-import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import {
   resolveDateTimestampMs,
   resolveTimestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { getRuntimeConfig } from "../../config/io.js";
@@ -28,11 +27,12 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { requestHeartbeat } from "../../infra/heartbeat-wake.js";
 import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
 import { validateExplicitMessageAccountSelection } from "../../infra/outbound/message-account-selection.js";
+import { withSystemEventOwner } from "../../infra/system-event-ownership.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
-import { toAgentStoreSessionKey } from "../../routing/session-key.js";
+import { isUnscopedSessionKeySentinel, toAgentStoreSessionKey } from "../../routing/session-key.js";
 import type { HookAgentDispatchPayload, HooksConfigResolved } from "../hooks.js";
 import {
   createHooksRequestHandler,
@@ -278,12 +278,13 @@ export function createGatewayHooksRequestHandler(params: {
         })()
       : undefined;
     const sessionKey = target?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
-    enqueueSystemEvent(value.text, {
-      sessionKey,
-      ...(isUnscopedSessionKeySentinel(sessionKey) && target?.heartbeatTarget.agentId
-        ? { ownerAgentId: normalizeAgentId(target.heartbeatTarget.agentId) }
-        : {}),
-    });
+    const eventOptions = { sessionKey };
+    enqueueSystemEvent(
+      value.text,
+      isUnscopedSessionKeySentinel(sessionKey) && target?.heartbeatTarget.agentId
+        ? withSystemEventOwner(eventOptions, target.heartbeatTarget.agentId)
+        : eventOptions,
+    );
     if (value.mode === "now") {
       requestHeartbeat({
         source: "hook",
@@ -328,22 +329,54 @@ export function createGatewayHooksRequestHandler(params: {
       state: { nextRunAtMs: nowMs },
     };
     let hookEventTarget: HookEventTarget | undefined;
+    const resolveGlobalTerminalAgentId = (status: string): string | undefined => {
+      const acceptedAgentId = hookEventTarget?.heartbeatTarget.agentId;
+      // Agent id is the stable principal: mutable config reloads preserve admission,
+      // but a principal absent from the fresh roster cannot receive terminal output.
+      if (acceptedAgentId && listAgentIds(getRuntimeConfig()).includes(acceptedAgentId)) {
+        return acceptedAgentId;
+      }
+      logHooks.warn("hook agent terminal event suppressed", {
+        sourcePath: value.sourcePath,
+        name: safeName,
+        runId,
+        jobId,
+        acceptedAgentId,
+        sessionKey,
+        status: sanitizeHookConsoleValue(status) ?? "unknown",
+        reason: "accepted-agent-removed",
+      });
+      return undefined;
+    };
     const reportHookFailure = (err: unknown) => {
       logHooks.warn(`hook agent failed: ${String(err)}`);
       const eventSessionKey = hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
-      const fallbackHeartbeatTarget = isUnscopedSessionKeySentinel(eventSessionKey)
-        ? {
-            agentId:
-              normalizeOptionalString(value.agentId) ?? resolveDefaultAgentId(getRuntimeConfig()),
-          }
-        : { sessionKey: eventSessionKey };
-      const heartbeatTarget = hookEventTarget?.heartbeatTarget ?? fallbackHeartbeatTarget;
-      enqueueSystemEvent(`Hook ${safeName} (error): ${String(err)}`, {
-        sessionKey: eventSessionKey,
-        ...(isUnscopedSessionKeySentinel(eventSessionKey) && heartbeatTarget.agentId
-          ? { ownerAgentId: normalizeAgentId(heartbeatTarget.agentId) }
-          : {}),
-      });
+      const isGlobalEvent = isUnscopedSessionKeySentinel(eventSessionKey);
+      let heartbeatTarget: HookEventTarget["heartbeatTarget"];
+      if (isGlobalEvent && hookEventTarget) {
+        const globalTerminalAgentId = resolveGlobalTerminalAgentId("error");
+        if (!globalTerminalAgentId) {
+          return;
+        }
+        heartbeatTarget = { agentId: globalTerminalAgentId };
+      } else {
+        heartbeatTarget =
+          hookEventTarget?.heartbeatTarget ??
+          (isGlobalEvent
+            ? {
+                agentId:
+                  normalizeOptionalString(value.agentId) ??
+                  resolveDefaultAgentId(getRuntimeConfig()),
+              }
+            : { sessionKey: eventSessionKey });
+      }
+      const failureEventOptions = { sessionKey: eventSessionKey };
+      enqueueSystemEvent(
+        `Hook ${safeName} (error): ${String(err)}`,
+        isGlobalEvent && heartbeatTarget.agentId
+          ? withSystemEventOwner(failureEventOptions, heartbeatTarget.agentId)
+          : failureEventOptions,
+      );
       if (value.wakeMode === "now") {
         requestHeartbeat({
           source: "hook",
@@ -505,19 +538,31 @@ export function createGatewayHooksRequestHandler(params: {
           if (shouldAnnounce) {
             const eventSessionKey =
               hookEventTarget?.eventSessionKey ?? resolveMainSessionKeyFromConfig();
-            enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
-              sessionKey: eventSessionKey,
-              ...(isUnscopedSessionKeySentinel(eventSessionKey) &&
-              hookEventTarget?.heartbeatTarget.agentId
-                ? { ownerAgentId: normalizeAgentId(hookEventTarget.heartbeatTarget.agentId) }
-                : {}),
-            });
+            const isGlobalEvent = isUnscopedSessionKeySentinel(eventSessionKey);
+            let announceEventOptions = { sessionKey: eventSessionKey };
+            let heartbeatTarget: HookEventTarget["heartbeatTarget"];
+            if (isGlobalEvent) {
+              const globalTerminalAgentId = resolveGlobalTerminalAgentId(result.status);
+              if (!globalTerminalAgentId) {
+                return;
+              }
+              announceEventOptions = withSystemEventOwner(
+                announceEventOptions,
+                globalTerminalAgentId,
+              );
+              heartbeatTarget = { agentId: globalTerminalAgentId };
+            } else {
+              heartbeatTarget = hookEventTarget?.heartbeatTarget ?? {
+                sessionKey: eventSessionKey,
+              };
+            }
+            enqueueSystemEvent(`${prefix}: ${summary}`.trim(), announceEventOptions);
             if (value.wakeMode === "now") {
               requestHeartbeat({
                 source: "hook",
                 intent: "immediate",
                 reason: `hook:${jobId}`,
-                ...(hookEventTarget?.heartbeatTarget ?? { sessionKey: eventSessionKey }),
+                ...heartbeatTarget,
               });
             }
           } else if (result.status === "ok" && !value.deliver) {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -332,12 +332,20 @@ export function createGatewayHooksRequestHandler(params: {
       });
       if (value.wakeMode === "now") {
         // Before config resolves, the error belongs to the fallback main session.
-        // Wake that exact session; the requested hook agent may not own it.
+        // Global scope has no session-owned target, so carry the explicit or
+        // current default agent without the shared sentinel session key.
+        const fallbackHeartbeatTarget = isUnscopedSessionKeySentinel(eventSessionKey)
+          ? {
+              agentId:
+                normalizeOptionalString(value.agentId) ??
+                resolveDefaultAgentId(getRuntimeConfig()),
+            }
+          : { sessionKey: eventSessionKey };
         requestHeartbeat({
           source: "hook",
           intent: "immediate",
           reason: `hook:${jobId}:error`,
-          ...(hookEventTarget?.heartbeatTarget ?? { sessionKey: eventSessionKey }),
+          ...(hookEventTarget?.heartbeatTarget ?? fallbackHeartbeatTarget),
         });
       }
     };

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -442,6 +442,7 @@ async function ensureSessionRuntimeCleanup(params: {
   clearFinishedSessionsForScopes(processScopeKeys);
   clearSessionResetRuntimeState([...queueKeys], {
     activeReplySessionId: params.sessionId,
+    agentId: normalizeAgentId(params.target.agentId ?? resolveDefaultAgentId(params.cfg)),
   });
   await stopSubagentsForRequester({
     cfg: params.cfg,

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -83,6 +83,7 @@ import { resolveHeartbeatVisibility } from "./heartbeat-visibility.js";
 import {
   inferHeartbeatWakeSourceFromReason,
   isConfiguredHeartbeatAgent,
+  isTargetedImmediateHookWake,
   isTargetedImmediateSystemEventWake,
 } from "./heartbeat-wake-policy.js";
 import {
@@ -176,7 +177,8 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
       ? []
       : [...(opts.tasks ?? [])].toSorted((left, right) => left.jobId.localeCompare(right.jobId));
   const allowsUnscheduledTarget =
-    isTargetedImmediateSystemEventWake(opts) && isConfiguredHeartbeatAgent(cfg, agentId);
+    (isTargetedImmediateSystemEventWake(opts) || isTargetedImmediateHookWake(opts)) &&
+    isConfiguredHeartbeatAgent(cfg, agentId);
   if (!areHeartbeatsEnabled()) {
     return { kind: "skipped", reason: "disabled" } as const;
   }

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -83,8 +83,7 @@ import { resolveHeartbeatVisibility } from "./heartbeat-visibility.js";
 import {
   inferHeartbeatWakeSourceFromReason,
   isConfiguredHeartbeatAgent,
-  isTargetedImmediateHookWake,
-  isTargetedImmediateSystemEventWake,
+  isTargetedImmediateUnscheduledWake,
 } from "./heartbeat-wake-policy.js";
 import {
   areHeartbeatsEnabled,
@@ -177,8 +176,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
       ? []
       : [...(opts.tasks ?? [])].toSorted((left, right) => left.jobId.localeCompare(right.jobId));
   const allowsUnscheduledTarget =
-    (isTargetedImmediateSystemEventWake(opts) || isTargetedImmediateHookWake(opts)) &&
-    isConfiguredHeartbeatAgent(cfg, agentId);
+    isTargetedImmediateUnscheduledWake(opts) && isConfiguredHeartbeatAgent(cfg, agentId);
   if (!areHeartbeatsEnabled()) {
     return { kind: "skipped", reason: "disabled" } as const;
   }

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -1,4 +1,3 @@
-import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isHeartbeatContentEffectivelyEmpty } from "../auto-reply/heartbeat.js";
@@ -36,6 +35,7 @@ import {
   type HeartbeatScheduledTask,
   type HeartbeatWakeSource,
 } from "./heartbeat-wake.js";
+import { selectAgentSystemEvents } from "./system-event-ownership.js";
 import {
   peekSystemEventEntries,
   resolveSystemEventDeliveryContext,
@@ -162,10 +162,10 @@ export async function resolveHeartbeatPreflight(params: {
     params.heartbeat,
     params.sessionKey,
   );
-  const runAgentId = normalizeAgentId(params.agentId);
-  const pendingEventEntries = (
-    params.runScope === "commitment-only" ? [] : peekSystemEventEntries(session.sessionKey)
-  ).filter((event) => !event.ownerAgentId || event.ownerAgentId === runAgentId);
+  const pendingEventEntries = selectAgentSystemEvents(
+    params.runScope === "commitment-only" ? [] : peekSystemEventEntries(session.sessionKey),
+    params.agentId,
+  );
   const dueCommitments = canHeartbeatDeliverCommitments(params.heartbeat)
     ? selectCommitmentDeliveryBatch(
         await listDueCommitmentsForSession({

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -1,3 +1,4 @@
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isHeartbeatContentEffectivelyEmpty } from "../auto-reply/heartbeat.js";
@@ -161,8 +162,10 @@ export async function resolveHeartbeatPreflight(params: {
     params.heartbeat,
     params.sessionKey,
   );
-  const pendingEventEntries =
-    params.runScope === "commitment-only" ? [] : peekSystemEventEntries(session.sessionKey);
+  const runAgentId = normalizeAgentId(params.agentId);
+  const pendingEventEntries = (
+    params.runScope === "commitment-only" ? [] : peekSystemEventEntries(session.sessionKey)
+  ).filter((event) => !event.ownerAgentId || event.ownerAgentId === runAgentId);
   const dueCommitments = canHeartbeatDeliverCommitments(params.heartbeat)
     ? selectCommitmentDeliveryBatch(
         await listDueCommitmentsForSession({

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -28,8 +28,7 @@ import {
 import { resolveHeartbeatIntervalMs } from "./heartbeat-summary.js";
 import {
   isConfiguredHeartbeatAgent,
-  isTargetedImmediateHookWake,
-  isTargetedImmediateSystemEventWake,
+  isTargetedImmediateUnscheduledWake,
 } from "./heartbeat-wake-policy.js";
 import {
   areHeartbeatsEnabled,
@@ -329,19 +328,13 @@ export function startHeartbeatRunner(opts: {
     const allowsUnscheduledTarget =
       requestedTargetAgentId !== undefined &&
       isConfiguredHeartbeatAgent(wakeConfig, requestedTargetAgentId) &&
-      (isTargetedImmediateSystemEventWake({
+      isTargetedImmediateUnscheduledWake({
         source: params.source,
         intent,
         reason,
+        agentId: requestedAgentId,
         sessionKey: requestedSessionKey,
-      }) ||
-        isTargetedImmediateHookWake({
-          source: params.source,
-          intent,
-          reason,
-          agentId: requestedAgentId,
-          sessionKey: requestedSessionKey,
-        }));
+      });
     if (state.agents.size === 0 && !allowsUnscheduledTarget) {
       return {
         status: "skipped",

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -28,6 +28,7 @@ import {
 import { resolveHeartbeatIntervalMs } from "./heartbeat-summary.js";
 import {
   isConfiguredHeartbeatAgent,
+  isTargetedImmediateHookWake,
   isTargetedImmediateSystemEventWake,
 } from "./heartbeat-wake-policy.js";
 import {
@@ -328,12 +329,18 @@ export function startHeartbeatRunner(opts: {
     const allowsUnscheduledTarget =
       requestedTargetAgentId !== undefined &&
       isConfiguredHeartbeatAgent(wakeConfig, requestedTargetAgentId) &&
-      isTargetedImmediateSystemEventWake({
+      (isTargetedImmediateSystemEventWake({
         source: params.source,
         intent,
         reason,
         sessionKey: requestedSessionKey,
-      });
+      }) ||
+        isTargetedImmediateHookWake({
+          source: params.source,
+          intent,
+          reason,
+          sessionKey: requestedSessionKey,
+        }));
     if (state.agents.size === 0 && !allowsUnscheduledTarget) {
       return {
         status: "skipped",

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -339,6 +339,7 @@ export function startHeartbeatRunner(opts: {
           source: params.source,
           intent,
           reason,
+          agentId: requestedAgentId,
           sessionKey: requestedSessionKey,
         }));
     if (state.agents.size === 0 && !allowsUnscheduledTarget) {

--- a/src/infra/heartbeat-runner.hook-wake.test.ts
+++ b/src/infra/heartbeat-runner.hook-wake.test.ts
@@ -1,0 +1,121 @@
+// Tests hook-source heartbeat wake dispatch for agents without a recurring
+// heartbeat schedule. Split out of heartbeat-runner.scheduler.test.ts so that
+// file stays inside the oxlint max-lines budget; these tests cover the
+// `isTargetedImmediateHookWake` path that lets a scoped hook wake run once for
+// a known but unscheduled agent (and rejects unconfigured targets).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetConfigRuntimeState, type OpenClawConfig } from "../config/config.js";
+import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import { requestHeartbeat } from "./heartbeat-wake.js";
+
+describe("startHeartbeatRunner hook wake targeting", () => {
+  type RunOnce = Parameters<typeof startHeartbeatRunner>[0]["runOnce"];
+  type MockRunOnce = RunOnce & { mock: { calls: unknown[][] } };
+  const TEST_SCHEDULER_SEED = "heartbeat-runner-test-seed";
+
+  function useFakeHeartbeatTime() {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+  }
+
+  function getRunCall(runSpy: MockRunOnce, callIndex: number) {
+    const call = runSpy.mock.calls[callIndex];
+    if (!call) {
+      throw new Error(`Expected heartbeat run call ${callIndex}`);
+    }
+    const options = call[0];
+    if (!options || typeof options !== "object") {
+      throw new Error(`expected heartbeat run options ${callIndex}`);
+    }
+    return options as Record<string, unknown>;
+  }
+
+  function expectRunCallFields(
+    runSpy: MockRunOnce,
+    callIndex: number,
+    expected: Record<string, unknown>,
+  ) {
+    const options = getRunCall(runSpy, callIndex);
+    for (const [key, value] of Object.entries(expected)) {
+      expect(options[key]).toEqual(value);
+    }
+    return options;
+  }
+
+  async function expectWakeDispatch(params: {
+    cfg: OpenClawConfig;
+    runSpy: MockRunOnce;
+    wake: Parameters<typeof requestHeartbeat>[0];
+    expectedCall: Record<string, unknown>;
+  }) {
+    const runner = startHeartbeatRunner({
+      cfg: params.cfg,
+      runOnce: params.runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat(params.wake);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(params.runSpy).toHaveBeenCalledTimes(1);
+    expectRunCallFields(params.runSpy, 0, params.expectedCall);
+
+    return runner;
+  }
+
+  afterEach(() => {
+    resetConfigRuntimeState();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("runs one targeted hook wake for an agent without a heartbeat schedule", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = await expectWakeDispatch({
+      cfg: {
+        agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
+      } as OpenClawConfig,
+      runSpy,
+      wake: {
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
+        agentId: "ops",
+        sessionKey: "agent:ops:main",
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: "ops",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
+        sessionKey: "agent:ops:main",
+      },
+    });
+    runner.stop();
+  });
+
+  it("rejects targeted hook wakes for unconfigured agents", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: { agents: { list: [{ id: "main", heartbeat: { every: "30m" } }] } } as OpenClawConfig,
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat({
+      source: "hook",
+      intent: "immediate",
+      reason: "hook:123e4567-e89b-12d3-a456-426614174000",
+      agentId: "bogus",
+      sessionKey: "agent:bogus:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+});

--- a/src/infra/heartbeat-runner.hook-wake.test.ts
+++ b/src/infra/heartbeat-runner.hook-wake.test.ts
@@ -69,7 +69,10 @@ describe("startHeartbeatRunner hook wake targeting", () => {
     vi.restoreAllMocks();
   });
 
-  it("runs one targeted hook wake for an agent without a heartbeat schedule", async () => {
+  it.each([
+    { name: "session-targeted", sessionKey: "agent:ops:main" },
+    { name: "agent-targeted", sessionKey: undefined },
+  ])("runs one $name hook wake for an agent without a heartbeat schedule", async (testCase) => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     const runner = await expectWakeDispatch({
@@ -82,7 +85,7 @@ describe("startHeartbeatRunner hook wake targeting", () => {
         intent: "immediate",
         reason: "hook:123e4567-e89b-12d3-a456-426614174000",
         agentId: "ops",
-        sessionKey: "agent:ops:main",
+        sessionKey: testCase.sessionKey,
         coalesceMs: 0,
       },
       expectedCall: {
@@ -90,7 +93,7 @@ describe("startHeartbeatRunner hook wake targeting", () => {
         source: "hook",
         intent: "immediate",
         reason: "hook:123e4567-e89b-12d3-a456-426614174000",
-        sessionKey: "agent:ops:main",
+        sessionKey: testCase.sessionKey,
       },
     });
     runner.stop();
@@ -110,7 +113,6 @@ describe("startHeartbeatRunner hook wake targeting", () => {
       intent: "immediate",
       reason: "hook:123e4567-e89b-12d3-a456-426614174000",
       agentId: "bogus",
-      sessionKey: "agent:bogus:main",
       coalesceMs: 0,
     });
     await vi.advanceTimersByTimeAsync(1);

--- a/src/infra/heartbeat-runner.identity.test.ts
+++ b/src/infra/heartbeat-runner.identity.test.ts
@@ -153,6 +153,65 @@ describe("runHeartbeatOnce identity", () => {
     });
   });
 
+  it("keeps a global hook event owned by another agent queued for its owner", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, replySpy }) => {
+      const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions.json");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: tmpDir },
+          entries: { main: { default: true }, alpha: {}, beta: {} },
+        },
+        session: { scope: "global", store: storeTemplate },
+      };
+      await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "alpha" }), "global", {});
+      await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "beta" }), "global", {});
+      // Two hook agents complete before the coalesced wakes fire; both events
+      // land in the shared `global` queue with per-agent ownership.
+      enqueueSystemEvent("Hook Alpha: done", { sessionKey: "global", ownerAgentId: "alpha" });
+      enqueueSystemEvent("Hook Beta: done", { sessionKey: "global", ownerAgentId: "beta" });
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const alphaResult = await runHeartbeatOnce({
+        cfg,
+        agentId: "alpha",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+        },
+      });
+
+      expect(alphaResult.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        AgentId: "alpha",
+        SessionKey: "global",
+      });
+      // The first targeted wake must not drain the other agent's queued event.
+      expect(peekSystemEventEntries("global").map((event) => event.text)).toEqual([
+        "Hook Beta: done",
+      ]);
+
+      const betaResult = await runHeartbeatOnce({
+        cfg,
+        agentId: "beta",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+        },
+      });
+
+      expect(betaResult.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledTimes(2);
+      expect(peekSystemEventEntries("global")).toEqual([]);
+    });
+  });
+
   it.each([
     { name: "alert", replyText: "needs attention", showOk: false },
     { name: "heartbeat ok", replyText: "HEARTBEAT_OK", showOk: true },

--- a/src/infra/heartbeat-runner.identity.test.ts
+++ b/src/infra/heartbeat-runner.identity.test.ts
@@ -11,6 +11,7 @@ import {
   readSessionStoreForTest,
   withTempHeartbeatSandbox,
 } from "./heartbeat-runner.test-utils.js";
+import { withSystemEventOwner } from "./system-event-ownership.js";
 import {
   enqueueSystemEvent,
   peekSystemEventEntries,
@@ -167,8 +168,11 @@ describe("runHeartbeatOnce identity", () => {
       await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "beta" }), "global", {});
       // Two hook agents complete before the coalesced wakes fire; both events
       // land in the shared `global` queue with per-agent ownership.
-      enqueueSystemEvent("Hook Alpha: done", { sessionKey: "global", ownerAgentId: "alpha" });
-      enqueueSystemEvent("Hook Beta: done", { sessionKey: "global", ownerAgentId: "beta" });
+      enqueueSystemEvent(
+        "Hook Alpha: done",
+        withSystemEventOwner({ sessionKey: "global" }, "alpha"),
+      );
+      enqueueSystemEvent("Hook Beta: done", withSystemEventOwner({ sessionKey: "global" }, "beta"));
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
       const alphaResult = await runHeartbeatOnce({

--- a/src/infra/heartbeat-runner.identity.test.ts
+++ b/src/infra/heartbeat-runner.identity.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveStorePath } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveIsolatedHeartbeatSessionKey } from "./heartbeat-runner-session.js";
@@ -11,10 +11,17 @@ import {
   readSessionStoreForTest,
   withTempHeartbeatSandbox,
 } from "./heartbeat-runner.test-utils.js";
+import {
+  enqueueSystemEvent,
+  peekSystemEventEntries,
+  resetSystemEventsForTest,
+} from "./system-events.js";
 
 installHeartbeatRunnerTestRuntime({ includeSlack: true });
 
 describe("runHeartbeatOnce identity", () => {
+  afterEach(() => resetSystemEventsForTest());
+
   it("uses metadata to distinguish a global heartbeat sibling from a matching user key", () => {
     const sessionKey = "agent:historian2:global:heartbeat";
     expect(
@@ -103,6 +110,48 @@ describe("runHeartbeatOnce identity", () => {
       });
     },
   );
+
+  it("runs a global hook wake for an agent without a heartbeat schedule", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, replySpy }) => {
+      const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions.json");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: tmpDir },
+          entries: { main: { default: true }, hooks: {} },
+        },
+        session: { scope: "global", store: storeTemplate },
+      };
+      const hooksStorePath = resolveStorePath(storeTemplate, { agentId: "hooks" });
+      await seedSessionStore(hooksStorePath, "global", {});
+      enqueueSystemEvent("Mapped hook wake", { sessionKey: "global" });
+      expect(peekSystemEventEntries("global").map((event) => event.text)).toEqual([
+        "Mapped hook wake",
+      ]);
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "hooks",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        AgentId: "hooks",
+        SessionKey: "global",
+      });
+      // The real reply admission layer formats generic events into the model
+      // envelope; this injected reply boundary still proves runner consumption.
+      expect(peekSystemEventEntries("global")).toEqual([]);
+    });
+  });
 
   it.each([
     { name: "alert", replyText: "needs attention", showOk: false },

--- a/src/infra/heartbeat-runner.reply-admission.test.ts
+++ b/src/infra/heartbeat-runner.reply-admission.test.ts
@@ -1,0 +1,144 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { markCompleteReplyConfig } from "../auto-reply/reply/get-reply-fast-path.test-support.js";
+import { resolveStorePath } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
+import { getReplyFromConfig } from "./heartbeat-runner.runtime.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import { seedSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+import { withSystemEventOwner } from "./system-event-ownership.js";
+import {
+  enqueueSystemEvent,
+  peekSystemEventEntries,
+  resetSystemEventsForTest,
+} from "./system-events.js";
+
+type RunEmbeddedAgentParams = Parameters<
+  typeof import("../agents/embedded-agent.js").runEmbeddedAgent
+>[0];
+
+const runEmbeddedAgentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/embedded-agent.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/embedded-agent.js")>();
+  return {
+    ...actual,
+    runEmbeddedAgent: (...args: unknown[]) => runEmbeddedAgentMock(...args),
+  };
+});
+
+installHeartbeatRunnerTestRuntime();
+
+const heartbeatDeps = {
+  getQueueSize: () => 0,
+  getReplyFromConfig,
+} satisfies HeartbeatDeps;
+
+function modelPrompt(index: number): string {
+  const prompt = runEmbeddedAgentMock.mock.calls[index]?.[0]?.prompt;
+  if (typeof prompt !== "string") {
+    throw new Error(`embedded-agent prompt ${index + 1} missing`);
+  }
+  return prompt;
+}
+
+describe("heartbeat reply admission", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    runEmbeddedAgentMock.mockReset().mockImplementation(async (params: RunEmbeddedAgentParams) => ({
+      payloads: [{ text: "HEARTBEAT_OK" }],
+      meta: {
+        durationMs: 5,
+        agentMeta: {
+          sessionId: params.sessionId,
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+      },
+    }));
+  });
+
+  afterEach(() => {
+    resetSystemEventsForTest();
+    vi.unstubAllEnvs();
+  });
+
+  it("keeps global events isolated through production reply admission", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir }) => {
+      const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions", "sessions.json");
+      const cfg = markCompleteReplyConfig(
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-6",
+              workspace: tmpDir,
+            },
+            entries: { main: { default: true }, alpha: {}, beta: {} },
+          },
+          models: {
+            providers: {
+              anthropic: {
+                baseUrl: "https://api.anthropic.test",
+                apiKey: "test-key",
+                models: [
+                  {
+                    id: "claude-opus-4-6",
+                    name: "Claude Opus 4.6",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 200_000,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
+            },
+          },
+          session: { scope: "global", store: storeTemplate },
+        },
+        { runtimeMode: "full" },
+      ) as OpenClawConfig;
+      await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "alpha" }), "global", {});
+      await seedSessionStore(resolveStorePath(storeTemplate, { agentId: "beta" }), "global", {});
+      enqueueSystemEvent(
+        "Alpha hook finished",
+        withSystemEventOwner({ sessionKey: "global" }, "alpha"),
+      );
+      enqueueSystemEvent(
+        "Beta hook finished",
+        withSystemEventOwner({ sessionKey: "global" }, "beta"),
+      );
+
+      const alphaResult = await runHeartbeatOnce({
+        cfg,
+        agentId: "alpha",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: heartbeatDeps,
+      });
+
+      expect(alphaResult.status).toBe("ran");
+      expect(modelPrompt(0)).toContain("Alpha hook finished");
+      expect(modelPrompt(0)).not.toContain("Beta hook finished");
+      expect(peekSystemEventEntries("global").map((event) => event.text)).toEqual([
+        "Beta hook finished",
+      ]);
+
+      const betaResult = await runHeartbeatOnce({
+        cfg,
+        agentId: "beta",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: heartbeatDeps,
+      });
+
+      expect(betaResult.status).toBe("ran");
+      expect(modelPrompt(1)).toContain("Beta hook finished");
+      expect(modelPrompt(1)).not.toContain("Alpha hook finished");
+      expect(peekSystemEventEntries("global")).toEqual([]);
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1056,6 +1056,56 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("runs one targeted hook wake for an agent without a heartbeat schedule", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = await expectWakeDispatch({
+      cfg: {
+        agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
+      } as OpenClawConfig,
+      runSpy,
+      wake: {
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
+        agentId: "ops",
+        sessionKey: "agent:ops:main",
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: "ops",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
+        sessionKey: "agent:ops:main",
+      },
+    });
+    runner.stop();
+  });
+
+  it("rejects targeted hook wakes for unconfigured agents", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: { agents: { list: [{ id: "main", heartbeat: { every: "30m" } }] } } as OpenClawConfig,
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat({
+      source: "hook",
+      intent: "immediate",
+      reason: "hook:123e4567-e89b-12d3-a456-426614174000",
+      agentId: "bogus",
+      sessionKey: "agent:bogus:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
   it("preserves immediate delivery for repeated background-task wakes", async () => {
     // Task-registry terminal updates wake the heartbeat with reason
     // 'background-task'. Documented as immediate so users don't wait for the

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1056,56 +1056,6 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
-  it("runs one targeted hook wake for an agent without a heartbeat schedule", async () => {
-    useFakeHeartbeatTime();
-    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = await expectWakeDispatch({
-      cfg: {
-        agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
-      } as OpenClawConfig,
-      runSpy,
-      wake: {
-        source: "hook",
-        intent: "immediate",
-        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
-        agentId: "ops",
-        sessionKey: "agent:ops:main",
-        coalesceMs: 0,
-      },
-      expectedCall: {
-        agentId: "ops",
-        source: "hook",
-        intent: "immediate",
-        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
-        sessionKey: "agent:ops:main",
-      },
-    });
-    runner.stop();
-  });
-
-  it("rejects targeted hook wakes for unconfigured agents", async () => {
-    useFakeHeartbeatTime();
-    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = startHeartbeatRunner({
-      cfg: { agents: { list: [{ id: "main", heartbeat: { every: "30m" } }] } } as OpenClawConfig,
-      runOnce: runSpy,
-      stableSchedulerSeed: TEST_SCHEDULER_SEED,
-    });
-
-    requestHeartbeat({
-      source: "hook",
-      intent: "immediate",
-      reason: "hook:123e4567-e89b-12d3-a456-426614174000",
-      agentId: "bogus",
-      sessionKey: "agent:bogus:main",
-      coalesceMs: 0,
-    });
-    await vi.advanceTimersByTimeAsync(1);
-
-    expect(runSpy).not.toHaveBeenCalled();
-    runner.stop();
-  });
-
   it("preserves immediate delivery for repeated background-task wakes", async () => {
     // Task-registry terminal updates wake the heartbeat with reason
     // 'background-task'. Documented as immediate so users don't wait for the

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -79,7 +79,7 @@ export async function seedHeartbeatScratchForTest(params: {
 export async function seedSessionStore(
   storePath: string,
   sessionKey: string,
-  session: HeartbeatSessionSeed,
+  session: Partial<HeartbeatSessionSeed>,
 ): Promise<void> {
   const {
     deliveryContext,

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -64,23 +64,24 @@ export function isTargetedImmediateSystemEventWake(params: {
 }
 
 /**
- * Hook result/failure wakes carry an explicit session target and must be able
+ * Hook result/failure wakes carry an explicit agent or session target and must be able
  * to wake a known agent that has no recurring heartbeat schedule; otherwise the
  * queued hook event sits unread. This is the hook counterpart of
- * `isTargetedImmediateSystemEventWake` — narrowly gated to hook sources with an
- * explicit session key.
+ * `isTargetedImmediateSystemEventWake` — narrowly gated to targeted hook sources.
  */
 export function isTargetedImmediateHookWake(params: {
   source?: HeartbeatWakeSource;
   intent?: HeartbeatWakeIntent;
   reason?: string;
+  agentId?: string;
   sessionKey?: string;
 }): boolean {
   return (
     params.source === "hook" &&
     params.intent === "immediate" &&
     (params.reason?.trim().startsWith("hook:") ?? false) &&
-    normalizeOptionalString(params.sessionKey) !== undefined
+    (normalizeOptionalString(params.agentId) !== undefined ||
+      normalizeOptionalString(params.sessionKey) !== undefined)
   );
 }
 

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -63,6 +63,27 @@ export function isTargetedImmediateSystemEventWake(params: {
   );
 }
 
+/**
+ * Hook result/failure wakes carry an explicit session target and must be able
+ * to wake a known agent that has no recurring heartbeat schedule; otherwise the
+ * queued hook event sits unread. This is the hook counterpart of
+ * `isTargetedImmediateSystemEventWake` — narrowly gated to hook sources with an
+ * explicit session key.
+ */
+export function isTargetedImmediateHookWake(params: {
+  source?: HeartbeatWakeSource;
+  intent?: HeartbeatWakeIntent;
+  reason?: string;
+  sessionKey?: string;
+}): boolean {
+  return (
+    params.source === "hook" &&
+    params.intent === "immediate" &&
+    (params.reason?.trim().startsWith("hook:") ?? false) &&
+    normalizeOptionalString(params.sessionKey) !== undefined
+  );
+}
+
 export function isConfiguredHeartbeatAgent(cfg: OpenClawConfig, agentId: string): boolean {
   const normalized = normalizeAgentId(agentId);
   return listAgentIds(cfg).some((candidate) => normalizeAgentId(candidate) === normalized);

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -49,12 +49,15 @@ export function resolveHeartbeatWakePayloadFlags(params: {
   };
 }
 
-export function isTargetedImmediateSystemEventWake(params: {
+type TargetedImmediateWakeParams = {
   source?: HeartbeatWakeSource;
   intent?: HeartbeatWakeIntent;
   reason?: string;
+  agentId?: string;
   sessionKey?: string;
-}): boolean {
+};
+
+export function isTargetedImmediateSystemEventWake(params: TargetedImmediateWakeParams): boolean {
   return (
     params.source === "notifications-event" &&
     params.intent === "immediate" &&
@@ -69,13 +72,7 @@ export function isTargetedImmediateSystemEventWake(params: {
  * queued hook event sits unread. This is the hook counterpart of
  * `isTargetedImmediateSystemEventWake` — narrowly gated to targeted hook sources.
  */
-export function isTargetedImmediateHookWake(params: {
-  source?: HeartbeatWakeSource;
-  intent?: HeartbeatWakeIntent;
-  reason?: string;
-  agentId?: string;
-  sessionKey?: string;
-}): boolean {
+export function isTargetedImmediateHookWake(params: TargetedImmediateWakeParams): boolean {
   return (
     params.source === "hook" &&
     params.intent === "immediate" &&
@@ -83,6 +80,10 @@ export function isTargetedImmediateHookWake(params: {
     (normalizeOptionalString(params.agentId) !== undefined ||
       normalizeOptionalString(params.sessionKey) !== undefined)
   );
+}
+
+export function isTargetedImmediateUnscheduledWake(params: TargetedImmediateWakeParams): boolean {
+  return isTargetedImmediateSystemEventWake(params) || isTargetedImmediateHookWake(params);
 }
 
 export function isConfiguredHeartbeatAgent(cfg: OpenClawConfig, agentId: string): boolean {

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -57,7 +57,7 @@ type TargetedImmediateWakeParams = {
   sessionKey?: string;
 };
 
-export function isTargetedImmediateSystemEventWake(params: TargetedImmediateWakeParams): boolean {
+function isTargetedImmediateSystemEventWake(params: TargetedImmediateWakeParams): boolean {
   return (
     params.source === "notifications-event" &&
     params.intent === "immediate" &&
@@ -72,7 +72,7 @@ export function isTargetedImmediateSystemEventWake(params: TargetedImmediateWake
  * queued hook event sits unread. This is the hook counterpart of
  * `isTargetedImmediateSystemEventWake` — narrowly gated to targeted hook sources.
  */
-export function isTargetedImmediateHookWake(params: TargetedImmediateWakeParams): boolean {
+function isTargetedImmediateHookWake(params: TargetedImmediateWakeParams): boolean {
   return (
     params.source === "hook" &&
     params.intent === "immediate" &&

--- a/src/infra/system-event-ownership.ts
+++ b/src/infra/system-event-ownership.ts
@@ -1,0 +1,64 @@
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
+type SystemEventOwnershipState = {
+  eventOwners: WeakMap<object, string>;
+  optionOwners: WeakMap<object, string>;
+};
+
+const SYSTEM_EVENT_OWNERSHIP_KEY = Symbol.for("openclaw.systemEvents.ownership");
+
+// The queue is process-global, so duplicated runtime chunks must share its
+// object-identity metadata or another agent can consume an owner-marked event.
+const { eventOwners, optionOwners } = resolveGlobalSingleton<SystemEventOwnershipState>(
+  SYSTEM_EVENT_OWNERSHIP_KEY,
+  () => ({
+    eventOwners: new WeakMap<object, string>(),
+    optionOwners: new WeakMap<object, string>(),
+  }),
+);
+
+function normalizeOwnerAgentId(agentId: string | null | undefined): string | null {
+  return normalizeOptionalString(agentId) ? normalizeAgentId(agentId) : null;
+}
+
+export function withSystemEventOwner<T extends object>(options: T, agentId: string): T {
+  optionOwners.set(options, normalizeAgentId(agentId));
+  return options;
+}
+
+export function resolveSystemEventOptionsOwnerAgentId(options: object): string | null {
+  return optionOwners.get(options) ?? null;
+}
+
+export function recordSystemEventOwner(event: object, agentId: string | null): void {
+  const normalized = normalizeOwnerAgentId(agentId);
+  if (normalized) {
+    eventOwners.set(event, normalized);
+  }
+}
+
+export function cloneSystemEventOwner(source: object, clone: object): void {
+  const ownerAgentId = eventOwners.get(source);
+  if (ownerAgentId) {
+    eventOwners.set(clone, ownerAgentId);
+  }
+}
+
+export function resolveSystemEventOwnerAgentId(event: object): string | null {
+  return eventOwners.get(event) ?? null;
+}
+
+export function selectAgentSystemEvents<T extends object>(
+  events: readonly T[],
+  agentId: string,
+): T[] {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  // Unowned events retain their legacy first-consumer semantics. Owner-marked
+  // events stay invisible to other agents sharing the transient global queue.
+  return events.filter((event) => {
+    const ownerAgentId = resolveSystemEventOwnerAgentId(event);
+    return ownerAgentId === null || ownerAgentId === normalizedAgentId;
+  });
+}

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -1,11 +1,16 @@
 // Covers system event queue routing, draining, and formatting.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-system-events.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import { isCronSystemEvent } from "./heartbeat-events-filter.js";
+import {
+  resolveSystemEventOwnerAgentId,
+  selectAgentSystemEvents,
+  withSystemEventOwner,
+} from "./system-event-ownership.js";
 import {
   consumeSelectedSystemEventEntries,
   consumeSystemEventEntries,
@@ -20,11 +25,21 @@ import {
 } from "./system-events.js";
 
 type SystemEventsModule = typeof import("./system-events.js");
+type SystemEventOwnershipModule = typeof import("./system-event-ownership.js");
 
 const systemEventsModuleUrl = new URL("./system-events.ts", import.meta.url).href;
+const systemEventOwnershipModuleUrl = new URL("./system-event-ownership.ts", import.meta.url).href;
 
 async function importSystemEventsModule(cacheBust: string): Promise<SystemEventsModule> {
   return (await import(`${systemEventsModuleUrl}?t=${cacheBust}`)) as SystemEventsModule;
+}
+
+async function importSystemEventOwnershipModule(
+  cacheBust: string,
+): Promise<SystemEventOwnershipModule> {
+  return (await import(
+    `${systemEventOwnershipModuleUrl}?t=${cacheBust}`
+  )) as SystemEventOwnershipModule;
 }
 
 const cfg = {} as unknown as OpenClawConfig;
@@ -36,6 +51,7 @@ async function drainFormattedEvents(
 ) {
   return await drainFormattedSystemEvents({
     cfg,
+    agentId: "main",
     sessionKey,
     isMainSession: false,
     isNewSession: false,
@@ -46,6 +62,10 @@ async function drainFormattedEvents(
 describe("system events (session routing)", () => {
   beforeEach(() => {
     resetSystemEventsForTest();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("does not leak session-scoped events into main", async () => {
@@ -282,6 +302,57 @@ describe("system events (session routing)", () => {
     first.resetSystemEventsForTest();
   });
 
+  it("shares ownership metadata across duplicate module instances", async () => {
+    const suffix = Date.now();
+    const firstEvents = await importSystemEventsModule(`owned-first-${suffix}`);
+    const secondEvents = await importSystemEventsModule(`owned-second-${suffix}`);
+    const firstOwnership = await importSystemEventOwnershipModule(`owned-first-${suffix}`);
+    const secondOwnership = await importSystemEventOwnershipModule(`owned-second-${suffix}`);
+    const key = "global";
+    const options = { sessionKey: key, contextKey: "hook:shared" };
+
+    firstEvents.resetSystemEventsForTest();
+    expect(
+      secondEvents.enqueueSystemEvent(
+        "Hook finished",
+        firstOwnership.withSystemEventOwner({ ...options }, "alpha"),
+      ),
+    ).toBe(true);
+    expect(
+      firstEvents.enqueueSystemEvent(
+        "Hook finished",
+        secondOwnership.withSystemEventOwner({ ...options }, "alpha"),
+      ),
+    ).toBe(false);
+    expect(
+      firstEvents.enqueueSystemEvent(
+        "Hook finished",
+        secondOwnership.withSystemEventOwner({ ...options }, "beta"),
+      ),
+    ).toBe(true);
+
+    const queued = secondEvents.peekSystemEventEntries(key);
+    expect(queued.map(secondOwnership.resolveSystemEventOwnerAgentId)).toEqual(["alpha", "beta"]);
+    const selectedBeta = firstOwnership.selectAgentSystemEvents(queued, "beta");
+    expect(
+      firstEvents
+        .consumeSelectedSystemEventEntries(key, selectedBeta)
+        .map(firstOwnership.resolveSystemEventOwnerAgentId),
+    ).toEqual(["beta"]);
+
+    const remaining = firstEvents.peekSystemEventEntries(key);
+    expect(remaining.map(secondOwnership.resolveSystemEventOwnerAgentId)).toEqual(["alpha"]);
+    const selectedAlpha = secondOwnership.selectAgentSystemEvents(remaining, "alpha");
+    expect(
+      secondEvents
+        .consumeSelectedSystemEventEntries(key, selectedAlpha)
+        .map(secondOwnership.resolveSystemEventOwnerAgentId),
+    ).toEqual(["alpha"]);
+    expect(firstEvents.peekSystemEventEntries(key)).toStrictEqual([]);
+
+    firstEvents.resetSystemEventsForTest();
+  });
+
   it("filters heartbeat/noise lines, returning undefined", async () => {
     const key = "agent:main:test-heartbeat-filter";
     enqueueSystemEvent("Read HEARTBEAT.md before continuing", { sessionKey: key });
@@ -494,6 +565,64 @@ describe("system events (session routing)", () => {
     expect(
       enqueueSystemEvent("Build completed", { sessionKey: key, contextKey: "build:123" }),
     ).toBe(true);
+  });
+
+  it("selects unowned and matching-owner events without consuming other owners", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-08T00:00:00Z"));
+    const key = "global";
+    const eventOptions = { sessionKey: key, contextKey: "hook:shared" };
+
+    expect(
+      enqueueSystemEvent("Hook finished", withSystemEventOwner({ ...eventOptions }, " Alpha ")),
+    ).toBe(true);
+    expect(
+      enqueueSystemEvent("Hook finished", withSystemEventOwner({ ...eventOptions }, "alpha")),
+    ).toBe(false);
+    expect(
+      enqueueSystemEvent("Hook finished", withSystemEventOwner({ ...eventOptions }, "beta")),
+    ).toBe(true);
+    expect(enqueueSystemEvent("Hook finished", eventOptions)).toBe(true);
+    expect(new Set(peekSystemEventEntries(key).map((event) => event.ts))).toEqual(
+      new Set([Date.now()]),
+    );
+
+    const selected = selectAgentSystemEvents(peekSystemEventEntries(key), "ALPHA");
+    expect(selected.map(resolveSystemEventOwnerAgentId)).toEqual(["alpha", null]);
+
+    vi.advanceTimersByTime(1);
+    enqueueSystemEvent("Later alpha event", withSystemEventOwner({ sessionKey: key }, "alpha"));
+    expect(
+      consumeSelectedSystemEventEntries(key, selected).map(resolveSystemEventOwnerAgentId),
+    ).toEqual(["alpha", null]);
+    expect(
+      peekSystemEventEntries(key).map((event) => [
+        event.text,
+        resolveSystemEventOwnerAgentId(event),
+      ]),
+    ).toEqual([
+      ["Hook finished", "beta"],
+      ["Later alpha event", "alpha"],
+    ]);
+  });
+
+  it("replaces only the matching owner slot", () => {
+    const key = "global";
+    const options = { sessionKey: key, contextKey: "hook:shared", replace: true };
+
+    enqueueSystemEvent("Alpha pending", withSystemEventOwner({ ...options }, "alpha"));
+    enqueueSystemEvent("Beta pending", withSystemEventOwner({ ...options }, "beta"));
+    enqueueSystemEvent("Alpha finished", withSystemEventOwner({ ...options }, "ALPHA"));
+
+    expect(
+      peekSystemEventEntries(key).map((event) => [
+        event.text,
+        resolveSystemEventOwnerAgentId(event),
+      ]),
+    ).toEqual([
+      ["Beta pending", "beta"],
+      ["Alpha finished", "alpha"],
+    ]);
   });
 });
 

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -3,6 +3,7 @@
 // events ephemeral. Events are session-scoped and require an explicit key.
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -20,6 +21,12 @@ export type SystemEvent = {
   ts: number;
   contextKey?: string | null;
   deliveryContext?: DeliveryContext;
+  /**
+   * Agent that owns this transient event. Events in a shared (global-scope)
+   * session queue carry their producer's agent so a targeted heartbeat wake
+   * cannot consume another agent's queued result or failure event.
+   */
+  ownerAgentId?: string | null;
 };
 
 const MAX_EVENTS = 20;
@@ -39,6 +46,13 @@ type SystemEventOptions = {
   deliveryContext?: DeliveryContext;
   /** Replace the pending event for this context and delivery route. Requires contextKey. */
   replace?: boolean;
+  /**
+   * Agent that owns this event. In global session scope the transient queue
+   * key is the shared `global` sentinel; ownership metadata keeps concurrent
+   * hook completions from cross-consuming each other's events while the
+   * store's literal `global` session row stays shared.
+   */
+  ownerAgentId?: string | null;
 };
 
 function requireSessionKey(key?: string | null): string {
@@ -92,13 +106,18 @@ function findDuplicateInQueue(
   text: string,
   contextKey: string | null,
   deliveryContext: DeliveryContext | undefined,
+  ownerAgentId: string | null,
 ): boolean {
-  const incoming = { text, contextKey, deliveryContext };
+  const incoming = { text, contextKey, deliveryContext, ownerAgentId };
   if (contextKey === null) {
     const last = queue[queue.length - 1];
     return last ? isDuplicateSystemEvent(last, incoming) : false;
   }
   return queue.some((event) => isDuplicateSystemEvent(event, incoming));
+}
+
+function normalizeOwnerAgentId(agentId: string | null | undefined): string | null {
+  return normalizeOptionalString(agentId) ? normalizeAgentId(agentId) : null;
 }
 
 export function enqueueSystemEventEntry(
@@ -116,7 +135,16 @@ export function enqueueSystemEventEntry(
   }
   const normalizedContextKey = normalizeContextKey(options.contextKey);
   const normalizedDeliveryContext = normalizeDeliveryContext(options.deliveryContext);
-  if (findDuplicateInQueue(entry.queue, cleaned, normalizedContextKey, normalizedDeliveryContext)) {
+  const normalizedOwnerAgentId = normalizeOwnerAgentId(options.ownerAgentId);
+  if (
+    findDuplicateInQueue(
+      entry.queue,
+      cleaned,
+      normalizedContextKey,
+      normalizedDeliveryContext,
+      normalizedOwnerAgentId,
+    )
+  ) {
     return null;
   }
   if (normalizedContextKey !== null) {
@@ -127,6 +155,7 @@ export function enqueueSystemEventEntry(
     ts: Date.now(),
     contextKey: normalizedContextKey,
     deliveryContext: normalizedDeliveryContext,
+    ownerAgentId: normalizedOwnerAgentId,
   };
   entry.queue.push(event);
   if (entry.queue.length > MAX_EVENTS) {
@@ -174,9 +203,11 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
     throw new Error("replaced system events require a contextKey");
   }
   const normalizedDeliveryContext = normalizeDeliveryContext(options.deliveryContext);
+  const normalizedOwnerAgentId = normalizeOwnerAgentId(options.ownerAgentId);
   const matching = entry.queue.filter(
     (event) =>
       (event.contextKey ?? null) === normalizedContextKey &&
+      (event.ownerAgentId ?? null) === normalizedOwnerAgentId &&
       areDeliveryContextsEqual(event.deliveryContext, normalizedDeliveryContext),
   );
   if (matching.length === 1 && matching[0]?.text === cleaned) {
@@ -188,6 +219,7 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
   entry.queue = entry.queue.filter(
     (event) =>
       (event.contextKey ?? null) !== normalizedContextKey ||
+      (event.ownerAgentId ?? null) !== normalizedOwnerAgentId ||
       !areDeliveryContextsEqual(event.deliveryContext, normalizedDeliveryContext),
   );
   const event: SystemEvent = {
@@ -195,6 +227,7 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
     ts: Date.now(),
     contextKey: normalizedContextKey,
     deliveryContext: normalizedDeliveryContext,
+    ownerAgentId: normalizedOwnerAgentId,
   };
   entry.queue.push(event);
   if (entry.queue.length > MAX_EVENTS) {
@@ -206,11 +239,12 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
 
 function isDuplicateSystemEvent(
   existing: SystemEvent,
-  incoming: Pick<SystemEvent, "text" | "contextKey" | "deliveryContext">,
+  incoming: Pick<SystemEvent, "text" | "contextKey" | "deliveryContext" | "ownerAgentId">,
 ): boolean {
   return (
     existing.text === incoming.text &&
     (existing.contextKey ?? null) === (incoming.contextKey ?? null) &&
+    (existing.ownerAgentId ?? null) === (incoming.ownerAgentId ?? null) &&
     areDeliveryContextsEqual(existing.deliveryContext, incoming.deliveryContext)
   );
 }
@@ -220,6 +254,7 @@ function areSystemEventsEqual(left: SystemEvent, right: SystemEvent): boolean {
     left.text === right.text &&
     left.ts === right.ts &&
     (left.contextKey ?? null) === (right.contextKey ?? null) &&
+    (left.ownerAgentId ?? null) === (right.ownerAgentId ?? null) &&
     areDeliveryContextsEqual(left.deliveryContext, right.deliveryContext)
   );
 }

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -3,7 +3,6 @@
 // events ephemeral. Events are session-scoped and require an explicit key.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -15,18 +14,18 @@ import {
   normalizeDeliveryContext,
 } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import {
+  cloneSystemEventOwner,
+  recordSystemEventOwner,
+  resolveSystemEventOptionsOwnerAgentId,
+  resolveSystemEventOwnerAgentId,
+} from "./system-event-ownership.js";
 
 export type SystemEvent = {
   text: string;
   ts: number;
   contextKey?: string | null;
   deliveryContext?: DeliveryContext;
-  /**
-   * Agent that owns this transient event. Events in a shared (global-scope)
-   * session queue carry their producer's agent so a targeted heartbeat wake
-   * cannot consume another agent's queued result or failure event.
-   */
-  ownerAgentId?: string | null;
 };
 
 const MAX_EVENTS = 20;
@@ -46,13 +45,6 @@ type SystemEventOptions = {
   deliveryContext?: DeliveryContext;
   /** Replace the pending event for this context and delivery route. Requires contextKey. */
   replace?: boolean;
-  /**
-   * Agent that owns this event. In global session scope the transient queue
-   * key is the shared `global` sentinel; ownership metadata keeps concurrent
-   * hook completions from cross-consuming each other's events while the
-   * store's literal `global` session row stays shared.
-   */
-  ownerAgentId?: string | null;
 };
 
 function requireSessionKey(key?: string | null): string {
@@ -86,10 +78,12 @@ function getOrCreateSessionQueue(sessionKey: string): SessionQueue {
 }
 
 function cloneSystemEvent(event: SystemEvent): SystemEvent {
-  return {
+  const clone = {
     ...event,
     ...(event.deliveryContext ? { deliveryContext: { ...event.deliveryContext } } : {}),
   };
+  cloneSystemEventOwner(event, clone);
+  return clone;
 }
 
 export function isSystemEventContextChanged(
@@ -116,11 +110,14 @@ function findDuplicateInQueue(
   return queue.some((event) => isDuplicateSystemEvent(event, incoming));
 }
 
-function normalizeOwnerAgentId(agentId: string | null | undefined): string | null {
-  return normalizeOptionalString(agentId) ? normalizeAgentId(agentId) : null;
+export function enqueueSystemEventEntry(
+  text: string,
+  options: SystemEventOptions,
+): SystemEvent | null {
+  return enqueueOwnedSystemEventEntry(text, options);
 }
 
-export function enqueueSystemEventEntry(
+function enqueueOwnedSystemEventEntry(
   text: string,
   options: SystemEventOptions,
 ): SystemEvent | null {
@@ -135,7 +132,7 @@ export function enqueueSystemEventEntry(
   }
   const normalizedContextKey = normalizeContextKey(options.contextKey);
   const normalizedDeliveryContext = normalizeDeliveryContext(options.deliveryContext);
-  const normalizedOwnerAgentId = normalizeOwnerAgentId(options.ownerAgentId);
+  const normalizedOwnerAgentId = resolveSystemEventOptionsOwnerAgentId(options);
   if (
     findDuplicateInQueue(
       entry.queue,
@@ -155,8 +152,8 @@ export function enqueueSystemEventEntry(
     ts: Date.now(),
     contextKey: normalizedContextKey,
     deliveryContext: normalizedDeliveryContext,
-    ownerAgentId: normalizedOwnerAgentId,
   };
+  recordSystemEventOwner(event, normalizedOwnerAgentId);
   entry.queue.push(event);
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
@@ -203,11 +200,11 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
     throw new Error("replaced system events require a contextKey");
   }
   const normalizedDeliveryContext = normalizeDeliveryContext(options.deliveryContext);
-  const normalizedOwnerAgentId = normalizeOwnerAgentId(options.ownerAgentId);
+  const normalizedOwnerAgentId = resolveSystemEventOptionsOwnerAgentId(options);
   const matching = entry.queue.filter(
     (event) =>
       (event.contextKey ?? null) === normalizedContextKey &&
-      (event.ownerAgentId ?? null) === normalizedOwnerAgentId &&
+      resolveSystemEventOwnerAgentId(event) === normalizedOwnerAgentId &&
       areDeliveryContextsEqual(event.deliveryContext, normalizedDeliveryContext),
   );
   if (matching.length === 1 && matching[0]?.text === cleaned) {
@@ -219,7 +216,7 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
   entry.queue = entry.queue.filter(
     (event) =>
       (event.contextKey ?? null) !== normalizedContextKey ||
-      (event.ownerAgentId ?? null) !== normalizedOwnerAgentId ||
+      resolveSystemEventOwnerAgentId(event) !== normalizedOwnerAgentId ||
       !areDeliveryContextsEqual(event.deliveryContext, normalizedDeliveryContext),
   );
   const event: SystemEvent = {
@@ -227,8 +224,8 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
     ts: Date.now(),
     contextKey: normalizedContextKey,
     deliveryContext: normalizedDeliveryContext,
-    ownerAgentId: normalizedOwnerAgentId,
   };
+  recordSystemEventOwner(event, normalizedOwnerAgentId);
   entry.queue.push(event);
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
@@ -239,12 +236,14 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
 
 function isDuplicateSystemEvent(
   existing: SystemEvent,
-  incoming: Pick<SystemEvent, "text" | "contextKey" | "deliveryContext" | "ownerAgentId">,
+  incoming: Pick<SystemEvent, "text" | "contextKey" | "deliveryContext"> & {
+    ownerAgentId: string | null;
+  },
 ): boolean {
   return (
     existing.text === incoming.text &&
     (existing.contextKey ?? null) === (incoming.contextKey ?? null) &&
-    (existing.ownerAgentId ?? null) === (incoming.ownerAgentId ?? null) &&
+    resolveSystemEventOwnerAgentId(existing) === incoming.ownerAgentId &&
     areDeliveryContextsEqual(existing.deliveryContext, incoming.deliveryContext)
   );
 }
@@ -254,7 +253,7 @@ function areSystemEventsEqual(left: SystemEvent, right: SystemEvent): boolean {
     left.text === right.text &&
     left.ts === right.ts &&
     (left.contextKey ?? null) === (right.contextKey ?? null) &&
-    (left.ownerAgentId ?? null) === (right.ownerAgentId ?? null) &&
+    resolveSystemEventOwnerAgentId(left) === resolveSystemEventOwnerAgentId(right) &&
     areDeliveryContextsEqual(left.deliveryContext, right.deliveryContext)
   );
 }

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -443,6 +443,7 @@ describe("session state events", () => {
 
     await drainFormattedSystemEvents({
       cfg,
+      agentId: "main",
       sessionKey: watcher,
       isMainSession: false,
       isNewSession: false,
@@ -454,6 +455,7 @@ describe("session state events", () => {
     enqueueSystemEvent("Exec completed", { sessionKey: watcher, contextKey: "exec:job-1" });
     await drainFormattedSystemEvents({
       cfg,
+      agentId: "main",
       sessionKey: watcher,
       isMainSession: false,
       isNewSession: false,


### PR DESCRIPTION
## What Problem This Solves

`requestHeartbeat` fired from the gateway hook agent dispatch path (`src/gateway/server/hooks.ts`) was **unscoped**. A hook POST like `{"agentId": "main", "wakeMode": "now", ...}` runs its isolated agent turn correctly, but the post-run wake (`hook:<jobId>` on the announce path, `hook:<jobId>:error` on the failure path) carried no `agentId`/`sessionKey`. In `heartbeat-wake.ts` an unscoped immediate wake is a global flush barrier that fans out to **every** heartbeat-enabled agent, so the hook's wake silently bought full `[OpenClaw heartbeat poll]` turns on unrelated agents — on the reporter's install, 33 heartbeat legs over ~11 days (~$0.49) on a premium-pinned model, 19 of them producing no output at all.

The third wake site, `dispatchWakeHook`, was already targeted (`...target?.heartbeatTarget`); only the two `dispatchAgentHook` sites leaked global wakes.

## Why

A hook names its target agent/session; the wake that follows the run must stay on that same target. `requestHeartbeat` supports `agentId` + `sessionKey` scoping, and the heartbeat runner uses it to run only the targeted agent/session (`heartbeat-runner-scheduler.ts`: `if (requestedSessionKey || requestedAgentId)` → targeted `runOnce`). The invariant is "the wake targets the exact agent/session the hook event was enqueued to" — the same key used for `enqueueSystemEvent` at both sites. When config resolution failed before the event key could be computed, the wake falls back to the same fallback session the error event used.

## User Impact

- Hook-triggered wakes no longer spend unbudgeted model tokens on unrelated heartbeat-enabled agents (the reported `$0.49`/33-turn bleed on a premium-pinned `reviewer` agent).
- Announced hook results and hook failures are still picked up promptly: the targeted wake runs the heartbeat turn for the agent/session the announcement actually landed on (agent derived from the session key when only the session is named).
- No behavior change for `wakeMode: "next-heartbeat"` (no immediate wake was requested) or for `deliver:false` non-announced runs (no wake at all).
- A known agent **without** a recurring heartbeat schedule is now woken once for its queued hook event instead of the wake being skipped as disabled and the event sitting unread.

## Evidence

### Scoped wakes (original fix)

- `src/gateway/server/hooks.ts`: both `requestHeartbeat` sites in `dispatchAgentHook` now pass `agentId` + `sessionKey` (event key = `hookEventSessionKey ?? resolveMainSessionKeyFromConfig()`); failure site gates `agentId` on the event key being resolved so agent/session stay consistent.
- Targeted-wake semantics verified in source: `resolveHeartbeatWakeTargetKey` (`heartbeat-wake-target.ts`) keys unscoped wakes as `"::"` (global flush) vs `::<sessionKey>` / `<agentId>::` for targeted ones; `heartbeat-runner-scheduler.ts:428` runs only the targeted agent when `requestedSessionKey || requestedAgentId`.
- Tests (4 new, `src/gateway/server/hooks.agent-trust.test.ts`): announce wake targets `{agentId:"hooks", sessionKey:"agent:hooks:main"}`; failure wake targets the same; unnamed-agent failure wake is scoped by session (`agent:main:main`, no agentId); config-unavailable failure wake falls back to `main-session`.

### Review P1 fixes (unscheduled-target + announce alignment)

Two P1 findings from ClawSweeper review are repaired on head `9c29882831`:

1. **Allow immediate hook wakes for unscheduled targets** — `isTargetedImmediateSystemEventWake` only recognized `notifications-event` sources, so a scoped hook wake targeting a known agent without a heartbeat schedule was skipped as `disabled` and its queued hook event was never consumed. Added `isTargetedImmediateHookWake` (`src/infra/heartbeat-wake-policy.ts`, gated to `source: "hook"` + `intent: "immediate"` + `reason: hook:*` + explicit `sessionKey`) and accepted it in the `allowsUnscheduledTarget` gate in both `heartbeat-runner-scheduler.ts` and `heartbeat-runner-execution.ts`. Unconfigured agents remain rejected.
2. **Keep the announce wake aligned with the queued event** — the announce path passed the dispatch-time resolved default `agentId` even when the hook named no agent; after a default-agent reload the scheduler could prefer that stale agent and run its main session instead of the session holding the event. The announce wake now only carries `agentId` when the hook explicitly named one (`acceptedValue.agentId`), so identity derives from the queued event session otherwise.

```text
$ PATH=~/node24/bin:$PATH ./node_modules/.bin/vitest run \
    src/gateway/server/hooks.agent-trust.test.ts src/infra/heartbeat-runner.scheduler.test.ts
 ✓  gateway-core  hooks.agent-trust.test.ts (26 tests)
 ✓  gateway-server hooks.agent-trust.test.ts (26 tests)
 ✓  gateway-client hooks.agent-trust.test.ts (26 tests)
 ✓  infra         heartbeat-runner.scheduler.test.ts (35 tests)
 Test Files  4 passed (4)
      Tests  113 passed (113)
```

```text
$ PATH=~/node24/bin:$PATH ./node_modules/.bin/vitest run \
    $(ls src/infra/heartbeat-runner.*.test.ts | grep -v e2e)
 Test Files  20 passed (20)
      Tests  256 passed (256)
```

New regression tests (5): targeted hook wake for an agent without a heartbeat schedule runs once; unconfigured hook targets rejected; announce wake omits default `agentId` when no agent is named (alongside the 4 original scoped-wake tests).

### Cruise fixes (head `961816ae999`)

**Global-scope announce/failure wakes now carry the fresh default agent.** ClawSweeper P1: in global session scope the event key resolves to the unscoped `"global"` sentinel, which carries no agent identity; `resolveAgentIdFromSessionKey("global")` throws, so the scheduler dropped the wake and the queued result/failure event sat unread. Both `dispatchAgentHook` wake sites now mirror the enqueue-wake path (`src/gateway/server/hooks.ts`): when no agent is named and the event key is an unscoped sentinel (`isUnscopedSessionKeySentinel`), the wake carries the fresh `resolveDefaultAgentId` alongside `sessionKey: "global"`. Non-global unnamed-hook wakes are unchanged (session key embeds the agent; frozen default would wake a stale agent after reload).

Verified in source: `resolveAgentIdFromSessionKey("global")` throws "Session key does not contain an agent id" (`src/routing/session-key.ts:150`); scheduler resolves the wake target from `requestedAgentId` before the session key (`heartbeat-runner-scheduler.ts:293-295`).

**check-lint (max-lines) fix.** The 2 hook-wake tests pushed the scheduler test file to 1045 effective lines (limit 1000). Split them into `src/infra/heartbeat-runner.hook-wake.test.ts`; `heartbeat-runner.scheduler.test.ts` is back to 999 effective lines. No production change, no baseline override added.

```text
$ node_modules/.bin/oxlint src/gateway/server/hooks.ts src/gateway/server/hooks.agent-trust.test.ts     src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.hook-wake.test.ts
Found 0 warnings and 0 errors.

$ node_modules/.bin/vitest run src/gateway/server/hooks.agent-trust.test.ts
 ✓ hooks.agent-trust.test.ts (28 tests x3 lanes) — 84 passed
   new: global-scope announce wake carries agentId "main" + sessionKey "global"
   new: global-scope failure wake carries agentId "main" + sessionKey "global"

$ node_modules/.bin/vitest run src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.hook-wake.test.ts
 ✓ 35 passed (33 scheduler + 2 hook-wake)
```


### Real gateway-to-runner trace — fresh run 2026-08-06 (real `startHeartbeatRunner` scheduler + real wake queue via `requestHeartbeat`, recording `runOnce` seam)

Production wiring: agent `main` has a recurring 30m heartbeat schedule; agent `ops` has NO heartbeat schedule (hook-only agent). A hook result/failure event for `ops` arrives as `source=hook, intent=immediate, reason=hook:<uuid>, agentId=ops, sessionKey=agent:ops:main`. Identical harness run against base `c37ba84f662` and PR head `3e356fee484`:

**Before (base `c37ba84f662`):** the scoped hook wake for the unscheduled agent is skipped as `disabled` — the queued hook event is never consumed:
```text
--- Scenario A: hook wake for unscheduled agent 'ops' ---
runOnce invocations: 0
targeted ops/agent:ops:main runs: 0
unrelated agent runs (must be 0): 0
FAIL
```

**After (PR head `3e356fee484`):** the targeted wake is consumed exactly once at the hook's agent/session; unrelated agents do not run:
```text
--- Scenario A: hook wake for unscheduled agent 'ops' ---
runOnce invocations: 1
  run agentId=ops sessionKey=agent:ops:main source=hook intent=immediate reason=hook:123e4567-e89b-12d3-a456-426614174000 scope=global
targeted ops/agent:ops:main runs: 1
unrelated agent runs (must be 0): 0
PASS: targeted hook wake consumed exactly once; unrelated agents did not run

--- Scenario B: hook wake for UNCONFIGURED agent 'bogus' ---
runOnce invocations: 0 (must be 0)
PASS: unconfigured target rejected, nothing ran
```

- Regression suites (real runs, Node 24.15.0): `heartbeat-runner.hook-wake.test.ts` + `heartbeat-runner.scheduler.test.ts` + `hooks.agent-trust.test.ts` → `Test Files 5 passed (5), Tests 125 passed (125)`.

### Review P1 fixes (reload drift — head `0a2447f686`)

Two late findings from the 2026-08-07 review repaired: the global announce (`hooks.ts` ~L500) and global failure (`hooks.ts` ~L320) wake paths resolved the default agent from **fresh** config at queue-execution time. If a default-agent reload happened between dispatch and queue execution, a global-scope wake retargeted at the new default while the isolated run used the dispatch-time accepted agent — the event produced under one agent was consumed by another.

Fix: freeze the accepted agent at dispatch (`acceptedHookAgentId = agentId`, set right after `validateHookAgentDeliveryAccount` / `resolveDefaultAgentId(dispatchCfg)`) and prefer it in both wake paths (`acceptedHookAgentId ?? resolveDefaultAgentId(...)`). Fresh resolution remains the fallback for pre-acceptance failures (config-unavailable path, which runs before `acceptedHookAgentId` is set — unchanged).

```text
$ PATH=~/node24/bin:$PATH ./node_modules/.bin/vitest run src/gateway/server/hooks.agent-trust.test.ts
 ✓  gateway-core  hooks.agent-trust.test.ts (34 tests)
 ✓  gateway-server hooks.agent-trust.test.ts (34 tests)
 ✓  gateway-client hooks.agent-trust.test.ts (34 tests)
 Test Files  3 passed (3)
      Tests  102 passed (102)

$ PATH=~/node24/bin:$PATH ./node_modules/.bin/vitest run \
    src/gateway/server/hooks.test.ts src/infra/heartbeat-runner.hook-wake.test.ts src/infra/heartbeat-runner.identity.test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

New regression tests (2): announce wake keeps `agentId: "main"` when default reloads `main -> work` mid-queue; failure wake keeps `agentId: "main"` under the same reload.


### Review P1 fix (concurrent global cross-consumption — head `68faee9fdf0`)

Remaining P1 from sallyom's 2026-08-07 review: global-scope hook events for different agents all landed in the single transient `global` system-event queue while each wake was agent-targeted, so two hook agents completing before the coalesced wakes fired let the first wake drain the other agent's queued result/failure into its prompt.

Fix: transient system events now carry an `ownerAgentId` (`src/infra/system-events.ts`), stamped by all three hook enqueue sites in `src/gateway/server/hooks.ts` (announce, failure, and wake-only `dispatchWakeHook`) whenever the event lands on the unscoped sentinel queue — always the frozen dispatch-time accepted agent, matching the wake target. The heartbeat preflight (`src/infra/heartbeat-runner-prompt.ts`) filters pending events to the running agent's owned entries, so consumption (already per-inspected-event) can only remove the owner's events. The store's literal `global` session row stays shared, and unowned events remain visible to every agent, so non-hook global events are unchanged. Dedupe/replace matching is ownership-scoped so identical texts from different agents no longer collapse.

```text
$ node_modules/.bin/vitest run src/infra/heartbeat-runner.identity.test.ts src/infra/heartbeat-runner.hook-wake.test.ts src/gateway/server/hooks.agent-trust.test.ts src/infra/system-events.test.ts
 Test Files  3 passed (3)
      Tests  52 passed (52)

$ node_modules/.bin/oxlint src/infra/system-events.ts src/gateway/server/hooks.ts src/infra/heartbeat-runner-prompt.ts src/infra/heartbeat-runner.identity.test.ts src/gateway/server/hooks.agent-trust.test.ts
Found 0 warnings and 0 errors.
```

New regression tests (2): two-agent concurrent global-scope test proving the first targeted wake leaves the other agent's event queued for its owner (`heartbeat-runner.identity.test.ts`); global-scope announce/failure enqueue assertions now include `ownerAgentId` (`hooks.agent-trust.test.ts`).

[AI-assisted]

Fixes #119808