### PR TITLE
fix(tooling): stop pnpm from reconciling shared worktree deps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -114,6 +114,8 @@ minimumReleaseAgeExclude:
   - "clawpdf"
 
 nodeLinker: hoisted
+# GWTs share node_modules; script commands must not reconcile that shared install.
+verifyDepsBeforeRun: false
 blockExoticSubdeps: true
 
 overrides:

--- a/test/package-manager-config.test.ts
+++ b/test/package-manager-config.test.ts
@@ -20,7 +20,9 @@ type RootPackageJson = {
   pnpm?: PnpmBuildConfig;
 };
 
-type WorkspaceConfig = PnpmBuildConfig;
+type WorkspaceConfig = PnpmBuildConfig & {
+  verifyDepsBeforeRun?: boolean;
+};
 
 function readJson(filePath: string): unknown {
   return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
@@ -53,6 +55,7 @@ describe("package manager build policy", () => {
     expect(workspace.allowBuilds?.["@discordjs/opus"]).toBe(false);
     expect(workspace.allowBuilds?.["node-llama-cpp"]).toBe(false);
     expect(workspace.blockExoticSubdeps).toBe(true);
+    expect(workspace.verifyDepsBeforeRun).toBe(false);
     expect(workspace.onlyBuiltDependencies).toBeUndefined();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running pnpm commands from a linked GWT could trigger dependency reconciliation against the shared `node_modules` install when that checkout's manifests appeared stale. That can purge or rewrite dependencies used by sibling worktrees and has blocked release preparation with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.

## Why This Change Was Made

The pinned pnpm 11.15.1 runtime defaults `verifyDepsBeforeRun` to `install`. The workspace now explicitly disables that pre-run dependency reconciliation. GWT dependency installation remains an explicit operator action, while `pnpm run` and `pnpm exec` execute only the requested command. A focused config test keeps that invariant from drifting.

Maintainer decision: accept the workspace-wide tradeoff. A checkout with stale dependencies must recover with an explicit `pnpm install`; repository scripts and executables must not implicitly install, remove, or reconcile dependencies shared by linked worktrees.

## User Impact

Maintainers can run pnpm scripts and executables in shared-install GWTs without an implicit install reconciling or removing the shared dependency tree.

Release-note context: prevent pnpm commands in linked GWTs from implicitly reconciling the shared dependency install. No changelog entry is included because release generation owns `CHANGELOG.md`.

## Evidence

- Frozen base: `5f054100487fe79bc12759216b84a79305750644`
- Exact head: `368a17a812c7b13209004c8cb17fec1769a7bc0b`
- Focused test: `node scripts/run-vitest.mjs test/package-manager-config.test.ts` - 1 file, 9 tests passed
- Disposable linked-worktree probe:
  - forced stale-state control exited nonzero before executing its marker
  - normal `pnpm run` and `pnpm exec` both executed their requested commands
  - shared `node_modules` symlink target remained unchanged
  - shared install state SHA-256 remained `1ffa6efc293c8b948a685bc7728bf87468b3c88ff9a6af9a9ee7b7db2fa1d8ba` before and after
- Blacksmith Testbox: `tbx_01kzat41wr9mh2a9mwy0seb6b4`
  - `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`
  - passed formatting, package-lock guards, typecheck, lint, and import-cycle checks
  - run: https://github.com/openclaw/openclaw/actions/runs/31075474444
- Autoreview: clean, no accepted/actionable findings; parallel focused test passed 9/9
