### PR TITLE
Feat/acp tui lazy init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Dependencies: refresh workspace dependency pins, including TypeBox 1.1.37, AWS SDK 3.1041.0, Microsoft Teams 2.0.9, and Marked 18.0.3. Thanks @mariozechner, @aws, and @microsoft.
 - Discord/channels: add reusable message-channel access groups plus Discord channel-audience DM authorization, so allowlists can reference `accessGroup:<name>` across channel auth paths. (#75813)
 - Crabbox/scripts: print the selected Crabbox binary, version, and supported providers before `pnpm crabbox:*` commands, and reject stale binaries that lack `blacksmith-testbox` provider support.
+- Feat/acp tui lazy init (#67692). Thanks @wangshu94
 
 ### Fixes
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1,3 +1,4 @@
+import type { AcpSessionResolution } from "../acp/control-plane/manager.types.js";
 import {
   formatThinkingLevels,
   isThinkingLevelSupported,
@@ -17,8 +18,7 @@ import {
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { normalizeAgentId } from "../routing/session-key.js";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
@@ -32,6 +32,7 @@ import { resolveAgentRuntimeConfig } from "./agent-runtime-config.js";
 import {
   listAgentIds,
   resolveAgentDir,
+  resolveAgentConfig,
   resolveEffectiveModelFallbacks,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
@@ -306,7 +307,34 @@ async function prepareAgentCommandExecution(
       );
     }
   }
-  const agentCfg = cfg.agents?.defaults;
+  // Resolve sessionAgentId and sessionResolution early for agent config selection
+  const sessionResolution = resolveSession({
+    cfg,
+    to: opts.to,
+    sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
+    agentId: agentIdOverride,
+  });
+
+  const {
+    sessionId,
+    sessionKey,
+    sessionEntry: sessionEntryRaw,
+    sessionStore,
+    storePath,
+    isNewSession,
+    persistedThinking,
+    persistedVerbose,
+  } = sessionResolution;
+  const sessionAgentId =
+    agentIdOverride ??
+    resolveSessionAgentId({
+      sessionKey: sessionKey ?? opts.sessionKey?.trim(),
+      config: cfg,
+    });
+
+  const resolvedAgentCfg = resolveAgentConfig(cfg, sessionAgentId);
+  const agentCfg = resolvedAgentCfg ?? cfg.agents?.defaults;
   const configuredModel = resolveConfiguredModelRef({
     cfg,
     defaultProvider: DEFAULT_PROVIDER,
@@ -350,30 +378,6 @@ async function prepareAgentCommandExecution(
     overrideSeconds: timeoutSecondsRaw,
   });
 
-  const sessionResolution = resolveSession({
-    cfg,
-    to: opts.to,
-    sessionId: opts.sessionId,
-    sessionKey: opts.sessionKey,
-    agentId: agentIdOverride,
-  });
-
-  const {
-    sessionId,
-    sessionKey,
-    sessionEntry: sessionEntryRaw,
-    sessionStore,
-    storePath,
-    isNewSession,
-    persistedThinking,
-    persistedVerbose,
-  } = sessionResolution;
-  const sessionAgentId =
-    agentIdOverride ??
-    resolveSessionAgentId({
-      sessionKey: sessionKey ?? opts.sessionKey?.trim(),
-      config: cfg,
-    });
   const outboundSession = buildOutboundSessionContext({
     cfg,
     agentId: sessionAgentId,
@@ -392,11 +396,11 @@ async function prepareAgentCommandExecution(
   const runId = opts.runId?.trim() || sessionId;
   const { getAcpSessionManager } = await loadAcpManagerRuntime();
   const acpManager = getAcpSessionManager();
-  const acpResolution = sessionKey
-    ? acpManager.resolveSession({
-        cfg,
-        sessionKey,
-      })
+  // Resolve existing ACP session metadata only; lazy initialization is deferred
+  // to agentCommandInternal so it runs after send-policy checks, ensuring that
+  // a policy denial never triggers ACP metadata writes or external runtime startup.
+  const acpResolution: AcpSessionResolution | null = sessionKey
+    ? acpManager.resolveSession({ cfg, sessionKey })
     : null;
   const body =
     !isRawModelRun && acpResolution?.kind === "ready"
@@ -431,6 +435,7 @@ async function prepareAgentCommandExecution(
     runId,
     acpManager,
     acpResolution,
+    resolvedAgentCfg,
   };
 }
 
@@ -466,8 +471,9 @@ async function agentCommandInternal(
     agentDir,
     runId,
     acpManager,
-    acpResolution,
+    resolvedAgentCfg,
   } = prepared;
+  let acpResolution = prepared.acpResolution;
   let sessionEntry = prepared.sessionEntry;
 
   try {
@@ -481,6 +487,42 @@ async function agentCommandInternal(
       });
       if (sendPolicy === "deny") {
         throw new Error("send blocked by session policy");
+      }
+    }
+
+    // Lazily initialize ACP session after send-policy passes, so a policy
+    // denial never triggers ACP metadata writes or external runtime startup.
+    if (acpResolution?.kind === "none" && resolvedAgentCfg?.runtime?.type === "acp" && sessionKey) {
+      const acpConfig = resolvedAgentCfg.runtime.acp;
+      const acpAgent = normalizeAgentId(
+        normalizeOptionalString(acpConfig?.agent) ?? sessionAgentId,
+      );
+      // Check dispatch and agent policy before writing any ACP metadata or starting a runtime.
+      const { resolveAcpDispatchPolicyError, resolveAcpAgentPolicyError } =
+        await loadAcpPolicyRuntime();
+      const dispatchPolicyError = resolveAcpDispatchPolicyError(cfg);
+      const agentPolicyError = !dispatchPolicyError
+        ? resolveAcpAgentPolicyError(cfg, acpAgent)
+        : null;
+      if (!dispatchPolicyError && !agentPolicyError) {
+        try {
+          await acpManager.initializeSession({
+            cfg,
+            sessionKey,
+            agent: acpAgent,
+            // Default to "persistent" so TUI sessions carry context across turns.
+            mode: acpConfig?.mode ?? "persistent",
+            cwd: normalizeOptionalString(acpConfig?.cwd),
+            backendId:
+              normalizeOptionalString(acpConfig?.backend) ??
+              normalizeOptionalString(cfg.acp?.backend),
+          });
+          // Re-resolve after initialization so the ready meta is available for runTurn.
+          acpResolution = acpManager.resolveSession({ cfg, sessionKey });
+        } catch (error) {
+          // Fall back to embedded if ACP initialization fails.
+          log.warn(`ACP initialization failed for ${sessionKey}: ${String(error)}`);
+        }
       }
     }
 

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -4,6 +4,7 @@ import type {
   AgentContextLimitsConfig,
   AgentDefaultsConfig,
 } from "../config/types.agent-defaults.js";
+import type { AgentRuntimeConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import { readStringValue } from "../shared/string-coerce.js";
@@ -34,6 +35,11 @@ export type ResolvedAgentConfig = {
   embeddedPi?: AgentEntry["embeddedPi"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
+  runtime?: AgentRuntimeConfig;
+  skipBootstrap?: AgentDefaultsConfig["skipBootstrap"];
+  skipOptionalBootstrapFiles?: AgentDefaultsConfig["skipOptionalBootstrapFiles"];
+  models?: AgentDefaultsConfig["models"];
+  contextTokens?: AgentDefaultsConfig["contextTokens"];
 };
 
 let defaultAgentWarned = false;
@@ -137,6 +143,11 @@ export function resolveAgentConfig(
       typeof entry.embeddedPi === "object" && entry.embeddedPi ? entry.embeddedPi : undefined,
     sandbox: entry.sandbox,
     tools: entry.tools,
+    runtime: entry.runtime,
+    skipBootstrap: agentDefaults?.skipBootstrap,
+    skipOptionalBootstrapFiles: agentDefaults?.skipOptionalBootstrapFiles,
+    models: agentDefaults?.models,
+    contextTokens: agentDefaults?.contextTokens,
   };
 }
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -565,6 +565,84 @@ describe("resolveAgentConfig", () => {
     expect(result?.tools?.allow).toEqual(["read"]);
   });
 
+  it("returns runtime, skipBootstrap, models, contextTokens from agent defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          skipBootstrap: true,
+          models: {
+            "anthropic/claude-sonnet-4-6": {
+              alias: "sonnet",
+            },
+          },
+          contextTokens: 150000,
+        },
+        list: [{ id: "main" }],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "main");
+
+    expect(result?.skipBootstrap).toBe(true);
+    expect(result?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": {
+        alias: "sonnet",
+      },
+    });
+    expect(result?.contextTokens).toBe(150000);
+  });
+
+  it("includes runtime config with ACP type", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "tui-agent",
+            runtime: {
+              type: "acp",
+              acp: {
+                agent: "custom-acp-agent",
+                mode: "persistent",
+                backend: "custom",
+              },
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "tui-agent");
+
+    expect(result?.runtime).toEqual({
+      type: "acp",
+      acp: {
+        agent: "custom-acp-agent",
+        mode: "persistent",
+        backend: "custom",
+      },
+    });
+  });
+
+  it("per-agent runtime config is included in resolved config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "acp-agent",
+            runtime: {
+              type: "acp",
+              acp: {
+                mode: "oneshot",
+              },
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "acp-agent");
+
+    expect(result?.runtime?.type).toBe("acp");
+    expect(result?.runtime?.type === "acp" && result.runtime.acp?.mode).toBe("oneshot");
+  });
+
   it("should normalize agent id", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -20,6 +20,7 @@ import { createAcpSessionMeta, createAcpTestConfig } from "./test-fixtures/acp-r
 const managerMocks = vi.hoisted(() => ({
   resolveSession: vi.fn(),
   runTurn: vi.fn(),
+  initializeSession: vi.fn(),
   getObservabilitySnapshot: vi.fn(() => ({
     turns: { queueDepth: 0 },
     runtimeCache: { activeSessions: 0 },
@@ -91,6 +92,10 @@ const transcriptMocks = vi.hoisted(() => ({
 const bindingServiceMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
   unbind: vi.fn<(input: unknown) => Promise<SessionBindingRecord[]>>(async () => []),
+}));
+
+const agentConfigMocks = vi.hoisted(() => ({
+  resolveAgentConfig: vi.fn<(cfg: OpenClawConfig, agentId: string) => unknown>(() => undefined),
 }));
 
 vi.mock("./dispatch-acp-manager.runtime.js", () => ({
@@ -179,6 +184,11 @@ vi.mock("../../logging/diagnostic.js", () => ({
 vi.mock("./dispatch-acp-transcript.runtime.js", () => ({
   persistAcpDispatchTranscript: (params: unknown) =>
     transcriptMocks.persistAcpDispatchTranscript(params),
+}));
+
+vi.mock("../../agents/agent-scope-config.js", () => ({
+  resolveAgentConfig: (cfg: OpenClawConfig, agentId: string) =>
+    agentConfigMocks.resolveAgentConfig(cfg, agentId),
 }));
 
 const sessionKey = "agent:codex-acp:session-1";
@@ -358,6 +368,7 @@ describe("tryDispatchAcpReply", () => {
   beforeEach(() => {
     managerMocks.resolveSession.mockReset();
     managerMocks.runTurn.mockReset();
+    managerMocks.initializeSession.mockReset();
     managerMocks.runTurn.mockImplementation(
       async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
         await onEvent?.({ type: "done" });
@@ -390,6 +401,8 @@ describe("tryDispatchAcpReply", () => {
     bindingServiceMocks.listBySession.mockReturnValue([]);
     bindingServiceMocks.unbind.mockReset();
     bindingServiceMocks.unbind.mockResolvedValue([]);
+    agentConfigMocks.resolveAgentConfig.mockReset();
+    agentConfigMocks.resolveAgentConfig.mockReturnValue(undefined);
     globalThis.fetch = originalFetch;
   });
 
@@ -1512,5 +1525,164 @@ describe("tryDispatchAcpReply", () => {
     expect(result?.counts.final).toBe(0);
     expect(routeMocks.routeReply).not.toHaveBeenCalled();
     expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
+  });
+
+  describe("lazy ACP session initialization", () => {
+    it("initializes ACP session when kind is 'none' and agent has runtime.type: 'acp'", async () => {
+      // Setup: acpResolution.kind === "none"
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: {
+            mode: "persistent",
+          },
+        },
+      });
+
+      // Setup: policies allow
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValue(null);
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValue(null);
+
+      // Setup: init succeeds, re-resolve returns ready
+      managerMocks.initializeSession.mockResolvedValueOnce(undefined);
+      managerMocks.resolveSession.mockReturnValueOnce({
+        kind: "ready",
+        sessionKey,
+        meta: createAcpSessionMeta(),
+      });
+
+      // Mock turn execution with visible text
+      mockVisibleTextTurn("initialized");
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      // Verify init was called
+      expect(managerMocks.initializeSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: expect.stringContaining("session"),
+        }),
+      );
+
+      // Verify turn was executed (not skipped)
+      expect(managerMocks.runTurn).toHaveBeenCalled();
+      expect(result).not.toBeNull();
+    });
+
+    it("skips ACP when kind is 'none' and agent doesn't have runtime.type: 'acp'", async () => {
+      // When resolveSession returns "none" but agent is not ACP-configured,
+      // the function should return null (fallback to embedded)
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      // Should not attempt init or turn
+      expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+      expect(managerMocks.runTurn).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("respects dispatch policy during lazy ACP init", async () => {
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      // Dispatch policy denies
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(
+        new AcpRuntimeError("ACP_DISPATCH_DISABLED", "Dispatch policy blocks ACP"),
+      );
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("respects agent policy during lazy ACP init", async () => {
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      // First policy check passes
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(null);
+      // Second policy check fails
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValueOnce(
+        new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "Agent policy blocks access"),
+      );
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("falls back to non-ACP path when lazy ACP init fails", async () => {
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      // Policies allow
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(null);
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValueOnce(null);
+
+      // Init fails
+      managerMocks.initializeSession.mockRejectedValueOnce(new Error("ACP backend unavailable"));
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      expect(result).toBeNull();
+      expect(managerMocks.runTurn).not.toHaveBeenCalled();
+    });
+
+    it("re-resolves ACP session after successful lazy init", async () => {
+      // First call: kind === "none"
+      managerMocks.resolveSession
+        .mockReturnValueOnce({ kind: "none" })
+        // Second call (after init): kind === "ready"
+        .mockReturnValueOnce({
+          kind: "ready",
+          sessionKey,
+          meta: createAcpSessionMeta(),
+        });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(null);
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValueOnce(null);
+
+      managerMocks.initializeSession.mockResolvedValueOnce(undefined);
+      mockVisibleTextTurn();
+
+      await runDispatch({ bodyForAgent: "test" });
+
+      // Verify resolveSession called twice: once for check, once for re-resolve
+      expect(managerMocks.resolveSession).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -186,7 +186,8 @@ vi.mock("./dispatch-acp-transcript.runtime.js", () => ({
     transcriptMocks.persistAcpDispatchTranscript(params),
 }));
 
-vi.mock("../../agents/agent-scope-config.js", () => ({
+vi.mock("../../agents/agent-scope-config.js", async () => ({
+  ...(await vi.importActual("../../agents/agent-scope-config.js")),
   resolveAgentConfig: (cfg: OpenClawConfig, agentId: string) =>
     agentConfigMocks.resolveAgentConfig(cfg, agentId),
 }));

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -7,6 +7,12 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
+import { resolveAgentConfig } from "../../agents/agent-scope-config.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveAgentIdFromSessionKey,
+  resolveMainSessionKey,
+} from "../../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -16,7 +22,6 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
 import { markDiagnosticSessionProgress } from "../../logging/diagnostic.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -76,6 +81,44 @@ type DispatchProcessedRecorder = (
     error?: string;
   },
 ) => void;
+
+function resolveConfigAwareAgentIdFromSessionKey(cfg: OpenClawConfig, sessionKey: string): string {
+  const configuredDefaultMainSessionKey = resolveMainSessionKey(cfg);
+  const configuredDefaultAgentId = resolveAgentIdFromSessionKey(configuredDefaultMainSessionKey);
+
+  const canonicalKey = canonicalizeMainSessionAlias({
+    cfg,
+    agentId: configuredDefaultAgentId,
+    sessionKey,
+  });
+
+  return resolveAgentIdFromSessionKey(canonicalKey);
+}
+
+function resolveAgentAcpInitInput(
+  cfg: OpenClawConfig,
+  sessionKey: string,
+): {
+  agentId: string;
+  acpAgentId?: string;
+  mode: "persistent" | "oneshot";
+  cwd?: string;
+  backendId?: string;
+} | null {
+  const agentId = resolveConfigAwareAgentIdFromSessionKey(cfg, sessionKey);
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  if (!agentConfig || agentConfig.runtime?.type !== "acp") {
+    return null;
+  }
+  const acpConfig = agentConfig.runtime.acp;
+  return {
+    agentId,
+    acpAgentId: normalizeOptionalString(acpConfig?.agent) ?? undefined,
+    mode: acpConfig?.mode ?? "persistent",
+    cwd: normalizeOptionalString(acpConfig?.cwd) ?? undefined,
+    backendId: normalizeOptionalString(acpConfig?.backend) ?? undefined,
+  };
+}
 
 function resolveFirstContextText(
   ctx: FinalizedMsgContext,
@@ -333,12 +376,56 @@ export async function tryDispatchAcpReply(params: {
 
   const { getAcpSessionManager } = await loadDispatchAcpManagerRuntime();
   const acpManager = getAcpSessionManager();
-  const acpResolution = acpManager.resolveSession({
+  let acpResolution = acpManager.resolveSession({
     cfg: params.cfg,
     sessionKey,
   });
   if (acpResolution.kind === "none") {
-    return null;
+    // For agents with `runtime.type: "acp"` (e.g. TUI sessions), ACP metadata has not yet
+    // been written. Lazily initialize the ACP session now so the turn flows through the ACP
+    // execution path rather than falling back to the embedded reply path.
+    //
+    // Guard: skip init entirely for turns that would be short-circuited as empty below.
+    // Without this, first-time sessions are initialized (metadata written, runtime started)
+    // for mention-only / empty inbound events that produce no ACP work.
+    if (!resolveAcpPromptText(params.ctx) && !hasInboundMedia(params.ctx)) {
+      return null;
+    }
+    const acpInit = resolveAgentAcpInitInput(params.cfg, sessionKey);
+    if (!acpInit) {
+      return null;
+    }
+    // Check dispatch and agent policy before writing any ACP metadata or starting a runtime.
+    if (resolveAcpDispatchPolicyError(params.cfg)) {
+      return null;
+    }
+    const candidateAgent = acpInit.acpAgentId ?? acpInit.agentId;
+    if (resolveAcpAgentPolicyError(params.cfg, candidateAgent)) {
+      return null;
+    }
+    try {
+      await acpManager.initializeSession({
+        cfg: params.cfg,
+        sessionKey,
+        agent: candidateAgent,
+        mode: acpInit.mode,
+        cwd: acpInit.cwd,
+        backendId: acpInit.backendId,
+      });
+    } catch (initErr) {
+      logVerbose(
+        `dispatch-acp: lazy ACP init failed for ${sessionKey}: ${formatErrorMessage(initErr)}`,
+      );
+      return null;
+    }
+    // Re-resolve after initialization.
+    acpResolution = acpManager.resolveSession({
+      cfg: params.cfg,
+      sessionKey,
+    });
+    if (acpResolution.kind === "none") {
+      return null;
+    }
   }
   const canonicalSessionKey = acpResolution.sessionKey;
   const acpAgentId = resolveAgentIdFromSessionKey(canonicalSessionKey);


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
