### PR TITLE
fix(qa): bind Slack commentary classifier to renderer

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -1,3 +1,5 @@
+import { createSlackProgressDraftPresentation } from "@openclaw/slack/api.js";
+import { createChannelProgressDraftCompositor } from "openclaw/plugin-sdk/channel-outbound";
 // Qa Lab tests cover slack live plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readQaScenarioById } from "../../scenario-catalog.js";
@@ -697,7 +699,7 @@ describe("Slack live QA runtime helpers", () => {
     }
   });
 
-  it("classifies only exact Slack commentary lane presentations", () => {
+  it("classifies only exact Slack commentary lane presentations", async () => {
     const scenario = testing.findScenario(["slack-progress-commentary-true"])[0];
     const run = scenario?.buildRun("U999999999");
     const input = run && "input" in run ? run.input : "";
@@ -706,6 +708,27 @@ describe("Slack live QA runtime helpers", () => {
     const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
     if (!commentaryMarker || !finalMarker || !verifyObserved) {
       throw new Error("missing Slack progress commentary lane verifier");
+    }
+    let portableCommentary = "";
+    const presentation = createSlackProgressDraftPresentation();
+    const progress = createChannelProgressDraftCompositor({
+      entry: {
+        streaming: {
+          mode: "progress",
+          progress: { commentary: true, label: false, toolProgress: false },
+        },
+      },
+      mode: "progress",
+      active: true,
+      seed: "slack-qa",
+      ...presentation,
+      update: (text) => {
+        portableCommentary = text;
+      },
+    });
+    await progress.pushCommentaryProgress(commentaryMarker, { itemId: "commentary" });
+    if (!portableCommentary) {
+      throw new Error("shared commentary renderer produced no Slack QA presentation");
     }
     const verifyCommentaryMessage = (message: { blockText?: string[]; text: string }) =>
       verifyObserved({
@@ -725,8 +748,8 @@ describe("Slack live QA runtime helpers", () => {
       });
 
     for (const message of [
-      { text: `_${commentaryMarker}_` },
-      { text: ` \n_${commentaryMarker}_\t` },
+      { text: portableCommentary },
+      { text: ` \n${portableCommentary}\t` },
       { text: `💬 ${commentaryMarker}` },
       { blockText: ["Update", commentaryMarker], text: "Working…" },
     ]) {
@@ -734,12 +757,106 @@ describe("Slack live QA runtime helpers", () => {
     }
     for (const text of [
       commentaryMarker,
-      `prefix _${commentaryMarker}_ suffix`,
-      `_${commentaryMarker}_\nmore`,
+      `prefix ${portableCommentary} suffix`,
+      `${portableCommentary}\nmore`,
     ]) {
       expect(() => verifyCommentaryMessage({ text })).toThrow(
         "expected commentary in the Slack progress commentary lane",
       );
+    }
+    expect(() => verifyCommentaryMessage({ text: commentaryMarker })).toThrow(
+      "portable renderer expected one exact italic line",
+    );
+  });
+
+  it("bounds Slack commentary mismatch diagnostics to structural counts", () => {
+    const scenario = testing.findScenario(["slack-progress-commentary-true"])[0];
+    const run = scenario?.buildRun("U999999999");
+    const input = run && "input" in run ? run.input : "";
+    const commentaryMarker = input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+    const finalMarker = input.match(/SLACK-QA-COMMENTARY-DONE-[0-9A-F]{8}/u)?.[0];
+    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
+    if (!commentaryMarker || !finalMarker || !verifyObserved) {
+      throw new Error("missing Slack progress commentary lane verifier");
+    }
+
+    const privateSentinel = "PRIVATE_SENTINEL";
+    const textSentinel = "TEXT_SENTINEL";
+    const blockSentinel = "BLOCK_SENTINEL";
+    const idSentinel = "ID_SENTINEL";
+    const timestampSentinel = "TIMESTAMP_SENTINEL";
+    const hashSentinel = "HASH_SENTINEL";
+    const messages = Array.from({ length: 20 }, (_observation, index) => {
+      const content = `${privateSentinel}_${index} ${textSentinel}_${index} ${hashSentinel}_${index} ${commentaryMarker}`;
+      const text =
+        index % 4 === 0
+          ? `_${content}_`
+          : index % 4 === 1
+            ? `🧠 ${content}`
+            : index % 4 === 2
+              ? `${content}\nmultiline`
+              : content;
+      return {
+        botId: `${idSentinel}_BOT_${index}`,
+        channelId: `${idSentinel}_CHANNEL_${index}`,
+        scenarioId: `${idSentinel}_SCENARIO_${index}`,
+        text,
+        blockText: [
+          "Update",
+          ...Array.from(
+            { length: 19 },
+            (_blockEntry, blockIndex) => `${blockSentinel}_${index}_${blockIndex}`,
+          ),
+        ],
+        threadTs: `${timestampSentinel}_THREAD_${index}`,
+        ts: timestampSentinel,
+      };
+    });
+
+    let diagnostic = "";
+    try {
+      verifyObserved({
+        finalMessage: { text: finalMarker, ts: "2.000000" },
+        messages: [
+          ...messages,
+          {
+            channelId: "C_FINAL",
+            text: finalMarker,
+            ts: "2.000000",
+          },
+        ],
+      });
+    } catch (error) {
+      diagnostic = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(new TextEncoder().encode(diagnostic).byteLength).toBeLessThanOrEqual(512);
+    const summary = JSON.parse(diagnostic.slice(diagnostic.indexOf("observed ") + 9));
+    expect(summary).toEqual({
+      v: 1,
+      observed: "16+",
+      sampled: 16,
+      observationsTruncated: true,
+      withBlocks: 16,
+      sampledBlockEntries: 256,
+      blockEntriesTruncated: true,
+      italicText: 4,
+      glyphText: 4,
+      multilineText: 4,
+      otherText: 4,
+      withUpdateBlock: 16,
+    });
+    for (const sentinel of [
+      privateSentinel,
+      textSentinel,
+      blockSentinel,
+      commentaryMarker,
+      finalMarker,
+      idSentinel,
+      timestampSentinel,
+      hashSentinel,
+    ]) {
+      expect(diagnostic).not.toContain(sentinel);
     }
   });
 

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -77,6 +77,12 @@ type SlackProgressCommentaryExpectation = {
   toolProgress: "absent" | "draft" | "standalone";
 };
 
+const SLACK_COMMENTARY_DIAGNOSTIC_MAX_OBSERVATIONS = 16;
+const SLACK_COMMENTARY_DIAGNOSTIC_MAX_BLOCK_ENTRIES = 16;
+const SLACK_COMMENTARY_DIAGNOSTIC_MAX_BYTES = 512;
+const SLACK_COMMENTARY_DIAGNOSTIC_FALLBACK =
+  'expected commentary in the Slack progress commentary lane; portable renderer expected one exact italic line; observed {"v":1,"observed":0,"sampled":0,"observationsTruncated":false,"withBlocks":0,"sampledBlockEntries":0,"blockEntriesTruncated":false,"italicText":0,"glyphText":0,"multilineText":0,"otherText":0,"withUpdateBlock":0}';
+
 function observedSlackText(message: { blockText?: string[]; text: string }) {
   return [message.text, ...(message.blockText ?? [])].join("\n");
 }
@@ -85,7 +91,8 @@ function hasSlackCommentaryLaneMarker(
   message: { blockText?: string[]; text: string },
   marker: string,
 ) {
-  if (message.text.includes(`💬 ${marker}`) || message.text.trim() === `_${marker}_`) {
+  const portableCommentary = /^_([^\r\n]+)_$/u.exec(message.text.trim())?.[1];
+  if (message.text.includes(`💬 ${marker}`) || portableCommentary === marker) {
     return true;
   }
   const blockText = message.blockText ?? [];
@@ -93,6 +100,68 @@ function hasSlackCommentaryLaneMarker(
     blockText.some((text) => text.trim() === "Update") &&
     blockText.some((text) => text.includes(marker))
   );
+}
+
+function describeSlackCommentaryLaneMismatch(
+  messages: ReadonlyArray<{ blockText?: string[]; text: string }>,
+) {
+  const sampledMessages = messages.slice(0, SLACK_COMMENTARY_DIAGNOSTIC_MAX_OBSERVATIONS);
+  let withBlocks = 0;
+  let sampledBlockEntries = 0;
+  let blockEntriesTruncated = false;
+  let italicText = 0;
+  let glyphText = 0;
+  let multilineText = 0;
+  let otherText = 0;
+  let withUpdateBlock = 0;
+
+  for (const message of sampledMessages) {
+    const text = message.text.trim();
+    if (/[\r\n]/u.test(text)) {
+      multilineText += 1;
+    } else if (/^_[^\r\n]+_$/u.test(text)) {
+      italicText += 1;
+    } else if (/^(?:🧠|💬)\s/u.test(text)) {
+      glyphText += 1;
+    } else {
+      otherText += 1;
+    }
+
+    const blockText = message.blockText ?? [];
+    if (blockText.length > 0) {
+      withBlocks += 1;
+    }
+    const sampledBlocks = blockText.slice(0, SLACK_COMMENTARY_DIAGNOSTIC_MAX_BLOCK_ENTRIES);
+    sampledBlockEntries += sampledBlocks.length;
+    blockEntriesTruncated ||= blockText.length > sampledBlocks.length;
+    withUpdateBlock += sampledBlocks.some((entry) => entry.trim() === "Update") ? 1 : 0;
+  }
+
+  const observationsTruncated = messages.length > sampledMessages.length;
+  const summary = {
+    v: 1,
+    observed: observationsTruncated
+      ? (`${SLACK_COMMENTARY_DIAGNOSTIC_MAX_OBSERVATIONS}+` as const)
+      : messages.length,
+    sampled: sampledMessages.length,
+    observationsTruncated,
+    withBlocks,
+    sampledBlockEntries,
+    blockEntriesTruncated,
+    italicText,
+    glyphText,
+    multilineText,
+    otherText,
+    withUpdateBlock,
+  };
+  const diagnostic = [
+    "expected commentary in the Slack progress commentary lane",
+    "portable renderer expected one exact italic line",
+    `observed ${JSON.stringify(summary)}`,
+  ].join("; ");
+  return new TextEncoder().encode(diagnostic).byteLength <= SLACK_COMMENTARY_DIAGNOSTIC_MAX_BYTES
+    ? diagnostic
+    : SLACK_COMMENTARY_DIAGNOSTIC_FALLBACK;
 }
 
 export function buildSlackProgressCommentaryRun(
@@ -150,7 +219,7 @@ export function buildSlackProgressCommentaryRun(
           expectation.commentary === "lane" &&
           (commentaryLaneTimestamps.size !== 1 || !commentaryLaneTimestamps.has(commentaryTs))
         ) {
-          throw new Error("expected commentary in the Slack progress commentary lane");
+          throw new Error(describeSlackCommentaryLaneMismatch(commentaryMessages));
         }
         if (expectation.commentary === "headline" && commentaryLaneTimestamps.size !== 0) {
           throw new Error("expected the preamble as the Slack progress status headline");

--- a/extensions/slack/api.ts
+++ b/extensions/slack/api.ts
@@ -98,6 +98,7 @@ export {
   hasSlackThreadParticipation,
   recordSlackThreadParticipation,
 } from "./src/sent-thread-cache.js";
+export { createSlackProgressDraftPresentation } from "./src/progress-draft-presentation.js";
 export {
   looksLikeSlackTargetId,
   normalizeSlackMessagingTarget,

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -25,6 +25,7 @@ import {
   reconcileSlackNativeTaskChunks,
   type SlackNativeTaskSnapshot,
 } from "../../progress-blocks.js";
+import { createSlackProgressDraftPresentation } from "../../progress-draft-presentation.js";
 import { applyAppendOnlyStreamUpdate } from "../../stream-mode.js";
 import {
   appendSlackStream,
@@ -32,7 +33,6 @@ import {
   stopSlackStream,
   type SlackStreamSession,
 } from "../../streaming.js";
-import { escapeSlackMrkdwn } from "../mrkdwn.js";
 import {
   resolveExplicitSlackProgressTitle,
   resolveSlackStreamRecipientTeamId,
@@ -323,16 +323,14 @@ export function createSlackProgressRuntime(runtimeParams: {
     progressReceiptCollapsed = await collapseSlackProgressReceipt({ setup, edit: params });
   };
 
+  const progressDraftPresentation = createSlackProgressDraftPresentation();
   const progressDraft = createChannelProgressDraftCompositor({
     entry: account.config,
     mode: slackStreaming.mode,
     active: progressDraftActive,
     seed: progressSeed,
-    formatLine: formatSlackProgressDraftLine,
-    reasoningLinePrefix: "🧠 ",
-    commentaryLinePrefix: "",
+    ...progressDraftPresentation,
     reasoningGate: previewToolProgressEnabled,
-    commentaryItalics: true,
     buildProgressEventLine: (input, options) =>
       input.event === "tool" || input.event === "item"
         ? buildChannelProgressDraftLineForEntry(account.config, input, options)
@@ -447,7 +445,7 @@ export function createSlackProgressRuntime(runtimeParams: {
       entry: account.config,
       lines: [...progressDraft.getSnapshot().lines],
       seed: progressSeed,
-      formatLine: formatSlackProgressDraftLine,
+      formatLine: progressDraftPresentation.formatLine,
       narration: explanation,
       plan: steps,
     });
@@ -660,32 +658,4 @@ export function createSlackProgressRuntime(runtimeParams: {
     },
     shouldYieldDraftProgress: () => shouldYieldDraftProgress(),
   };
-}
-
-function formatSlackProgressDraftLine(line: string): string {
-  if (/^(?:🧠|💬)\s/u.test(line)) {
-    return line;
-  }
-
-  const italicCommentary = /^_(.*)_$/su.exec(line);
-  if (!italicCommentary) {
-    return escapeSlackMrkdwn(line);
-  }
-
-  const content = italicCommentary[1]!
-    .split(/(`[^`\n]+`)/u)
-    .map((segment, index) => {
-      if (index % 2 === 0) {
-        return escapeSlackMrkdwn(segment);
-      }
-      const code = segment
-        .slice(1, -1)
-        .replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;");
-      return `\`${code}\``;
-    })
-    .join("");
-
-  return `_${content}_`;
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -2,6 +2,7 @@ import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-ru
 // Slack tests cover dispatch.preview fallback plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackProgressDraftPresentation } from "../../progress-draft-presentation.js";
 
 const FINAL_REPLY_TEXT = "final answer";
 const THREAD_TS = "thread-1";
@@ -61,6 +62,14 @@ let mockedReplyThreadTs: string | undefined = THREAD_TS;
 let mockedReplyThreadTsSequence: Array<string | undefined> | undefined;
 let mockedSlackReplyBlocks: unknown[] | undefined;
 let mockedSlackIsThreadReply = true;
+let capturedProgressDraftPresentation:
+  | {
+      commentaryItalics: boolean | undefined;
+      commentaryLinePrefix: string | undefined;
+      formatLine: ((line: string) => string) | undefined;
+      reasoningLinePrefix: string | undefined;
+    }
+  | undefined;
 let capturedTyping:
   | {
       start: () => Promise<void>;
@@ -457,8 +466,14 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
     ...actual,
     createChannelProgressDraftCompositor: (
       params: Parameters<typeof actual.createChannelProgressDraftCompositor>[0],
-    ) =>
-      actual.createChannelProgressDraftCompositor({
+    ) => {
+      capturedProgressDraftPresentation = {
+        commentaryItalics: params.commentaryItalics,
+        commentaryLinePrefix: params.commentaryLinePrefix,
+        formatLine: params.formatLine,
+        reasoningLinePrefix: params.reasoningLinePrefix,
+      };
+      return actual.createChannelProgressDraftCompositor({
         ...params,
         // Gate timing lives in the compositor suite; dispatch tests exercise
         // Slack rendering and delivery after work admits the draft.
@@ -467,7 +482,8 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
           return 0 as never;
         }) as unknown as typeof setTimeout,
         clearTimeoutFn: (() => {}) as typeof clearTimeout,
-      }),
+      });
+    },
     createChannelMessageReplyPipeline: (params: {
       transformReplyPayload?: (payload: TestReplyPayload) => TestReplyPayload | null;
       typing?: {
@@ -1118,6 +1134,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedSlackDraftMode = "append";
     mockedPinnedMainDmOwner = undefined;
     capturedReplyOptions = undefined;
+    capturedProgressDraftPresentation = undefined;
     capturedStatusReactionOptions = undefined;
     capturedTyping = undefined;
     mockedReplyThreadTs = THREAD_TS;
@@ -3877,6 +3894,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
+    expect(capturedProgressDraftPresentation).toEqual(createSlackProgressDraftPresentation());
     expect(draftStream.update).toHaveBeenLastCalledWith(
       "_I’m using the `monorepo` skill on Linux x86\\_64._",
     );

--- a/extensions/slack/src/progress-draft-presentation.ts
+++ b/extensions/slack/src/progress-draft-presentation.ts
@@ -1,0 +1,38 @@
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+
+function formatSlackProgressDraftLine(line: string): string {
+  if (/^(?:🧠|💬)\s/u.test(line)) {
+    return line;
+  }
+
+  const italicCommentary = /^_(.*)_$/su.exec(line);
+  if (!italicCommentary) {
+    return escapeSlackMrkdwn(line);
+  }
+
+  const content = italicCommentary[1]!
+    .split(/(`[^`\n]+`)/u)
+    .map((segment, index) => {
+      if (index % 2 === 0) {
+        return escapeSlackMrkdwn(segment);
+      }
+      const code = segment
+        .slice(1, -1)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
+      return `\`${code}\``;
+    })
+    .join("");
+
+  return `_${content}_`;
+}
+
+export function createSlackProgressDraftPresentation() {
+  return {
+    commentaryItalics: true,
+    commentaryLinePrefix: "",
+    formatLine: formatSlackProgressDraftLine,
+    reasoningLinePrefix: "🧠 ",
+  } as const;
+}


### PR DESCRIPTION
Related: #119698

## What Problem This Solves

Slack release QA duplicated the renderer's portable commentary shape and could
drift from product behavior. Its mismatch diagnostic also risked echoing raw
Slack observations.

## Why This Change Was Made

Slack now owns one progress-draft presentation factory. Runtime spreads that
policy into the shared compositor, while QA imports it only through
`@openclaw/slack/api.js` to generate product-owned output and retains an
independent verifier. Mismatch diagnostics contain bounded structural counts
only: at most 16 observations, 16 block entries per observation, 256 sampled
entries total, and 512 UTF-8 bytes.

## Evidence

- Exact head: `cce5bb7a5d7aeb83299c8db60d7d7aa88d3e7ed1`.
- Exact base: `33a5f379371bb134671ae79c372713aa6032184d`.
- Stable patch-id matches prior reviewed head
  `da87b75f6f4c0925b1475357d176f6f317c45da1`; range-diff is patch-equivalent.
- Scoped formatting, focused oxlint, `pnpm plugin-sdk:surface:check`,
  `git diff --check`, and added-line privacy scan passed.
- Structural diagnostic probe: 337 UTF-8 bytes, 16 sampled observations, 256
  sampled block entries, with both truncation flags set.
- Focused Vitest and `check-changed` are blocked by the unrelated shared
  heavy-check lock for #119981. The lock was not waited on, bypassed, or touched.
- Live Slack proof: pending.
- Private QA build: pending.
- Exact-head CI: pending; no CI was dispatched before independent review.

Production: `+43/-34` (net `+9`) for the Slack-owned policy/public owner
boundary; the formatter moved from the handler unchanged.

QA harness: `+71/-2`.

Tests: `+143/-8`.

Punchcard-Session: quiet-meadow-timber-mj
Punchcard-Session: amber-workshop-workshop-36
Punchcard-Commit-Attestation: att_01KZHFBXSW39HTKGYBGEMWPGQD
Punchcard-Receipt: att_01KZHFBY5CQ413NWY32Z4Q5W17

## Boundary

No release, tag, version, package publication, deployment, live Slack run,
private QA build, or CI dispatch is part of this pull request.

AI-assisted: yes.
