### PR TITLE
fix(test): auth billing coverage uses current session stores

### DIFF
--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -939,14 +939,7 @@ describe("runEmbeddedAgent auth profile rotation", () => {
 
   it("marks inline provider api key billing prompt failures without an auth profile", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
-      await fs.writeFile(
-        path.join(agentDir, "auth-profiles.json"),
-        JSON.stringify({ version: 1, profiles: {} }),
-      );
-      await fs.writeFile(
-        path.join(agentDir, "auth-state.json"),
-        JSON.stringify({ version: 1, usageStats: {} }),
-      );
+      saveAuthProfileStore({ version: 1, profiles: {}, usageStats: {} }, agentDir);
       runEmbeddedAttemptMock.mockResolvedValueOnce(
         makeAttempt({
           terminal: { kind: "failed", source: "prompt", error: new Error("insufficient credits") },
@@ -957,7 +950,6 @@ describe("runEmbeddedAgent auth profile rotation", () => {
         runEmbeddedAgentInline({
           sessionId: "session:test",
           sessionKey: "agent:test:inline-api-key-prompt-billing",
-          sessionFile: path.join(workspaceDir, "session.jsonl"),
           workspaceDir,
           agentDir,
           config: makeConfig(),


### PR DESCRIPTION
Closes #119820

## What Problem This Solves

Resolves a problem where the auth-profile rotation E2E suite stopped before its inline-key billing assertion because one case still created retired credential sidecars and a JSONL transcript target.

## Why This Change Was Made

The fixture now seeds the same canonical SQLite auth store as its sibling cases and relies on the explicit storage-neutral session key already supplied to the runner. Runtime migration enforcement remains unchanged.

## User Impact

No direct user-visible behavior changes. Maintainers regain coverage that proves an inline provider API key is marked billing-disabled when prompt construction reports insufficient credits.

## Evidence

- Current-main reproduction: 27/28 tests passed; the billing case first failed on the unsupported JSONL target, then on legacy credential migration once that target was removed.
- Final Testbox run [31067241950](https://github.com/openclaw/openclaw/actions/runs/31067241950): 28/28 passed, including the intended billing cooldown assertions.
- `oxfmt --check src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts`
- `git diff --check`
- AutoReview: clean, no accepted/actionable findings, 0.99.

Production LOC: +0/-0. Tests: +1/-9.

Provenance: the stale fixture was added in #88709 by @MertBasar0 and merged by @Patrick-Erichsen after the runtime had moved both contracts to SQLite/storage-neutral ownership.
