### PR TITLE
fix: compaction command E2E restores post-usage evidence

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts
@@ -284,6 +284,7 @@ function mockSuccessfulCompaction() {
       summary: "summary",
       firstKeptEntryId: "x",
       tokensBefore: 12000,
+      tokensAfter: 1000,
     },
   });
 }
@@ -561,7 +562,7 @@ describe("trigger handling", () => {
         cfg,
       );
       const text = maybeReplyText(res);
-      expect(text?.startsWith("⚙️ Compacted")).toBe(true);
+      expect(text).toMatch(/^⚙️ Compacted/u);
       expect(getCompactEmbeddedAgentSessionMock()).toHaveBeenCalledOnce();
       const sessionKey = resolveSessionKey("per-sender", request, undefined, "main");
       expect(loadSessionEntry({ storePath, sessionKey })?.compactionCount).toBe(1);
@@ -587,7 +588,7 @@ describe("trigger handling", () => {
       );
 
       const text = maybeReplyText(res);
-      expect(text?.startsWith("⚙️ Compacted")).toBe(true);
+      expect(text).toMatch(/^⚙️ Compacted/u);
       expect(getCompactEmbeddedAgentSessionMock()).toHaveBeenCalledOnce();
       const call = firstMockCallArg(
         getCompactEmbeddedAgentSessionMock(),


### PR DESCRIPTION
Closes #119905

AI-assisted: yes

## What Problem This Solves

Fixes an issue where the main-session and explicit-worker `/compact` E2E cases failed even though command targeting and compaction succeeded.

The shared mock returned a successful compaction with `tokensBefore` but no `tokensAfter`. Since #117580, that incomplete result intentionally renders `Compaction finished (resulting context unknown)` rather than the normal `Compacted` label, so both tests stopped proving their intended command path.

## Why This Change Was Made

The successful-compaction fixture now includes authoritative post-compaction usage. The two prefix assertions use Vitest's matcher directly so future failures print the actual reply instead of only `false`.

Production compaction behavior, the unknown-context safety label, session targeting, and persistence are unchanged.

Production LOC: +0/-0. Tests: +3/-2.

## User Impact

Contributors and scheduled repo-E2E runs regain deterministic main/worker `/compact` command coverage without weakening the product's post-compaction evidence requirement.

## Evidence

Before:

- Scheduled repo-E2E [run 31074185331](https://github.com/openclaw/openclaw/actions/runs/31074185331): both compaction cases failed.
- Fresh current-main Testbox `tbx_01kzb6ffe006g0bgmcpg5dm5wx`, [run 31089298851](https://github.com/openclaw/openclaw/actions/runs/31089298851): the paired lifecycle file passed 10/10 and the trigger file passed 19/21, with only the two compaction cases failing.
- Diagnostic reply from both cases: `⚙️ Compaction finished (resulting context unknown) • Context ?/200k`.

After:

- Focused compaction cases: 2/2 passed.
- Original two-file order: 31/31 passed.
- Twenty sequential fresh Vitest processes: 20/20 passed, covering 40 compaction command assertions in 3m26s.
- Exact-base `pnpm check:changed` on fresh Testbox `tbx_01kzb86k5yvb0k7ngm5sqmegza`, [run 31091388012](https://github.com/openclaw/openclaw/actions/runs/31091388012): formatting, guards, dead-code, core-test typecheck, and changed-file lint passed with 0 warnings/errors.
- AutoReview (`gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings; overall correctness 0.99.
- Public model identifier gate: PASS; the diff contains no model identifiers.

Provenance: [#117580](https://github.com/openclaw/openclaw/pull/117580) correctly made missing post-compaction usage a visible non-success. This PR updates only the stale E2E fixture to the current result contract.
