### PR TITLE
fix(cron): reject blank --agent/--session-key on cron edit

### DIFF
--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -106,6 +106,86 @@ describe("cron edit command", () => {
     }
   });
 
+  it.each(["", "   "])(
+    "rejects blank --agent %j instead of silently ignoring it",
+    async (agent) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        await createCronProgram().parseAsync(["edit", "job-1", "--agent", agent], { from: "user" });
+
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--agent must not be blank"));
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each(["", "   "])("rejects blank --agent %j combined with --clear-agent", async (agent) => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+
+    try {
+      await createCronProgram().parseAsync(["edit", "job-1", "--agent", agent, "--clear-agent"], {
+        from: "user",
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--agent must not be blank"));
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("rejects --agent combined with --clear-agent", async () => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+
+    try {
+      await createCronProgram().parseAsync(["edit", "job-1", "--agent", "main", "--clear-agent"], {
+        from: "user",
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Use --agent or --clear-agent, not both"),
+      );
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it.each(["", "   "])(
+    "rejects blank --session-key %j instead of silently ignoring it",
+    async (sessionKey) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        await createCronProgram().parseAsync(["edit", "job-1", "--session-key", sessionKey], {
+          from: "user",
+        });
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("--session-key must not be blank"),
+        );
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    },
+  );
+
   it("keeps --best-effort-deliver-only edits delivery-only (#83908)", async () => {
     const program = createCronProgram();
 

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -23,6 +23,22 @@ function createCronProgram(): Command {
   return program;
 }
 
+async function expectCronEditRejection(args: string[], message: string): Promise<void> {
+  const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+  const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+
+  try {
+    await createCronProgram().parseAsync(["edit", "job-1", ...args], { from: "user" });
+
+    expect(errorSpy).toHaveBeenCalledExactlyOnceWith(expect.stringContaining(message));
+    expect(exitSpy).toHaveBeenCalledExactlyOnceWith(1);
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+  } finally {
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+}
+
 describe("cron edit command", () => {
   beforeEach(() => {
     callGatewayFromCli.mockReset();
@@ -106,129 +122,59 @@ describe("cron edit command", () => {
     }
   });
 
-  it.each(["", "   "])(
-    "rejects blank --agent %j instead of silently ignoring it",
-    async (agent) => {
-      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
-
-      try {
-        await createCronProgram().parseAsync(["edit", "job-1", "--agent", agent], { from: "user" });
-
-        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--agent must not be blank"));
-        expect(callGatewayFromCli).not.toHaveBeenCalled();
-      } finally {
-        errorSpy.mockRestore();
-        exitSpy.mockRestore();
-      }
+  it.each([
+    {
+      label: "empty --agent",
+      args: ["--agent", ""],
+      message: "--agent must not be blank",
     },
-  );
-
-  it.each(["", "   "])("rejects blank --agent %j combined with --clear-agent", async (agent) => {
-    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
-
-    try {
-      await createCronProgram().parseAsync(["edit", "job-1", "--agent", agent, "--clear-agent"], {
-        from: "user",
-      });
-
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--agent must not be blank"));
-      expect(callGatewayFromCli).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
-  });
-
-  it("rejects --agent combined with --clear-agent", async () => {
-    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
-
-    try {
-      await createCronProgram().parseAsync(["edit", "job-1", "--agent", "main", "--clear-agent"], {
-        from: "user",
-      });
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Use --agent or --clear-agent, not both"),
-      );
-      expect(callGatewayFromCli).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
-  });
-
-  it.each(["", "   "])(
-    "rejects blank --session-key %j instead of silently ignoring it",
-    async (sessionKey) => {
-      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
-
-      try {
-        await createCronProgram().parseAsync(["edit", "job-1", "--session-key", sessionKey], {
-          from: "user",
-        });
-
-        expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("--session-key must not be blank"),
-        );
-        expect(callGatewayFromCli).not.toHaveBeenCalled();
-      } finally {
-        errorSpy.mockRestore();
-        exitSpy.mockRestore();
-      }
+    {
+      label: "whitespace --agent",
+      args: ["--agent", "   "],
+      message: "--agent must not be blank",
     },
-  );
-
-  it.each(["", "   "])(
-    "rejects blank --session-key %j combined with --clear-session-key",
-    async (sessionKey) => {
-      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
-
-      try {
-        await createCronProgram().parseAsync(
-          ["edit", "job-1", "--session-key", sessionKey, "--clear-session-key"],
-          { from: "user" },
-        );
-
-        expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("--session-key must not be blank"),
-        );
-        expect(callGatewayFromCli).not.toHaveBeenCalled();
-      } finally {
-        errorSpy.mockRestore();
-        exitSpy.mockRestore();
-      }
+    {
+      label: "empty --agent with --clear-agent",
+      args: ["--agent", "", "--clear-agent"],
+      message: "--agent must not be blank",
     },
-  );
-
-  it("rejects --session-key combined with --clear-session-key", async () => {
-    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
-
-    try {
-      await createCronProgram().parseAsync(
-        ["edit", "job-1", "--session-key", "agent:main:main", "--clear-session-key"],
-        { from: "user" },
-      );
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Use --session-key or --clear-session-key, not both"),
-      );
-      expect(callGatewayFromCli).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
+    {
+      label: "whitespace --agent with --clear-agent",
+      args: ["--agent", "   ", "--clear-agent"],
+      message: "--agent must not be blank",
+    },
+    {
+      label: "--agent with --clear-agent",
+      args: ["--agent", "main", "--clear-agent"],
+      message: "Use --agent or --clear-agent, not both",
+    },
+    {
+      label: "empty --session-key",
+      args: ["--session-key", ""],
+      message: "--session-key must not be blank",
+    },
+    {
+      label: "whitespace --session-key",
+      args: ["--session-key", "   "],
+      message: "--session-key must not be blank",
+    },
+    {
+      label: "empty --session-key with --clear-session-key",
+      args: ["--session-key", "", "--clear-session-key"],
+      message: "--session-key must not be blank",
+    },
+    {
+      label: "whitespace --session-key with --clear-session-key",
+      args: ["--session-key", "   ", "--clear-session-key"],
+      message: "--session-key must not be blank",
+    },
+    {
+      label: "--session-key with --clear-session-key",
+      args: ["--session-key", "agent:main:main", "--clear-session-key"],
+      message: "Use --session-key or --clear-session-key, not both",
+    },
+  ])("rejects $label", async ({ args, message }) => {
+    await expectCronEditRejection(args, message);
   });
 
   it("keeps --best-effort-deliver-only edits delivery-only (#83908)", async () => {

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -186,6 +186,51 @@ describe("cron edit command", () => {
     },
   );
 
+  it.each(["", "   "])(
+    "rejects blank --session-key %j combined with --clear-session-key",
+    async (sessionKey) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        await createCronProgram().parseAsync(
+          ["edit", "job-1", "--session-key", sessionKey, "--clear-session-key"],
+          { from: "user" },
+        );
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("--session-key must not be blank"),
+        );
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    },
+  );
+
+  it("rejects --session-key combined with --clear-session-key", async () => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+
+    try {
+      await createCronProgram().parseAsync(
+        ["edit", "job-1", "--session-key", "agent:main:main", "--clear-session-key"],
+        { from: "user" },
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Use --session-key or --clear-session-key, not both"),
+      );
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("keeps --best-effort-deliver-only edits delivery-only (#83908)", async () => {
     const program = createCronProgram();
 

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -262,20 +262,31 @@ export function registerCronEditCommand(cron: Command) {
             }
             patch.wakeMode = wakeMode;
           }
-          if (opts.agent && opts.clearAgent) {
+          // Match cron list / pacing: blank values are errors, not silent no-ops.
+          // An empty Commander string is falsy, so it skipped the clear-* mutex
+          // and still reached --clear-agent; whitespace-only values were ignored.
+          const agentId = normalizeOptionalString(opts.agent);
+          if (typeof opts.agent === "string" && !agentId) {
+            throw new Error("--agent must not be blank");
+          }
+          if (agentId && opts.clearAgent) {
             throw new Error("Use --agent or --clear-agent, not both");
           }
-          if (typeof opts.agent === "string" && opts.agent.trim()) {
-            patch.agentId = sanitizeAgentId(opts.agent.trim());
+          if (agentId) {
+            patch.agentId = sanitizeAgentId(agentId);
           }
           if (opts.clearAgent) {
             patch.agentId = null;
           }
-          if (opts.sessionKey && opts.clearSessionKey) {
+          const sessionKey = normalizeOptionalString(opts.sessionKey);
+          if (typeof opts.sessionKey === "string" && !sessionKey) {
+            throw new Error("--session-key must not be blank");
+          }
+          if (sessionKey && opts.clearSessionKey) {
             throw new Error("Use --session-key or --clear-session-key, not both");
           }
-          if (typeof opts.sessionKey === "string" && opts.sessionKey.trim()) {
-            patch.sessionKey = opts.sessionKey.trim();
+          if (sessionKey) {
+            patch.sessionKey = sessionKey;
           }
           if (opts.clearSessionKey) {
             patch.sessionKey = null;

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -262,9 +262,6 @@ export function registerCronEditCommand(cron: Command) {
             }
             patch.wakeMode = wakeMode;
           }
-          // Match cron list / pacing: blank values are errors, not silent no-ops.
-          // An empty Commander string is falsy, so it skipped the clear-* mutex
-          // and still reached --clear-agent; whitespace-only values were ignored.
           const agentId = normalizeOptionalString(opts.agent);
           if (typeof opts.agent === "string" && !agentId) {
             throw new Error("--agent must not be blank");


### PR DESCRIPTION
Closes #119878

## Review feedback addressed

ClawSweeper's durable review on `10d21b050adeabb118003a7c3ffd7e26745acd47` (Overall 2/6) left four Before-merge items. All are answered on tip `8b1ef2a642418169b66b5eccfe559ad86f077f13`:

1. **Add real behavior proof** — exact-head CLI terminal run via `node --import tsx src/entry.ts cron edit ...` with isolated `OPENCLAW_HOME` on tip `8b1ef2a642418169b66b5eccfe559ad86f077f13`. Blank/whitespace `--agent` / `--session-key` exit `1` with `must not be blank` before any websocket; see Real-behavior proof below (Artifact `cee6638da2c1…`).
2. **Resolve merge risk (P1) — blank routing values now fail before RPC** — the same transcript shows the intentional compatibility break: blank set-flags never reach `cron.update`. Intentional `--clear-agent` / `--clear-session-key` alone leave validation and hit the real gateway credential gate (`GatewayCredentialsRequiredError`), proving fail-before-RPC vs preserved clear path.
3. **Resolve merge risk (P1) — symmetric session-key clear/mutex coverage** — tip `8b1ef2a642418169b66b5eccfe559ad86f077f13` adds blank+`--clear-session-key` and non-blank mutex cases in `register.cron-edit.test.ts` (symmetric with `--agent`); focused file is **63/63** green.
4. **Complete next step (P2)** — contributor-provided exact-head CLI proof is in the PR body proof block; `@clawsweeper re-review` already queued on `8b1ef2a642418169b66b5eccfe559ad86f077f13`.

Before-merge checklist status against that review:

- [x] **Add real behavior proof** — exact-head CLI transcript on `8b1ef2a6424` (not Commander-mocked only)
- [x] **Resolve merge risk (P1)** — blank routing fail-before-RPC proven by real CLI exits + clear-alone credential gate
- [x] **Resolve merge risk (P1)** — `--session-key` / `--clear-session-key` blank+clear and mutex tests added
- [x] **Complete next step (P2)** — proof attached; re-review requested

Final PR head: `8b1ef2a642418169b66b5eccfe559ad86f077f13`.

## What Problem This Solves

`cron edit` accepted blank or whitespace-only `--agent` / `--session-key` without error, while sibling CLI paths already reject blank agent filters and blank pacing bounds. An empty `--agent ''` is falsy, so it skipped the `--clear-agent` mutual-exclusion guard and still cleared `agentId`. Operators could therefore ship a no-op edit they believed changed routing, or clear an agent while also passing `--agent`.

Unfixed anchors on base `245dbacbe091`:

- https://github.com/openclaw/openclaw/blob/245dbacbe0917c3f6536f12e40a1b27d67502e66/src/cli/cron-cli/register.cron-edit.ts#L265
- https://github.com/openclaw/openclaw/blob/245dbacbe0917c3f6536f12e40a1b27d67502e66/src/cli/cron-cli/register.cron-edit.ts#L268
- https://github.com/openclaw/openclaw/blob/245dbacbe0917c3f6536f12e40a1b27d67502e66/src/cli/cron-cli/register.cron-add.ts#L63

## Why This Change Was Made

Normalize `--agent` and `--session-key` with `normalizeOptionalString` before mutex and patch writes, matching the blank-rejection pattern already used for `cron list --agent` and edit pacing flags. Reject explicit blank values up front, then apply the clear-* mutex on the normalized value, then sanitize/set only when a real id remains. Keep intentional `--clear-agent` / `--clear-session-key` alone on the RPC path. Regression tests cover blank alone, blank+clear, and non-blank mutex for both agent and session-key.

Changed files on tip `8b1ef2a64241`:

- https://github.com/zyw02/openclaw/blob/8b1ef2a642418169b66b5eccfe559ad86f077f13/src/cli/cron-cli/register.cron-edit.ts#L268
- https://github.com/zyw02/openclaw/blob/8b1ef2a642418169b66b5eccfe559ad86f077f13/src/cli/cron-cli/register.cron-edit.test.ts#L109

## User Impact

Cron operators and scripts that accidentally pass empty/whitespace agent or session-key flags now get an immediate validation error instead of a silent no-op or an unintended agent clear. This is an intentional compatibility break for templated invocations that previously relied on blank routing values being ignored: those calls now fail before any gateway RPC. Intentional `--clear-agent` / `--clear-session-key` without a conflicting set flag continues past validation to the gateway call.

## Evidence

### Real-behavior proof

<!-- issue-hunter-proof:start -->
```text
Exact-head real CLI proof
reviewed_head=8b1ef2a642418169b66b5eccfe559ad86f077f13
base_sha=245dbacbe0917c3f6536f12e40a1b27d67502e66
date=2026-08-06T08:56:24Z
node=v24.15.0
runner=node --import tsx src/entry.ts
workdir=/root/workspace/manual-prospect-1

----- blank-agent -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --agent 
Error: --agent must not be blank
exit=1

----- spaces-agent -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --agent    
Error: --agent must not be blank
exit=1

----- empty-agent-clear -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --agent  --clear-agent
Error: --agent must not be blank
exit=1

----- agent-mutex -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --agent main --clear-agent
Error: Use --agent or --clear-agent, not both
exit=1

----- blank-session-key -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --session-key 
Error: --session-key must not be blank
exit=1

----- spaces-session-key -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --session-key    
Error: --session-key must not be blank
exit=1

----- empty-session-clear -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --session-key  --clear-session-key
Error: --session-key must not be blank
exit=1

----- session-mutex -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --session-key agent:main:main --clear-session-key
Error: Use --session-key or --clear-session-key, not both
exit=1

----- clear-agent-alone -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --clear-agent
GatewayCredentialsRequiredError: gateway cron.update requires credentials before opening a websocket
Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.
Config: /tmp/prospect-119879-cli-proof-8b1ef2a642418169b66b5eccfe559ad86f077f13/home-clear-agent-alone/.openclaw/openclaw.json
exit=1

----- clear-session-alone -----
$ node --import tsx src/entry.ts cron edit job-proof-1 --clear-session-key
GatewayCredentialsRequiredError: gateway cron.update requires credentials before opening a websocket
Fix: configure gateway.auth token/password, pair this device, or pass --token/--password.
Config: /tmp/prospect-119879-cli-proof-8b1ef2a642418169b66b5eccfe559ad86f077f13/home-clear-session-alone/.openclaw/openclaw.json
exit=1
```

Interpretation on exact head `8b1ef2a642418169b66b5eccfe559ad86f077f13`:

- Blank/whitespace `--agent` and `--session-key` exit 1 with `must not be blank` before any websocket/RPC.
- Empty set-flag combined with the matching clear-flag also fails with the blank error (no silent clear).
- Non-blank set+clear still hits the mutex.
- Intentional clear-alone leaves validation and reaches the real gateway credential gate (`GatewayCredentialsRequiredError` for `cron.update`), proving the clear contract is preserved and blank rejection is fail-before-RPC.

Artifact SHA-256: `cee6638da2c1dd0e5d4e54c70ee4f4cd84401fbeb1c6630298b8b8681a5776ac`
<!-- issue-hunter-proof:end -->

Evidence scope: This proof exercises the official CLI entry (`src/entry.ts` via `node --import tsx`) on reviewed head `8b1ef2a642418169b66b5eccfe559ad86f077f13` with an isolated OPENCLAW_HOME. It covers option validation and the pre-RPC boundary for blank routing values and clear/mutex pairs. It does not require a live authenticated gateway to demonstrate fail-before-RPC; clear-alone intentionally stops at the credential gate after validation succeeds.

### Focused regression tests

```text
node node_modules/vitest/vitest.mjs run src/cli/cron-cli/register.cron-edit.test.ts --reporter=dot
Test Files  1 passed (1)
     Tests  63 passed (63)
Reviewed head: 8b1ef2a642418169b66b5eccfe559ad86f077f13
```

Includes symmetric `--session-key` / `--clear-session-key` blank+clear and mutex cases in addition to the `--agent` suite.

```text
git diff --check
Passed.
```

Artifact SHA-256: `cee6638da2c1dd0e5d4e54c70ee4f4cd84401fbeb1c6630298b8b8681a5776ac`

## Remaining Risk

GitHub required checks and maintainer review on the final PR head remain the normal merge gate. Callers that previously depended on blank `--agent` / `--session-key` being ignored will need to omit those flags instead; that is the intended compatibility change proven above. No additional known product regressions were observed in the focused evidence.

## AI-assisted development

This change was implemented with AI-assisted development and published through a guarded approval workflow. The exact diff and exact-head CLI terminal evidence were verified before publication.

Artifact SHA-256: `cee6638da2c1dd0e5d4e54c70ee4f4cd84401fbeb1c6630298b8b8681a5776ac`

