### PR TITLE
fix(config): use real newline in invalid-config log message (#119870)

### DIFF
--- a/src/config/io.invalid-config.test.ts
+++ b/src/config/io.invalid-config.test.ts
@@ -72,7 +72,7 @@ describe("config io invalid config formatting", () => {
     );
     expect(logger.error).toHaveBeenCalledOnce();
     expect(logger.error).toHaveBeenCalledWith(
-      "Invalid config at /tmp/openclaw.json:\\n- nope: Unknown key(s): nope",
+      "Invalid config at /tmp/openclaw.json:\n- nope: Unknown key(s): nope",
     );
   });
 });

--- a/src/config/io.invalid-config.ts
+++ b/src/config/io.invalid-config.ts
@@ -25,7 +25,7 @@ export function formatInvalidConfigDetails(issues: ConfigValidationIssueLike[]):
 
 /** Builds the one-line invalid-config prefix plus preformatted validation details. */
 function formatInvalidConfigLogMessage(configPath: string, details: string): string {
-  return `Invalid config at ${configPath}:\\n${details}`;
+  return `Invalid config at ${configPath}:\n${details}`;
 }
 
 /** Logs an invalid config message once per path during a load sequence. */


### PR DESCRIPTION
## What Problem This Solves

`formatInvalidConfigLogMessage` used `\\n` (escaped backslash-n) in a template literal, producing the literal two-character sequence `\n` in gateway startup logs instead of a real line break. The sibling `createInvalidConfigError` on the next line correctly used `\n`. Operators saw a single-line `Invalid config at /path:\n- ...` instead of a readable multi-line block.

Fixes #119870

## Why This Change Was Made

The log path and the error path for the same invalid config produced different output: the error had real newlines, while the log had literal `\n`. The fix aligns the log path with the error path by using a real newline in the template literal.

## User Impact

- **Before:** invalid config logs showed literal `\n` text on one line.
- **After:** invalid config logs show a readable multi-line block, matching the thrown error format.

## Evidence

Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31086972831

Focused config I/O coverage:

```text
src/config/io.invalid-config.test.ts  3 passed
src/config/io.state.test.ts           3 passed
Test Files  2 passed (2)
Tests       6 passed (6)
```

Disposable invalid config through the real gateway startup command:

```text
gateway_exit=78
Gateway failed to start: Invalid config at <TEMP>/openclaw.json:
<root>: Unrecognized key: "nope"
Run "openclaw doctor --fix" to repair, then retry.
multiline_output=ok
literal_backslash_n=absent
```

The test used isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` values and a non-default port. Paths above are redacted.

**Competition / linked PR analysis:** No overlapping PR found.

**Boundary:** 2 files, 1 character change in production (`\\n` to a real newline) plus 1 test assertion update. No config shape, default, API, or behavior change beyond log formatting.
