### PR TITLE
fix(config): render real newline in invalid-config log message

### DIFF
--- a/src/config/io.invalid-config.test.ts
+++ b/src/config/io.invalid-config.test.ts
@@ -72,7 +72,7 @@ describe("config io invalid config formatting", () => {
     );
     expect(logger.error).toHaveBeenCalledOnce();
     expect(logger.error).toHaveBeenCalledWith(
-      "Invalid config at /tmp/openclaw.json:\\n- nope: Unknown key(s): nope",
+      "Invalid config at /tmp/openclaw.json:\n- nope: Unknown key(s): nope",
     );
   });
 });

--- a/src/config/io.invalid-config.ts
+++ b/src/config/io.invalid-config.ts
@@ -25,7 +25,7 @@ export function formatInvalidConfigDetails(issues: ConfigValidationIssueLike[]):
 
 /** Builds the one-line invalid-config prefix plus preformatted validation details. */
 function formatInvalidConfigLogMessage(configPath: string, details: string): string {
-  return `Invalid config at ${configPath}:\\n${details}`;
+  return `Invalid config at ${configPath}:\n${details}`;
 }
 
 /** Logs an invalid config message once per path during a load sequence. */


### PR DESCRIPTION
## What Problem

`formatInvalidConfigLogMessage` in `src/config/io.invalid-config.ts` used `\\n` (escaped backslash-n) inside a template literal, so gateway startup logs printed the literal two-character sequence `\n` instead of a real line break:

```
Invalid config at /path:\n- nope: Unknown key(s): nope
```

The sibling `createInvalidConfigError` (next line) correctly produces a real newline, so the thrown error and the logged message disagreed in format.

## Why

The log is the first thing an operator sees when a config fails to load. A literal `\n` on one long line is harder to read and inconsistent with the error message thrown for the same failure. Reported in #119870 with a clear repro (add `nope: true` to a config, start the gateway, observe the log).

## User Impact

Gateway startup error logs for invalid configs now show a readable multi-line block:

```
Invalid config at /path:
- nope: Unknown key(s): nope
```

No behavioral change beyond the log line rendering; the thrown `InvalidConfigError` message format is untouched.

## Evidence

- Diff: `src/config/io.invalid-config.ts:28` — `\\n` → `\n` (1 char).
- The existing unit test in `src/config/io.invalid-config.test.ts:74-76` asserted the buggy literal `\n`; updated it to assert the real newline, matching the sibling error-format assertion at line 37.
- Verified: `./node_modules/.bin/vitest run src/config/io.invalid-config.test.ts` → `Test Files 1 passed (1), Tests 3 passed (3)`.

[AI-assisted]
