### PR TITLE
fix(plugins): isolate malformed manifest schemas from plugin load and config validation

### DIFF
--- a/src/config/channel-config-metadata.test.ts
+++ b/src/config/channel-config-metadata.test.ts
@@ -1,0 +1,51 @@
+// Verifies channel config metadata collection stays total on untrusted manifest schemas.
+
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { collectChannelSchemaMetadataWithOwnership } from "./channel-config-metadata.js";
+
+function createExternalChannelSchemaRegistry(channelId: string, schema: Record<string, unknown>) {
+  return {
+    diagnostics: [],
+    plugins: [
+      {
+        id: "deep-channel-schema-plugin",
+        channels: [channelId],
+        channelConfigs: { [channelId]: { schema } },
+        cliBackends: [],
+        hooks: [],
+        manifestPath: "/tmp/deep-channel-schema-plugin/openclaw.plugin.json",
+        origin: "global",
+        providers: [],
+        rootDir: "/tmp/deep-channel-schema-plugin",
+        skills: [],
+        source: "/tmp/deep-channel-schema-plugin/index.js",
+      } satisfies PluginManifestRecord,
+    ],
+  };
+}
+
+describe("collectChannelSchemaMetadataWithOwnership", () => {
+  // Non-bundled channel schemas are cloned and recursively walked here, before any validator
+  // runs, so this producer is where a deeply nested manifest has to be contained; otherwise
+  // config validation dies with a raw RangeError instead of reporting an issue. "feishu" takes
+  // only the core-owned normalization; "qqbot" additionally hits the official-channel secret
+  // widening, which clones the schema a second time.
+  it.each(["feishu", "qqbot"])(
+    "surfaces a deeply nested %s schema instead of overflowing the stack",
+    (channelId) => {
+      let schema: Record<string, unknown> = { type: "object" };
+      for (let depth = 0; depth < 3_000; depth++) {
+        schema = { type: "object", properties: { nested: schema } };
+      }
+
+      const entries = collectChannelSchemaMetadataWithOwnership(
+        createExternalChannelSchemaRegistry(channelId, schema),
+      );
+
+      expect(entries).toContainEqual(
+        expect.objectContaining({ id: channelId, configSchema: schema }),
+      );
+    },
+  );
+});

--- a/src/config/channel-config-metadata.test.ts
+++ b/src/config/channel-config-metadata.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it } from "vitest";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { collectChannelSchemaMetadataWithOwnership } from "./channel-config-metadata.js";
 
-function createExternalChannelSchemaRegistry(channelId: string, schema: Record<string, unknown>) {
+function createChannelSchemaRegistry(
+  channelId: string,
+  schema: Record<string, unknown>,
+  origin: PluginManifestRecord["origin"] = "global",
+) {
   return {
     diagnostics: [],
     plugins: [
@@ -15,7 +19,7 @@ function createExternalChannelSchemaRegistry(channelId: string, schema: Record<s
         cliBackends: [],
         hooks: [],
         manifestPath: "/tmp/deep-channel-schema-plugin/openclaw.plugin.json",
-        origin: "global",
+        origin,
         providers: [],
         rootDir: "/tmp/deep-channel-schema-plugin",
         skills: [],
@@ -40,7 +44,7 @@ describe("collectChannelSchemaMetadataWithOwnership", () => {
       }
 
       const entries = collectChannelSchemaMetadataWithOwnership(
-        createExternalChannelSchemaRegistry(channelId, schema),
+        createChannelSchemaRegistry(channelId, schema),
       );
 
       expect(entries).toContainEqual(
@@ -48,4 +52,17 @@ describe("collectChannelSchemaMetadataWithOwnership", () => {
       );
     },
   );
+
+  it("keeps bundled schema preparation failures on the throwing path", () => {
+    let schema: Record<string, unknown> = { type: "object" };
+    for (let depth = 0; depth < 3_000; depth++) {
+      schema = { type: "object", properties: { nested: schema } };
+    }
+
+    expect(() =>
+      collectChannelSchemaMetadataWithOwnership(
+        createChannelSchemaRegistry("qqbot", schema, "bundled"),
+      ),
+    ).toThrow();
+  });
 });

--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -11,7 +11,7 @@ import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
 
 type ChannelSchemaMetadataWithOwnership = ChannelUiMetadata & {
   schemaPluginId?: string;
-  schemaPluginOrigin?: PluginOrigin;
+  schemaPluginOrigin: PluginOrigin;
 };
 
 type ChannelMetadataRecord = ChannelSchemaMetadataWithOwnership & {
@@ -162,17 +162,17 @@ function prepareChannelConfigSchema(
   channelId: string,
   schema: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
+  if (origin === "bundled") {
+    return widenOfficialExternalChannelSecretSchema({ channelId, schema });
+  }
   try {
-    const coreOwnedSchema =
-      origin === "bundled" || schema === undefined
-        ? schema
-        : normalizeCoreOwnedChannelSchema(schema);
+    const coreOwnedSchema = schema === undefined ? schema : normalizeCoreOwnedChannelSchema(schema);
     return widenOfficialExternalChannelSecretSchema({ channelId, schema: coreOwnedSchema });
   } catch {
     // Normalization and official-channel widening both clone and walk the schema, so a deeply
     // nested external manifest overflows here, before any validator runs. Surfacing the raw
     // schema keeps metadata collection total and leaves the diagnostic to the one owner of it,
-    // validateManifestSchemaValue.
+    // validatePluginSchemaValue.
     return schema;
   }
 }
@@ -200,7 +200,7 @@ export function collectChannelSchemaMetadataWithOwnership(
           configSchema: current?.configSchema,
           configUiHints: current?.configUiHints,
           schemaPluginId: current?.schemaPluginId,
-          schemaPluginOrigin: current?.schemaPluginOrigin,
+          schemaPluginOrigin: current?.schemaPluginOrigin ?? record.origin,
           originRank,
         });
       }

--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -157,6 +157,26 @@ export function collectPluginSchemaMetadataCore(
     .map(({ originRank: _originRank, ...record }) => record);
 }
 
+function prepareChannelConfigSchema(
+  origin: PluginOrigin,
+  channelId: string,
+  schema: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  try {
+    const coreOwnedSchema =
+      origin === "bundled" || schema === undefined
+        ? schema
+        : normalizeCoreOwnedChannelSchema(schema);
+    return widenOfficialExternalChannelSecretSchema({ channelId, schema: coreOwnedSchema });
+  } catch {
+    // Normalization and official-channel widening both clone and walk the schema, so a deeply
+    // nested external manifest overflows here, before any validator runs. Surfacing the raw
+    // schema keeps metadata collection total and leaves the diagnostic to the one owner of it,
+    // validateManifestSchemaValue.
+    return schema;
+  }
+}
+
 /** Collects per-channel config metadata with the plugin that supplied the selected schema. */
 export function collectChannelSchemaMetadataWithOwnership(
   registry: PluginManifestRegistry,
@@ -197,14 +217,11 @@ export function collectChannelSchemaMetadataWithOwnership(
         // advertises the same channel id.
         continue;
       }
-      const coreOwnedSchema =
-        record.origin === "bundled" || channelConfig.schema === undefined
-          ? channelConfig.schema
-          : normalizeCoreOwnedChannelSchema(channelConfig.schema);
-      const configSchema = widenOfficialExternalChannelSecretSchema({
+      const configSchema = prepareChannelConfigSchema(
+        record.origin,
         channelId,
-        schema: coreOwnedSchema,
-      });
+        channelConfig.schema,
+      );
       byChannelId.set(channelId, {
         id: channelId,
         label: channelConfig.label ?? rootLabel ?? current?.label,

--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -229,7 +229,7 @@ export function collectChannelSchemaMetadataWithOwnership(
         configSchema,
         configUiHints: channelConfig.uiHints as ChannelUiMetadata["configUiHints"],
         schemaPluginId: configSchema === undefined ? undefined : record.id,
-        schemaPluginOrigin: configSchema === undefined ? undefined : record.origin,
+        schemaPluginOrigin: record.origin,
         originRank,
       });
     }

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "../plugins/installed-plugin-index-records.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import { resolveConfigWidePluginManifestRegistry } from "./io.plugin-metadata.js";
 import { validateConfigObjectWithPlugins as validateConfigObjectWithPluginsRaw } from "./validation.js";
@@ -310,6 +311,39 @@ describe("config plugin validation", () => {
         "invalid schema",
       );
     }
+  });
+
+  it("keeps malformed bundled plugin schemas on the throwing path", () => {
+    const bundledRecord = {
+      id: "bundled-schema-plugin",
+      channels: [],
+      cliBackends: [],
+      configSchema: {
+        type: "object",
+        properties: { mode: { $ref: "#/$defs/Mode" } },
+      },
+      hooks: [],
+      manifestPath: "/bundled/schema/openclaw.plugin.json",
+      origin: "bundled",
+      providers: [],
+      rootDir: "/bundled/schema",
+      skills: [],
+      source: "/bundled/schema/index.js",
+    } satisfies PluginManifestRecord;
+
+    expect(() =>
+      validateConfigObjectWithPlugins(
+        {
+          agents: { list: [{ id: "openclaw" }] },
+          plugins: { entries: { "bundled-schema-plugin": { enabled: true } } },
+        },
+        {
+          pluginMetadataSnapshot: {
+            manifestRegistry: { diagnostics: [], plugins: [bundledRecord] },
+          },
+        },
+      ),
+    ).toThrow("invalid schema");
   });
 
   it("reports missing plugin refs across entries and allowlist surfaces", () => {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -131,6 +131,7 @@ describe("config plugin validation", () => {
   let bundlePluginDir = "";
   let manifestlessClaudeBundleDir = "";
   let blockedPluginDir = "";
+  let malformedSchemaPluginDir = "";
   const suiteEnv = () =>
     ({
       HOME: suiteHome,
@@ -257,6 +258,15 @@ describe("config plugin validation", () => {
       id: "blocked-plugin",
       schema: { type: "object" },
     });
+    malformedSchemaPluginDir = path.join(suiteHome, "malformed-schema-plugin");
+    await writePluginFixture({
+      dir: malformedSchemaPluginDir,
+      id: "malformed-schema-plugin",
+      schema: {
+        type: "object",
+        properties: { mode: { $ref: "#/$defs/Mode" } },
+      },
+    });
     voiceCallSchemaPluginDir = path.join(suiteHome, "voice-call-schema-plugin");
     const voiceCallManifestPath = path.join(
       process.cwd(),
@@ -279,6 +289,27 @@ describe("config plugin validation", () => {
 
   afterAll(async () => {
     await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("reports a malformed plugin configSchema as an issue instead of throwing", () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "openclaw" }] },
+      plugins: {
+        enabled: true,
+        load: { paths: [malformedSchemaPluginDir] },
+        entries: { "malformed-schema-plugin": { enabled: true } },
+        allow: ["malformed-schema-plugin"],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expectPathMessageIncludes(
+        res.issues,
+        "plugins.entries.malformed-schema-plugin.config",
+        "invalid schema",
+      );
+    }
   });
 
   it("reports missing plugin refs across entries and allowlist surfaces", () => {

--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -13,7 +13,7 @@ import {
   getOfficialExternalPluginCatalogEntry,
   resolveOfficialExternalPluginInstall,
 } from "../plugins/official-external-plugin-catalog.js";
-import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
+import { validateManifestSchemaValue } from "../plugins/schema-validator.js";
 import { hasKind } from "../plugins/slots.js";
 import { isRecord, resolveUserPath } from "../utils.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
@@ -387,7 +387,7 @@ export function validateExplicitPluginConfig(params: {
     const shouldValidate = enabled || entryHasConfig;
     if (shouldValidate) {
       if (record.configSchema) {
-        const result = validateJsonSchemaValue({
+        const result = validateManifestSchemaValue({
           schema: record.configSchema,
           cacheKey: record.schemaCacheKey ?? record.manifestPath ?? pluginId,
           value: entry?.config ?? {},

--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -13,7 +13,7 @@ import {
   getOfficialExternalPluginCatalogEntry,
   resolveOfficialExternalPluginInstall,
 } from "../plugins/official-external-plugin-catalog.js";
-import { validateManifestSchemaValue } from "../plugins/schema-validator.js";
+import { validatePluginSchemaValue } from "../plugins/schema-validator.js";
 import { hasKind } from "../plugins/slots.js";
 import { isRecord, resolveUserPath } from "../utils.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
@@ -387,7 +387,8 @@ export function validateExplicitPluginConfig(params: {
     const shouldValidate = enabled || entryHasConfig;
     if (shouldValidate) {
       if (record.configSchema) {
-        const result = validateManifestSchemaValue({
+        const result = validatePluginSchemaValue({
+          origin: record.origin,
           schema: record.configSchema,
           cacheKey: record.schemaCacheKey ?? record.manifestPath ?? pluginId,
           value: entry?.config ?? {},

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -649,46 +649,6 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("reports a malformed external channel manifest schema as an issue instead of throwing", () => {
-    // channelConfigs.*.schema is untrusted external-plugin input (channel-config-metadata.ts
-    // merges every plugin origin, not just bundled), so a structurally invalid schema must
-    // isolate the same way a malformed plugin configSchema already does.
-    mockLoadPluginManifestRegistry.mockReturnValue({
-      diagnostics: [],
-      plugins: [
-        createPluginManifestRecord({
-          id: "broken-channel-schema-plugin",
-          origin: "global",
-          channels: ["feishu"],
-          channelConfigs: {
-            feishu: {
-              schema: {
-                type: "object",
-                properties: { mode: { $ref: "#/$defs/Mode" } },
-              },
-            },
-          },
-        }),
-      ],
-    });
-
-    const result = validateConfigObjectRawWithPlugins({
-      channels: {
-        feishu: { appId: "app-id" },
-      },
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.issues).toContainEqual(
-        expect.objectContaining({
-          path: "channels.feishu",
-          message: expect.stringContaining("invalid schema"),
-        }),
-      );
-    }
-  });
-
   it("accepts core-owned heartbeat visibility in closed channel and account schemas", () => {
     mockLoadPluginManifestRegistry.mockReturnValue(createExternalFeishuSchemaRegistry());
 

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -649,6 +649,46 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("reports a malformed external channel manifest schema as an issue instead of throwing", () => {
+    // channelConfigs.*.schema is untrusted external-plugin input (channel-config-metadata.ts
+    // merges every plugin origin, not just bundled), so a structurally invalid schema must
+    // isolate the same way a malformed plugin configSchema already does.
+    mockLoadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [
+        createPluginManifestRecord({
+          id: "broken-channel-schema-plugin",
+          origin: "global",
+          channels: ["feishu"],
+          channelConfigs: {
+            feishu: {
+              schema: {
+                type: "object",
+                properties: { mode: { $ref: "#/$defs/Mode" } },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        feishu: { appId: "app-id" },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          path: "channels.feishu",
+          message: expect.stringContaining("invalid schema"),
+        }),
+      );
+    }
+  });
+
   it("accepts core-owned heartbeat visibility in closed channel and account schemas", () => {
     mockLoadPluginManifestRegistry.mockReturnValue(createExternalFeishuSchemaRegistry());
 

--- a/src/config/validation.channel-schema-errors.test.ts
+++ b/src/config/validation.channel-schema-errors.test.ts
@@ -1,0 +1,58 @@
+// Verifies channel schema failures follow the plugin manifest trust boundary.
+
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { validateConfigObjectRawWithPlugins } from "./validation.js";
+
+const malformedSchema = {
+  type: "object",
+  properties: { mode: { $ref: "#/$defs/Mode" } },
+};
+
+function createRegistry(origin: PluginManifestRecord["origin"]): PluginManifestRegistry {
+  return {
+    diagnostics: [],
+    plugins: [
+      {
+        id: "schema-owner",
+        channels: ["schema-channel"],
+        channelConfigs: { "schema-channel": { schema: malformedSchema } },
+        cliBackends: [],
+        hooks: [],
+        manifestPath: "/plugins/schema-owner/openclaw.plugin.json",
+        origin,
+        providers: [],
+        rootDir: "/plugins/schema-owner",
+        skills: [],
+        source: "/plugins/schema-owner/index.js",
+      },
+    ],
+  };
+}
+
+function validate(origin: PluginManifestRecord["origin"]) {
+  return validateConfigObjectRawWithPlugins(
+    { channels: { "schema-channel": {} } },
+    { pluginMetadataSnapshot: { manifestRegistry: createRegistry(origin) } },
+  );
+}
+
+describe("channel schema error ownership", () => {
+  it("reports malformed external channel schemas as scoped issues", () => {
+    const result = validate("global");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          path: "channels.schema-channel",
+          message: expect.stringContaining("invalid schema"),
+        }),
+      );
+    }
+  });
+
+  it("keeps malformed bundled channel schemas on the throwing path", () => {
+    expect(() => validate("bundled")).toThrow("invalid schema");
+  });
+});

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -10,7 +10,7 @@ import { normalizePluginsConfig, normalizePluginId } from "../plugins/config-sta
 import { loadInstalledPluginIndexInstallRecordsSync } from "../plugins/installed-plugin-index-record-reader.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
+import { validateManifestSchemaValue } from "../plugins/schema-validator.js";
 import { resolveWebSearchInstallCatalogEntries } from "../plugins/web-search-install-catalog.js";
 import { resolveSecretRefProviderSourceMismatch } from "../secrets/ref-contract.js";
 import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
@@ -623,7 +623,11 @@ function validateConfigObjectWithPluginsBase(
       if (!channelSchema?.schema) {
         continue;
       }
-      const result = validateJsonSchemaValue({
+      // channelSchema.schema can come from an external plugin's channelConfigs.*.schema
+      // (channel-config-metadata.ts merges every plugin origin, not just bundled), so it
+      // is untrusted manifest input and must use the isolation path instead of the
+      // throwing validator reserved for repo-owned schemas.
+      const result = validateManifestSchemaValue({
         schema: channelSchema.schema,
         cacheKey: `channel:${trimmed}`,
         value: config.channels[trimmed],

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -10,7 +10,8 @@ import { normalizePluginsConfig, normalizePluginId } from "../plugins/config-sta
 import { loadInstalledPluginIndexInstallRecordsSync } from "../plugins/installed-plugin-index-record-reader.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import { validateManifestSchemaValue } from "../plugins/schema-validator.js";
+import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import { validatePluginSchemaValue } from "../plugins/schema-validator.js";
 import { resolveWebSearchInstallCatalogEntries } from "../plugins/web-search-install-catalog.js";
 import { resolveSecretRefProviderSourceMismatch } from "../secrets/ref-contract.js";
 import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
@@ -72,7 +73,10 @@ type RegistryInfo = {
   overriddenPluginIds?: Set<string>;
   normalizedPlugins?: ReturnType<typeof normalizePluginsConfig>;
   channelDmAllowFromModes?: Map<string, ChannelDmAllowFromMode>;
-  channelSchemas?: Map<string, { schema?: Record<string, unknown>; pluginId?: string }>;
+  channelSchemas?: Map<
+    string,
+    { schema?: Record<string, unknown>; pluginId?: string; origin: PluginOrigin }
+  >;
 };
 
 function collectSecretRefProviderSourceIssues(params: {
@@ -338,13 +342,13 @@ function validateConfigObjectWithPluginsBase(
 
   const ensureChannelSchemas = (): Map<
     string,
-    { schema?: Record<string, unknown>; pluginId?: string }
+    { schema?: Record<string, unknown>; pluginId?: string; origin: PluginOrigin }
   > => {
     const info = ensureRegistry();
     if (!info.channelSchemas) {
       info.channelSchemas = new Map(
         GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.map(
-          (entry) => [entry.channelId, { schema: entry.schema }] as const,
+          (entry) => [entry.channelId, { schema: entry.schema, origin: "bundled" }] as const,
         ),
       );
       for (const entry of collectChannelSchemaMetadataWithOwnership(info.registry)) {
@@ -353,9 +357,12 @@ function validateConfigObjectWithPluginsBase(
           info.channelSchemas.set(entry.id, {
             schema: entry.configSchema,
             pluginId: entry.schemaPluginOrigin === "bundled" ? undefined : entry.schemaPluginId,
+            origin: entry.schemaPluginOrigin,
           });
         } else if (!current) {
-          info.channelSchemas.set(entry.id, {});
+          info.channelSchemas.set(entry.id, {
+            origin: entry.schemaPluginOrigin,
+          });
         }
       }
     }
@@ -627,7 +634,8 @@ function validateConfigObjectWithPluginsBase(
       // (channel-config-metadata.ts merges every plugin origin, not just bundled), so it
       // is untrusted manifest input and must use the isolation path instead of the
       // throwing validator reserved for repo-owned schemas.
-      const result = validateManifestSchemaValue({
+      const result = validatePluginSchemaValue({
+        origin: channelSchema.origin,
         schema: channelSchema.schema,
         cacheKey: `channel:${trimmed}`,
         value: config.channels[trimmed],

--- a/src/plugins/cli-root-descriptors.ts
+++ b/src/plugins/cli-root-descriptors.ts
@@ -48,6 +48,7 @@ export async function getPluginCliCommandDescriptors(
       const pluginConfig = normalizedConfig.entries[normalizePluginPolicyId(plugin.id)]?.config;
       if (
         !validatePluginConfig({
+          origin: plugin.origin,
           schema: plugin.configSchema,
           cacheKey: plugin.schemaCacheKey,
           value: pluginConfig,

--- a/src/plugins/install-persistence.enablement.test.ts
+++ b/src/plugins/install-persistence.enablement.test.ts
@@ -379,6 +379,44 @@ describe("persistPluginInstall enablement", () => {
     });
   });
 
+  it("rejects a malformed manifest schema instead of treating it as missing config", async () => {
+    const { persistPluginInstall } = await import("./install-persistence.js");
+    const baseConfig = {
+      plugins: { allow: ["memory-core"], deny: ["broken-schema"], entries: {} },
+    } as OpenClawConfig;
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [
+        createManifestRecord("broken-schema", {
+          configSchema: {
+            type: "object",
+            properties: { mode: { $ref: "#/$defs/Mode" } },
+          },
+        }),
+      ],
+      diagnostics: [],
+    });
+
+    await expect(
+      persistPluginInstall({
+        snapshot: {
+          config: baseConfig,
+          baseHash: "config-1",
+          writeOptions: installWriteOptions,
+        },
+        pluginId: "broken-schema",
+        install: {
+          source: "npm",
+          spec: "broken-schema@1.0.0",
+          installPath: "/tmp/broken-schema",
+        },
+      }),
+    ).rejects.toThrow("has invalid configured settings");
+
+    expect(enablePluginInConfigMock).not.toHaveBeenCalled();
+    expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
+    expect(configWriteMock).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid authored plugin config even for a disabled install", async () => {
     const { persistPluginInstall } = await import("./install-persistence.js");
     let committed = false;

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -38,7 +38,7 @@ import { loadPluginManifestRegistryCore, type PluginManifestRecord } from "./man
 import { safeRealpathSync } from "./path-safety.js";
 import { tracePluginLifecyclePhaseAsync } from "./plugin-lifecycle-trace.js";
 import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
-import { validateJsonSchemaValue } from "./schema-validator.js";
+import { validateManifestSchemaValue } from "./schema-validator.js";
 import { applySlotSelectionForPlugin } from "./slot-selection.js";
 import { buildPluginSnapshotReport } from "./status.js";
 import { recordPluginPackageUninstallPlan } from "./uninstall-package-plan.js";
@@ -459,7 +459,7 @@ function resolvePluginConfigEnablement(params: {
   }
   const entry = params.config.plugins?.entries?.[params.pluginId];
   const hasConfig = isRecord(entry) && Object.hasOwn(entry, "config");
-  const result = validateJsonSchemaValue({
+  const result = validateManifestSchemaValue({
     schema: manifest.configSchema,
     cacheKey: manifest.schemaCacheKey ?? manifest.manifestPath,
     value: hasConfig ? entry.config : {},

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -38,7 +38,7 @@ import { loadPluginManifestRegistryCore, type PluginManifestRecord } from "./man
 import { safeRealpathSync } from "./path-safety.js";
 import { tracePluginLifecyclePhaseAsync } from "./plugin-lifecycle-trace.js";
 import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
-import { validateManifestSchemaValue } from "./schema-validator.js";
+import { validatePluginSchemaValue } from "./schema-validator.js";
 import { applySlotSelectionForPlugin } from "./slot-selection.js";
 import { buildPluginSnapshotReport } from "./status.js";
 import { recordPluginPackageUninstallPlan } from "./uninstall-package-plan.js";
@@ -459,7 +459,8 @@ function resolvePluginConfigEnablement(params: {
   }
   const entry = params.config.plugins?.entries?.[params.pluginId];
   const hasConfig = isRecord(entry) && Object.hasOwn(entry, "config");
-  const result = validateManifestSchemaValue({
+  const result = validatePluginSchemaValue({
+    origin: manifest.origin,
     schema: manifest.configSchema,
     cacheKey: manifest.schemaCacheKey ?? manifest.manifestPath,
     value: hasConfig ? entry.config : {},

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -468,7 +468,10 @@ function resolvePluginConfigEnablement(params: {
   if (result.ok) {
     return { mode: "ready" };
   }
-  if (!hasConfig) {
+  // A malformed manifest schema fails validation regardless of what config is supplied,
+  // so it is never "missing" (no config value could satisfy it) even when hasConfig is
+  // false; only a well-formed schema rejecting an absent/empty config counts as missing.
+  if (!hasConfig && !result.schemaError) {
     return { mode: "missing" };
   }
   return { mode: "invalid", error: result.errors[0]?.text ?? "invalid plugin config" };

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -199,6 +199,7 @@ export async function loadOpenClawPluginCliRegistry(
       continue;
     }
     const validatedConfig = validatePluginConfig({
+      origin: candidate.origin,
       schema: manifestRecord.configSchema,
       cacheKey: manifestRecord.schemaCacheKey,
       value: entry?.config,

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -334,6 +334,7 @@ export function loadRuntimePluginCandidate(params: {
     }
   }
   const validatedConfig = validatePluginConfig({
+    origin: candidate.origin,
     schema: manifestRecord.configSchema,
     cacheKey: manifestRecord.schemaCacheKey,
     value: entry?.config,

--- a/src/plugins/loader-shared.test.ts
+++ b/src/plugins/loader-shared.test.ts
@@ -9,7 +9,7 @@ import type { PluginCandidate } from "./discovery.js";
 import {
   createManifestPluginRecord,
   createPluginCandidatesFromManifestRegistry,
-  validatePluginConfig,
+  validatePluginConfig as validatePluginConfigByOrigin,
 } from "./loader-shared.js";
 import { loadOpenClawPluginCliRegistry, loadOpenClawPlugins } from "./loader.js";
 import {
@@ -24,6 +24,12 @@ const emptyObjectSchema = {
   additionalProperties: false,
   properties: {},
 } as const;
+
+function validatePluginConfig(
+  params: Omit<Parameters<typeof validatePluginConfigByOrigin>[0], "origin">,
+) {
+  return validatePluginConfigByOrigin({ ...params, origin: "global" });
+}
 
 function withSchemaKeyword(key: "if" | "then" | "else", value: unknown) {
   return { [key]: value };
@@ -165,6 +171,19 @@ describe("validatePluginConfig manifest schema isolation", () => {
     }
 
     expect(validatePluginConfig({ schema, value: {} })).toMatchObject({ ok: false });
+  });
+
+  it("keeps malformed bundled schemas on the throwing path", () => {
+    expect(() =>
+      validatePluginConfigByOrigin({
+        origin: "bundled",
+        schema: {
+          type: "object",
+          properties: { mode: { $ref: "#/$defs/Mode" } },
+        },
+        value: {},
+      }),
+    ).toThrow("invalid schema");
   });
 });
 

--- a/src/plugins/loader-shared.test.ts
+++ b/src/plugins/loader-shared.test.ts
@@ -144,6 +144,30 @@ describe("validatePluginConfig source values", () => {
   });
 });
 
+describe("validatePluginConfig manifest schema isolation", () => {
+  it("returns an error instead of throwing on a structurally invalid schema", () => {
+    const result = validatePluginConfig({
+      schema: {
+        type: "object",
+        properties: { mode: { $ref: "#/$defs/Mode" } },
+      },
+      value: {},
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok ? [] : result.error.join(" ")).toContain("invalid schema");
+  });
+
+  it("returns an error instead of throwing when a schema is nested past the stack limit", () => {
+    let schema: Record<string, unknown> = { type: "object" };
+    for (let depth = 0; depth < 3_000; depth++) {
+      schema = { type: "object", properties: { nested: schema } };
+    }
+
+    expect(validatePluginConfig({ schema, value: {} })).toMatchObject({ ok: false });
+  });
+});
+
 describe("validatePluginConfig empty schema classification", () => {
   it("validates pattern properties instead of requiring empty config", () => {
     const schema = {

--- a/src/plugins/loader-shared.test.ts
+++ b/src/plugins/loader-shared.test.ts
@@ -169,6 +169,18 @@ describe("validatePluginConfig manifest schema isolation", () => {
 });
 
 describe("validatePluginConfig empty schema classification", () => {
+  it("validates an empty-looking schema carrying an unresolvable $ref", () => {
+    // The empty-config shortcut answers before the schema is ever compiled, so a schema it
+    // cannot reason about must fall through to validation instead of being silently accepted.
+    const result = validatePluginConfig({
+      schema: { ...emptyObjectSchema, $ref: "#/$defs/Missing" },
+      value: {},
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok ? [] : result.error.join(" ")).toContain("invalid schema");
+  });
+
   it("validates pattern properties instead of requiring empty config", () => {
     const schema = {
       ...emptyObjectSchema,
@@ -224,13 +236,18 @@ describe("validatePluginConfig empty schema classification", () => {
     withSchemaKeyword("if", true),
     withSchemaKeyword("then", { minProperties: 1 }),
     withSchemaKeyword("else", { minProperties: 1 }),
-  ])("keeps standalone conditional keywords on the empty-config path: %o", (keyword) => {
+  ])("keeps a closed empty schema closed under an inert conditional keyword: %o", (keyword) => {
+    // A standalone if/then/else imposes nothing, but it also takes the schema off the
+    // empty-config shortcut, so the closed-object rejection has to come from validation.
     expect(
       validatePluginConfig({
         schema: { ...emptyObjectSchema, ...keyword },
         value: { unexpected: true },
       }),
-    ).toEqual({ ok: false, error: ["<root>: config must be empty"] });
+    ).toMatchObject({ ok: false });
+    expect(
+      validatePluginConfig({ schema: { ...emptyObjectSchema, ...keyword }, value: {} }),
+    ).toMatchObject({ ok: true });
   });
 });
 

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -235,6 +235,24 @@ export function validatePluginConfig(params: {
     : resultError(result.errors.map((error) => error.text));
 }
 
+// The empty-config shortcut answers without compiling the schema, so it is only sound for
+// schemas built purely from keywords it accounts for. An allowlist holds that invariant where
+// a denylist leaked every new keyword: an extra constraint, an unresolvable `$ref`, or an
+// unknown keyword now falls through to validateManifestSchemaValue, which owns the diagnostic.
+const EMPTY_PLUGIN_CONFIG_SHORTCUT_KEYWORDS = new Set([
+  "type",
+  "additionalProperties",
+  "properties",
+  "title",
+  "description",
+  "$schema",
+  "$id",
+  "$comment",
+  "deprecated",
+  "readOnly",
+  "writeOnly",
+]);
+
 function isEmptyPluginConfigJsonSchema(schema: Record<string, unknown>): boolean {
   if (schema.type !== "object" || schema.additionalProperties !== false) {
     return false;
@@ -248,20 +266,7 @@ function isEmptyPluginConfigJsonSchema(schema: Record<string, unknown>): boolean
   ) {
     return false;
   }
-  const hasConditional = "if" in schema && ("then" in schema || "else" in schema);
-  return !(
-    "required" in schema ||
-    "dependentRequired" in schema ||
-    "dependentSchemas" in schema ||
-    "dependencies" in schema ||
-    "minProperties" in schema ||
-    "allOf" in schema ||
-    "anyOf" in schema ||
-    "oneOf" in schema ||
-    "not" in schema ||
-    "patternProperties" in schema ||
-    hasConditional
-  );
+  return Object.keys(schema).every((keyword) => EMPTY_PLUGIN_CONFIG_SHORTCUT_KEYWORDS.has(keyword));
 }
 
 export function pushDiagnostics(diagnostics: PluginDiagnostic[], append: PluginDiagnostic[]): void {

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -35,6 +35,7 @@ import {
 } from "./manifest-install-owner.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
+import type { PluginOrigin } from "./plugin-origin.types.js";
 import type { PluginRecord, PluginRegistry } from "./registry.js";
 import {
   captureActivePluginRegistrySnapshot,
@@ -42,7 +43,7 @@ import {
   rollbackStagedPluginRegistry,
   stageActivePluginRegistry,
 } from "./runtime.js";
-import { validateManifestSchemaValue } from "./schema-validator.js";
+import { validatePluginSchemaValue } from "./schema-validator.js";
 import { hasKind } from "./slots.js";
 import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
 import type { PluginLogger } from "./types.js";
@@ -199,6 +200,7 @@ class PluginLoadFailureError extends Error {
 }
 
 export function validatePluginConfig(params: {
+  origin: PluginOrigin;
   schema?: Record<string, unknown>;
   cacheKey?: string;
   value?: unknown;
@@ -223,7 +225,8 @@ export function validatePluginConfig(params: {
     }
     return resultError(["<root>: config must be empty"]);
   }
-  const result = validateManifestSchemaValue({
+  const result = validatePluginSchemaValue({
+    origin: params.origin,
     schema,
     cacheKey: params.cacheKey ?? JSON.stringify(schema),
     value: value ?? {},
@@ -238,7 +241,7 @@ export function validatePluginConfig(params: {
 // The empty-config shortcut answers without compiling the schema, so it is only sound for
 // schemas built purely from keywords it accounts for. An allowlist holds that invariant where
 // a denylist leaked every new keyword: an extra constraint, an unresolvable `$ref`, or an
-// unknown keyword now falls through to validateManifestSchemaValue, which owns the diagnostic.
+// unknown keyword now falls through to validatePluginSchemaValue, which owns the diagnostic.
 const EMPTY_PLUGIN_CONFIG_SHORTCUT_KEYWORDS = new Set([
   "type",
   "additionalProperties",

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -42,7 +42,7 @@ import {
   rollbackStagedPluginRegistry,
   stageActivePluginRegistry,
 } from "./runtime.js";
-import { validateJsonSchemaValue } from "./schema-validator.js";
+import { validateManifestSchemaValue } from "./schema-validator.js";
 import { hasKind } from "./slots.js";
 import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
 import type { PluginLogger } from "./types.js";
@@ -223,7 +223,7 @@ export function validatePluginConfig(params: {
     }
     return resultError(["<root>: config must be empty"]);
   }
-  const result = validateJsonSchemaValue({
+  const result = validateManifestSchemaValue({
     schema,
     cacheKey: params.cacheKey ?? JSON.stringify(schema),
     value: value ?? {},

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -19,7 +19,12 @@ function makePluginLoaderTempDir() {
   return dir;
 }
 
-function writePlugin(params: { id: string; body: string; dir?: string }): {
+function writePlugin(params: {
+  id: string;
+  body: string;
+  dir?: string;
+  configSchema?: Record<string, unknown>;
+}): {
   id: string;
   file: string;
   dir: string;
@@ -36,7 +41,7 @@ function writePlugin(params: { id: string; body: string; dir?: string }): {
       name: params.id,
       version: "1.0.0",
       main: filename,
-      configSchema: { type: "object" },
+      configSchema: params.configSchema ?? { type: "object" },
     }),
     "utf-8",
   );
@@ -116,6 +121,66 @@ describe("graceful plugin initialization failure", () => {
     const registry = await loadPlugins([failing.file, working.file]);
 
     expect(registry.plugins.find((plugin) => plugin.id === "plugin-ok")?.status).toBe("loaded");
+  });
+
+  it("keeps loading other plugins when one manifest declares a malformed configSchema", async () => {
+    const broken = writePlugin({
+      id: "broken-schema-plugin",
+      body: `module.exports = { id: "broken-schema-plugin", register() {} };`,
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: { mode: { $ref: "#/$defs/Mode" } },
+        definitions: { Mode: { type: "string", enum: ["fast", "slow"] } },
+      },
+    });
+    const healthy = writePlugin({
+      id: "healthy-schema-plugin",
+      body: `module.exports = { id: "healthy-schema-plugin", register() {} };`,
+    });
+
+    const registry = await loadPlugins([broken.file, healthy.file]);
+
+    expect(requirePluginEntry(registry, "healthy-schema-plugin").status).toBe("loaded");
+  });
+
+  it("records a malformed configSchema as a validation failure", async () => {
+    const broken = writePlugin({
+      id: "unresolved-ref-plugin",
+      body: `module.exports = { id: "unresolved-ref-plugin", register() {} };`,
+      configSchema: {
+        type: "object",
+        properties: { mode: { $ref: "#/$defs/Mode" } },
+      },
+    });
+
+    const registry = await loadPlugins([broken.file]);
+
+    const failed = requirePluginEntry(registry, "unresolved-ref-plugin");
+    expect(failed.status).toBe("error");
+    expect(failed.failurePhase).toBe("validation");
+    expect(failed.error).toContain("invalid schema");
+  });
+
+  it("keeps loading other plugins when a manifest schema is nested past the stack limit", async () => {
+    let deep: Record<string, unknown> = { type: "object" };
+    for (let depth = 0; depth < 3_000; depth++) {
+      deep = { type: "object", properties: { nested: deep } };
+    }
+    const broken = writePlugin({
+      id: "deep-schema-plugin",
+      body: `module.exports = { id: "deep-schema-plugin", register() {} };`,
+      configSchema: deep,
+    });
+    const healthy = writePlugin({
+      id: "shallow-schema-plugin",
+      body: `module.exports = { id: "shallow-schema-plugin", register() {} };`,
+    });
+
+    const registry = await loadPlugins([broken.file, healthy.file]);
+
+    expect(requirePluginEntry(registry, "shallow-schema-plugin").status).toBe("loaded");
+    expect(requirePluginEntry(registry, "deep-schema-plugin").status).toBe("error");
   });
 
   it("records failed register metadata", async () => {

--- a/src/plugins/schema-validator.manifest.test.ts
+++ b/src/plugins/schema-validator.manifest.test.ts
@@ -37,4 +37,20 @@ describe("validateManifestSchemaValue", () => {
 
     expect(result).toEqual({ ok: true, value: { a: "ok" } });
   });
+
+  it("flags schemaError only when the schema itself is unusable, not on ordinary value failures", () => {
+    const malformedSchema = validateManifestSchemaValue({
+      cacheKey: "manifest-schema.schema-error-flag",
+      schema: { type: "object", properties: { mode: { $ref: "#/$defs/Mode" } } },
+      value: {},
+    });
+    expect(malformedSchema).toMatchObject({ ok: false, schemaError: true });
+
+    const wellFormedSchemaRejectingValue = validateManifestSchemaValue({
+      cacheKey: "manifest-schema.value-error-flag",
+      schema: { type: "object", required: ["token"], properties: { token: { type: "string" } } },
+      value: {},
+    });
+    expect(wellFormedSchemaRejectingValue).toMatchObject({ ok: false, schemaError: false });
+  });
 });

--- a/src/plugins/schema-validator.manifest.test.ts
+++ b/src/plugins/schema-validator.manifest.test.ts
@@ -1,9 +1,10 @@
 // Covers the manifest-schema boundary that keeps third-party schema failures out of the loader.
 import { describe, expect, it } from "vitest";
-import { validateManifestSchemaValue } from "./schema-validator.js";
-describe("validateManifestSchemaValue", () => {
+import { validatePluginSchemaValue } from "./schema-validator.js";
+describe("validatePluginSchemaValue", () => {
   it("returns an error instead of throwing for a structurally invalid schema", () => {
-    const result = validateManifestSchemaValue({
+    const result = validatePluginSchemaValue({
+      origin: "global",
       cacheKey: "manifest-schema.unresolved-ref",
       schema: { type: "object", properties: { mode: { $ref: "#/$defs/Mode" } } },
       value: {},
@@ -15,7 +16,8 @@ describe("validateManifestSchemaValue", () => {
 
   it("strips terminal control characters a manifest embedded in the thrown text", () => {
     const escape = String.fromCharCode(27);
-    const result = validateManifestSchemaValue({
+    const result = validatePluginSchemaValue({
+      origin: "global",
       cacheKey: "manifest-schema.ansi-pattern",
       schema: {
         type: "object",
@@ -29,7 +31,8 @@ describe("validateManifestSchemaValue", () => {
   });
 
   it("keeps returning results for a valid schema", () => {
-    const result = validateManifestSchemaValue({
+    const result = validatePluginSchemaValue({
+      origin: "global",
       cacheKey: "manifest-schema.valid",
       schema: { type: "object", properties: { a: { type: "string" } } },
       value: { a: "ok" },
@@ -39,14 +42,16 @@ describe("validateManifestSchemaValue", () => {
   });
 
   it("flags schemaError only when the schema itself is unusable, not on ordinary value failures", () => {
-    const malformedSchema = validateManifestSchemaValue({
+    const malformedSchema = validatePluginSchemaValue({
+      origin: "global",
       cacheKey: "manifest-schema.schema-error-flag",
       schema: { type: "object", properties: { mode: { $ref: "#/$defs/Mode" } } },
       value: {},
     });
     expect(malformedSchema).toMatchObject({ ok: false, schemaError: true });
 
-    const wellFormedSchemaRejectingValue = validateManifestSchemaValue({
+    const wellFormedSchemaRejectingValue = validatePluginSchemaValue({
+      origin: "global",
       cacheKey: "manifest-schema.value-error-flag",
       schema: { type: "object", required: ["token"], properties: { token: { type: "string" } } },
       value: {},

--- a/src/plugins/schema-validator.manifest.test.ts
+++ b/src/plugins/schema-validator.manifest.test.ts
@@ -1,0 +1,40 @@
+// Covers the manifest-schema boundary that keeps third-party schema failures out of the loader.
+import { describe, expect, it } from "vitest";
+import { validateManifestSchemaValue } from "./schema-validator.js";
+describe("validateManifestSchemaValue", () => {
+  it("returns an error instead of throwing for a structurally invalid schema", () => {
+    const result = validateManifestSchemaValue({
+      cacheKey: "manifest-schema.unresolved-ref",
+      schema: { type: "object", properties: { mode: { $ref: "#/$defs/Mode" } } },
+      value: {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.errors[0]?.text).toContain("invalid schema");
+  });
+
+  it("strips terminal control characters a manifest embedded in the thrown text", () => {
+    const escape = String.fromCharCode(27);
+    const result = validateManifestSchemaValue({
+      cacheKey: "manifest-schema.ansi-pattern",
+      schema: {
+        type: "object",
+        properties: { a: { type: "string", pattern: `${escape}[31m(unclosed` } },
+      },
+      value: { a: "x" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.errors[0]?.text).not.toContain(escape);
+  });
+
+  it("keeps returning results for a valid schema", () => {
+    const result = validateManifestSchemaValue({
+      cacheKey: "manifest-schema.valid",
+      schema: { type: "object", properties: { a: { type: "string" } } },
+      value: { a: "ok" },
+    });
+
+    expect(result).toEqual({ ok: true, value: { a: "ok" } });
+  });
+});

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -12,6 +12,7 @@ import {
 } from "../shared/json-schema-defaults.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
 import { PluginLruCache } from "./plugin-cache-primitives.js";
+import type { PluginOrigin } from "./plugin-origin.types.js";
 
 type TypeBoxValidationError = {
   keyword?: string;
@@ -352,22 +353,26 @@ function formatValidationErrors(
  * "config invalid" need this to avoid telling an operator to fill in config that no
  * value could ever satisfy.
  */
-export type ManifestSchemaValidationResult =
+type PluginSchemaValidationResult =
   | { ok: true; value: unknown }
   | { ok: false; errors: JsonSchemaValidationError[]; schemaError: boolean };
 
 /**
  * Validate a value against a schema supplied by a plugin manifest.
- * Manifest schemas are third-party input, so every failure mode is a validation
- * result: a structurally invalid schema, and a traversal that exhausts the stack
- * on a deeply nested one. validateJsonSchemaValue keeps throwing for repo-owned
- * schemas, where a malformed one is a programming error and must stay loud.
+ * External manifest schemas are third-party input, so every failure mode becomes
+ * a validation result. Bundled schemas stay on the throwing path because a malformed
+ * repository-owned schema is a programming error and must stay loud.
  */
-export function validateManifestSchemaValue(
-  params: Parameters<typeof validateJsonSchemaValue>[0],
-): ManifestSchemaValidationResult {
+export function validatePluginSchemaValue(
+  params: Parameters<typeof validateJsonSchemaValue>[0] & { origin: PluginOrigin },
+): PluginSchemaValidationResult {
+  const { origin, ...validationParams } = params;
+  if (origin === "bundled") {
+    const result = validateJsonSchemaValue(validationParams);
+    return result.ok ? result : { ...result, schemaError: false };
+  }
   try {
-    const result = validateJsonSchemaValue(params);
+    const result = validateJsonSchemaValue(validationParams);
     return result.ok ? result : { ...result, schemaError: false };
   } catch (error) {
     // The thrown text can embed raw manifest content (TypeBox echoes a bad regex

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -346,6 +346,17 @@ function formatValidationErrors(
 }
 
 /**
+ * Result of validating manifest-sourced input. `schemaError` on the failure branch tells
+ * callers whether the schema itself is unusable (true) versus the value failing a
+ * well-formed schema's constraints (false) — callers that report "config missing" vs.
+ * "config invalid" need this to avoid telling an operator to fill in config that no
+ * value could ever satisfy.
+ */
+export type ManifestSchemaValidationResult =
+  | { ok: true; value: unknown }
+  | { ok: false; errors: JsonSchemaValidationError[]; schemaError: boolean };
+
+/**
  * Validate a value against a schema supplied by a plugin manifest.
  * Manifest schemas are third-party input, so every failure mode is a validation
  * result: a structurally invalid schema, and a traversal that exhausts the stack
@@ -354,14 +365,15 @@ function formatValidationErrors(
  */
 export function validateManifestSchemaValue(
   params: Parameters<typeof validateJsonSchemaValue>[0],
-): ReturnType<typeof validateJsonSchemaValue> {
+): ManifestSchemaValidationResult {
   try {
-    return validateJsonSchemaValue(params);
+    const result = validateJsonSchemaValue(params);
+    return result.ok ? result : { ...result, schemaError: false };
   } catch (error) {
     // The thrown text can embed raw manifest content (TypeBox echoes a bad regex
     // pattern), and callers log it, so it is sanitized like every other error path.
     const text = sanitizeTerminalText(error instanceof Error ? error.message : String(error));
-    return { ok: false, errors: [{ path: "<root>", message: text, text }] };
+    return { ok: false, errors: [{ path: "<root>", message: text, text }], schemaError: true };
   }
 }
 

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -346,6 +346,26 @@ function formatValidationErrors(
 }
 
 /**
+ * Validate a value against a schema supplied by a plugin manifest.
+ * Manifest schemas are third-party input, so every failure mode is a validation
+ * result: a structurally invalid schema, and a traversal that exhausts the stack
+ * on a deeply nested one. validateJsonSchemaValue keeps throwing for repo-owned
+ * schemas, where a malformed one is a programming error and must stay loud.
+ */
+export function validateManifestSchemaValue(
+  params: Parameters<typeof validateJsonSchemaValue>[0],
+): ReturnType<typeof validateJsonSchemaValue> {
+  try {
+    return validateJsonSchemaValue(params);
+  } catch (error) {
+    // The thrown text can embed raw manifest content (TypeBox echoes a bad regex
+    // pattern), and callers log it, so it is sanitized like every other error path.
+    const text = sanitizeTerminalText(error instanceof Error ? error.message : String(error));
+    return { ok: false, errors: [{ path: "<root>", message: text, text }] };
+  }
+}
+
+/**
  * Validate a plugin-owned value against a JSON Schema, optionally hydrating schema defaults.
  * The cache key is caller-owned so repeated plugin/schema validations can reuse compiled TypeBox validators.
  */


### PR DESCRIPTION
## What Problem This Solves

Closes #119315.

A malformed `configSchema` in one external plugin could throw out of config validation and plugin loading. The gateway then lost every plugin, including healthy siblings, instead of reporting one broken plugin to Doctor.

The documented contract predates this fix: `docs/plugins/manifest.md` says broken plugin schemas fail validation and Doctor reports the plugin error.

## Why This Change Was Made

`validateJsonSchemaValue` intentionally throws for malformed repository-owned schemas. External manifest schemas reached that strict validator through loader, config, channel, and install callers without an external-input containment boundary.

This repair adds one origin-aware plugin schema validator:

- External `config`, `workspace`, and `global` manifest schemas convert structural errors and stack exhaustion into scoped validation results.
- Bundled schemas keep the strict throwing behavior because they are repository-owned programming errors.
- Channel metadata preparation catches recursive clone failures only for external schemas and carries schema origin into validation.
- The empty-config shortcut uses an allowlist, so unresolved references and unknown constraints cannot bypass schema validation.
- Install persistence distinguishes an unusable schema from ordinary missing configuration.

The shared strict validator and its Plugin SDK behavior remain unchanged.

## User Impact

One malformed external plugin no longer takes down healthy plugins or makes config validation throw. Doctor and config validation receive a path-scoped plugin error, while repository-owned schema defects remain loud.

## Evidence

Real production entry points ran against real plugin directories and manifests.

Current `main` at `ed90980a12ac5c3138bcc8f42c3accbf7ec64ece`:

```json
{
  "loaderThrown": "invalid schema: <schema>.properties.mode.$ref: unresolved ref",
  "loadedPluginIds": [],
  "healthySiblingLoaded": false,
  "configValidationThrown": "invalid schema: <schema>.properties.mode.$ref: unresolved ref",
  "issuePaths": []
}
```

Exact head `592f02b7f3f837dab66eaafa1e8de79d23370166`:

```json
{
  "loaderThrown": null,
  "loadedPluginIds": ["proofbad", "proofchan", "proofgood"],
  "healthySiblingLoaded": true,
  "configValidationThrown": null,
  "issuePaths": ["channels.proofchan", "plugins.entries.proofbad.config"],
  "strictValidatorThrown": true,
  "bundledPluginValidationThrown": true
}
```

Anti-cheat checks required a separate healthy plugin to reach `loaded`, both plugin and channel issue paths to appear, and the bundled schema path to throw.

Focused validation:

```text
145 tests passed across 7 focused files
oxfmt: clean
oxlint: clean
max-lines ratchet: clean
assertion-safety ratchet: clean
import cycles: 0
git diff --check: clean
```

The final rebase was patch-identical. Hosted CI owns type checking and build validation for this host.

Production code: `+118/-36`. Tests: `+420/-5`. The production growth carries schema origin through all callers, contains the pre-validator channel traversal, and preserves the existing install result distinction.

🤖 AI-assisted: investigation, repair, and proof used an AI coding agent; maintainers review and own the result.
