### PR TITLE
fix(reply): dedupe room-event prompt envelope and make ambient turns cache-stable

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -161,7 +161,7 @@ function createGatewayDrainingError(): Error {
 }
 
 const ROOM_EVENT_MESSAGE_TOOL_DIRECTIVE =
-  "Treat this as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.";
+  "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.";
 
 function createInboundBody<T extends string>(body: T) {
   return { Body: body, RawBody: body, CommandBody: body };
@@ -2285,9 +2285,9 @@ describe("runPreparedReply media-only handling", () => {
     );
 
     const call = requireLastRunReplyAgentCall();
-    expect(call?.commandBody).toBe("[OpenClaw room event]");
+    expect(call?.commandBody).toBe("#35676 Keśava: No wtf");
     expect(call?.transcriptCommandBody).toBe("#35676 Keśava: No wtf");
-    expect(call?.followupRun.prompt).toBe("[OpenClaw room event]");
+    expect(call?.followupRun.prompt).toBe("#35676 Keśava: No wtf");
     expect(call?.followupRun.transcriptPrompt).toBe("#35676 Keśava: No wtf");
     expect(call?.followupRun.currentInboundEventKind).toBe("room_event");
     expect(call?.followupRun.currentInboundAudio).toBe(true);
@@ -2334,9 +2334,7 @@ describe("runPreparedReply media-only handling", () => {
       ROOM_EVENT_MESSAGE_TOOL_DIRECTIVE,
     );
     expect(call?.followupRun.currentInboundContext?.text).not.toContain("visible_reply_contract:");
-    expect(call?.followupRun.currentInboundContext?.text).toContain(
-      "Current event:\n#35676 Keśava: No wtf",
-    );
+    expect(call?.followupRun.currentInboundContext?.text).not.toContain("Current event:");
   });
 
   it("queues active room events as followups instead of steering fake prompts", async () => {
@@ -2378,10 +2376,10 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.shouldFollowup).toBe(true);
     expect(call.isActive).toBe(true);
     expect(call.resolvedQueue.mode).toBe("steer");
-    expect(call.followupRun.prompt).toBe("[OpenClaw room event]");
+    expect(call.followupRun.prompt).toBe("#992 Alice: ambient");
     expect(call.followupRun.currentInboundEventKind).toBe("room_event");
     expect(call.followupRun.abortSignal).toBe(abortController.signal);
-    expect(call.followupRun.currentInboundContext?.text).toContain("Current event:");
+    expect(call.followupRun.currentInboundContext?.text).toContain("Room context:");
   });
 
   it("uses queued followup abort ownership instead of borrowed active-lane abort ownership", async () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -73,9 +73,7 @@ function refreshActiveGoalContextText(params: {
     return retained.join("\n\n");
   }
   if (insertionIndex === undefined) {
-    const anchorIndex = retained.findLastIndex(
-      (block) => block.startsWith("Current message:") || block.startsWith("Current event:"),
-    );
+    const anchorIndex = retained.findLastIndex((block) => block.startsWith("Current message:"));
     insertionIndex = anchorIndex >= 0 ? anchorIndex : retained.length;
   }
   retained.splice(Math.min(insertionIndex, retained.length), 0, params.activeGoalContext);

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -153,13 +153,16 @@ describe("buildReplyPromptEnvelope", () => {
       sourceReplyDeliveryMode: "message_tool_only",
     });
 
-    expect(envelope.prefixedCommandBody).toBe("[OpenClaw room event]");
-    expect(envelope.queuedBody).toBe("[OpenClaw room event]");
+    // The active room-event prompt is the attributed transcript row itself, so
+    // the turn replays byte-identically as history instead of swapping a
+    // placeholder marker for the chat line on the next request.
+    expect(envelope.prefixedCommandBody).toBe("#35676 Keśava: No wtf");
+    expect(envelope.queuedBody).toBe("#35676 Keśava: No wtf");
     expect(envelope.transcriptCommandBody).toBe("#35676 Keśava: No wtf");
+    expect(envelope.queuedBody).toBe(envelope.transcriptCommandBody);
     expect(envelope.currentInboundContext?.text).toBe(
       [
         "[OpenClaw room event]",
-        "inbound_event_kind: room_event",
         [
           "Room context:",
           "Conversation info:",
@@ -171,14 +174,16 @@ describe("buildReplyPromptEnvelope", () => {
           "#35674 Other: I wish I could enjoy 5.5",
           "#35675 User ->#35674: Are you fr fr",
         ].join("\n"),
-        "Current event:\n#35676 Keśava: No wtf",
-        "Treat this as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.",
+        "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.",
       ].join("\n\n"),
     );
+    // Each room-event fact appears exactly once per request: kind lives in the
+    // Conversation info JSON, the event line lives in the user turn body.
+    expect(envelope.currentInboundContext?.text).not.toContain("inbound_event_kind: room_event\n");
+    expect(envelope.currentInboundContext?.text).not.toContain("Current event:");
     expect(envelope.currentInboundContext?.resumableText).toBe(
       [
         "[OpenClaw room event]",
-        "inbound_event_kind: room_event",
         [
           "Room context:",
           "Conversation info:",
@@ -186,8 +191,7 @@ describe("buildReplyPromptEnvelope", () => {
           JSON.stringify({ message_id: "35676", inbound_event_kind: "room_event" }, null, 2),
           "```",
         ].join("\n"),
-        "Current event:\n#35676 Keśava: No wtf",
-        "Treat this as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.",
+        "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.",
       ].join("\n\n"),
     );
     expect(envelope.currentInboundContext?.resumableText).not.toContain(
@@ -220,9 +224,8 @@ describe("buildReplyPromptEnvelope", () => {
     });
 
     expect(envelope.transcriptCommandBody).toBe(ambientTranscriptBody);
-    expect(envelope.currentInboundContext?.text).toContain(
-      `Current event:\n${ambientTranscriptBody}`,
-    );
+    expect(envelope.queuedBody).toBe(ambientTranscriptBody);
+    expect(envelope.currentInboundContext?.text).not.toContain(ambientTranscriptBody);
   });
 
   it("uses the raw current body for room-event current event text", () => {
@@ -251,19 +254,15 @@ describe("buildReplyPromptEnvelope", () => {
 
     expect(envelope.currentInboundContext?.text).toContain("Room context:");
     expect(envelope.currentInboundContext?.text).toContain("Alice: old context");
+    expect(envelope.queuedBody).toBe("#2002 Bob: current note");
     expect(envelope.currentInboundContext?.text).toContain(
-      "Current event:\n#2002 Bob: current note",
-    );
-    expect(envelope.currentInboundContext?.text).toContain(
-      "Treat this as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.",
+      "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.",
     );
     expect(envelope.currentInboundContext?.text).not.toContain("message(action=send)");
     expect(envelope.currentInboundContext?.text).not.toContain(
       "your final text here stays private",
     );
-    expect(envelope.currentInboundContext?.text).not.toContain(
-      "Current event:\n#2002 Bob: [Chat history]",
-    );
+    expect(envelope.queuedBody).not.toContain("[Chat history]");
   });
 
   it("keeps media-only notes in ordinary user request transcripts", () => {

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -159,8 +159,8 @@ function resolvePerTurnDeliveryDirective(params: {
 }): string | undefined {
   if (params.inboundEventKind === "room_event") {
     return params.sourceReplyDeliveryMode === "message_tool_only"
-      ? "Treat this as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way."
-      : "Treat this as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.";
+      ? "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way."
+      : "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.";
   }
   if (
     params.inboundEventKind === "user_request" &&
@@ -171,19 +171,13 @@ function resolvePerTurnDeliveryDirective(params: {
   return undefined;
 }
 
+// The current event itself is the user turn body; the context block carries
+// only the marker, the room backlog, and the reply-policy directive so no
+// fact is stated twice in one request.
 function buildRoomEventContext(params: ReplyPromptEnvelopeBaseParams, roomContext: string): string {
-  const roomEventBody = resolveRoomEventTranscriptBody(params);
   const roomContextBlock = roomContext.trim() ? `Room context:\n${roomContext.trim()}` : "";
   const deliveryDirective = resolvePerTurnDeliveryDirective(params);
-  return [
-    "[OpenClaw room event]",
-    "inbound_event_kind: room_event",
-    roomContextBlock,
-    `Current event:\n${roomEventBody}`,
-    deliveryDirective,
-  ]
-    .filter(Boolean)
-    .join("\n\n");
+  return [ROOM_EVENT_PROMPT, roomContextBlock, deliveryDirective].filter(Boolean).join("\n\n");
 }
 
 function buildResumableRoomContext(roomContext: string): string {
@@ -226,22 +220,17 @@ export function buildReplyPromptEnvelopeBase(
         .filter(Boolean)
         .join("\n\n")
     : params.baseBody;
-  const effectiveBaseBody = isRoomEvent
-    ? ROOM_EVENT_PROMPT
-    : params.hasUserBody
-      ? resetModelBody
-      : MEDIA_ONLY_USER_TEXT;
-  // Room-event transcript rows are plain chat lines; replay treats them as
-  // conversation, while the OpenClaw marker remains current-turn context only.
+  // Room-event turns and their transcript rows share one attributed chat line
+  // so the active turn replays byte-identically as history; the room-event
+  // marker and directive stay current-turn context only.
+  const roomEventBody = isRoomEvent ? resolveRoomEventTranscriptBody(params) : undefined;
+  const effectiveBaseBody =
+    roomEventBody ?? (params.hasUserBody ? resetModelBody : MEDIA_ONLY_USER_TEXT);
   const transcriptBody = params.isHeartbeat
     ? HEARTBEAT_TRANSCRIPT_PROMPT
     : params.isBareSessionReset
       ? softResetTail || `[OpenClaw session ${params.startupAction}]`
-      : isRoomEvent
-        ? resolveRoomEventTranscriptBody(params)
-        : params.hasUserBody
-          ? params.baseBody
-          : MEDIA_ONLY_USER_TEXT;
+      : (roomEventBody ?? (params.hasUserBody ? params.baseBody : MEDIA_ONLY_USER_TEXT));
   const currentInboundContext: CurrentInboundPromptContext | undefined =
     !params.isBareSessionReset && currentInboundContextText
       ? {

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -197,17 +197,12 @@ export function buildReplyPromptEnvelopeBase(
   const softResetTail = params.softResetTail?.trim() ?? "";
   const isRoomEvent = params.inboundEventKind === "room_event";
   const inboundUserContext = params.inboundUserContext.trim();
-  const roomEventContext = buildRoomEventContext(params, inboundUserContext);
   const resumableRoomEventContext = isRoomEvent
     ? buildRoomEventContext(params, buildResumableRoomContext(inboundUserContext))
     : undefined;
-  const userRequestDeliveryDirective = resolvePerTurnDeliveryDirective({
-    inboundEventKind: params.inboundEventKind,
-    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-  });
   const currentInboundContextText = isRoomEvent
-    ? roomEventContext
-    : [inboundUserContext, userRequestDeliveryDirective].filter(Boolean).join("\n\n");
+    ? buildRoomEventContext(params, inboundUserContext)
+    : [inboundUserContext, resolvePerTurnDeliveryDirective(params)].filter(Boolean).join("\n\n");
   const resetModelBody = params.isBareSessionReset
     ? [
         params.inboundUserContext,


### PR DESCRIPTION
## What Problem This Solves

Ambient room-event turns sent the same facts to the model several times per request, and the active turn could never be a prompt-cache prefix hit on the next request:

- The model-visible user turn was a constant `[OpenClaw room event]` placeholder while the persisted transcript row was the attributed chat line (`#48271 Sender: text`), so every room-event turn changed bytes when it became history and broke the provider prefix cache there.
- The room-event context block restated the marker, added a bare `inbound_event_kind: room_event` line duplicating the same key in the `Conversation info` JSON a few lines below, and carried a `Current event:` copy of the chatter that the transcript row already holds.
- The placeholder turn still got the full sender/timestamp envelope stamp, all of whose facts were repeated in the context block of the same request.

## Why This Change Was Made

The active room-event prompt body now **is** the attributed transcript line, so the turn replays byte-identically as history (the same invariant `projectPersistedSenderContext` documents for group turns). The context block keeps only what is not already in the request: the marker, the room backlog, and the reply-policy directive. The now-dead `Current event:` goal-context anchor in `inbound-meta.ts` is removed. The marker predates ambient-row persistence (`7ed4ad8d177` vs `3ad465d32b3`); the divergence was accretion, not design.

Net −13 production LOC.

## User Impact

Ambient rooms (`messages.groupChat.unmentionedInbound: "room_event"`) spend fewer tokens per observed message (~120 duplicated chars removed per event, and the prior turn stays cache-stable instead of re-prefilling). No behavior change: room events stay quiet, visible replies still require `message(action=send)`.

## Evidence

- Regression tests: the three updated room-event cases in `src/auto-reply/reply/prompt-prelude.test.ts` fail on the previous production code (`3 failed | 8 passed`, placeholder body + duplicated context lines) and pass with this change.
- Focused suites green: `prompt-prelude.test.ts` (11), `inbound-meta.test.ts` (77), `get-reply-run.media-only.test.ts`, `queue.collect.test.ts`, `attempt.llm-boundary.cache-stability.test.ts` (14).
- Real-behavior proof (mock-gateway harness: real Telegram group turn through TDLib user driver + mock provider + ephemeral gateway from this branch): room-event request now carries the chatter once as `#48283 OpenClaw: …` in the user turn, context block 1261→1135 chars with no duplicate marker/kind/`Current event:` lines; the following mention turn replays the identical bytes. Recorded timeline shows no visible room message.

```json
{"recordingComplete":true,"totals":{"reaction":2},"sutTotals":{},"providerRequests":2,"roomEventVisibleMessages":0}
```

- `check:changed` typecheck/lint fan-out green on Blacksmith Testbox (run 31077694700).
