### PR TITLE
fix(doctor): recover terminal NUL archive tails

### DIFF
--- a/src/infra/state-migrations.media-persistence.nul-tail.test.ts
+++ b/src/infra/state-migrations.media-persistence.nul-tail.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import {
+  encodeSessionArchiveContent,
+  readSessionArchiveContentSync,
+  SESSION_ARCHIVE_ZSTD_SUFFIX,
+} from "../config/sessions/archive-compression.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+  tempDirs.length = 0;
+});
+
+describe("legacy media persistence terminal NUL-tail recovery", () => {
+  it("recovers only a terminal NUL-only logical JSONL suffix", () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-nul-tail-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    openOpenClawAgentDatabase({ agentId: "main", env });
+    closeOpenClawAgentDatabasesForTest();
+    const archiveDir = path.join(stateDir, "agents", "main", "sessions");
+    const plainPath = path.join(archiveDir, "nul-tail.jsonl.deleted.2026-08-06T01-02-03.000Z");
+    const plainContent =
+      '{"type":"message", "id":"event-1", "parentId":null, "timestamp":1000, "message":{"role":"user", "content":"hello\\u0021"}}\r\n';
+    const nulTail = Buffer.alloc(284);
+    fs.mkdirSync(archiveDir, { recursive: true });
+    fs.writeFileSync(plainPath, Buffer.concat([Buffer.from(plainContent), nulTail]));
+
+    const compressedPath = `${path.join(
+      archiveDir,
+      "nul-tail-zstd.jsonl.deleted.2026-08-06T01-02-04.000Z",
+    )}${SESSION_ARCHIVE_ZSTD_SUFFIX}`;
+    const compressedContent =
+      '{"type":"message","id":"event-zstd","parentId":null,"timestamp":1001,"message":{"role":"assistant","content":"zstd"}}';
+    const encoded = encodeSessionArchiveContent(`${compressedContent}\0\0`);
+    if (encoded.suffix !== SESSION_ARCHIVE_ZSTD_SUFFIX) {
+      throw new Error("test runtime does not support zstd");
+    }
+    fs.writeFileSync(compressedPath, encoded.bytes);
+
+    const corruptions = new Map<string, Buffer>([
+      [
+        path.join(archiveDir, "blank.jsonl.deleted.2026-08-06T01-02-05.000Z"),
+        Buffer.from(`${plainContent}\n`),
+      ],
+      [
+        path.join(archiveDir, "interior-nul.jsonl.deleted.2026-08-06T01-02-06.000Z"),
+        Buffer.from(`${plainContent}\0\n`),
+      ],
+      [
+        path.join(archiveDir, "terminal-garbage.jsonl.deleted.2026-08-06T01-02-07.000Z"),
+        Buffer.from(`${plainContent}garbage`),
+      ],
+      [
+        path.join(archiveDir, "truncated.jsonl.deleted.2026-08-06T01-02-08.000Z"),
+        Buffer.from(`${plainContent}{"type":"message"`),
+      ],
+      [path.join(archiveDir, "all-nul.jsonl.deleted.2026-08-06T01-02-09.000Z"), Buffer.alloc(284)],
+    ]);
+    for (const [filePath, bytes] of corruptions) {
+      fs.writeFileSync(filePath, bytes);
+    }
+
+    const result = migrateLegacyMediaPersistence({ env });
+
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        `Migrated archived transcript media in ${plainPath}.`,
+        `Migrated archived transcript media in ${compressedPath}.`,
+      ]),
+    );
+    expect(result.warnings).toHaveLength(corruptions.size);
+    expect(fs.readFileSync(plainPath)).toEqual(Buffer.from(plainContent));
+    expect(readSessionArchiveContentSync(compressedPath)).toBe(compressedContent);
+    for (const [filePath, bytes] of corruptions) {
+      expect(result.warnings.join("\n")).toContain(filePath);
+      expect(fs.readFileSync(filePath)).toEqual(bytes);
+    }
+
+    const rerun = migrateLegacyMediaPersistence({ env });
+    expect(rerun.changes).toEqual([]);
+    expect(rerun.warnings).toHaveLength(corruptions.size);
+    expect(fs.readFileSync(plainPath)).toEqual(Buffer.from(plainContent));
+    expect(readSessionArchiveContentSync(compressedPath)).toBe(compressedContent);
+  });
+});

--- a/src/infra/state-migrations.media-persistence.nul-tail.test.ts
+++ b/src/infra/state-migrations.media-persistence.nul-tail.test.ts
@@ -66,6 +66,10 @@ describe("legacy media persistence terminal NUL-tail recovery", () => {
         path.join(archiveDir, "truncated.jsonl.deleted.2026-08-06T01-02-08.000Z"),
         Buffer.from(`${plainContent}{"type":"message"`),
       ],
+      [
+        path.join(archiveDir, "blank-only-nul-tail.jsonl.deleted.2026-08-06T01-02-08.500Z"),
+        Buffer.from("\n\0"),
+      ],
       [path.join(archiveDir, "all-nul.jsonl.deleted.2026-08-06T01-02-09.000Z"), Buffer.alloc(284)],
     ]);
     for (const [filePath, bytes] of corruptions) {

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -498,6 +498,23 @@ function parseArchiveContent(content: string, filePath: string): TranscriptEvent
   });
 }
 
+function recoverTerminalNulArchiveTail(content: string): {
+  content: string;
+  recovered: boolean;
+} {
+  if (!content.endsWith("\0")) {
+    return { content, recovered: false };
+  }
+  let tailStart = content.length;
+  while (tailStart > 0 && content.charCodeAt(tailStart - 1) === 0) {
+    tailStart -= 1;
+  }
+  if (tailStart === 0) {
+    return { content, recovered: false };
+  }
+  return { content: content.slice(0, tailStart), recovered: true };
+}
+
 function serializeArchiveEvents(
   events: readonly TranscriptEvent[],
   trailingNewline: boolean,
@@ -514,18 +531,23 @@ function migrateTranscriptArchive(
 ): boolean {
   const source = readArchiveSourceSnapshot(filePath);
   const content = readSessionArchiveContentSync(filePath);
-  const events = parseArchiveContent(content, filePath);
-  let changed = false;
+  const recoveredContent = recoverTerminalNulArchiveTail(content);
+  const archiveContent = recoveredContent.content;
+  const events = parseArchiveContent(archiveContent, filePath);
+  let transformedArchive = false;
   const transformed = events.map((event) => {
     const result = transformTranscriptEvent(event);
-    changed ||= result.changed;
+    transformedArchive ||= result.changed;
     return result.event;
   });
-  if (!changed) {
+  if (!recoveredContent.recovered && !transformedArchive) {
     return false;
   }
   assertEventIdentitiesUnchanged(events, transformed, filePath);
-  const rewritten = serializeArchiveEvents(transformed, content.endsWith("\n"));
+  // Recovery removes only the corrupt suffix; preserve valid JSONL bytes when no media changes.
+  const rewritten = transformedArchive
+    ? serializeArchiveEvents(transformed, archiveContent.endsWith("\n"))
+    : archiveContent;
   const compressed = filePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX);
   const encoded = compressed
     ? encodeSessionArchiveContent(rewritten)

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -509,10 +509,11 @@ function recoverTerminalNulArchiveTail(content: string): {
   while (tailStart > 0 && content.charCodeAt(tailStart - 1) === 0) {
     tailStart -= 1;
   }
-  if (tailStart === 0) {
+  const prefix = content.slice(0, tailStart);
+  if (tailStart === 0 || !prefix.trim()) {
     return { content, recovered: false };
   }
-  return { content: content.slice(0, tailStart), recovered: true };
+  return { content: prefix, recovered: true };
 }
 
 function serializeArchiveEvents(

--- a/test/scripts/doctor-media-persistence-nul-tail.built-cli.e2e.test.ts
+++ b/test/scripts/doctor-media-persistence-nul-tail.built-cli.e2e.test.ts
@@ -1,0 +1,89 @@
+// Built CLI proof: Doctor recovers only an interrupted terminal NUL JSONL suffix.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerOpenClawAgentDatabase } from "../../src/state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../src/state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../src/state/openclaw-state-db.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../helpers/openclaw-test-instance.js";
+
+const instances: OpenClawTestInstance[] = [];
+
+afterEach(async () => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  await Promise.all(instances.splice(0).map((instance) => instance.cleanup()));
+});
+
+describe("Doctor terminal NUL-tail built CLI proof", () => {
+  it("recovers six valid archive records without rewriting their valid bytes", async () => {
+    const instance = await createOpenClawTestInstance({
+      name: "doctor-media-persistence-nul-tail",
+      env: { OPENCLAW_TEST_FAST: "1" },
+    });
+    instances.push(instance);
+
+    const database = openOpenClawAgentDatabase({ agentId: "main", env: instance.env });
+    closeOpenClawAgentDatabasesForTest();
+    registerOpenClawAgentDatabase({
+      agentId: "main",
+      env: instance.env,
+      path: database.path,
+    });
+    closeOpenClawStateDatabaseForTest();
+
+    const archivePath = path.join(
+      instance.stateDir,
+      "agents",
+      "main",
+      "sessions",
+      "nul-tail.jsonl.deleted.2026-08-06T01-02-03.000Z",
+    );
+    const archiveContent = `${Array.from({ length: 6 }, (_, index) =>
+      JSON.stringify({
+        type: "message",
+        id: `event-${index + 1}`,
+        parentId: null,
+        timestamp: 1_000 + index,
+        message: { role: "user", content: `record ${index + 1}` },
+      }),
+    ).join("\n")}\n`;
+    const expected = Buffer.from(archiveContent, "utf8");
+    fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+    fs.writeFileSync(archivePath, Buffer.concat([expected, Buffer.alloc(284)]));
+
+    await expect(instance.entrypoint()).resolves.toEqual([
+      expect.stringMatching(/^dist\/index\.(?:js|mjs)$/u),
+    ]);
+    const first = await instance.cli(["doctor", "--fix", "--non-interactive"], {
+      timeoutMs: 90_000,
+    });
+    expect(first.code, `${first.stderr}\n${first.stdout}`).toBe(0);
+    expect(fs.readFileSync(archivePath)).toEqual(expected);
+    expect(
+      archiveContent
+        .trimEnd()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toHaveLength(6);
+
+    const beforeRerun = fs.statSync(archivePath);
+    const rerun = await instance.cli(["doctor", "--fix", "--non-interactive"], {
+      timeoutMs: 90_000,
+    });
+    const afterRerun = fs.statSync(archivePath);
+    expect(rerun.code, `${rerun.stderr}\n${rerun.stdout}`).toBe(0);
+    expect(fs.readFileSync(archivePath)).toEqual(expected);
+    expect(afterRerun).toMatchObject({
+      ino: beforeRerun.ino,
+      mtimeMs: beforeRerun.mtimeMs,
+      size: beforeRerun.size,
+    });
+  }, 180_000);
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2618,6 +2618,7 @@ describe("scripts/test-projects changed-target routing", () => {
         config: "test/vitest/vitest.e2e.config.ts",
         forwardedArgs: [
           "test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts",
+          "test/scripts/doctor-media-persistence-nul-tail.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts",
         ],
@@ -2804,6 +2805,7 @@ describe("scripts/test-projects changed-target routing", () => {
         config: "test/vitest/vitest.e2e.config.ts",
         forwardedArgs: [
           "test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts",
+          "test/scripts/doctor-media-persistence-nul-tail.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts",
         ],


### PR DESCRIPTION
Closes #119887

## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` warns forever when an archived session is valid JSONL followed only by an interrupted terminal NUL-byte fragment.

## Why This Change Was Made

Doctor strictly parses the valid JSONL prefix, removes a terminal NUL-only logical suffix atomically, and retains strict rejection for every other malformed archive. A recovery-only rewrite writes the exact valid prefix, preserving formatting, escaping, and line endings.

## User Impact

Operators can recover these interrupted archived sessions without losing valid records. Other corrupt archives remain unchanged and visible as warnings.

## Evidence

- Built CLI proof: `node scripts/run-vitest.mjs test/scripts/doctor-media-persistence-nul-tail.built-cli.e2e.test.ts` passed. It creates six synthetic JSONL records plus 284 NUL bytes in an isolated `OPENCLAW_STATE_DIR`, runs `dist/index` with `doctor --fix --non-interactive` twice, confirms six records and exact prefix bytes after the first run, then confirms inode, mtime, and bytes do not change on rerun.
- Migration contract proof: `node scripts/run-vitest.mjs src/infra/state-migrations.media-persistence.test.ts src/infra/state-migrations.media-persistence.nul-tail.test.ts` passed (15 tests). The focused combined run, including the built CLI proof, passed all 16 tests.
- CI routing proof: `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts` passed (261 tests). The added built-CLI test is now explicitly included in both changed-target routing snapshots.
- Formatting, Oxlint, core tsgo, and root-test tsgo lanes passed.
- `node scripts/build-all.mjs` passed in 3m01.7s.
- GitHub CI for exact head `0f4116a8136`: https://github.com/openclaw/openclaw/actions/runs/31098837455 (pending).
- The prior CI run exposed only the missing routing snapshots above; all build, smoke, and other selected lanes passed before the CI gate. The correction is in this head.
- Blacksmith Testbox was unavailable from this host because `blacksmith` is not authenticated. Local trusted-source build and actual built-CLI proof were run; GitHub Actions validates the pushed head.
