### PR TITLE
fix(gateway): preserve plain-text metadata on HEAD

### DIFF
--- a/src/gateway/control-ui-http-utils.ts
+++ b/src/gateway/control-ui-http-utils.ts
@@ -34,6 +34,9 @@ export function acceptsControlUiHtmlResponse(accept: string | undefined): boolea
 export function respondPlainText(res: ServerResponse, statusCode: number, body: string): void {
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  if (statusCode !== 204) {
+    res.setHeader("Content-Length", String(Buffer.byteLength(body)));
+  }
   res.end(body);
 }
 

--- a/src/gateway/control-ui-response-metadata.http.test.ts
+++ b/src/gateway/control-ui-response-metadata.http.test.ts
@@ -1,0 +1,173 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { respondNotFound, respondPlainText } from "./control-ui-http-utils.js";
+import { respondControlUiNotAcceptable } from "./control-ui-static.js";
+import { handleControlUiHttpRequest, type ControlUiRootState } from "./control-ui.js";
+
+type HttpResult = {
+  body: Buffer;
+  headers: Headers;
+  statusCode: number;
+};
+
+type RootResponseCase = {
+  body: string;
+  path: string;
+  root?: ControlUiRootState;
+  headers?: Record<string, string>;
+  missingHeaders?: string[];
+};
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+    if (pathname === "/plain-not-found") {
+      respondNotFound(res);
+      return;
+    }
+    if (pathname === "/no-content") {
+      respondPlainText(res, 204, "");
+      return;
+    }
+    if (pathname === "/not-acceptable") {
+      respondControlUiNotAcceptable(res);
+      return;
+    }
+
+    const root = ROOT_RESPONSE_CASES.find((entry) => entry.path === pathname)?.root;
+    void handleControlUiHttpRequest(req, res, root ? { root } : undefined).catch(
+      (error: unknown) => {
+        res.statusCode = 500;
+        res.end(error instanceof Error ? error.message : String(error));
+      },
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+async function send(method: "GET" | "HEAD", path: string): Promise<HttpResult> {
+  const response = await fetch(`${baseUrl}${path}`, { method });
+  return {
+    body: Buffer.from(await response.arrayBuffer()),
+    headers: response.headers,
+    statusCode: response.status,
+  };
+}
+
+function expectRepresentationMetadata(
+  response: HttpResult,
+  expected: { body: string; headers?: Record<string, string>; missingHeaders?: string[] },
+) {
+  expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+  expect(response.headers.get("content-length")).toBe(String(Buffer.byteLength(expected.body)));
+  for (const [name, value] of Object.entries(expected.headers ?? {})) {
+    expect(response.headers.get(name)).toBe(value);
+  }
+  for (const name of expected.missingHeaders ?? []) {
+    expect(response.headers.get(name)).toBeNull();
+  }
+}
+
+const ROOT_RESPONSE_CASES: RootResponseCase[] = [
+  {
+    path: "/root-invalid",
+    root: { kind: "invalid", path: "/missing/界" },
+    body: "Control UI assets not found at /missing/界. Build them with `pnpm ui:build` (auto-installs UI deps), or update gateway.controlUi.root.",
+    missingHeaders: ["retry-after"],
+  },
+  {
+    path: "/root-preparing",
+    root: { kind: "preparing" },
+    body: "Control UI assets are being prepared. Try again shortly.",
+    headers: { "cache-control": "no-store", "retry-after": "1" },
+  },
+  {
+    path: "/root-failed",
+    root: { kind: "failed" },
+    body: "Control UI assets could not be prepared. Check the Gateway logs or run `openclaw doctor --fix`.",
+    missingHeaders: ["retry-after"],
+  },
+  {
+    path: "/root-missing",
+    root: { kind: "missing" },
+    body: "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.",
+    missingHeaders: ["retry-after"],
+  },
+  {
+    path: "/root-disappeared",
+    root: { kind: "resolved", path: "/openclaw-test/missing-control-ui-root" },
+    body: "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.",
+    missingHeaders: ["retry-after"],
+  },
+];
+
+describe("Control UI plain-text response metadata", () => {
+  it("preserves byte length while Node suppresses the HEAD body", async () => {
+    const body = "Not Found";
+    const get = await send("GET", "/plain-not-found");
+    const head = await send("HEAD", "/plain-not-found");
+
+    expect(get.statusCode).toBe(404);
+    expect(get.body.toString()).toBe(body);
+    expectRepresentationMetadata(get, { body });
+    expect(head.statusCode).toBe(404);
+    expect(head.body).toHaveLength(0);
+    expectRepresentationMetadata(head, { body });
+  });
+
+  it("keeps 406 cache negotiation headers on GET and HEAD", async () => {
+    const body = "Not Acceptable";
+    const expected = {
+      body,
+      headers: { "cache-control": "no-store", vary: "Accept-Encoding" },
+    };
+    const get = await send("GET", "/not-acceptable");
+    const head = await send("HEAD", "/not-acceptable");
+
+    expect(get.statusCode).toBe(406);
+    expect(get.body.toString()).toBe(body);
+    expectRepresentationMetadata(get, expected);
+    expect(head.statusCode).toBe(406);
+    expect(head.body).toHaveLength(0);
+    expectRepresentationMetadata(head, expected);
+  });
+
+  it.each(ROOT_RESPONSE_CASES)(
+    "keeps 503 metadata and HEAD suppression for $path",
+    async ({ body, path, headers, missingHeaders }) => {
+      const get = await send("GET", path);
+      const head = await send("HEAD", path);
+      const expected = { body, headers, missingHeaders };
+
+      expect(get.statusCode).toBe(503);
+      expect(get.body.toString()).toBe(body);
+      expectRepresentationMetadata(get, expected);
+      expect(head.statusCode).toBe(503);
+      expect(head.body).toHaveLength(0);
+      expectRepresentationMetadata(head, expected);
+    },
+  );
+
+  it("omits Content-Length and bodies for 204", async () => {
+    for (const method of ["GET", "HEAD"] as const) {
+      const response = await send(method, "/no-content");
+      expect(response.statusCode).toBe(204);
+      expect(response.body).toHaveLength(0);
+      expect(response.headers.get("content-length")).toBeNull();
+    }
+  });
+});

--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { brotliCompress, constants as zlibConstants, gzip } from "node:zlib";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { getOrCreatePromise } from "../shared/lazy-promise.js";
+import { respondPlainText } from "./control-ui-http-utils.js";
 
 const CONTROL_UI_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 const CONTROL_UI_HTML_COMPRESSION_CACHE_MAX_ENTRIES = 4;
@@ -309,11 +310,9 @@ function cachedCompressedControlUiHtml(
 }
 
 export function respondControlUiNotAcceptable(res: ServerResponse) {
-  res.statusCode = 406;
-  res.setHeader("Content-Type", "text/plain; charset=utf-8");
   res.setHeader("Cache-Control", "no-store");
   res.setHeader("Vary", "Accept-Encoding");
-  res.end("Not Acceptable");
+  respondPlainText(res, 406, "Not Acceptable");
 }
 
 export async function sendControlUiHtmlBody(

--- a/src/gateway/control-ui.auto-root.http.test.ts
+++ b/src/gateway/control-ui.auto-root.http.test.ts
@@ -84,57 +84,43 @@ describe("handleControlUiHttpRequest prepared root lifecycle", () => {
     });
   });
 
-  it.each(["GET", "HEAD"])(
-    "marks %s requests retryable while assets are preparing",
-    async (method) => {
-      const { res, end, setHeader } = makeMockHttpResponse();
+  it("marks requests retryable while assets are preparing", async () => {
+    const { res, end, setHeader } = makeMockHttpResponse();
 
-      const handled = await handleControlUiHttpRequest(
-        { url: "/", method } as IncomingMessage,
-        res,
-        { root: { kind: "preparing" } },
-      );
+    const handled = await handleControlUiHttpRequest(
+      { url: "/", method: "GET" } as IncomingMessage,
+      res,
+      { root: { kind: "preparing" } },
+    );
 
-      expect(handled).toBe(true);
-      expect(res.statusCode).toBe(503);
-      expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
-      expect(setHeader).toHaveBeenCalledWith("Retry-After", "1");
-      if (method === "HEAD") {
-        expect(end).toHaveBeenCalledWith();
-      } else {
-        expect(responseBody(end)).toContain("being prepared");
-      }
-    },
-  );
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+    expect(setHeader).toHaveBeenCalledWith("Retry-After", "1");
+    expect(responseBody(end)).toContain("being prepared");
+  });
 
-  it.each(["GET", "HEAD"])(
-    "keeps failed %s requests terminal without retry hints",
-    async (method) => {
-      const { res, end, setHeader } = makeMockHttpResponse();
-      const privateBuildFailure =
-        "Control UI build failed: private-credential in registry.invalid/package from /home/operator/private";
-      const failedRoot = { kind: "failed" as const, message: privateBuildFailure };
+  it("keeps failed requests terminal without retry hints", async () => {
+    const { res, end, setHeader } = makeMockHttpResponse();
+    const privateBuildFailure =
+      "Control UI build failed: private-credential in registry.invalid/package from /home/operator/private";
+    const failedRoot = { kind: "failed" as const, message: privateBuildFailure };
 
-      const handled = await handleControlUiHttpRequest(
-        { url: "/", method } as IncomingMessage,
-        res,
-        { root: failedRoot },
-      );
+    const handled = await handleControlUiHttpRequest(
+      { url: "/", method: "GET" } as IncomingMessage,
+      res,
+      { root: failedRoot },
+    );
 
-      expect(handled).toBe(true);
-      expect(res.statusCode).toBe(503);
-      expect(setHeader).not.toHaveBeenCalledWith("Retry-After", expect.anything());
-      if (method === "HEAD") {
-        expect(end).toHaveBeenCalledWith();
-      } else {
-        expect(responseBody(end)).toBe(
-          "Control UI assets could not be prepared. Check the Gateway logs or run `openclaw doctor --fix`.",
-        );
-        expect(responseBody(end)).not.toContain("private-credential");
-        expect(responseBody(end)).not.toContain("/home/operator/private");
-      }
-    },
-  );
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(setHeader).not.toHaveBeenCalledWith("Retry-After", expect.anything());
+    expect(responseBody(end)).toBe(
+      "Control UI assets could not be prepared. Check the Gateway logs or run `openclaw doctor --fix`.",
+    );
+    expect(responseBody(end)).not.toContain("private-credential");
+    expect(responseBody(end)).not.toContain("/home/operator/private");
+  });
 
   it("keeps invalid configured roots terminal and preserves their repair guidance", async () => {
     const { res, end, setHeader } = makeMockHttpResponse();

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -207,7 +207,6 @@ function respondControlUiAssetsUnavailable(
   options?: {
     configuredRootPath?: string;
     failed?: boolean;
-    head?: boolean;
     preparing?: boolean;
   },
 ) {
@@ -221,12 +220,6 @@ function respondControlUiAssetsUnavailable(
   if (options?.preparing) {
     res.setHeader("Cache-Control", "no-store");
     res.setHeader("Retry-After", "1");
-  }
-  if (options?.head) {
-    res.statusCode = 503;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end();
-    return;
   }
   respondPlainText(res, 503, message);
 }
@@ -1103,13 +1096,11 @@ export async function handleControlUiHttpRequest(
   if (rootState?.kind === "invalid") {
     respondControlUiAssetsUnavailable(res, {
       configuredRootPath: rootState.path,
-      head: req.method === "HEAD",
     });
     return true;
   }
   if (rootState?.kind === "preparing") {
     respondControlUiAssetsUnavailable(res, {
-      head: req.method === "HEAD",
       preparing: true,
     });
     return true;
@@ -1117,12 +1108,11 @@ export async function handleControlUiHttpRequest(
   if (rootState?.kind === "failed") {
     respondControlUiAssetsUnavailable(res, {
       failed: true,
-      head: req.method === "HEAD",
     });
     return true;
   }
   if (!rootState || rootState.kind === "missing") {
-    respondControlUiAssetsUnavailable(res, { head: req.method === "HEAD" });
+    respondControlUiAssetsUnavailable(res);
     return true;
   }
 
@@ -1141,7 +1131,7 @@ export async function handleControlUiHttpRequest(
     }
   })();
   if (!rootReal) {
-    respondControlUiAssetsUnavailable(res, { head: req.method === "HEAD" });
+    respondControlUiAssetsUnavailable(res);
     return true;
   }
 


### PR DESCRIPTION
## Summary

- Fix Control UI plain-text responses so GET and HEAD expose the byte length of the selected representation for 404, 406, and all five 503 root-state paths.
- Keep `respondPlainText` as the single metadata owner. The 406 path preserves `Cache-Control` and `Vary`, while the 503 path no longer carries a separate HEAD-only response branch.
- Keep 204 bodyless and omit `Content-Length`.

## Why this is the best fix

Node already suppresses response bodies for HEAD while retaining explicitly declared representation metadata. Encoding request-method policy in each caller duplicated behavior and caused the unavailable-assets path to diverge.

This rewrite records the byte-accurate length once in `respondPlainText`, delegates 406 and every 503 variant to that helper, and removes the dedicated 503 HEAD option and branch. HTTP permits `Content-Length` on HEAD when it equals the corresponding GET representation length; 204 does not carry `Content-Length`.

## User impact

Clients probing the Control UI with HEAD now receive the same useful plain-text representation metadata as GET without transferring a body. UTF-8 payloads use byte length rather than JavaScript string length.

## Verification

- Added a real `http.createServer` loopback matrix covering GET and HEAD for 404, 406, five 503 root states, and 204.
- Before the production fix, the new regression test failed 7 of 8 cases on missing `Content-Length`; the 204 case passed.
- Focused gateway suite: 149 tests passed.
- New loopback suite repeated three times: 8/8 passed each run.
- Targeted formatting, lint, and `git diff --check`: passed.
- Max-P1 local autoreview: no findings, correctness confidence 0.96.
- Blacksmith Testbox lint authority: [run 31087168885](https://github.com/openclaw/openclaw/actions/runs/31087168885), terminal success with 0 warnings and 0 errors.

Production delta: +7/-15 (net -8). Test delta: +206/-47.

## Release provenance

- The shared 404 helper behavior is present from v2026.3.11 through current main.
- The 406 path is present from v2026.7.2-beta.1 through v2026.7.2-beta.7.
- The preparing/failed 503 variants were added on main by #118388 and have not shipped in a release tag.

No changelog entry: this is a narrow HTTP response-metadata correction. Original report and contributor credit: Dirk (@xzh-icenter).
