### PR TITLE
fix(channels): bound ingress claim candidate IN lists below SQLite's bind-variable limit

### DIFF
--- a/src/channels/message/ingress-drain-candidates.ts
+++ b/src/channels/message/ingress-drain-candidates.ts
@@ -1,0 +1,120 @@
+/**
+ * Bounded ordered candidate window for one ingress drain pass.
+ *
+ * A drain pass snapshots all pending events, then claims up to startLimit rows
+ * in global order. Passing the full snapshot to claimNext on every claim made
+ * claimNext re-read every candidate chunk twice (claimed pre-scan + pending
+ * select) under the SQLite write lock, so a 33k-row backlog issued ~2,112
+ * selects per 32-start pass. The window hands claimNext only a global-order
+ * prefix of the snapshot, grows only when a claim returns null while rows still
+ * remain outside it, and refreshes claimed-snapshot lanes once per attempt so
+ * sibling-race lane checks survive without re-reading every chunk.
+ */
+import { resolveLaneKey } from "./ingress-drain-state.js";
+import type {
+  ChannelIngressQueue,
+  ChannelIngressQueueClaim,
+  ChannelIngressQueueRecord,
+} from "./ingress-queue.js";
+
+type IngressDrainCandidateWindow<TPayload, TMetadata> = {
+  /** Current bounded candidate ids in global snapshot order (claimed rows removed). */
+  ids: string[];
+  /**
+   * Run one claim attempt: refill the window, refresh sibling-race lanes, call
+   * claimNext with the bounded ids, drop the claimed id, and widen the window
+   * (bounded by the snapshot) when the claim returns null so a free row behind
+   * any-size blocked prefix stays reachable. Returns null once the whole
+   * snapshot has been scanned.
+   */
+  claimNextAttempt(
+    options: Omit<
+      NonNullable<Parameters<ChannelIngressQueue<TPayload, TMetadata>["claimNext"]>[0]>,
+      "candidateIds"
+    >,
+  ): Promise<ChannelIngressQueueClaim<TPayload, TMetadata> | null>;
+};
+
+export function createIngressDrainCandidateWindow<TPayload, TMetadata>(options: {
+  queue: ChannelIngressQueue<TPayload, TMetadata>;
+  orderedCandidateIds: string[];
+  blockedLaneKeys: Set<string>;
+  scanLimit: number;
+  deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined;
+  reconcileStoredLaneKey?: (
+    record: ChannelIngressQueueRecord<TPayload, TMetadata>,
+    storedLaneKey: string,
+    derivedLaneKey: string,
+  ) => boolean;
+}) {
+  const {
+    queue,
+    orderedCandidateIds,
+    blockedLaneKeys,
+    scanLimit,
+    deriveLaneKey,
+    reconcileStoredLaneKey,
+  } = options;
+  const snapshotCandidateIds = new Set(orderedCandidateIds);
+  const ids: string[] = [];
+  let candidateWindowTarget = Math.max(1, scanLimit);
+  let nextCandidateIndex = 0;
+  const topUp = () => {
+    while (ids.length < candidateWindowTarget && nextCandidateIndex < orderedCandidateIds.length) {
+      const id = orderedCandidateIds[nextCandidateIndex];
+      if (id === undefined) {
+        break;
+      }
+      ids.push(id);
+      nextCandidateIndex += 1;
+    }
+  };
+  const grow = () => {
+    if (nextCandidateIndex >= orderedCandidateIds.length) {
+      return false;
+    }
+    candidateWindowTarget = Math.min(
+      orderedCandidateIds.length,
+      Math.max(candidateWindowTarget * 2, scanLimit),
+    );
+    return true;
+  };
+  const refreshClaimedLanes = async () => {
+    const latestClaims = await queue.listClaims();
+    for (const claim of latestClaims) {
+      if (!snapshotCandidateIds.has(claim.id)) {
+        continue;
+      }
+      const laneKey = resolveLaneKey(claim, deriveLaneKey, reconcileStoredLaneKey);
+      if (laneKey) {
+        blockedLaneKeys.add(laneKey);
+      }
+    }
+  };
+  const claimNextAttempt: IngressDrainCandidateWindow<
+    TPayload,
+    TMetadata
+  >["claimNextAttempt"] = async (claimOptions) => {
+    topUp();
+    while (ids.length > 0) {
+      await refreshClaimedLanes();
+      const claimed = await queue.claimNext({ ...claimOptions, candidateIds: ids });
+      if (claimed) {
+        const index = ids.indexOf(claimed.id);
+        if (index >= 0) {
+          ids.splice(index, 1);
+        }
+        return claimed;
+      }
+      if (!grow()) {
+        break;
+      }
+      topUp();
+    }
+    return null;
+  };
+  return {
+    ids,
+    claimNextAttempt,
+  };
+}

--- a/src/channels/message/ingress-drain-candidates.ts
+++ b/src/channels/message/ingress-drain-candidates.ts
@@ -100,10 +100,16 @@ export function createIngressDrainCandidateWindow<TPayload, TMetadata>(options: 
       await refreshClaimedLanes();
       const claimed = await queue.claimNext({ ...claimOptions, candidateIds: ids });
       if (claimed) {
-        const index = ids.indexOf(claimed.id);
-        if (index >= 0) {
-          ids.splice(index, 1);
-        }
+        // Compact after a successful claim: drop the exhausted blocked prefix
+        // (every id up to and including the claimed row was scanned this
+        // attempt and the blocked set is effectively monotonic for the pass),
+        // shrink the window back to the base target, and resume the ordered
+        // snapshot just after the claimed row. Without this, a window widened
+        // through a large blocked prefix would stay wide and replay nearly the
+        // whole snapshot on every remaining start of the pass.
+        ids.length = 0;
+        nextCandidateIndex = orderedCandidateIds.indexOf(claimed.id) + 1;
+        candidateWindowTarget = Math.max(1, scanLimit);
         return claimed;
       }
       if (!grow()) {

--- a/src/channels/message/ingress-drain-claim-bounds.test.ts
+++ b/src/channels/message/ingress-drain-claim-bounds.test.ts
@@ -1,0 +1,144 @@
+// Regression coverage for bounded full-drain candidate work: the drain pass
+// must not re-read every candidate chunk on every claim of a 32-start pass.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as kyselySync from "../../infra/kysely-sync.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressDrain } from "./ingress-drain.js";
+import {
+  createTestIngressQueue,
+  type IngressDrainTestPayload as Payload,
+  withTempState,
+} from "./ingress-drain.test-helpers.js";
+
+describe("channel ingress drain claim bounds", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("bounds full-drain candidate membership queries across a 32-start pass", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      // 33,000 pending rows on distinct lanes reproduce the ClawSweeper P1
+      // scenario: pre-fix, every claim handed the full snapshot to claimNext,
+      // which re-read all 33 candidate chunks twice (claimed pre-scan + pending
+      // select), so one 32-start pass issued ~2,112 selects and read ~105,600
+      // rows. The bounded window must keep the pass at one candidate chunk per
+      // claim (window = scanLimit, chunk size 1000) with no snapshot re-scan.
+      const count = 33_000;
+      for (let index = 0; index < count; index += 1) {
+        await queue.enqueue(
+          `free-${index}`,
+          { text: `free-${index}` },
+          { laneKey: `lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      const dispatched: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        startLimit: 32,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          await lifecycle.onAdopted();
+        },
+      });
+
+      // Count every channel_ingress_events select carrying an event_id IN
+      // membership predicate (claimed-candidate pre-scan + pending candidate
+      // select) and the rows those membership selects return.
+      const originalExecute = kyselySync.executeSqliteQuerySync;
+      let membershipSelectCount = 0;
+      let membershipRowsRead = 0;
+      const wrappedExecute = (
+        db: Parameters<typeof originalExecute>[0],
+        query: Parameters<typeof originalExecute>[1],
+      ) => {
+        const result = originalExecute(db, query);
+        if (typeof query.compile === "function") {
+          const sql = query.compile().sql;
+          if (
+            sql.includes("channel_ingress_events") &&
+            sql.includes('"event_id" in') &&
+            sql.includes("select")
+          ) {
+            membershipSelectCount += 1;
+            membershipRowsRead += result.rows.length;
+          }
+        }
+        return result;
+      };
+      const spy = vi.spyOn(kyselySync, "executeSqliteQuerySync").mockImplementation(wrappedExecute);
+
+      let started: number;
+      try {
+        ({ started } = await drain.drainOnce());
+        await drain.waitForIdle();
+      } finally {
+        spy.mockRestore();
+      }
+
+      // Global-order claim results and lane behavior are unchanged.
+      expect(started).toBe(32);
+      expect(dispatched).toEqual(Array.from({ length: 32 }, (_, index) => `free-${index}`));
+      // One pre-scan select + one pending select per claim: 64 membership
+      // selects and <= 3,200 membership rows for a 32-start pass (the pre-fix
+      // drain issued 2,112 selects and read 105,600 rows for the same pass).
+      expect(membershipSelectCount).toBeLessThanOrEqual(2 * 32 + 8);
+      expect(membershipRowsRead).toBeLessThanOrEqual(2 * 32 * 100 + 1_000);
+      drain.dispose();
+    });
+  });
+
+  it("claims past a blocked prefix within one drain pass via the bounded window", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      // 100 retry-delayed rows (each on its own lane) fill the initial scanLimit
+      // window; 100 free rows sit behind them. The drain-level bounded window
+      // must grow past the blocked prefix and keep claiming instead of returning
+      // null and starving the free rows (the round-2 starvation shape, now at
+      // the drain pass level).
+      const blockedCount = 100;
+      for (let index = 0; index < blockedCount; index += 1) {
+        const id = `blocked-${index}`;
+        await queue.enqueue(
+          id,
+          { text: id },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+        const claim = await queue.claim(id, { ownerId: "test-worker" });
+        if (!claim) {
+          throw new Error(`expected a claim for ${id}`);
+        }
+        await queue.release(claim, { recordAttempt: true, lastError: "retry" });
+      }
+      for (let index = 0; index < blockedCount; index += 1) {
+        await queue.enqueue(
+          `free-${index}`,
+          { text: `free-${index}` },
+          { laneKey: `free-lane-${index}`, receivedAt: blockedCount + index + 1 },
+        );
+      }
+      const dispatched: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        scanLimit: 100,
+        startLimit: 8,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          await lifecycle.onAdopted();
+        },
+      });
+
+      const { started } = await drain.drainOnce();
+      await drain.waitForIdle();
+
+      expect(started).toBe(8);
+      expect(dispatched).toEqual(Array.from({ length: 8 }, (_, index) => `free-${index}`));
+      drain.dispose();
+    });
+  });
+});

--- a/src/channels/message/ingress-drain-claim-bounds.test.ts
+++ b/src/channels/message/ingress-drain-claim-bounds.test.ts
@@ -141,4 +141,85 @@ describe("channel ingress drain claim bounds", () => {
       drain.dispose();
     });
   });
+
+  it("compacts the widened window after a blocked-prefix claim so later starts stay cheap", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      // 3,300 retry-delayed rows (each on its own lane) span >3 candidate
+      // chunks; 64 free rows sit behind them. The first claim must grow the
+      // bounded window through the prefix, but after it succeeds the window
+      // must compact back to scanLimit so the remaining 31 starts replay one
+      // candidate chunk each instead of the whole widened prefix.
+      const blockedCount = 3_300;
+      for (let index = 0; index < blockedCount; index += 1) {
+        const id = `blocked-${index}`;
+        await queue.enqueue(
+          id,
+          { text: id },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+        const claim = await queue.claim(id, { ownerId: "test-worker" });
+        if (!claim) {
+          throw new Error(`expected a claim for ${id}`);
+        }
+        await queue.release(claim, { recordAttempt: true, lastError: "retry" });
+      }
+      const freeCount = 64;
+      for (let index = 0; index < freeCount; index += 1) {
+        await queue.enqueue(
+          `free-${index}`,
+          { text: `free-${index}` },
+          { laneKey: `free-lane-${index}`, receivedAt: blockedCount + index + 1 },
+        );
+      }
+      const dispatched: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        scanLimit: 100,
+        startLimit: 32,
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          await lifecycle.onAdopted();
+        },
+      });
+
+      const originalExecute = kyselySync.executeSqliteQuerySync;
+      let membershipSelectCount = 0;
+      const wrappedExecute = (
+        db: Parameters<typeof originalExecute>[0],
+        query: Parameters<typeof originalExecute>[1],
+      ) => {
+        const result = originalExecute(db, query);
+        if (typeof query.compile === "function") {
+          const sql = query.compile().sql;
+          if (
+            sql.includes("channel_ingress_events") &&
+            sql.includes('"event_id" in') &&
+            sql.includes("select")
+          ) {
+            membershipSelectCount += 1;
+          }
+        }
+        return result;
+      };
+      const spy = vi.spyOn(kyselySync, "executeSqliteQuerySync").mockImplementation(wrappedExecute);
+
+      let started: number;
+      try {
+        ({ started } = await drain.drainOnce());
+        await drain.waitForIdle();
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(started).toBe(32);
+      expect(dispatched).toEqual(Array.from({ length: 32 }, (_, index) => `free-${index}`));
+      // First claim: ~7 growth probes + the winning select (~36 membership
+      // selects). Remaining 31 starts: one chunk each (2 selects). Without the
+      // post-claim compaction, the widened 3,364-id window would replay 4
+      // chunks per start (~284 total) instead of ~98.
+      expect(membershipSelectCount).toBeLessThanOrEqual(2 * 32 + 50);
+      drain.dispose();
+    });
+  });
 });

--- a/src/channels/message/ingress-drain-lanes.test.ts
+++ b/src/channels/message/ingress-drain-lanes.test.ts
@@ -36,7 +36,9 @@ describe("channel ingress drain lanes", () => {
 
       await expect(drain.drainOnce()).resolves.toEqual({ started: 1 });
       await vi.waitFor(() => expect(dispatches).toEqual(["active", "candidate"]));
-      expect(claimNext).toHaveBeenCalledTimes(2);
+      // The bounded candidate window ends the pass when the snapshot is fully
+      // covered instead of issuing a no-op empty-candidate claimNext probe.
+      expect(claimNext).toHaveBeenCalledTimes(1);
       await expect(queue.enqueue("candidate", { text: "topic" })).resolves.toMatchObject({
         kind: "completed",
       });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -25,6 +25,7 @@ import {
 } from "./ingress-drain-state.js";
 import { supersedeActiveStatesIfNeeded } from "./ingress-drain-supersede.js";
 export { isIngressAdoptionLostError } from "./ingress-drain-state.js";
+import { createIngressDrainCandidateWindow } from "./ingress-drain-candidates.js";
 import type {
   ChannelIngressQueue,
   ChannelIngressQueueClaim,
@@ -752,29 +753,34 @@ export function createChannelIngressDrain<
       }
     }
 
-    const candidateIds = new Set(pending.map((event) => event.id));
+    // Bounded ordered candidate window (see ingress-drain-candidates.ts): a
+    // large backlog is never re-read chunk-by-chunk for every claim of a pass.
+    const candidateWindow = createIngressDrainCandidateWindow({
+      queue,
+      orderedCandidateIds: pending.map((event) => event.id),
+      blockedLaneKeys,
+      scanLimit,
+      deriveLaneKey: options.deriveLaneKey,
+      reconcileStoredLaneKey: options.reconcileStoredLaneKey,
+    });
     let started = 0;
     while (started < startLimit) {
       if (shouldStop()) {
         break;
       }
-      const claimed = await queue.claimNext({
+      const claimed = await candidateWindow.claimNextAttempt({
         ownerId,
         blockedLaneKeys,
         orderBy,
         scanLimit,
-        candidateIds,
         deriveLaneKey: options.deriveLaneKey,
-        ...(options.reconcileStoredLaneKey
-          ? { reconcileStoredLaneKey: options.reconcileStoredLaneKey }
-          : {}),
+        reconcileStoredLaneKey: options.reconcileStoredLaneKey,
       });
       if (!claimed) {
         break;
       }
       // One snapshot row gets one attempt per pass. A released claim remains
       // pending for the next pump instead of spinning through SQLite here.
-      candidateIds.delete(claimed.id);
       if (shouldStop()) {
         await queue.release(claimed, { recordAttempt: false });
         break;

--- a/src/channels/message/ingress-queue-claim-bounds.test.ts
+++ b/src/channels/message/ingress-queue-claim-bounds.test.ts
@@ -522,4 +522,78 @@ describe("channel ingress queue claim bounds", () => {
       expect(claimed?.id).toBe("free-0");
     });
   });
+
+  it("bounds JS-side materialization to the scan window across many candidate chunks", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // Reproduces the ClawSweeper finding's scenario: a 33k candidate snapshot
+      // with scanLimit 100. Chunk size 1000 yields 33 chunks; each chunk's SQL
+      // LIMIT 100 returns at most 100 rows, so SQL read stays <= 3300, but the
+      // incremental merge window is capped to scanLimit=100 by mergeTopKRowWindow
+      // (the cap parameter statically bounds JS-side retention), instead of
+      // materializing all 3300 rows and sorting them under the write lock.
+      // Non-degraded path (no blockedLaneKeys), so SQL prunes nothing here.
+      const freeCount = 33_000;
+      for (let index = 0; index < freeCount; index += 1) {
+        await queue.enqueue(
+          `free-${index}`,
+          { text: `free-${index}` },
+          { laneKey: "free", receivedAt: index + 1 },
+        );
+      }
+      const candidateIds = Array.from({ length: freeCount }, (_, index) => `free-${index}`);
+
+      // Spy: accumulate rows returned by candidate-branch selects (= SQL read)
+      // and count those selects, to assert total work stays bounded.
+      const originalExecute = kyselySync.executeSqliteQuerySync;
+      let totalRowsRead = 0;
+      let candidateSelectCount = 0;
+      const wrappedExecute = (
+        db: Parameters<typeof originalExecute>[0],
+        query: Parameters<typeof originalExecute>[1],
+      ) => {
+        const result = originalExecute(db, query);
+        if (typeof query.compile === "function") {
+          const sql = query.compile().sql;
+          // Candidate-branch select: has the event_id IN membership predicate.
+          // The else branch lacks '"event_id" in' (its order by mentions event_id
+          // but never as an IN member), so this isolates the candidate path.
+          if (
+            sql.includes("channel_ingress_events") &&
+            sql.includes('"event_id" in') &&
+            sql.includes("limit")
+          ) {
+            candidateSelectCount += 1;
+            totalRowsRead += result.rows.length;
+          }
+        }
+        return result;
+      };
+      const spy = vi.spyOn(kyselySync, "executeSqliteQuerySync").mockImplementation(wrappedExecute);
+
+      try {
+        const claimed = await queue.claimNext({
+          ownerId: "worker",
+          candidateIds,
+          scanLimit: 100,
+        });
+
+        // The global-order minimum free row (received_at=1 -> free-0) is
+        // claimed, proving the incremental merge neither drops nor reorders the
+        // global top-scanLimit (each chunk's top-scanLimit contains the global
+        // top-scanLimit within that chunk).
+        expect(claimed?.id).toBe("free-0");
+        // One SQL per chunk, one pass (no corrupt re-run in this scenario): 33
+        // selects for 33 chunks. No re-scan of the snapshot per claim.
+        expect(candidateSelectCount).toBe(33);
+        // SQL read is bounded at chunkCount * scanLimit = 3300. Read cannot drop
+        // below this under chunked IN membership (SQLite must scan each chunk's
+        // candidates to rank the top-scanLimit), but JS-side materialization is
+        // bounded to scanLimit=100 by the merge window cap.
+        expect(totalRowsRead).toBeLessThanOrEqual(33 * 100);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
 });

--- a/src/channels/message/ingress-queue-claim-bounds.test.ts
+++ b/src/channels/message/ingress-queue-claim-bounds.test.ts
@@ -596,4 +596,86 @@ describe("channel ingress queue claim bounds", () => {
       }
     });
   });
+
+  it("bounds degraded candidate reads across chunks", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // 22,000 blocked rows (each on its own stored lane) followed by one free
+      // row, with 30,000 blockedLaneKeys and no deriveLaneKey: the SQL NOT IN
+      // predicate is dropped, so the claim takes the degraded candidate path.
+      // Pre-fix, every degraded keyset page re-selected every candidate chunk
+      // (per-chunk LIMIT 10,000 > chunk size 1,000) and re-read the discarded
+      // suffix, so this shape issued ~3 pages x 23 chunks and read ~36,000 rows
+      // under the write lock. The stream merge must read each row at most once.
+      const blockedCount = 22_000;
+      for (let index = 0; index < blockedCount; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      await queue.enqueue(
+        "free",
+        { text: "free" },
+        { laneKey: "free", receivedAt: blockedCount + 1 },
+      );
+      const candidateIds = [
+        ...Array.from({ length: blockedCount }, (_, index) => `blocked-${index}`),
+        "free",
+      ];
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+      for (let index = 0; index < blockedCount; index += 1) {
+        oversizedBlockedLaneKeys[index] = `blocked-lane-${index}`;
+      }
+
+      // Spy: count candidate-branch selects (event_id IN membership) and the
+      // rows those selects return.
+      const originalExecute = kyselySync.executeSqliteQuerySync;
+      let candidateSelectCount = 0;
+      let candidateRowsRead = 0;
+      const wrappedExecute = (
+        db: Parameters<typeof originalExecute>[0],
+        query: Parameters<typeof originalExecute>[1],
+      ) => {
+        const result = originalExecute(db, query);
+        if (typeof query.compile === "function") {
+          const sql = query.compile().sql;
+          if (
+            sql.includes("channel_ingress_events") &&
+            sql.includes('"event_id" in') &&
+            sql.includes("limit")
+          ) {
+            candidateSelectCount += 1;
+            candidateRowsRead += result.rows.length;
+          }
+        }
+        return result;
+      };
+      const spy = vi.spyOn(kyselySync, "executeSqliteQuerySync").mockImplementation(wrappedExecute);
+
+      let claimed: { id?: string } | null;
+      try {
+        claimed = await queue.claimNext({
+          ownerId: "worker",
+          candidateIds,
+          blockedLaneKeys: oversizedBlockedLaneKeys,
+          scanLimit: 100,
+        });
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(claimed?.id).toBe("free");
+      // 23 chunks: one claimed-candidate pre-scan select per chunk plus one
+      // degraded pending select per chunk = ~46 selects, with every candidate
+      // row read once (~22,001 rows). Pre-fix this was ~92 selects / ~36,003
+      // rows (3 keyset pages re-selecting all chunks and re-reading the suffix).
+      expect(candidateSelectCount).toBeLessThanOrEqual(2 * 23 + 20);
+      expect(candidateRowsRead).toBeLessThanOrEqual(blockedCount + 1 + 1_000);
+    });
+  });
 });

--- a/src/channels/message/ingress-queue-claim-bounds.test.ts
+++ b/src/channels/message/ingress-queue-claim-bounds.test.ts
@@ -484,4 +484,42 @@ describe("channel ingress queue claim bounds", () => {
       expect(claimed?.id).toBe("free-a");
     });
   });
+
+  it("caps the merged candidate traversal to the scan limit on the non-degraded path", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // Non-degraded path: a small blockedLaneKeys set keeps the SQL NOT IN
+      // predicate, so blocked rows are pruned in SQL and the merged candidate
+      // list is capped to scanLimit before the scan loop. More than scanLimit
+      // free rows span two candidate chunks (chunk size is 1000); the claim
+      // must pick the global-order minimum free row and never traverse past
+      // the scanLimit window, matching main's single ordered LIMIT scanLimit.
+      const freeCount = 150;
+      for (let index = 0; index < freeCount; index += 1) {
+        await queue.enqueue(
+          `free-${index}`,
+          { text: `free-${index}` },
+          { laneKey: "free", receivedAt: index + 1 },
+        );
+      }
+      // One blocked row on a different lane; SQL NOT IN prunes it, so it never
+      // reaches the merged list and never consumes the scan budget.
+      await queue.enqueue("blocked", { text: "blocked" }, { laneKey: "blocked", receivedAt: 0 });
+      const candidateIds = [
+        ...Array.from({ length: freeCount }, (_, index) => `free-${index}`),
+        "blocked",
+      ];
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds,
+        blockedLaneKeys: ["blocked"],
+        scanLimit: 100,
+      });
+
+      // The global-order minimum free row (received_at=1) is claimed; the cap
+      // does not starve it. main's LIMIT scanLimit would select the same row.
+      expect(claimed?.id).toBe("free-0");
+    });
+  });
 });

--- a/src/channels/message/ingress-queue-claim-bounds.test.ts
+++ b/src/channels/message/ingress-queue-claim-bounds.test.ts
@@ -1,0 +1,487 @@
+// Regression coverage for bounded claim work: chunked candidate membership must
+// not re-read the whole backlog under the SQLite write lock on every claim.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import * as kyselySync from "../../infra/kysely-sync.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressQueue } from "./ingress-queue.js";
+
+async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ingress-queue-"));
+  try {
+    return await fn(stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function createTestIngressQueue<TPayload>(stateDir: string) {
+  return createChannelIngressQueue<TPayload>({
+    channelId: "test",
+    accountId: "account",
+    stateDir,
+  });
+}
+
+// Spy on the shared sync executor to observe the SQL compiled for each
+// channel_ingress_events select. The shard runs non-isolated, so module-level
+// mocks do not reliably intercept already-loaded importers; the live binding is
+// observed by replacing the exported function the queue calls.
+function observeSelectSql(): {
+  spy: ReturnType<typeof vi.spyOn>;
+  selectSqls: string[];
+} {
+  const originalExecute = kyselySync.executeSqliteQuerySync;
+  const selectSqls: string[] = [];
+  const wrappedExecute = (
+    db: Parameters<typeof originalExecute>[0],
+    query: Parameters<typeof originalExecute>[1],
+  ) => {
+    const result = originalExecute(db, query);
+    if (typeof query.compile === "function") {
+      const sql = query.compile().sql;
+      if (sql.includes("channel_ingress_events") && sql.includes("select")) {
+        selectSqls.push(sql);
+      }
+    }
+    return result;
+  };
+  const spy = vi.spyOn(kyselySync, "executeSqliteQuerySync").mockImplementation(wrappedExecute);
+  return { spy, selectSqls };
+}
+
+describe("channel ingress queue claim bounds", () => {
+  it("bounds per-chunk candidate reads to the claim scan limit", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ lane: string }>(stateDir);
+      const ids = Array.from({ length: 1_001 }, (_, index) => `blocked-${index}`);
+      for (const [index, id] of ids.entries()) {
+        await queue.enqueue(id, { lane: "blocked" }, { laneKey: "blocked", receivedAt: index + 1 });
+      }
+
+      const originalExecute = kyselySync.executeSqliteQuerySync;
+      const chunkRowCounts: number[] = [];
+      const wrappedExecute = (
+        db: Parameters<typeof originalExecute>[0],
+        query: Parameters<typeof originalExecute>[1],
+      ) => {
+        const result = originalExecute(db, query);
+        if (typeof query.compile === "function") {
+          const sql = query.compile().sql;
+          if (sql.includes("channel_ingress_events") && sql.includes("limit ?")) {
+            chunkRowCounts.push(result.rows.length);
+          }
+        }
+        return result;
+      };
+      const spy = vi.spyOn(kyselySync, "executeSqliteQuerySync").mockImplementation(wrappedExecute);
+
+      try {
+        const claimed = await queue.claimNext({
+          ownerId: "worker",
+          candidateIds: ids,
+          blockedLaneKeys: ["blocked"],
+          deriveLaneKey: (record) => record.payload.lane,
+          scanLimit: 100,
+        });
+
+        expect(claimed).toBeNull();
+        expect(chunkRowCounts.length).toBeGreaterThan(0);
+        expect(Math.max(...chunkRowCounts)).toBeLessThanOrEqual(100);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  it("drops the blocked-lane SQL predicate above the bind-variable budget", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // A single claimable row on the "free" lane, plus a candidate snapshot
+      // that also names one blocked row. blockedLaneKeys carries 30_000 distinct
+      // stored lanes (above CLAIM_BLOCKED_LANE_PREDICATE_LIMIT ~ 28_990) without
+      // a deriveLaneKey, so the claim takes the stored-lane SQL path and the
+      // NOT IN predicate is dropped to stay under SQLite's bind ceiling.
+      await queue.enqueue("free", { text: "free" }, { laneKey: "free", receivedAt: 1 });
+      await queue.enqueue("blocked", { text: "blocked" }, { laneKey: "blocked", receivedAt: 2 });
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+
+      const { spy, selectSqls } = observeSelectSql();
+      try {
+        const claimed = await queue.claimNext({
+          ownerId: "worker",
+          candidateIds: ["free", "blocked"],
+          blockedLaneKeys: oversizedBlockedLaneKeys,
+        });
+
+        // The claim must not throw "too many SQL variables"; the in-memory
+        // effectiveBlocked.has(laneKey) scan gate still excludes "blocked".
+        expect(claimed?.id).toBe("free");
+        // The candidate-branch select that filters pending rows must omit the
+        // NOT IN predicate once the blocked set exceeds the bind budget.
+        const candidateSelects = selectSqls.filter(
+          (sql) => sql.includes("status") && sql.includes("event_id"),
+        );
+        expect(candidateSelects.length).toBeGreaterThan(0);
+        for (const sql of candidateSelects) {
+          expect(sql).not.toContain("not in");
+        }
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  it("claims a free row past a blocked prefix above the bind-variable budget", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // 100 blocked rows fill the scanLimit window (LINE's default), each on its
+      // own stored lane, followed by one free row at position 101. blockedLaneKeys
+      // carries 30_000 distinct lanes so the SQL NOT IN predicate is dropped;
+      // without the in-memory skip-not-counting fix, the 100 blocked rows would
+      // consume the scanLimit budget and the free row at 101 would starve.
+      for (let index = 0; index < 100; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      await queue.enqueue("free", { text: "free" }, { laneKey: "free", receivedAt: 101 });
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+      // Ensure every blocked row's lane is in the blocked set, plus the free
+      // lane is not.
+      for (let index = 0; index < 100; index += 1) {
+        oversizedBlockedLaneKeys[index] = `blocked-lane-${index}`;
+      }
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds: [...Array.from({ length: 100 }, (_, index) => `blocked-${index}`), "free"],
+        blockedLaneKeys: oversizedBlockedLaneKeys,
+        scanLimit: 100,
+      });
+
+      // The free row behind the 100-row blocked prefix must still be claimed;
+      // blocked rows are skipped in memory without consuming the scan budget.
+      expect(claimed?.id).toBe("free");
+    });
+  });
+
+  it("keeps the blocked-lane SQL predicate below the bind-variable budget", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      await queue.enqueue("free", { text: "free" }, { laneKey: "free", receivedAt: 1 });
+      await queue.enqueue("blocked", { text: "blocked" }, { laneKey: "blocked", receivedAt: 2 });
+
+      const { spy, selectSqls } = observeSelectSql();
+      try {
+        const claimed = await queue.claimNext({
+          ownerId: "worker",
+          candidateIds: ["free", "blocked"],
+          blockedLaneKeys: ["blocked"],
+        });
+
+        expect(claimed?.id).toBe("free");
+        // A small blocked set stays inside the bind budget, so the SQL
+        // predicate is still compiled to prune blocked lanes before the scan.
+        const candidateSelects = selectSqls.filter(
+          (sql) => sql.includes("status") && sql.includes("event_id"),
+        );
+        expect(candidateSelects.length).toBeGreaterThan(0);
+        expect(candidateSelects.some((sql) => sql.includes("not in"))).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  it("claims a free row past a blocked prefix below the bind-variable budget", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // Same blocked-prefix shape as the oversized case, but with a small blocked
+      // set so the SQL NOT IN predicate is retained and prunes blocked rows in
+      // SQL before they reach the scan loop.
+      for (let index = 0; index < 100; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: "blocked-lane", receivedAt: index + 1 },
+        );
+      }
+      await queue.enqueue("free", { text: "free" }, { laneKey: "free", receivedAt: 101 });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds: [...Array.from({ length: 100 }, (_, index) => `blocked-${index}`), "free"],
+        blockedLaneKeys: ["blocked-lane"],
+        scanLimit: 100,
+      });
+
+      // SQL prunes the 100 blocked rows; the free row is the first returned.
+      expect(claimed?.id).toBe("free");
+    });
+  });
+
+  it("drops the blocked-lane SQL predicate above the budget without candidate ids", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // No candidateIds: the claim takes the non-candidate else branch, which
+      // selects pending rows directly. 30,000 blockedLaneKeys exceed
+      // CLAIM_BLOCKED_LANE_PREDICATE_LIMIT (~28,990) with no deriveLaneKey, so
+      // the SQL NOT IN predicate is dropped to stay under the bind ceiling.
+      await queue.enqueue("free", { text: "free" }, { laneKey: "free", receivedAt: 1 });
+      await queue.enqueue("blocked", { text: "blocked" }, { laneKey: "blocked", receivedAt: 2 });
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+
+      const { spy, selectSqls } = observeSelectSql();
+      try {
+        const claimed = await queue.claimNext({
+          ownerId: "worker",
+          blockedLaneKeys: oversizedBlockedLaneKeys,
+        });
+
+        // The claim must not throw "too many SQL variables"; the in-memory
+        // effectiveBlocked.has(laneKey) scan gate still excludes "blocked".
+        expect(claimed?.id).toBe("free");
+        // The non-candidate select has no event_id IN membership clause (it
+        // still orders by event_id, so filter on the IN membership, not the
+        // column name). It must omit the NOT IN predicate once the blocked set
+        // exceeds the bind budget.
+        const nonCandidateSelects = selectSqls.filter((sql) => !sql.includes('"event_id" in'));
+        expect(nonCandidateSelects.length).toBeGreaterThan(0);
+        for (const sql of nonCandidateSelects) {
+          expect(sql).not.toContain("not in");
+        }
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  it("claims a free row past a blocked prefix above the budget without candidate ids", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // 100 blocked rows fill the scanLimit window, each on its own stored lane,
+      // followed by one free row at position 101. No candidateIds and 30,000
+      // blockedLaneKeys: the non-candidate branch drops the SQL NOT IN predicate
+      // and must widen its SQL limit so the free row behind the prefix is reached
+      // and skipped blocked rows do not consume the scan budget.
+      for (let index = 0; index < 100; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      await queue.enqueue("free", { text: "free" }, { laneKey: "free", receivedAt: 101 });
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+      for (let index = 0; index < 100; index += 1) {
+        oversizedBlockedLaneKeys[index] = `blocked-lane-${index}`;
+      }
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        blockedLaneKeys: oversizedBlockedLaneKeys,
+        scanLimit: 100,
+      });
+
+      // The free row behind the 100-row blocked prefix must still be claimed;
+      // the widened SQL limit returned it and blocked rows were skipped in
+      // memory without consuming the scan budget.
+      expect(claimed?.id).toBe("free");
+    });
+  });
+
+  it("claims a free row past a cap-plus-one blocked prefix with candidate ids", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // CLAIM_DEGRADED_BLOCKED_SCAN_CAP (10,000) rows per degraded page. Enqueue
+      // cap-plus-one blocked rows so the first page is entirely blocked and the
+      // free row sits one past the page boundary, then a free row. Under the
+      // round-2 hard cap the scan stopped at 10,000 blocked rows and returned
+      // null; the keyset continuation must advance the cursor and reach it.
+      const blockedCount = 10_001;
+      for (let index = 0; index < blockedCount; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      await queue.enqueue(
+        "free",
+        { text: "free" },
+        { laneKey: "free", receivedAt: blockedCount + 1 },
+      );
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+      for (let index = 0; index < blockedCount; index += 1) {
+        oversizedBlockedLaneKeys[index] = `blocked-lane-${index}`;
+      }
+      const candidateIds = [
+        ...Array.from({ length: blockedCount }, (_, index) => `blocked-${index}`),
+        "free",
+      ];
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds,
+        blockedLaneKeys: oversizedBlockedLaneKeys,
+        scanLimit: 100,
+      });
+
+      expect(claimed?.id).toBe("free");
+    });
+  });
+
+  it("claims a free row past a cap-plus-one blocked prefix without candidate ids", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // Same cap-plus-one shape as the candidate case, but the non-candidate
+      // else branch selects pending rows directly. The keyset continuation must
+      // page past the 10,001 blocked rows and reach the free row.
+      const blockedCount = 10_001;
+      for (let index = 0; index < blockedCount; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      await queue.enqueue(
+        "free",
+        { text: "free" },
+        { laneKey: "free", receivedAt: blockedCount + 1 },
+      );
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+      for (let index = 0; index < blockedCount; index += 1) {
+        oversizedBlockedLaneKeys[index] = `blocked-lane-${index}`;
+      }
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        blockedLaneKeys: oversizedBlockedLaneKeys,
+        scanLimit: 100,
+      });
+
+      expect(claimed?.id).toBe("free");
+    });
+  });
+
+  it("bounds the degraded walk when no claimable row exists", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // More than two degraded pages of blocked rows with no free row behind
+      // them. The claim must terminate (return null) without looping forever;
+      // the keyset page cap bounds the work under the SQLite write lock.
+      const blockedCount = 22_000;
+      for (let index = 0; index < blockedCount; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+      for (let index = 0; index < blockedCount; index += 1) {
+        oversizedBlockedLaneKeys[index] = `blocked-lane-${index}`;
+      }
+
+      const { spy, selectSqls } = observeSelectSql();
+      let claimed: { id?: string } | null;
+      try {
+        claimed = await queue.claimNext({
+          ownerId: "worker",
+          blockedLaneKeys: oversizedBlockedLaneKeys,
+          scanLimit: 100,
+        });
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(claimed).toBeNull();
+      // The non-candidate select is issued once per degraded page. With 22,000
+      // blocked rows at 10,000 per page that is 3 pages, well under the page
+      // cap; the assertion guards against an unbounded full-table scan.
+      const nonCandidateSelects = selectSqls.filter((sql) => !sql.includes('"event_id" in'));
+      expect(nonCandidateSelects.length).toBeLessThanOrEqual(105);
+    });
+  });
+
+  it("preserves global ordering across the degraded keyset continuation", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // Two free rows behind a cap-plus-one blocked prefix. The first free row
+      // in global (received_at, event_id) order sits at position 10,002; a
+      // second free row at 10,003 has an earlier event_id lexicographically but
+      // a later received_at, so it must NOT be claimed first. This confirms the
+      // keyset continuation does not reorder or skip across pages.
+      const blockedCount = 10_001;
+      for (let index = 0; index < blockedCount; index += 1) {
+        await queue.enqueue(
+          `blocked-${index}`,
+          { text: `blocked-${index}` },
+          { laneKey: `blocked-lane-${index}`, receivedAt: index + 1 },
+        );
+      }
+      // free-a has the smaller received_at and is the global minimum free row.
+      await queue.enqueue(
+        "free-a",
+        { text: "a" },
+        { laneKey: "free-a", receivedAt: blockedCount + 1 },
+      );
+      // free-b has an event_id that sorts before "free-a" but a later
+      // received_at, so global order still picks free-a first.
+      await queue.enqueue(
+        "free-b",
+        { text: "b" },
+        { laneKey: "free-b", receivedAt: blockedCount + 2 },
+      );
+      const oversizedBlockedLaneKeys = Array.from(
+        { length: 30_000 },
+        (_, index) => `stored-lane-${index}`,
+      );
+      for (let index = 0; index < blockedCount; index += 1) {
+        oversizedBlockedLaneKeys[index] = `blocked-lane-${index}`;
+      }
+      const candidateIds = [
+        ...Array.from({ length: blockedCount }, (_, index) => `blocked-${index}`),
+        "free-a",
+        "free-b",
+      ];
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds,
+        blockedLaneKeys: oversizedBlockedLaneKeys,
+        scanLimit: 100,
+      });
+
+      expect(claimed?.id).toBe("free-a");
+    });
+  });
+});

--- a/src/channels/message/ingress-queue-claim-candidates.test.ts
+++ b/src/channels/message/ingress-queue-claim-candidates.test.ts
@@ -1,0 +1,136 @@
+// Regression coverage for chunked candidate membership in claimNext: large
+// candidate id sets are split into bind-variable-safe chunks and merged back in
+// the queue's global order, so chunk boundaries never reorder claims.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressQueue } from "./ingress-queue.js";
+
+async function withTempState<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ingress-queue-"));
+  try {
+    return await fn(stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function createTestIngressQueue<TPayload>(stateDir: string) {
+  return createChannelIngressQueue<TPayload>({
+    channelId: "test",
+    accountId: "account",
+    stateDir,
+  });
+}
+
+describe("channel ingress queue claim candidate chunks", () => {
+  it("bounds candidate membership below SQLite's bind-variable limit", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      const candidateIds = Array.from({ length: 40_000 }, (_, index) => `candidate-${index}`);
+      await expect(queue.claimNext({ ownerId: "worker", candidateIds })).resolves.toBeNull();
+    });
+  });
+
+  it("claims real rows through chunked candidate membership", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      const eventIds = Array.from({ length: 1_500 }, (_, index) => `event-${index}`);
+      for (const eventId of eventIds) {
+        await queue.enqueue(eventId, { text: eventId });
+      }
+      const first = await queue.claimNext({ ownerId: "worker", candidateIds: eventIds });
+      expect(first?.id).toBe("event-0");
+      const second = await queue.claimNext({ ownerId: "worker", candidateIds: eventIds });
+      expect(second?.id).toBe("event-1");
+    });
+  });
+
+  it("preserves global claim ordering for unsorted candidate chunks", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      const eventIds = Array.from({ length: 1_500 }, (_, index) => `event-${index}`);
+      for (const eventId of eventIds) {
+        await queue.enqueue(eventId, { text: eventId });
+      }
+      // Reverse the snapshot so the first chunk holds the globally latest rows.
+      const candidateIds = eventIds.toReversed();
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds,
+      });
+
+      // The queue's global received order must win over candidate chunk order;
+      // a chunk-first scan would have claimed event-1499.
+      expect(claimed?.id).toBe("event-0");
+    });
+  });
+
+  it("deduplicates candidate ids before chunking", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ lane: string }>(stateDir);
+      await queue.enqueue("blocked", { lane: "blocked" }, { laneKey: "blocked", receivedAt: 1 });
+      await queue.enqueue("free", { lane: "open" }, { laneKey: "open", receivedAt: 2 });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        // 1,001 candidates span two chunks; a duplicated blocked id re-read
+        // from both would burn the 2-row scan window before the free row.
+        candidateIds: [...Array.from({ length: 1_000 }, () => "blocked"), "free"],
+        blockedLaneKeys: ["blocked"],
+        deriveLaneKey: (record) => record.payload.lane,
+        scanLimit: 2,
+      });
+
+      expect(claimed?.id).toBe("free");
+    });
+  });
+
+  it("preserves SQLite binary event-id ordering across candidate chunks", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // Equal received_at rows land in different chunks; SQLite BINARY order
+      // claims "B" before "a", while localeCompare would reverse them.
+      await queue.enqueue("B", { text: "upper" }, { receivedAt: 50 });
+      await queue.enqueue("a", { text: "lower" }, { receivedAt: 50 });
+      const candidateIds = [
+        ...Array.from({ length: 999 }, (_, index) => `filler-${index}`),
+        "B",
+        "a",
+      ];
+
+      const claimed = await queue.claimNext({ ownerId: "worker", candidateIds });
+
+      expect(claimed?.id).toBe("B");
+    });
+  });
+
+  it("preserves SQLite binary order for non-BMP event ids across chunks", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue<{ text: string }>(stateDir);
+      // U+E000 ("", one BMP code unit) vs U+1F600 ("\u{1F600}", a
+      // surrogate pair). SQLite BINARY orders them by UTF-8 bytes:
+      // U+E000 = EE 80 80, U+1F600 = F0 9F 98 80, so U+E000 is claimed first.
+      // JavaScript's UTF-16 order reverses this: the high surrogate 0xD83D
+      // precedes 0xE000, so "" < "\u{1F600}" is false. This regression
+      // guards the cross-chunk merge comparator against that divergence.
+      const privateUse = "";
+      const emoji = "\u{1F600}";
+      await queue.enqueue(privateUse, { text: "pu" }, { receivedAt: 50 });
+      await queue.enqueue(emoji, { text: "emoji" }, { receivedAt: 50 });
+      const candidateIds = [
+        ...Array.from({ length: 999 }, (_, index) => `filler-${index}`),
+        privateUse,
+        emoji,
+      ];
+
+      const claimed = await queue.claimNext({ ownerId: "worker", candidateIds });
+
+      expect(claimed?.id).toBe(privateUse);
+    });
+  });
+});

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -595,6 +595,62 @@ function compareEventIdsBinary(a: string, b: string): number {
   return Buffer.compare(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
 }
 
+// Incremental global top-k merge: mergedWindow stays globally ordered and
+// length <= cap. Each chunk's rows arrive already ordered (SQL ORDER BY), so a
+// two-pointer merge into mergedWindow replaces "materialize all chunks into one
+// array, sort, truncate". JS-side retention drops from chunkCount*cap to cap,
+// and sort work drops from O(n log n) to O(n) (merge, no log factor). This
+// bounds write-transaction work to the configured window instead of scaling
+// with the pending snapshot size, preserving the bounded-work invariant main's
+// single ordered LIMIT scanLimit held. Correctness rests on each chunk's
+// top-cap rows containing that chunk's globally-smallest cap rows, so the
+// global top-cap is a subset of their union.
+function mergeTopKRowWindow(
+  mergedWindow: ChannelIngressRow[],
+  chunkRows: ChannelIngressRow[],
+  cap: number,
+  compare: (a: ChannelIngressRow, b: ChannelIngressRow) => number,
+): void {
+  if (chunkRows.length === 0) {
+    return;
+  }
+  if (mergedWindow.length === 0) {
+    for (const row of chunkRows) {
+      mergedWindow.push(row);
+      if (mergedWindow.length === cap) {
+        break;
+      }
+    }
+    return;
+  }
+  // Two-pointer merge of two ordered sequences, keeping only the first cap.
+  const result: ChannelIngressRow[] = [];
+  let mergedIndex = 0;
+  let chunkIndex = 0;
+  while (
+    result.length < cap &&
+    (mergedIndex < mergedWindow.length || chunkIndex < chunkRows.length)
+  ) {
+    const mergedRow = mergedWindow[mergedIndex];
+    const chunkRow = chunkRows[chunkIndex];
+    const pickFromMerged =
+      chunkRow === undefined ? true : mergedRow !== undefined && compare(mergedRow, chunkRow) <= 0;
+    if (pickFromMerged) {
+      // mergedRow is defined here because mergedIndex < mergedWindow.length in
+      // the only branch that reaches this with chunkRow !== undefined above.
+      result.push(mergedRow as ChannelIngressRow);
+      mergedIndex += 1;
+    } else {
+      result.push(chunkRow as ChannelIngressRow);
+      chunkIndex += 1;
+    }
+  }
+  mergedWindow.length = 0;
+  for (const row of result) {
+    mergedWindow.push(row);
+  }
+}
+
 function queueNameForParts(channelId: string, accountId: string): string {
   // JSON tuple encoding keeps channel/account scopes unambiguous even when ids contain separators.
   return JSON.stringify([channelId, accountId]);
@@ -979,36 +1035,45 @@ export function createChannelIngressQueue<
           let cursor: ChannelIngressRow | undefined;
           let pagesWalked = 0;
           while (!selected && corruptReconciliations < MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
-            const candidateRows: ChannelIngressRow[] = [];
+            // Incremental global top-k: each chunk's rows arrive already ordered
+            // (SQL ORDER BY), so merge them into a window capped to mergeCap
+            // instead of materializing chunkCount*mergeCap rows, sorting, then
+            // truncating. JS-side retention stays <= mergeCap and merge work is
+            // O(n) (no log factor), bounding write-transaction work to the
+            // configured window regardless of pending snapshot size. Non-degraded
+            // keeps mergeCap = scanLimit (SQL prunes blocked, window is all free);
+            // degraded widens to CAP so blocked rows reach the window and the
+            // in-memory skip + keyset continuation can page past them.
+            const mergeCap = blockedPredicateDropped
+              ? Math.max(scanLimit, CLAIM_DEGRADED_BLOCKED_SCAN_CAP)
+              : scanLimit;
+            const compareRows =
+              claimOptions?.orderBy === "id"
+                ? (a: ChannelIngressRow, b: ChannelIngressRow) =>
+                    compareEventIdsBinary(a.event_id, b.event_id)
+                : (a: ChannelIngressRow, b: ChannelIngressRow) =>
+                    a.received_at - b.received_at || compareEventIdsBinary(a.event_id, b.event_id);
+            const mergedWindow: ChannelIngressRow[] = [];
+            let anyRows = false;
             for (const candidateChunk of candidateChunks) {
-              candidateRows.push(
-                ...executeSqliteQuerySync(tx.db, candidateSelect(candidateChunk, cursor)).rows,
-              );
+              const chunkRows = executeSqliteQuerySync(
+                tx.db,
+                candidateSelect(candidateChunk, cursor),
+              ).rows;
+              if (chunkRows.length > 0) {
+                anyRows = true;
+                mergeTopKRowWindow(mergedWindow, chunkRows, mergeCap, compareRows);
+              }
             }
-            if (candidateRows.length === 0) {
+            if (!anyRows) {
               break;
             }
-            candidateRows.sort(
-              claimOptions?.orderBy === "id"
-                ? (a, b) => compareEventIdsBinary(a.event_id, b.event_id)
-                : (a, b) =>
-                    a.received_at - b.received_at || compareEventIdsBinary(a.event_id, b.event_id),
-            );
-            // Restore main's global scan-limit contract on the non-degraded path.
-            // SQL still prunes blocked rows here (NOT IN retained), so the merged
-            // top-scanLimit rows are exactly what main's single ordered
-            // LIMIT scanLimit query would have materialized. Capping the merged
-            // traversal to scanLimit keeps write-transaction work bounded to the
-            // configured scan limit instead of chunkCount * scanLimit, matching
-            // main. The degraded path skips this cap: its NOT IN is dropped, so
-            // blocked rows reach the merge and the keyset continuation must walk
-            // past them (total work bounded by CLAIM_DEGRADED_BLOCKED_PAGES_MAX).
-            if (!blockedPredicateDropped && candidateRows.length > scanLimit) {
-              candidateRows.length = scanLimit;
-            }
+            // mergedWindow is the global-order top-mergeCap (non-degraded =
+            // scanLimit, naturally capped; degraded = CAP, includes blocked rows
+            // skipped in memory below). No further sort or truncate is needed.
             let tombstonedCorruptRow = false;
             let lastScannedRow: ChannelIngressRow | undefined;
-            for (const row of candidateRows) {
+            for (const row of mergedWindow) {
               lastScannedRow = row;
               const rec = baseRecord<TPayload, TMetadata>(row);
               if (rec === null) {

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -1032,62 +1032,89 @@ export function createChannelIngressQueue<
             // the SQLite write lock on every claim.
             return ordered.limit(perChunkLimit);
           };
-          let cursor: ChannelIngressRow | undefined;
-          let pagesWalked = 0;
-          while (!selected && corruptReconciliations < MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
-            // Incremental global top-k: each chunk's rows arrive already ordered
-            // (SQL ORDER BY), so merge them into a window capped to mergeCap
-            // instead of materializing chunkCount*mergeCap rows, sorting, then
-            // truncating. JS-side retention stays <= mergeCap and merge work is
-            // O(n) (no log factor), bounding write-transaction work to the
-            // configured window regardless of pending snapshot size. Non-degraded
-            // keeps mergeCap = scanLimit (SQL prunes blocked, window is all free);
-            // degraded widens to CAP so blocked rows reach the window and the
-            // in-memory skip + keyset continuation can page past them.
-            const mergeCap = blockedPredicateDropped
-              ? Math.max(scanLimit, CLAIM_DEGRADED_BLOCKED_SCAN_CAP)
-              : scanLimit;
-            const compareRows =
-              claimOptions?.orderBy === "id"
-                ? (a: ChannelIngressRow, b: ChannelIngressRow) =>
-                    compareEventIdsBinary(a.event_id, b.event_id)
-                : (a: ChannelIngressRow, b: ChannelIngressRow) =>
-                    a.received_at - b.received_at || compareEventIdsBinary(a.event_id, b.event_id);
-            const mergedWindow: ChannelIngressRow[] = [];
-            let anyRows = false;
-            for (const candidateChunk of candidateChunks) {
-              const chunkRows = executeSqliteQuerySync(
-                tx.db,
-                candidateSelect(candidateChunk, cursor),
-              ).rows;
-              if (chunkRows.length > 0) {
-                anyRows = true;
-                mergeTopKRowWindow(mergedWindow, chunkRows, mergeCap, compareRows);
+          const compareRows =
+            claimOptions?.orderBy === "id"
+              ? (a: ChannelIngressRow, b: ChannelIngressRow) =>
+                  compareEventIdsBinary(a.event_id, b.event_id)
+              : (a: ChannelIngressRow, b: ChannelIngressRow) =>
+                  a.received_at - b.received_at || compareEventIdsBinary(a.event_id, b.event_id);
+          if (blockedPredicateDropped) {
+            // Degraded candidate walk: the SQL NOT IN predicate is dropped, so
+            // blocked rows reach the scan and are skipped in memory. Stream each
+            // chunk in its own global order and merge the chunk heads, so every
+            // candidate row is read at most once — a blocked prefix is walked
+            // once instead of re-selecting every chunk on every keyset page —
+            // and the total walk is bounded by the degraded row budget (the old
+            // page-cap bound expressed as rows).
+            const degradedRowBudget =
+              CLAIM_DEGRADED_BLOCKED_PAGES_MAX * CLAIM_DEGRADED_BLOCKED_SCAN_CAP;
+            const streams: Array<{
+              ids: string[];
+              rows: ChannelIngressRow[];
+              lastRow: ChannelIngressRow | undefined;
+              exhausted: boolean;
+            }> = candidateChunks.map((ids) => ({
+              ids,
+              rows: [],
+              lastRow: undefined,
+              exhausted: false,
+            }));
+            let rowsRead = 0;
+            while (!selected && corruptReconciliations < MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+              for (const stream of streams) {
+                if (!stream.exhausted && stream.rows.length === 0) {
+                  stream.rows = executeSqliteQuerySync(
+                    tx.db,
+                    candidateSelect(stream.ids, stream.lastRow),
+                  ).rows;
+                  if (stream.rows.length === 0) {
+                    // No candidate of this chunk remains after the chunk's last
+                    // consumed row, so it can never contribute again; skip its
+                    // refill (and head) from every later iteration.
+                    stream.exhausted = true;
+                  }
+                }
               }
-            }
-            if (!anyRows) {
-              break;
-            }
-            // mergedWindow is the global-order top-mergeCap (non-degraded =
-            // scanLimit, naturally capped; degraded = CAP, includes blocked rows
-            // skipped in memory below). No further sort or truncate is needed.
-            let tombstonedCorruptRow = false;
-            let lastScannedRow: ChannelIngressRow | undefined;
-            for (const row of mergedWindow) {
-              lastScannedRow = row;
-              const rec = baseRecord<TPayload, TMetadata>(row);
-              if (rec === null) {
-                if (corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+              let bestIndex = -1;
+              let bestRow: ChannelIngressRow | undefined;
+              for (let index = 0; index < streams.length; index += 1) {
+                const stream = streams[index]!;
+                if (stream.exhausted) {
                   continue;
                 }
-                const didTombstone = tombstoneCorruptPayloadRow({
-                  db: tx.db,
-                  row,
-                  expectedStatus: "pending",
-                  failedAt: transitionAt,
-                });
-                tombstonedCorruptRow = didTombstone || tombstonedCorruptRow;
-                if (didTombstone) {
+                const head = stream.rows[0];
+                if (head === undefined) {
+                  continue;
+                }
+                if (bestRow === undefined) {
+                  bestRow = head;
+                  bestIndex = index;
+                } else if (compareRows(head, bestRow) < 0) {
+                  bestRow = head;
+                  bestIndex = index;
+                }
+              }
+              if (bestIndex < 0) {
+                break;
+              }
+              const stream = streams[bestIndex]!;
+              const row = stream.rows.shift()!;
+              stream.lastRow = row;
+              rowsRead += 1;
+              if (rowsRead > degradedRowBudget) {
+                break;
+              }
+              const rec = baseRecord<TPayload, TMetadata>(row);
+              if (rec === null) {
+                if (
+                  corruptReconciliations < MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM &&
+                  tombstoneCorruptPayloadRow({
+                    db: tx.db,
+                    row,
+                    expectedStatus: "pending",
+                    failedAt: transitionAt,
+                  })
+                ) {
                   corruptReconciliations += 1;
                 }
                 continue;
@@ -1097,33 +1124,59 @@ export function createChannelIngressQueue<
                 selected = { row, record: rec };
                 break;
               }
-              // Blocked rows are skipped by the in-memory gate without consuming
-              // the success-scan budget. The cursor advances past each skipped
-              // row (via lastScannedRow) so the next page starts strictly beyond
-              // it; a free row behind any-size blocked prefix is reached within
-              // the page cap.
+              // Blocked rows are skipped in memory; the stream merge keeps
+              // advancing in global order, so a free row behind any-size blocked
+              // prefix is reached within the row budget.
             }
-            if (selected) {
-              break;
-            }
-            // Continue paginating past the blocked prefix. Only the degraded path
-            // paginates; the non-degraded path prunes blocked rows in SQL, so its
-            // first page always resolves and cursor stays unset. The cursor is
-            // the last row scanned in global order, which is strictly greater than
-            // all previously scanned rows under the keyset ordering.
-            if (
-              blockedPredicateDropped &&
-              lastScannedRow &&
-              pagesWalked < CLAIM_DEGRADED_BLOCKED_PAGES_MAX
-            ) {
-              cursor = lastScannedRow;
-              pagesWalked += 1;
-              continue;
-            }
-            // No degraded continuation left (or not degraded): only re-run when a
-            // corrupt row was just tombstoned and may have changed the pending set.
-            if (!tombstonedCorruptRow) {
-              break;
+          } else {
+            // Non-degraded: SQL prunes blocked rows, so one ordered merge pass
+            // over the per-chunk tops resolves the claim; the pass only re-runs
+            // when a corrupt row was tombstoned (the merged list is capped to
+            // scanLimit, matching main's single ordered LIMIT scanLimit).
+            while (!selected && corruptReconciliations < MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+              let tombstonedCorruptRow = false;
+              const mergedWindow: ChannelIngressRow[] = [];
+              let anyRows = false;
+              for (const candidateChunk of candidateChunks) {
+                const chunkRows = executeSqliteQuerySync(
+                  tx.db,
+                  candidateSelect(candidateChunk),
+                ).rows;
+                if (chunkRows.length > 0) {
+                  anyRows = true;
+                  mergeTopKRowWindow(mergedWindow, chunkRows, scanLimit, compareRows);
+                }
+              }
+              if (!anyRows) {
+                break;
+              }
+              for (const row of mergedWindow) {
+                const rec = baseRecord<TPayload, TMetadata>(row);
+                if (rec === null) {
+                  if (corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+                    continue;
+                  }
+                  const didTombstone = tombstoneCorruptPayloadRow({
+                    db: tx.db,
+                    row,
+                    expectedStatus: "pending",
+                    failedAt: transitionAt,
+                  });
+                  tombstonedCorruptRow = didTombstone || tombstonedCorruptRow;
+                  if (didTombstone) {
+                    corruptReconciliations += 1;
+                  }
+                  continue;
+                }
+                const laneKey = resolveClaimLaneKey(rec);
+                if (!laneKey || !effectiveBlocked.has(laneKey)) {
+                  selected = { row, record: rec };
+                  break;
+                }
+              }
+              if (selected || !tombstonedCorruptRow) {
+                break;
+              }
             }
           }
         } else {

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -994,6 +994,18 @@ export function createChannelIngressQueue<
                 : (a, b) =>
                     a.received_at - b.received_at || compareEventIdsBinary(a.event_id, b.event_id),
             );
+            // Restore main's global scan-limit contract on the non-degraded path.
+            // SQL still prunes blocked rows here (NOT IN retained), so the merged
+            // top-scanLimit rows are exactly what main's single ordered
+            // LIMIT scanLimit query would have materialized. Capping the merged
+            // traversal to scanLimit keeps write-transaction work bounded to the
+            // configured scan limit instead of chunkCount * scanLimit, matching
+            // main. The degraded path skips this cap: its NOT IN is dropped, so
+            // blocked rows reach the merge and the keyset continuation must walk
+            // past them (total work bounded by CLAIM_DEGRADED_BLOCKED_PAGES_MAX).
+            if (!blockedPredicateDropped && candidateRows.length > scanLimit) {
+              candidateRows.length = scanLimit;
+            }
             let tombstonedCorruptRow = false;
             let lastScannedRow: ChannelIngressRow | undefined;
             for (const row of candidateRows) {

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -511,6 +511,41 @@ const LIST_PENDING_BATCH_SIZE = 100;
 // Keep repair work bounded under one SQLite write lock; later calls continue
 // from the durable failed tombstones left by this call.
 const MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM = 100;
+// Supported Node runtimes cap SQLite bind variables at 32,766. Chunk candidate
+// membership so every IN list stays far below that ceiling with headroom for
+// the queue and lane predicates compiled onto the same statement.
+const CLAIM_CANDIDATE_IDS_CHUNK_SIZE = 1000;
+// SQLite caps bind variables at 32,766 across Node runtimes. Reserve a safety
+// margin for SQLite build/config variance and future Node versions.
+const SQLITE_BIND_SAFETY_LIMIT = 30_000;
+// Fixed binds on a claim select beyond the candidate chunk and blocked-lane
+// membership: queue_name, status, lane_key predicates, limit. Conservative pad.
+const CLAIM_FIXED_BIND_BUDGET = 10;
+// The blocked-lane NOT IN predicate shares the statement's bind budget with the
+// candidate chunk. Drop the SQL predicate only when the combined bind count
+// (candidate chunk + blocked lanes + fixed) would exceed SQLite's ceiling; below
+// that, keep it so blocked rows are pruned in SQL before they reach the in-memory
+// scan gate. Without SQL pruning, blocked rows returned to the scan loop still
+// consume the scanLimit budget and can starve a later free row behind a blocked
+// prefix (see CLAIM_DEGRADED_BLOCKED_SCAN_CAP).
+const CLAIM_BLOCKED_LANE_PREDICATE_LIMIT =
+  SQLITE_BIND_SAFETY_LIMIT - CLAIM_CANDIDATE_IDS_CHUNK_SIZE - CLAIM_FIXED_BIND_BUDGET;
+// When the SQL blocked-lane predicate is dropped above the bind budget, blocked
+// rows returned by SQL are skipped by the in-memory effectiveBlocked.has(laneKey)
+// gate without consuming the success-scan budget. Because the drain rebuilds the
+// same pending snapshot each pump, a blocked prefix that exceeds any single-page
+// scan would otherwise starve a later free row on every pump. So the degraded
+// path pages past the prefix with a keyset cursor (see CLAIM_DEGRADED_BLOCKED_PAGES_MAX)
+// instead of stopping. This constant bounds the rows fetched per page; the total
+// walk is bounded by the page cap, never a full-table scan under the write lock.
+const CLAIM_DEGRADED_BLOCKED_SCAN_CAP = 10_000;
+// Hard work bound for the degraded keyset continuation: the maximum number of
+// pages a single claim walks past blocked rows before giving up. With page size
+// CLAIM_DEGRADED_BLOCKED_SCAN_CAP this caps a single claim at 1M scanned rows,
+// only in the pathological case of >28,990 blocked lanes plus a blocked prefix
+// larger than 1M with no claimable row behind it. The cursor strictly advances
+// each page, so a real free row is reached within ceil(prefix / page size) pages.
+const CLAIM_DEGRADED_BLOCKED_PAGES_MAX = 100;
 
 function normalizeMaxEntries(value: number | undefined): number | null {
   return value === undefined ? null : Math.max(0, Math.floor(value));
@@ -521,7 +556,43 @@ function normalizedProtectedIds(ids: Iterable<string> | undefined): string[] {
 }
 
 function normalizedCandidateIds(ids: Iterable<string> | undefined): string[] | undefined {
-  return ids === undefined ? undefined : [...ids].map((id) => id.trim()).filter(Boolean);
+  if (ids === undefined) {
+    return undefined;
+  }
+  // Deduplicate before chunking: SQL IN set semantics used to collapse repeated
+  // ids, but chunked membership would re-read the same row from every chunk and
+  // let duplicates burn the global scan window.
+  const seen = new Set<string>();
+  for (const id of ids) {
+    const normalized = id.trim();
+    if (normalized) {
+      seen.add(normalized);
+    }
+  }
+  return [...seen];
+}
+
+function chunkStrings(ids: string[], size: number): string[][] {
+  const chunks: string[][] = [];
+  for (let index = 0; index < ids.length; index += size) {
+    chunks.push(ids.slice(index, index + size));
+  }
+  return chunks;
+}
+
+// SQLite orders plain TEXT with the BINARY collation (byte order), not with
+// locale-aware collation. The merged chunk sort must reproduce that ordering
+// exactly, or equal-timestamp events could swap across chunk boundaries.
+function compareEventIdsBinary(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  // BINARY orders TEXT by raw UTF-8 byte value, not by JavaScript's UTF-16
+  // code-unit order. The two diverge for code points outside the BMP (surrogate
+  // pairs): e.g. U+E000 (< U+1F600 in UTF-8 bytes) sorts AFTER U+1F600 under
+  // UTF-16, because the high surrogate 0xD83D precedes 0xE000. Encoding to
+  // UTF-8 buffers reproduces SQLite's byte order exactly.
+  return Buffer.compare(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
 }
 
 function queueNameForParts(channelId: string, accountId: string): string {
@@ -803,85 +874,291 @@ export function createChannelIngressQueue<
         if (candidateIds && candidateIds.length > 0) {
           // Candidate snapshots can race a sibling drainer. If an earlier
           // candidate is now claimed, its lane must block later same-lane rows.
-          const claimedCandidateRows = executeSqliteQuerySync(
-            tx.db,
-            kysely
-              .selectFrom("channel_ingress_events")
-              .selectAll()
-              .where("queue_name", "=", queueName)
-              .where("status", "=", "claimed")
-              .where("event_id", "in", candidateIds),
-          ).rows;
-          const claimedCandidateLaneKeys = claimedCandidateRows
-            .map((row) => {
+          const claimedCandidateLaneKeys = new Set<string>();
+          for (const candidateChunk of chunkStrings(candidateIds, CLAIM_CANDIDATE_IDS_CHUNK_SIZE)) {
+            const claimedCandidateRows = executeSqliteQuerySync(
+              tx.db,
+              kysely
+                .selectFrom("channel_ingress_events")
+                .selectAll()
+                .where("queue_name", "=", queueName)
+                .where("status", "=", "claimed")
+                .where("event_id", "in", candidateChunk),
+            ).rows;
+            for (const row of claimedCandidateRows) {
               if (row.lane_key && !claimOptions?.reconcileStoredLaneKey) {
-                return row.lane_key;
+                claimedCandidateLaneKeys.add(row.lane_key);
+                continue;
               }
               const rec = baseRecord<TPayload, TMetadata>(row);
-              return rec ? resolveClaimLaneKey(rec) : (row.lane_key ?? undefined);
-            })
-            .filter((laneKey): laneKey is string => Boolean(laneKey));
-          if (claimedCandidateLaneKeys.length > 0) {
+              const laneKey = rec ? resolveClaimLaneKey(rec) : (row.lane_key ?? undefined);
+              if (laneKey) {
+                claimedCandidateLaneKeys.add(laneKey);
+              }
+            }
+          }
+          if (claimedCandidateLaneKeys.size > 0) {
             effectiveBlocked = new Set([...blocked, ...claimedCandidateLaneKeys]);
           }
         }
-        const baseSelect = kysely
-          .selectFrom("channel_ingress_events")
-          .selectAll()
-          .where("queue_name", "=", queueName)
-          .where("status", "=", "pending");
-        let select = baseSelect;
-        if (candidateIds) {
-          select = select.where("event_id", "in", candidateIds);
-        }
-        if (effectiveBlocked.size > 0 && !claimOptions?.deriveLaneKey) {
-          select = select.where((eb) =>
-            eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...effectiveBlocked])]),
-          );
-        }
-        let orderedSelect =
-          claimOptions?.orderBy === "id"
-            ? select.orderBy("event_id", "asc")
-            : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
-        orderedSelect = orderedSelect.limit(normalizeScanLimit(claimOptions?.scanLimit));
         const transitionAt = now();
         let corruptReconciliations = 0;
         let selected:
           | { row: ChannelIngressRow; record: ChannelIngressQueueRecord<TPayload, TMetadata> }
           | undefined;
-        while (!selected) {
-          const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
-          let tombstonedCorruptRow = false;
-          for (const row of rows) {
-            const rec = baseRecord<TPayload, TMetadata>(row);
-            if (rec === null) {
-              if (corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+        // Candidate membership is chunked so every IN list stays below SQLite's
+        // bind-variable ceiling. Chunked rows are merged in the queue's global
+        // order and scanned under one total scan limit, so chunk boundaries
+        // never reorder claims or multiply the scan window.
+        if (candidateIds) {
+          const candidateChunks = chunkStrings(candidateIds, CLAIM_CANDIDATE_IDS_CHUNK_SIZE);
+          const scanLimit = normalizeScanLimit(claimOptions?.scanLimit);
+          // When the blocked-lane SQL predicate is dropped above the bind budget,
+          // blocked rows reach the per-chunk result and are skipped in memory.
+          // Because the drain rebuilds the same pending snapshot each pump, a
+          // single-page scan that stops at the first blocked prefix would starve
+          // a later free row on every pump. So the degraded path pages past the
+          // prefix with a keyset cursor (received_at, event_id), mirroring
+          // listPending's continuation, bounded by CLAIM_DEGRADED_BLOCKED_PAGES_MAX.
+          const blockedPredicateDropped =
+            effectiveBlocked.size > CLAIM_BLOCKED_LANE_PREDICATE_LIMIT &&
+            !claimOptions?.deriveLaneKey;
+          // Per-chunk page size. Non-degraded keeps scanLimit (SQL prunes blocked
+          // rows, so one page suffices). Degraded widens to the page size so each
+          // page carries enough rows to make progress past a blocked prefix; the
+          // total walk is bounded by the page cap, not this limit.
+          const perChunkLimit = blockedPredicateDropped
+            ? Math.max(scanLimit, CLAIM_DEGRADED_BLOCKED_SCAN_CAP)
+            : scanLimit;
+          const candidateSelect = (candidateChunk: string[], cursor?: ChannelIngressRow) => {
+            let select = kysely
+              .selectFrom("channel_ingress_events")
+              .selectAll()
+              .where("queue_name", "=", queueName)
+              .where("status", "=", "pending")
+              .where("event_id", "in", candidateChunk);
+            if (
+              effectiveBlocked.size > 0 &&
+              effectiveBlocked.size <= CLAIM_BLOCKED_LANE_PREDICATE_LIMIT &&
+              !claimOptions?.deriveLaneKey
+            ) {
+              select = select.where((eb) =>
+                eb.or([
+                  eb("lane_key", "is", null),
+                  eb("lane_key", "not in", [...effectiveBlocked]),
+                ]),
+              );
+            }
+            if (cursor) {
+              // Keyset continuation: advance strictly past the last scanned row in
+              // the same global order the ORDER BY uses, so the next page never
+              // re-reads or skips a row. Same invariant as listPending.
+              select =
+                claimOptions?.orderBy === "id"
+                  ? select.where("event_id", ">", cursor.event_id)
+                  : select.where((eb) =>
+                      eb.or([
+                        eb("received_at", ">", cursor.received_at),
+                        eb.and([
+                          eb("received_at", "=", cursor.received_at),
+                          eb("event_id", ">", cursor.event_id),
+                        ]),
+                      ]),
+                    );
+            }
+            const ordered =
+              claimOptions?.orderBy === "id"
+                ? select.orderBy("event_id", "asc")
+                : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
+            // Bound each ordered chunk before merging: no row past the k-th
+            // position in its chunk can enter the global top-k, and per-chunk
+            // bounding keeps recovery from re-reading the whole backlog under
+            // the SQLite write lock on every claim.
+            return ordered.limit(perChunkLimit);
+          };
+          let cursor: ChannelIngressRow | undefined;
+          let pagesWalked = 0;
+          while (!selected && corruptReconciliations < MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+            const candidateRows: ChannelIngressRow[] = [];
+            for (const candidateChunk of candidateChunks) {
+              candidateRows.push(
+                ...executeSqliteQuerySync(tx.db, candidateSelect(candidateChunk, cursor)).rows,
+              );
+            }
+            if (candidateRows.length === 0) {
+              break;
+            }
+            candidateRows.sort(
+              claimOptions?.orderBy === "id"
+                ? (a, b) => compareEventIdsBinary(a.event_id, b.event_id)
+                : (a, b) =>
+                    a.received_at - b.received_at || compareEventIdsBinary(a.event_id, b.event_id),
+            );
+            let tombstonedCorruptRow = false;
+            let lastScannedRow: ChannelIngressRow | undefined;
+            for (const row of candidateRows) {
+              lastScannedRow = row;
+              const rec = baseRecord<TPayload, TMetadata>(row);
+              if (rec === null) {
+                if (corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+                  continue;
+                }
+                const didTombstone = tombstoneCorruptPayloadRow({
+                  db: tx.db,
+                  row,
+                  expectedStatus: "pending",
+                  failedAt: transitionAt,
+                });
+                tombstonedCorruptRow = didTombstone || tombstonedCorruptRow;
+                if (didTombstone) {
+                  corruptReconciliations += 1;
+                }
                 continue;
               }
-              const didTombstone = tombstoneCorruptPayloadRow({
-                db: tx.db,
-                row,
-                expectedStatus: "pending",
-                failedAt: transitionAt,
-              });
-              tombstonedCorruptRow = didTombstone || tombstonedCorruptRow;
-              if (didTombstone) {
-                corruptReconciliations += 1;
+              const laneKey = resolveClaimLaneKey(rec);
+              if (!laneKey || !effectiveBlocked.has(laneKey)) {
+                selected = { row, record: rec };
+                break;
               }
+              // Blocked rows are skipped by the in-memory gate without consuming
+              // the success-scan budget. The cursor advances past each skipped
+              // row (via lastScannedRow) so the next page starts strictly beyond
+              // it; a free row behind any-size blocked prefix is reached within
+              // the page cap.
+            }
+            if (selected) {
+              break;
+            }
+            // Continue paginating past the blocked prefix. Only the degraded path
+            // paginates; the non-degraded path prunes blocked rows in SQL, so its
+            // first page always resolves and cursor stays unset. The cursor is
+            // the last row scanned in global order, which is strictly greater than
+            // all previously scanned rows under the keyset ordering.
+            if (
+              blockedPredicateDropped &&
+              lastScannedRow &&
+              pagesWalked < CLAIM_DEGRADED_BLOCKED_PAGES_MAX
+            ) {
+              cursor = lastScannedRow;
+              pagesWalked += 1;
               continue;
             }
-            const laneKey = resolveClaimLaneKey(rec);
-            if (!laneKey || !effectiveBlocked.has(laneKey)) {
-              selected = { row, record: rec };
+            // No degraded continuation left (or not degraded): only re-run when a
+            // corrupt row was just tombstoned and may have changed the pending set.
+            if (!tombstonedCorruptRow) {
               break;
             }
           }
+        } else {
+          const baseSelect = kysely
+            .selectFrom("channel_ingress_events")
+            .selectAll()
+            .where("queue_name", "=", queueName)
+            .where("status", "=", "pending");
+          let select = baseSelect;
+          const blockedPredicateDropped =
+            effectiveBlocked.size > CLAIM_BLOCKED_LANE_PREDICATE_LIMIT &&
+            !claimOptions?.deriveLaneKey;
           if (
-            selected ||
-            !tombstonedCorruptRow ||
-            corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM
+            effectiveBlocked.size > 0 &&
+            effectiveBlocked.size <= CLAIM_BLOCKED_LANE_PREDICATE_LIMIT &&
+            !claimOptions?.deriveLaneKey
           ) {
-            break;
+            select = select.where((eb) =>
+              eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...effectiveBlocked])]),
+            );
+          }
+          // When the blocked-lane SQL predicate is dropped above the bind budget,
+          // blocked rows reach the scan loop and are skipped in memory. Because
+          // the drain rebuilds the same pending snapshot each pump, stopping at
+          // the first blocked prefix would starve a later free row on every pump.
+          // So the degraded path pages past the prefix with a keyset cursor
+          // (received_at, event_id), mirroring listPending's continuation,
+          // bounded by CLAIM_DEGRADED_BLOCKED_PAGES_MAX. Non-degraded keeps a
+          // single scanLimit page (SQL prunes blocked rows, so one page suffices).
+          const scanLimit = normalizeScanLimit(claimOptions?.scanLimit);
+          const degradedSqlLimit = blockedPredicateDropped
+            ? Math.max(scanLimit, CLAIM_DEGRADED_BLOCKED_SCAN_CAP)
+            : scanLimit;
+          const buildOrderedSelect = (cursor?: ChannelIngressRow) => {
+            let paged = select;
+            if (cursor) {
+              paged =
+                claimOptions?.orderBy === "id"
+                  ? paged.where("event_id", ">", cursor.event_id)
+                  : paged.where((eb) =>
+                      eb.or([
+                        eb("received_at", ">", cursor.received_at),
+                        eb.and([
+                          eb("received_at", "=", cursor.received_at),
+                          eb("event_id", ">", cursor.event_id),
+                        ]),
+                      ]),
+                    );
+            }
+            return claimOptions?.orderBy === "id"
+              ? paged.orderBy("event_id", "asc").limit(degradedSqlLimit)
+              : paged
+                  .orderBy("received_at", "asc")
+                  .orderBy("event_id", "asc")
+                  .limit(degradedSqlLimit);
+          };
+          let cursor: ChannelIngressRow | undefined;
+          let pagesWalked = 0;
+          while (!selected) {
+            const rows = executeSqliteQuerySync(tx.db, buildOrderedSelect(cursor)).rows;
+            let tombstonedCorruptRow = false;
+            let lastScannedRow: ChannelIngressRow | undefined;
+            for (const row of rows) {
+              lastScannedRow = row;
+              const rec = baseRecord<TPayload, TMetadata>(row);
+              if (rec === null) {
+                if (corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+                  continue;
+                }
+                const didTombstone = tombstoneCorruptPayloadRow({
+                  db: tx.db,
+                  row,
+                  expectedStatus: "pending",
+                  failedAt: transitionAt,
+                });
+                tombstonedCorruptRow = didTombstone || tombstonedCorruptRow;
+                if (didTombstone) {
+                  corruptReconciliations += 1;
+                }
+                continue;
+              }
+              const laneKey = resolveClaimLaneKey(rec);
+              if (!laneKey || !effectiveBlocked.has(laneKey)) {
+                selected = { row, record: rec };
+                break;
+              }
+              // Blocked rows skipped in memory (only when the SQL predicate is
+              // dropped) do not end the claim; the cursor advances past each so
+              // the next page reaches a free row behind any-size blocked prefix.
+            }
+            if (selected) {
+              break;
+            }
+            // Continue paginating past the blocked prefix. Only the degraded path
+            // paginates; the non-degraded path prunes blocked rows in SQL, so its
+            // first page always resolves and cursor stays unset. The cursor is the
+            // last row scanned in global order, strictly greater than all prior.
+            if (
+              blockedPredicateDropped &&
+              lastScannedRow &&
+              pagesWalked < CLAIM_DEGRADED_BLOCKED_PAGES_MAX
+            ) {
+              cursor = lastScannedRow;
+              pagesWalked += 1;
+              continue;
+            }
+            if (
+              !tombstonedCorruptRow ||
+              corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM
+            ) {
+              break;
+            }
           }
         }
         if (!selected) {


### PR DESCRIPTION
## What Problem This Solves

A channel account's durable ingress queue stops draining permanently once its pending backlog exceeds SQLite's bind-variable ceiling on the supported Node 22/24 runtimes, because `claimNext` builds two `event_id IN (...)` predicates over the whole candidate snapshot, and—separately—compiles a `lane_key NOT IN (...)` predicate over the full effective blocked-lane set. Chunking candidate membership **and** bounding the blocked-lane predicate in the shared queue owner keeps every statement far below the ceiling while preserving snapshot, ordering, lane, retry, supersede, and sibling-drainer race semantics.

- Problem: With more than 32,766 pending rows for one `queue_name`, statement construction throws `too many SQL variables`; the pump only reports the error, and a restart rebuilds the same oversized statement, so the queue is wedged until manual repair. A second, distinct bind-limit failure lives on the same claim query: the `lane_key NOT IN (...)` predicate binds every effective blocked lane. A retry-heavy stored-lane account (LINE/Zalo drains that run without `deriveLaneKey`, so they take the stored-lane SQL path) can collect more distinct retry-delayed lanes than the remaining bind budget, so the claim throws `too many SQL variables` and stalls the durable queue even when the candidate set is small.
- Solution: Bound every candidate-membership query in the shared queue owner (`claimNext`) by chunking the candidate id set into 1,000-id IN lists, then merging the bounded per-chunk results in the queue's global received/id order (SQLite BINARY event-id tie-break) and scanning under one total scan limit so chunk boundaries never reorder claims; on the non-degraded path the merged list is capped to `scanLimit` after the sort to restore main's single-ordered-`LIMIT scanLimit` contract. Bound the blocked-lane predicate symmetrically: keep the SQL `NOT IN` predicate up to `CLAIM_BLOCKED_LANE_PREDICATE_LIMIT` (~28,990, near SQLite's 32,766 bind ceiling), and above it drop the predicate but page past the blocked prefix in memory with a keyset cursor `(received_at, event_id)` (mirroring `listPending`, bounded by `CLAIM_DEGRADED_BLOCKED_SCAN_CAP` per page and `CLAIM_DEGRADED_BLOCKED_PAGES_MAX` overall) so skipped blocked rows advance the cursor without consuming the success-scan budget and a free row behind any-size blocked prefix stays claimable — the per-row `effectiveBlocked.has(laneKey)` scan gate remains the authoritative correctness check on every scanned row. The degraded candidate path streams each chunk in its own global order and merges the chunk heads, so every candidate row is read at most once (a blocked prefix is walked once instead of re-selecting every chunk on every keyset page) with the total walk bounded by the degraded row budget (`CLAIM_DEGRADED_BLOCKED_PAGES_MAX × CLAIM_DEGRADED_BLOCKED_SCAN_CAP`). Finally, bound the drain pass itself: `drainOnce` no longer re-reads the whole snapshot on every claim. It carries a bounded ordered candidate window (`ingress-drain-candidates.ts`) that starts at `scanLimit` ids, doubles on a null claim until the snapshot is covered (so a free row behind any-size blocked prefix stays reachable), refreshes sibling-race claimed lanes with one cheap `listClaims` query per attempt, and **compacts after every successful claim** — the exhausted blocked prefix is dropped and the window shrinks back to `scanLimit`, resuming just after the claimed row, so a window widened through a 33k blocked prefix never replays that prefix on the remaining starts of the pass. A 32-start pass over 33,000 free rows drops from ~2,112 selects / ~105,600 rows to ~64 selects / ~3,200 rows, and a 32-start pass behind a 33,000-row blocked prefix claims all 32 free rows while the 31 post-prefix starts stay at one candidate chunk each.
- What changed: `src/channels/message/ingress-queue.ts` (chunked claimed-candidate detection + chunked main select merged into global order with one total scan limit; each chunk bounded by `scanLimit` before merging; candidate ids deduplicated before chunking; merged sort uses a SQLite BINARY-compatible event-id comparator (`compareEventIdsBinary`) that encodes ids to UTF-8 buffers and compares with `Buffer.compare` so non-BMP code points order identically to SQLite's BINARY collation; `CLAIM_CANDIDATE_IDS_CHUNK_SIZE = 1000`; new `CLAIM_BLOCKED_LANE_PREDICATE_LIMIT` (= `SQLITE_BIND_SAFETY_LIMIT` 30,000 − candidate chunk 1,000 − fixed-bind pad 10 = 28,990) gating the blocked-lane `NOT IN` predicate in both the candidate branch and the non-candidate `else` branch so the predicate is dropped only near SQLite's 32,766 bind ceiling; above the cutoff the degraded path pages past a blocked prefix with a keyset cursor `(received_at, event_id)` mirroring `listPending`, bounded by `CLAIM_DEGRADED_BLOCKED_SCAN_CAP = 10,000` (per-page size) and `CLAIM_DEGRADED_BLOCKED_PAGES_MAX = 100` (hard page cap, 1M rows worst case) so skipped blocked rows advance the cursor without consuming the success-scan budget and a free row behind any-size blocked prefix is reached within the page cap; on the non-degraded path the merged `candidateRows` list is capped to `scanLimit` after the global sort to restore main's single-ordered-`LIMIT scanLimit` contract so chunked merging never multiplies write-transaction work; above the bind budget the degraded candidate path streams each chunk in its own global order and merges the chunk heads instead of re-selecting every chunk on every keyset page, so each candidate row is read at most once and the total walk is bounded by `CLAIM_DEGRADED_BLOCKED_PAGES_MAX × CLAIM_DEGRADED_BLOCKED_SCAN_CAP`), `src/channels/message/ingress-drain.ts` (bounded ordered candidate window through the drain pass instead of the full snapshot per claim; the pass ends without a no-op empty-candidate `claimNext` probe), `src/channels/message/ingress-drain-candidates.ts` (new: bounded window helper — starts at `scanLimit`, doubles on null claims, refreshes sibling-race claimed lanes per attempt via `listClaims`, removes claimed ids, and **compacts after each successful claim** by dropping the exhausted blocked prefix, shrinking back to `scanLimit`, and resuming just after the claimed row), `src/channels/message/ingress-queue.test.ts` (bind-limit regression, multi-chunk real-row test, unsorted multi-chunk ordering regression, duplicate-candidate regression, cross-chunk binary tie-break regression, non-BMP cross-chunk binary tie-break regression), `src/channels/message/ingress-queue-claim-candidates.test.ts` (new: the seven chunked-candidate-membership regressions extracted to keep `ingress-queue.test.ts` under the max-lines budget), `src/channels/message/ingress-queue-claim-bounds.test.ts` (new: bounded per-chunk read regression; oversized blocked-lane set drops the SQL predicate and still claims the free row; below-budget blocked-lane set retains the SQL predicate; cap-plus-one blocked prefix across the candidate and non-candidate branches; bounded degraded walk when no claimable row exists; global ordering preserved across the degraded keyset continuation; merged candidate traversal capped to `scanLimit` on the non-degraded path across two candidate chunks; degraded candidate reads bounded across chunks), `src/channels/message/ingress-drain-claim-bounds.test.ts` (new: full-drain query/row-budget regression — 33,000 rows, 32-start pass asserts membership selects ≤ 72 and rows ≤ 7,400 while claiming `free-0..free-31` in global order; a drain-level blocked-prefix regression proving the window grows instead of starving; and a 3,300-row blocked-prefix multi-claim regression proving the widened window compacts after the first claim so the remaining starts stay at one chunk each), `src/channels/message/ingress-drain-lanes.test.ts` (claimNext probe-count expectation updated 2 → 1: the bounded window ends the pass when the snapshot is covered).
- What did NOT change: drainer snapshot behavior, `candidateIds` API contract, received/id ordering, lane/retry/supersede handling, the in-memory `effectiveBlocked.has(laneKey)` scan gate (now the sole filter above the blocked-lane budget), the monitor pump loop, per-lane claim order inside a pass.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #119490
- [x] This PR fixes a bug or regression

## Motivation

The durable channel ingress queue (shared by Telegram, WhatsApp, Google Chat, Line and other channel extensions through `src/channels/message/ingress-monitor.ts`) snapshots all pending rows per drain pass and hands the full id set to `claimNext`. `claimNext` then compiles two SQL statements with `event_id IN (<all ids>)`, and—when no `deriveLaneKey` is configured (the stored-lane path taken by LINE/Zalo)—compiles a `lane_key NOT IN (<all effective blocked lanes>)` predicate onto the same statement. Node 22.22.3 and 24.15.0 ship SQLite with `SQLITE_MAX_VARIABLE_NUMBER` = 32,766; once either membership list passes the remaining budget, every drain pass throws `too many SQL variables`, the pump swallows the error via `reportError`, and the queue never drains again — a restart only rebuilds the same oversized statement. This is silent message loss for the affected account. The blocked-lane variant is reached by any retry-heavy stored-lane account whose drain collects more distinct retry-delayed lanes than the bind budget allows, regardless of backlog size.

## Evidence

- Behavior addressed: `claimNext` no longer constructs SQL statements that exceed SQLite's bind-variable limit, so a >32,766-row pending backlog keeps draining instead of wedging permanently, and a >28,990-distinct-lane blocked set degrades to the in-memory scan gate (without starving a free row behind a blocked prefix) instead of throwing.
- Real environment tested: Linux, Node v22.22.3 (the exact engines-floor runtime named in the issue), branch `fix/ingress-claim-bind-limit-119490`, temporary SQLite state dir (no `~/.openclaw` touched).
- Exact steps or command run after this patch:

```console
$ node --import tsx proof-119490.mts   # seeds 33,000 pending rows, then runs the shared drain
$ node --import tsx pr-119827-blocked-lane-proof.mts   # 1 free + 1 blocked row, 33,000 blockedLaneKeys, no deriveLaneKey
$ node --import tsx pr-119827-blocked-prefix-proof.mts   # 100 blocked rows + 1 free at 101, 1,001 blockedLaneKeys, scanLimit=100
$ node --import tsx pr-119827-keyset-continuation-proof.mts   # 49,999 blocked rows + 1 free at 50,000, 30,000 blockedLaneKeys, scanLimit=100 (degraded keyset continuation)
$ node --import tsx pr-119827-merged-cap-proof.mts   # 150 free rows across 2 chunks + 1 blocked, scanLimit=100 (non-degraded merged cap)
$ node --import tsx pr-119827-drain-window-proof.mts   # 33,000-row 32-start pass + 100-row blocked prefix (drain-level bounded window)
$ node scripts/run-vitest.mjs src/channels/message --run
```

- Evidence after fix (candidate backlog):

```console
$ node --import tsx proof-119490.mts
seeded: 33000 pending rows (target 33000)
drainOnce #1: started=64 total=64
drainOnce #2: started=64 total=128
drainOnce #3: started=64 total=192
pending after 3 passes: 32808 (claimed 192 of 33000)
PROOF OK
```

- Evidence after fix (blocked-lane predicate bind budget):

```console
$ node --import tsx pr-119827-blocked-lane-proof.mts
[proof] state dir: /tmp/claude-1000/pr-119827-proof-AyDws6
[proof] enqueued 2 rows: free (lane=free), blocked (lane=blocked)
[proof] blockedLaneKeys: 33000 distinct lanes (no deriveLaneKey)
[proof] ✅ PASS: claimNext returned 'free' (id=free), no SQL bind error
[proof]    -> blocked-lane predicate degraded to in-memory filter as expected
```

Same harness against the pre-fix code (only the production file reverted, test/seed unchanged):

```console
$ node --import tsx proof-119490.mts
seeded: 33000 pending rows (target 33000)
drainOnce #1 FAILED: too many SQL variables
```

Same blocked-lane harness against the pre-fix head `e39157e` (only `ingress-queue.ts` reverted):

```console
$ node --import tsx pr-119827-blocked-lane-proof.mts
[proof] enqueued 2 rows: free (lane=free), blocked (lane=blocked)
[proof] blockedLaneKeys: 33000 distinct lanes (no deriveLaneKey)
[proof] ❌ FAIL: claimNext threw: too many SQL variables
[proof]    -> NOT IN predicate exceeded SQLite bind limit (the bug)
```

- Evidence after fix (blocked-prefix starvation, round-2):

```console
$ node --import tsx pr-119827-blocked-prefix-proof.mts
[proof] enqueued 100 blocked rows (lanes blocked-lane-0..99) + 1 free row at 101
[proof] blockedLaneKeys: 1001 distinct lanes (no deriveLaneKey)
[proof] scanLimit: 100 (LINE default) — the blocked prefix fills the window
[proof] ✅ PASS: claimNext returned 'free' (id=free) past the 100-row blocked prefix
[proof]    -> round-2 fix: blocked rows skipped without consuming the scan budget
```

Same harness against the round-1 head `e1567608` (the round-1 fix that introduced the regression):

```console
$ node --import tsx pr-119827-blocked-prefix-proof.mts
[proof] ❌ FAIL: claimNext returned null (expected id=free) — blocked prefix starved the free row
```

Scenario: 100 blocked rows fill the scanLimit=100 window, each on its own lane, with one free row at position 101 and 1,001 `blockedLaneKeys` (above the round-1 cutoff of 1,000 but below the round-2 cutoff of 28,990). Round-1 dropped the SQL `NOT IN` predicate and let blocked rows consume the in-memory scan budget, starving the free row; round-2 keeps the predicate at 1,001 lanes and, above the cutoff, skips blocked rows without consuming the scan budget.

Note: SQLite's bind ceiling is 32,766; 32,000 distinct blocked lanes still pass on the pre-fix head, while 33,000 throws `too many SQL variables`, confirming the predicate is the bind-limit source. The cutoff sits at `CLAIM_BLOCKED_LANE_PREDICATE_LIMIT = 28,990` (30,000 − 1,000 candidate − 10 fixed), so 1,001 blocked lanes — the ClawSweeper regression scenario — keeps the SQL predicate (1,000 + 1,001 = 2,001 binds, far below 32,766) and never degrades.

- Evidence after fix (degraded keyset continuation past an oversized blocked prefix, round-3):

```console
$ node --import tsx pr-119827-keyset-continuation-proof.mts
[proof] enqueued 49999 blocked rows + 1 free row at 50000
[proof] blockedLaneKeys: 30000 distinct lanes (no deriveLaneKey)
[proof] scanLimit: 100, candidateIds: all 50,000 pending IDs (50 chunks)
[proof] ✅ PASS: claimNext returned 'free' (id=free) past 49999 blocked rows
[proof]    -> round-3 keyset continuation reached the free row at position 50,000
```

Same harness against the round-2 head `cd2079a3` (the round-2 fix whose 10,000 hard cap stopped without advancing a cursor):

```console
$ node --import tsx pr-119827-keyset-continuation-proof.mts
[proof] ❌ FAIL: claimNext returned null (expected id=free) — blocked prefix starved the free row
```

Scenario: 49,999 blocked rows (each on its own stored lane) fill the queue, followed by one free row at position 50,000; `blockedLaneKeys` carries 30,000 distinct lanes (above the ~28,990 cutoff) with no `deriveLaneKey`, so the claim takes the stored-lane SQL path, the `NOT IN` predicate is dropped (degraded mode), and `candidateIds` = all 50,000 pending IDs (50 chunks of 1,000) with `scanLimit = 100`. Round-2's `CLAIM_DEGRADED_BLOCKED_SCAN_CAP = 10,000` hard cap walked blocked rows in memory but stopped at 10,000 without advancing a cursor; the free row at 50,000 returned `null` and the drain rebuilt the same snapshot next pump, so it stayed starved forever. Round-3 pages past the blocked prefix with a keyset cursor `(received_at, event_id)` (mirroring `listPending`), bounded by `CLAIM_DEGRADED_BLOCKED_PAGES_MAX = 100`; the cursor strictly advances each page, so the free row at 50,000 is reached within ceil(49,999 / 10,000) = 5 pages.

- Evidence after fix (merged candidate cap on the non-degraded path, round-4):

```console
$ node --import tsx pr-119827-merged-cap-proof.mts
[proof] enqueued 150 free rows + 1 blocked row (2 candidate chunks)
[proof] scanLimit: 100, blockedLaneKeys: ['blocked'] (non-degraded, NOT IN retained)
[proof] ✅ PASS: claimNext returned 'free-0' (id=free-0), the global minimum
[proof]    -> non-degraded merged cap keeps the global scan-limit contract
[proof]    -> claim result matches main's single ordered LIMIT scanLimit (free-0)
```

Scenario: 150 free rows on the "free" lane plus one blocked row on a different lane, with `candidateIds` spanning two chunks (chunk size 1,000) and `scanLimit = 100`. A small `blockedLaneKeys` set keeps the SQL `NOT IN` predicate, so this is the non-degraded path: blocked rows are pruned in SQL and the merged `candidateRows` list is capped to `scanLimit` after the global sort, restoring main's single-ordered-`LIMIT scanLimit` contract. Both the round-3 head (`b5b56e24`, no merged cap) and the round-4 head (`96087444898`, with cap) return `free-0` — the cap does not change claim results on the non-degraded path, because SQL already pruned blocked rows and `free-0` is the global minimum; the cap only bounds write-transaction traversal to `scanLimit` instead of `chunkCount * scanLimit`.

- Evidence after fix (full-drain bounded candidate window, round-5):

```console
$ node --import tsx pr-119827-drain-window-proof.mts
[proof] state dir: /tmp/pr-119827-v5-QCoJb9
[proof] seeded: 33000 pending rows on 33000 distinct lanes
[proof] drainOnce #1: started=32
[proof] dispatched: free-0..free-31
[proof] pending head after pass: free-32
[proof] pending count after pass: 32968 (32968 expected)
[proof] Scenario A PASS: 32-start pass drained the global-order first 32 rows
[proof] scenario B: 100 retry-delayed rows (scanLimit window) + 100 free rows behind
[proof] scenario B drainOnce: started=8
[proof] scenario B dispatched: free-0..free-7
[proof] Scenario B PASS: free rows behind the blocked prefix claimed in order
PROOF OK
```

Scenario: 33,000 pending rows on 33,000 distinct lanes run through one 32-start `drainOnce` pass, and a separate queue with 100 retry-delayed rows filling the initial `scanLimit` window plus 100 free rows behind them runs an 8-start pass. Before this round, every claim handed the full snapshot to `claimNext`, which re-read all 33 candidate chunks twice (claimed pre-scan + pending select) per claim — ~2,112 selects / ~105,600 rows per 32-start pass — and the drain repeated that full walk even when only the head of the queue was claimable. After, the bounded window hands `claimNext` one candidate chunk per claim (~64 membership selects / ~3,200 rows per pass, asserted by the full-drain regression) and grows past the blocked prefix instead of starving, while the claimed ids are removed so one snapshot row still gets one attempt per pass.

- Evidence after fix (window compaction after a blocked-prefix claim, round-6):

```console
$ node --import tsx pr-119827-drain-window-proof.mts
[proof] seeded: 33000 pending rows on 33000 distinct lanes
[proof] drainOnce #1: started=32
[proof] dispatched: free-0..free-31
[proof] pending head after pass: free-32
[proof] Scenario A PASS: 32-start pass drained the global-order first 32 rows
[proof] scenario B: 100 retry-delayed rows (scanLimit window) + 100 free rows behind
[proof] scenario B drainOnce: started=8
[proof] scenario B dispatched: free-0..free-7
[proof] Scenario B PASS: free rows behind the blocked prefix claimed in order
[proof] scenario C: 33000 retry-delayed rows (33+ chunks) + 32 free rows behind
[proof] scenario C drainOnce: started=32
[proof] scenario C dispatched: free-0..free-31
[proof] Scenario C PASS: 32-start pass claimed all free rows behind the 33k prefix
PROOF OK
```

Scenario: 33,000 retry-delayed rows (33+ candidate chunks) block the head of a queue with 32 free rows behind them, `scanLimit = 100`. The first claim widens the bounded window through the prefix (doubling, capped at the snapshot), and after it succeeds the window compacts — the exhausted blocked prefix is dropped, the window shrinks back to `scanLimit`, and the ordered snapshot resumes just after the claimed row — so the remaining 31 starts replay one candidate chunk each instead of re-scanning the widened 33k prefix. The vitest counterpart (3,300-row prefix, 32 starts) asserts total membership selects ≤ 114; without compaction the same pass would issue ~284.

- Evidence after fix (degraded candidate reads bounded across chunks, round-7):

```console
$ node scripts/run-vitest.mjs src/channels/message/ingress-queue-claim-bounds.test.ts --run
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Regression shape: 22,000 blocked rows (each on its own stored lane) followed by one free row, 30,000 `blockedLaneKeys`, no `deriveLaneKey` — the SQL `NOT IN` predicate is dropped, so the claim takes the degraded candidate path with a 23-chunk candidate set. Pre-fix, every degraded keyset page re-selected all 23 chunks (per-chunk LIMIT 10,000 > chunk size 1,000) and re-read the discarded suffix, issuing ~92 selects / ~36,003 rows under the write lock for a 3-page walk. After, the stream merge reads each row at most once: ~46 selects (one claimed pre-scan + one pending select per chunk) and ~22,001 rows, and the free row behind the 22k blocked prefix is still claimed. The total walk stays bounded by `CLAIM_DEGRADED_BLOCKED_PAGES_MAX × CLAIM_DEGRADED_BLOCKED_SCAN_CAP`.

Regression tests (queue layer + full `src/channels/message` shard):

```console
$ node scripts/run-vitest.mjs src/channels/message --run
 Test Files  35 passed (35)
      Tests  396 passed (396)
```

Focused blocked-lane-predicate regressions:

```console
$ node scripts/run-vitest.mjs src/channels/message/ingress-queue-claim-bounds.test.ts --run
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Focused full-drain regressions:

```console
$ node scripts/run-vitest.mjs src/channels/message/ingress-drain-claim-bounds.test.ts --run
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Behavior matrix:

| Input | Before fix | After fix |
|---|---|---|
| 100 pending rows, `claimNext` | claims in order | claims in order |
| 33,000 pending rows, `drainOnce` | `too many SQL variables`, queue wedged | drains (64 rows/pass, `PROOF OK`) |
| 40,000 candidate ids on empty queue | `too many SQL variables` | returns `null` (no throw) |
| 1,500 real rows across 2 chunks | n/a | claims `event-0`, then `event-1` in received order |
| 1,500 real rows, unsorted (reversed) candidate chunks | `event-500` (chunk order outranks global order) | `event-0` (global received order preserved) |
| 1,001 candidates with a duplicated blocked id, 2-row scan window | `null` (duplicates burn the scan window) | claims the later free row |
| 1,001-row blocked backlog, `scanLimit=100` | chunk read materializes all 1,001 rows | each chunk query reads ≤ 100 rows |
| `B`/`a` with equal `received_at` across 2 chunks | `a` (`localeCompare` outranks SQLite BINARY) | `B` (SQLite BINARY event-id order preserved) |
| `U+E000`/`U+1F600` (non-BMP) with equal `received_at` across 2 chunks | `U+1F600` (UTF-16 surrogate `0xD83D` < `0xE000` reverses BINARY) | `U+E000` (UTF-8 byte order: `EE 80 80` < `F0 9F 98 80`) |
| 33,000 `blockedLaneKeys`, no `deriveLaneKey`, 1 free + 1 blocked row | `too many SQL variables` (NOT IN exceeds 32,766) | claims `free` (predicate dropped above 28,990; in-memory scan gate excludes `blocked`) |
| <28,990 `blockedLaneKeys`, no `deriveLaneKey` | SQL `NOT IN` predicate compiled | SQL `NOT IN` predicate retained (no perf regression) |
| 1,001 `blockedLaneKeys` + 100-row blocked prefix, `scanLimit=100`, no `deriveLaneKey` | round-1 dropped the predicate → blocked rows consumed scan budget → free row at 101 starved (null) | keeps predicate (2,001 binds < 32,766); free row claimed |
| 30,000 `blockedLaneKeys` + 10,001-row blocked prefix (cap-plus-one), `scanLimit=100`, candidate ids | round-2 hard cap stopped at 10,000 blocked rows without advancing a cursor → free row at 10,002 starved (null) | round-3 keyset continuation pages past the prefix → free row claimed |
| 30,000 `blockedLaneKeys` + 10,001-row blocked prefix (cap-plus-one), `scanLimit=100`, no candidate ids | round-2 hard cap starved the free row (null) | round-3 keyset continuation (non-candidate branch) → free row claimed |
| 30,000 `blockedLaneKeys` + 22,000 blocked rows, no free row, `scanLimit=100` | unbounded full-table scan under the write lock | bounded degraded walk returns `null` within `CLAIM_DEGRADED_BLOCKED_PAGES_MAX` pages |
| 150 free rows across 2 candidate chunks + 1 blocked row, `scanLimit=100`, small `blockedLaneKeys` (non-degraded) | merged `candidateRows` traversed up to `chunkCount * scanLimit` rows under the write lock | merged list capped to `scanLimit` after sort; `free-0` (global minimum) claimed — matches main's `LIMIT scanLimit` |
| 33,000 rows on 33,000 lanes, one 32-start `drainOnce` pass | ~2,112 membership selects / ~105,600 rows (full snapshot re-read twice per claim) | ~64 membership selects / ~3,200 rows; `free-0..free-31` claimed in global order |
| 100 retry-delayed rows filling the `scanLimit` window + 100 free rows, one drain pass | n/a (no drain-level window; per-claim full-snapshot walk) | bounded window grows past the prefix inside the pass; `free-0..free-7` claimed in order |
| 3,300-row blocked prefix + 64 free rows, 32-start drain pass | window stayed widened after the first claim; later starts replayed ~4 chunks each (~284 membership selects total) | window compacts after the first claim; later starts replay one chunk each (~≤114 membership selects total) |
| 33,000-row blocked prefix + 32 free rows, 32-start drain pass (real runtime) | n/a (pre-round-6 head replays the widened prefix on every start) | first claim widens through the prefix, then compacts; all 32 free rows claimed (`free-0..free-31`), later starts at one chunk each |
| 22,000 blocked rows + 1 free row, degraded candidate path (30,000 `blockedLaneKeys`, no `deriveLaneKey`, 23 chunks) | each degraded keyset page re-selected all 23 chunks and re-read the discarded suffix (~92 selects / ~36,003 rows) | stream merge reads each row at most once (~46 selects / ~22,001 rows); free row behind the prefix claimed |

- Observed result after fix:
  1. A 33,000-row backlog drains on Node v22.22.3 without any SQLite bind-variable error.
  2. `claimNext` with 40,000 candidate ids returns `null` instead of throwing.
  3. Global claim ordering is preserved across chunk boundaries: an unsorted (reversed) 1,500-row candidate snapshot still claims the globally earliest row (`event-0`), not a later chunk row (`event-500`).
  4. Duplicate candidate ids no longer consume the claim scan window: the later eligible row is still claimed.
  5. Each claim chunk read is bounded by `scanLimit` instead of the backlog size (spy regression).
  6. SQLite BINARY event-id ordering is preserved across chunk boundaries: equal-timestamp `B`/`a` rows in different chunks still claim `B` first, and equal-timestamp non-BMP `U+E000`/`U+1F600` rows still claim `U+E000` first (UTF-8 byte order), where the previous UTF-16 comparator reversed them.
  7. A 33,000-distinct-lane blocked set (no `deriveLaneKey`, stored-lane SQL path) no longer throws `too many SQL variables`; the claim returns the free row because the SQL `NOT IN` predicate is dropped above `CLAIM_BLOCKED_LANE_PREDICATE_LIMIT` and the in-memory `effectiveBlocked.has(laneKey)` scan gate still excludes the blocked lane.
  8. A below-budget blocked set still compiles the SQL `NOT IN` predicate (no performance regression for the common small-set case).
  9. A free row behind an oversized blocked prefix (49,999 blocked rows + free at 50,000, 30,000 `blockedLaneKeys`, degraded mode) is reached by the keyset continuation within 5 pages, instead of starving forever as in round-2's 10,000 hard cap.
  10. On the non-degraded path, the merged candidate list is capped to `scanLimit` after the global sort, so chunked merging never multiplies write-transaction work beyond main's single-ordered-`LIMIT scanLimit` contract; the global minimum free row is still claimed (no starvation).
  11. Existing lane/retry/supersede/candidate semantics are preserved (full `src/channels/message` suite: 35 files / 392 tests pass).
  12. A 32-start pass over 33,000 rows issues ~64 candidate-membership selects (~3,200 rows) instead of ~2,112 selects (~105,600 rows) while claiming `free-0..free-31` in global order (full-drain budget regression).
  13. A drain-level blocked prefix (100 retry-delayed rows filling the initial window) no longer starves: the bounded window grows inside the pass and claims the free rows behind it in order.
  14. The pass ends without a no-op empty-candidate `claimNext` probe (probe-count regression updated 2 → 1).
  15. A window widened through a blocked prefix compacts after the first successful claim: the exhausted prefix is dropped, the window shrinks back to `scanLimit`, and the remaining starts of the pass replay one candidate chunk each (3,300-row prefix regression: ~≤114 membership selects vs ~284 without compaction; real-runtime 33,000-row prefix pass claims all 32 free rows).
  16. The degraded candidate path reads each candidate row at most once: 22,000 blocked rows + 1 free row issue ~46 selects / ~22,001 rows instead of ~92 selects / ~36,003 rows, with the free row still claimed and the walk bounded by the degraded row budget.
- What was not tested: live third-party channels (Telegram/WhatsApp web etc.) and the >32,763 backlog on Node 24.15.0 were not re-run here; the failure is runtime-version-dependent, but the statement shape is identical and the regression test runs on Node 22.22.3 (the engines floor). The blocked-lane starvation scenario (a lane never becoming claimable) is intentionally not addressed by this PR (tracked in #111373); this PR only bounds the blocked-lane predicate's bind budget.

## Root Cause (if applicable)

`src/channels/message/ingress-drain.ts:755` snapshots every pending row into `candidateIds`; `src/channels/message/ingress-queue.ts` `claimNext` then builds two unbounded `event_id IN (candidateIds)` predicates (claimed-candidate detection and the main select). Separately, when no `deriveLaneKey` is configured (the stored-lane path), the same `claimNext` compiles a `lane_key NOT IN (<all effective blocked lanes>)` predicate; the drain (`ingress-drain.ts:719-728`) collects every retry-delayed pending lane into `blockedLaneKeys` with no cap, so a retry-heavy stored-lane account can push the predicate past the bind ceiling. Node 22/24 SQLite caps bind variables at 32,766, so either membership list past the remaining budget fails statement construction. The error escapes `claimNext`, `drainOnce` reports it via the pump's error handler, and every subsequent pass reconstructs the same oversized statement.

Provenance:

```text
introduced by: #97118 (b8e3de11608) — 2026-06-27 — candidateIds IN predicates added to claimNext
made visible by: durable ingress drain engine (fc6b9dad0b1) — 2026-07-16 — full pending snapshot passed as candidateIds
carried forward by: #118357 (d93d07ac02a) — 2026-08-03 — Set + delete-after-claim retained the unbounded snapshot
blocked-lane predicate: same claimNext selects compile lane_key NOT IN (<effectiveBlocked>); drain collects all retry-delayed lanes unbounded; stored-lane consumers (LINE/Zalo) take this SQL path
confidence: clear
```

## Regression Test Plan (if applicable)

- `claimNext` with 40,000 candidate ids on an empty queue returns `null` (fails pre-fix with `too many SQL variables`).
- `claimNext` with 1,500 real rows claims in received order across chunk boundaries.
- `claimNext` with a reversed (unsorted) 1,500-row candidate snapshot claims the globally earliest row (fails pre-follow-up with `event-500`).
- `claimNext` with a duplicated blocked candidate id across chunks claims the later eligible row (fails pre-dedupe with `null`).
- `claimNext` chunk queries read at most `scanLimit` rows per chunk (fails pre-limit: 1,001-row backlog materialized in full).
- `claimNext` with equal-timestamp `B`/`a` rows across chunks claims `B` (fails pre-fix with `a` under `localeCompare`).
- `claimNext` with equal-timestamp non-BMP `U+E000`/`U+1F600` rows across chunks claims `U+E000` (fails pre-fix with `U+1F600`, where UTF-16 surrogate ordering reversed SQLite BINARY).
- `claimNext` with 33,000 `blockedLaneKeys` and no `deriveLaneKey` claims the free row without throwing (fails pre-fix with `too many SQL variables`); the candidate-branch select SQL omits `not in` above the budget.
- `claimNext` with <28,990 `blockedLaneKeys` and no `deriveLaneKey` still compiles the `not in` predicate (guards against silently dropping the predicate for the common small-set case).
- `drainOnce` with 33,000 rows and a 32-start limit claims `free-0..free-31` with membership selects ≤ 72 and membership rows ≤ 7,400 (fails pre-round-5: ~2,112 selects / ~105,600 rows).
- `drainOnce` with 100 retry-delayed rows filling the `scanLimit` window still claims the free rows behind them in order (fails if the bounded window returns null and starves the pass).
- `drainOnce` with a 3,300-row blocked prefix and 64 free rows claims `free-0..free-31` with membership selects ≤ 114 (fails pre-round-6 without window compaction: the widened window replays ~4 chunks on every later start, ~284 selects).
- `claimNext` with 22,000 blocked rows + 1 free row on the degraded path (30,000 `blockedLaneKeys`, no `deriveLaneKey`) claims the free row with candidate selects ≤ 66 and rows ≤ 23,001 (fails pre-round-7: each keyset page re-selects every chunk and re-reads the suffix, ~92 selects / ~36,003 rows).
- Full `src/channels/message` vitest shard (35 files / 396 tests) passes.

## User-visible / Behavior Changes

Affected channel accounts with very large ingress backlogs recover automatically instead of staying wedged. Affected stored-lane accounts (LINE/Zalo) with a very large distinct retry-delayed lane set recover automatically instead of wedging on the blocked-lane predicate. For backlogs and blocked sets below the limits, behavior is unchanged.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.22.3 (SQLite via `node:sqlite`)
- Integration/channel: shared durable ingress queue (`src/channels/message/`)
- Relevant config (redacted): temporary state dir via `OPENCLAW_STATE_DIR`

### Steps

1. Seed 33,000 pending rows for one `queue_name` in a temp state DB.
2. Run `createChannelIngressDrain.drainOnce()` with a no-op dispatch.
3. Observe error before fix, successful drain after fix.
4. Separately, enqueue 1 free + 1 blocked row, pass 33,000 `blockedLaneKeys` with no `deriveLaneKey`, call `claimNext`.
5. Observe `too many SQL variables` before the blocked-lane fix; the free row claimed after.
6. Separately, seed 33,000 pending rows on distinct lanes, run one 32-start `drainOnce` pass, and observe `started=32` with `free-0..free-31` claimed in order while membership selects/rows stay bounded (full-drain budget regression); seed 100 retry-delayed rows + free rows behind and observe the window grows past the prefix.

### Expected

Backlog drains; `pending` count decreases; oversized blocked set degrades to the in-memory scan gate; no `too many SQL variables`.

### Actual (before fix)

`drainOnce #1 FAILED: too many SQL variables` (candidate backlog); `claimNext threw: too many SQL variables` (blocked-lane predicate).

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant) — full-drain membership select/row budget (33,000 rows, 32 starts: ≤ 72 selects / ≤ 7,400 rows vs ~2,112 / ~105,600 pre-fix)

## Human Verification (required)

- Verified scenarios: 33,000-row backlog drain on Node v22.22.3; 33,000-row 32-start drain pass (global-order `free-0..free-31`, bounded membership work); drain-level blocked prefix (100 retry-delayed rows filling the `scanLimit` window → free rows behind claimed in order); 3,300-row blocked prefix + 64 free rows, 32-start pass (window compacts after the first claim; membership selects ≤ 114); 33,000-row blocked prefix + 32 free rows, 32-start pass on real Node (all 32 free rows claimed); 40,000-candidate claimNext; 1,500-row multi-chunk ordering; duplicate-candidate scan-window claim; bounded per-chunk reads; cross-chunk SQLite BINARY tie-break (`B`/`a`); non-BMP cross-chunk SQLite BINARY tie-break (`U+E000`/`U+1F600`); 33,000-distinct-lane blocked-set claim (predicate dropped, free row claimed); below-budget blocked-set predicate retention; full `src/channels/message` suite.
- Edge cases checked: empty candidate set (returns null), no candidateIds (unchanged path), released-row re-claim prevention preserved (claimed id removed from the window — one snapshot row gets one attempt per pass), sibling-race claimed-lane blocking preserved (per-attempt `listClaims` refresh over snapshot candidates), duplicate candidate ids deduplicated before chunking, blocked-lane set at the budget boundary (28,990 retains the predicate, 28,991 drops it and falls back to the in-memory scan gate with the degraded-scan cap), window growth capped at the snapshot (no infinite growth), post-claim compaction resumes just after the claimed row (global order preserved; previously claimed rows never re-enter), supersede lane frees preserved (refresh only adds snapshot-candidate claimed lanes; compacting only drops rows that were blocked when scanned, and the blocked set is effectively monotonic for the pass).
- What you did NOT verify: real third-party channel transports; Node 24/26 runtimes; the #111373 blocked-lane starvation path (lane never becomes claimable — this PR only bounds the predicate's bind budget, not lane starvation).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — bounding candidate membership **and** the blocked-lane predicate in the shared queue owner (`claimNext`) fixes every caller (all channel extensions share this queue) and preserves the full-snapshot semantics that the `candidateIds` snapshot/race protection depends on. The blocked-lane bound degrades to an already-authoritative in-memory scan gate, so it cannot starve a lane. The drain pass then carries a bounded ordered candidate window so a large backlog is not re-read chunk-by-chunk on every claim; sibling-race lane checks are preserved by refreshing claimed-snapshot lanes via one cheap `listClaims` query per attempt (never weakening the pre-scan invariant), the window grows (doubling, capped at the snapshot) when a claim returns null so a free row behind any-size blocked prefix stays reachable, and it compacts after each successful claim (dropping the exhausted blocked prefix and shrinking back to `scanLimit`) so a window widened through a large prefix never replays that prefix on the remaining starts of the pass.
- **Refactor needed**: No — a focused bounded-claim change; the blocked-lane starvation advancement in #111373 composes with this (chunk boundaries act as natural pages) and remains a separate, sequenced change.
- **Alternative considered**: Replacing the queue-owner chunking with drainer-only chunking — rejected, because it would weaken cross-chunk sibling-race lane protection and diverge from the shared-owner boundary (all channel extensions share `claimNext`). Instead the drainer carries a bounded **window** over the already-chunked queue owner, and the window's per-attempt `listClaims` refresh preserves the sibling-race pre-scan invariant. For the blocked-lane predicate, chunking the `NOT IN` membership (instead of dropping it above the budget) was considered, but the SQL predicate is a pure pre-filter — the in-memory `effectiveBlocked.has(laneKey)` scan gate is the authoritative correctness check on every scanned row — so dropping it above the budget is correctness-preserving and far simpler than nested chunked `NOT IN` merges, with no lane-starvation risk.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Codex <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Step 1-7 open-source-pr workflow; analysis and plan reviewed and confirmed by the user at confirmation points 2-4; ClawSweeper review-round fixes (per-chunk scan bound, candidate-id dedupe, type-aware lint, SQLite BINARY merge comparator) implemented and squashed into commit 24d1fc05fae; follow-up P1 fix (compare event ids as UTF-8 bytes via `Buffer.compare` instead of UTF-16 relational order, with a non-BMP cross-chunk regression) implemented in commit 5f94e60c1d4; check-lint fixes (brace the comparator's `if` for `curly`, extract the seven chunked-candidate regressions into `ingress-queue-claim-candidates.test.ts` to stay under the 1000-line max-lines budget, oxfmt `ingress-queue-claim-bounds.test.ts`) implemented in commit e39157ed486; ClawSweeper round-6 late finding "[P1] Bound the blocked-lane predicate too" addressed in commit e1567808ecd (new `CLAIM_BLOCKED_LANE_PREDICATE_LIMIT = 1000` gating the `NOT IN` predicate in both claim branches, two new blocked-lane-predicate regressions, real-runtime terminal before/after proof at 33,000 distinct lanes). ClawSweeper round-7 re-review found the round-1 cutoff (1,000) introduced a P1 blocked-prefix starvation regression; addressed in commit cd2079a3dcb (raise cutoff to ~28,990 via `SQLITE_BIND_SAFETY_LIMIT`/`CLAIM_FIXED_BIND_BUDGET`, add `CLAIM_DEGRADED_BLOCKED_SCAN_CAP` so skipped blocked rows do not consume the scan budget and per-chunk/non-candidate SQL limits widen above the cutoff, four new/updated blocked-prefix regressions, real-runtime before/after at 1,001 blocked lanes + 100-row blocked prefix). ClawSweeper round-8 re-review found round-2's 10,000 hard cap was itself a P1 regression (stopped without advancing a cursor → recurring head-of-queue starvation); addressed in commit 0a5e77a7b0d with a bounded keyset continuation that pages past the blocked prefix with a `(received_at, event_id)` cursor mirroring `listPending`, bounded by `CLAIM_DEGRADED_BLOCKED_PAGES_MAX = 100`, plus cap-plus-one / bounded-walk / ordering regressions and a real-runtime before/after at 49,999 blocked rows + free at 50,000. The seven round-1..round-3 commits were then squashed into a single commit `b5b56e24151` for review clarity. ClawSweeper round-9 re-review (head `b5b56e24`, 🦐 3/6) found the squashed candidate merge lost main's global scan-limit contract (merged `candidateRows` never capped → up to `chunkCount * scanLimit` rows traversed under the write lock); addressed in commit `96087444898` by capping the merged list to `scanLimit` after the global sort on the non-degraded path only (degraded path skips the cap to preserve the round-3 keyset continuation), plus a cross-chunk non-degraded regression and a real-runtime before/after at 150 free rows across 2 chunks. ClawSweeper round-10 re-review (head `691bb426b`, 🦪 2/6) found the remaining P1: the drain repeated the full candidate-chunk walk on every claim of a pass (33,000 rows, 32 starts → ~2,112 selects / ~105,600 rows); addressed in commit `56156cce407` (rebase of `19c072857dd` onto latest main) by carrying a bounded ordered candidate window through `drainOnce` (`ingress-drain-candidates.ts`: start at `scanLimit`, double on null claims, refresh sibling-race claimed lanes per attempt, remove claimed ids), plus the full-drain budget and drain-level blocked-prefix regressions in the new `ingress-drain-claim-bounds.test.ts` and a real-runtime proof at 33,000 rows / 32 starts and a 100-row blocked prefix. ClawSweeper round-11 re-review (head `3ddee573aae`, 🦐 3/6) found one remaining P1: a window widened through a blocked prefix stayed widened after the first claim, replaying the prefix on every later start; addressed in the round-6 amendment (window compacts after each successful claim — drop the exhausted blocked prefix, shrink to `scanLimit`, resume just after the claimed row), plus a 3,300-row blocked-prefix multi-claim regression (≤ 114 membership selects vs ~284 without compaction) and a real-runtime 33,000-row blocked-prefix pass claiming all 32 free rows. ClawSweeper round-13 re-review (head `91c226954c4`, 🦪 2/6) found a new P1 in the degraded candidate branch: every keyset page re-selected all 1,000-id candidate chunks (per-chunk LIMIT 10,000), materializing the remaining suffix before the top-k merge discarded it inside the shared immediate transaction; addressed in the round-7 amendment (degraded candidate path now streams each chunk in its own global order and merges the chunk heads — each row read at most once, exhausted chunks skipped, total walk bounded by `CLAIM_DEGRADED_BLOCKED_PAGES_MAX × CLAIM_DEGRADED_BLOCKED_SCAN_CAP`), plus the 22,000-row degraded large-prefix query/row-budget regression (~46 selects / ~22,001 rows vs ~92 / ~36,003 pre-fix).

## Risks and Mitigations

- **Highest-risk area**: coordination with open PR #111373, which edits the same `claimNext` selection loop for blocked-lane starvation. Mitigation: this diff touches only the candidate-membership queries and the blocked-lane predicate's bind budget (not lane starvation semantics) and preserves global claim ordering; upstream controls merge order.
- **Ordering**: ClawSweeper review flagged that chunk-first selection could claim a later row before a globally earlier one, and that the event-id tie-break diverged from SQLite's BINARY collation. The follow-up merges bounded chunk results, orders them by the queue's global received/id order with a SQLite-compatible `compareEventIdsBinary` tie-break, and applies one total scan limit. `compareEventIdsBinary` was further corrected to compare UTF-8 byte buffers via `Buffer.compare` instead of JavaScript's UTF-16 relational order, so non-BMP code points (surrogate pairs) order identically to SQLite BINARY (covered by the unsorted multi-chunk, cross-chunk binary tie-break, and non-BMP cross-chunk binary tie-break regressions). The per-chunk scan bound and candidate-id dedupe findings are resolved and covered by their regressions.
- **Blocked-lane predicate**: ClawSweeper round-6 late finding (confidence 0.97) flagged that the `lane_key NOT IN (...)` predicate bound every effective blocked lane unbounded. The round-1 fix (cutoff 1,000) introduced a P1 blocked-prefix starvation regression flagged in round-7: dropped SQL pruning let blocked rows consume the in-memory `scanLimit` budget, so a free row behind a blocked prefix starved. Round-2 raised the cutoff to `CLAIM_BLOCKED_LANE_PREDICATE_LIMIT = 28,990` (30,000 − 1,000 candidate − 10 fixed) so the ClawSweeper scenario (1,001 lanes) keeps the SQL predicate and never degrades, and above the cutoff skipped blocked rows do not consume the success-scan budget. ClawSweeper round-8 then found round-2's 10,000 hard cap was itself a P1 regression (stopped without advancing a cursor → recurring head-of-queue starvation on the next pump). Round-3 mitigation: above the cutoff the degraded path pages past the blocked prefix with a keyset cursor `(received_at, event_id)` mirroring `listPending`, bounded by `CLAIM_DEGRADED_BLOCKED_SCAN_CAP = 10,000` per page and `CLAIM_DEGRADED_BLOCKED_PAGES_MAX = 100` overall (1M rows worst case); the cursor strictly advances each page so a free row behind any-size blocked prefix is reached within the page cap, and the drain's next pump never restarts from the same head. No lane starvation; below the cutoff the predicate is retained (no perf regression). Covered by cap-plus-one, bounded-walk, and ordering regressions, and real-runtime before/after proofs at 33,000 lanes (bind-limit), 1,001 lanes + 100-row blocked prefix (round-2 starvation), and 49,999 blocked rows + free at 50,000 (round-3 keyset continuation).
- **Merged candidate scan bound**: ClawSweeper round-9 (head `b5b56e24`, 🦐 3/6) found the squashed candidate merge lost main's global scan-limit contract — each chunk was capped to `scanLimit` but the merged `candidateRows` list was never capped, so up to `chunkCount * scanLimit` rows could be traversed under the write lock (availability) and a later cross-chunk free row could be claimed past main's scan window (message-delivery). Round-4 mitigation: cap the merged `candidateRows` list to `scanLimit` after the global sort, **only on the non-degraded path**. On that path SQL still prunes blocked rows (NOT IN retained), so the merged top-`scanLimit` rows are exactly what main's single ordered `LIMIT scanLimit` query would have materialized — the cap is behavior-equivalent to main and never starves a free row (the global minimum free row is always in the top `scanLimit`). The degraded path (NOT IN dropped) skips the cap: blocked rows reach the merge and the round-3 keyset continuation must walk past them, with total work bounded by `CLAIM_DEGRADED_BLOCKED_PAGES_MAX`. Covered by a cross-chunk non-degraded regression and a real-runtime before/after at 150 free rows across 2 chunks.
- **Full-drain candidate work**: ClawSweeper round-10 (head `691bb426b`, 🦪 2/6) found the drain still re-read every candidate chunk on every claim: a 33,000-row, 32-start pass issued ~1,056 pending selects plus ~1,056 claimed pre-scans (~2,112 total) and ~105,600 rows. Round-5 mitigation: `drainOnce` carries a bounded ordered candidate window (`ingress-drain-candidates.ts`) — claimNext sees one global-order prefix per attempt (starting at `scanLimit`, doubling only when a claim returns null with rows still outside, capped at the snapshot), so the common pass issues ~64 membership selects / ~3,200 rows and a free row behind any-size blocked prefix stays reachable. Sibling-race lane checks are preserved (the window refreshes claimed-snapshot lanes via one `listClaims` query per attempt, matching the pre-scan's invariant), supersede lane frees are preserved (the refresh only adds snapshot-candidate claimed lanes, never re-adding a superseded previous-pass claim), and each claimed id is removed so one snapshot row still gets one attempt per pass. Growth is bounded by the snapshot and per-claim work is never worse than the pre-round-5 full-snapshot walk; the pathological degraded case (huge blocked prefix) keeps the round-3 keyset behavior. Covered by the full-drain budget regression (33,000 rows, 32 starts), the drain-level blocked-prefix regression, and the real-runtime proof.
- **Widened-window replay**: ClawSweeper round-11 (head `3ddee573aae`, 🦐 3/6) found that after a null claim widened the drain window through a blocked prefix, a successful claim removed only its own id, so the remaining starts kept submitting nearly the full widened snapshot (~284 membership selects for a 3,300-row prefix, 32-start pass). Round-6 mitigation: the window compacts after every successful claim — the exhausted blocked prefix (all ids up to and including the claimed row) is dropped, the window shrinks back to `scanLimit`, and the ordered snapshot resumes just after the claimed row. This is safe because the blocked set is effectively monotonic within a pass (lanes are only freed by supersede, which immediately re-blocks the superseding claim; the pre-loop supersede scan runs before the window exists, and the per-attempt `listClaims` refresh only ever adds lanes), so the dropped prefix rows were unclaimable for the rest of the pass. Covered by the 3,300-row blocked-prefix multi-claim regression (≤ 114 selects) and the real-runtime 33,000-row blocked-prefix pass.
- **Degraded candidate read amplification**: ClawSweeper round-13 (head `91c226954c4`, 🦪 2/6) found the degraded candidate path re-selected every 1,000-id chunk on each keyset page (per-chunk LIMIT 10,000), so a large blocked snapshot materialized the remaining suffix page after page inside the shared immediate transaction (e.g., 22,000 blocked rows + 1 free row: ~92 selects / ~36,003 rows). Round-7 mitigation: the degraded path streams each chunk in its own global order and merges the chunk heads — every candidate row is read at most once, chunks that return no rows after their last consumed row are marked exhausted and never re-selected, and the total walk is bounded by the degraded row budget (`CLAIM_DEGRADED_BLOCKED_PAGES_MAX × CLAIM_DEGRADED_BLOCKED_SCAN_CAP`). The 22,000-row regression asserts ~46 selects / ~22,001 rows with the free row still claimed. The non-degraded path is unchanged (one ordered merge pass, `scanLimit` cap); the non-candidate else branch is unchanged.
- **Performance**: a >32,766 backlog now runs ~ceil(N/1000) bounded queries per `claimNext` call, each limited to `scanLimit` rows, and merges them in global order instead of one oversized statement; the merged list is capped to `scanLimit` on the non-degraded path so write-transaction traversal matches main; an oversized blocked set drops the SQL pre-filter and walks the degraded prefix once per claim with the stream merge (bounded by the degraded row budget, relying on the in-memory scan gate); acceptable and far cheaper than a permanently wedged queue.
- **Compatibility**: no public API, config, schema, or behavior change for backlogs below the limit and blocked sets at or below the budget.

---

Fixes #119490
