### PR TITLE
fix: agent exec loads installed harnesses locally

### DIFF
--- a/src/agents/agent-command-local.ts
+++ b/src/agents/agent-command-local.ts
@@ -1,0 +1,63 @@
+/** Owns local agent-command admission scopes outside a running Gateway. */
+import type { CliDeps } from "../cli/deps.types.js";
+import { getRuntimeConfig } from "../config/io.js";
+import { withLocalGatewayRequestScope } from "../gateway/local-request-context.js";
+import {
+  captureAgentRunLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
+} from "../infra/agent-events.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { runWithAgentCommandRecoveryOwner } from "./agent-command-recovery-owner.js";
+import {
+  prepareAgentCommandExecution,
+  type PreparedAgentCommandExecution,
+} from "./command/prepare.js";
+import { resolveAgentCommandDeps } from "./command/runtime-loaders.js";
+import type { AgentCommandOpts } from "./command/types.js";
+import { withAgentPluginRegistry } from "./runtime-plugins.js";
+import { measureAgentStartup } from "./startup-timing.js";
+
+type ResolvedAgentCommandDeps = Awaited<ReturnType<typeof resolveAgentCommandDeps>>;
+
+/** Runs a local command under one request, recovery, and plugin-registry generation. */
+export async function runLocalAgentCommand<TResult>(params: {
+  opts: AgentCommandOpts;
+  runtime: RuntimeEnv;
+  deps?: CliDeps;
+  run: (
+    prepared: PreparedAgentCommandExecution,
+    resolvedDeps: ResolvedAgentCommandDeps,
+  ) => Promise<TResult>;
+}): Promise<TResult> {
+  const resolvedDeps = await measureAgentStartup("command-dependencies", () =>
+    resolveAgentCommandDeps(params.deps),
+  );
+  const lifecycleGeneration =
+    params.opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(params.opts.runId ?? "");
+  return await withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
+    withLocalGatewayRequestScope(
+      { deps: resolvedDeps, getRuntimeConfig },
+      async () =>
+        await runWithAgentCommandRecoveryOwner({
+          lifecycleGeneration,
+          mode: "reject_uncoordinated",
+          opts: {
+            ...params.opts,
+            lifecycleGeneration,
+            senderIsOwner: params.opts.senderIsOwner ?? true,
+            allowModelOverride: params.opts.allowModelOverride ?? true,
+          },
+          prepare: async (preparedOpts) =>
+            await measureAgentStartup("command-prepare", () =>
+              prepareAgentCommandExecution(preparedOpts, params.runtime),
+            ),
+          run: async (prepared) =>
+            await withAgentPluginRegistry({
+              config: prepared.cfg,
+              workspaceDir: prepared.workspaceDir,
+              run: () => params.run(prepared, resolvedDeps),
+            }),
+        }),
+    ),
+  );
+}

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -104,6 +104,10 @@ vi.mock("./harness/runtime-plugin.js", () => ({
   ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
 }));
 
+vi.mock("./runtime-plugins.js", () => ({
+  withAgentPluginRegistry: ({ run }: { run: () => unknown }) => run(),
+}));
+
 vi.mock("./workspace.js", () => ({
   ensureAgentWorkspace: vi.fn(async () => undefined),
 }));

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -249,6 +249,10 @@ vi.mock("./harness/runtime-plugin.js", () => ({
   ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
 }));
 
+vi.mock("./runtime-plugins.js", () => ({
+  withAgentPluginRegistry: ({ run }: { run: () => unknown }) => run(),
+}));
+
 // Harness selection has dedicated coverage; this command suite registers no auto harnesses.
 vi.mock("./harness/support.js", () => ({
   resolveAutoAgentHarnessId: () => undefined,

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2,12 +2,10 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 import type { CliDeps } from "../cli/deps.types.js";
-import { getRuntimeConfig } from "../config/io.js";
 import { resolveSessionWorkStartError } from "../config/sessions/lifecycle.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../config/sessions/restart-recovery-state.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../config/sessions/restart-recovery-types.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import { withLocalGatewayRequestScope } from "../gateway/local-request-context.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   captureAgentRunLifecycleGeneration,
@@ -25,6 +23,7 @@ import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admissi
 import { classifySessionStateActor } from "../sessions/session-state-events.js";
 import { sessionDeliveryChannel, type DeliveryContext } from "../utils/delivery-context.shared.js";
 import { executionIdentity } from "./agent-command-execution-identity.js";
+import { runLocalAgentCommand } from "./agent-command-local.js";
 import { runWithAgentCommandRecoveryOwner } from "./agent-command-recovery-owner.js";
 import {
   buildCurrentRunRestartRecoveryClaim,
@@ -599,43 +598,13 @@ async function agentCommandWithAdmissionIngress(
   runtime: RuntimeEnv = defaultRuntime,
   deps?: CliDeps,
 ) {
-  const resolvedDeps = await measureAgentStartup("command-dependencies", () =>
-    resolveAgentCommandDeps(deps),
-  );
-  const lifecycleGeneration =
-    opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(opts.runId ?? "");
-  return await withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
-    withLocalGatewayRequestScope(
-      {
-        deps: resolvedDeps,
-        getRuntimeConfig,
-      },
-      async () =>
-        await runWithAgentCommandRecoveryOwner({
-          lifecycleGeneration,
-          mode: "reject_uncoordinated",
-          opts: {
-            ...opts,
-            lifecycleGeneration,
-            // Only the local entrypoint may inherit trusted-operator defaults.
-            senderIsOwner: opts.senderIsOwner ?? true,
-            allowModelOverride: opts.allowModelOverride ?? true,
-          },
-          prepare: async (preparedOpts) =>
-            await measureAgentStartup("command-prepare", () =>
-              prepareAgentCommandExecution(preparedOpts, runtime),
-            ),
-          run: async (prepared) =>
-            await agentCommandInternal(
-              prepared,
-              prepared.opts,
-              admissionIngress,
-              runtime,
-              resolvedDeps,
-            ),
-        }),
-    ),
-  );
+  return await runLocalAgentCommand({
+    opts,
+    runtime,
+    deps,
+    run: async (prepared, resolvedDeps) =>
+      await agentCommandInternal(prepared, prepared.opts, admissionIngress, runtime, resolvedDeps),
+  });
 }
 
 export async function agentCommand(

--- a/src/agents/command/assistant-transcript-repair.test.ts
+++ b/src/agents/command/assistant-transcript-repair.test.ts
@@ -113,6 +113,10 @@ vi.mock("../harness/runtime-plugin.js", () => ({
   ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
 }));
 
+vi.mock("../runtime-plugins.js", () => ({
+  withAgentPluginRegistry: ({ run }: { run: () => unknown }) => run(),
+}));
+
 vi.mock("../workspace.js", () => ({
   ensureAgentWorkspace: vi.fn(async () => undefined),
 }));

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -102,4 +102,22 @@ describe("agent runtime plugin registries", () => {
       }),
     );
   });
+
+  it("lets direct local hosts bound the registry to configured runtime owners", () => {
+    const config = {} as never;
+
+    loadAgentRuntimePluginRegistryHandle({
+      basePluginIds: [],
+      config,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(hoisted.getCurrentPluginMetadataSnapshot).not.toHaveBeenCalled();
+    expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/workspace",
+      basePluginIds: [],
+      selections: [],
+    });
+  });
 });

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -3,6 +3,10 @@ import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { loadPluginRegistryHandle } from "../plugins/loader.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeRegistryScope,
+} from "../plugins/runtime/gateway-request-scope.js";
 import { resolveUserPath } from "../utils.js";
 import { collectConfiguredAgentHarnessRuntimes } from "./harness-runtimes.js";
 import {
@@ -40,6 +44,8 @@ type AgentRuntimePluginRegistryParams = {
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string | null;
   allowGatewaySubagentBinding?: boolean;
+  /** Explicit base scope for hosts without a Gateway startup registry. */
+  basePluginIds?: readonly string[];
   selections?: readonly AgentHarnessPluginSelection[];
 };
 
@@ -63,11 +69,14 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
       },
     };
   }
-  const startupPluginIds = resolveStartupPluginIdsFromCurrentSnapshot({
-    config: params.config,
-    env: params.env,
-    workspaceDir,
-  });
+  const startupPluginIds =
+    params.basePluginIds !== undefined
+      ? [...params.basePluginIds]
+      : resolveStartupPluginIdsFromCurrentSnapshot({
+          config: params.config,
+          env: params.env,
+          workspaceDir,
+        });
   const plan = resolveAgentRuntimePluginLoadPlan({
     config: params.config,
     workspaceDir: workspaceDir ?? process.cwd(),
@@ -105,4 +114,21 @@ export function loadAgentRuntimePluginRegistryHandle(
 ): PluginRegistry {
   const load = resolveAgentRuntimePluginRegistryLoad(params);
   return loadPluginRegistryHandle({ ...load.loadOptions, activate: false });
+}
+
+/** Binds a scoped plugin generation when a direct host has no Gateway owner. */
+export async function withAgentPluginRegistry<T>(params: {
+  config: OpenClawConfig;
+  workspaceDir: string;
+  run: () => Promise<T>;
+}): Promise<T> {
+  if (getPluginRuntimeGatewayRequestScope()?.pluginRegistry) {
+    return await params.run();
+  }
+  const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
+    basePluginIds: [],
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
+  return await withPluginRuntimeRegistryScope(pluginRegistry, params.run);
 }

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -10,6 +10,10 @@ vi.mock("../agents/harness/runtime-plugin.js", () => ({
   ensureSelectedAgentHarnessPlugin: agentHarnessPluginMocks.ensureSelectedAgentHarnessPlugin,
 }));
 
+vi.mock("../agents/runtime-plugins.js", () => ({
+  withAgentPluginRegistry: ({ run }: { run: () => unknown }) => run(),
+}));
+
 vi.mock("../logging/subsystem.js", () => {
   const createMockLogger = () => ({
     subsystem: "test",

--- a/src/commands/agent-exec-plugin.e2e.test.ts
+++ b/src/commands/agent-exec-plugin.e2e.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { writePersistedInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 
 const execFileAsync = promisify(execFile);
 const tempRoots: string[] = [];
@@ -89,35 +91,63 @@ async function writeHarnessPlugin(stateDir: string): Promise<void> {
     };\n`,
     "utf8",
   );
+  await writePersistedInstalledPluginIndexInstallRecords(
+    {
+      "exec-proof": {
+        source: "path",
+        sourcePath: pluginDir,
+        installPath: pluginDir,
+      },
+    },
+    {
+      stateDir,
+      config: buildExecProofConfig(),
+      candidates: [
+        {
+          idHint: "exec-proof",
+          source: path.join(pluginDir, "index.js"),
+          rootDir: pluginDir,
+          origin: "global",
+        },
+      ],
+    },
+  );
+}
+
+function buildExecProofConfig(): OpenClawConfig {
+  return {
+    plugins: {
+      allow: ["exec-proof"],
+      entries: { "exec-proof": { enabled: true } },
+    },
+    models: {
+      providers: {
+        "exec-proof": {
+          api: "openai-responses",
+          baseUrl: "https://example.invalid/v1",
+          models: [
+            {
+              id: "proof-model",
+              name: "Proof model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 4096,
+              agentRuntime: { id: "exec-proof" },
+            },
+          ],
+        },
+      },
+    },
+    agents: { defaults: { model: { primary: "exec-proof/proof-model" } } },
+  };
 }
 
 async function writeConfig(stateDir: string): Promise<void> {
   await fs.writeFile(
     path.join(stateDir, "openclaw.json"),
-    JSON.stringify({
-      plugins: {
-        allow: ["exec-proof"],
-        entries: { "exec-proof": { enabled: true } },
-      },
-      models: {
-        providers: {
-          "exec-proof": {
-            api: "openai-responses",
-            baseUrl: "https://example.invalid/v1",
-            models: [
-              {
-                id: "proof-model",
-                name: "Proof model",
-                contextWindow: 128000,
-                maxTokens: 4096,
-                agentRuntime: { id: "exec-proof" },
-              },
-            ],
-          },
-        },
-      },
-      agents: { defaults: { model: { primary: "exec-proof/proof-model" } } },
-    }),
+    JSON.stringify(buildExecProofConfig()),
     "utf8",
   );
 }


### PR DESCRIPTION
Closes #119852

## What Problem This Solves

Fixes an issue where users running `openclaw agent exec` with a configured plugin-owned native harness would receive `Agent harness runtime ... is not present in the prepared registry` before the harness could start.

## Why This Change Was Made

Direct local agent commands now bind one bounded plugin-registry generation around preparation and execution when no Gateway-owned registry is already in scope. The local scope loads only configured runtime owners, while Gateway and embedded hosts keep their existing authoritative registry. The regression fixture now represents a real installed plugin by seeding the canonical SQLite install index.

The local admission/scoping flow moved into a focused module so `agent-command.ts` remains below the repository's max-lines gate instead of adding a suppression.

Production LOC: +102/-44 (net +58) | Tests: +88/-24 (net +64)

The positive production delta establishes the missing local registry ownership boundary and extracts the existing local admission flow from an oversized orchestrator.

## User Impact

Operators can use installed native harness plugins through `openclaw agent exec` again. Normal runs inherit the configured harness; `--isolated` still cannot access it, and one-shot run state remains ephemeral.

## Evidence

- Current-main reproduction: `src/commands/agent-exec-plugin.e2e.test.ts` failed 1/1 with the prepared-registry error on https://github.com/openclaw/openclaw/actions/runs/31069323224.
- Final focused Testbox: 145 agent-command/runtime tests plus the 1/1 agent-exec E2E passed on https://github.com/openclaw/openclaw/actions/runs/31074090230.
- Source-blind CLI validation: a freshly installed randomized harness returned its exact marker; `--isolated` exited 1 without the marker; no `agents` directory persisted; only `openclaw.sqlite*` registry files remained. https://github.com/openclaw/openclaw/actions/runs/31075489600
- The first hosted CI run exposed two explicit command-suite mocks that did not isolate the new registry owner, plus an unrelated base-fetch timeout. The two mock boundaries were repaired; both exact failed CI bins then passed on Testbox, including 144 agent-support files and the full command/doctor/plugin-sdk siblings. The same exact-head Testbox run also passed `pnpm build` and `pnpm check:changed`: https://github.com/openclaw/openclaw/actions/runs/31076853010.
- Exact-head hosted CI is green for `ad56b2ceb8efcfb9866469c63fdb176775eaa7c3`: https://github.com/openclaw/openclaw/actions/runs/31078325974.
- AutoReview: the exact final branch is clean with no accepted/actionable findings, overall confidence 0.98.
- ClawSweeper: exact-head immutable artifact rates overall/proof/patch A, clears security, reports no risks or findings, and lists no rank-up steps. The shard artifact completed in https://github.com/openclaw/clawsweeper/actions/runs/31078230930; its later batch publication step hit the GitHub App installation quota, so the PR placeholder was not edited.
- Final patch ID: `be647c32918125a65512ab9a0ceb358cb5ce6d65`.

An exploratory broad `test:changed` fallback did not complete: https://github.com/openclaw/openclaw/actions/runs/31071327908 ended with Vitest `Worker exited unexpectedly` after its preceding shards passed. The exact failed bins, full build, repository-native changed gate, and exact-head hosted CI above are green.

AI-assisted: yes. I reviewed the complete affected command, plugin-registry, prepared-runtime, and test paths and understand the ownership change.
