### PR TITLE
fix(onboarding): honor external gateway supervision

### DIFF
--- a/scripts/e2e/system-agent-first-run-docker.sh
+++ b/scripts/e2e/system-agent-first-run-docker.sh
@@ -24,6 +24,7 @@ set +e
 docker_e2e_run_with_harness \
   --name "$CONTAINER_NAME" \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
+  -e "OPENCLAW_SUPERVISOR_MODE=external" \
   "$IMAGE_NAME" \
   bash -lc "set -euo pipefail
     source scripts/lib/openclaw-e2e-instance.sh

--- a/src/system-agent/setup-apply.test.ts
+++ b/src/system-agent/setup-apply.test.ts
@@ -1018,17 +1018,15 @@ describe("applySystemAgentSetup transaction boundaries", () => {
     expect(result.gateway).toEqual({ status: "failed", error: "service exploded" });
   });
 
-  it("preserves the service owner's failed install outcome after config commits", async () => {
-    mocks.ensureGatewayService.mockResolvedValueOnce({
-      gateway: { status: "failed", error: "gateway install blocked" },
-      containerWithoutUserSystemd: false,
-    });
-
+  it.each([
+    { status: "failed", error: "gateway install blocked" } as const,
+    { status: "skipped", reason: "external" } as const,
+  ])("preserves the service owner's $status outcome after config commits", async (gateway) => {
+    mocks.ensureGatewayService.mockResolvedValueOnce({ gateway });
     const result = await applySystemAgentSetup(baseParams({ surface: "cli" }));
-
-    expect(result.workspaceReady).toBe(true);
-    expect(result.gateway).toEqual({ status: "failed", error: "gateway install blocked" });
-    expect(result.lines).toContain("Gateway service: gateway install blocked");
+    const marker = gateway.status === "failed" ? gateway.error : "SUPERVISOR_MODE=external";
+    expect(result.gateway).toEqual(gateway);
+    expect(result.lines.join("\n")).toContain(marker);
     expect(mocks.waitForGatewayReachable).not.toHaveBeenCalled();
   });
 

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -14,6 +14,7 @@ import { applyMergePatch } from "../config/merge-patch.js";
 import type { AgentModelEntryConfig } from "../config/types.agent-defaults.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { formatExternalSupervisorActionRequired } from "../infra/gateway-supervision.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -692,6 +693,8 @@ export async function applySystemAgentSetup(
             gateway = { status: "failed", error: `Gateway is not reachable yet (${detail}).` };
             lines.push(`Gateway: not reachable yet (${detail}) — say \`gateway status\` to check`);
           }
+        } else if (gateway.reason === "external") {
+          lines.push(`Gateway: ${formatExternalSupervisorActionRequired("start the gateway")}`);
         } else {
           lines.push(
             "Gateway: service install skipped — say `start gateway` when you want it running.",

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayTlsConfig } from "../config/types.gateway.js";
 import type { PluginWebSearchProviderEntry } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
 
 type DefaultModelAuthStatus = ReturnType<typeof AuthChoiceModelCheck.resolveDefaultModelAuthStatus>;
 type DefaultModelCatalogFacts = ReturnType<
@@ -1316,6 +1317,75 @@ describe("finalizeSetupWizard", () => {
 
     expect(result.gateway).toEqual({ status: "failed", error: "service install exploded" });
     expectNoteContains(prompter, "service install exploded", "Gateway");
+  });
+
+  it("recognizes external supervision before probing Linux systemd", async () => {
+    await withPlatform("linux", async () => {
+      await withEnvAsync({ OPENCLAW_SUPERVISOR_MODE: "external" }, async () => {
+        isSystemdUserServiceAvailable.mockResolvedValue(false);
+        isContainerEnvironment.mockReturnValue(true);
+        const prompter = createLaterPrompter();
+
+        const result = await ensureGatewayServiceForOnboarding({
+          flow: "quickstart",
+          opts: {},
+          nextConfig: {},
+          settings: { port: 18789 },
+          prompter,
+          runtime: createRuntime(),
+        });
+
+        expect(result).toEqual({
+          gateway: { status: "skipped", reason: "external" },
+          containerWithoutUserSystemd: false,
+        });
+        expect(isSystemdUserServiceAvailable).not.toHaveBeenCalled();
+        expect(isContainerEnvironment).not.toHaveBeenCalled();
+        expectNoteContains(
+          prompter,
+          "OpenClaw gateway lifecycle is managed by an external supervisor",
+          "Gateway",
+        );
+        expectNoteNotContains(prompter, "Systemd user services are not available");
+        expect(gatewayServiceInstall).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  it("preserves external supervision through unreachable container recovery", async () => {
+    await withPlatform("linux", async () => {
+      await withEnvAsync({ OPENCLAW_SUPERVISOR_MODE: "external" }, async () => {
+        isSystemdUserServiceAvailable.mockResolvedValue(false);
+        isContainerEnvironment.mockReturnValue(true);
+        waitForGatewayReachable.mockResolvedValue({
+          ok: false,
+          detail: "external gateway is offline",
+        });
+        probeGatewayReachable.mockResolvedValue({
+          ok: false,
+          detail: "external gateway is offline",
+        });
+        const prompter = createLaterPrompter();
+        const args = createAdvancedFinalizeArgs({ prompter });
+
+        await finalizeSetupWizard({
+          ...args,
+          opts: { ...args.opts, skipHealth: false, skipUi: false },
+        });
+
+        expect(isSystemdUserServiceAvailable).not.toHaveBeenCalled();
+        expect(isContainerEnvironment).not.toHaveBeenCalled();
+        expect(startGatewayServer).not.toHaveBeenCalled();
+        expectNoteContains(prompter, "Use that supervisor to start the gateway.", "Gateway");
+        expectNoteNotContains(prompter, "openclaw gateway run");
+        expectNoteNotContains(prompter, "openclaw onboard --install-daemon");
+        expect(prompter.outro).toHaveBeenCalledWith(
+          "Gateway not detected yet. OpenClaw gateway lifecycle is managed by an external " +
+            "supervisor (OPENCLAW_SUPERVISOR_MODE=external). Use that supervisor to start the " +
+            "gateway.",
+        );
+      });
+    });
   });
 
   it("installs a missing gateway service when onboarding resumes before installation", async () => {

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -163,6 +163,37 @@ export type GatewayServiceSetupOutcome =
   | { status: "skipped"; reason: "explicit" | "systemd-unavailable" | "external" }
   | { status: "failed"; error: string };
 
+function buildGatewayRecoveryProjection(gateway: GatewayServiceSetupOutcome): {
+  detail: string;
+  summary: string;
+} {
+  const startGuidance =
+    gateway.status === "skipped" && gateway.reason === "external"
+      ? formatExternalSupervisorActionRequired("start the gateway")
+      : t("wizard.finalize.startGatewayNow", {
+          command: formatCliCommand("openclaw gateway run"),
+        });
+  const notDetected = t("wizard.finalize.gatewayNotDetected");
+  const summary = [notDetected, startGuidance].join(" ");
+  if (gateway.status === "skipped" && gateway.reason === "external") {
+    return { detail: [notDetected, startGuidance].join("\n"), summary };
+  }
+  return {
+    detail: [
+      notDetected,
+      t("wizard.finalize.noBackgroundGatewayExpected"),
+      startGuidance,
+      t("wizard.finalize.rerunInstallDaemon", {
+        command: formatCliCommand("openclaw onboard --install-daemon"),
+      }),
+      t("wizard.finalize.skipHealthNextTime", {
+        command: formatCliCommand("openclaw onboard --skip-health"),
+      }),
+    ].join("\n"),
+    summary,
+  };
+}
+
 /**
  * Ensure the gateway service matches the onboarding decision: prompt/decide
  * whether to install the daemon, then install/restart/reinstall it. Shared by
@@ -196,6 +227,17 @@ export async function ensureGatewayServiceForOnboarding(params: {
       );
     }
   };
+
+  if (isGatewayExternallySupervised()) {
+    await prompter.note(
+      formatExternalSupervisorActionRequired("manage the gateway service"),
+      "Gateway",
+    );
+    return {
+      gateway: { status: "skipped", reason: "external" },
+      containerWithoutUserSystemd: false,
+    };
+  }
 
   const systemdAvailable =
     process.platform === "linux" ? await isSystemdUserServiceAvailable() : true;
@@ -257,14 +299,6 @@ export async function ensureGatewayServiceForOnboarding(params: {
       },
       containerWithoutUserSystemd,
     };
-  }
-
-  if (isGatewayExternallySupervised()) {
-    await prompter.note(
-      formatExternalSupervisorActionRequired("manage the gateway service"),
-      "Gateway",
-    );
-    return { gateway: { status: "skipped", reason: "external" }, containerWithoutUserSystemd };
   }
 
   let gateway: GatewayServiceSetupOutcome = { status: "ready", action: "reused" };
@@ -458,6 +492,7 @@ export async function finalizeSetupWizard(
     prompter,
     runtime,
   });
+  const gatewayRecovery = buildGatewayRecoveryProjection(gateway);
   if (gateway.status === "failed") {
     gatewayProbe = { ok: false, detail: gateway.error };
   }
@@ -565,22 +600,7 @@ export async function finalizeSetupWizard(
           t("wizard.finalize.healthCheckHelp"),
         );
       } else {
-        await prompter.note(
-          [
-            t("wizard.finalize.gatewayNotDetected"),
-            t("wizard.finalize.noBackgroundGatewayExpected"),
-            t("wizard.finalize.startGatewayNow", {
-              command: formatCliCommand("openclaw gateway run"),
-            }),
-            t("wizard.finalize.rerunInstallDaemon", {
-              command: formatCliCommand("openclaw onboard --install-daemon"),
-            }),
-            t("wizard.finalize.skipHealthNextTime", {
-              command: formatCliCommand("openclaw onboard --skip-health"),
-            }),
-          ].join("\n"),
-          "Gateway",
-        );
+        await prompter.note(gatewayRecovery.detail, "Gateway");
       }
     }
 
@@ -946,12 +966,7 @@ export async function finalizeSetupWizard(
                 }),
               ].join(" ")
             : t("wizard.guided.complete")
-        : [
-            t("wizard.finalize.gatewayNotDetected"),
-            t("wizard.finalize.startGatewayNow", {
-              command: formatCliCommand("openclaw gateway run"),
-            }),
-          ].join(" "),
+        : gatewayRecovery.summary,
     );
 
     if (shouldLaunchTui) {

--- a/test/e2e/qa-lab/runtime/system-agent-first-run-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/system-agent-first-run-docker-client.ts
@@ -304,6 +304,32 @@ async function main() {
       result.code === 0 && output.includes(command.expectOutput),
       `OpenClaw first-run command ${command.id} did not apply: ${output}`,
     );
+    if (command.id === "setup") {
+      assert(result.code === 0, `OpenClaw setup exited with ${result.code}: ${output}`);
+      assert(
+        output.includes("[openclaw] done: openclaw.setup"),
+        `OpenClaw setup did not report completion: ${output}`,
+      );
+      assert(
+        output.includes(
+          "Gateway: OpenClaw gateway lifecycle is managed by an external supervisor " +
+            "(OPENCLAW_SUPERVISOR_MODE=external). Use that supervisor to start the gateway.",
+        ),
+        `OpenClaw setup did not report the externally supervised gateway: ${output}`,
+      );
+      assert(
+        !output.includes("Systemd user services are not available"),
+        `OpenClaw setup probed systemd before honoring external supervision: ${output}`,
+      );
+      assert(
+        !output.includes("Gateway service install failed"),
+        `OpenClaw setup attempted and failed gateway service installation: ${output}`,
+      );
+      assert(
+        !output.includes("service management skipped: non-default state dir or config path"),
+        `OpenClaw setup used the non-default-path service-management skip: ${output}`,
+      );
+    }
     if (command.planner) {
       assert(
         output.includes(`[openclaw] planner: ${spec.model}`) &&

--- a/test/scripts/docker-e2e-system-agent.test.ts
+++ b/test/scripts/docker-e2e-system-agent.test.ts
@@ -8,9 +8,11 @@ function readScript(pathname: string): string {
 
 describe("OpenClaw Docker E2E scripts", () => {
   it("keeps first-run checks wired to packaged CLI and OpenClaw behavior", () => {
+    const shell = readScript("scripts/e2e/system-agent-first-run-docker.sh");
     const source = readScript("test/e2e/qa-lab/runtime/system-agent-first-run-docker-client.ts");
     const spec = readScript("scripts/e2e/system-agent-first-run-spec.json");
 
+    expect(shell).toContain('-e "OPENCLAW_SUPERVISOR_MODE=external"');
     expect(source).toContain("../../../../dist/cli/run-main.js");
     expect(source).toContain("../../../../dist/system-agent/setup-inference.js");
     expect(source).toContain("shouldStartOnboardingForFreshInstall");
@@ -32,6 +34,10 @@ describe("OpenClaw Docker E2E scripts", () => {
     expect(source).toContain("expected one fuzzy setup planner prompt");
     expect(source).toContain("OpenClaw did not enable Discord");
     expect(source).toContain("OpenClaw did not write Discord token SecretRef");
+    expect(source).toContain(
+      "(OPENCLAW_SUPERVISOR_MODE=external). Use that supervisor to start the gateway.",
+    );
+    expect(source).toContain("OpenClaw setup probed systemd before honoring external supervision");
     expect(source).toContain("OpenClaw first-run Docker E2E passed");
     expect(spec).toContain('"auditOperations"');
     expect(spec).toContain('"openclaw.setup"');


### PR DESCRIPTION
## What Problem This Solves

Linux first-run setup could probe systemd before honoring the explicit
`OPENCLAW_SUPERVISOR_MODE=external` ownership contract. In containers without a
user systemd bus, setup therefore returned `systemd-unavailable` instead of the
authoritative external-supervision outcome.

The system-agent projection rendered both skipped reasons with the same generic
text, so the Docker assertion could false-pass. Classic wizard health recovery
also discarded `reason: "external"` after an unreachable health check and
recommended native `gateway run` / `onboard --install-daemon` commands that
contradicted external ownership.

## Why This Change Was Made

`ensureGatewayServiceForOnboarding` owns service-install disposition. It now
resolves explicit external supervision before Linux systemd or container
probing and removes the later duplicate ownership check.

The system-agent and classic wizard projections preserve that authoritative
outcome. External-supervisor recovery now says:

```text
OpenClaw gateway lifecycle is managed by an external supervisor (OPENCLAW_SUPERVISOR_MODE=external). Use that supervisor to start the gateway.
```

Native systemd/launchd recovery remains unchanged for OpenClaw-owned services.

## User Impact

Externally supervised Linux/container installs no longer report a misleading
systemd skip or suggest native daemon commands after health failure. Operators
are directed back to the supervisor that owns the Gateway lifecycle.

## Evidence

- exact signed head `8bb39aeb4389da029a9b7d61b11c3df94278204b`
- focused producer/projection/classic proof:
  `node scripts/run-vitest.mjs src/infra/gateway-supervision.test.ts src/system-agent/setup-apply.test.ts src/wizard/setup.finalize.test.ts test/scripts/docker-e2e-system-agent.test.ts`
  passed 98/98
- focused max-lines lint:
  `node_modules/.bin/oxlint src/system-agent/setup-apply.test.ts`
- targeted `oxfmt --check` and `git diff --check`
- exact-head direct AWS Crabbox proof:
  - provider `aws`, lease `cbx_41402a6f39b3`, run `run_707ddbd63d5d`
  - https://crabbox.openclaw.ai/portal/runs/run_707ddbd63d5d
  - public network, Tailscale disabled, no instance profile
  - `pnpm test:docker:system-agent-first-run` passed
  - Docker transcript:

    ```text
    OpenClaw first-run Docker E2E passed
    OK
    ```

    `OK` is emitted only after the client observes the external-specific
    outcome and rejects the `systemd-unavailable`/generic fallback.
  - full `pnpm check:changed` passed on the same exact head
  - final remote SHA/tree checks passed; lease auto-released
- exact-head autoreview: no accepted/actionable findings, correctness `0.98`
- exact-head ClawSweeper review: no correctness finding; its proof-refresh
  Rank-up move is satisfied by the evidence above. Ordinary maintainer review
  remains intentionally pending while this PR is draft.

Production LOC: `+48/-30` (net `+18`). Tests/QA: `+111/-10` (net `+101`).
Total: `+159/-40`.

No changelog. No release.

## Related Work

- https://github.com/openclaw/openclaw/pull/109162 merged the canonical
  external-supervision contract.
- https://github.com/openclaw/openclaw/pull/118388 introduced the structured
  onboarding recovery path where the precedence/projection gaps surfaced.
- https://github.com/openclaw/openclaw/issues/112386 is closed as completed by
  the broader external-supervision support.
- https://github.com/openclaw/openclaw/issues/89791 remains open and separate:
  it concerns macOS dual-LaunchAgent topology, not this Linux/container owner
  projection.

Live duplicate search found no closer open issue or PR.

- [x] AI-assisted; the exact commit was reviewed before publication.

## Punchcard Attestation

Current exact commit `8bb39aeb4389da029a9b7d61b11c3df94278204b`
and PR #119846 have server-signed Punchcard attestations under
`quiet-meadow-timber-mj`; both receipts verify valid and unrevoked.

Punchcard-Session: quiet-meadow-timber-mj
