### PR TITLE
fix(doctor): enforce version-bound plugin convergence

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -929,7 +929,7 @@ function readInstalledPluginIndex() {
   return index;
 }
 
-function assertExternalPluginInstall(records, pluginId, packageName) {
+function assertExternalPluginInstall(records, pluginId, packageName, expectedVersion) {
   const record = records[pluginId];
   assert(record, `configured external ${pluginId} plugin install record missing`);
   const installedFromNpm = record.source === "npm";
@@ -958,6 +958,13 @@ function assertExternalPluginInstall(records, pluginId, packageName) {
   assert(
     packageJson.name === packageName,
     `configured external ${pluginId} package name changed: ${packageJson.name}`,
+  );
+  assert(
+    !expectedVersion ||
+      [record.version, record.resolvedVersion, packageJson.version].every(
+        (version) => version === expectedVersion,
+      ),
+    `configured external ${pluginId} version mismatch: expected ${expectedVersion}`,
   );
   if (installedFromNpm) {
     const stateDir = requireEnv("OPENCLAW_STATE_DIR");
@@ -993,6 +1000,8 @@ function assertConfiguredPluginInstalls() {
   }
   const index = readInstalledPluginIndex();
   const records = index.installRecords ?? {};
+  const candidateVersion = requireEnv("OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE_VERSION");
+  assertExternalPluginInstall(records, "codex", "@openclaw/codex", candidateVersion);
   assertOptionalConfiguredPluginIndex(records, index.plugins ?? [], {
     bundled: true,
     packageName: "@openclaw/matrix",

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -428,6 +428,9 @@ NODE
   OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
     node scripts/e2e/lib/plugins/npm-registry-server.mjs \
     "$port_file" \
+    "@openclaw/codex" \
+    "$candidate_version" \
+    "${OPENCLAW_UPGRADE_SURVIVOR_CODEX_PLUGIN_TGZ:?Configured plugin install validation requires a Codex candidate tarball.}" \
     "@openclaw/brave-plugin" \
     "2026.5.2" \
     "$tarball" \
@@ -1058,6 +1061,7 @@ resolve_candidate_version() {
   OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT="$(
     node scripts/e2e/lib/package-compat.mjs "$candidate_version"
   )"
+  export OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE_VERSION="$candidate_version"
   export OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT
 }
 

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -142,6 +142,10 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
   fi
 
   OPENCLAW_TEST_STATE_FUNCTION_B64="$(docker_e2e_test_state_function_b64)"
+  CODEX_PLUGIN_ARGS=()
+  if [ "${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}" = "configured-plugin-installs" ]; then
+    CODEX_PLUGIN_ARGS=(-e OPENCLAW_UPGRADE_SURVIVOR_CODEX_PLUGIN_TGZ=/tmp/openclaw-codex-plugin-current.tgz -v "$OPENCLAW_UPGRADE_SURVIVOR_CODEX_PLUGIN_TGZ:/tmp/openclaw-codex-plugin-current.tgz:ro")
+  fi
 
   docker_e2e_build_or_reuse "$IMAGE_NAME" upgrade-survivor "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" "bare" "$SKIP_BUILD"
 
@@ -165,6 +169,7 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro" \
     "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
+    "${CODEX_PLUGIN_ARGS[@]}" \
     "${DOCKER_RUN_USER_ARGS[@]}" \
     "$IMAGE_NAME" \
     timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" bash /tmp/openclaw-upgrade-survivor-run.sh

--- a/scripts/test-docker-all.d.mts
+++ b/scripts/test-docker-all.d.mts
@@ -9,6 +9,7 @@ export function canStartSchedulerLane(
   parallelism: unknown,
   options: unknown,
 ): boolean;
+export function lanesNeedCodexPluginPackage(lanes: unknown): boolean;
 export function githubWorkflowRerunCommand(
   laneNames: unknown,
   ref: unknown,

--- a/scripts/test-docker-all.mjs
+++ b/scripts/test-docker-all.mjs
@@ -1011,6 +1011,32 @@ async function prepareOpenClawPackage(baseEnv, logDir) {
   console.log(`==> OpenClaw package: ${baseEnv.OPENCLAW_CURRENT_PACKAGE_TGZ}`);
 }
 
+const CODEX_LANE = /^(published-upgrade-survivor|update-migration)-.+-configured-plugin-installs$/u;
+export function lanesNeedCodexPluginPackage(lanes) {
+  return lanes.some(({ name }) => CODEX_LANE.test(String(name ?? "")));
+}
+
+async function prepareCodexPluginPackage(baseEnv, logDir) {
+  const packDir = path.join(logDir, "codex-plugin-package");
+  const packageJson = JSON.parse(
+    await readFile(path.join(ROOT_DIR, "extensions/codex/package.json"), "utf8"),
+  );
+  const packageTgz = path.join(packDir, `openclaw-codex-${packageJson.version}.tgz`);
+  await mkdir(packDir, { recursive: true });
+  await runForeground(
+    "Build Codex plugin runtime once",
+    "node scripts/lib/plugin-npm-runtime-build.mjs extensions/codex",
+    baseEnv,
+  );
+  await runForeground(
+    "Prepare Codex plugin package once",
+    `node scripts/lib/plugin-npm-package-manifest.mjs --run extensions/codex -- npm pack --json --ignore-scripts --pack-destination ${shellQuote(packDir)}`,
+    baseEnv,
+  );
+  await fs.promises.access(packageTgz);
+  baseEnv.OPENCLAW_UPGRADE_SURVIVOR_CODEX_PLUGIN_TGZ = packageTgz;
+}
+
 function e2eImageForLane(poolLane, baseEnv) {
   if (poolLane.e2eImageKind === "bare") {
     return baseEnv.OPENCLAW_DOCKER_E2E_BARE_IMAGE;
@@ -1654,6 +1680,11 @@ async function main() {
     });
   } else {
     console.log("==> OpenClaw package: not needed for selected lanes");
+  }
+  if (lanesNeedCodexPluginPackage(scheduledLanes)) {
+    await runPhase(phases, "prepare-codex-plugin-package", {}, () =>
+      prepareCodexPluginPackage(baseEnv, logDir),
+    );
   }
 
   if (buildEnabled) {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -121,6 +121,8 @@ export async function installCandidate(params: {
   updateChannel?: UpdateChannel;
   mode?: "install" | "update";
   preferNpm?: boolean;
+  npmInstallSpecOverride?: string;
+  validateNpmRecord?: (record: PluginInstallRecord) => Promise<string | undefined>;
   repairReason?: InstallCandidateRepairReason;
   acknowledgeClawHubRisk?: boolean;
   onClawHubRisk?: (request: ClawHubRiskAcknowledgementRequest) => boolean | Promise<boolean>;
@@ -152,7 +154,8 @@ export async function installCandidate(params: {
       })
     : null;
   const clawhubInstallSpec = clawhubSpecs?.installSpec ?? candidate.clawhubSpec;
-  const npmInstallSpec = npmSpecs?.installSpec ?? candidate.npmSpec;
+  const npmInstallSpec =
+    params.npmInstallSpecOverride ?? npmSpecs?.installSpec ?? candidate.npmSpec;
   const npmDir = resolveDefaultPluginNpmDir(params.env);
   const existingClawHubPackagePath = clawhubInstallSpec
     ? resolveExistingCandidateClawHubPackagePath({
@@ -303,21 +306,32 @@ export async function installCandidate(params: {
     };
   }
   const pluginId = result.pluginId;
+  const record: PluginInstallRecord = {
+    source: "npm",
+    spec: resolveNpmInstallRecordSpec({
+      requestedSpec: npmSpecs?.recordSpec ?? npmInstallSpec,
+      resolution: result.npmResolution,
+      pinResolvedRegistrySpec: false,
+    }),
+    installPath: result.targetDir,
+    version: result.version,
+    installedAt: new Date().toISOString(),
+    ...buildNpmResolutionInstallFields(result.npmResolution),
+  };
+  const validationFailure = await params.validateNpmRecord?.(record);
+  if (validationFailure) {
+    return {
+      records: params.records,
+      changes: [],
+      notices: [],
+      warnings: [validationFailure],
+      failedPluginId: pluginId,
+    };
+  }
   return {
     records: {
       ...params.records,
-      [pluginId]: {
-        source: "npm",
-        spec: resolveNpmInstallRecordSpec({
-          requestedSpec: npmSpecs?.recordSpec ?? npmInstallSpec,
-          resolution: result.npmResolution,
-          pinResolvedRegistrySpec: false,
-        }),
-        installPath: result.targetDir,
-        version: result.version,
-        installedAt: new Date().toISOString(),
-        ...buildNpmResolutionInstallFields(result.npmResolution),
-      },
+      [pluginId]: record,
     },
     changes: [
       ...changes,
@@ -372,7 +386,7 @@ function resolveExistingCandidateClawHubPackagePath(params: {
   }
 }
 
-async function readNpmPackageVersion(packagePath: string): Promise<string | undefined> {
+export async function readNpmPackageVersion(packagePath: string): Promise<string | undefined> {
   try {
     const parsed = JSON.parse(await readFile(path.join(packagePath, "package.json"), "utf-8")) as {
       version?: unknown;

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -8,6 +8,10 @@ import { updateNpmInstalledPlugins } from "../../../plugins/update.js";
 import { resolveUserPath } from "../../../utils.js";
 import { resolveCompatibilityHostVersion } from "../../../version.js";
 import {
+  resolveConfiguredRuntimePluginInstallCandidate,
+  VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+} from "./configured-runtime-plugin-installs.js";
+import {
   collectDownloadableInstallCandidates,
   collectUpdateDeferredPluginIds,
   resolveConfiguredPluginInstallContext,
@@ -22,6 +26,7 @@ import {
   installCandidate,
   isActionableClawHubSkippedOutcome,
   isClawHubReviewNotice,
+  readNpmPackageVersion,
   recordClawHubInstallSpec,
 } from "./missing-configured-plugin-install.install.js";
 import {
@@ -63,6 +68,20 @@ type RepairMissingPluginInstallsResult = {
    */
   records: Record<string, PluginInstallRecord>;
 };
+
+async function installRecordSatisfiesHostCohort(
+  record: PluginInstallRecord | undefined,
+  env: NodeJS.ProcessEnv,
+  acceptsVersion: (version: string) => boolean,
+): Promise<boolean> {
+  const payloadVersion =
+    record?.source === "npm" && record.installPath?.trim()
+      ? await readNpmPackageVersion(resolveUserPath(record.installPath, env))
+      : undefined;
+  return [record?.version, record?.resolvedVersion, payloadVersion].every(
+    (version) => typeof version === "string" && acceptsVersion(version.trim()),
+  );
+}
 
 /** Repair missing installs inferred from the current OpenClaw config. */
 export async function repairMissingConfiguredPluginInstalls(params: {
@@ -162,6 +181,18 @@ async function repairMissingPluginInstalls(params: {
   const repairedPluginIds = new Set<string>();
   const deferredPluginIds = new Set<string>();
   const preferNpmInstalls = isLegacyPackageUpdateDoctorPass(env);
+  const hostVersion = resolveCompatibilityHostVersion(env);
+  const satisfiesHostCohort = (version: string) =>
+    updateChannel === "beta"
+      ? version.replace(/-beta\.[1-9]\d*$/u, "") === hostVersion.replace(/-beta\.[1-9]\d*$/u, "")
+      : version === hostVersion;
+  const cohortFailure = (pluginId: string) =>
+    `Failed to converge version-bound configured plugin "${pluginId}" to the ${hostVersion} host cohort. Prior install records were retained; inspect the record and payload before retrying.`;
+  const targetsHostCohort = (pluginId: string, record: PluginInstallRecord | undefined) =>
+    VERSION_BOUND_RUNTIME_PLUGIN_IDS.has(pluginId) &&
+    (installedPluginIdsWithStaleVersionBoundRuntimePackages.has(pluginId) ||
+      !record ||
+      isInstalledRecordMissingOnDisk(record, env));
   let nextRecords = records;
 
   for (const [pluginId, record] of Object.entries(records)) {
@@ -210,6 +241,12 @@ async function repairMissingPluginInstalls(params: {
   );
 
   if (missingRecordedPluginIds.length > 0) {
+    const authoritativeRecords = nextRecords;
+    const versionBoundConvergencePluginIds = new Set(
+      missingRecordedPluginIds.filter((pluginId) =>
+        targetsHostCohort(pluginId, nextRecords[pluginId]),
+      ),
+    );
     for (const pluginId of missingRecordedPluginIds) {
       const record = nextRecords[pluginId];
       if (!record) {
@@ -223,6 +260,12 @@ async function repairMissingPluginInstalls(params: {
         nextRecords[pluginId] = forced;
       }
     }
+    const specOverrides = Object.fromEntries(
+      [...versionBoundConvergencePluginIds].flatMap((pluginId) => {
+        const spec = resolveConfiguredRuntimePluginInstallCandidate(pluginId)?.npmSpec;
+        return updateChannel !== "beta" && spec ? [[pluginId, `${spec}@${hostVersion}`]] : [];
+      }),
+    );
     const updateResult = await updateNpmInstalledPlugins({
       config: {
         ...params.cfg,
@@ -233,7 +276,8 @@ async function repairMissingPluginInstalls(params: {
       },
       pluginIds: missingRecordedPluginIds,
       updateChannel,
-      coreVersion: resolveCompatibilityHostVersion(env),
+      coreVersion: hostVersion,
+      ...(Object.keys(specOverrides).length > 0 ? { specOverrides } : {}),
       logger: {
         terminalLinks: false,
         warn: (message) => {
@@ -248,8 +292,29 @@ async function repairMissingPluginInstalls(params: {
       ...(params.acknowledgeClawHubRisk ? { acknowledgeClawHubRisk: true } : {}),
       ...(params.onClawHubRisk ? { onClawHubRisk: params.onClawHubRisk } : {}),
     });
+    const acceptedRecords = { ...(updateResult.config.plugins?.installs ?? nextRecords) };
+    let acceptedRepair = false;
     for (const outcome of updateResult.outcomes) {
       if (outcome.status === "updated" || outcome.status === "unchanged") {
+        const convergenceFailure =
+          versionBoundConvergencePluginIds.has(outcome.pluginId) &&
+          !(await installRecordSatisfiesHostCohort(
+            acceptedRecords[outcome.pluginId],
+            env,
+            satisfiesHostCohort,
+          ))
+            ? cohortFailure(outcome.pluginId)
+            : undefined;
+        if (convergenceFailure) {
+          // Npm installs land in a non-authoritative managed generation. The install record
+          // activates it, so retaining the prior record leaves the rejected generation for
+          // normal managed cleanup while the prior generation remains authoritative.
+          warnings.push(convergenceFailure);
+          failedPluginIds.add(outcome.pluginId);
+          acceptedRecords[outcome.pluginId] = authoritativeRecords[outcome.pluginId];
+          continue;
+        }
+        acceptedRepair = true;
         repairedPluginIds.add(outcome.pluginId);
         changes.push(
           installedPluginIdsWithStaleVersionBoundRuntimePackages.has(outcome.pluginId)
@@ -265,13 +330,13 @@ async function repairMissingPluginInstalls(params: {
         warnings.push(
           appendClawHubRiskAcknowledgementGuidance({
             message: outcome.message,
-            spec: recordClawHubInstallSpec(nextRecords[outcome.pluginId]),
+            spec: recordClawHubInstallSpec(authoritativeRecords[outcome.pluginId]),
           }),
         );
         failedPluginIds.add(outcome.pluginId);
       }
     }
-    nextRecords = updateResult.config.plugins?.installs ?? nextRecords;
+    nextRecords = acceptedRepair ? acceptedRecords : authoritativeRecords;
   }
 
   const missingPluginIds = new Set(
@@ -301,7 +366,7 @@ async function repairMissingPluginInstalls(params: {
         ? new Set([...(params.blockedPluginIds ?? []), ...deferredPluginIds])
         : params.blockedPluginIds,
   })) {
-    if (bundledPluginsById.has(candidate.pluginId)) {
+    if (failedPluginIds.has(candidate.pluginId) || bundledPluginsById.has(candidate.pluginId)) {
       continue;
     }
     const shouldReplaceBrokenOfficialInstall = officialReplacementPluginIds.has(candidate.pluginId);
@@ -333,20 +398,34 @@ async function repairMissingPluginInstalls(params: {
         })
       : null;
     const previousRecords = nextRecords;
+    const enforceVersionBoundCohort = targetsHostCohort(candidate.pluginId, record);
     const installed = await installCandidate({
       candidate,
       config: params.cfg,
       records: nextRecords,
       env,
       updateChannel,
-      mode: shouldReplaceBrokenOfficialInstall ? "update" : "install",
+      mode: shouldReplaceBrokenOfficialInstall || enforceVersionBoundCohort ? "update" : "install",
       preferNpm: preferNpmInstalls,
+      npmInstallSpecOverride:
+        enforceVersionBoundCohort && updateChannel !== "beta" && candidate.npmSpec
+          ? `${candidate.npmSpec}@${hostVersion}`
+          : undefined,
+      validateNpmRecord: enforceVersionBoundCohort
+        ? async (record) =>
+            (await installRecordSatisfiesHostCohort(record, env, satisfiesHostCohort))
+              ? undefined
+              : cohortFailure(candidate.pluginId)
+        : undefined,
       ...(installedPluginIdsWithStaleVersionBoundRuntimePackages.has(candidate.pluginId)
         ? { repairReason: "stale-version-bound-runtime" as const }
         : {}),
       ...(params.acknowledgeClawHubRisk ? { acknowledgeClawHubRisk: true } : {}),
       ...(params.onClawHubRisk ? { onClawHubRisk: params.onClawHubRisk } : {}),
     });
+    nextRecords = installed.records;
+    notices.push(...installed.notices);
+    warnings.push(...installed.warnings);
     if (shouldReplaceBrokenOfficialInstall) {
       const installedRecord = installed.records[candidate.pluginId];
       const replacementSucceeded = installed.records !== previousRecords;
@@ -365,10 +444,7 @@ async function repairMissingPluginInstalls(params: {
         }
       }
     }
-    nextRecords = installed.records;
     changes.push(...installed.changes);
-    notices.push(...installed.notices);
-    warnings.push(...installed.warnings);
     if (!installed.failedPluginId && installed.records[candidate.pluginId]) {
       repairedPluginIds.add(candidate.pluginId);
     }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -32,11 +32,27 @@ function expectedNpmInstallSpec(spec: string): string {
   }).installSpec;
 }
 
+function expectedCodexNpmInstallSpec(
+  updateChannel = resolveRegistryUpdateChannel({ currentVersion: VERSION }),
+  coreVersion = VERSION,
+): string {
+  return updateChannel === "beta"
+    ? resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/codex",
+        updateChannel,
+      }).installSpec
+    : `@openclaw/codex@${coreVersion}`;
+}
+
 function expectedClawHubInstallSpec(spec: string): string {
   return resolveClawHubInstallSpecsForUpdateChannel({
     spec,
     updateChannel: resolveRegistryUpdateChannel({ currentVersion: VERSION }),
   }).installSpec;
+}
+
+function expectedCodexCohortFailure(): string {
+  return `Failed to converge version-bound configured plugin "codex" to the ${VERSION} host cohort. Prior install records were retained; inspect the record and payload before retrying.`;
 }
 
 function currentOpenClawReleaseBase(): string {
@@ -136,6 +152,32 @@ function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-stub-repair-"));
   tempDirs.push(dir);
   return dir;
+}
+
+function mockSuccessfulCodexInstall(
+  params: {
+    version?: string;
+    targetDir?: string;
+    resolution?: Record<string, unknown>;
+  } = {},
+): string {
+  const version = params.version ?? VERSION;
+  const targetDir = params.targetDir ?? makeTempDir();
+  mocks.installPluginFromNpmSpec.mockImplementationOnce(async () => {
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(targetDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version }),
+    );
+    return successfulInstall({
+      pluginId: "codex",
+      npmSpec: "@openclaw/codex",
+      targetDir,
+      version,
+      resolution: params.resolution,
+    });
+  });
+  return targetDir;
 }
 
 function writeLegacyNpmDeclarationStub(params: {
@@ -1746,6 +1788,87 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
   });
 
+  it("converges an exact Codex candidate after core update and is a no-op on the second pass", async () => {
+    const npmRoot = makeTempDir();
+    const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "codex");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: VERSION }),
+    );
+    mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
+    mockSuccessfulCodexInstall({ targetDir: packageDir });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        install: {
+          npmSpec: "@openclaw/codex",
+          defaultChoice: "npm",
+        },
+      },
+    ]);
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const env = {
+      OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
+    };
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const firstPass = await repairMissingConfiguredPluginInstalls({ cfg, env });
+
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: expectedCodexNpmInstallSpec(),
+      mode: "update",
+    });
+    expect(firstPass.warnings).toEqual([]);
+    expect(firstPass.repairedPluginIds).toEqual(["codex"]);
+    expectRecordFields(firstPass.records.codex, {
+      source: "npm",
+      spec: "@openclaw/codex",
+      installPath: packageDir,
+      version: VERSION,
+      resolvedVersion: VERSION,
+      resolvedSpec: `@openclaw/codex@${VERSION}`,
+    });
+
+    mocks.writePersistedInstalledPluginIndexInstallRecords.mockClear();
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(firstPass.records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: VERSION,
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: VERSION,
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+
+    mocks.installPluginFromNpmSpec.mockClear();
+    const secondPass = await repairMissingConfiguredPluginInstalls({ cfg, env });
+
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(secondPass).toEqual({ changes: [], warnings: [], records: firstPass.records });
+  });
+
   it("passes the post-core compatibility host version to ClawHub repair", async () => {
     const npmRoot = makeTempDir();
     mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
@@ -2262,17 +2385,12 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       ]),
     );
 
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-      successfulInstall({
-        pluginId: "codex",
-        npmSpec: "@openclaw/codex",
-        version: "2026.7.2",
-        resolution: {
-          integrity: "sha512-codex-supervisor-upgrade",
-          resolvedAt: "2026-07-10T00:00:00.000Z",
-        },
-      }),
-    );
+    const codexInstallDir = mockSuccessfulCodexInstall({
+      resolution: {
+        integrity: "sha512-codex-supervisor-upgrade",
+        resolvedAt: "2026-07-10T00:00:00.000Z",
+      },
+    });
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       {
         id: "codex",
@@ -2294,7 +2412,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: expectedCodexNpmInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2302,10 +2420,10 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expectRecordFields((records as Record<string, unknown>).codex, {
       source: "npm",
       spec: "@openclaw/codex",
-      installPath: "/tmp/openclaw-plugins/codex",
-      version: "2026.7.2",
+      installPath: codexInstallDir,
+      version: VERSION,
       resolvedName: "@openclaw/codex",
-      resolvedSpec: "@openclaw/codex@2026.7.2",
+      resolvedSpec: `@openclaw/codex@${VERSION}`,
       integrity: "sha512-codex-supervisor-upgrade",
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
@@ -2313,7 +2431,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {},
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Installed missing configured plugin "codex" from ${expectedCodexNpmInstallSpec()}.`,
     ]);
     expect(result.warnings).toEqual([]);
     expect(result.repairedPluginIds).toEqual(["codex"]);
@@ -2321,13 +2439,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it("installs a missing default Codex runtime plugin from the official external catalog", async () => {
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-      successfulInstall({
-        pluginId: "codex",
-        npmSpec: "@openclaw/codex",
-        version: "2026.5.2",
-      }),
-    );
+    const codexInstallDir = mockSuccessfulCodexInstall();
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       {
         id: "codex",
@@ -2356,7 +2468,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     expect(mocks.resolveProviderInstallCatalogEntries).toHaveBeenCalled();
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: expectedCodexNpmInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2364,17 +2476,61 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expectRecordFields((records as Record<string, unknown>).codex, {
       source: "npm",
       spec: "@openclaw/codex",
-      installPath: "/tmp/openclaw-plugins/codex",
-      version: "2026.5.2",
+      installPath: codexInstallDir,
+      version: VERSION,
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: expect.any(Object),
       env: {},
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Installed missing configured plugin "codex" from ${expectedCodexNpmInstallSpec()}.`,
     ]);
     expect(result.warnings).toStrictEqual([]);
+  });
+
+  it("reports an unavailable exact stable Codex package without falling back", async () => {
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: false,
+      error: `No matching version found for @openclaw/codex@${VERSION}.`,
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        install: {
+          npmSpec: "@openclaw/codex",
+          defaultChoice: "npm",
+        },
+      },
+    ]);
+
+    const { repairMissingPluginInstallsForIds } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingPluginInstallsForIds({
+      cfg: {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+          },
+        },
+      },
+      pluginIds: ["codex"],
+      env: {},
+    });
+
+    expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: expectedCodexNpmInstallSpec(),
+      expectedPluginId: "codex",
+    });
+    expect(result.changes).toEqual([]);
+    expect(result.repairedPluginIds).toBeUndefined();
+    expect(result.failedPluginIds).toEqual(["codex"]);
+    expect(result.warnings).toEqual([
+      `Failed to install missing configured plugin "codex" from ${expectedCodexNpmInstallSpec()}: No matching version found for @openclaw/codex@${VERSION}.`,
+    ]);
+    expect(result.warnings.join("\n")).not.toMatch(/@(?:latest|beta)\b/u);
   });
 
   it("refreshes a stale managed Codex runtime plugin selected by the OpenAI Codex route", async () => {
@@ -2416,16 +2572,12 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         ],
       ]),
     });
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-      successfulInstall({
-        pluginId: "codex",
-        npmSpec: "@openclaw/codex",
-        version: VERSION,
-        resolution: {
-          integrity: "sha512-new-codex",
-        },
-      }),
-    );
+    mockSuccessfulCodexInstall({
+      targetDir: installDir,
+      resolution: {
+        integrity: "sha512-new-codex",
+      },
+    });
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       {
         id: "codex",
@@ -2453,23 +2605,62 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(mocks.resolveDirectBundledProviderPolicySurface).toHaveBeenCalledWith("openai");
     expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: expectedCodexNpmInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
       mode: "update",
     });
     expect(result.changes).toEqual([
-      `Refreshed stale configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Refreshed stale configured plugin "codex" from ${expectedCodexNpmInstallSpec()}.`,
     ]);
     expectRecordFields(result.records.codex, {
       source: "npm",
       spec: "@openclaw/codex",
-      installPath: "/tmp/openclaw-plugins/codex",
+      installPath: installDir,
       version: VERSION,
       resolvedName: "@openclaw/codex",
       resolvedVersion: VERSION,
       resolvedSpec: `@openclaw/codex@${VERSION}`,
     });
+
+    mocks.installPluginFromNpmSpec.mockClear();
+    mocks.writePersistedInstalledPluginIndexInstallRecords.mockClear();
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(result.records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: VERSION,
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: VERSION,
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+
+    const secondPass = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(secondPass).toEqual({ changes: [], warnings: [], records: result.records });
   });
 
   it("does not refresh a converged beta Codex runtime plugin on the second doctor pass", async () => {
@@ -2512,17 +2703,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         ],
       ]),
     });
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-      successfulInstall({
-        pluginId: "codex",
-        npmSpec: "@openclaw/codex",
-        targetDir: installDir,
-        version: codexBetaVersion,
-        resolution: {
-          integrity: "sha512-new-codex-beta",
-        },
-      }),
-    );
+    mockSuccessfulCodexInstall({
+      targetDir: installDir,
+      version: codexBetaVersion,
+      resolution: {
+        integrity: "sha512-new-codex-beta",
+      },
+    });
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       {
         id: "codex",
@@ -2660,6 +2847,349 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result).toEqual({ changes: [], warnings: [], records });
   });
 
+  it("does not apply cohort pinning to a newer Codex package with a repairable diagnostic", async () => {
+    const installDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "9999.1.1" }),
+    );
+    const records = {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        resolvedName: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@9999.1.1",
+        resolvedVersion: "9999.1.1",
+        version: "9999.1.1",
+        installPath: installDir,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: "9999.1.1",
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [
+        {
+          level: "error",
+          pluginId: "codex",
+          message: "extension entry escapes package directory: ./index.ts",
+        },
+      ],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: "9999.1.1",
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+    mockSuccessfulCodexInstall({
+      targetDir: installDir,
+      version: "9999.1.1",
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        install: {
+          npmSpec: "@openclaw/codex",
+          defaultChoice: "npm",
+        },
+      },
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+        },
+      },
+      env: {},
+    });
+
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: "@openclaw/codex",
+      mode: "update",
+    });
+    expectRecordFields(result.records.codex, {
+      version: "9999.1.1",
+      resolvedVersion: "9999.1.1",
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("retains the prior record when a direct Codex repair misses the exact cohort", async () => {
+    const installDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "2026.5.2" }),
+    );
+    const records = {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        resolvedName: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@2026.5.2",
+        resolvedVersion: "2026.5.2",
+        version: "2026.5.2",
+        installPath: installDir,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "codex",
+          packageVersion: "2026.5.2",
+          providers: ["codex"],
+        },
+      ],
+      diagnostics: [],
+      byPluginId: new Map([
+        [
+          "codex",
+          {
+            id: "codex",
+            packageVersion: "2026.5.2",
+            providers: ["codex"],
+          },
+        ],
+      ]),
+    });
+    mockSuccessfulCodexInstall({
+      targetDir: installDir,
+      version: "2026.5.2",
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        install: {
+          npmSpec: "@openclaw/codex",
+          defaultChoice: "npm",
+        },
+      },
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+        },
+      },
+      env: {},
+    });
+
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: expectedCodexNpmInstallSpec(),
+      mode: "update",
+    });
+    expect(result.records).toBe(records);
+    expect(result.changes).toEqual([]);
+    expect(result.repairedPluginIds).toBeUndefined();
+    expect(result.pluginInventoryChanged).toBeUndefined();
+    expect(result.failedPluginIds).toEqual(["codex"]);
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(result.warnings).toEqual([expectedCodexCohortFailure()]);
+  });
+
+  it.each(["updated", "unchanged"] as const)(
+    "rejects a version-bound updater %s outcome when record and payload miss the host cohort",
+    async (status) => {
+      const installDir = makeTempDir();
+      fs.writeFileSync(
+        path.join(installDir, "package.json"),
+        JSON.stringify({ name: "@openclaw/codex", version: "2026.5.2" }),
+      );
+      const records = {
+        codex: {
+          source: "npm",
+          spec: "@openclaw/codex",
+          version: VERSION,
+          resolvedVersion: VERSION,
+          installPath: "/missing/codex",
+        },
+      };
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.updateNpmInstalledPlugins.mockResolvedValue({
+        changed: status === "updated",
+        config: {
+          plugins: {
+            installs: {
+              codex: {
+                source: "npm",
+                spec: "@openclaw/codex",
+                version: "2026.5.2",
+                resolvedVersion: "2026.5.2",
+                installPath: installDir,
+              },
+            },
+          },
+        },
+        outcomes: [{ pluginId: "codex", status, message: `${status} codex.` }],
+      });
+
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const result = await repairMissingConfiguredPluginInstalls({
+        cfg: {
+          agents: {
+            defaults: {
+              model: "openai/gpt-5.5",
+            },
+          },
+        },
+        env: {},
+      });
+
+      expectRecordFields(mockCallArg(mocks.updateNpmInstalledPlugins), {
+        pluginIds: ["codex"],
+        specOverrides: {
+          codex: expectedCodexNpmInstallSpec(),
+        },
+      });
+      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+      expect(result.changes).toEqual([]);
+      expect(result.records).toBe(records);
+      expect(result.records.codex).toBe(records.codex);
+      expect(result.records.codex.installPath).toBe("/missing/codex");
+      expect(result.repairedPluginIds).toBeUndefined();
+      expect(result.pluginInventoryChanged).toBeUndefined();
+      expect(result.failedPluginIds).toEqual(["codex"]);
+      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+      expect(result.warnings).toEqual([expectedCodexCohortFailure()]);
+    },
+  );
+
+  it("persists an unrelated successful repair while retaining a failed cohort record", async () => {
+    const codexPayload = makeTempDir();
+    const bravePayload = makeTempDir();
+    fs.writeFileSync(
+      path.join(codexPayload, "package.json"),
+      JSON.stringify({ name: "@openclaw/codex", version: "2026.5.2" }),
+    );
+    const records = {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        version: VERSION,
+        resolvedVersion: VERSION,
+        installPath: "/missing/codex",
+      },
+      brave: {
+        source: "npm",
+        spec: "@openclaw/brave-plugin",
+        version: "2026.5.1",
+        resolvedVersion: "2026.5.1",
+        installPath: "/missing/brave",
+      },
+    };
+    const repairedBrave = {
+      ...records.brave,
+      version: "2026.5.2",
+      resolvedVersion: "2026.5.2",
+      installPath: bravePayload,
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.updateNpmInstalledPlugins.mockResolvedValue({
+      changed: true,
+      config: {
+        plugins: {
+          installs: {
+            codex: {
+              ...records.codex,
+              version: "2026.5.2",
+              resolvedVersion: "2026.5.2",
+              installPath: codexPayload,
+            },
+            brave: repairedBrave,
+          },
+        },
+      },
+      outcomes: [
+        { pluginId: "codex", status: "updated", message: "updated codex." },
+        { pluginId: "brave", status: "updated", message: "updated brave." },
+      ],
+    });
+
+    const { repairMissingPluginInstallsForIds } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingPluginInstallsForIds({
+      cfg: {},
+      pluginIds: ["codex", "brave"],
+      env: {},
+    });
+
+    expect(result.records.codex).toBe(records.codex);
+    expect(result.records.brave).toBe(repairedBrave);
+    expect(result.changes).toEqual(['Repaired missing configured plugin "brave".']);
+    expect(result.repairedPluginIds).toEqual(["brave"]);
+    expect(result.failedPluginIds).toEqual(["codex"]);
+    expect(result.pluginInventoryChanged).toBe(true);
+    expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords)).toEqual({
+      codex: records.codex,
+      brave: repairedBrave,
+    });
+  });
+
+  it("rejects a cohort result with missing record and payload versions", async () => {
+    const records = {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        version: VERSION,
+        resolvedVersion: VERSION,
+        installPath: "/missing/codex",
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.updateNpmInstalledPlugins.mockResolvedValue({
+      changed: false,
+      config: {
+        plugins: {
+          installs: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex",
+              resolvedVersion: VERSION,
+              installPath: "/missing/returned-codex",
+            },
+          },
+        },
+      },
+      outcomes: [{ pluginId: "codex", status: "unchanged", message: "unchanged codex." }],
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: { agents: { defaults: { model: "openai/gpt-5.5" } } },
+      env: {},
+    });
+
+    expect(result.records).toBe(records);
+    expect(result.repairedPluginIds).toBeUndefined();
+    expect(result.pluginInventoryChanged).toBeUndefined();
+    expect(result.failedPluginIds).toEqual(["codex"]);
+    expect(result.warnings).toEqual([expectedCodexCohortFailure()]);
+  });
+
   it.each([
     [
       "default OpenAI model route",
@@ -2732,13 +3262,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       {},
     ],
   ])("repairs a missing Codex plugin selected by %s", async (_label, cfg, env) => {
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-      successfulInstall({
-        pluginId: "codex",
-        npmSpec: "@openclaw/codex",
-        version: "2026.5.2",
-      }),
-    );
+    const codexInstallDir = mockSuccessfulCodexInstall();
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       {
         id: "codex",
@@ -2758,7 +3282,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/codex"),
+      spec: expectedCodexNpmInstallSpec(),
       expectedPluginId: "codex",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -2766,25 +3290,26 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expectRecordFields((records as Record<string, unknown>).codex, {
       source: "npm",
       spec: "@openclaw/codex",
-      installPath: "/tmp/openclaw-plugins/codex",
-      version: "2026.5.2",
+      installPath: codexInstallDir,
+      version: VERSION,
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: cfg,
       env,
     });
     expect(result.changes).toEqual([
-      `Installed missing configured plugin "codex" from ${expectedNpmInstallSpec("@openclaw/codex")}.`,
+      `Installed missing configured plugin "codex" from ${expectedCodexNpmInstallSpec()}.`,
     ]);
     expect(result.warnings).toEqual([]);
     expect(Object.keys(result.records)).toEqual(["codex"]);
     expectRecordFields(result.records.codex, {
       source: "npm",
       spec: "@openclaw/codex",
-      installPath: "/tmp/openclaw-plugins/codex",
-      version: "2026.5.2",
+      installPath: codexInstallDir,
+      version: VERSION,
       resolvedName: "@openclaw/codex",
-      resolvedSpec: "@openclaw/codex@2026.5.2",
+      resolvedVersion: VERSION,
+      resolvedSpec: `@openclaw/codex@${VERSION}`,
       integrity: "sha512-codex",
       resolvedAt: "2026-05-01T00:00:00.000Z",
     });

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -23,6 +23,7 @@ import {
   dockerPreflightContainerNames,
   dockerPreflightSmokeCommand,
   githubWorkflowRerunCommand,
+  lanesNeedCodexPluginPackage,
   LOG_TAIL_MAX_BYTES,
   parseDockerAllCliArgs,
   resolveDockerPreflightPlatform,
@@ -136,6 +137,23 @@ describe("scripts/test-docker-all scheduler", () => {
       help: true,
       planJson: false,
     });
+  });
+
+  it("packs the Codex candidate only for configured-plugin survivor lanes", () => {
+    expect(
+      lanesNeedCodexPluginPackage([
+        {
+          name: "published-upgrade-survivor-2026-7-1-configured-plugin-installs",
+        },
+        { name: "update-migration-2026-7-1-configured-plugin-installs" },
+      ]),
+    ).toBe(true);
+    expect(
+      lanesNeedCodexPluginPackage([
+        { name: "published-upgrade-survivor-2026-7-1" },
+        { name: "unrelated-configured-plugin-installs" },
+      ]),
+    ).toBe(false);
   });
 
   it("prints CLI help without a stack trace", () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1963,6 +1963,22 @@ grep -qx -- "OPENCLAW_E2E_COMMAND_TIMEOUT=23s" "$TMPDIR/package-args"
     }
   });
 
+  it("mounts and serves the exact Codex candidate for configured plugin convergence", () => {
+    const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
+    const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+
+    expectTextToIncludeAll(runner, [
+      "OPENCLAW_UPGRADE_SURVIVOR_CODEX_PLUGIN_TGZ",
+      "/tmp/openclaw-codex-plugin-current.tgz:ro",
+    ]);
+    expectTextToIncludeAll(publishedRunner, [
+      '"${OPENCLAW_UPGRADE_SURVIVOR_CODEX_PLUGIN_TGZ:?',
+      '"@openclaw/codex"',
+      '"$candidate_version"',
+      'export OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE_VERSION="$candidate_version"',
+    ]);
+  });
+
   it("wraps package-backed scenario OpenClaw CLI calls with the shared timeout helper", () => {
     const paths = [
       CODEX_ON_DEMAND_DOCKER_E2E_PATH,

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -90,15 +90,32 @@ function writeMigratedSessionState(stateDir: string): void {
   }
 }
 
-function assertConfiguredPluginState(params: { installPath?: string } = {}): void {
+function assertConfiguredPluginState(
+  params: {
+    installPath?: string;
+    codexPayloadVersion?: string;
+    codexRecordVersion?: string;
+  } = {},
+): void {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-"));
   try {
     const stateDir = join(root, "state");
     const workspace = join(root, "workspace");
     const matrixInstallDir = params.installPath ?? join(stateDir, "extensions", "matrix");
+    const codexVersion = "2026.7.2";
+    const codexInstallDir = join(
+      stateDir,
+      "npm",
+      "projects",
+      "codex",
+      "node_modules",
+      "@openclaw",
+      "codex",
+    );
     mkdirSync(join(stateDir, "agents", "main", "sessions"), { recursive: true });
     mkdirSync(join(stateDir, "plugins"), { recursive: true });
     mkdirSync(matrixInstallDir, { recursive: true });
+    mkdirSync(codexInstallDir, { recursive: true });
     mkdirSync(workspace, { recursive: true });
     writeFileSync(join(workspace, "IDENTITY.md"), "# survivor\n");
     writeJson(join(stateDir, "agents", "main", "sessions", "legacy-session.json"), {
@@ -108,8 +125,21 @@ function assertConfiguredPluginState(params: { installPath?: string } = {}): voi
     writeJson(join(matrixInstallDir, "package.json"), {
       name: "@openclaw/matrix",
     });
+    writeJson(join(codexInstallDir, "package.json"), {
+      name: "@openclaw/codex",
+      version: params.codexPayloadVersion ?? codexVersion,
+    });
     writeJson(join(stateDir, "plugins", "installs.json"), {
       installRecords: {
+        codex: {
+          source: "npm",
+          spec: "@openclaw/codex",
+          resolvedName: "@openclaw/codex",
+          resolvedSpec: `@openclaw/codex@${params.codexRecordVersion ?? codexVersion}`,
+          version: params.codexRecordVersion ?? codexVersion,
+          resolvedVersion: params.codexRecordVersion ?? codexVersion,
+          installPath: codexInstallDir,
+        },
         matrix: {
           source: "clawhub",
           spec: "clawhub:@openclaw/matrix",
@@ -119,7 +149,10 @@ function assertConfiguredPluginState(params: { installPath?: string } = {}): voi
           artifactKind: "npm-pack",
         },
       },
-      plugins: [{ pluginId: "matrix", enabled: true }],
+      plugins: [
+        { pluginId: "codex", enabled: true },
+        { pluginId: "matrix", enabled: true },
+      ],
     });
     const coveragePath = join(root, "coverage.json");
     writeJson(coveragePath, {
@@ -132,6 +165,7 @@ function assertConfiguredPluginState(params: { installPath?: string } = {}): voi
         ...process.env,
         OPENCLAW_STATE_DIR: stateDir,
         OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+        OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE_VERSION: codexVersion,
         OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON: coveragePath,
         OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "configured-plugin-installs",
       },
@@ -320,6 +354,18 @@ describe("upgrade survivor assertions", () => {
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
+  });
+
+  it("rejects a configured Codex install record outside the candidate cohort", () => {
+    expect(() => assertConfiguredPluginState({ codexRecordVersion: "2026.7.1" })).toThrow(
+      /codex version mismatch/,
+    );
+  });
+
+  it("rejects a configured Codex payload outside the candidate cohort", () => {
+    expect(() => assertConfiguredPluginState({ codexPayloadVersion: "2026.7.1" })).toThrow(
+      /codex version mismatch/,
+    );
   });
 
   it("accepts executed update.run package transition and post-restart health evidence", () => {


### PR DESCRIPTION
Related:
- #119799 / #119758 own targeted floating official-plugin beta-channel inference.
- #118012 / #118002 own removal of false generic package-version equality QA evidence.
- #118911 owns the stable companion-package publication incident.
- #80197, #87650, and #90891 are earlier stale managed Codex and Doctor drift reports.
- #105374 owns operator guidance for stale official plugin pins.

## What Problem This Solves

Addresses a problem where Doctor could report a configured version-bound runtime plugin as repaired after an npm updater or installer returned `updated` or `unchanged`, even when the resulting install record or payload did not satisfy the running OpenClaw release cohort. The mismatched record could become authoritative, trigger an unnecessary restart, and hide the failed convergence.

It also makes prepublication upgrade-survivor validation use the candidate checkout's `@openclaw/codex` package instead of depending on registry publication order.

## Why This Change Was Made

### Root cause

The configured-plugin Doctor repair path trusted updater status and persisted returned records before checking the complete runtime cohort postcondition. Exact version overrides were also at risk of applying to newer packages or records selected only for unrelated package diagnostics.

### Owner

The owner is the configured-runtime Doctor repair and install-record persistence boundary in `missing-configured-plugin-install`, not the generic plugin updater or targeted update command.

### Canonical fix

For stale or missing plugins explicitly marked `versionBoundToOpenClaw`:

- stable and extended-stable converge to the exact host version;
- beta converges within the same release cohort;
- newer packages and unrelated repairable diagnostics remain untouched;
- success requires the npm record `version`, `resolvedVersion`, and installed payload package version to satisfy that cohort.

If the postcondition fails, Doctor emits a visible failure, retains the prior authoritative record, does not claim repair, and does not advertise inventory change solely from the rejected attempt. Successful unrelated repairs in the same pass still persist.

### Compatibility boundary

Generic plugin compatibility remains range-based through independent minimum-host and plugin-API contracts. This change does not introduce generic package-version equality. `versionBoundToOpenClaw` is a separate, explicit configured-runtime policy used only for selected stale or missing managed runtime targets.

Codex app-server initialization uses client version as identity/analytics metadata, while OpenClaw separately validates the managed app-server version. Neither contract makes generic plugin package compatibility an equality check.

### Activation invariant

Successful npm installation writes a non-authoritative managed generation. The persisted install record is the activation boundary. Rejecting a mismatched record keeps the prior generation authoritative and leaves the rejected generation for normal managed cleanup.

## User Impact

Operators running Doctor after a core update now get an honest, visible failure when the configured version-bound runtime did not actually converge. Doctor no longer persists or restarts from a bad cohort record, while unrelated successful repairs continue normally.

No release or package publication is performed by this PR.

## Evidence

- Focused tests: 337 passed.
  - configured-plugin Doctor and install-channel coverage: 104 passed;
  - Docker scheduler, build-helper, and upgrade-survivor assertion coverage: 233 passed.
- Regression coverage includes stable exact convergence, beta cohort convergence, newer/no-downgrade behavior, unrelated diagnostics, mismatched `updated` and `unchanged` outcomes, prior record and install-path authority, no persistence/restart claim on failure, mixed unrelated success, missing payload/version failure, and lane-bounded candidate tarball wiring.
- Production and scripts: `+163/-23`, net `+140`.
- Tests: `+672/-67`, net `+605`.
- Formatting, shell syntax, `git diff --check`, changed-file classification, and local autoreview passed.
- Current `origin/main` has no changes on the 11 touched paths relative to this branch's reviewed base.
- Full Docker upgrade-survivor execution against the candidate tarball is still pending; the scheduler, mount, proxy-registry, and record/payload assertion plumbing is covered by focused tests.

## Scope

- Does not modify `src/cli/plugins-update-command.ts`.
- Does not change generic updater semantics.
- Does not change Codex handshake or version enforcement.
- Does not publish OpenClaw or `@openclaw/codex`.

Punchcard-Session: quiet-timber-willow-jr
