### PR TITLE
fix(qa): enforce scenario provider lane metadata

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -161,9 +161,14 @@ describe("qa scenario catalog channel contracts", () => {
     const scenario = requireFlowScenario(readQaScenarioById("subagent-completion-direct-fallback"));
     const flow = JSON.stringify(scenario.execution.flow);
     const config = scenario.execution.config as
-      | { cases?: Array<{ name?: string; marker?: string; expectedSendCount?: number }> }
+      | {
+          requiredProviderMode?: string;
+          cases?: Array<{ name?: string; marker?: string; expectedSendCount?: number }>;
+        }
       | undefined;
 
+    expect(scenario.execution.providerMode).toBe("mock-openai");
+    expect(config?.requiredProviderMode).toBe("mock-openai");
     expect(config?.cases).toEqual([
       {
         name: "visible",
@@ -184,6 +189,7 @@ describe("qa scenario catalog channel contracts", () => {
     expect(flow).toContain("readSettledTerminalTask('restart')");
     expect(flow).toContain("readSettledTerminalTask('empty')");
     expect(flow).toContain("postRestartUnexpectedPayloads.length === 0");
+    expect(flow).toContain("env.providerMode === config.requiredProviderMode");
     expect(flow).not.toContain("interrupted by a gateway restart");
     expect(flow).toContain("verdicts.length === 5");
     expect(flow).not.toContain('"call":"sleep"');

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -11,6 +11,7 @@ import {
   readQaScenarioById,
   readQaScenarioExecutionConfig,
   readQaScenarioPack,
+  resolveQaScenarioRequiredProviderMode,
 } from "./scenario-catalog.js";
 import {
   flowContainsCall,
@@ -189,6 +190,25 @@ describe("qa scenario catalog", () => {
     expect(cronAuthorityFlow).toContain("overbroad policy was not intersected");
     expect(cronAuthorityFlow).not.toContain("cron.run");
     expect(cronAuthorityFlow).not.toContain("waitForCronRunCompletion");
+  });
+
+  it("rejects invalid provider metadata at the catalog boundary", () => {
+    const scenario = structuredClone(
+      requireFlowScenario(readQaScenarioById("subagent-completion-direct-fallback")),
+    );
+    scenario.execution.config = {
+      ...scenario.execution.config,
+      requiredProviderMode: "live-frontier",
+    };
+
+    expect(() => resolveQaScenarioRequiredProviderMode(scenario)).toThrow(
+      "QA scenario subagent-completion-direct-fallback declares conflicting provider modes: execution.providerMode=mock-openai, execution.config.requiredProviderMode=live-frontier",
+    );
+
+    scenario.execution.config.requiredProviderMode = "mock-ish";
+    expect(() => resolveQaScenarioRequiredProviderMode(scenario)).toThrow(
+      "QA scenario subagent-completion-direct-fallback declares unknown provider mode: mock-ish",
+    );
   });
 
   it("requires explicit suite isolation for gateway state restart scenarios", () => {

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -363,6 +363,32 @@ export type QaBootstrapScenarioCatalog = {
   scenarios: QaSeedScenarioWithSource[];
 };
 
+export function resolveQaScenarioRequiredProviderMode(
+  scenario: Pick<QaSeedScenarioWithSource, "id" | "execution">,
+) {
+  const configuredValue = scenario.execution.config?.requiredProviderMode;
+  const configuredResult =
+    configuredValue === undefined
+      ? undefined
+      : qaScenarioModuleFlow.providerModeSchema.safeParse(
+          typeof configuredValue === "string" ? configuredValue.trim() : configuredValue,
+        );
+  if (configuredResult && !configuredResult.success) {
+    throw new Error(
+      `QA scenario ${scenario.id} declares unknown provider mode: ${String(configuredValue)}`,
+    );
+  }
+  const configuredMode = configuredResult?.success ? configuredResult.data : undefined;
+  const executionMode =
+    scenario.execution.kind === "flow" ? scenario.execution.providerMode : undefined;
+  if (configuredMode && executionMode && configuredMode !== executionMode) {
+    throw new Error(
+      `QA scenario ${scenario.id} declares conflicting provider modes: execution.providerMode=${executionMode}, execution.config.requiredProviderMode=${configuredMode}`,
+    );
+  }
+  return configuredMode ?? executionMode;
+}
+
 const QA_SCENARIO_PACK_INDEX_PATH = "qa/scenarios/index.yaml";
 const QA_SCENARIO_LEGACY_OVERVIEW_PATH = "qa/scenarios.md";
 const QA_SCENARIO_DIR_PATH = "qa/scenarios";
@@ -463,7 +489,7 @@ export function readQaScenarioPack(): QaScenarioPack {
         parsedScenarioFile.title,
       );
       qaScenarioModuleFlow.assertDefined({ executionKind: execution.kind, flow, relativePath });
-      return {
+      const scenario = {
         ...parsedScenario,
         sourcePath: relativePath,
         execution: {
@@ -471,6 +497,8 @@ export function readQaScenarioPack(): QaScenarioPack {
           ...(flow ? { flow, flowKind } : {}),
         },
       } satisfies QaSeedScenarioWithSource;
+      resolveQaScenarioRequiredProviderMode(scenario);
+      return scenario;
     })(),
   );
   const seenScenarioIds = new Set<string>();

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -65,6 +65,11 @@ describe("QA scenario lane matching", () => {
       rejectedProviderMode: "live-frontier" as const,
     },
     {
+      id: "subagent-completion-direct-fallback",
+      allowedProviderMode: "mock-openai" as const,
+      rejectedProviderMode: "live-frontier" as const,
+    },
+    {
       id: "cron-explicit-authority-execution",
       allowedProviderMode: "live-frontier" as const,
       rejectedProviderMode: "mock-openai" as const,

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -1,10 +1,12 @@
 import type { QaCliBackendAuthMode } from "./gateway-child.js";
 import { splitQaModelRef, type QaProviderMode } from "./model-selection.js";
-import { isQaProviderModeInput } from "./providers/index.js";
-import type { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
+import {
+  resolveQaScenarioRequiredProviderMode,
+  type QaSeedScenarioWithSource,
+} from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
 
-type QaSeedScenario = ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"][number];
+type QaSeedScenario = QaSeedScenarioWithSource;
 
 export type QaScenarioExecutionCell = {
   scenarioId: string;
@@ -14,22 +16,6 @@ export type QaScenarioExecutionCell = {
 
 function normalizeQaConfigString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-export function resolveQaScenarioRequiredProviderMode(scenario: QaSeedScenario) {
-  const configuredMode = normalizeQaConfigString(scenario.execution.config?.requiredProviderMode);
-  const executionMode =
-    scenario.execution.kind === "flow" ? scenario.execution.providerMode : undefined;
-  if (configuredMode && executionMode && configuredMode !== executionMode) {
-    throw new Error(
-      `QA scenario ${scenario.id} declares conflicting provider modes: execution.providerMode=${executionMode}, execution.config.requiredProviderMode=${configuredMode}`,
-    );
-  }
-  const providerMode = configuredMode ?? executionMode;
-  if (providerMode !== undefined && !isQaProviderModeInput(providerMode)) {
-    throw new Error(`QA scenario ${scenario.id} declares unknown provider mode: ${providerMode}`);
-  }
-  return providerMode;
 }
 
 function resolveQaScenarioLaneChannels(params: {

--- a/extensions/qa-lab/src/scenario-module-flow.ts
+++ b/extensions/qa-lab/src/scenario-module-flow.ts
@@ -25,8 +25,9 @@ const qaFlowModuleSchema = z.object({
   call: z.string().trim().min(1),
   args: z.array(qaFlowModuleArgSchema).optional(),
 });
+const qaFlowProviderModeSchema = z.enum(["aimock", "live-frontier", "mock-openai"]);
 const qaFlowExecutionShape = {
-  providerMode: z.enum(["aimock", "live-frontier", "mock-openai"]).optional(),
+  providerMode: qaFlowProviderModeSchema.optional(),
   retryCount: z.number().int().min(0).max(1).optional(),
   runtime: z.enum(["openclaw", "codex"]).optional(),
   timeoutMs: z.number().int().positive().optional(),
@@ -106,6 +107,7 @@ export const qaScenarioModuleFlow = {
   moduleSchema: qaFlowModuleSchema,
   executionShape: qaFlowExecutionShape,
   normalizeMetadata: normalizeQaScenarioFileMetadata,
+  providerModeSchema: qaFlowProviderModeSchema,
   resolveKind: resolveQaScenarioFlowKind,
   resolveFlow: resolveQaScenarioFileFlow,
 };

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -23,13 +23,10 @@ import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
 import { defaultQaModelForMode, normalizeQaProviderMode } from "./run-config.js";
 import {
   readQaBootstrapScenarioCatalog,
+  resolveQaScenarioRequiredProviderMode,
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
-import {
-  expandQaScenarioExecutionCells,
-  resolveQaScenarioRequiredProviderMode,
-  type QaScenarioExecutionCell,
-} from "./scenario-lane.js";
+import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,

--- a/extensions/qa-lab/src/suite-model-selection.ts
+++ b/extensions/qa-lab/src/suite-model-selection.ts
@@ -6,8 +6,10 @@ import {
 } from "./model-selection.js";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE } from "./providers/index.js";
 import { defaultQaModelForMode } from "./run-config.js";
-import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
-import { resolveQaScenarioRequiredProviderMode } from "./scenario-lane.js";
+import {
+  resolveQaScenarioRequiredProviderMode,
+  type QaSeedScenarioWithSource,
+} from "./scenario-catalog.js";
 
 function normalizeQaSuiteModelRef(input: string | undefined, fallback: string) {
   const model = input?.trim();

--- a/extensions/qa-lab/src/suite-provider-selection.test.ts
+++ b/extensions/qa-lab/src/suite-provider-selection.test.ts
@@ -89,6 +89,7 @@ describe("qa suite provider selection", () => {
       ],
     },
     { scenarioId: "goal-context-next-turn", adapterFactories: undefined },
+    { scenarioId: "subagent-completion-direct-fallback", adapterFactories: undefined },
   ])("adopts the provider requirement for directly selected $scenarioId", async (selection) => {
     const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-provider-lane-"));
     const startLab = vi.fn(async () => {

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -37,9 +37,11 @@ scenario:
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
+    providerMode: mock-openai
     retryCount: 0
     summary: Exercise terminal-reply dispositions through mock provider, ephemeral Gateway, SQLite task state, and qa-channel capture.
     config:
+      requiredProviderMode: mock-openai
       cases:
         - name: visible
           marker: QA-SUBAGENT-TERMINAL-VISIBLE-OK
@@ -57,6 +59,10 @@ flow:
   steps:
     - name: proves terminal-reply channel behavior including restart recovery
       actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message:
+              expr: "`expected provider mode ${config.requiredProviderMode}, got ${env.providerMode}`"
         - call: waitForGatewayHealthy
           args:
             - ref: env


### PR DESCRIPTION
## Summary

- validate QA scenario provider metadata while loading the catalog
- keep direct scenario execution on its declared provider lane
- pin `subagent-completion-direct-fallback` to `mock-openai` and assert the active lane

## Root cause and best fix

`subagent-completion-direct-fallback` uses scripted mock requests but declared no provider metadata, so direct execution could retain the default `live-frontier` lane. Provider metadata was also validated only in a downstream lane consumer, allowing unknown or conflicting catalog data to survive until execution.

The catalog is the canonical owner of scenario metadata. This change moves provider-mode resolution and validation there, rejects unknown or conflicting declarations before execution, and lets lane/model selection reuse the validated result. A scenario-only CLI override or another downstream guard would leave malformed catalog entries latent; migrating all existing config-only declarations is unnecessary churn.

## Evidence map

- Entry points: QA flow and unified suite launch.
- Owner: `extensions/qa-lab/src/scenario-catalog.ts`.
- Callers: suite model selection, scenario lane filtering, and unified suite launch.
- Schema/callee: `scenario-module-flow.ts` execution metadata.
- Siblings: config-only and typed `providerMode` scenarios share the same resolver.
- Tests: catalog validation, lane matching, suite provider selection, and the exact scenario.

## Related work

- https://github.com/openclaw/openclaw/pull/118600 improved terminal-reply timing; it did not own provider metadata.
- https://github.com/openclaw/openclaw/pull/118703 fixed duplicate yielded-subagent fanout; unrelated runtime ownership.
- https://github.com/openclaw/openclaw/pull/119491 established scenario-required provider selection; this repair validates that metadata at its catalog owner and supplies the missing declaration.
- https://github.com/openclaw/openclaw/pull/119752 fixed session timestamp completion races; it did not add the provider declaration.
- Live GitHub search found no open duplicate for this catalog/provider-metadata repair. Gitcrawl archive verification was unavailable because its cloud token returned 401, so dispositions were rechecked against live GitHub and current source.

## LOC

- Production QA TypeScript: +43/-28, net +15.
- Tests: +33/-1, net +32.
- Scenario fixture: +6/-0.

The positive production delta implements the catalog-owned validation boundary and removes duplicated downstream policy.

## Verification

- Signed exact head: `cb3ba3868cce3781e4ea72d3e2caa6e81c87424b`, parent `f5add8197fa990890d3f96142cba1523e9c6c0df`.
- Focused local tests: 106/106 passed across the six required QA Lab files.
- Exact scenario: `subagent-completion-direct-fallback` passed 1/1, with 0 failed and 0 skipped, at concurrency 1.
- Scenario-selected lane: `mock-openai`; model: `mock-openai/gpt-5.6-luna`.
- Schema-v2 evidence: every entry passed.
- Artifacts: `.artifacts/qa-e2e/pr-119908-cb3ba386-subagent-direct-fallback/qa-evidence.json`, `qa-suite-summary.json`, and `qa-suite-report.md`.
- `git diff --check` and targeted `oxfmt --check`: passed.
- Fresh autoreview against `origin/main`: clean, exit 0, no accepted/actionable findings.
- Blacksmith Testbox and direct AWS Crabbox both failed before lease allocation because their local CLIs require login. Trusted-source local fallback was used; no remote lease or hosted run ID exists for this exact head.

## Boundaries

- No changelog change.
- No release, tag, version, publish, protocol, dependency, or SQLite change.
- Commit and PR attested. Punchcard receipt marker: `Punchcard-Session: cobalt-valley-meadow-mg`.
