### PR TITLE
fix(agents): resolve unique stored session key for delegated context-engine compaction

### DIFF
--- a/src/agents/run-session-target.test.ts
+++ b/src/agents/run-session-target.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { upsertSessionEntry } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -70,6 +70,54 @@ describe("agent run session target", () => {
       sessionKey: "agent:main:compat-session",
       storePath,
     });
+  });
+
+  it("resolves a unique stored session key when callers omit sessionKey", async () => {
+    const storePath = path.join(tempDir, "keyed", "sessions.json");
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey: "agent:main:keyed-123", storePath },
+      { sessionId: "s2", updatedAt: 1 },
+    );
+
+    await expect(
+      resolveAgentRunSessionTarget({
+        config: { session: { store: storePath } } as OpenClawConfig,
+        agentId: "main",
+        sessionId: "s2",
+      }),
+    ).resolves.toMatchObject({
+      sessionKey: "agent:main:keyed-123",
+      storePath,
+    });
+  });
+
+  it("keeps the session id fallback when the stored sessionId match is ambiguous", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-06T00:00:00Z"));
+    try {
+      const storePath = path.join(tempDir, "ambiguous", "sessions.json");
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey: "agent:main:amb-1", storePath },
+        { sessionId: "dup-session" },
+      );
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey: "agent:main:amb-2", storePath },
+        { sessionId: "dup-session" },
+      );
+
+      await expect(
+        resolveAgentRunSessionTarget({
+          config: { session: { store: storePath } } as OpenClawConfig,
+          agentId: "main",
+          sessionId: "dup-session",
+        }),
+      ).resolves.toMatchObject({
+        sessionKey: "agent:main:dup-session",
+        storePath,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("round-trips a plain compatibility key through sessionFile", async () => {

--- a/src/agents/run-session-target.ts
+++ b/src/agents/run-session-target.ts
@@ -108,11 +108,36 @@ export async function resolveAgentRunSessionTarget(params: {
   ) {
     throw new Error("Legacy SQLite transcript marker session key is ambiguous");
   }
+  // A delegated context-engine compaction can reach this resolver with only the
+  // host-projected sessionId (the compatibility projection strips sessionKey and
+  // sessionTarget for engines without declared host params). Resolve a unique
+  // stored session key from agentId + sessionId before falling back to treating
+  // the sessionId as the key, so the keyed SQLite transcript row is found. The
+  // legacy fallback stays intact for zero or ambiguous store matches.
+  const storeResolvedSessionKey =
+    agentId &&
+    sessionId &&
+    !targetSessionKey &&
+    !suppliedSessionKey &&
+    !compatibilitySessionKey &&
+    !markerSessionKey
+      ? resolvePreferredSessionKeyForSessionIdMatches(
+          listSessionEntries({
+            agentId,
+            storePath:
+              targetStorePath ?? resolveStorePath(params.config?.session?.store, { agentId }),
+          })
+            .filter(({ entry }) => entry.sessionId === sessionId)
+            .map(({ sessionKey: entryKey, entry }) => [entryKey, entry]),
+          sessionId,
+        )
+      : undefined;
   const sessionKey =
     targetSessionKey ??
     suppliedSessionKey ??
     compatibilitySessionKey ??
     markerSessionKey ??
+    storeResolvedSessionKey ??
     normalizeOptionalString(sessionId);
   const compatibilitySessionKeySelected =
     !targetSessionKey && !suppliedSessionKey && sessionKey === compatibilitySessionKey;

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -61,13 +61,22 @@ function registerTestContextEngine(id: string, factory: ContextEngineFactory) {
   });
 }
 
-const { compactEmbeddedAgentSessionDirectMock } = vi.hoisted(() => ({
+const { compactEmbeddedAgentSessionDirectMock, runtimeConfigMock } = vi.hoisted(() => ({
   compactEmbeddedAgentSessionDirectMock: vi.fn(),
+  runtimeConfigMock: vi.fn(),
 }));
 
 vi.mock("../agents/embedded-agent-runner/compact.runtime.js", () => ({
   compactEmbeddedAgentSessionDirect: compactEmbeddedAgentSessionDirectMock,
 }));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    getRuntimeConfig: runtimeConfigMock,
+  };
+});
 
 function installCompactRuntimeSpy() {
   return compactEmbeddedAgentSessionDirectMock.mockResolvedValue({
@@ -226,6 +235,7 @@ describe("Engine contract tests", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     compactEmbeddedAgentSessionDirectMock.mockReset();
+    runtimeConfigMock.mockReturnValue({});
     clearMemoryPluginState();
   });
 
@@ -296,6 +306,112 @@ describe("Engine contract tests", () => {
         details: undefined,
         sessionTarget,
       },
+    });
+  });
+
+  it("delegates undeclared-engine projected params without a session key", async () => {
+    const receivedByEngine: Array<Record<string, unknown>> = [];
+    const engineId = "proof-delegate-projection";
+    registerTestContextEngine(engineId, () => ({
+      info: { id: engineId, name: "Proof Delegate Projection" },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble(callParams) {
+        return { messages: callParams.messages as AgentMessage[], estimatedTokens: 0 };
+      },
+      async compact(callParams) {
+        receivedByEngine.push({ ...callParams });
+        return delegateCompactionToRuntime(callParams as Parameters<ContextEngine["compact"]>[0]);
+      },
+    }));
+    installCompactRuntimeSpy();
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+    const runtimeSettings = {};
+
+    await engine.compact({
+      agentId: "main",
+      sessionId: "s2",
+      sessionKey: "agent:main:keyed-123",
+      sessionTarget: {
+        agentId: "main",
+        sessionId: "s2",
+        sessionKey: "agent:main:keyed-123",
+      },
+      runtimeSettings,
+      runtimeContext: { tokenBudget: 1000 },
+    } as Parameters<ContextEngine["compact"]>[0]);
+
+    // The undeclared engine received only the projected identity…
+    expect(receivedByEngine[0]).toMatchObject({ agentId: "main", sessionId: "s2" });
+    expect(receivedByEngine[0]).not.toHaveProperty("sessionKey");
+    expect(receivedByEngine[0]).not.toHaveProperty("sessionTarget");
+    // …and the delegate re-attached the authoritative configured store identity
+    // (the projection stripped sessionTarget, but the delegate resolves the
+    // store path from config + agentId so the runtime resolver searches the
+    // store the session actually lives in instead of a fabricated key).
+    const runtimeParams = requireCompactRuntimeParams(0);
+    expect(runtimeParams).toMatchObject({ agentId: "main", sessionId: "s2" });
+    expect(runtimeParams).not.toHaveProperty("sessionKey");
+    expect(runtimeParams.sessionTarget).toMatchObject({
+      agentId: "main",
+      storePath: expect.stringContaining("agents/main/sessions/sessions.json"),
+    });
+    expect(runtimeParams.sessionTarget).not.toHaveProperty("sessionKey");
+  });
+
+  it("delegateCompactionToRuntime resolves the configured custom store for projected delegates", async () => {
+    // Regression for installs with a non-default session.store: the projection
+    // strips sessionTarget and runtimeContext for undeclared engines, so the
+    // delegate must re-attach the authoritative store path from config + agentId
+    // rather than let the resolver fall back to the default per-agent store.
+    const customStore = "/custom/state/{agentId}/sessions.json";
+    runtimeConfigMock.mockReturnValue({ session: { store: customStore } });
+    installCompactRuntimeSpy();
+
+    await delegateCompactionToRuntime({
+      // Projected delegate call: only agentId + sessionId survive the host-param
+      // projection for an undeclared engine.
+      agentId: "main",
+      sessionId: "s2",
+      tokenBudget: 4096,
+    } as Parameters<ContextEngine["compact"]>[0]);
+
+    const runtimeParams = requireCompactRuntimeParams(0);
+    expect(runtimeParams).toMatchObject({ agentId: "main", sessionId: "s2" });
+    // The store path comes from the configured custom store, not the default
+    // ~/.openclaw/agents/main/sessions/sessions.json.
+    expect(runtimeParams.sessionTarget).toMatchObject({
+      agentId: "main",
+      storePath: "/custom/state/main/sessions.json",
+    });
+    expect(runtimeParams.sessionTarget).not.toHaveProperty("sessionKey");
+  });
+
+  it("delegateCompactionToRuntime preserves a caller-supplied storePath over the configured store", async () => {
+    // When the caller already carries a storePath (e.g. post-window full params
+    // or a typed sessionTarget), the delegate must not overwrite it.
+    runtimeConfigMock.mockReturnValue({
+      session: { store: "/should/not/be/used/{agentId}/sessions.json" },
+    });
+    installCompactRuntimeSpy();
+    const callerStorePath = "/explicit/store/main/sessions.json";
+
+    await delegateCompactionToRuntime({
+      agentId: "main",
+      sessionId: "s2",
+      sessionTarget: {
+        agentId: "main",
+        sessionId: "s2",
+        storePath: callerStorePath,
+      },
+      tokenBudget: 4096,
+    } as Parameters<ContextEngine["compact"]>[0]);
+
+    const runtimeParams = requireCompactRuntimeParams(0);
+    expect(runtimeParams.sessionTarget).toMatchObject({
+      agentId: "main",
+      storePath: callerStorePath,
     });
   });
 

--- a/src/context-engine/delegate-store-identity.proof.test.ts
+++ b/src/context-engine/delegate-store-identity.proof.test.ts
@@ -1,0 +1,174 @@
+// Real-behavior proof: a projected delegated compaction (only agentId + sessionId
+// survive the host-param compatibility projection) must resolve the configured
+// custom session.store and find the real stored session key in it, instead of
+// falling back to the default per-agent store and substituting the sessionId
+// UUID for the session key.
+//
+// This proof does NOT mock the delegate's store-resolution logic, the resolver,
+// or the SQLite session-accessor. It mocks only:
+//   - getRuntimeConfig (to pin a non-default session.store without writing a
+//     real config file)
+//   - compactEmbeddedAgentSessionDirect (to capture what the delegate forwards
+//     without running a full LLM compaction)
+// Everything upstream of that boundary — delegate.ts store-resolution,
+// resolveAgentRunSessionTarget, listSessionEntries, real SQLite upsert/read —
+// runs as shipped. Mirrors the compaction.failure-proof.test.ts pattern.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+
+const { compactEmbeddedAgentSessionDirectMock, runtimeConfigMock } = vi.hoisted(() => ({
+  compactEmbeddedAgentSessionDirectMock: vi.fn(),
+  runtimeConfigMock: vi.fn(),
+}));
+
+vi.mock("../agents/embedded-agent-runner/compact.runtime.js", () => ({
+  compactEmbeddedAgentSessionDirect: compactEmbeddedAgentSessionDirectMock,
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    getRuntimeConfig: runtimeConfigMock,
+  };
+});
+
+const { resolveStorePath } = await import("../config/sessions/paths.js");
+const { upsertSessionEntry, listSessionEntries } =
+  await import("../config/sessions/session-accessor.js");
+const { resolveAgentRunSessionTarget } = await import("../agents/run-session-target.js");
+const { delegateCompactionToRuntime } = await import("./delegate.js");
+
+function installCompactRuntimeCapture() {
+  return compactEmbeddedAgentSessionDirectMock.mockImplementation(async (params) => {
+    // Capture exactly what the delegate forwarded, then run the REAL resolver
+    // against it (the same resolver compactEmbeddedAgentSessionDirect would
+    // call internally) so the proof exercises the full delegate → resolver →
+    // session-accessor chain with the storePath the delegate attached.
+    const resolved = await resolveAgentRunSessionTarget(params);
+    return {
+      ok: true,
+      compacted: false,
+      reason: "proof capture",
+      result: undefined,
+      proofResolved: resolved,
+    };
+  });
+}
+
+describe("delegated compaction store identity real-behavior proof (#119018)", () => {
+  let proofRoot: string;
+
+  beforeAll(() => {
+    proofRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pr-119018-proof-"));
+  });
+
+  afterAll(() => {
+    closeOpenClawAgentDatabasesForTest();
+    fs.rmSync(proofRoot, { recursive: true, force: true });
+  });
+
+  it("a projected delegate resolves the configured custom store and the real session key", async () => {
+    // Config declares a NON-DEFAULT session.store. This is what
+    // getRuntimeConfig().session?.store returns inside the delegate.
+    const customStore = `${proofRoot}/custom-state/{agentId}/sessions.json`;
+    runtimeConfigMock.mockReturnValue({ session: { store: customStore } });
+    installCompactRuntimeCapture();
+
+    const agentId = "main";
+    const sessionId = "proof-session-uuid";
+    const realSessionKey = "agent:main:proof-real-key";
+
+    const storePath = resolveStorePath(customStore, { agentId });
+    const defaultStorePath = resolveStorePath(undefined, { agentId });
+
+    // Write a REAL session entry into the CUSTOM store, mapping sessionId ->
+    // realSessionKey. The entry must NOT exist in the default store.
+    await upsertSessionEntry(
+      { agentId, sessionKey: realSessionKey, storePath },
+      { sessionId, updatedAt: 1 },
+    );
+    const entriesInCustom = listSessionEntries({ agentId, storePath }).filter(
+      ({ entry }) => entry.sessionId === sessionId,
+    );
+    const entriesInDefault = listSessionEntries({ agentId, storePath: defaultStorePath }).filter(
+      ({ entry }) => entry.sessionId === sessionId,
+    );
+
+    // Proof step 1: the real session entry lives in the custom store, not the default.
+    expect(entriesInCustom).toHaveLength(1);
+    expect(entriesInDefault).toHaveLength(0);
+
+    // Call the REAL delegate with PROJECTED params: only agentId + sessionId
+    // survive the host-param projection for an undeclared engine (no
+    // sessionTarget, no sessionKey, no runtimeContext).
+    await delegateCompactionToRuntime({
+      agentId,
+      sessionId,
+      tokenBudget: 4096,
+    } as Parameters<typeof delegateCompactionToRuntime>[0]);
+
+    // Proof step 2: the delegate re-attached the configured custom store path
+    // (not the default) to the sessionTarget forwarded to the runtime.
+    const forwarded = compactEmbeddedAgentSessionDirectMock.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(forwarded).toBeTruthy();
+    const forwardedSessionTarget = forwarded!.sessionTarget as
+      | { agentId?: string; storePath?: string; sessionKey?: string }
+      | undefined;
+    expect(forwardedSessionTarget).toMatchObject({
+      agentId,
+      storePath,
+    });
+    expect(forwardedSessionTarget).not.toHaveProperty("sessionKey");
+    expect(forwardedSessionTarget?.storePath).not.toBe(defaultStorePath);
+
+    // Proof step 3: the REAL resolver, given the storePath the delegate
+    // attached, returns the real stored session key — not the sessionId UUID.
+    const resolvedResult = (await compactEmbeddedAgentSessionDirectMock.mock.results[0]?.value) as
+      | { proofResolved?: { sessionKey?: string; storePath?: string } }
+      | undefined;
+    const resolved = resolvedResult?.proofResolved;
+    expect(resolved).toBeTruthy();
+    expect(resolved!.sessionKey).toBe(realSessionKey);
+    expect(resolved!.sessionKey).not.toBe(sessionId);
+    expect(resolved!.storePath).toBe(storePath);
+  });
+
+  it("without the delegate fix the resolver falls back to the default store and misses the custom-store row", async () => {
+    // Contrast proof: if the delegate did NOT attach the configured storePath
+    // (pre-fix behavior), the resolver would search the default store, find no
+    // row for the sessionId, and fall back to a sessionId-derived key.
+    const customStore = `${proofRoot}/custom-state-2/{agentId}/sessions.json`;
+    runtimeConfigMock.mockReturnValue({ session: { store: customStore } });
+
+    const agentId = "main";
+    const sessionId = "proof-session-uuid-2";
+    const realSessionKey = "agent:main:proof-real-key-2";
+    const storePath = resolveStorePath(customStore, { agentId });
+    const defaultStorePath = resolveStorePath(undefined, { agentId });
+
+    await upsertSessionEntry(
+      { agentId, sessionKey: realSessionKey, storePath },
+      { sessionId, updatedAt: 1 },
+    );
+
+    // The resolver with NO storePath (pre-fix delegate did not attach one)
+    // searches the default store and cannot find the real key.
+    const resolvedWithoutStore = await resolveAgentRunSessionTarget({
+      agentId,
+      sessionId,
+    });
+    expect(resolvedWithoutStore.sessionKey).not.toBe(realSessionKey);
+    expect(resolvedWithoutStore.storePath).not.toBe(storePath);
+    // And the default store genuinely has no row for this sessionId.
+    const defaultMatches = listSessionEntries({ agentId, storePath: defaultStorePath }).filter(
+      ({ entry }) => entry.sessionId === sessionId,
+    );
+    expect(defaultMatches).toHaveLength(0);
+  });
+});

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -2,7 +2,9 @@
 import path from "node:path";
 import { normalizeStructuredPromptSection } from "@openclaw/ai/internal/shared";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getRuntimeConfig } from "../config/config.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
 import { listSessionEntries, loadSessionEntry } from "../config/sessions/session-accessor.js";
 import {
   buildMemoryPromptSection,
@@ -172,12 +174,34 @@ export async function delegateCompactionToRuntime(
       ? Math.floor(runtimeContext.currentTokenCount)
       : undefined);
 
+  // A delegated compaction can reach here with the host-projected sessionId
+  // only: the compatibility projection strips sessionTarget and runtimeContext
+  // for engines without declared host params during the legacy window
+  // (context-engine-legacy-host-param-default, removeAfter 2026-08-12). Without
+  // the configured store path, the runtime resolver falls back to the default
+  // per-agent store, misses the real row for installs using a custom
+  // session.store, and reverts to treating the sessionId UUID as the session
+  // key. Re-attach the authoritative configured store identity here so the
+  // resolver searches the store the session actually lives in. The legacy
+  // window expires after 2026-08-12 (projection then keeps full params), but
+  // this stays correct afterwards: a caller-supplied storePath short-circuits
+  // this lookup, and a missing one is still resolved from config.
+  const resolvedSessionTarget = sessionTarget?.storePath
+    ? sessionTarget
+    : agentId
+      ? {
+          ...sessionTarget,
+          agentId,
+          storePath: resolveStorePath(getRuntimeConfig().session?.store, { agentId }),
+        }
+      : sessionTarget;
+
   const result = await compactEmbeddedAgentSessionDirect({
     ...runtimeContextParams,
     ...(agentId ? { agentId } : {}),
     sessionId: params.sessionId,
     ...(sessionKey ? { sessionKey } : {}),
-    ...(sessionTarget ? { sessionTarget } : {}),
+    ...(resolvedSessionTarget ? { sessionTarget: resolvedSessionTarget } : {}),
     tokenBudget: params.tokenBudget,
     ...(currentTokenCount !== undefined ? { currentTokenCount } : {}),
     force: params.force,


### PR DESCRIPTION
## What Problem This Solves

A delegated context-engine compaction can lose its session identity: the host-parameter compatibility projection strips `sessionKey`/`sessionTarget` for engines without declared `acceptedHostParams`, the delegation re-enters `resolveAgentRunSessionTarget` with only the `sessionId`, and the resolver's final fallback turns that `sessionId` into the session key — so the keyed SQLite transcript row is missed, the append returns `false`, and every compaction fails with `reason=unknown` after paying for the summarization pass. The resolver now resolves a unique stored session key from `agentId + sessionId` before that legacy fallback, keeping the fallback for zero or ambiguous store matches.

- Problem: A context engine that does not declare `acceptedHostParams` has `sessionKey`/`sessionTarget` stripped by `src/context-engine/registry.ts`; its `delegateCompactionToRuntime({ sessionId })` re-enters `resolveAgentRunSessionTarget` with no key, and the fallback `normalizeOptionalString(sessionId)` selects a store row that does not exist.
- Solution (round 1, resolver): In `src/agents/run-session-target.ts`, before falling back to the sessionId, look up the store for a unique session key matching `agentId + sessionId` (reusing the existing `listSessionEntries` + `resolvePreferredSessionKeyForSessionIdMatches` pattern already used for legacy markers and context-engine successors).
- Solution (round 2, delegate): In `src/context-engine/delegate.ts`, when the caller did not supply a `sessionTarget.storePath`, re-attach the authoritative configured store by resolving `getRuntimeConfig().session?.store` + `agentId` via `resolveStorePath`. The resolver-first fix alone searched the default per-agent store for custom `session.store` installs (projected delegates carry no `config`); the delegate fix routes the resolver to the configured store.
- What changed: `src/agents/run-session-target.ts` (resolver-first `storeResolvedSessionKey`), `src/context-engine/delegate.ts` (delegate re-attaches configured `storePath` for projected delegates), `src/agents/run-session-target.test.ts` (unique-key resolution + ambiguity fallback regression), `src/context-engine/context-engine.test.ts` (undeclared-engine projected delegation boundary regression + non-default `session.store` projected-delegate regression + caller-supplied storePath preservation).
- What did NOT change: the final sessionId fallback (preserved for zero/ambiguous matches), legacy marker/compatibility behavior, the host-param projection (compat window `removeAfter 2026-08-12` intact), the `delegateCompactionToRuntime` SDK contract, or the SQLite transcript writer.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #119018
- Related #119024 (diagnostic-only companion PR; unchanged by this fix)
- [x] This PR fixes a bug or regression

## Motivation

The context-engine delegation path is a documented integration surface: `delegateCompactionToRuntime` is the standard way for third-party engines to use the built-in compaction runtime, and the architecture example does not declare `acceptedHostParams`, so the compatibility projection strips the key-carrying host params. When the runtime re-resolves the session target from the projected `sessionId` only, the resolver's compatibility fallback fabricates a key from the sessionId; the real transcript row is stored under the agent-scoped session key, the SQLite append finds no row and returns `false`, and the compaction is reported as `reason=unknown` — a silent, expensive failure (full summarization already paid).

## Evidence

- Behavior addressed: `resolveAgentRunSessionTarget` resolves the real stored session key from `agentId + sessionId` before falling back to the sessionId, so delegated projected compactions write to the keyed transcript row.
- Real environment tested: Linux, Node v22.22.3, branch `fix/context-engine-compaction-key-119018`.
- Exact steps or command run after this patch (in-branch real-behavior proof covers host projection → delegation → session-key resolution → real SQLite session-accessor lookup):

```console
$ node scripts/run-vitest.mjs src/context-engine/delegate-store-identity.proof.test.ts --run
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

The chain harness output below was captured by the earlier standalone proof; the same projection → delegation → resolution path is now exercised by the in-branch `delegate-store-identity.proof.test.ts` (round 2 evidence links the two).

- Evidence after fix:

```console
=== 1) undeclared engine compact() received (after host-param projection) ===
{
  "agentId": "main",
  "sessionId": "s2"
}
projection: sessionKey stripped=true, sessionTarget stripped=true, agentId retained=main, sessionId retained=s2
=== 2) resolveAgentRunSessionTarget(agentId=main, sessionId=s2) ===
resolved sessionKey: agent:main:keyed-123
=== 3) appendSqliteTranscriptEventSync outcome ===
resolved key (agent:main:keyed-123): appended=true
sessionId-as-key (agent:main:s2, pre-fix behavior): appended=false
PROOF OK: resolved keyed row persists; sessionId-as-key is refused
```

Same harness against the pre-fix resolver (only the production file reverted):

```console
=== 1) undeclared engine compact() received (after host-param projection) ===
{
  "agentId": "main",
  "sessionId": "s2"
}
projection: sessionKey stripped=true, sessionTarget stripped=true, agentId retained=main, sessionId retained=s2
=== 2) resolveAgentRunSessionTarget(agentId=main, sessionId=s2) ===
resolved sessionKey: agent:main:s2
=== 3) appendSqliteTranscriptEventSync outcome ===
resolved key (agent:main:s2): appended=false
sessionId-as-key (agent:main:s2, pre-fix behavior): appended=false
UNEXPECTED OUTCOME
```

Behavior matrix:

| Input | Before fix | After fix |
|---|---|---|
| Undeclared engine `compact()` with full identity | receives `{agentId, sessionId}` only (sessionKey/sessionTarget stripped) | unchanged (projection is untouched) |
| Delegate forwarding of projected params | forwards `{agentId, sessionId}` without sessionKey | unchanged |
| Stored `agent:main:keyed-123` (sessionId `s2`), caller passes agentId+sessionId only | resolves `agent:main:s2` → append misses row → `reason=unknown` | resolves `agent:main:keyed-123` → keyed row found → compaction persists |
| Empty store, caller passes sessionId only | sessionId compatibility key | sessionId compatibility key (fallback preserved) |
| Two stored rows sharing one sessionId | n/a (freshest/ambiguous selection) | unique-or-freshest key selected; ambiguous tie keeps sessionId fallback |

Regression tests (ClawSweeper acceptance shard + related):

```console
$ node scripts/run-vitest.mjs src/agents/run-session-target.test.ts \
    src/context-engine/host-param-projection.test.ts src/context-engine/context-engine.test.ts \
    src/agents/embedded-agent-runner/compact-reasons.test.ts src/sessions/session-id-resolution.test.ts \
    src/config/sessions/session-accessor.conformance.test.ts --run
[test] passed 5 Vitest shards
```

- Observed result after fix:
  1. A keyed session with only `agentId + sessionId` supplied resolves to the real stored key instead of a fabricated sessionId key.
  2. The undeclared engine's `compact()` receives only the projected identity (`agentId + sessionId`), and the delegation boundary forwards exactly that identity — no `sessionKey`/`sessionTarget` leaks through (covered by the new `context-engine` boundary regression).
  3. Keyed persistence succeeds with the resolved key and is refused with the sessionId-as-key value (pre-fix behavior).
  4. Zero-match and ambiguous-tie lookups still fall back to the legacy sessionId key (existing compatibility tests pass unchanged).
  5. The full acceptance shard (run-session-target, host-param-projection, context-engine, compact-reasons, session-id-resolution) passes.
- What was not tested: a live gateway compaction with a real third-party context-engine plugin driving a real model summarization pass (the chain harness exercises projection, delegation, resolution, and persistence with real runtime code; only the model-runtime hop is not executed); Node 24/26 runtimes; non-SQLite legacy stores.

## Round 2 — Configured store identity through projected delegation (ClawSweeper P1)

ClawSweeper's second review (head `0bce3e414cc`, 2026-08-06 06:44 UTC) flagged a P1: the resolver-first fix resolves the store from `params.config?.session?.store`, but a projected delegate call has no `config` (the compatibility projection strips `runtimeContext`, and `compact()` callers do not pass `config` to the engine). Installs with a non-default `session.store` therefore search the default per-agent store, miss the real row, and still fall back to the sessionId-as-key.

### What changed (round 2)

- `src/context-engine/delegate.ts`: in `delegateCompactionToRuntime`, when the caller did not supply a `sessionTarget.storePath`, resolve one from `getRuntimeConfig().session?.store` + `agentId` via `resolveStorePath` and attach it to the `sessionTarget` forwarded to the runtime. The delegate is the natural owner for runtime identity (it already supplies `agentId`/`sessionId` for engines); this does not touch the projection, so the `context-engine-legacy-host-param-default` compat contract (`host-param-projection.test.ts`) is preserved. After the window expires (2026-08-12), the projection keeps full params and a caller-supplied `storePath` short-circuits this lookup, so the change is a no-op there.
- `src/context-engine/context-engine.test.ts`: regression that a projected delegate (only `agentId` + `sessionId`) with a non-default `session.store` forwards the custom store path to the runtime boundary; and that a caller-supplied `storePath` is preserved over the configured store.

### What did NOT change (round 2)

The host-parameter projection (`registry.ts`), the resolver's `storeResolvedSessionKey` (round 1, still load-bearing for the no-config path), the compat window contract, and the SQLite transcript writer.

### Evidence (round 2)

**In-branch real-behavior proof** (`src/context-engine/delegate-store-identity.proof.test.ts`, following the `compaction.failure-proof.test.ts` convention). The proof does NOT mock the delegate's store-resolution, the resolver, or the SQLite session-accessor — it mocks only `getRuntimeConfig` (to pin a non-default `session.store`) and `compactEmbeddedAgentSessionDirect` (to capture what the delegate forwards without running a full LLM compaction). Everything upstream of that boundary runs as shipped: `delegate.ts` store-resolution, `resolveAgentRunSessionTarget`, `listSessionEntries`, real SQLite upsert/read.

```console
$ node scripts/run-vitest.mjs src/context-engine/delegate-store-identity.proof.test.ts --run
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

The proof's two cases:

1. **Projected delegate resolves the configured custom store and the real session key** — a non-default `session.store` is pinned; a real session entry is upserted into the custom store (real SQLite); `delegateCompactionToRuntime` is called with projected params (`agentId` + `sessionId` only, matching what an undeclared engine receives after the host-param projection strips `sessionKey`/`sessionTarget`/`runtimeContext`). The proof asserts:
   - the real session entry lives in the custom store, not the default (`entries-in-custom-store: 1`, `entries-in-default-store: 0`);
   - the delegate re-attached the configured custom `storePath` (not the default) to the forwarded `sessionTarget`, and did not fabricate a `sessionKey`;
   - the real resolver, given the storePath the delegate attached, returns the stored session key (`agent:main:proof-real-key`) — not the `sessionId` UUID.

2. **Contrast: without the delegate-attached storePath the resolver falls back to the default store and misses the custom-store row** — the resolver with no `storePath` (pre-fix delegate behavior) searches the default store, finds no row for the `sessionId`, and does not return the real key; the default store genuinely has no matching row.

The earlier standalone tsx proof (round 2) produced the same result against the same production path; it has been folded into the in-branch `*.proof.test.ts` above so the exact-head projection-to-persistence result is independently inspectable from the branch.

Behavior matrix (round 2):

| Input | Before round 2 | After round 2 |
|---|---|---|
| Projected delegate (`agentId`+`sessionId` only), default `session.store` | delegate forwards no `sessionTarget`; resolver uses default store (round-1 fix finds row) | delegate attaches default store path; resolver short-circuits to it (same outcome, explicit) |
| Projected delegate, **custom** `session.store` | delegate forwards no `sessionTarget`; resolver resolves `params.config?.session?.store` = undefined → default store → misses real row → sessionId-as-key | delegate resolves custom store from `getRuntimeConfig().session?.store` + `agentId` → resolver finds real row → real session key |
| Caller-supplied `sessionTarget.storePath` (post-window full params) | forwarded as-is | forwarded as-is (short-circuits configured-store lookup) |

Regression tests (round 2):

```console
$ node scripts/run-vitest.mjs src/context-engine/context-engine.test.ts \
    src/context-engine/host-param-projection.test.ts src/agents/run-session-target.test.ts \
    src/agents/embedded-agent-runner/compact-reasons.test.ts \
    src/config/sessions/session-accessor.conformance.test.ts --run
[test] passed 4 Vitest shards
```

### What was not tested (round 2)

A live gateway compaction with a real third-party context-engine plugin driving a real model summarization pass against a custom `session.store` (the proof exercises the real delegate store-resolution → resolver → real SQLite session-accessor chain; only the model-runtime hop is not executed). The compact-runtime boundary is captured, not executed, in the tsx proof.

---

## Root Cause (if applicable)

`src/context-engine/registry.ts` `projectParams` strips `sessionKey`/`sessionTarget`/`runtimeContext` for engines without declared `acceptedHostParams` (legacy window, removeAfter 2026-08-12); `src/context-engine/delegate.ts` forwarded only received identity (no `config`, no `storePath`); `src/agents/run-session-target.ts` then had no configured store path and fell back to the default per-agent store, missing the real row for custom `session.store` installs, ultimately selecting `normalizeOptionalString(sessionId)` as the session key; `src/config/sessions/session-accessor.sqlite-transcript-write.ts` returns `false` when the keyed row is absent, surfacing as `reason=unknown`.

Round 1 fixed the resolver (`storeResolvedSessionKey` from `agentId`+`sessionId`). Round 2 fixes the delegate (re-attach configured `storePath` so the resolver searches the right store). Both are needed: round 1 alone misses custom-store installs; round 2 alone would still need the resolver's stored-key lookup once the store is correct.

Provenance:

```text
introduced by: session-target resolution seam (0dfa22c6e0fc, Josh Lehman) — final fallback chain
made visible by: bde1602e6e86 (2026-08-01, Peter Steinberger) — host-param compatibility projection strips key for undeclared engines
carried forward by: 4273ca9dbd9b (2026-07-27) — resolver restructure retained the fallback
confidence: clear
```

## Regression Test Plan (if applicable)

- Unique keyed match: seed one `agent:main:keyed-123` row (sessionId `s2`), resolve with agentId+sessionId only → expects `agent:main:keyed-123`.
- Ambiguous match: two rows sharing one sessionId with identical `updatedAt` → expects the sessionId fallback key.
- Zero match: existing "uses the session id as the compatibility key" test → fallback preserved.

## User-visible / Behavior Changes

Delegated context-engine compactions for undeclared engines persist to the correct keyed transcript instead of failing with `reason=unknown`. All other resolution paths (explicit key, compatibility key, marker key) are unchanged.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.22.3
- Integration/channel: context-engine SDK delegation → session-target resolution → SQLite transcript persistence
- Relevant config (redacted): temporary session store path

### Steps

1. Seed `agent:main:keyed-123` with `sessionId = s2` in a temp store.
2. Call `resolveAgentRunSessionTarget({ agentId: "main", sessionId: "s2" })`.
3. Compare resolved `sessionKey` before/after the patch.

### Expected

Resolved key equals the stored key `agent:main:keyed-123` (after), not `agent:main:s2` (before).

### Actual

Before: `agent:main:s2` (misses the keyed row). After: `agent:main:keyed-123`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: unique keyed resolution; ambiguity fallback; zero-match fallback; full acceptance shard.
- Edge cases checked: explicit/supplied keys skip the lookup; compatibility and marker paths unchanged; legacy file-backed guard unchanged.
- What you did NOT verify: live third-party engine compaction over a full gateway run; non-SQLite stores.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — the resolver-first unique lookup restores the canonical key at the single re-entry point the delegate path uses, and reuses the established `listSessionEntries` + `resolvePreferredSessionKeyForSessionIdMatches` selection contract (same pattern as legacy-marker and successor resolution).
- **Refactor needed**: No — a focused resolver change; the diagnostic companion PR #119024 remains useful and independent.
- **Alternative considered**: Fixing `buildContextEngineCompactionSessionTarget` or the delegate call sites — rejected because the delegate path re-enters the same resolver, so call-site fixes would only move the substitution (confirmed in issue comments by abacha).

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Codex <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: open-source-pr workflow Steps 1-6; analysis and plan confirmed by the user before implementation.

## Risks and Mitigations

- **Highest-risk area**: behavior change in the no-key fallback path of a shared resolver. Mitigation: the lookup only runs when no key is available from any source, reuses the existing unique/freshest selection semantics, and keeps the legacy fallback for zero or ambiguous matches (covered by regression tests).
- **Performance**: one bounded store read added on the rare no-key path; the legacy-marker path already performs the same `listSessionEntries` read.
- **Competition**: `clawsweeper:queueable-fix` is set; the open companion PR #119024 touches only diagnostics files, so there is no code overlap.
- **Compatibility**: no public API, config, schema, or behavior change for paths that already supply a key.

---

Fixes #119018


