### PR TITLE
fix(cron): mutex blank --model/--thinking with matching clear flags

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1429,33 +1429,23 @@ describe("cron cli", () => {
     expect(params?.payload?.fallbacks).toEqual(["openrouter/gpt-4.1-mini", "openai/gpt-5"]);
   });
 
-  it("cron edit rejects blank model/thinking instead of omitting them", async () => {
-    await expectCronCommandExit([
-      "cron",
-      "edit",
-      "job-1",
-      "--message",
-      "hello",
-      "--model",
-      "   ",
-      "--thinking",
-      "  ",
-    ]);
-    expectRuntimeErrorContaining("--model must not be blank");
-    expect(callGatewayFromCli).not.toHaveBeenCalled();
-  });
-
-  it("cron edit trims model and thinking", async () => {
-    const patch = await runCronEditAndGetPatch([
-      "--message",
-      "hello",
-      "--model",
-      "  opus  ",
-      "--thinking",
-      "  high  ",
-    ]);
-    expect(patch?.patch?.payload?.model).toBe("opus");
-    expect(patch?.patch?.payload?.thinking).toBe("high");
+  it.each([
+    {
+      label: "omits empty model and thinking",
+      args: ["--message", "hello", "--model", "   ", "--thinking", "  "],
+      expectedModel: undefined,
+      expectedThinking: undefined,
+    },
+    {
+      label: "trims model and thinking",
+      args: ["--message", "hello", "--model", "  opus  ", "--thinking", "  high  "],
+      expectedModel: "opus",
+      expectedThinking: "high",
+    },
+  ])("cron edit $label", async ({ args, expectedModel, expectedThinking }) => {
+    const patch = await runCronEditAndGetPatch(args);
+    expect(patch?.patch?.payload?.model).toBe(expectedModel);
+    expect(patch?.patch?.payload?.thinking).toBe(expectedThinking);
   });
 
   it("splits PowerShell-style space-separated --tools on cron edit", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1429,23 +1429,33 @@ describe("cron cli", () => {
     expect(params?.payload?.fallbacks).toEqual(["openrouter/gpt-4.1-mini", "openai/gpt-5"]);
   });
 
-  it.each([
-    {
-      label: "omits empty model and thinking",
-      args: ["--message", "hello", "--model", "   ", "--thinking", "  "],
-      expectedModel: undefined,
-      expectedThinking: undefined,
-    },
-    {
-      label: "trims model and thinking",
-      args: ["--message", "hello", "--model", "  opus  ", "--thinking", "  high  "],
-      expectedModel: "opus",
-      expectedThinking: "high",
-    },
-  ])("cron edit $label", async ({ args, expectedModel, expectedThinking }) => {
-    const patch = await runCronEditAndGetPatch(args);
-    expect(patch?.patch?.payload?.model).toBe(expectedModel);
-    expect(patch?.patch?.payload?.thinking).toBe(expectedThinking);
+  it("cron edit rejects blank model/thinking instead of omitting them", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "edit",
+      "job-1",
+      "--message",
+      "hello",
+      "--model",
+      "   ",
+      "--thinking",
+      "  ",
+    ]);
+    expectRuntimeErrorContaining("--model must not be blank");
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+  });
+
+  it("cron edit trims model and thinking", async () => {
+    const patch = await runCronEditAndGetPatch([
+      "--message",
+      "hello",
+      "--model",
+      "  opus  ",
+      "--thinking",
+      "  high  ",
+    ]);
+    expect(patch?.patch?.payload?.model).toBe("opus");
+    expect(patch?.patch?.payload?.thinking).toBe("high");
   });
 
   it("splits PowerShell-style space-separated --tools on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -33,12 +33,23 @@ export async function resolveCronEditPayloadDeliveryPatch(
   if (commandShell && commandArgv) {
     throw new Error("Pass command payload either with --command or --command-argv, not both.");
   }
+  // Match delivery clears / fallbacks: presence is typeof string, not truthy
+  // normalized value. Empty Commander strings are falsy after normalize and would
+  // otherwise skip the clear-* mutex while --clear-model/--clear-thinking still apply.
+  const hasModel = typeof opts.model === "string";
   const model = normalizeOptionalString(opts.model);
-  if (model && opts.clearModel) {
+  if (hasModel && !model) {
+    throw new Error("--model must not be blank");
+  }
+  if (hasModel && opts.clearModel) {
     throw new Error("Use --model or --clear-model, not both");
   }
+  const hasThinking = typeof opts.thinking === "string";
   const thinking = normalizeOptionalString(opts.thinking);
-  if (thinking && opts.clearThinking) {
+  if (hasThinking && !thinking) {
+    throw new Error("--thinking must not be blank");
+  }
+  if (hasThinking && opts.clearThinking) {
     throw new Error("Use --thinking or --clear-thinking, not both");
   }
   const fallbacks = parseCronFallbacks(opts.fallbacks);

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -33,9 +33,7 @@ export async function resolveCronEditPayloadDeliveryPatch(
   if (commandShell && commandArgv) {
     throw new Error("Pass command payload either with --command or --command-argv, not both.");
   }
-  // Match delivery clears / fallbacks: presence is typeof string, not truthy
-  // normalized value. Empty Commander strings stay omitted, but still conflict
-  // with --clear-model/--clear-thinking instead of silently applying the clear.
+  // Raw flag presence owns the set/clear mutex even when normalization omits a blank value.
   const hasModel = typeof opts.model === "string";
   const model = normalizeOptionalString(opts.model);
   if (hasModel && opts.clearModel) {

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -34,21 +34,15 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new Error("Pass command payload either with --command or --command-argv, not both.");
   }
   // Match delivery clears / fallbacks: presence is typeof string, not truthy
-  // normalized value. Empty Commander strings are falsy after normalize and would
-  // otherwise skip the clear-* mutex while --clear-model/--clear-thinking still apply.
+  // normalized value. Empty Commander strings stay omitted, but still conflict
+  // with --clear-model/--clear-thinking instead of silently applying the clear.
   const hasModel = typeof opts.model === "string";
   const model = normalizeOptionalString(opts.model);
-  if (hasModel && !model) {
-    throw new Error("--model must not be blank");
-  }
   if (hasModel && opts.clearModel) {
     throw new Error("Use --model or --clear-model, not both");
   }
   const hasThinking = typeof opts.thinking === "string";
   const thinking = normalizeOptionalString(opts.thinking);
-  if (hasThinking && !thinking) {
-    throw new Error("--thinking must not be blank");
-  }
   if (hasThinking && opts.clearThinking) {
     throw new Error("Use --thinking or --clear-thinking, not both");
   }

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -698,6 +698,62 @@ describe("cron edit command", () => {
     );
   });
 
+  it.each(["", "   "])(
+    "rejects blank --model %j instead of silently ignoring it",
+    async (model) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        await createCronProgram().parseAsync(["edit", "job-1", "--model", model], { from: "user" });
+
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--model must not be blank"));
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each(["", "   "])("rejects blank --model %j combined with --clear-model", async (model) => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+
+    try {
+      await createCronProgram().parseAsync(["edit", "job-1", "--model", model, "--clear-model"], {
+        from: "user",
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--model must not be blank"));
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("rejects --model combined with --clear-model", async () => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+
+    try {
+      await createCronProgram().parseAsync(["edit", "job-1", "--model", "opus", "--clear-model"], {
+        from: "user",
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Use --model or --clear-model, not both"),
+      );
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("stores an explicit wildcard with --clear-tools", async () => {
     callGatewayFromCli.mockImplementation(async (method: string) => {
       if (method === "cron.get") {
@@ -930,6 +986,55 @@ describe("cron edit command", () => {
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  it.each(["", "   "])(
+    "rejects blank --thinking %j instead of silently ignoring it",
+    async (thinking) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        await createCronProgram().parseAsync(["edit", "job-1", "--thinking", thinking], {
+          from: "user",
+        });
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("--thinking must not be blank"),
+        );
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each(["", "   "])(
+    "rejects blank --thinking %j combined with --clear-thinking",
+    async (thinking) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        await createCronProgram().parseAsync(
+          ["edit", "job-1", "--thinking", thinking, "--clear-thinking"],
+          { from: "user" },
+        );
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("--thinking must not be blank"),
+        );
+        expect(callGatewayFromCli).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    },
+  );
 
   it("documents the --clear-model flag alongside the sibling --clear-tools", () => {
     const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -698,25 +698,24 @@ describe("cron edit command", () => {
     );
   });
 
-  it.each(["", "   "])(
-    "rejects blank --model %j instead of silently ignoring it",
-    async (model) => {
-      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
+  it.each(["", "   "])("omits blank --model %j from the update patch", async (model) => {
+    await createCronProgram().parseAsync(
+      ["edit", "job-1", "--message", "hello", "--model", model],
+      {
+        from: "user",
+      },
+    );
 
-      try {
-        await createCronProgram().parseAsync(["edit", "job-1", "--model", model], { from: "user" });
-
-        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--model must not be blank"));
-        expect(callGatewayFromCli).not.toHaveBeenCalled();
-      } finally {
-        errorSpy.mockRestore();
-        exitSpy.mockRestore();
-      }
-    },
-  );
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: {
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+        },
+      },
+    });
+  });
 
   it.each(["", "   "])("rejects blank --model %j combined with --clear-model", async (model) => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
@@ -727,7 +726,9 @@ describe("cron edit command", () => {
         from: "user",
       });
 
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--model must not be blank"));
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Use --model or --clear-model, not both"),
+      );
       expect(callGatewayFromCli).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
@@ -987,29 +988,22 @@ describe("cron edit command", () => {
     exitSpy.mockRestore();
   });
 
-  it.each(["", "   "])(
-    "rejects blank --thinking %j instead of silently ignoring it",
-    async (thinking) => {
-      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
+  it.each(["", "   "])("omits blank --thinking %j from the update patch", async (thinking) => {
+    await createCronProgram().parseAsync(
+      ["edit", "job-1", "--message", "hello", "--thinking", thinking],
+      { from: "user" },
+    );
 
-      try {
-        await createCronProgram().parseAsync(["edit", "job-1", "--thinking", thinking], {
-          from: "user",
-        });
-
-        expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("--thinking must not be blank"),
-        );
-        expect(callGatewayFromCli).not.toHaveBeenCalled();
-      } finally {
-        errorSpy.mockRestore();
-        exitSpy.mockRestore();
-      }
-    },
-  );
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: {
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+        },
+      },
+    });
+  });
 
   it.each(["", "   "])(
     "rejects blank --thinking %j combined with --clear-thinking",
@@ -1026,7 +1020,7 @@ describe("cron edit command", () => {
         );
 
         expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("--thinking must not be blank"),
+          expect.stringContaining("Use --thinking or --clear-thinking, not both"),
         );
         expect(callGatewayFromCli).not.toHaveBeenCalled();
       } finally {

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -698,61 +698,16 @@ describe("cron edit command", () => {
     );
   });
 
-  it.each(["", "   "])("omits blank --model %j from the update patch", async (model) => {
-    await createCronProgram().parseAsync(
-      ["edit", "job-1", "--message", "hello", "--model", model],
-      {
-        from: "user",
-      },
+  it.each([
+    ["--model", "", "--clear-model"],
+    ["--model", "   ", "--clear-model"],
+    ["--thinking", "", "--clear-thinking"],
+    ["--thinking", "   ", "--clear-thinking"],
+  ])("rejects blank %s %j combined with %s", async (flag, value, clearFlag) => {
+    await expectCronEditRejection(
+      [flag, value, clearFlag],
+      `Use ${flag} or ${clearFlag}, not both`,
     );
-
-    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
-      id: "job-1",
-      patch: {
-        payload: {
-          kind: "agentTurn",
-          message: "hello",
-        },
-      },
-    });
-  });
-
-  it.each(["", "   "])("rejects blank --model %j combined with --clear-model", async (model) => {
-    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
-
-    try {
-      await createCronProgram().parseAsync(["edit", "job-1", "--model", model, "--clear-model"], {
-        from: "user",
-      });
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Use --model or --clear-model, not both"),
-      );
-      expect(callGatewayFromCli).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
-  });
-
-  it("rejects --model combined with --clear-model", async () => {
-    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
-
-    try {
-      await createCronProgram().parseAsync(["edit", "job-1", "--model", "opus", "--clear-model"], {
-        from: "user",
-      });
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Use --model or --clear-model, not both"),
-      );
-      expect(callGatewayFromCli).not.toHaveBeenCalled();
-    } finally {
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
   });
 
   it("stores an explicit wildcard with --clear-tools", async () => {
@@ -987,48 +942,6 @@ describe("cron edit command", () => {
     errorSpy.mockRestore();
     exitSpy.mockRestore();
   });
-
-  it.each(["", "   "])("omits blank --thinking %j from the update patch", async (thinking) => {
-    await createCronProgram().parseAsync(
-      ["edit", "job-1", "--message", "hello", "--thinking", thinking],
-      { from: "user" },
-    );
-
-    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
-      id: "job-1",
-      patch: {
-        payload: {
-          kind: "agentTurn",
-          message: "hello",
-        },
-      },
-    });
-  });
-
-  it.each(["", "   "])(
-    "rejects blank --thinking %j combined with --clear-thinking",
-    async (thinking) => {
-      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(defaultRuntime, "exit")
-        .mockImplementation((() => undefined) as never);
-
-      try {
-        await createCronProgram().parseAsync(
-          ["edit", "job-1", "--thinking", thinking, "--clear-thinking"],
-          { from: "user" },
-        );
-
-        expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("Use --thinking or --clear-thinking, not both"),
-        );
-        expect(callGatewayFromCli).not.toHaveBeenCalled();
-      } finally {
-        errorSpy.mockRestore();
-        exitSpy.mockRestore();
-      }
-    },
-  );
 
   it("documents the --clear-model flag alongside the sibling --clear-tools", () => {
     const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");


### PR DESCRIPTION
Closes #119893

## What Problem This Solves

`cron edit` intentionally normalizes blank/whitespace `--model` and `--thinking` to omission. The matching set/clear mutex was incorrectly gated on that normalized value, so blank `--model` plus `--clear-model` (and the thinking pair) bypassed the conflict and applied the clear.

Provenance: `d03985415dba` adopted `normalizeOptionalString` for cron edit’s existing blank-to-omission model/thinking behavior; `0888debcd3eb` later introduced the truthy model set/clear mutex pattern. #111112 / `68771ebdfef1` subsequently extracted and carried those checks (including the thinking sibling) into the current cron CLI producer; it was not the sole origin.

## Fix

- Use raw string presence only to enforce each set/clear mutex.
- Continue using normalized values for payload-kind detection and assignment, so standalone blank values remain omitted.
- Preserve `null` as intentional clear semantics through normalization and payload merge.
- Keep protocol and Gateway validation unchanged.

Maintainer follow-up removes redundant test cases while preserving @zyw02's contributor-authored commits.

## Evidence

```text
head=00f805f646c47b411f35142c780435d4def1475d
merge_base=94f042ba861d1795da02e767c95ef2cc220757b5
latest_origin_main_checked=0f2facaf140 (merge-tree clean; no overlap-driven rebase required)
production LOC=+5/-2 (net +3)
test LOC=+12/-0
CHANGELOG.md=unchanged
```

Focused tests:

```text
node scripts/run-vitest.mjs \
  src/cli/cron-cli/register.cron-edit.test.ts \
  src/cli/cron-cli.test.ts \
  src/cron/normalize.test.ts \
  src/cron/service/payload-merge.test.ts \
  --reporter=dot

4 files passed; 351 tests passed (75 cron + 276 CLI)
```

`node scripts/check-changed.mjs -- <2 changed files>` passed formatting, production/test typechecks, lint, dead-code scans, and repository guards. `git diff --check` passed.

Repeated real CLI parsing with an isolated `OPENCLAW_HOME` (three runs per case):

- empty/whitespace model plus `--clear-model`: 3/3 local mutex errors for each value
- empty/whitespace thinking plus `--clear-thinking`: 3/3 local mutex errors for each value
- standalone whitespace model with a message: 3/3 omitted locally and reached the expected Gateway-credentials boundary
- standalone whitespace thinking with a message: 3/3 omitted locally and reached the expected Gateway-credentials boundary

This proves the mutex without changing the intentional blank-omission contract.

## Review

- Repo autoreview: clean, patch correct, confidence 0.99, no actionable findings.
- Independent read-only Codex review: **APPROVE**, no actionable findings; inspected CLI presence/normalization, protocol, Gateway application, `null` clear merge, and tests.
- Codex source hard gate: sibling `openai/codex@bd19459358f` inspected, including omitted model/reasoning settings versus explicit updates.

## Remaining risk

Low. This changes only CLI mutual exclusion. Clear-only, nonblank set-only, normalizer, protocol, and Gateway behavior remain unchanged.