### PR TITLE
fix: models list alias test avoids cold runtime timeout

### DIFF
--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -54,6 +54,49 @@ const modelRegistryState = {
   getAvailableError: undefined as unknown,
   findError: undefined as unknown,
 };
+
+function createMockModelRegistry() {
+  return new (class {
+    fork() {
+      return createMockModelRegistry();
+    }
+
+    find(provider: string, id: string) {
+      if (modelRegistryState.findError !== undefined) {
+        throw toLintErrorObject(modelRegistryState.findError, "Non-Error thrown");
+      }
+      return (
+        modelRegistryState.models.find((model) => model.provider === provider && model.id === id) ??
+        null
+      );
+    }
+
+    getAll() {
+      if (modelRegistryState.getAllError !== undefined) {
+        throw toLintErrorObject(modelRegistryState.getAllError, "Non-Error thrown");
+      }
+      return modelRegistryState.models;
+    }
+
+    getAvailable() {
+      if (modelRegistryState.getAvailableError !== undefined) {
+        throw toLintErrorObject(modelRegistryState.getAvailableError, "Non-Error thrown");
+      }
+      return modelRegistryState.available;
+    }
+
+    getProviderMetadataOwners() {
+      return undefined;
+    }
+
+    hasConfiguredAuth(model: { provider: string; id: string }) {
+      return modelRegistryState.available.some(
+        (available) => available.provider === model.provider && available.id === model.id,
+      );
+    }
+  })();
+}
+
 let previousExitCode: typeof process.exitCode;
 let previousOpenAiApiKey: string | undefined;
 
@@ -109,6 +152,30 @@ vi.mock("../agents/prepared-model-catalog.js", () => ({
   },
 }));
 
+vi.mock("./models/list.scoped-catalog.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./models/list.scoped-catalog.js")>();
+  return {
+    ...actual,
+    loadScopedListModelCatalogSnapshot: async (
+      params: Parameters<typeof actual.loadScopedListModelCatalogSnapshot>[0],
+    ) => {
+      if (!params.providerIds.includes("zai")) {
+        return await actual.loadScopedListModelCatalogSnapshot(params);
+      }
+      const entries = await loadModelCatalog();
+      return { entries, routeVariants: entries, staticEntries: [] };
+    },
+  };
+});
+
+vi.mock("../agents/prepared-model-registry.js", () => ({
+  loadPreparedAgentModelRegistry: async (config: object, options?: { agentDir?: string }) => ({
+    agentDir: options?.agentDir ?? "/tmp/openclaw-agent",
+    config,
+    registry: createMockModelRegistry(),
+  }),
+}));
+
 vi.mock("../agents/embedded-agent-runner/model.js", () => ({
   resolveModelWithRegistry: ({
     provider,
@@ -121,67 +188,21 @@ vi.mock("../agents/embedded-agent-runner/model.js", () => ({
   }) => modelRegistry.find(provider, modelId),
 }));
 
-vi.mock("../agents/agent-model-discovery.js", () => {
-  class MockAuthStorage {
-    getAll() {
-      return {};
-    }
-  }
+vi.mock("../agents/agent-model-discovery.js", () => ({
+  discoverAuthStorage: () => ({ getAll: () => ({}) }),
+  discoverModels: () => createMockModelRegistry(),
+  normalizeDiscoveredAgentModel: (model: unknown) => model,
+}));
 
-  class MockModelRegistry {
-    fork() {
-      return new MockModelRegistry();
-    }
-
-    find(provider: string, id: string) {
-      if (modelRegistryState.findError !== undefined) {
-        throw toLintErrorObject(modelRegistryState.findError, "Non-Error thrown");
-      }
-      return (
-        modelRegistryState.models.find((model) => model.provider === provider && model.id === id) ??
-        null
-      );
-    }
-
-    getAll() {
-      if (modelRegistryState.getAllError !== undefined) {
-        throw toLintErrorObject(modelRegistryState.getAllError, "Non-Error thrown");
-      }
-      return modelRegistryState.models;
-    }
-
-    getAvailable() {
-      if (modelRegistryState.getAvailableError !== undefined) {
-        throw toLintErrorObject(modelRegistryState.getAvailableError, "Non-Error thrown");
-      }
-      return modelRegistryState.available;
-    }
-
-    getProviderMetadataOwners() {
-      return undefined;
-    }
-
-    hasConfiguredAuth(model: { provider: string; id: string }) {
-      return modelRegistryState.available.some(
-        (available) => available.provider === model.provider && available.id === model.id,
-      );
-    }
-  }
-
-  return {
-    discoverAuthStorage: () => new MockAuthStorage() as unknown,
-    discoverModels: () => new MockModelRegistry() as unknown,
-    normalizeDiscoveredAgentModel: (model: unknown) => model,
-  };
-});
-
-vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
-  return {
-    ...actual,
-    normalizeProviderResolvedModelWithPlugin,
-  };
-});
+vi.mock("../plugins/provider-runtime.js", () => ({
+  applyProviderNativeStreamingUsageCompatWithPlugin: vi.fn(() => undefined),
+  buildProviderMissingAuthMessageWithPlugin: vi.fn(() => undefined),
+  normalizeProviderConfigWithPlugin: vi.fn(() => undefined),
+  normalizeProviderResolvedModelWithPlugin,
+  resolveProviderConfigApiKeyWithPlugin: vi.fn(() => undefined),
+  resolveProviderSyntheticAuthWithPlugin: vi.fn(() => undefined),
+  shouldDeferProviderSyntheticProfileAuthWithPlugin: vi.fn(() => false),
+}));
 
 vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
   resolveRuntimeSyntheticAuthProviderRefs: () => [],
@@ -590,7 +611,6 @@ describe("models list/status", () => {
       },
     });
     const runtime = makeRuntime();
-
     try {
       await withEnvAsync(
         {


### PR DESCRIPTION
Closes #119867

AI-assisted: yes

## What Problem This Solves

Fixes an issue where contributors running the focused models-list command E2E would hit a 120-second timeout on the first Z.AI provider-alias case when the test process started cold.

On current `main`, the file took 223.08 seconds, with the first general list case taking 78.969 seconds and the first alias case timing out after 120 seconds. That made a heavily mocked command fixture enter repository-wide prepared runtime discovery instead of testing its intended boundary.

## Why This Change Was Made

The fixture still mocked `agent-model-discovery` after registry ownership moved to `prepared-model-registry`, and it mocked `prepared-model-catalog` after provider-filtered lists moved to `list.scoped-catalog`. This change centralizes the existing mock registry behind both the legacy discovery seam and the current prepared-registry seam, and intercepts only Z.AI scoped-catalog requests with the existing catalog fixture.

Non-Z.AI scoped catalogs continue through the real implementation. In particular, the workspace auth-evidence and Moonshot manifest-catalog cases retain their real discovery coverage. Production composition and runtime behavior are unchanged.

Production LOC: +0/-0. Tests: +81/-61.

## User Impact

Contributors and CI get deterministic feedback from the models-list E2E instead of a cold-process timeout. There is no product runtime behavior change.

## Evidence

Before, on `main` at `245dbacbe0917c3f6536f12e40a1b27d67502e66`:

- `node scripts/run-vitest.mjs src/commands/models.list.e2e.test.ts --reporter=verbose`
- 20 passed, 1 timed out; duration 223.08s.
- First general list case: 78.969s.
- First Z.AI alias: timed out after 120s.

After, on fresh Blacksmith Testbox `tbx_01kzb1rqeh4r8hc7atsztn8wa9` ([Actions run 31083563515](https://github.com/openclaw/openclaw/actions/runs/31083563515)):

- `pnpm test src/commands/models.list.e2e.test.ts -- --reporter=verbose`
  - 21/21 passed from a freshly hydrated box.
  - Vitest duration 82.64s.
  - First general list case: 1.792s.
  - Z.AI aliases: 162ms, 154ms, 149ms.
- Five sequential fresh Vitest processes running the alias table:
  - 15/15 alias assertions passed.
  - First alias remained 1.05-1.22s per process; later aliases 120-152ms.
- `pnpm check:changed`
  - Core-test typecheck, formatting, lint, boundary, dependency, dead-code, and ratchet checks passed.
  - 0 lint warnings and 0 errors.
- AutoReview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings; overall correctness 0.99.
- Public model identifier gate: PASS. The added lines introduce no model identifiers.

The initial warm-box pass also completed 21/21 in 68.17s. One transient fixture failure exposed two missing no-op provider-policy exports in the explicit test mock; those exports were added, the full file was rerun, and all final proof above covers the corrected candidate.
