### PR TITLE
perf(tasks): benchmark durable task registration churn

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -119,6 +119,8 @@ const rootEntries = [
   "scripts/openclaw-cross-os-release-checks.ts!",
   // Spawned by the agent concurrency benchmark; no static import edge exists.
   "scripts/bench-agent-concurrency-worker.ts!",
+  // Spawned by the durable task registry churn benchmark in a fresh GC-enabled process.
+  "scripts/bench-task-registry-sqlite-worker.ts!",
   "scripts/bench-sqlite-reliability.ts!",
   // Docker/manual E2E executables and their nested assertion/probe entrypoints.
   "scripts/e2e/*.{js,mjs,ts}!",

--- a/package.json
+++ b/package.json
@@ -1868,6 +1868,7 @@
     "test:parallels:windows:prepare": "bash scripts/e2e/parallels-windows-prepare.sh",
     "test:parallels:windows": "bash scripts/e2e/parallels-windows-smoke.sh",
     "test:agents:concurrency": "node --import tsx scripts/bench-agent-concurrency.ts",
+    "test:tasks:sqlite-churn": "node --import tsx scripts/bench-task-registry-sqlite.ts",
     "test:perf:budget": "node scripts/test-perf-budget.mjs",
     "test:perf:changed:bench": "node scripts/bench-test-changed.mjs",
     "test:perf:groups": "node scripts/test-group-report.mjs",

--- a/scripts/bench-task-registry-sqlite-worker.ts
+++ b/scripts/bench-task-registry-sqlite-worker.ts
@@ -1,0 +1,470 @@
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+import type { DB as OpenClawStateKyselyDatabase } from "../src/state/openclaw-state-db.generated.js";
+import {
+  WORKER_RESULT_SENTINEL,
+  type MemorySample,
+  type RegistryLifecycleCounts,
+  type RegistrySnapshot,
+  type RetainedMemoryMetrics,
+  type WorkerResult,
+} from "./bench-task-registry-sqlite.js";
+
+type WorkerOptions = {
+  size: number;
+  cycles: number;
+  warmup: number;
+  stateDir: string;
+};
+
+type TimingSample = {
+  registrationMs: number;
+  terminalMs: number;
+  teardownMs: number;
+  registration: RegistrySnapshot;
+  terminal: RegistrySnapshot;
+  teardown: RegistrySnapshot;
+};
+
+type BenchmarkStateDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "task_delivery_state" | "task_runs"
+>;
+
+type TaskRecordApi = Pick<
+  typeof import("../src/tasks/task-registry-record-api.js"),
+  "createTaskRecord" | "markTaskTerminalById"
+>;
+
+type TaskRegistryQueryApi = Pick<
+  typeof import("../src/tasks/task-registry-query.js"),
+  "deleteTaskRecordById"
+>;
+
+function parseInteger(raw: string | undefined, flag: string, min: number, max: number): number {
+  if (!raw || !/^\d+$/u.test(raw)) {
+    throw new Error(`${flag} must be an integer`);
+  }
+  const value = Number(raw);
+  if (value < min || value > max) {
+    throw new Error(`${flag} must be between ${min} and ${max}`);
+  }
+  return value;
+}
+
+function parseOptions(argv: string[]): WorkerOptions {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error(`invalid worker argument near ${flag ?? "end"}`);
+    }
+    if (values.has(flag)) {
+      throw new Error(`${flag} was provided more than once`);
+    }
+    values.set(flag, value);
+  }
+  const stateDir = values.get("--state-dir");
+  if (!stateDir || !path.isAbsolute(stateDir)) {
+    throw new Error("--state-dir must be an absolute path");
+  }
+  return {
+    size: parseInteger(values.get("--size"), "--size", 1, 4096),
+    cycles: parseInteger(values.get("--cycles"), "--cycles", 1, 200),
+    warmup: parseInteger(values.get("--warmup"), "--warmup", 0, 20),
+    stateDir,
+  };
+}
+
+function processPeakRssBytes(): number {
+  return Math.max(0, Math.round(process.resourceUsage().maxRSS * 1024));
+}
+
+function forceGc(): void {
+  const gc = (globalThis as typeof globalThis & { gc?: () => void }).gc;
+  if (!gc) {
+    throw new Error("benchmark worker requires --expose-gc");
+  }
+  gc();
+  gc();
+}
+
+function readMemorySample(cycle: number): MemorySample {
+  const memory = process.memoryUsage();
+  return {
+    cycle,
+    heapUsedBytes: memory.heapUsed,
+    heapTotalBytes: memory.heapTotal,
+    rssBytes: memory.rss,
+    externalBytes: memory.external,
+    arrayBuffersBytes: memory.arrayBuffers,
+    processPeakRssBytes: processPeakRssBytes(),
+  };
+}
+
+function slope(values: number[]): number {
+  if (values.length < 2) {
+    return 0;
+  }
+  const xMean = (values.length - 1) / 2;
+  const yMean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  let numerator = 0;
+  let denominator = 0;
+  for (let index = 0; index < values.length; index += 1) {
+    const xDelta = index - xMean;
+    numerator += xDelta * ((values[index] ?? 0) - yMean);
+    denominator += xDelta * xDelta;
+  }
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+function retainedMemorySlopes(samples: MemorySample[]): RetainedMemoryMetrics {
+  return {
+    heapUsedBytes: slope(samples.map((sample) => sample.heapUsedBytes)),
+    heapTotalBytes: slope(samples.map((sample) => sample.heapTotalBytes)),
+    rssBytes: slope(samples.map((sample) => sample.rssBytes)),
+    externalBytes: slope(samples.map((sample) => sample.externalBytes)),
+    arrayBuffersBytes: slope(samples.map((sample) => sample.arrayBuffersBytes)),
+  };
+}
+
+function retainedMemoryDelta(
+  baseline: MemorySample,
+  finalSample: MemorySample,
+): RetainedMemoryMetrics {
+  return {
+    heapUsedBytes: finalSample.heapUsedBytes - baseline.heapUsedBytes,
+    heapTotalBytes: finalSample.heapTotalBytes - baseline.heapTotalBytes,
+    rssBytes: finalSample.rssBytes - baseline.rssBytes,
+    externalBytes: finalSample.externalBytes - baseline.externalBytes,
+    arrayBuffersBytes: finalSample.arrayBuffersBytes - baseline.arrayBuffersBytes,
+  };
+}
+
+function assertLifecycleCounts(
+  actual: RegistryLifecycleCounts,
+  expected: RegistryLifecycleCounts,
+  phase: string,
+  surface: string,
+): void {
+  for (const field of Object.keys(expected) as Array<keyof RegistryLifecycleCounts>) {
+    if (actual[field] !== expected[field]) {
+      throw new Error(
+        `${phase} ${surface} invariant failed: ${JSON.stringify({ expected, actual })}`,
+      );
+    }
+  }
+}
+
+function assertSnapshot(
+  actual: RegistrySnapshot,
+  expected: RegistryLifecycleCounts,
+  phase: string,
+): void {
+  for (const surface of ["memory", "sqlite"] as const) {
+    assertLifecycleCounts(actual[surface], expected, phase, surface);
+  }
+}
+
+async function createCountReader() {
+  const [{ executeSqliteQuerySync, getNodeSqliteKysely }, stateDb, state] = await Promise.all([
+    import("../src/infra/kysely-sync.js"),
+    import("../src/state/openclaw-state-db.js"),
+    import("../src/tasks/task-registry-state.js"),
+  ]);
+  return (): RegistrySnapshot => {
+    const database = stateDb.openOpenClawStateDatabase();
+    const db = getNodeSqliteKysely<BenchmarkStateDatabase>(database.db);
+    const taskRows = executeSqliteQuerySync(
+      database.db,
+      db.selectFrom("task_runs").select(["status", "delivery_status", "terminal_outcome"]),
+    ).rows;
+    const deliveryRows = executeSqliteQuerySync(
+      database.db,
+      db.selectFrom("task_delivery_state").select(({ fn }) => fn.countAll<number>().as("count")),
+    ).rows[0]?.count;
+    const summarize = (
+      taskRecords: Iterable<{
+        status: string;
+        deliveryStatus: string;
+        terminalOutcome?: string | null;
+      }>,
+      deliveryStateCount: number,
+    ): RegistryLifecycleCounts => {
+      let taskCount = 0;
+      let runningTasks = 0;
+      let succeededTasks = 0;
+      let pendingDeliveryTasks = 0;
+      let succeededTerminalOutcomes = 0;
+      for (const task of taskRecords) {
+        taskCount += 1;
+        runningTasks += task.status === "running" ? 1 : 0;
+        succeededTasks += task.status === "succeeded" ? 1 : 0;
+        pendingDeliveryTasks += task.deliveryStatus === "pending" ? 1 : 0;
+        succeededTerminalOutcomes += task.terminalOutcome === "succeeded" ? 1 : 0;
+      }
+      return {
+        taskCount,
+        deliveryStateCount,
+        runningTasks,
+        succeededTasks,
+        pendingDeliveryTasks,
+        succeededTerminalOutcomes,
+      };
+    };
+    return {
+      memory: summarize(
+        [...state.tasks.values()].map((task) => ({
+          status: task.status,
+          deliveryStatus: task.deliveryStatus,
+          terminalOutcome: task.terminalOutcome,
+        })),
+        state.taskDeliveryStates.size,
+      ),
+      sqlite: summarize(
+        taskRows.map((task) => ({
+          status: task.status,
+          deliveryStatus: task.delivery_status,
+          terminalOutcome: task.terminal_outcome,
+        })),
+        deliveryRows ?? 0,
+      ),
+    };
+  };
+}
+
+async function runCycle(
+  size: number,
+  serial: number,
+  readSnapshot: () => RegistrySnapshot,
+  taskRecordApi: TaskRecordApi,
+  taskRegistryQuery: TaskRegistryQueryApi,
+): Promise<TimingSample> {
+  const taskIds: string[] = [];
+  const startedAt = Date.now();
+  const registrationStartedAt = performance.now();
+  for (let index = 0; index < size; index += 1) {
+    const task = taskRecordApi.createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:benchmark:main",
+      ownerKey: "agent:benchmark:main",
+      scopeKind: "session",
+      requesterOrigin: { channel: "benchmark", to: "task-registry" },
+      childSessionKey: `agent:benchmark:subagent:${serial}:${index}`,
+      runId: `benchmark-task-${serial}-${index}`,
+      task: `durable registration benchmark ${index}`,
+      status: "running",
+      deliveryStatus: "pending",
+      notifyPolicy: "silent",
+      startedAt,
+      lastEventAt: startedAt,
+    });
+    if (!task) {
+      throw new Error(`task registration failed at ${index + 1}/${size}`);
+    }
+    taskIds.push(task.taskId);
+  }
+  const registrationMs = performance.now() - registrationStartedAt;
+  const emptyCounts: RegistryLifecycleCounts = {
+    taskCount: 0,
+    deliveryStateCount: 0,
+    runningTasks: 0,
+    succeededTasks: 0,
+    pendingDeliveryTasks: 0,
+    succeededTerminalOutcomes: 0,
+  };
+  const registration = readSnapshot();
+  assertSnapshot(
+    registration,
+    {
+      ...emptyCounts,
+      taskCount: size,
+      deliveryStateCount: size,
+      runningTasks: size,
+      pendingDeliveryTasks: size,
+    },
+    "registration",
+  );
+
+  const terminalStartedAt = performance.now();
+  for (const taskId of taskIds) {
+    const endedAt = Date.now();
+    const task = taskRecordApi.markTaskTerminalById({
+      taskId,
+      status: "succeeded",
+      endedAt,
+      lastEventAt: endedAt,
+      terminalOutcome: "succeeded",
+    });
+    if (!task) {
+      throw new Error(`terminal transition failed for task ${taskId}`);
+    }
+  }
+  const terminalMs = performance.now() - terminalStartedAt;
+  const terminal = readSnapshot();
+  assertSnapshot(
+    terminal,
+    {
+      ...emptyCounts,
+      taskCount: size,
+      deliveryStateCount: size,
+      succeededTasks: size,
+      pendingDeliveryTasks: size,
+      succeededTerminalOutcomes: size,
+    },
+    "terminal",
+  );
+
+  const teardownStartedAt = performance.now();
+  for (const taskId of taskIds) {
+    if (!taskRegistryQuery.deleteTaskRecordById(taskId)) {
+      throw new Error(`teardown failed for task ${taskId}`);
+    }
+  }
+  const teardownMs = performance.now() - teardownStartedAt;
+  const teardown = readSnapshot();
+  assertSnapshot(teardown, emptyCounts, "teardown");
+  return { registrationMs, terminalMs, teardownMs, registration, terminal, teardown };
+}
+
+async function resetRuntime(persist: boolean): Promise<void> {
+  const [tasks, stateDb] = await Promise.all([
+    import("../src/tasks/task-runtime.test-helpers.js"),
+    import("../src/state/openclaw-state-db.js"),
+  ]);
+  tasks.resetTaskRegistryForTests({ persist });
+  stateDb.closeOpenClawStateDatabaseForTest();
+}
+
+async function runBenchmark(options: WorkerOptions): Promise<WorkerResult> {
+  await resetRuntime(true);
+  // Load lifecycle owners before the baseline so warmup=0 still measures task churn,
+  // not one-time module initialization retained by the worker.
+  const [readSnapshot, taskRecordApi, taskRegistryQuery] = await Promise.all([
+    createCountReader(),
+    import("../src/tasks/task-registry-record-api.js"),
+    import("../src/tasks/task-registry-query.js"),
+  ]);
+  const emptyCounts: RegistryLifecycleCounts = {
+    taskCount: 0,
+    deliveryStateCount: 0,
+    runningTasks: 0,
+    succeededTasks: 0,
+    pendingDeliveryTasks: 0,
+    succeededTerminalOutcomes: 0,
+  };
+  assertSnapshot(readSnapshot(), emptyCounts, "initial");
+  const timingsMs = {
+    registration: [] as number[],
+    terminal: [] as number[],
+    teardown: [] as number[],
+  };
+  const postGcSamples: MemorySample[] = [];
+  let lastSample: TimingSample | undefined;
+  for (let index = 0; index < options.warmup; index += 1) {
+    await runCycle(options.size, index, readSnapshot, taskRecordApi, taskRegistryQuery);
+    forceGc();
+  }
+  forceGc();
+  const postGcBaseline = readMemorySample(-1);
+  for (let index = 0; index < options.cycles; index += 1) {
+    lastSample = await runCycle(
+      options.size,
+      options.warmup + index,
+      readSnapshot,
+      taskRecordApi,
+      taskRegistryQuery,
+    );
+    forceGc();
+    timingsMs.registration.push(lastSample.registrationMs);
+    timingsMs.terminal.push(lastSample.terminalMs);
+    timingsMs.teardown.push(lastSample.teardownMs);
+    postGcSamples.push(readMemorySample(index));
+  }
+  if (!lastSample) {
+    throw new Error("benchmark completed without a cycle");
+  }
+  const finalPostGcSample = postGcSamples.at(-1);
+  if (!finalPostGcSample) {
+    throw new Error("benchmark completed without a post-GC sample");
+  }
+  return {
+    size: options.size,
+    timingsMs,
+    memory: {
+      postGcBaseline,
+      postGcSamples,
+      retainedSlopesBytesPerCycle: retainedMemorySlopes(postGcSamples),
+      retainedDeltasBytes: retainedMemoryDelta(postGcBaseline, finalPostGcSample),
+      processPeakRssBytes: processPeakRssBytes(),
+    },
+    invariant: {
+      ok: true,
+      cyclesValidated: options.warmup + options.cycles,
+      registration: lastSample.registration,
+      terminal: lastSample.terminal,
+      teardown: lastSample.teardown,
+      serializedSharedConnection: true,
+    },
+  };
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  const previousNodeEnv = process.env.NODE_ENV;
+  let result: WorkerResult | undefined;
+  let failure: unknown;
+  process.env.OPENCLAW_STATE_DIR = options.stateDir;
+  process.env.NODE_ENV = "test";
+  try {
+    const { pinRuntimePaths } = await import("../src/config/paths.js");
+    pinRuntimePaths();
+    result = await runBenchmark(options);
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      await resetRuntime(false);
+    } catch (error) {
+      failure ??= error;
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  }
+  if (failure) {
+    throw toError(failure);
+  }
+  if (!result) {
+    throw new Error("benchmark worker completed without a result");
+  }
+  process.stdout.write(`${WORKER_RESULT_SENTINEL}${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.stack : String(error));
+    process.exitCode = 1;
+  } finally {
+    if (process.exitCode && process.exitCode !== 0) {
+      console.error(`[bench-task-registry-sqlite-worker] FAILED (exit ${process.exitCode})`);
+    }
+  }
+}

--- a/scripts/bench-task-registry-sqlite.ts
+++ b/scripts/bench-task-registry-sqlite.ts
@@ -1,0 +1,621 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+const DEFAULT_SIZES = [24, 64, 128];
+const WORKER_TIMEOUT_MS = 300_000;
+export const WORKER_RESULT_SENTINEL = "[bench-task-registry-sqlite-result] ";
+
+export type MemorySample = {
+  cycle: number;
+  heapUsedBytes: number;
+  heapTotalBytes: number;
+  rssBytes: number;
+  externalBytes: number;
+  arrayBuffersBytes: number;
+  processPeakRssBytes: number;
+};
+
+export type RetainedMemoryMetrics = Pick<
+  MemorySample,
+  "heapUsedBytes" | "heapTotalBytes" | "rssBytes" | "externalBytes" | "arrayBuffersBytes"
+>;
+
+export type RegistryLifecycleCounts = {
+  taskCount: number;
+  deliveryStateCount: number;
+  runningTasks: number;
+  succeededTasks: number;
+  pendingDeliveryTasks: number;
+  succeededTerminalOutcomes: number;
+};
+
+export type RegistrySnapshot = {
+  memory: RegistryLifecycleCounts;
+  sqlite: RegistryLifecycleCounts;
+};
+
+export type WorkerResult = {
+  size: number;
+  timingsMs: {
+    registration: number[];
+    terminal: number[];
+    teardown: number[];
+  };
+  memory: {
+    postGcBaseline: MemorySample;
+    postGcSamples: MemorySample[];
+    retainedSlopesBytesPerCycle: RetainedMemoryMetrics;
+    retainedDeltasBytes: RetainedMemoryMetrics;
+    processPeakRssBytes: number;
+  };
+  invariant: {
+    ok: boolean;
+    cyclesValidated: number;
+    registration: RegistrySnapshot;
+    terminal: RegistrySnapshot;
+    teardown: RegistrySnapshot;
+    serializedSharedConnection: boolean;
+  };
+};
+
+type Options = {
+  sizes: number[];
+  cycles: number;
+  warmup: number;
+  output?: string;
+  json: boolean;
+  help: boolean;
+};
+
+type TimingSummary = {
+  count: number;
+  min: number;
+  p50: number;
+  max: number;
+  p95?: number;
+  p99?: number;
+};
+
+type WorkerProcessResult = {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error & { code?: string };
+};
+
+type WorkerSpawner = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    encoding: "utf8";
+    env: NodeJS.ProcessEnv;
+    timeout: number;
+    killSignal: NodeJS.Signals;
+    maxBuffer: number;
+  },
+) => WorkerProcessResult;
+
+type WorkerLaunchRuntime = {
+  spawnWorker?: WorkerSpawner;
+};
+
+type BenchmarkRuntime = {
+  runWorker?: typeof runWorker;
+  writeProgress?: (line: string) => void;
+  now?: () => number;
+};
+
+function usage(): string {
+  return `OpenClaw durable task registry churn benchmark
+
+Usage:
+  node --import tsx scripts/bench-task-registry-sqlite.ts [options]
+
+Options:
+  --sizes <list>  Comma-separated subagent task-record registration burst sizes (default: 24,64,128)
+  --cycles <n>    Measured create/terminal/delete cycles per size (default: 20)
+  --warmup <n>    Warmup cycles per size (default: 3)
+  --output <path> Write the JSON report to a file
+  --json          Print only the JSON report
+  --help          Show this text
+`;
+}
+
+function parseInteger(raw: string, flag: string, min: number, max: number): number {
+  if (!/^\d+$/u.test(raw)) {
+    throw new Error(`${flag} must be an integer`);
+  }
+  const value = Number(raw);
+  if (value < min) {
+    throw new Error(`${flag} must be at least ${min}`);
+  }
+  if (value > max) {
+    throw new Error(`${flag} must be at most ${max}`);
+  }
+  return value;
+}
+
+function parseList(raw: string, flag: string): number[] {
+  if (!raw || raw.split(",").some((value) => value.length === 0)) {
+    throw new Error(`${flag} requires a comma-separated integer list`);
+  }
+  const values = raw.split(",").map((value) => parseInteger(value, flag, 1, 4096));
+  if (new Set(values).size !== values.length) {
+    throw new Error(`${flag} contains duplicate values`);
+  }
+  return values;
+}
+
+function parseOptions(argv: string[]): Options {
+  const options: Options = {
+    sizes: DEFAULT_SIZES,
+    cycles: 20,
+    warmup: 3,
+    json: false,
+    help: false,
+  };
+  const seen = new Set<string>();
+  const valueFlags = new Set(["--sizes", "--cycles", "--warmup", "--output"]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!flag?.startsWith("--")) {
+      throw new Error(`Unknown argument: ${flag}`);
+    }
+    if (seen.has(flag)) {
+      throw new Error(`${flag} was provided more than once`);
+    }
+    seen.add(flag);
+    if (flag === "--json" || flag === "--help") {
+      options[flag === "--json" ? "json" : "help"] = true;
+      continue;
+    }
+    if (!valueFlags.has(flag)) {
+      throw new Error(`Unknown argument: ${flag}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    index += 1;
+    if (flag === "--sizes") {
+      options.sizes = parseList(value, flag);
+    } else if (flag === "--cycles") {
+      options.cycles = parseInteger(value, flag, 1, 200);
+    } else if (flag === "--warmup") {
+      options.warmup = parseInteger(value, flag, 0, 20);
+    } else {
+      options.output = value;
+    }
+  }
+  return options;
+}
+
+function percentile(sorted: number[], ratio: number): number {
+  return sorted[Math.max(0, Math.ceil(sorted.length * ratio) - 1)] ?? 0;
+}
+
+function summarizeTimings(values: number[]): TimingSummary {
+  if (values.length === 0) {
+    throw new Error("cannot summarize an empty timing set");
+  }
+  const sorted = values.toSorted((left, right) => left - right);
+  const summary: TimingSummary = {
+    count: sorted.length,
+    min: sorted[0] ?? 0,
+    p50: percentile(sorted, 0.5),
+    max: sorted.at(-1) ?? 0,
+  };
+  if (sorted.length >= 20) {
+    summary.p95 = percentile(sorted, 0.95);
+    summary.p99 = percentile(sorted, 0.99);
+  }
+  return summary;
+}
+
+function assertFinite(value: unknown, field: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`worker result field ${field} must be finite`);
+  }
+}
+
+function assertFiniteNonNegative(value: unknown, field: string): asserts value is number {
+  assertFinite(value, field);
+  if (value < 0) {
+    throw new Error(`worker result field ${field} must be nonnegative`);
+  }
+}
+
+const MEMORY_FIELDS = [
+  "heapUsedBytes",
+  "heapTotalBytes",
+  "rssBytes",
+  "externalBytes",
+  "arrayBuffersBytes",
+  "processPeakRssBytes",
+] as const;
+
+const RETAINED_MEMORY_FIELDS = [
+  "heapUsedBytes",
+  "heapTotalBytes",
+  "rssBytes",
+  "externalBytes",
+  "arrayBuffersBytes",
+] as const;
+
+const LIFECYCLE_COUNT_FIELDS = [
+  "taskCount",
+  "deliveryStateCount",
+  "runningTasks",
+  "succeededTasks",
+  "pendingDeliveryTasks",
+  "succeededTerminalOutcomes",
+] as const;
+
+function validateMemorySample(
+  value: unknown,
+  expectedCycle: number,
+  field: string,
+): asserts value is MemorySample {
+  if (!isRecord(value) || value.cycle !== expectedCycle) {
+    throw new Error(`worker result ${field} has an invalid cycle`);
+  }
+  for (const memoryField of MEMORY_FIELDS) {
+    assertFiniteNonNegative(value[memoryField], `${field}.${memoryField}`);
+  }
+}
+
+function validateRegistrySnapshot(
+  value: unknown,
+  field: string,
+  expected: RegistryLifecycleCounts,
+): asserts value is RegistrySnapshot {
+  if (!isRecord(value) || !isRecord(value.memory) || !isRecord(value.sqlite)) {
+    throw new Error(`worker result field ${field} must be a registry snapshot`);
+  }
+  for (const surface of ["memory", "sqlite"] as const) {
+    const counts = surface === "memory" ? value.memory : value.sqlite;
+    for (const countField of LIFECYCLE_COUNT_FIELDS) {
+      const count = counts[countField];
+      assertFiniteNonNegative(count, `${field}.${surface}.${countField}`);
+      if (count !== expected[countField]) {
+        throw new Error(`worker result field ${field}.${surface}.${countField} was unexpected`);
+      }
+    }
+  }
+}
+
+function validateWorkerResult(
+  value: unknown,
+  expected: { size: number; cycles: number; warmup: number },
+): WorkerResult {
+  if (!isRecord(value)) {
+    throw new Error("worker result must be an object");
+  }
+  if (value.size !== expected.size) {
+    throw new Error(`worker size ${expected.size} returned mismatched identity`);
+  }
+  if (!isRecord(value.timingsMs)) {
+    throw new Error("worker result timingsMs must be an object");
+  }
+  for (const phase of ["registration", "terminal", "teardown"] as const) {
+    const timings = value.timingsMs[phase];
+    if (!Array.isArray(timings) || timings.length !== expected.cycles) {
+      throw new Error(
+        `worker size ${expected.size} returned ${Array.isArray(timings) ? timings.length : "invalid"} ${phase} samples; expected ${expected.cycles}`,
+      );
+    }
+    timings.forEach((timing, index) =>
+      assertFiniteNonNegative(timing, `timingsMs.${phase}[${index}]`),
+    );
+  }
+  if (!isRecord(value.memory)) {
+    throw new Error("worker result memory must be an object");
+  }
+  const postGcBaseline = value.memory.postGcBaseline;
+  validateMemorySample(postGcBaseline, -1, "memory.postGcBaseline");
+  if (
+    !Array.isArray(value.memory.postGcSamples) ||
+    value.memory.postGcSamples.length !== expected.cycles
+  ) {
+    throw new Error(
+      `worker size ${expected.size} returned invalid post-GC sample count; expected ${expected.cycles}`,
+    );
+  }
+  value.memory.postGcSamples.forEach((sample, index) =>
+    validateMemorySample(sample, index, `memory.postGcSamples[${index}]`),
+  );
+  const postGcSamples = value.memory.postGcSamples as MemorySample[];
+  if (!isRecord(value.memory.retainedSlopesBytesPerCycle)) {
+    throw new Error("worker result retained memory slopes must be an object");
+  }
+  if (!isRecord(value.memory.retainedDeltasBytes)) {
+    throw new Error("worker result retained memory deltas must be an object");
+  }
+  const finalPostGcSample = postGcSamples.at(-1);
+  if (!finalPostGcSample) {
+    throw new Error("worker result must include a final post-GC sample");
+  }
+  for (const field of RETAINED_MEMORY_FIELDS) {
+    assertFinite(
+      value.memory.retainedSlopesBytesPerCycle[field],
+      `memory.retainedSlopesBytesPerCycle.${field}`,
+    );
+    assertFinite(value.memory.retainedDeltasBytes[field], `memory.retainedDeltasBytes.${field}`);
+    const expectedDelta = finalPostGcSample[field] - postGcBaseline[field];
+    if (value.memory.retainedDeltasBytes[field] !== expectedDelta) {
+      throw new Error(
+        `worker result memory.retainedDeltasBytes.${field} must be end minus baseline`,
+      );
+    }
+  }
+  if ("processPeakRssBytes" in value.memory.retainedSlopesBytesPerCycle) {
+    throw new Error("worker result retained memory slopes must exclude process peak RSS");
+  }
+  if ("processPeakRssBytes" in value.memory.retainedDeltasBytes) {
+    throw new Error("worker result retained memory deltas must exclude process peak RSS");
+  }
+  assertFiniteNonNegative(value.memory.processPeakRssBytes, "memory.processPeakRssBytes");
+  if (!isRecord(value.invariant)) {
+    throw new Error("worker result invariant must be an object");
+  }
+  assertFiniteNonNegative(value.invariant.cyclesValidated, "invariant.cyclesValidated");
+  const emptyCounts: RegistryLifecycleCounts = {
+    taskCount: 0,
+    deliveryStateCount: 0,
+    runningTasks: 0,
+    succeededTasks: 0,
+    pendingDeliveryTasks: 0,
+    succeededTerminalOutcomes: 0,
+  };
+  validateRegistrySnapshot(value.invariant.registration, "invariant.registration", {
+    ...emptyCounts,
+    taskCount: expected.size,
+    deliveryStateCount: expected.size,
+    runningTasks: expected.size,
+    pendingDeliveryTasks: expected.size,
+  });
+  validateRegistrySnapshot(value.invariant.terminal, "invariant.terminal", {
+    ...emptyCounts,
+    taskCount: expected.size,
+    deliveryStateCount: expected.size,
+    succeededTasks: expected.size,
+    pendingDeliveryTasks: expected.size,
+    succeededTerminalOutcomes: expected.size,
+  });
+  validateRegistrySnapshot(value.invariant.teardown, "invariant.teardown", emptyCounts);
+  if (
+    value.invariant.ok !== true ||
+    value.invariant.serializedSharedConnection !== true ||
+    value.invariant.cyclesValidated !== expected.cycles + expected.warmup
+  ) {
+    throw new Error(`worker size ${expected.size} reported a failed invariant`);
+  }
+  return value as WorkerResult;
+}
+
+function parseWorkerProcessResult(
+  result: WorkerProcessResult,
+  expected: { size: number; cycles: number; warmup: number },
+): WorkerResult {
+  if (result.error) {
+    const detail =
+      result.error.code === "ETIMEDOUT"
+        ? `timed out after ${WORKER_TIMEOUT_MS}ms`
+        : result.error.message;
+    throw new Error(`worker size ${expected.size} failed: ${detail}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `worker size ${expected.size} failed (${result.status ?? "signal"}): ${result.stderr.trim() || result.stdout.trim()}`,
+    );
+  }
+  const payloads = result.stdout
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith(WORKER_RESULT_SENTINEL));
+  if (payloads.length !== 1) {
+    throw new Error(`worker size ${expected.size} returned ${payloads.length} result payloads`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payloads[0]!.slice(WORKER_RESULT_SENTINEL.length));
+  } catch {
+    throw new Error(`worker size ${expected.size} returned invalid JSON`);
+  }
+  return validateWorkerResult(parsed, expected);
+}
+
+function buildWorkerArgs(options: Options, size: number, stateDir: string): string[] {
+  return [
+    "--expose-gc",
+    "--import",
+    "tsx",
+    "scripts/bench-task-registry-sqlite-worker.ts",
+    "--size",
+    String(size),
+    "--cycles",
+    String(options.cycles),
+    "--warmup",
+    String(options.warmup),
+    "--state-dir",
+    stateDir,
+  ];
+}
+
+function runWorker(
+  options: Options,
+  size: number,
+  runtime: WorkerLaunchRuntime = {},
+): WorkerResult {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-task-registry-bench-"));
+  const spawnWorker =
+    runtime.spawnWorker ??
+    ((command, args, spawnOptions) => spawnSync(command, args, spawnOptions));
+  try {
+    const result = spawnWorker(process.execPath, buildWorkerArgs(options, size, stateDir), {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+      timeout: WORKER_TIMEOUT_MS,
+      killSignal: "SIGTERM",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return parseWorkerProcessResult(result, {
+      size,
+      cycles: options.cycles,
+      warmup: options.warmup,
+    });
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+function aggregateWorkerResults(options: Options, workers: WorkerResult[]) {
+  const bySize = new Map(workers.map((worker) => [worker.size, worker]));
+  if (bySize.size !== workers.length) {
+    throw new Error("worker results contain duplicate sizes");
+  }
+  const missing = options.sizes.filter((size) => !bySize.has(size));
+  const unexpected = [...bySize.keys()].filter((size) => !options.sizes.includes(size));
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `worker result mismatch: missing=${missing.join(",") || "none"} unexpected=${unexpected.join(",") || "none"}`,
+    );
+  }
+  const sizes = options.sizes.map((size) => {
+    const worker = bySize.get(size);
+    if (!worker) {
+      throw new Error(`missing worker result for size ${size}`);
+    }
+    return {
+      size,
+      timingsMs: {
+        registration: summarizeTimings(worker.timingsMs.registration),
+        terminal: summarizeTimings(worker.timingsMs.terminal),
+        teardown: summarizeTimings(worker.timingsMs.teardown),
+      },
+      memory: worker.memory,
+      invariant: worker.invariant,
+    };
+  });
+  const failures = sizes
+    .filter((entry) => !entry.invariant.ok)
+    .map((entry) => `size:${entry.size}`);
+  return {
+    schemaVersion: 1,
+    benchmark: "durable-task-registry-churn",
+    generatedAt: new Date().toISOString(),
+    runtime: { node: process.version, platform: process.platform, arch: process.arch },
+    model: {
+      unit: "subagent task-record registrations",
+      execution:
+        "serialized create, terminal, and delete calls through one process-local shared SQLite connection",
+      isolation: "fresh --expose-gc worker process per size",
+      workload:
+        "all task records start running with pending delivery, transition to succeeded with a succeeded terminal outcome, then delete",
+    },
+    interpretation: {
+      timings: "advisory only; this is not a concurrent SQLite writer benchmark",
+      memory:
+        "post-GC baseline, end-minus-baseline retained deltas, and retained slopes are diagnostic only; they neither claim nor rule out a memory leak",
+    },
+    options: {
+      sizes: options.sizes,
+      cycles: options.cycles,
+      warmup: options.warmup,
+    },
+    memory: {
+      workerProcessPeakRssBytes: Math.max(
+        ...workers.map((worker) => worker.memory.processPeakRssBytes),
+      ),
+    },
+    sizes,
+    invariants: {
+      ok: failures.length === 0,
+      failures,
+      exactRegistrationTerminalAndTeardownState: failures.length === 0,
+      zeroRowsAfterEveryTeardown: failures.length === 0,
+    },
+  };
+}
+
+function benchmark(options: Options, runtime: BenchmarkRuntime = {}) {
+  const run = runtime.runWorker ?? runWorker;
+  const writeProgress =
+    runtime.writeProgress ?? ((line: string) => process.stderr.write(`${line}\n`));
+  const now = runtime.now ?? Date.now;
+  const workers = options.sizes.map((size, index) => {
+    const ordinal = index + 1;
+    writeProgress(
+      `[bench-task-registry-sqlite] worker ${ordinal}/${options.sizes.length} start size=${size}`,
+    );
+    const startedAt = now();
+    try {
+      const worker = run(options, size);
+      writeProgress(
+        `[bench-task-registry-sqlite] worker ${ordinal}/${options.sizes.length} complete size=${size} elapsed=${(Math.max(0, now() - startedAt) / 1_000).toFixed(3)}s`,
+      );
+      return worker;
+    } catch (error) {
+      writeProgress(
+        `[bench-task-registry-sqlite] worker ${ordinal}/${options.sizes.length} failed size=${size} elapsed=${(Math.max(0, now() - startedAt) / 1_000).toFixed(3)}s`,
+      );
+      throw error;
+    }
+  });
+  return aggregateWorkerResults(options, workers);
+}
+
+async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseOptions(argv);
+  if (options.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  const report = benchmark(options);
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.output) {
+    fs.mkdirSync(path.dirname(path.resolve(options.output)), { recursive: true });
+    fs.writeFileSync(options.output, json);
+  }
+  if (options.json) {
+    process.stdout.write(json);
+    return;
+  }
+  for (const entry of report.sizes) {
+    const registration = entry.timingsMs.registration;
+    const heapSlope = entry.memory.retainedSlopesBytesPerCycle.heapUsedBytes;
+    console.log(
+      `size=${entry.size} registration-p50=${registration.p50.toFixed(3)}ms registration-max=${registration.max.toFixed(3)}ms post-gc-heap-slope=${heapSlope.toFixed(1)}B/cycle`,
+    );
+  }
+  console.log(report.interpretation.timings);
+  console.log(report.interpretation.memory);
+}
+
+export const testing = {
+  aggregateWorkerResults,
+  benchmark,
+  buildWorkerArgs,
+  parseOptions,
+  parseWorkerProcessResult,
+  runWorker,
+  summarizeTimings,
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  } finally {
+    if (process.exitCode && process.exitCode !== 0) {
+      console.error(`[bench-task-registry-sqlite] FAILED (exit ${process.exitCode})`);
+    }
+  }
+}

--- a/test/scripts/bench-task-registry-sqlite.test.ts
+++ b/test/scripts/bench-task-registry-sqlite.test.ts
@@ -1,0 +1,398 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  testing,
+  WORKER_RESULT_SENTINEL,
+  type MemorySample,
+  type WorkerResult,
+} from "../../scripts/bench-task-registry-sqlite.ts";
+
+function memorySample(cycle: number): MemorySample {
+  return {
+    cycle,
+    heapUsedBytes: 100 + cycle,
+    heapTotalBytes: 150 + cycle,
+    rssBytes: 200 + cycle,
+    externalBytes: 30 + cycle,
+    arrayBuffersBytes: 10 + cycle,
+    processPeakRssBytes: 250 + cycle,
+  };
+}
+
+function workerResult(size: number, cycles = 3, warmup = 1): WorkerResult {
+  return {
+    size,
+    timingsMs: {
+      registration: Array.from({ length: cycles }, (_, index) => index + 1),
+      terminal: Array.from({ length: cycles }, (_, index) => index + 2),
+      teardown: Array.from({ length: cycles }, (_, index) => index + 3),
+    },
+    memory: {
+      postGcBaseline: memorySample(-1),
+      postGcSamples: Array.from({ length: cycles }, (_, index) => memorySample(index)),
+      retainedSlopesBytesPerCycle: {
+        heapUsedBytes: 1,
+        heapTotalBytes: 1,
+        rssBytes: 1,
+        externalBytes: 1,
+        arrayBuffersBytes: 1,
+      },
+      retainedDeltasBytes: {
+        heapUsedBytes: cycles,
+        heapTotalBytes: cycles,
+        rssBytes: cycles,
+        externalBytes: cycles,
+        arrayBuffersBytes: cycles,
+      },
+      processPeakRssBytes: 300,
+    },
+    invariant: {
+      ok: true,
+      cyclesValidated: cycles + warmup,
+      registration: {
+        memory: {
+          taskCount: size,
+          deliveryStateCount: size,
+          runningTasks: size,
+          succeededTasks: 0,
+          pendingDeliveryTasks: size,
+          succeededTerminalOutcomes: 0,
+        },
+        sqlite: {
+          taskCount: size,
+          deliveryStateCount: size,
+          runningTasks: size,
+          succeededTasks: 0,
+          pendingDeliveryTasks: size,
+          succeededTerminalOutcomes: 0,
+        },
+      },
+      terminal: {
+        memory: {
+          taskCount: size,
+          deliveryStateCount: size,
+          runningTasks: 0,
+          succeededTasks: size,
+          pendingDeliveryTasks: size,
+          succeededTerminalOutcomes: size,
+        },
+        sqlite: {
+          taskCount: size,
+          deliveryStateCount: size,
+          runningTasks: 0,
+          succeededTasks: size,
+          pendingDeliveryTasks: size,
+          succeededTerminalOutcomes: size,
+        },
+      },
+      teardown: {
+        memory: {
+          taskCount: 0,
+          deliveryStateCount: 0,
+          runningTasks: 0,
+          succeededTasks: 0,
+          pendingDeliveryTasks: 0,
+          succeededTerminalOutcomes: 0,
+        },
+        sqlite: {
+          taskCount: 0,
+          deliveryStateCount: 0,
+          runningTasks: 0,
+          succeededTasks: 0,
+          pendingDeliveryTasks: 0,
+          succeededTerminalOutcomes: 0,
+        },
+      },
+      serializedSharedConnection: true,
+    },
+  };
+}
+
+function workerStdout(result: WorkerResult): string {
+  return `${WORKER_RESULT_SENTINEL}${JSON.stringify(result)}\n`;
+}
+
+describe("durable task registry churn benchmark", () => {
+  it("parses bounded defaults and explicit options", () => {
+    expect(testing.parseOptions([])).toMatchObject({
+      sizes: [24, 64, 128],
+      cycles: 20,
+      warmup: 3,
+    });
+    expect(
+      testing.parseOptions([
+        "--sizes",
+        "2,4",
+        "--cycles",
+        "5",
+        "--warmup",
+        "0",
+        "--output",
+        "bench.json",
+        "--json",
+      ]),
+    ).toMatchObject({
+      sizes: [2, 4],
+      cycles: 5,
+      warmup: 0,
+      output: "bench.json",
+      json: true,
+    });
+    expect(() => testing.parseOptions(["--sizes", "2,2"])).toThrow(
+      "--sizes contains duplicate values",
+    );
+    expect(() => testing.parseOptions(["--cycles", "201"])).toThrow("--cycles must be at most 200");
+    expect(() => testing.parseOptions(["--wat"])).toThrow("Unknown argument: --wat");
+  });
+
+  it("always launches a fresh expose-gc worker for one size", () => {
+    const options = testing.parseOptions(["--sizes", "8", "--cycles", "2", "--warmup", "1"]);
+    const stateDir = path.join(os.tmpdir(), "benchmark-state");
+    expect(testing.buildWorkerArgs(options, 8, stateDir)).toEqual([
+      "--expose-gc",
+      "--import",
+      "tsx",
+      "scripts/bench-task-registry-sqlite-worker.ts",
+      "--size",
+      "8",
+      "--cycles",
+      "2",
+      "--warmup",
+      "1",
+      "--state-dir",
+      stateDir,
+    ]);
+  });
+
+  it("removes the parent-owned worker state directory after a timeout", () => {
+    const options = testing.parseOptions(["--sizes", "2", "--cycles", "1", "--warmup", "0"]);
+    let stateDir: string | undefined;
+    expect(() =>
+      testing.runWorker(options, 2, {
+        spawnWorker: (_command, args) => {
+          const stateDirIndex = args.indexOf("--state-dir");
+          stateDir = args[stateDirIndex + 1];
+          if (!stateDir) {
+            throw new Error("missing worker state directory");
+          }
+          fs.writeFileSync(path.join(stateDir, "openclaw.sqlite"), "timeout fixture");
+          return {
+            status: null,
+            stdout: "",
+            stderr: "",
+            error: Object.assign(new Error("spawnSync timed out"), { code: "ETIMEDOUT" }),
+          };
+        },
+      }),
+    ).toThrow("timed out after 300000ms");
+    expect(stateDir).toBeDefined();
+    expect(fs.existsSync(stateDir!)).toBe(false);
+  });
+
+  it("aggregates schema version 1 with raw memory samples and explicit interpretation", () => {
+    const options = testing.parseOptions(["--sizes", "2,4", "--cycles", "3", "--warmup", "1"]);
+    const report = testing.aggregateWorkerResults(options, [workerResult(2), workerResult(4)]);
+    expect(report).toMatchObject({
+      schemaVersion: 1,
+      benchmark: "durable-task-registry-churn",
+      model: {
+        unit: "subagent task-record registrations",
+        isolation: "fresh --expose-gc worker process per size",
+        workload:
+          "all task records start running with pending delivery, transition to succeeded with a succeeded terminal outcome, then delete",
+      },
+      options: { sizes: [2, 4], cycles: 3, warmup: 1 },
+      invariants: {
+        ok: true,
+        exactRegistrationTerminalAndTeardownState: true,
+        zeroRowsAfterEveryTeardown: true,
+      },
+    });
+    expect(report.interpretation.timings).toContain("advisory only");
+    expect(report.interpretation.memory).toContain("neither claim nor rule out a memory leak");
+    expect(report.sizes[0]?.memory.postGcBaseline.cycle).toBe(-1);
+    expect(report.sizes[0]?.memory.postGcSamples).toHaveLength(3);
+    expect(report.sizes[0]?.memory.retainedDeltasBytes.heapUsedBytes).toBe(3);
+    expect(report.sizes[0]?.memory.retainedSlopesBytesPerCycle).not.toHaveProperty(
+      "processPeakRssBytes",
+    );
+    expect(report.sizes[0]?.timingsMs.registration).toEqual({
+      count: 3,
+      min: 1,
+      p50: 2,
+      max: 3,
+    });
+    expect(JSON.stringify(report)).not.toContain(process.cwd());
+  });
+
+  it("rejects malformed, incomplete, failed, and timed-out worker results", () => {
+    const expected = { size: 2, cycles: 3, warmup: 1 };
+    const valid = workerResult(2);
+    expect(
+      testing.parseWorkerProcessResult(
+        { status: 0, stdout: workerStdout(valid), stderr: "" },
+        expected,
+      ),
+    ).toEqual(valid);
+    expect(() =>
+      testing.parseWorkerProcessResult(
+        { status: 0, stdout: `${WORKER_RESULT_SENTINEL}{\n`, stderr: "" },
+        expected,
+      ),
+    ).toThrow("returned invalid JSON");
+    expect(() =>
+      testing.parseWorkerProcessResult(
+        { status: 0, stdout: workerStdout(workerResult(3)), stderr: "" },
+        expected,
+      ),
+    ).toThrow("mismatched identity");
+    expect(() =>
+      testing.parseWorkerProcessResult(
+        {
+          status: 0,
+          stdout: workerStdout({
+            ...valid,
+            memory: { ...valid.memory, postGcSamples: valid.memory.postGcSamples.slice(1) },
+          }),
+          stderr: "",
+        },
+        expected,
+      ),
+    ).toThrow("invalid post-GC sample count");
+    expect(() =>
+      testing.parseWorkerProcessResult(
+        {
+          status: 0,
+          stdout: workerStdout({
+            ...valid,
+            memory: {
+              ...valid.memory,
+              retainedDeltasBytes: { ...valid.memory.retainedDeltasBytes, heapUsedBytes: 99 },
+            },
+          }),
+          stderr: "",
+        },
+        expected,
+      ),
+    ).toThrow("retainedDeltasBytes.heapUsedBytes must be end minus baseline");
+    expect(() =>
+      testing.parseWorkerProcessResult(
+        {
+          status: 0,
+          stdout: workerStdout({
+            ...valid,
+            invariant: {
+              ...valid.invariant,
+              terminal: {
+                ...valid.invariant.terminal,
+                sqlite: { ...valid.invariant.terminal.sqlite, succeededTasks: 1 },
+              },
+            },
+          }),
+          stderr: "",
+        },
+        expected,
+      ),
+    ).toThrow("invariant.terminal.sqlite.succeededTasks was unexpected");
+    expect(() =>
+      testing.parseWorkerProcessResult(
+        { status: 7, stdout: "", stderr: "worker exploded" },
+        expected,
+      ),
+    ).toThrow("failed (7): worker exploded");
+    expect(() =>
+      testing.parseWorkerProcessResult(
+        {
+          status: null,
+          stdout: "",
+          stderr: "",
+          error: Object.assign(new Error("spawnSync timed out"), { code: "ETIMEDOUT" }),
+        },
+        expected,
+      ),
+    ).toThrow("timed out after 300000ms");
+  });
+
+  it("runs a tiny durable create, terminal, delete smoke", () => {
+    const smoke = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "scripts/bench-task-registry-sqlite.ts",
+        "--sizes",
+        "2",
+        "--cycles",
+        "1",
+        "--warmup",
+        "0",
+        "--json",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, NODE_NO_WARNINGS: "1" },
+        timeout: 120_000,
+      },
+    );
+    expect(smoke.status, smoke.stderr).toBe(0);
+    expect(smoke.stderr).toContain("worker 1/1 complete size=2");
+    const report = JSON.parse(smoke.stdout) as {
+      invariants: { ok: boolean };
+      sizes: Array<{ invariant: WorkerResult["invariant"] }>;
+    };
+    expect(report.invariants.ok).toBe(true);
+    expect(report.sizes[0]?.invariant).toMatchObject({
+      registration: {
+        memory: { taskCount: 2, deliveryStateCount: 2, runningTasks: 2 },
+        sqlite: { taskCount: 2, deliveryStateCount: 2, runningTasks: 2 },
+      },
+      terminal: {
+        memory: {
+          taskCount: 2,
+          deliveryStateCount: 2,
+          succeededTasks: 2,
+          pendingDeliveryTasks: 2,
+          succeededTerminalOutcomes: 2,
+        },
+        sqlite: {
+          taskCount: 2,
+          deliveryStateCount: 2,
+          succeededTasks: 2,
+          pendingDeliveryTasks: 2,
+          succeededTerminalOutcomes: 2,
+        },
+      },
+      teardown: {
+        memory: { taskCount: 0, deliveryStateCount: 0 },
+        sqlite: { taskCount: 0, deliveryStateCount: 0 },
+      },
+    });
+  });
+
+  it("supports help and ends failures with the marker", () => {
+    const help = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "scripts/bench-task-registry-sqlite.ts", "--help"],
+      { cwd: process.cwd(), encoding: "utf8", env: { ...process.env, NODE_NO_WARNINGS: "1" } },
+    );
+    expect(help.status).toBe(0);
+    expect(help.stdout).toContain("OpenClaw durable task registry churn benchmark");
+    expect(help.stdout).toContain("--sizes <list>");
+    expect(help.stderr).toBe("");
+
+    const failure = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "scripts/bench-task-registry-sqlite.ts", "--wat"],
+      { cwd: process.cwd(), encoding: "utf8", env: { ...process.env, NODE_NO_WARNINGS: "1" } },
+    );
+    expect(failure.status).toBe(1);
+    expect(failure.stdout).toBe("");
+    expect(failure.stderr.trim().split("\n").at(-1)).toBe(
+      "[bench-task-registry-sqlite] FAILED (exit 1)",
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

OpenClaw lacked a repeatable stress artifact for the canonical durable task-registry path under high logical subagent churn. The existing agent concurrency benchmark covers broader spawn and lifecycle behavior, so it cannot isolate SQLite task registration, terminal transition, teardown, or retained-memory trends.

## Why This Change Was Made

Adds a separate benchmark with a fresh `--expose-gc` worker per size. Each worker uses one process-local shared SQLite connection and runs serialized create, terminal, and delete bursts through the canonical `createTaskRecord`, `markTaskTerminalById`, and `deleteTaskRecordById` APIs.

The report uses schema version 1 and records:

- default logical task counts `24,64,128`
- 3 warmups and 20 measured cycles
- advisory registration, terminal, teardown, and total timings
- a forced-GC baseline after module preload and warmup
- raw post-GC heap-used, heap-total, RSS, external, array-buffer, and process peak-RSS samples
- explicit retained end-minus-baseline deltas and retained bytes-per-cycle slopes, excluding peak RSS
- exact in-memory and SQLite task/delivery lifecycle states at registration, terminal transition, and teardown

Every task begins `running` with pending delivery, transitions to `succeeded` with a succeeded task outcome while delivery remains pending, and is then deleted. The benchmark asserts zero in-memory and durable rows after every teardown.

The parent launcher owns temporary-state allocation and cleanup, including worker timeout and failure paths. The worker owns closing its database/runtime state. This fixes the prior timeout-cleanup finding without adding a fallback path.

This is a serialized shared-connection task-registry benchmark, not concurrent SQLite writer load. Memory measurements are diagnostic and do not claim or rule out a leak.

## User Impact

No user-visible runtime change. Maintainers gain an isolated, repeatable artifact for evaluating durable task-registration churn before changing the task registry or high-concurrency subagent paths.

No runtime, SQLite schema, public config, dependency, or changelog changes.

## Evidence

Exact head: `5c7f53346689a7479ec36fbaed27e93fc6aca753`

- Independent exact-head review: no findings; canonical owner boundary and benchmark contract judged the best fix for this scope.
- `node scripts/run-vitest.mjs test/scripts/bench-task-registry-sqlite.test.ts`: 7/7 passed.
- Focused contract coverage includes real SQLite create -> terminal -> delete lifecycle proof, forced-GC baseline semantics, and timeout cleanup with an injected SQLite fixture.
- Targeted `oxfmt`, `oxlint`, and `git diff --check`: passed.
- Local `--warmup 0` smoke: lifecycle invariants passed and the benchmark temporary-directory prefix was unchanged before/after.
- Node 24 exact-commit Testbox `tbx_01kzb319f96812qjgw6m1y4syh`: https://github.com/openclaw/openclaw/actions/runs/31085073982
  - Node `v24.19.0`
  - scoped changed gate passed, including format, lint, tsgo, declarations, SDK surface, dependency, and boundary checks
  - focused contract suite passed 7/7
  - full default `24,64,128` matrix passed with exact lifecycle invariants and zero teardown rows
- Node 26 exact-commit Testbox `tbx_01kzb319f6yympd71xamkv7mp3`: https://github.com/openclaw/openclaw/actions/runs/31085073708
  - Node `v26.7.0`
  - full default `24,64,128` matrix passed with exact lifecycle invariants and zero teardown rows
- ClawSweeper reviewed the exact head with no actionable findings.

Surface: runtime production `+0/-0`; benchmark tooling `+1,093/-0`; tests `+398/-0`; config/package wiring `+3/-0`. The tooling growth is the isolated benchmark capability; it does not change shipped runtime behavior.

AI-assisted: yes. The implementation and benchmark contract were inspected and validated by the author.
