### PR TITLE
fix(pr): fail fast on exhausted temporary storage

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -315,6 +315,8 @@ main() {
     local locked_pr="${1-}"
     acquire_pr_operation_lock "$locked_pr"
     begin_pr_operation_validation_phase
+    # Temp-backed shell redirections must fail while the supervisor can auto-release.
+    validate_pr_temp_storage
     trap 'exit 129' HUP
     trap 'exit 130' INT
     trap 'exit 131' QUIT

--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -6,6 +6,22 @@ require_artifact() {
   fi
 }
 
+validate_pr_temp_storage() {
+  local temp_dir="${TMPDIR:-/tmp}"
+  local probe=""
+  if ! probe=$(mktemp "${temp_dir%/}/openclaw-pr.XXXXXX"); then
+    :
+  elif ! printf 'openclaw-pr-temp-probe\n' >"$probe"; then
+    rm -f "$probe" 2>/dev/null || true
+  elif rm -f "$probe"; then
+    return 0
+  fi
+
+  echo "scripts/pr temporary-storage preflight failed under TMPDIR=$temp_dir." >&2
+  echo "Free disk space or set TMPDIR to a writable filesystem, then retry." >&2
+  return 1
+}
+
 path_is_docsish() {
   local path="$1"
   case "$path" in
@@ -20,13 +36,19 @@ file_list_is_docsish_only() {
   local files="$1"
   local saw_any=false
   local path
-  while IFS= read -r path; do
+  while [ -n "$files" ]; do
+    path="${files%%$'\n'*}"
+    if [ "$path" = "$files" ]; then
+      files=""
+    else
+      files="${files#*$'\n'}"
+    fi
     [ -n "$path" ] || continue
     saw_any=true
     if ! path_is_docsish "$path"; then
       return 1
     fi
-  done <<< "$files"
+  done
 
   [ "$saw_any" = "true" ]
 }

--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -385,7 +385,13 @@ prepare_gates() {
   local has_changelog_update=false
   local unsupported_changelog_fragments=""
   local changed_path
-  while IFS= read -r changed_path; do
+  while [ -n "$changed_files" ]; do
+    changed_path="${changed_files%%$'\n'*}"
+    if [ "$changed_path" = "$changed_files" ]; then
+      changed_files=""
+    else
+      changed_files="${changed_files#*$'\n'}"
+    fi
     [ -n "$changed_path" ] || continue
     case "$changed_path" in
       CHANGELOG.md)
@@ -395,7 +401,7 @@ prepare_gates() {
         unsupported_changelog_fragments="${unsupported_changelog_fragments}${changed_path}"$'\n'
         ;;
     esac
-  done <<<"$changed_files"
+  done
   if [ -n "$unsupported_changelog_fragments" ]; then
     echo "Unsupported changelog fragment files detected:"
     printf '%s\n' "$unsupported_changelog_fragments"

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -837,6 +837,38 @@ describePosix("scripts/pr per-PR operation lock", () => {
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(refExists(repoDir)).toBe(false);
   });
+  it("releases a validation-phase lock when temporary storage is unavailable", () => {
+    const repoDir = createRepo();
+    const { binDir, cli } = installPrCliFixture(repoDir);
+    const reviewScript = join(repoDir, "scripts/pr-lib/review.sh");
+    writeFileSync(
+      reviewScript,
+      `${readFileSync(reviewScript, "utf8")}\nreview_init() { printf 'review ran\\n'; }\n`,
+    );
+    for (const command of ["gh", "jq", "pnpm", "rg"]) {
+      const stub = join(binDir, command);
+      writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+      chmodSync(stub, 0o755);
+    }
+    const mktempStub = join(binDir, "mktemp");
+    writeFileSync(mktempStub, "#!/bin/sh\necho 'mktemp: No space left on device' >&2\nexit 1\n");
+    chmodSync(mktempStub, 0o755);
+
+    const result = spawnSync(cli, ["review-init", "42"], {
+      cwd: repoDir,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+    expect(result.stderr).toContain("mktemp: No space left on device");
+    expect(result.stderr).toContain("temporary-storage preflight failed");
+    expect(result.stderr).toContain("Free disk space or set TMPDIR");
+    expect(result.stderr).not.toContain("Retaining the operation lock");
+    expect(result.stderr).not.toContain("scripts/pr lock-recover");
+    expect(result.stdout).not.toContain("review ran");
+    expect(refExists(repoDir)).toBe(false);
+  });
   it.each([["--dryrun"], ["--dry-run", "extra"]])(
     "rejects invalid gc arguments before cleanup: %s",
     (...args: string[]) => {
@@ -1919,9 +1951,12 @@ describePosix("scripts/pr per-PR operation lock", () => {
     expect(result.status, result.stdout + "\n" + result.stderr).toBe(0);
     expect(result.stdout.trim()).toBe("23 23");
   });
-  it("accepts only nonempty docs-only file lists", () => {
+  it("parses docs and mixed file lists without temp files or producer processes", () => {
     const repoDir = createRepo();
+    const unusableTmpDir = join(repoDir, "missing-tmp");
     const result = runLockShell(repoDir, [
+      `TMPDIR='${unusableTmpDir}'`,
+      "printf() { echo 'unexpected producer' >&2; return 99; }",
       "set +e",
       "file_list_is_docsish_only ''",
       'empty_status="$?"',
@@ -1929,10 +1964,12 @@ describePosix("scripts/pr per-PR operation lock", () => {
       'docs_status="$?"',
       "file_list_is_docsish_only $'docs/guide.md\\nsrc/index.ts'",
       'mixed_status="$?"',
-      'printf "%s %s %s\\n" "$empty_status" "$docs_status" "$mixed_status"',
+      'command printf "%s %s %s\\n" "$empty_status" "$docs_status" "$mixed_status"',
     ]);
     expect(result.status, result.stdout + "\n" + result.stderr).toBe(0);
     expect(result.stdout.trim()).toBe("1 0 1");
+    expect(result.stderr).not.toContain("unexpected producer");
+    expect(readFileSync(commonScript, "utf8")).not.toMatch(/done\s+(?:<<<|<\s*<\()/u);
   });
   it("prunes a registered worktree whose directory is already gone", () => {
     const repoDir = createRepo();

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -1,7 +1,15 @@
 // Covers the scripts/pr prepare-gates remote testbox mode and the
 // cross-worktree gate lock that serializes whole gate blocks.
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -393,6 +401,37 @@ describe("prepare gate changed-file plan", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe("true");
+  });
+
+  it("scans changed files without temporary input storage", () => {
+    const workDir = makeTempDir("openclaw-pr-gates-no-tmp-");
+    mkdirSync(join(workDir, ".local"));
+    writeFileSync(join(workDir, ".local", "pr-meta.env"), "PR_AUTHOR=steipete\n");
+    const result = runGatesBash(
+      [
+        "enter_worktree() { :; }",
+        "checkout_prep_branch() { :; }",
+        "derive_prepare_gate_change_plan() {",
+        "  PREPARE_GATE_CHANGED_FILES=$'CHANGELOG.md\\nchangelog/fragments/stale.md'",
+        "  PREPARE_GATE_DOCS_ONLY=true",
+        "  PREPARE_GATE_CHANGELOG_ONLY=false",
+        "  PREPARE_GATE_CHANGELOG_REQUIRED=false",
+        "}",
+        "prepare_gates 4242",
+      ].join("\n"),
+      {
+        cwd: workDir,
+        env: { TMPDIR: join(workDir, "missing-tmp") },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("Unsupported changelog fragment files detected:");
+    expect(result.stdout).toContain("changelog/fragments/stale.md");
+    expect(result.stderr).not.toContain("cannot create temp file");
+    expect(readFileSync(join(repoRoot, "scripts/pr-lib/gates.sh"), "utf8")).not.toMatch(
+      /done\s+(?:<<<|<\s*<\()/u,
+    );
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where locked `scripts/pr` operations could hang after temporary
storage filled up. Bash attempted to materialize changed-file input after the
operation had crossed into side effects, so the failure was neither prompt nor
automatically recoverable.

## Why This Change Was Made

Locked operations now create, write, and remove a small temporary probe while
the operation lock is still in its validation phase. The two affected
newline-delimited changed-file scans now iterate in pure Bash, avoiding
temp-backed here-strings without reintroducing unjoined producer processes.

Production LOC: +34/-4 (net +30) | Tests: +79/-3

## User Impact

Maintainers now get an immediate disk/TMPDIR error and exit code 1 before any PR
workflow side effect. The supervisor releases the operation lock automatically,
so release and landing work can retry after freeing space without manual lock
recovery. Product runtime behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pr-operation-lock.test.ts -t 'releases a validation-phase lock when temporary storage is unavailable|parses docs and mixed file lists without temp files or producer processes'` (2 passed)
- `node scripts/run-vitest.mjs test/scripts/pr-prepare-gates.test.ts -t 'scans changed files without temporary input storage'` (1 passed)
- `bash -n scripts/pr scripts/pr-lib/common.sh scripts/pr-lib/gates.sh`
- `git diff --check`
- `./node_modules/.bin/oxfmt --check test/scripts/pr-operation-lock.test.ts test/scripts/pr-prepare-gates.test.ts`
- Blacksmith Testbox `tbx_01kzb4mq8bv37e77hj68ec28cx`: changed tooling/test-root gate passed, exit 0
- GitHub Actions run: https://github.com/openclaw/openclaw/actions/runs/31087014317
- Blacksmith Testbox `tbx_01kzb51mk3ct3dv8h4npqg1gg3`: 108 focused tests passed across both touched test files
- Focused-test Actions run: https://github.com/openclaw/openclaw/actions/runs/31087520833
- Fresh autoreview: no accepted or actionable findings
