### PR TITLE
docs(install): document ClawBox appliance operating commands

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1110,6 +1110,7 @@
                 "group": "Hosting",
                 "pages": [
                   "install/azure",
+                  "install/clawbox",
                   "install/daytona",
                   "install/digitalocean",
                   "install/docker-vm-runtime",

--- a/docs/install/clawbox.md
+++ b/docs/install/clawbox.md
@@ -1,0 +1,101 @@
+---
+summary: "Operate OpenClaw on a ClawBox appliance, where the Gateway is managed by a system service"
+read_when:
+  - Running OpenClaw on a ClawBox device
+  - The standard gateway service commands do not work on your hardware
+  - OpenClaw shipped preinstalled and you need to update or troubleshoot it
+title: "ClawBox"
+---
+
+ClawBox is a Jetson-based appliance that ships with OpenClaw preinstalled, so there is nothing to install -- but the standard operating commands in these docs do not apply as written. The Gateway runs as a **system** service rather than a `systemctl --user` unit, the `openclaw` binary is not on `PATH` for non-interactive shells, and the Control UI is bound to the LAN instead of loopback. This page documents the working commands.
+
+If you are setting up Jetson hardware yourself rather than using a preconfigured appliance, follow the general Linux and ARM64 guidance in the [install overview](/install) instead.
+
+## What is different
+
+| Standard instruction | On ClawBox |
+| -------------------- | ---------- |
+| `openclaw <command>` | Not on `PATH` over SSH -- use the absolute path or export it first |
+| `systemctl --user status openclaw-gateway.service` | No user unit exists; the Gateway is the system service `clawbox-gateway.service` |
+| `journalctl --user -u openclaw-gateway.service` | Use the system journal for `clawbox-gateway` |
+| Gateway on loopback, reached via SSH tunnel | Gateway binds to the LAN on port `18789`; open it directly |
+
+## Running the CLI
+
+The CLI is installed under a user-owned npm prefix. Interactive login shells pick it up from `~/.bashrc`, but non-interactive shells (including `ssh host 'openclaw ...'`) do not:
+
+```bash
+# Explicit path -- always works
+~/.npm-global/bin/openclaw status
+
+# Or export once for the current shell
+export PATH="$HOME/.npm-global/bin:$PATH"
+openclaw status
+```
+
+## Gateway service
+
+The Gateway is supervised by the appliance as a system service, so the `--user` commands in the rest of these docs do not apply:
+
+```bash
+systemctl status clawbox-gateway.service
+sudo systemctl restart clawbox-gateway.service
+journalctl -u clawbox-gateway.service -f
+```
+
+Do not start a second Gateway by hand -- the service already owns the port and the state directory.
+
+## Control UI
+
+The Gateway is configured with `"bind": "lan"` and listens on `0.0.0.0:18789`, so the dashboard is reachable directly from another machine on the same network:
+
+```
+http://<clawbox-address>:18789
+```
+
+No SSH tunnel is required. Because the UI is served over the LAN rather than loopback, the origin you browse from must be present in `gateway.controlUi.allowedOrigins`; the appliance ships with its own address allowlisted. If you reach the box under a different hostname or address, add that origin to the list.
+
+## Updating
+
+The npm tree is user-owned, so updates do not need `sudo`, but they do need the explicit path:
+
+```bash
+~/.npm-global/bin/openclaw update
+sudo systemctl restart clawbox-gateway.service
+```
+
+Restart the service afterwards so the running Gateway picks up the new version.
+
+## Configuration and state
+
+State lives in the standard location, so everything in [Gateway configuration](/gateway/configuration) applies unchanged:
+
+- `~/.openclaw/` -- `openclaw.json`, per-agent `auth-profiles.json`, channel/provider state, sessions
+- `~/.openclaw/workspace/` -- agent workspace
+
+Snapshots work the same way:
+
+```bash
+~/.npm-global/bin/openclaw backup create
+```
+
+## Troubleshooting
+
+**`openclaw: command not found`** -- Expected over SSH. Use `~/.npm-global/bin/openclaw` or export the prefix onto `PATH` first.
+
+**`systemctl --user` reports no such unit** -- Expected. The Gateway is a system service on this appliance: `systemctl status clawbox-gateway.service`.
+
+**Control UI rejects the origin** -- Add the address you are browsing from to `gateway.controlUi.allowedOrigins`, then restart the service.
+
+**Gateway will not start** -- Check `journalctl -u clawbox-gateway.service --no-pager -n 100`, then run `~/.npm-global/bin/openclaw doctor --non-interactive`.
+
+## Next steps
+
+- [Channels](/channels) -- connect Telegram, WhatsApp, Discord, and more
+- [Gateway configuration](/gateway/configuration) -- all config options
+- [Updating](/install/updating) -- general update guidance
+
+## Related
+
+- [Install overview](/install)
+- [Platforms](/platforms)


### PR DESCRIPTION
## What Problem This Solves

ClawBox is a Jetson-based appliance that ships with OpenClaw preinstalled. Its users are OpenClaw users, but the operating instructions in these docs do not work as written on it, so following the official documentation produces errors:

| Documented instruction | Result on the appliance |
| --- | --- |
| `openclaw <command>` | `openclaw: command not found` over SSH — the CLI lives under a user npm prefix that non-interactive shells do not pick up |
| `systemctl --user status openclaw-gateway.service` | No such user unit — the Gateway is supervised as a **system** service |
| `journalctl --user -u openclaw-gateway.service` | Empty — the logs are in the system journal |
| Gateway on loopback, reached by SSH tunnel | Gateway is configured `"bind": "lan"` and listens on `0.0.0.0:18789`; the tunnel step is unnecessary and the Control UI enforces `gateway.controlUi.allowedOrigins` instead |

This mirrors the case made for the Daytona guide in #116411 (merged 2026-08-03), which documented a platform that also ships OpenClaw preinstalled and where the generic instructions were misleading — no service manager, a differently-owned npm tree, and a non-loopback dashboard origin.

## Why This Change Was Made

Adds `docs/install/clawbox.md`, covering only where behaviour diverges: invoking the CLI, the Gateway service commands, Control UI access and the origin allowlist, updating, and the matching troubleshooting entries. State and configuration are unchanged, so the page defers to [Gateway configuration](/gateway/configuration) rather than restating it. Registered in the `docs.json` Hosting navigation so it is discoverable.

The page is operational only. It contains no product description, specifications, pricing, purchase links, or comparisons — if it reads as promotion anywhere, that is a defect and I will remove it.

## Evidence

Every command was run against the shipping configuration — OpenClaw 2026.7.1, Node 22.23.2, L4T R36.5.0 (JetPack 6.2), Jetson Orin Nano:

```console
$ ssh box 'openclaw status'
bash: line 1: openclaw: command not found

$ ls -l ~/.npm-global/bin/openclaw
... -> ../lib/node_modules/openclaw/openclaw.mjs

$ systemctl --user list-unit-files | grep -c openclaw-gateway
0

$ systemctl list-units --type=service | grep clawbox-gateway
clawbox-gateway.service   loaded active running

$ grep -o '"bind": "[a-z]*"' ~/.openclaw/openclaw.json
"bind": "lan"

$ ss -tln | grep 18789
LISTEN 0 511 0.0.0.0:18789
```

## Disclosure

I work at ID-Robots, which builds this appliance. I also opened #118594 (a vendor-neutral Jetson guide) and #94893 (the docs-scope question behind it). I am following the boundary set on #87627 — no product page — and the precedent set by #116411 for documenting a platform that ships OpenClaw preinstalled.

If maintainers would rather this content lived in our own documentation, say so and I will close this without argument.
