### PR TITLE
fix(macos): keep discovered gateways on trusted transport [AI]

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30051,7 +30051,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 399,
+      "line": 406,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "These settings changed outside the app while you were editing: \\(fieldList). Choose which version to keep.",
       "surface": "apple",
@@ -30059,7 +30059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1014,
+      "line": 1022,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -30067,7 +30067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1014,
+      "line": 1022,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -512,54 +512,37 @@ final class AppState {
             UserDefaults.standard.set(IconOverrideSelection.system.rawValue, forKey: iconOverrideKey)
         }
 
-        let loadedConfigRoot = OpenClawConfigFile.loadDict()
-        let legacyRouteMigration = isPreview
-            ? (root: loadedConfigRoot, changed: false)
-            : Self.migrateLegacyUnboundDiscoveryRoute(loadedConfigRoot)
-        let legacyRouteMigrationPersisted = !legacyRouteMigration.changed ||
-            gatewayConfigSaver(legacyRouteMigration.root)
-        let configRoot = legacyRouteMigration.root
-        if !legacyRouteMigrationPersisted {
-            Self.logger.error("legacy discovery route migration could not be persisted")
-        }
-        self.lastConfigFingerprint = Self.configFingerprint(configRoot)
-        self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(configRoot)
-        let configRemoteToken = GatewayRemoteConfig.resolveTokenValue(root: configRoot)
-        let configRemoteResolution = GatewayRemoteConfig.resolveTransportResolution(root: configRoot)
-        let configRemoteTransport = configRemoteResolution.transport
-        let configRemoteUrl = configRemoteResolution.directURL?.absoluteString
-            ?? GatewayRemoteConfig.resolveUrlString(root: configRoot)
-        let resolvedConnectionMode = ConnectionModeResolver.resolve(root: configRoot).mode
-        self.remoteTransport = configRemoteTransport
-        self.connectionMode = resolvedConnectionMode
+        let startupConfig = GatewayDiscoveryPreferences.prepareStartupConfig(
+            isPreview: isPreview, saver: gatewayConfigSaver)
+        self.lastConfigFingerprint = Self.configFingerprint(startupConfig.root)
+        self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(startupConfig.root)
+        self.remoteTransport = startupConfig.remoteTransport
+        self.connectionMode = startupConfig.connectionMode
 
-        let configRemote = (configRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
+        let configRemote = (startupConfig.root["gateway"] as? [String: Any])?["remote"] as? [String: Any]
         let hasConfigRemoteTarget = configRemote?.keys.contains("sshTarget") == true
         let configRemoteTarget = (configRemote?["sshTarget"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let storedRemoteTarget = UserDefaults.standard.string(forKey: remoteTargetKey) ?? ""
-        if resolvedConnectionMode == .remote,
+        if startupConfig.connectionMode == .remote,
            hasConfigRemoteTarget
         {
             self.remoteTarget = configRemoteTarget
-        } else if resolvedConnectionMode == .remote,
-                  configRemoteTransport != .direct,
+        } else if startupConfig.connectionMode == .remote,
+                  startupConfig.remoteTransport != .direct,
                   storedRemoteTarget.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                  let host = AppState.remoteHost(from: configRemoteUrl),
+                  let host = AppState.remoteHost(from: startupConfig.remoteURL),
                   !LoopbackHost.isLoopbackHost(host)
         {
             self.remoteTarget = "\(NSUserName())@\(host)"
         } else {
             self.remoteTarget = storedRemoteTarget
         }
-        self.remoteUrl = configRemoteUrl ?? ""
-        self.remoteToken = configRemoteToken.textFieldValue
-        self.remoteTokenUnsupported = configRemoteToken.isUnsupportedNonString
-        let hasConfigRemoteIdentity = configRemote?.keys.contains("sshIdentity") == true
-        let configRemoteIdentity = (configRemote?["sshIdentity"] as? String)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        self.remoteIdentity = hasConfigRemoteIdentity
-            ? configRemoteIdentity
+        self.remoteUrl = startupConfig.remoteURL ?? ""
+        self.remoteToken = startupConfig.remoteToken.textFieldValue
+        self.remoteTokenUnsupported = startupConfig.remoteToken.isUnsupportedNonString
+        self.remoteIdentity = startupConfig.remoteIdentityConfigured
+            ? startupConfig.remoteIdentity
             : UserDefaults.standard.string(forKey: remoteIdentityKey)?.nonEmpty ?? ""
         self.remoteProjectRoot = UserDefaults.standard.string(forKey: remoteProjectRootKey)?.nonEmpty ?? ""
         self.remoteCliPath = UserDefaults.standard.string(forKey: remoteCliPathKey)?.nonEmpty ?? ""
@@ -590,11 +573,11 @@ final class AppState {
         }
 
         if !self.isPreview {
-            if !legacyRouteMigrationPersisted {
+            if !startupConfig.migrationPersisted {
                 // Failed persistence must keep routing closed instead of letting the watcher
                 // republish the old Direct endpoint from disk.
                 self.gatewayConfigSyncState = .failed
-            } else if legacyRouteMigration.changed {
+            } else if startupConfig.migrationChanged {
                 GatewayDiscoveryPreferences.setPreferredStableID(nil)
             } else {
                 self.reconcilePreferredGatewayRouteBinding()
@@ -604,7 +587,7 @@ final class AppState {
         if !self.isPreview {
             scheduleExecApprovalModeReadRetry()
         }
-        if !self.isPreview, legacyRouteMigrationPersisted {
+        if !self.isPreview, startupConfig.migrationPersisted {
             self.startConfigWatcher()
         }
     }
@@ -1280,28 +1263,6 @@ extension AppState {
 }
 
 extension AppState {
-    static func migrateLegacyUnboundDiscoveryRoute(_ currentRoot: [String: Any])
-        -> (root: [String: Any], changed: Bool)
-    {
-        guard GatewayDiscoveryPreferences.preferredStableID() != nil,
-              GatewayDiscoveryPreferences.preferredRouteBinding() == nil,
-              ConnectionModeResolver.resolve(root: currentRoot).mode == .remote,
-              GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
-        else {
-            return (currentRoot, false)
-        }
-
-        var root = currentRoot
-        var gateway = root["gateway"] as? [String: Any] ?? [:]
-        var remote = gateway["remote"] as? [String: Any] ?? [:]
-        remote["transport"] = RemoteTransport.ssh.rawValue
-        remote["url"] = GatewayDiscoverySelectionSupport.sshTunnelGatewayUrl(
-            current: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "")
-        gateway["remote"] = remote
-        root["gateway"] = gateway
-        return (root, true)
-    }
-
     private static func syncedGatewayRoot(
         currentRoot: [String: Any],
         draft: GatewayConfigSyncDraft,

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -296,6 +296,13 @@ final class AppState {
     }
 
     var connectionMode: ConnectionMode {
+        willSet {
+            if self.connectionMode == .remote, newValue != .remote {
+                // Route ownership is still observable until the mode changes. Retire automatic
+                // Direct authority here so every settings and config-driven exit is covered.
+                GatewayDiscoveryPreferences.retirePreferredRouteBeforeLeavingRemote(state: self)
+            }
+        }
         didSet {
             self.ifNotPreview { UserDefaults.standard.set(self.connectionMode.rawValue, forKey: connectionModeKey) }
             if oldValue != self.connectionMode {

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -894,11 +894,6 @@ extension AppState {
         }
 
         self.isApplyingGatewayConfig = true
-        self.applyGatewayConfigMode(
-            desiredMode,
-            hasRemoteUrl: hasRemoteUrl,
-            forcing: forcedFields.contains(.mode))
-
         let shouldApplyTransport = forcedFields.contains(.remoteTransport) ||
             !self.dirtyGatewayConfigFields.contains(.remoteTransport)
         if shouldApplyTransport, remoteTransport != self.remoteTransport {
@@ -950,6 +945,12 @@ extension AppState {
                 self.remoteIdentity = configuredIdentity
             }
         }
+        // Apply mode last so a Remote exit retires authority against the final incoming route.
+        // Applying it first lets later transport fields recreate Direct without its owner receipt.
+        self.applyGatewayConfigMode(
+            desiredMode,
+            hasRemoteUrl: hasRemoteUrl,
+            forcing: forcedFields.contains(.mode))
         self.isApplyingGatewayConfig = false
     }
 

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -512,7 +512,16 @@ final class AppState {
             UserDefaults.standard.set(IconOverrideSelection.system.rawValue, forKey: iconOverrideKey)
         }
 
-        let configRoot = OpenClawConfigFile.loadDict()
+        let loadedConfigRoot = OpenClawConfigFile.loadDict()
+        let legacyRouteMigration = isPreview
+            ? (root: loadedConfigRoot, changed: false)
+            : Self.migrateLegacyUnboundDiscoveryRoute(loadedConfigRoot)
+        let legacyRouteMigrationPersisted = !legacyRouteMigration.changed ||
+            gatewayConfigSaver(legacyRouteMigration.root)
+        let configRoot = legacyRouteMigration.root
+        if !legacyRouteMigrationPersisted {
+            Self.logger.error("legacy discovery route migration could not be persisted")
+        }
         self.lastConfigFingerprint = Self.configFingerprint(configRoot)
         self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(configRoot)
         let configRemoteToken = GatewayRemoteConfig.resolveTokenValue(root: configRoot)
@@ -581,13 +590,21 @@ final class AppState {
         }
 
         if !self.isPreview {
-            self.reconcilePreferredGatewayRouteBinding()
+            if !legacyRouteMigrationPersisted {
+                // Failed persistence must keep routing closed instead of letting the watcher
+                // republish the old Direct endpoint from disk.
+                self.gatewayConfigSyncState = .failed
+            } else if legacyRouteMigration.changed {
+                GatewayDiscoveryPreferences.setPreferredStableID(nil)
+            } else {
+                self.reconcilePreferredGatewayRouteBinding()
+            }
         }
         self.isInitializing = false
         if !self.isPreview {
             scheduleExecApprovalModeReadRetry()
         }
-        if !self.isPreview {
+        if !self.isPreview, legacyRouteMigrationPersisted {
             self.startConfigWatcher()
         }
     }
@@ -1263,6 +1280,28 @@ extension AppState {
 }
 
 extension AppState {
+    static func migrateLegacyUnboundDiscoveryRoute(_ currentRoot: [String: Any])
+        -> (root: [String: Any], changed: Bool)
+    {
+        guard GatewayDiscoveryPreferences.preferredStableID() != nil,
+              GatewayDiscoveryPreferences.preferredRouteBinding() == nil,
+              ConnectionModeResolver.resolve(root: currentRoot).mode == .remote,
+              GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
+        else {
+            return (currentRoot, false)
+        }
+
+        var root = currentRoot
+        var gateway = root["gateway"] as? [String: Any] ?? [:]
+        var remote = gateway["remote"] as? [String: Any] ?? [:]
+        remote["transport"] = RemoteTransport.ssh.rawValue
+        remote["url"] = GatewayDiscoverySelectionSupport.sshTunnelGatewayUrl(
+            current: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "")
+        gateway["remote"] = remote
+        root["gateway"] = gateway
+        return (root, true)
+    }
+
     private static func syncedGatewayRoot(
         currentRoot: [String: Any],
         draft: GatewayConfigSyncDraft,

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift
@@ -50,9 +50,7 @@ enum GatewayDiscoveryHelpers {
             return nil
         }
         let scheme: String
-        // A discovered Tailnet route is selected automatically, so its transport must not be
-        // downgraded by unauthenticated discovery metadata. Explicit LAN routes may still use ws.
-        if gatewayTls || endpoint.host.lowercased().hasSuffix(".ts.net") {
+        if gatewayTls {
             scheme = "wss"
         } else if self.isLoopbackHost(endpoint.host)
             || GatewayRemoteConfig.isTrustedPlaintextRemoteHost(endpoint.host)

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift
@@ -50,7 +50,9 @@ enum GatewayDiscoveryHelpers {
             return nil
         }
         let scheme: String
-        if gatewayTls {
+        // A discovered Tailnet route is selected automatically, so its transport must not be
+        // downgraded by unauthenticated discovery metadata. Explicit LAN routes may still use ws.
+        if gatewayTls || endpoint.host.lowercased().hasSuffix(".ts.net") {
             scheme = "wss"
         } else if self.isLoopbackHost(endpoint.host)
             || GatewayRemoteConfig.isTrustedPlaintextRemoteHost(endpoint.host)

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -82,27 +82,35 @@ enum GatewayDiscoveryPreferences {
         -> (root: [String: Any], changed: Bool)
     {
         let connectionMode = ConnectionModeResolver.resolve(root: currentRoot).mode
-        guard connectionMode == .remote,
-              GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct,
-              let preferredStableID = self.preferredStableID()
+        guard GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
         else {
             return (currentRoot, false)
         }
-        if self.isVerifiedTailscaleServeRoute(
-            stableID: preferredStableID,
-            root: currentRoot)
-        {
-            return (currentRoot, false)
+        if connectionMode == .remote {
+            guard let preferredStableID = self.preferredStableID() else {
+                // Active Direct without a discovery receipt is operator-owned.
+                return (currentRoot, false)
+            }
+            if self.isVerifiedTailscaleServeRoute(
+                stableID: preferredStableID,
+                root: currentRoot)
+            {
+                return (currentRoot, false)
+            }
+            if let storedBinding = self.preferredRouteBinding() {
+                let currentBinding = self.routeBinding(
+                    connectionMode: .remote,
+                    remoteTransport: .direct,
+                    remoteURL: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "",
+                    remoteTarget: "")
+                // A mismatched binding proves the route was edited after discovery selected it.
+                guard storedBinding == currentBinding else { return (currentRoot, false) }
+            }
         }
-        if let storedBinding = self.preferredRouteBinding() {
-            let currentBinding = self.routeBinding(
-                connectionMode: .remote,
-                remoteTransport: .direct,
-                remoteURL: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "",
-                remoteTarget: "")
-            // A mismatched binding proves the route was edited after discovery selected it.
-            guard storedBinding == currentBinding else { return (currentRoot, false) }
-        }
+
+        // Shipped mode-exit flows cleared the discovery receipt, so an inactive Direct route has
+        // no reliable ownership provenance. Keeping it would let a mode-only return to Remote
+        // reactivate an attacker-selected endpoint without another trusted Direct decision.
 
         var root = currentRoot
         var gateway = root["gateway"] as? [String: Any] ?? [:]

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -55,7 +55,7 @@ enum GatewayDiscoveryPreferences {
         let loadedRoot = OpenClawConfigFile.loadDict()
         let migration = isPreview
             ? (root: loadedRoot, changed: false)
-            : self.migrateLegacyUnboundDiscoveryRoute(loadedRoot)
+            : self.migrateUnsafeDiscoveryRoute(loadedRoot)
         let persisted = !migration.changed || saver(migration.root)
         if !persisted {
             self.logger.error("legacy discovery route migration could not be persisted")
@@ -78,14 +78,24 @@ enum GatewayDiscoveryPreferences {
     }
 
     @MainActor
-    static func migrateLegacyUnboundDiscoveryRoute(_ currentRoot: [String: Any])
+    static func migrateUnsafeDiscoveryRoute(_ currentRoot: [String: Any])
         -> (root: [String: Any], changed: Bool)
     {
         let connectionMode = ConnectionModeResolver.resolve(root: currentRoot).mode
         guard let preferredStableID = self.preferredStableID(),
-              self.preferredRouteBinding() == nil,
               GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
         else {
+            return (currentRoot, false)
+        }
+        let storedBinding = self.preferredRouteBinding()
+        let expectedDirectBinding = self.routeBinding(
+            connectionMode: .remote,
+            remoteTransport: .direct,
+            remoteURL: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "",
+            remoteTarget: "")
+        let isInactiveBoundRoute = connectionMode != .remote &&
+            storedBinding != nil && storedBinding == expectedDirectBinding
+        guard storedBinding == nil || isInactiveBoundRoute else {
             return (currentRoot, false)
         }
         if connectionMode == .remote,

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -112,8 +112,16 @@ enum GatewayDiscoveryPreferences {
 
     @discardableResult
     static func clearPreferredStableIDIfRouteBindingMismatch(_ currentRouteBinding: String?) -> Bool {
-        guard self.preferredStableID() != nil else {
+        guard let preferredStableID = self.preferredStableID() else {
             UserDefaults.standard.removeObject(forKey: self.preferredRouteBindingKey)
+            return false
+        }
+        if self.preferredRouteBinding() == nil,
+           let current = self.normalized(currentRouteBinding)
+        {
+            // Releases predating route bindings persisted only the discovery id. Adopt the
+            // current route once so its automatic transport cannot look like a manual choice.
+            self.setPreferredStableID(preferredStableID, routeBinding: current)
             return false
         }
         guard let stored = self.preferredRouteBinding(),

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -33,6 +33,22 @@ enum GatewayDiscoveryPreferences {
         return trimmed?.isEmpty == false ? trimmed : nil
     }
 
+    @MainActor
+    static func currentRouteIsDiscoveryOwned(state: AppState) -> Bool {
+        guard self.preferredStableID() != nil,
+              let storedBinding = self.preferredRouteBinding()
+        else {
+            return false
+        }
+        // Match the bound route itself, not only the persisted discovery id. A manual route edit
+        // transfers authority immediately, before asynchronous preference cleanup catches up.
+        return storedBinding == self.routeBinding(
+            connectionMode: state.connectionMode,
+            remoteTransport: state.remoteTransport,
+            remoteURL: state.remoteUrl,
+            remoteTarget: state.remoteTarget)
+    }
+
     static func setPreferredStableID(_ stableID: String?, routeBinding: String?) {
         self.setPreferredStableID(stableID)
         guard self.preferredStableID() != nil,

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -47,6 +47,7 @@ enum GatewayDiscoveryPreferences {
         return trimmed?.isEmpty == false ? trimmed : nil
     }
 
+    @MainActor
     static func prepareStartupConfig(
         isPreview: Bool,
         saver: ([String: Any]) -> Bool) -> StartupConfig
@@ -76,6 +77,7 @@ enum GatewayDiscoveryPreferences {
             remoteIdentity: remoteIdentity)
     }
 
+    @MainActor
     static func migrateLegacyUnboundDiscoveryRoute(_ currentRoot: [String: Any])
         -> (root: [String: Any], changed: Bool)
     {

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -87,10 +87,8 @@ enum GatewayDiscoveryPreferences {
             return (currentRoot, false)
         }
         if connectionMode == .remote {
-            guard let preferredStableID = self.preferredStableID(),
-                  self.preferredRouteBinding() == nil
-            else {
-                // Active Direct without an unbound discovery receipt is operator-owned.
+            guard let preferredStableID = self.preferredStableID() else {
+                // Active Direct without a discovery receipt is operator-owned.
                 return (currentRoot, false)
             }
             if self.isVerifiedTailscaleServeRoute(
@@ -98,6 +96,15 @@ enum GatewayDiscoveryPreferences {
                 root: currentRoot)
             {
                 return (currentRoot, false)
+            }
+            if let storedBinding = self.preferredRouteBinding() {
+                let currentBinding = self.routeBinding(
+                    connectionMode: .remote,
+                    remoteTransport: .direct,
+                    remoteURL: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "",
+                    remoteTarget: "")
+                // A mismatched binding proves the route was edited after discovery selected it.
+                guard storedBinding == currentBinding else { return (currentRoot, false) }
             }
         }
 

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -82,28 +82,23 @@ enum GatewayDiscoveryPreferences {
         -> (root: [String: Any], changed: Bool)
     {
         let connectionMode = ConnectionModeResolver.resolve(root: currentRoot).mode
-        guard let preferredStableID = self.preferredStableID(),
-              GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
+        guard GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
         else {
             return (currentRoot, false)
         }
-        let storedBinding = self.preferredRouteBinding()
-        let expectedDirectBinding = self.routeBinding(
-            connectionMode: .remote,
-            remoteTransport: .direct,
-            remoteURL: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "",
-            remoteTarget: "")
-        let isInactiveBoundRoute = connectionMode != .remote &&
-            storedBinding != nil && storedBinding == expectedDirectBinding
-        guard storedBinding == nil || isInactiveBoundRoute else {
-            return (currentRoot, false)
-        }
-        if connectionMode == .remote,
-           self.isVerifiedTailscaleServeRoute(
-            stableID: preferredStableID,
-            root: currentRoot)
-        {
-            return (currentRoot, false)
+        if connectionMode == .remote {
+            guard let preferredStableID = self.preferredStableID(),
+                  self.preferredRouteBinding() == nil
+            else {
+                // Active Direct without an unbound discovery receipt is operator-owned.
+                return (currentRoot, false)
+            }
+            if self.isVerifiedTailscaleServeRoute(
+                stableID: preferredStableID,
+                root: currentRoot)
+            {
+                return (currentRoot, false)
+            }
         }
 
         var root = currentRoot

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -136,6 +136,20 @@ enum GatewayDiscoveryPreferences {
             remoteTarget: state.remoteTarget)
     }
 
+    @MainActor
+    static func retirePreferredRouteBeforeLeavingRemote(state: AppState) {
+        // Clear automatic Direct authority while its route binding is still observable.
+        // Clearing the receipt first would make a later discovery choice look manual.
+        if self.currentRouteIsDiscoveryOwned(state: state),
+           state.remoteTransport == .direct
+        {
+            state.remoteTransport = .ssh
+            state.remoteUrl = GatewayDiscoverySelectionSupport.sshTunnelGatewayUrl(
+                current: state.remoteUrl)
+        }
+        self.setPreferredStableID(nil)
+    }
+
     static func setPreferredStableID(_ stableID: String?, routeBinding: String?) {
         self.setPreferredStableID(stableID)
         guard self.preferredStableID() != nil,

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -82,30 +82,26 @@ enum GatewayDiscoveryPreferences {
         -> (root: [String: Any], changed: Bool)
     {
         let connectionMode = ConnectionModeResolver.resolve(root: currentRoot).mode
-        guard GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
+        guard connectionMode == .remote,
+              GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct,
+              let preferredStableID = self.preferredStableID()
         else {
             return (currentRoot, false)
         }
-        if connectionMode == .remote {
-            guard let preferredStableID = self.preferredStableID() else {
-                // Active Direct without a discovery receipt is operator-owned.
-                return (currentRoot, false)
-            }
-            if self.isVerifiedTailscaleServeRoute(
-                stableID: preferredStableID,
-                root: currentRoot)
-            {
-                return (currentRoot, false)
-            }
-            if let storedBinding = self.preferredRouteBinding() {
-                let currentBinding = self.routeBinding(
-                    connectionMode: .remote,
-                    remoteTransport: .direct,
-                    remoteURL: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "",
-                    remoteTarget: "")
-                // A mismatched binding proves the route was edited after discovery selected it.
-                guard storedBinding == currentBinding else { return (currentRoot, false) }
-            }
+        if self.isVerifiedTailscaleServeRoute(
+            stableID: preferredStableID,
+            root: currentRoot)
+        {
+            return (currentRoot, false)
+        }
+        if let storedBinding = self.preferredRouteBinding() {
+            let currentBinding = self.routeBinding(
+                connectionMode: .remote,
+                remoteTransport: .direct,
+                remoteURL: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "",
+                remoteTarget: "")
+            // A mismatched binding proves the route was edited after discovery selected it.
+            guard storedBinding == currentBinding else { return (currentRoot, false) }
         }
 
         var root = currentRoot

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -81,11 +81,17 @@ enum GatewayDiscoveryPreferences {
     static func migrateLegacyUnboundDiscoveryRoute(_ currentRoot: [String: Any])
         -> (root: [String: Any], changed: Bool)
     {
-        guard self.preferredStableID() != nil,
+        guard let preferredStableID = self.preferredStableID(),
               self.preferredRouteBinding() == nil,
               ConnectionModeResolver.resolve(root: currentRoot).mode == .remote,
               GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
         else {
+            return (currentRoot, false)
+        }
+        if self.isVerifiedTailscaleServeRoute(
+            stableID: preferredStableID,
+            root: currentRoot)
+        {
             return (currentRoot, false)
         }
 
@@ -98,6 +104,20 @@ enum GatewayDiscoveryPreferences {
         gateway["remote"] = remote
         root["gateway"] = gateway
         return (root, true)
+    }
+
+    private static func isVerifiedTailscaleServeRoute(
+        stableID: String,
+        root: [String: Any]) -> Bool
+    {
+        guard let url = GatewayRemoteConfig.resolveGatewayUrl(root: root),
+              url.scheme?.lowercased() == "wss",
+              let host = url.host?.lowercased(),
+              url.port == nil || url.port == 443
+        else {
+            return false
+        }
+        return stableID.lowercased() == "tailscale-serve|\(host)"
     }
 
     @MainActor

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -81,14 +81,15 @@ enum GatewayDiscoveryPreferences {
     static func migrateLegacyUnboundDiscoveryRoute(_ currentRoot: [String: Any])
         -> (root: [String: Any], changed: Bool)
     {
+        let connectionMode = ConnectionModeResolver.resolve(root: currentRoot).mode
         guard let preferredStableID = self.preferredStableID(),
               self.preferredRouteBinding() == nil,
-              ConnectionModeResolver.resolve(root: currentRoot).mode == .remote,
               GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
         else {
             return (currentRoot, false)
         }
-        if self.isVerifiedTailscaleServeRoute(
+        if connectionMode == .remote,
+           self.isVerifiedTailscaleServeRoute(
             stableID: preferredStableID,
             root: currentRoot)
         {

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -1,6 +1,20 @@
 import Foundation
+import OSLog
 
 enum GatewayDiscoveryPreferences {
+    struct StartupConfig {
+        let root: [String: Any]
+        let migrationChanged: Bool
+        let migrationPersisted: Bool
+        let remoteToken: GatewayRemoteConfig.TokenValue
+        let remoteTransport: AppState.RemoteTransport
+        let remoteURL: String?
+        let connectionMode: AppState.ConnectionMode
+        let remoteIdentityConfigured: Bool
+        let remoteIdentity: String
+    }
+
+    private static let logger = Logger(subsystem: "ai.openclaw", category: "gateway-discovery-preferences")
     private static let preferredStableIDKey = "gateway.preferredStableID"
     private static let legacyPreferredStableIDKey = "bridge.preferredStableID"
     private static let preferredRouteBindingKey = "gateway.preferredStableIDRouteBinding.v1"
@@ -31,6 +45,57 @@ enum GatewayDiscoveryPreferences {
         let raw = UserDefaults.standard.string(forKey: self.preferredRouteBindingKey)
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    static func prepareStartupConfig(
+        isPreview: Bool,
+        saver: ([String: Any]) -> Bool) -> StartupConfig
+    {
+        let loadedRoot = OpenClawConfigFile.loadDict()
+        let migration = isPreview
+            ? (root: loadedRoot, changed: false)
+            : self.migrateLegacyUnboundDiscoveryRoute(loadedRoot)
+        let persisted = !migration.changed || saver(migration.root)
+        if !persisted {
+            self.logger.error("legacy discovery route migration could not be persisted")
+        }
+        let resolution = GatewayRemoteConfig.resolveTransportResolution(root: migration.root)
+        let remote = (migration.root["gateway"] as? [String: Any])?["remote"] as? [String: Any]
+        let remoteIdentity = (remote?["sshIdentity"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return StartupConfig(
+            root: migration.root,
+            migrationChanged: migration.changed,
+            migrationPersisted: persisted,
+            remoteToken: GatewayRemoteConfig.resolveTokenValue(root: migration.root),
+            remoteTransport: resolution.transport,
+            remoteURL: resolution.directURL?.absoluteString ??
+                GatewayRemoteConfig.resolveUrlString(root: migration.root),
+            connectionMode: ConnectionModeResolver.resolve(root: migration.root).mode,
+            remoteIdentityConfigured: remote?.keys.contains("sshIdentity") == true,
+            remoteIdentity: remoteIdentity)
+    }
+
+    static func migrateLegacyUnboundDiscoveryRoute(_ currentRoot: [String: Any])
+        -> (root: [String: Any], changed: Bool)
+    {
+        guard self.preferredStableID() != nil,
+              self.preferredRouteBinding() == nil,
+              ConnectionModeResolver.resolve(root: currentRoot).mode == .remote,
+              GatewayRemoteConfig.resolveTransport(root: currentRoot) == .direct
+        else {
+            return (currentRoot, false)
+        }
+
+        var root = currentRoot
+        var gateway = root["gateway"] as? [String: Any] ?? [:]
+        var remote = gateway["remote"] as? [String: Any] ?? [:]
+        remote["transport"] = AppState.RemoteTransport.ssh.rawValue
+        remote["url"] = GatewayDiscoverySelectionSupport.sshTunnelGatewayUrl(
+            current: GatewayRemoteConfig.resolveUrlString(root: currentRoot) ?? "")
+        gateway["remote"] = remote
+        root["gateway"] = gateway
+        return (root, true)
     }
 
     @MainActor

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
@@ -27,7 +27,7 @@ enum GatewayDiscoverySelectionSupport {
         state.remoteTarget = GatewayDiscoveryHelpers.sshTarget(for: gateway) ?? ""
     }
 
-    private static func sshTunnelGatewayUrl(current: String) -> String {
+    static func sshTunnelGatewayUrl(current: String) -> String {
         let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
               let url = URL(string: trimmed),

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
@@ -53,10 +53,6 @@ enum GatewayDiscoverySelectionSupport {
         for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> Bool
     {
         guard GatewayDiscoveryHelpers.directUrl(for: gateway) != nil else { return false }
-        if gateway.gatewayTls || gateway.gatewayDirectReachable {
-            return true
-        }
-
         guard let host = GatewayDiscoveryHelpers.resolvedServiceHost(for: gateway)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
@@ -8,11 +8,13 @@ enum GatewayDiscoverySelectionSupport {
 
     static func applyRemoteSelection(
         gateway: GatewayDiscoveryModel.DiscoveredGateway,
+        currentRouteIsDiscoveryOwned: Bool,
         state: AppState)
     {
         let preferredTransport = self.preferredTransport(
             for: gateway,
-            current: state.remoteTransport)
+            current: state.remoteTransport,
+            currentRouteIsDiscoveryOwned: currentRouteIsDiscoveryOwned)
         if preferredTransport != state.remoteTransport {
             state.remoteTransport = preferredTransport
         }
@@ -41,10 +43,16 @@ enum GatewayDiscoverySelectionSupport {
 
     static func preferredTransport(
         for gateway: GatewayDiscoveryModel.DiscoveredGateway,
-        current: AppState.RemoteTransport) -> AppState.RemoteTransport
+        current: AppState.RemoteTransport,
+        currentRouteIsDiscoveryOwned: Bool = false) -> AppState.RemoteTransport
     {
         if self.shouldPreferDirectTransport(for: gateway) {
             return .direct
+        }
+        // A discovery-owned route must be recomputed for every selected gateway. Otherwise a
+        // previous automatic Direct choice can leak into an unrelated plaintext LAN selection.
+        if currentRouteIsDiscoveryOwned {
+            return .ssh
         }
         return current
     }
@@ -53,12 +61,8 @@ enum GatewayDiscoverySelectionSupport {
         for gateway: GatewayDiscoveryModel.DiscoveredGateway) -> Bool
     {
         guard GatewayDiscoveryHelpers.directUrl(for: gateway) != nil else { return false }
-        guard let host = GatewayDiscoveryHelpers.resolvedServiceHost(for: gateway)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        else {
-            return false
-        }
-        return host.hasSuffix(".ts.net")
+        // Only the internal Tailscale Serve probe establishes direct-route authority. Bonjour
+        // stable ids cannot enter this namespace, so unauthenticated TXT flags remain hints.
+        return gateway.stableID.hasPrefix("tailscale-serve|")
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
@@ -14,8 +14,7 @@ enum GatewayDiscoverySelectionSupport {
         let preferredTransport = self.preferredTransport(
             for: gateway,
             current: state.remoteTransport,
-            preserveCurrentTransport: state.connectionMode == .remote &&
-                !currentRouteIsDiscoveryOwned)
+            currentRouteIsDiscoveryOwned: currentRouteIsDiscoveryOwned)
         if preferredTransport != state.remoteTransport {
             state.remoteTransport = preferredTransport
         }
@@ -45,14 +44,14 @@ enum GatewayDiscoverySelectionSupport {
     static func preferredTransport(
         for gateway: GatewayDiscoveryModel.DiscoveredGateway,
         current: AppState.RemoteTransport,
-        preserveCurrentTransport: Bool = true) -> AppState.RemoteTransport
+        currentRouteIsDiscoveryOwned: Bool = false) -> AppState.RemoteTransport
     {
         if self.shouldPreferDirectTransport(for: gateway) {
             return .direct
         }
-        // Discovery-owned and inactive routes must be recomputed for every selected gateway.
-        // Otherwise an old Direct choice can leak into an unrelated plaintext LAN selection.
-        if !preserveCurrentTransport {
+        // A discovery-owned route must be recomputed for every selected gateway. Otherwise a
+        // previous automatic Direct choice can leak into an unrelated plaintext LAN selection.
+        if currentRouteIsDiscoveryOwned {
             return .ssh
         }
         return current

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
@@ -14,7 +14,8 @@ enum GatewayDiscoverySelectionSupport {
         let preferredTransport = self.preferredTransport(
             for: gateway,
             current: state.remoteTransport,
-            currentRouteIsDiscoveryOwned: currentRouteIsDiscoveryOwned)
+            preserveCurrentTransport: state.connectionMode == .remote &&
+                !currentRouteIsDiscoveryOwned)
         if preferredTransport != state.remoteTransport {
             state.remoteTransport = preferredTransport
         }
@@ -44,14 +45,14 @@ enum GatewayDiscoverySelectionSupport {
     static func preferredTransport(
         for gateway: GatewayDiscoveryModel.DiscoveredGateway,
         current: AppState.RemoteTransport,
-        currentRouteIsDiscoveryOwned: Bool = false) -> AppState.RemoteTransport
+        preserveCurrentTransport: Bool = true) -> AppState.RemoteTransport
     {
         if self.shouldPreferDirectTransport(for: gateway) {
             return .direct
         }
-        // A discovery-owned route must be recomputed for every selected gateway. Otherwise a
-        // previous automatic Direct choice can leak into an unrelated plaintext LAN selection.
-        if currentRouteIsDiscoveryOwned {
+        // Discovery-owned and inactive routes must be recomputed for every selected gateway.
+        // Otherwise an old Direct choice can leak into an unrelated plaintext LAN selection.
+        if !preserveCurrentTransport {
             return .ssh
         }
         return current

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -888,7 +888,11 @@ extension GeneralSettings {
     }
 
     private func applyDiscoveredGateway(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) {
-        GatewayDiscoverySelectionSupport.applyRemoteSelection(gateway: gateway, state: self.state)
+        GatewayDiscoverySelectionSupport.applyRemoteSelection(
+            gateway: gateway,
+            currentRouteIsDiscoveryOwned: GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(
+                state: self.state),
+            state: self.state)
         MacNodeModeCoordinator.shared.setPreferredGatewayStableID(gateway.stableID, state: self.state)
     }
 }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -40,7 +40,11 @@ extension OnboardingView {
         }
         defaultsToLocalGateway = false
         preferredGatewayID = gateway.stableID
-        GatewayDiscoverySelectionSupport.applyRemoteSelection(gateway: gateway, state: state)
+        GatewayDiscoverySelectionSupport.applyRemoteSelection(
+            gateway: gateway,
+            currentRouteIsDiscoveryOwned: GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(
+                state: state),
+            state: state)
 
         state.connectionMode = .remote
         MacNodeModeCoordinator.shared.setPreferredGatewayStableID(gateway.stableID, state: state)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -7,23 +7,23 @@ extension OnboardingView {
         if state.connectionMode != .local {
             resetGatewayBoundAIState()
         }
+        GatewayDiscoveryPreferences.retirePreferredRouteBeforeLeavingRemote(state: state)
         defaultsToLocalGateway = false
         state.connectionMode = .local
         preferredGatewayID = nil
         showAdvancedConnection = false
         showRemoteChoices = false
-        GatewayDiscoveryPreferences.setPreferredStableID(nil)
         probeConfiguredGatewayForDashboard()
     }
 
     func selectUnconfiguredGateway() {
         resetGatewayBoundAIState()
+        GatewayDiscoveryPreferences.retirePreferredRouteBeforeLeavingRemote(state: state)
         defaultsToLocalGateway = false
         state.connectionMode = .unconfigured
         preferredGatewayID = nil
         showAdvancedConnection = false
         showRemoteChoices = false
-        GatewayDiscoveryPreferences.setPreferredStableID(nil)
     }
 
     func selectRemoteGateway(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Actions.swift
@@ -7,7 +7,6 @@ extension OnboardingView {
         if state.connectionMode != .local {
             resetGatewayBoundAIState()
         }
-        GatewayDiscoveryPreferences.retirePreferredRouteBeforeLeavingRemote(state: state)
         defaultsToLocalGateway = false
         state.connectionMode = .local
         preferredGatewayID = nil
@@ -18,7 +17,6 @@ extension OnboardingView {
 
     func selectUnconfiguredGateway() {
         resetGatewayBoundAIState()
-        GatewayDiscoveryPreferences.retirePreferredRouteBeforeLeavingRemote(state: state)
         defaultsToLocalGateway = false
         state.connectionMode = .unconfigured
         preferredGatewayID = nil

--- a/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
@@ -249,6 +249,11 @@ private func saveConfigRoot(_ root: [String: Any], to url: URL) throws {
 private func writeAppDefaults(opts: ConfigureRemoteOptions, target: String, suites: [String]) {
     for suite in suites {
         guard let defaults = UserDefaults(suiteName: suite) else { continue }
+        // CLI configuration is an explicit operator route, so it must not inherit automatic
+        // discovery ownership that would make startup migrate the newly written endpoint.
+        defaults.removeObject(forKey: "gateway.preferredStableID")
+        defaults.removeObject(forKey: "bridge.preferredStableID")
+        defaults.removeObject(forKey: "gateway.preferredStableIDRouteBinding.v1")
         defaults.set("remote", forKey: "openclaw.connectionMode")
         setDefaultString(defaults, key: "openclaw.remoteTarget", value: target)
         defaults.set(true, forKey: "openclaw.onboardingSeen")

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -206,13 +206,45 @@ struct AppStateRemoteConfigTests {
                 ],
             ],
         ]
-        GatewayDiscoveryPreferences.setPreferredStableID("tailscale-serve|\(tailnetHost)")
+        GatewayDiscoveryPreferences.setPreferredStableID(
+            "tailscale-serve|\(tailnetHost)",
+            routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                connectionMode: .remote,
+                remoteTransport: .direct,
+                remoteURL: "wss://\(tailnetHost)",
+                remoteTarget: ""))
 
         let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 
         #expect(!migration.changed)
         #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .direct)
         #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "wss://\(tailnetHost)")
+    }
+
+    @Test
+    func `active bound non serve discovery route is retired`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let directURL = "ws://192.168.1.42:18789"
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": ["transport": "direct", "url": directURL],
+            ],
+        ]
+        GatewayDiscoveryPreferences.setPreferredStableID(
+            "bonjour|nearby-gateway",
+            routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                connectionMode: .remote,
+                remoteTransport: .direct,
+                remoteURL: directURL,
+                remoteTarget: ""))
+
+        let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
+
+        #expect(migration.changed)
+        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "ws://127.0.0.1:18789")
     }
 
     @Test
@@ -310,6 +342,35 @@ struct AppStateRemoteConfigTests {
             ],
         ]
         GatewayDiscoveryPreferences.setPreferredStableID(nil)
+
+        let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
+
+        #expect(!migration.changed)
+        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .direct)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) ==
+            "wss://manual-gateway.example.test")
+    }
+
+    @Test
+    func `active direct route with a mismatched binding remains operator owned`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://manual-gateway.example.test",
+                ],
+            ],
+        ]
+        GatewayDiscoveryPreferences.setPreferredStableID(
+            "bonjour|old-gateway",
+            routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                connectionMode: .remote,
+                remoteTransport: .direct,
+                remoteURL: "wss://old-gateway.example.test",
+                remoteTarget: ""))
 
         let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -248,7 +248,7 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
-    func `inactive direct route without discovery provenance remains operator owned`() {
+    func `inactive direct route without reliable provenance is retired`() {
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
         GatewayDiscoveryPreferences.setPreferredStableID(nil)
@@ -264,13 +264,13 @@ struct AppStateRemoteConfigTests {
         ]
         let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 
-        #expect(!migration.changed)
-        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .direct)
-        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "wss://\(tailnetHost)")
+        #expect(migration.changed)
+        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "ws://127.0.0.1:18789")
     }
 
     @Test
-    func `cold inactive direct route is preserved but cannot authorize next discovery selection`() async {
+    func `cold inactive direct route is retired before mode only reactivation`() async {
         let configPath = TestIsolation.tempConfigPath()
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
@@ -301,27 +301,12 @@ struct AppStateRemoteConfigTests {
             let startup = GatewayDiscoveryPreferences.prepareStartupConfig(
                 isPreview: false,
                 saver: { OpenClawConfigFile.saveDict($0) })
-            #expect(!startup.migrationChanged)
+            #expect(startup.migrationChanged)
             #expect(startup.migrationPersisted)
-            #expect(startup.remoteTransport == .direct)
+            #expect(startup.remoteTransport == .ssh)
 
             let state = AppState(preview: true)
-            GatewayDiscoverySelectionSupport.applyRemoteSelection(
-                gateway: GatewayDiscoveryModel.DiscoveredGateway(
-                    displayName: "Nearby gateway",
-                    serviceHost: "nearby-gateway.local",
-                    servicePort: 18789,
-                    lanHost: nil,
-                    tailnetDns: nil,
-                    sshPort: 22,
-                    gatewayPort: 18789,
-                    gatewayDirectReachable: true,
-                    stableID: "bonjour|nearby-gateway",
-                    debugID: "nearby-gateway",
-                    isLocal: false),
-                currentRouteIsDiscoveryOwned: GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(
-                    state: state),
-                state: state)
+            state.connectionMode = .remote
 
             #expect(state.remoteTransport == .ssh)
             #expect(state.remoteUrl == "ws://127.0.0.1:18789")

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -215,6 +215,29 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
+    func `legacy direct route is retired while gateway mode is inactive`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let tailnetHost = "gateway-host.tailnet-example.ts.net"
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "local",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://\(tailnetHost)",
+                ],
+            ],
+        ]
+        GatewayDiscoveryPreferences.setPreferredStableID("tailscale-serve|\(tailnetHost)")
+
+        let migration = GatewayDiscoveryPreferences.migrateLegacyUnboundDiscoveryRoute(root)
+
+        #expect(migration.changed)
+        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "ws://127.0.0.1:18789")
+    }
+
+    @Test
     func `invalid remote drafts cannot be persisted for a configured gateway probe`() {
         let base = AppState.GatewayConfigSyncDraft(
             connectionMode: .remote,

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -173,7 +173,7 @@ struct AppStateRemoteConfigTests {
             ]
             GatewayDiscoveryPreferences.setPreferredStableID("legacy-gateway")
 
-            let migration = AppState.migrateLegacyUnboundDiscoveryRoute(vulnerableRoot)
+            let migration = GatewayDiscoveryPreferences.migrateLegacyUnboundDiscoveryRoute(vulnerableRoot)
             #expect(migration.changed)
             #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
             #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) ==

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawDiscovery
 import Testing
 @testable import OpenClaw
 
@@ -670,6 +671,57 @@ struct AppStateRemoteConfigTests {
         #expect(routeIdentity != "remote:id:gateway-a")
         #expect(!OnboardingSystemAgentResumeStore.isPending(for: routeIdentity))
         #expect(OnboardingSystemAgentResumeStore.isPending(for: "remote:id:gateway-a"))
+    }
+
+    @Test
+    func `config watcher mode exit retires discovered direct before next selection`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+
+        for destination in [AppState.ConnectionMode.local, .unconfigured] {
+            let trustedURL = "wss://trusted-gateway.example.ts.net"
+            let state = AppState(preview: true)
+            state._testApplyConfigOverrides([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": ["transport": "direct", "url": trustedURL],
+                ],
+            ])
+            GatewayDiscoveryPreferences.setPreferredStableID(
+                "tailscale-serve|trusted-gateway.example.ts.net",
+                routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                    connectionMode: state.connectionMode,
+                    remoteTransport: state.remoteTransport,
+                    remoteURL: state.remoteUrl,
+                    remoteTarget: state.remoteTarget))
+
+            state._testApplyConfigOverrides([
+                "gateway": [
+                    "mode": destination.rawValue,
+                    "remote": ["transport": "direct", "url": trustedURL],
+                ],
+            ])
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: GatewayDiscoveryModel.DiscoveredGateway(
+                    displayName: "Nearby gateway",
+                    serviceHost: "nearby-gateway.local",
+                    servicePort: 18789,
+                    lanHost: nil,
+                    tailnetDns: nil,
+                    sshPort: 22,
+                    gatewayPort: 18789,
+                    gatewayDirectReachable: true,
+                    stableID: "bonjour|nearby-gateway",
+                    debugID: "nearby-gateway",
+                    isLocal: false),
+                currentRouteIsDiscoveryOwned: GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(
+                    state: state),
+                state: state)
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:18789")
+            #expect(GatewayDiscoveryPreferences.preferredStableID() == nil)
+        }
     }
 
     @Test

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -153,24 +153,41 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
-    func `legacy unbound discovery selection adopts its current route`() {
+    func `legacy unbound direct selection is retired before endpoint publication`() async {
+        let configPath = TestIsolation.tempConfigPath()
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
-        let state = AppState(preview: true)
-        state.connectionMode = .remote
-        state.remoteTransport = .direct
-        state.remoteUrl = "ws://legacy-gateway.local:18789"
-        GatewayDiscoveryPreferences.setPreferredStableID("legacy-gateway")
+        await TestIsolation.withIsolatedState(
+            env: ["OPENCLAW_CONFIG_PATH": configPath],
+            defaults: [connectionModeKey: AppState.ConnectionMode.remote.rawValue])
+        {
+            let vulnerableRoot: [String: Any] = [
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "ws://legacy-gateway.local:18789",
+                        "token": "stored-token",
+                    ],
+                ],
+            ]
+            GatewayDiscoveryPreferences.setPreferredStableID("legacy-gateway")
 
-        #expect(!state._testReconcilePreferredGatewayRouteBinding())
-        #expect(GatewayDiscoveryPreferences.preferredStableID() == "legacy-gateway")
-        #expect(GatewayDiscoveryPreferences.preferredRouteBinding() ==
-            GatewayDiscoveryPreferences.routeBinding(
-                connectionMode: state.connectionMode,
-                remoteTransport: state.remoteTransport,
-                remoteURL: state.remoteUrl,
-                remoteTarget: state.remoteTarget))
-        #expect(GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(state: state))
+            let migration = AppState.migrateLegacyUnboundDiscoveryRoute(vulnerableRoot)
+            #expect(migration.changed)
+            #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
+            #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) ==
+                "ws://127.0.0.1:18789")
+            #expect(OpenClawConfigFile.saveDict(migration.root))
+
+            let state = AppState(preview: true)
+            let source = await GatewayEndpointStore._testLiveSourceSnapshot(
+                state: state,
+                beforeConfigRead: {})
+            #expect(state.remoteTransport == .ssh)
+            #expect(source.remoteTransport == .ssh)
+            #expect(source.directRemoteURL == nil)
+        }
     }
 
     @Test

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -219,6 +219,7 @@ struct AppStateRemoteConfigTests {
     func `legacy direct route is retired while gateway mode is inactive`() {
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
+        GatewayDiscoveryPreferences.setPreferredStableID(nil)
         let tailnetHost = "gateway-host.tailnet-example.ts.net"
         let root: [String: Any] = [
             "gateway": [
@@ -229,8 +230,6 @@ struct AppStateRemoteConfigTests {
                 ],
             ],
         ]
-        GatewayDiscoveryPreferences.setPreferredStableID("tailscale-serve|\(tailnetHost)")
-
         let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 
         #expect(migration.changed)
@@ -298,25 +297,19 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
-    func `inactive direct route with a mismatched binding remains operator owned`() {
+    func `active direct route without a discovery receipt remains operator owned`() {
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
         let root: [String: Any] = [
             "gateway": [
-                "mode": "local",
+                "mode": "remote",
                 "remote": [
                     "transport": "direct",
                     "url": "wss://manual-gateway.example.test",
                 ],
             ],
         ]
-        GatewayDiscoveryPreferences.setPreferredStableID(
-            "bonjour|old-gateway",
-            routeBinding: GatewayDiscoveryPreferences.routeBinding(
-                connectionMode: .remote,
-                remoteTransport: .direct,
-                remoteURL: "wss://old-gateway.example.test",
-                remoteTarget: ""))
+        GatewayDiscoveryPreferences.setPreferredStableID(nil)
 
         let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -153,6 +153,27 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
+    func `legacy unbound discovery selection adopts its current route`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let state = AppState(preview: true)
+        state.connectionMode = .remote
+        state.remoteTransport = .direct
+        state.remoteUrl = "ws://legacy-gateway.local:18789"
+        GatewayDiscoveryPreferences.setPreferredStableID("legacy-gateway")
+
+        #expect(!state._testReconcilePreferredGatewayRouteBinding())
+        #expect(GatewayDiscoveryPreferences.preferredStableID() == "legacy-gateway")
+        #expect(GatewayDiscoveryPreferences.preferredRouteBinding() ==
+            GatewayDiscoveryPreferences.routeBinding(
+                connectionMode: state.connectionMode,
+                remoteTransport: state.remoteTransport,
+                remoteURL: state.remoteUrl,
+                remoteTarget: state.remoteTarget))
+        #expect(GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(state: state))
+    }
+
+    @Test
     func `invalid remote drafts cannot be persisted for a configured gateway probe`() {
         let base = AppState.GatewayConfigSyncDraft(
             connectionMode: .remote,

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -175,7 +175,7 @@ struct AppStateRemoteConfigTests {
             GatewayDiscoveryPreferences.setPreferredStableID(
                 "tailscale-serve|verified-gateway.example.ts.net")
 
-            let migration = GatewayDiscoveryPreferences.migrateLegacyUnboundDiscoveryRoute(vulnerableRoot)
+            let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(vulnerableRoot)
             #expect(migration.changed)
             #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
             #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) ==
@@ -208,7 +208,7 @@ struct AppStateRemoteConfigTests {
         ]
         GatewayDiscoveryPreferences.setPreferredStableID("tailscale-serve|\(tailnetHost)")
 
-        let migration = GatewayDiscoveryPreferences.migrateLegacyUnboundDiscoveryRoute(root)
+        let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 
         #expect(!migration.changed)
         #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .direct)
@@ -231,11 +231,99 @@ struct AppStateRemoteConfigTests {
         ]
         GatewayDiscoveryPreferences.setPreferredStableID("tailscale-serve|\(tailnetHost)")
 
-        let migration = GatewayDiscoveryPreferences.migrateLegacyUnboundDiscoveryRoute(root)
+        let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 
         #expect(migration.changed)
         #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
         #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "ws://127.0.0.1:18789")
+    }
+
+    @Test
+    func `cold inactive bound direct route is retired before next discovery selection`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+
+        await TestIsolation.withIsolatedState(
+            env: ["OPENCLAW_CONFIG_PATH": configPath],
+            defaults: [connectionModeKey: AppState.ConnectionMode.local.rawValue])
+        {
+            let trustedURL = "wss://trusted-gateway.example.ts.net"
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                    "remote": [
+                        "transport": "direct",
+                        "url": trustedURL,
+                        "token": "stored-token",
+                    ],
+                ],
+            ]))
+            GatewayDiscoveryPreferences.setPreferredStableID(
+                "tailscale-serve|trusted-gateway.example.ts.net",
+                routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                    connectionMode: .remote,
+                    remoteTransport: .direct,
+                    remoteURL: trustedURL,
+                    remoteTarget: ""))
+
+            let startup = GatewayDiscoveryPreferences.prepareStartupConfig(
+                isPreview: false,
+                saver: { OpenClawConfigFile.saveDict($0) })
+            #expect(startup.migrationChanged)
+            #expect(startup.migrationPersisted)
+            #expect(startup.remoteTransport == .ssh)
+
+            let state = AppState(preview: true)
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: GatewayDiscoveryModel.DiscoveredGateway(
+                    displayName: "Nearby gateway",
+                    serviceHost: "nearby-gateway.local",
+                    servicePort: 18789,
+                    lanHost: nil,
+                    tailnetDns: nil,
+                    sshPort: 22,
+                    gatewayPort: 18789,
+                    gatewayDirectReachable: true,
+                    stableID: "bonjour|nearby-gateway",
+                    debugID: "nearby-gateway",
+                    isLocal: false),
+                currentRouteIsDiscoveryOwned: GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(
+                    state: state),
+                state: state)
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:18789")
+        }
+    }
+
+    @Test
+    func `inactive direct route with a mismatched binding remains operator owned`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "local",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://manual-gateway.example.test",
+                ],
+            ],
+        ]
+        GatewayDiscoveryPreferences.setPreferredStableID(
+            "bonjour|old-gateway",
+            routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                connectionMode: .remote,
+                remoteTransport: .direct,
+                remoteURL: "wss://old-gateway.example.test",
+                remoteTarget: ""))
+
+        let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
+
+        #expect(!migration.changed)
+        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .direct)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) ==
+            "wss://manual-gateway.example.test")
     }
 
     @Test

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -129,6 +129,30 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
+    func `discovery ownership requires the bound route to remain current`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let state = AppState(preview: true)
+        state.connectionMode = .remote
+        state.remoteTransport = .direct
+        state.remoteUrl = "wss://gateway-a.example.test"
+
+        GatewayDiscoveryPreferences.setPreferredStableID(
+            "gateway-a",
+            routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                connectionMode: state.connectionMode,
+                remoteTransport: state.remoteTransport,
+                remoteURL: state.remoteUrl,
+                remoteTarget: state.remoteTarget))
+
+        #expect(GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(state: state))
+
+        state.remoteUrl = "ws://gateway-b.example.ts.net:18789"
+
+        #expect(!GatewayDiscoveryPreferences.currentRouteIsDiscoveryOwned(state: state))
+    }
+
+    @Test
     func `invalid remote drafts cannot be persisted for a configured gateway probe`() {
         let base = AppState.GatewayConfigSyncDraft(
             connectionMode: .remote,

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -171,7 +171,8 @@ struct AppStateRemoteConfigTests {
                     ],
                 ],
             ]
-            GatewayDiscoveryPreferences.setPreferredStableID("legacy-gateway")
+            GatewayDiscoveryPreferences.setPreferredStableID(
+                "tailscale-serve|verified-gateway.example.ts.net")
 
             let migration = GatewayDiscoveryPreferences.migrateLegacyUnboundDiscoveryRoute(vulnerableRoot)
             #expect(migration.changed)
@@ -188,6 +189,29 @@ struct AppStateRemoteConfigTests {
             #expect(source.remoteTransport == .ssh)
             #expect(source.directRemoteURL == nil)
         }
+    }
+
+    @Test
+    func `legacy verified tailscale serve route remains direct`() {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let tailnetHost = "gateway-host.tailnet-example.ts.net"
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://\(tailnetHost)",
+                ],
+            ],
+        ]
+        GatewayDiscoveryPreferences.setPreferredStableID("tailscale-serve|\(tailnetHost)")
+
+        let migration = GatewayDiscoveryPreferences.migrateLegacyUnboundDiscoveryRoute(root)
+
+        #expect(!migration.changed)
+        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .direct)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "wss://\(tailnetHost)")
     }
 
     @Test

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -248,7 +248,7 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
-    func `legacy direct route is retired while gateway mode is inactive`() {
+    func `inactive direct route without discovery provenance remains operator owned`() {
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
         GatewayDiscoveryPreferences.setPreferredStableID(nil)
@@ -264,13 +264,13 @@ struct AppStateRemoteConfigTests {
         ]
         let migration = GatewayDiscoveryPreferences.migrateUnsafeDiscoveryRoute(root)
 
-        #expect(migration.changed)
-        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .ssh)
-        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "ws://127.0.0.1:18789")
+        #expect(!migration.changed)
+        #expect(GatewayRemoteConfig.resolveTransport(root: migration.root) == .direct)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: migration.root) == "wss://\(tailnetHost)")
     }
 
     @Test
-    func `cold inactive bound direct route is retired before next discovery selection`() async {
+    func `cold inactive direct route is preserved but cannot authorize next discovery selection`() async {
         let configPath = TestIsolation.tempConfigPath()
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
@@ -301,9 +301,9 @@ struct AppStateRemoteConfigTests {
             let startup = GatewayDiscoveryPreferences.prepareStartupConfig(
                 isPreview: false,
                 saver: { OpenClawConfigFile.saveDict($0) })
-            #expect(startup.migrationChanged)
+            #expect(!startup.migrationChanged)
             #expect(startup.migrationPersisted)
-            #expect(startup.remoteTransport == .ssh)
+            #expect(startup.remoteTransport == .direct)
 
             let state = AppState(preview: true)
             GatewayDiscoverySelectionSupport.applyRemoteSelection(

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
@@ -170,12 +170,20 @@ struct ConfigureRemoteCommandTests {
         try FileManager().createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try initialData.write(to: configURL)
 
+        let defaultsSuite = "ConfigureRemoteCommandTests.direct.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsSuite))
+        defaults.set("bonjour|old-gateway", forKey: "gateway.preferredStableID")
+        defaults.set(
+            "remote:direct:wss://old-gateway.example",
+            forKey: "gateway.preferredStableIDRouteBinding.v1")
+        defer { defaults.removePersistentDomain(forName: defaultsSuite) }
+
         try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configURL.path]) {
             let output = try configureRemote(
                 .init(
                     directUrl: "ws://192.168.0.202:18789",
                     token: "test-token"), // pragma: allowlist secret
-                defaultsSuites: [])
+                defaultsSuites: [defaultsSuite])
 
             #expect(output.transport == "direct")
             #expect(output.remoteUrl == "ws://192.168.0.202:18789")
@@ -195,6 +203,8 @@ struct ConfigureRemoteCommandTests {
             #expect(remote["sshTarget"] == nil)
             #expect(remote["sshHostKeyPolicy"] == nil)
             #expect(remote["token"] as? String == "test-token") // pragma: allowlist secret
+            #expect(defaults.string(forKey: "gateway.preferredStableID") == nil)
+            #expect(defaults.string(forKey: "gateway.preferredStableIDRouteBinding.v1") == nil)
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryHelpersTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryHelpersTests.swift
@@ -79,7 +79,12 @@ struct GatewayDiscoveryHelpersTests {
         let wsGateway = self.makeGateway(
             serviceHost: "resolved.example.ts.net",
             servicePort: 18789)
-        #expect(GatewayDiscoveryHelpers.directUrl(for: wsGateway) == "ws://resolved.example.ts.net:18789")
+        #expect(GatewayDiscoveryHelpers.directUrl(for: wsGateway) == "wss://resolved.example.ts.net:18789")
+
+        let lanGateway = self.makeGateway(
+            serviceHost: "resolved.local",
+            servicePort: 18789)
+        #expect(GatewayDiscoveryHelpers.directUrl(for: lanGateway) == "ws://resolved.local:18789")
 
         let localGateway = self.makeGateway(
             serviceHost: "127.0.0.1",

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryHelpersTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryHelpersTests.swift
@@ -79,7 +79,7 @@ struct GatewayDiscoveryHelpersTests {
         let wsGateway = self.makeGateway(
             serviceHost: "resolved.example.ts.net",
             servicePort: 18789)
-        #expect(GatewayDiscoveryHelpers.directUrl(for: wsGateway) == "wss://resolved.example.ts.net:18789")
+        #expect(GatewayDiscoveryHelpers.directUrl(for: wsGateway) == "ws://resolved.example.ts.net:18789")
 
         let lanGateway = self.makeGateway(
             serviceHost: "resolved.local",

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
@@ -46,6 +46,7 @@ struct GatewayDiscoverySelectionSupportTests {
                     tailnetDns: tailnetHost,
                     gatewayTls: true,
                     stableID: "tailscale-serve|\(tailnetHost)"),
+                currentRouteIsDiscoveryOwned: false,
                 state: state)
 
             #expect(state.remoteTransport == .direct)
@@ -54,7 +55,7 @@ struct GatewayDiscoverySelectionSupportTests {
         }
     }
 
-    @Test func `selecting merged tailnet gateway still switches to direct transport`() async {
+    @Test func `selecting txt advertised tailnet gateway keeps ssh transport`() async {
         let tailnetHost = "gateway-host.tailnet-example.ts.net"
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
@@ -68,14 +69,15 @@ struct GatewayDiscoverySelectionSupportTests {
                     tailnetDns: tailnetHost,
                     gatewayTls: true,
                     stableID: "wide-area|openclaw.internal.|gateway-host"),
+                currentRouteIsDiscoveryOwned: false,
                 state: state)
 
-            #expect(state.remoteTransport == .direct)
-            #expect(state.remoteUrl == "wss://\(tailnetHost)")
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:18789")
         }
     }
 
-    @Test func `tailnet discovery without reachability flags uses secure direct transport`() async {
+    @Test func `tailnet discovery without verified serve source keeps ssh transport`() async {
         let tailnetHost = "gateway-host.tailnet-example.ts.net"
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
@@ -88,10 +90,11 @@ struct GatewayDiscoverySelectionSupportTests {
                     servicePort: 18789,
                     tailnetDns: tailnetHost,
                     stableID: "wide-area|openclaw.internal.|gateway-host"),
+                currentRouteIsDiscoveryOwned: false,
                 state: state)
 
-            #expect(state.remoteTransport == .direct)
-            #expect(state.remoteUrl == "wss://\(tailnetHost):18789")
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:18789")
         }
     }
 
@@ -108,6 +111,7 @@ struct GatewayDiscoverySelectionSupportTests {
                     serviceHost: "nearby-gateway.local",
                     servicePort: 18789,
                     stableID: "bonjour|nearby-gateway"),
+                currentRouteIsDiscoveryOwned: false,
                 state: state)
 
             #expect(state.remoteTransport == .ssh)
@@ -129,6 +133,7 @@ struct GatewayDiscoverySelectionSupportTests {
                     servicePort: 19999,
                     gatewayDirectReachable: true,
                     stableID: "bonjour|nearby-gateway-custom"),
+                currentRouteIsDiscoveryOwned: false,
                 state: state)
 
             #expect(state.remoteTransport == .ssh)
@@ -149,6 +154,7 @@ struct GatewayDiscoverySelectionSupportTests {
                     servicePort: 443,
                     gatewayTls: true,
                     stableID: "bonjour|nearby-gateway-tls"),
+                currentRouteIsDiscoveryOwned: false,
                 state: state)
 
             #expect(state.remoteTransport == .ssh)
@@ -167,10 +173,52 @@ struct GatewayDiscoverySelectionSupportTests {
                     serviceHost: "nearby-gateway.local",
                     servicePort: 19999,
                     stableID: "bonjour|nearby-gateway-manual"),
+                currentRouteIsDiscoveryOwned: false,
                 state: state)
 
             #expect(state.remoteTransport == .direct)
             #expect(state.remoteUrl == "ws://nearby-gateway.local:19999")
+        }
+    }
+
+    @Test func `selecting raw tailnet gateway preserves explicit direct transport`() async {
+        let tailnetHost = "gateway-host.tailnet-example.ts.net"
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
+            let state = AppState(preview: true)
+            state.remoteTransport = .direct
+
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: self.makeGateway(
+                    serviceHost: tailnetHost,
+                    servicePort: 18789,
+                    stableID: "wide-area|openclaw.internal.|gateway-host"),
+                currentRouteIsDiscoveryOwned: false,
+                state: state)
+
+            #expect(state.remoteTransport == .direct)
+            #expect(state.remoteUrl == "ws://\(tailnetHost):18789")
+        }
+    }
+
+    @Test func `new lan selection retires prior discovery owned direct transport`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
+            let state = AppState(preview: true)
+            state.remoteTransport = .direct
+            state.remoteUrl = "wss://old-gateway.example.ts.net"
+
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: self.makeGateway(
+                    serviceHost: "nearby-gateway.local",
+                    servicePort: 18789,
+                    gatewayDirectReachable: true,
+                    stableID: "bonjour|nearby-gateway-new"),
+                currentRouteIsDiscoveryOwned: true,
+                state: state)
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:18789")
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
@@ -75,7 +75,7 @@ struct GatewayDiscoverySelectionSupportTests {
         }
     }
 
-    @Test func `legacy tailnet discovery without reachability flags still switches to direct transport`() async {
+    @Test func `tailnet discovery without reachability flags uses secure direct transport`() async {
         let tailnetHost = "gateway-host.tailnet-example.ts.net"
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
@@ -91,7 +91,7 @@ struct GatewayDiscoverySelectionSupportTests {
                 state: state)
 
             #expect(state.remoteTransport == .direct)
-            #expect(state.remoteUrl == "ws://\(tailnetHost):18789")
+            #expect(state.remoteUrl == "wss://\(tailnetHost):18789")
         }
     }
 
@@ -116,7 +116,7 @@ struct GatewayDiscoverySelectionSupportTests {
         }
     }
 
-    @Test func `selecting direct reachable lan gateway ignores stale local tunnel port`() async {
+    @Test func `selecting direct reachable lan gateway keeps ssh transport`() async {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
             let state = AppState(preview: true)
@@ -129,6 +129,44 @@ struct GatewayDiscoverySelectionSupportTests {
                     servicePort: 19999,
                     gatewayDirectReachable: true,
                     stableID: "bonjour|nearby-gateway-custom"),
+                state: state)
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:29876")
+        }
+    }
+
+    @Test func `selecting tls advertised lan gateway keeps ssh transport`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
+            let state = AppState(preview: true)
+            state.remoteTransport = .ssh
+            state.remoteUrl = "ws://localhost:29876"
+
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: self.makeGateway(
+                    serviceHost: "nearby-gateway.local",
+                    servicePort: 443,
+                    gatewayTls: true,
+                    stableID: "bonjour|nearby-gateway-tls"),
+                state: state)
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:29876")
+        }
+    }
+
+    @Test func `selecting lan gateway preserves explicit direct transport`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
+            let state = AppState(preview: true)
+            state.remoteTransport = .direct
+
+            GatewayDiscoverySelectionSupport.applyRemoteSelection(
+                gateway: self.makeGateway(
+                    serviceHost: "nearby-gateway.local",
+                    servicePort: 19999,
+                    stableID: "bonjour|nearby-gateway-manual"),
                 state: state)
 
             #expect(state.remoteTransport == .direct)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
@@ -166,7 +166,6 @@ struct GatewayDiscoverySelectionSupportTests {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
             let state = AppState(preview: true)
-            state.connectionMode = .remote
             state.remoteTransport = .direct
 
             GatewayDiscoverySelectionSupport.applyRemoteSelection(
@@ -187,7 +186,6 @@ struct GatewayDiscoverySelectionSupportTests {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
             let state = AppState(preview: true)
-            state.connectionMode = .remote
             state.remoteTransport = .direct
 
             GatewayDiscoverySelectionSupport.applyRemoteSelection(
@@ -207,7 +205,6 @@ struct GatewayDiscoverySelectionSupportTests {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
             let state = AppState(preview: true)
-            state.connectionMode = .remote
             state.remoteTransport = .direct
             state.remoteUrl = "wss://old-gateway.example.ts.net"
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
@@ -166,6 +166,7 @@ struct GatewayDiscoverySelectionSupportTests {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
             let state = AppState(preview: true)
+            state.connectionMode = .remote
             state.remoteTransport = .direct
 
             GatewayDiscoverySelectionSupport.applyRemoteSelection(
@@ -186,6 +187,7 @@ struct GatewayDiscoverySelectionSupportTests {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
             let state = AppState(preview: true)
+            state.connectionMode = .remote
             state.remoteTransport = .direct
 
             GatewayDiscoverySelectionSupport.applyRemoteSelection(
@@ -205,6 +207,7 @@ struct GatewayDiscoverySelectionSupportTests {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
             let state = AppState(preview: true)
+            state.connectionMode = .remote
             state.remoteTransport = .direct
             state.remoteUrl = "wss://old-gateway.example.ts.net"
 

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -499,6 +499,48 @@ struct OnboardingViewSmokeTests {
             defaults: defaults))
     }
 
+    @Test func `leaving remote retires discovered direct transport before another selection`() {
+        let previousGatewayPreference = captureOnboardingGatewayPreference()
+        defer { restoreOnboardingGatewayPreference(previousGatewayPreference) }
+        let destinations: [AppState.ConnectionMode] = [.local, .unconfigured]
+
+        for destination in destinations {
+            let state = AppState(preview: true)
+            state.connectionMode = .remote
+            state.remoteTransport = .direct
+            state.remoteUrl = "wss://trusted-gateway.example.ts.net"
+            GatewayDiscoveryPreferences.setPreferredStableID(
+                "tailscale-serve|trusted-gateway.example.ts.net",
+                routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                    connectionMode: state.connectionMode,
+                    remoteTransport: state.remoteTransport,
+                    remoteURL: state.remoteUrl,
+                    remoteTarget: state.remoteTarget))
+            let view = OnboardingView(state: state)
+
+            if destination == .local {
+                view.selectLocalGateway()
+            } else {
+                view.selectUnconfiguredGateway()
+            }
+            view.selectRemoteGateway(GatewayDiscoveryModel.DiscoveredGateway(
+                displayName: "Nearby gateway",
+                serviceHost: "nearby-gateway.local",
+                servicePort: 18789,
+                lanHost: nil,
+                tailnetDns: nil,
+                sshPort: 22,
+                gatewayPort: 18789,
+                gatewayDirectReachable: true,
+                stableID: "bonjour|nearby-gateway",
+                debugID: "nearby-gateway",
+                isLocal: false))
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:18789")
+        }
+    }
+
     @Test func `same local selection preserves pending gateway setup state`() throws {
         let (defaults, suiteName) = try makeOnboardingResumeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -314,7 +314,6 @@ struct OnboardingViewSmokeTests {
             restoreOnboardingGatewayPreference(previousGatewayPreference)
             defaults.removePersistentDomain(forName: suiteName)
         }
-        GatewayDiscoveryPreferences.setPreferredStableID("gateway-a")
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-a",
             defaults: defaults)
@@ -322,6 +321,13 @@ struct OnboardingViewSmokeTests {
         await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
             let state = AppState(preview: true)
             state.connectionMode = .remote
+            GatewayDiscoveryPreferences.setPreferredStableID(
+                "gateway-a",
+                routeBinding: GatewayDiscoveryPreferences.routeBinding(
+                    connectionMode: state.connectionMode,
+                    remoteTransport: state.remoteTransport,
+                    remoteURL: state.remoteUrl,
+                    remoteTarget: state.remoteTarget))
             let view = OnboardingView(
                 state: state,
                 permissionMonitor: PermissionMonitor.shared,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where selecting a discovered gateway in the macOS app could unexpectedly switch away from the configured SSH transport when optional discovery hints were present.

## Why This Change Was Made

Automatic direct selection now relies on the resolved Tailnet endpoint and always uses `wss://`. Explicitly selected direct LAN routes continue to support `ws://`, so operator-chosen local setups keep working without letting discovery hints change the transport choice.

## User Impact

Nearby gateway selection keeps the configured SSH route unless the resolved endpoint is a secure Tailnet route. Existing explicit direct LAN configurations remain supported.

## Evidence

- Added regression coverage for both direct-reachability and TLS discovery hints while SSH is configured.
- Added a positive control for explicit direct LAN selection.
- Added coverage that automatic Tailnet selection uses `wss://` without relying on discovery flags.
- Further validation is tracked in the PR checks.

AI-assisted change.
