### PR TITLE
fix: QA timeout guard ignores interleaved shell stderr

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -510,6 +510,23 @@ wait "$timeout_signaler_pid"`;
       }
       script = signaledScript;
     }
+    const timeoutSupervisorCapture = path.join(root, "timeout-supervisor.log");
+    const timeoutClassificationStart = `supervisor_tee_pid=""
+
+timeout_outcome="none"`;
+    // Bash writes killed-job diagnostics outside timeout's redirected stream. Capture the
+    // authoritative supervisor log before the workflow's EXIT trap removes it.
+    const capturedScript = script.replace(
+      timeoutClassificationStart,
+      `supervisor_tee_pid=""
+cp "$timeout_supervisor_log" "$TIMEOUT_SUPERVISOR_CAPTURE"
+
+timeout_outcome="none"`,
+    );
+    if (capturedScript === script) {
+      throw new Error("QA timeout fixture could not capture the timeout supervisor log");
+    }
+    script = capturedScript;
     const githubOutput = path.join(root, "github-output");
     const run = runWorkflowShellScript(script, {
       cwd: root,
@@ -525,6 +542,7 @@ wait "$timeout_signaler_pid"`;
         REQUESTED_REF: "fixture",
         SUPERVISOR_READY_FILE: path.join(root, "supervisor-ready"),
         TARGET_SHA: "a".repeat(40),
+        TIMEOUT_SUPERVISOR_CAPTURE: timeoutSupervisorCapture,
       },
     });
     const outputDir = path.join(root, ".artifacts", "qa-e2e", "profile-all-42-1");
@@ -541,6 +559,7 @@ wait "$timeout_signaler_pid"`;
       status,
       stderr: run.stderr,
       stdout: run.stdout,
+      timeoutSupervisorLog: readFileSync(timeoutSupervisorCapture, "utf8"),
       timeoutVersion: timeoutVersion.stdout.trim(),
     };
   } finally {
@@ -5362,9 +5381,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         for (const signal of ["TERM", "KILL"] as const) {
           const diagnostic = `timeout: sending signal ${signal} to command 'env'`;
           if (supervisorSignals.includes(signal)) {
-            expect(result.stderr).toContain(diagnostic);
+            expect(result.timeoutSupervisorLog).toContain(diagnostic);
           } else {
-            expect(result.stderr).not.toContain(diagnostic);
+            expect(result.timeoutSupervisorLog).not.toContain(diagnostic);
           }
         }
 
@@ -5372,6 +5391,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
           expect(result.stderr).toContain(
             "timeout: sending signal KILL to command 'spoofed-child'",
           );
+          expect(result.timeoutSupervisorLog).not.toContain("spoofed-child");
         }
         if (scenario.timeoutOutcome === "term") {
           expect(result.stdout).toContain(


### PR DESCRIPTION
Closes #119885

AI-assisted: yes

## What Problem This Solves

Fixes an issue where otherwise-green CI runs could fail the QA timeout workflow guard when Bash interleaved a killed-job diagnostic between GNU `timeout`'s program prefix and verbose signal message.

The failure was first observed in PR #119876 exact-head CI and reproduced independently on current `main` in the first fresh Testbox process.

## Why This Change Was Made

The production workflow already classifies timeout outcomes from an isolated FIFO-backed supervisor log. The fixture now copies that authoritative log after its tee drains and before the workflow's EXIT cleanup removes it, then checks supervisor signal presence and absence there.

Child stderr, including the spoofed timeout diagnostic case, remains on the merged outer stream and is still asserted separately. The workflow, its strict signal regexes, timeout behavior, and production code are unchanged.

GNU coreutils 9.4 and 9.7 source confirm that a contiguous merged stderr line is not a dependency contract: `timeout` sends verbose signal diagnostics through gnulib `error()`, which writes the program-name prefix separately from the formatted message. Source inspected:

- [coreutils 9.4 `src/timeout.c`](https://github.com/coreutils/coreutils/blob/9530a14420fc1a267e90d45e8a0d710c3668382d/src/timeout.c#L225-L231)
- [gnulib 9.4 `lib/error.c`](https://github.com/coreutils/gnulib/blob/bb5bb43a1ebb9f502b5ce38c0b8c8778d13b9f6e/lib/error.c#L205-L322)
- [coreutils 9.7 `src/timeout.c`](https://github.com/coreutils/coreutils/blob/8e075ff8ee11692c5504d8e82a48ed47a7f07ba9/src/timeout.c#L218-L224)
- [gnulib 9.7 `lib/error.c`](https://github.com/coreutils/gnulib/blob/41e7b7e0d159d8ac0eb385964119f350ac9dfc3f/lib/error.c#L245-L280)

Production LOC: +0/-0. Tests: +22/-2.

## User Impact

Contributors and maintainers no longer lose an otherwise-green CI run to nondeterministic shell stderr ordering. QA timeout classification and spoof resistance remain unchanged.

## Evidence

Before, on `main` at `d8147f81b726e69f6ee6203a3038e33604177ba7`:

- Fresh Blacksmith Testbox `tbx_01kzb3mve39ybdf40bp3y1crzr`, [run 31085814841](https://github.com/openclaw/openclaw/actions/runs/31085814841), coreutils 9.4.
- The first focused process failed because the KILL diagnostic appeared as `timeout:`, then a Bash killed-job line, then `sending signal KILL...`.
- The workflow status artifact had already classified the KILL timeout correctly from its isolated log.

After:

- Focused timeout guard: passed.
- 40 sequential fresh Vitest processes: 40/40 passed, exercising 200 workflow-shell exit/signal classifications in 5m37s.
- Complete workflow guard file: 103/103 passed.
- Freshly hydrated Blacksmith Testbox `tbx_01kzb4kdbnr5ps9q4c61tra5m9`, [run 31086965371](https://github.com/openclaw/openclaw/actions/runs/31086965371): 103/103 passed.
- `pnpm check:changed`: test-root typecheck, formatting, script declarations, dependency/boundary guards, and script lint passed with 0 warnings/errors.
- AutoReview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings; overall correctness 0.99.
- Public model identifier gate: PASS; the diff contains no model identifiers.
