### PR TITLE
fix(android): label channel messages with gateway senderLabel

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -5597,6 +5597,7 @@ class ChatController internal constructor(
           timestampMs = ts,
           idempotencyKey = obj["idempotencyKey"].asStringOrNull(),
           entryId = obj["__openclaw"].asObjectOrNull()?.get("id").asStringOrNull(),
+          senderLabel = obj["senderLabel"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
         )
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -28,6 +28,8 @@ data class ChatMessage(
   val idempotencyKey: String? = null,
   /** Canonical transcript-tree identity supplied by chat.history. */
   val entryId: String? = null,
+  /** Gateway-resolved display name of the originating sender for inbound channel messages. */
+  val senderLabel: String? = null,
 )
 
 /** One selectable transcript branch returned by sessions.branches.list. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -1306,6 +1306,7 @@ private fun ChatMessageList(
               live = false,
               content = item.message.content,
               timestampMs = item.message.timestampMs,
+              senderLabel = item.message.senderLabel,
               onReplyMessage = onReplyMessage,
               sessionActionsEnabled = sessionActionsEnabled,
               onRewindMessage = onRewindMessage,
@@ -1349,6 +1350,7 @@ private fun ChatMessageList(
               live = true,
               content = listOf(ChatMessageContent(text = item.text)),
               timestampMs = null,
+              senderLabel = null,
               onReplyMessage = onReplyMessage,
               sessionActionsEnabled = false,
               onRewindMessage = onRewindMessage,
@@ -1599,6 +1601,7 @@ private fun ChatBubble(
   live: Boolean,
   content: List<ChatMessageContent>,
   timestampMs: Long?,
+  senderLabel: String?,
   onReplyMessage: (String) -> Unit,
   sessionActionsEnabled: Boolean,
   onRewindMessage: (String) -> Unit,
@@ -1662,7 +1665,9 @@ private fun ChatBubble(
             text =
               when {
                 live -> nativeString("OpenClaw · Live")
-                isUser -> nativeString("You")
+                isUser ->
+                  senderLabel?.takeIf { it.isNotBlank() }?.let(::nativeString)
+                    ?: nativeString("You")
                 normalizedRole == "system" -> nativeString("System")
                 else -> nativeString("OpenClaw")
               },


### PR DESCRIPTION
## What Problem

In the Android app transcript, every message with `role: "user"` is labeled `You`, regardless of who actually sent it. A Slack/Discord/Telegram channel member's message mentioning the bot is misattributed to the reader. The gateway already resolves the originating sender's display name and ships it as `senderLabel` on the same `chat.history` response that the Control UI renders correctly (`ui/src/pages/chat/components/chat-message-group.ts`); the Android app never decoded it (`grep -rn "senderLabel" apps/android` → no hits, confirmed in #119854).

## Why

In a shared channel the transcript gives no way to tell who asked what, and `You` actively misattributes other members' messages to the reader (P1, `impact:ux-friction`). This is client-only: the identity is computed by the channel extensions (`extensions/slack/src/monitor/message-handler/prepare.ts`), attached by the gateway (`src/gateway/chat-sanitize.ts`, with an existing test asserting `senderLabel === "alice"`), and already consumed by the Control UI over the same RPC. No gateway/protocol change needed.

## User Impact

Messages from channel members now show that member's display name (e.g. `Alice` instead of `You`) in the Android chat transcript, matching the Control UI. The operator's own app-sent messages still show `You` because they carry no `senderLabel`. The outbox bubble (`ChatMessageViews.kt`) and voice transcript (`VoiceScreen.kt`) are unchanged — those are always the operator's own messages, where `You` is correct.

## Evidence

- `apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt` — `ChatMessage` gains `senderLabel: String? = null` (default keeps all existing construction sites unchanged).
- `apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt:5600` — `parseHistory` now reads `senderLabel` off the wire: `obj["senderLabel"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }`.
- `apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt` — `ChatBubble` takes `senderLabel`; the user-role label becomes `senderLabel ?: "You"` (falls back to `You` only when no sender identity exists), mirroring the Control UI rule: use the operator name only when the message actually came from the operator.
- Diff is +9/−1 across 3 files; rendering via `nativeString(...)` follows the existing dynamic-source pattern (`VoiceScreen.kt` passes runtime strings through the same helper, which falls back to the verbatim source).
- Note: this environment has no Android SDK, so the Kotlin change could not be compiled here; it is limited to adding a defaulted model field, one `asStringOrNull()` read following the adjacent lines, and a `when`-branch fallback, all mirroring existing code. Offline cached transcripts (`ChatTranscriptCache`) do not yet persist `senderLabel` — left as a named follow-up to avoid a Room schema migration in this fix.

[AI-assisted]
