### PR TITLE
fix(cron): preserve trigger.once when replacing trigger script

### DIFF
--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -955,14 +955,56 @@ describe("cron edit command", () => {
     exitSpy.mockRestore();
   });
 
+  it.each([
+    ["empty", "", undefined],
+    ["whitespace", "   ", undefined],
+    ["empty with --clear-trigger", "", "--clear-trigger"],
+    ["whitespace with --clear-trigger", "   ", "--clear-trigger"],
+  ])("rejects %s --trigger-script before Gateway access", async (_label, value, clearFlag) => {
+    await expectCronEditRejection(
+      ["--trigger-script", value, ...(clearFlag ? [clearFlag] : [])],
+      "--trigger-script must not be blank",
+    );
+  });
+
+  it("validates trigger script files before Gateway access", async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "cron-edit-invalid-"));
+    const emptyPath = path.join(fixtureDir, "empty.js");
+    const oversizedPath = path.join(fixtureDir, "oversized.js");
+    const missingPath = path.join(fixtureDir, "missing.js");
+    await Promise.all([
+      fs.writeFile(emptyPath, " \n", "utf8"),
+      fs.writeFile(oversizedPath, "x".repeat(65_537), "utf8"),
+    ]);
+
+    try {
+      await expectCronEditRejection(
+        ["--pacing-min", "30m", "--trigger-script", emptyPath],
+        "Trigger script must not be empty",
+      );
+      await expectCronEditRejection(
+        ["--pacing-min", "30m", "--trigger-script", oversizedPath],
+        "Trigger script exceeds 65536 bytes",
+      );
+      await expectCronEditRejection(
+        ["--pacing-min", "30m", "--trigger-script", missingPath],
+        "ENOENT",
+      );
+    } finally {
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves trigger.once when --trigger-script replaces the script body", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-edit-trigger-"));
     const scriptPath = path.join(dir, "next.js");
     await fs.writeFile(scriptPath, "return { fire: true };\n", "utf8");
+    const configRevision = "trigger-script-revision";
     callGatewayFromCli.mockImplementation(async (method: string) => {
       if (method === "cron.get") {
         return {
           id: "job-1",
+          configRevision,
           trigger: { script: "return { fire: false };", once: true },
         };
       }
@@ -974,15 +1016,20 @@ describe("cron edit command", () => {
         from: "user",
       });
 
-      expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
-        id: "job-1",
-        patch: {
-          trigger: {
-            script: "return { fire: true };",
-            once: true,
+      expect(callGatewayFromCli).toHaveBeenCalledWith(
+        "cron.update",
+        expect.anything(),
+        expect.objectContaining({
+          id: "job-1",
+          patch: {
+            trigger: {
+              script: "return { fire: true };",
+              once: true,
+            },
           },
-        },
-      });
+          expectedConfigRevision: configRevision,
+        }),
+      );
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1,4 +1,7 @@
 // Cron edit register tests cover cron edit command registration and option wiring.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../../runtime.js";
@@ -950,5 +953,128 @@ describe("cron edit command", () => {
 
     errorSpy.mockRestore();
     exitSpy.mockRestore();
+  });
+
+  it("preserves trigger.once when --trigger-script replaces the script body", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-edit-trigger-"));
+    const scriptPath = path.join(dir, "next.js");
+    await fs.writeFile(scriptPath, "return { fire: true };\n", "utf8");
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.get") {
+        return {
+          id: "job-1",
+          trigger: { script: "return { fire: false };", once: true },
+        };
+      }
+      return { ok: true };
+    });
+
+    try {
+      await createCronProgram().parseAsync(["edit", "job-1", "--trigger-script", scriptPath], {
+        from: "user",
+      });
+
+      expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+        id: "job-1",
+        patch: {
+          trigger: {
+            script: "return { fire: true };",
+            once: true,
+          },
+        },
+      });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies --trigger-once when combined with --trigger-script", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-edit-trigger-once-"));
+    const scriptPath = path.join(dir, "next.js");
+    await fs.writeFile(scriptPath, "return { fire: true };\n", "utf8");
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.get") {
+        return {
+          id: "job-1",
+          trigger: { script: "return { fire: false };" },
+        };
+      }
+      return { ok: true };
+    });
+
+    try {
+      await createCronProgram().parseAsync(
+        ["edit", "job-1", "--trigger-script", scriptPath, "--trigger-once"],
+        { from: "user" },
+      );
+
+      expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+        id: "job-1",
+        patch: {
+          trigger: {
+            script: "return { fire: true };",
+            once: true,
+          },
+        },
+      });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not invent trigger.once when replacing a repeatable trigger script", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-edit-trigger-repeat-"));
+    const scriptPath = path.join(dir, "next.js");
+    await fs.writeFile(scriptPath, "return { fire: true };\n", "utf8");
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.get") {
+        return {
+          id: "job-1",
+          trigger: { script: "return { fire: false };" },
+        };
+      }
+      return { ok: true };
+    });
+
+    try {
+      await createCronProgram().parseAsync(["edit", "job-1", "--trigger-script", scriptPath], {
+        from: "user",
+      });
+
+      expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+        id: "job-1",
+        patch: {
+          trigger: {
+            script: "return { fire: true };",
+          },
+        },
+      });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects --clear-trigger combined with --trigger-script", async () => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-edit-trigger-clear-"));
+    const scriptPath = path.join(dir, "next.js");
+    await fs.writeFile(scriptPath, "return { fire: true };\n", "utf8");
+
+    try {
+      await createCronProgram().parseAsync(
+        ["edit", "job-1", "--clear-trigger", "--trigger-script", scriptPath],
+        { from: "user" },
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Use --clear-trigger or trigger options, not both"),
+      );
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
@@ -133,7 +133,6 @@ describe("cron edit trigger-once CLI→gateway", () => {
       ["cron", "edit", jobId, "--trigger-script", nextScriptPath, "--url", url, "--token", token],
       env,
     );
-    // eslint-disable-next-line no-console
     console.log(
       [
         "----- cli-edit-trigger-script-preserve-once -----",
@@ -152,7 +151,6 @@ describe("cron edit trigger-once CLI→gateway", () => {
     };
     expect(job.trigger?.once).toBe(true);
     expect(job.trigger?.script).toContain("fire: true");
-    // eslint-disable-next-line no-console
     console.log(
       [
         "----- gateway-cron-get-trigger -----",

--- a/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
@@ -1,0 +1,163 @@
+// Exact-head CLI → ephemeral gateway proof: --trigger-script preserves trigger.once.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  connectOk,
+  installGatewayTestHooks,
+  rpcReq,
+  startServerWithClient,
+  testState,
+} from "../../gateway/test-helpers.js";
+import { testConfigRoot } from "../../gateway/test-helpers.runtime-state.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const entry = path.join(repoRoot, "src/entry.ts");
+
+async function runCli(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return await new Promise((resolve) => {
+    const child = spawn(process.execPath, ["--import", "tsx", entry, ...args], {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("close", (code) => {
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function jobIdFromCronAdd(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+  const record = payload as { id?: unknown; job?: { id?: unknown } };
+  if (typeof record.id === "string" && record.id.trim()) {
+    return record.id.trim();
+  }
+  if (typeof record.job?.id === "string" && record.job.id.trim()) {
+    return record.job.id.trim();
+  }
+  return "";
+}
+
+describe("cron edit trigger-once CLI→gateway", () => {
+  let started: Awaited<ReturnType<typeof startServerWithClient>> | undefined;
+  let tempRoot = "";
+  const token = "proof-trigger-once-token";
+
+  beforeAll(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trigger-once-proof-"));
+    process.env.OPENCLAW_SKIP_CRON = "0";
+    testState.cronEnabled = true;
+    const configPath = path.join(testConfigRoot.value, "openclaw.json");
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          cron: {
+            enabled: true,
+            triggers: { enabled: true },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    started = await startServerWithClient(token);
+    await connectOk(started.ws);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (started) {
+      started.ws.close();
+      await started.server.close().catch(() => undefined);
+      started.envSnapshot.restore();
+    }
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("CLI --trigger-script keeps existing trigger.once=true", async () => {
+    expect(started).toBeDefined();
+    const { ws, port } = started!;
+    const url = `ws://127.0.0.1:${port}`;
+    const env = {
+      ...process.env,
+      HOME: tempRoot,
+      OPENCLAW_HOME: tempRoot,
+      OPENCLAW_STATE_DIR: path.join(tempRoot, ".openclaw"),
+      OPENCLAW_CONFIG_PATH: path.join(tempRoot, ".openclaw", "openclaw.json"),
+      OPENCLAW_GATEWAY_TOKEN: token,
+    };
+
+    const add = await rpcReq(ws, "cron.add", {
+      name: "proof-trigger-once",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 3_600_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "wake" },
+      trigger: {
+        script: "return { fire: false };",
+        once: true,
+      },
+    });
+    expect(add.ok, JSON.stringify(add.error ?? add.payload)).toBe(true);
+    const jobId = jobIdFromCronAdd(add.payload);
+    expect(jobId.length > 0).toBe(true);
+
+    const nextScriptPath = path.join(tempRoot, "next-trigger.js");
+    await fs.writeFile(nextScriptPath, "return { fire: true };\n", "utf8");
+
+    const edit = await runCli(
+      ["cron", "edit", jobId, "--trigger-script", nextScriptPath, "--url", url, "--token", token],
+      env,
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      [
+        "----- cli-edit-trigger-script-preserve-once -----",
+        `$ openclaw cron edit ${jobId} --trigger-script next-trigger.js --url ${url} --token ***`,
+        edit.stdout.trim(),
+        edit.stderr.trim(),
+        `exit=${edit.code}`,
+      ].join("\n"),
+    );
+    expect(edit.code, `${edit.stdout}\n${edit.stderr}`).toBe(0);
+
+    const get = await rpcReq(ws, "cron.get", { id: jobId });
+    expect(get.ok, JSON.stringify(get.error ?? get.payload)).toBe(true);
+    const job = get.payload as {
+      trigger?: { script?: string; once?: boolean };
+    };
+    expect(job.trigger?.once).toBe(true);
+    expect(job.trigger?.script).toContain("fire: true");
+    // eslint-disable-next-line no-console
+    console.log(
+      [
+        "----- gateway-cron-get-trigger -----",
+        JSON.stringify({ id: jobId, trigger: job.trigger }, null, 2),
+      ].join("\n"),
+    );
+  }, 120_000);
+});

--- a/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
@@ -60,10 +60,12 @@ function jobIdFromCronAdd(payload: unknown): string {
 describe("cron edit trigger-once CLI→gateway", () => {
   let started: Awaited<ReturnType<typeof startServerWithClient>> | undefined;
   let tempRoot = "";
+  let previousCronEnabled: boolean | undefined;
   const token = "proof-trigger-once-token";
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trigger-once-proof-"));
+    previousCronEnabled = testState.cronEnabled;
     process.env.OPENCLAW_SKIP_CRON = "0";
     testState.cronEnabled = true;
     const configPath = path.join(testConfigRoot.value, "openclaw.json");
@@ -92,6 +94,7 @@ describe("cron edit trigger-once CLI→gateway", () => {
       await started.server.close().catch(() => undefined);
       started.envSnapshot.restore();
     }
+    testState.cronEnabled = previousCronEnabled;
     if (tempRoot) {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }

--- a/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
@@ -61,11 +61,13 @@ describe("cron edit trigger-once CLI→gateway", () => {
   let started: Awaited<ReturnType<typeof startServerWithClient>> | undefined;
   let tempRoot = "";
   let previousCronEnabled: boolean | undefined;
+  let previousSkipCron: string | undefined;
   const token = "proof-trigger-once-token";
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trigger-once-proof-"));
     previousCronEnabled = testState.cronEnabled;
+    previousSkipCron = process.env.OPENCLAW_SKIP_CRON;
     process.env.OPENCLAW_SKIP_CRON = "0";
     testState.cronEnabled = true;
     const configPath = path.join(testConfigRoot.value, "openclaw.json");
@@ -95,6 +97,11 @@ describe("cron edit trigger-once CLI→gateway", () => {
       started.envSnapshot.restore();
     }
     testState.cronEnabled = previousCronEnabled;
+    if (previousSkipCron === undefined) {
+      delete process.env.OPENCLAW_SKIP_CRON;
+    } else {
+      process.env.OPENCLAW_SKIP_CRON = previousSkipCron;
+    }
     if (tempRoot) {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }

--- a/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts
@@ -10,7 +10,6 @@ import {
   installGatewayTestHooks,
   rpcReq,
   startServerWithClient,
-  testState,
 } from "../../gateway/test-helpers.js";
 import { testConfigRoot } from "../../gateway/test-helpers.runtime-state.js";
 
@@ -18,12 +17,13 @@ installGatewayTestHooks({ scope: "suite" });
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const entry = path.join(repoRoot, "src/entry.ts");
+const CLI_CHILD_TIMEOUT_MS = 60_000;
 
 async function runCli(
   args: string[],
   env: NodeJS.ProcessEnv,
 ): Promise<{ code: number; stdout: string; stderr: string }> {
-  return await new Promise((resolve) => {
+  return await new Promise((resolve, reject) => {
     const child = spawn(process.execPath, ["--import", "tsx", entry, ...args], {
       cwd: repoRoot,
       env,
@@ -31,14 +31,41 @@ async function runCli(
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    const finish = (result: { code: number; stdout: string; stderr: string }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(
+        Object.assign(new Error("CLI process did not exit before the deadlock guard"), {
+          stdout,
+          stderr,
+        }),
+      );
+    }, CLI_CHILD_TIMEOUT_MS);
+    timer.unref();
     child.stdout.on("data", (chunk) => {
       stdout += String(chunk);
     });
     child.stderr.on("data", (chunk) => {
       stderr += String(chunk);
     });
+    child.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
     child.on("close", (code) => {
-      resolve({ code: code ?? 1, stdout, stderr });
+      finish({ code: code ?? 1, stdout, stderr });
     });
   });
 }
@@ -60,30 +87,17 @@ function jobIdFromCronAdd(payload: unknown): string {
 describe("cron edit trigger-once CLI→gateway", () => {
   let started: Awaited<ReturnType<typeof startServerWithClient>> | undefined;
   let tempRoot = "";
-  let previousCronEnabled: boolean | undefined;
-  let previousSkipCron: string | undefined;
   const token = "proof-trigger-once-token";
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trigger-once-proof-"));
-    previousCronEnabled = testState.cronEnabled;
-    previousSkipCron = process.env.OPENCLAW_SKIP_CRON;
-    process.env.OPENCLAW_SKIP_CRON = "0";
-    testState.cronEnabled = true;
+    // Allow trigger payloads on cron.add without enabling the scheduler /
+    // trigger-watcher lifecycle (default SKIP_CRON + cronEnabled=false).
     const configPath = path.join(testConfigRoot.value, "openclaw.json");
     await fs.mkdir(path.dirname(configPath), { recursive: true });
     await fs.writeFile(
       configPath,
-      `${JSON.stringify(
-        {
-          cron: {
-            enabled: true,
-            triggers: { enabled: true },
-          },
-        },
-        null,
-        2,
-      )}\n`,
+      `${JSON.stringify({ cron: { triggers: { enabled: true } } }, null, 2)}\n`,
       "utf8",
     );
     started = await startServerWithClient(token);
@@ -96,12 +110,6 @@ describe("cron edit trigger-once CLI→gateway", () => {
       await started.server.close().catch(() => undefined);
       started.envSnapshot.restore();
     }
-    testState.cronEnabled = previousCronEnabled;
-    if (previousSkipCron === undefined) {
-      delete process.env.OPENCLAW_SKIP_CRON;
-    } else {
-      process.env.OPENCLAW_SKIP_CRON = previousSkipCron;
-    }
     if (tempRoot) {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
@@ -111,14 +119,23 @@ describe("cron edit trigger-once CLI→gateway", () => {
     expect(started).toBeDefined();
     const { ws, port } = started!;
     const url = `ws://127.0.0.1:${port}`;
-    const env = {
+    // Keep the spawned source-entry CLI single-process: host CI may export
+    // NODE_COMPILE_CACHE / VITEST from the runner.
+    const env: NodeJS.ProcessEnv = {
       ...process.env,
       HOME: tempRoot,
       OPENCLAW_HOME: tempRoot,
       OPENCLAW_STATE_DIR: path.join(tempRoot, ".openclaw"),
       OPENCLAW_CONFIG_PATH: path.join(tempRoot, ".openclaw", "openclaw.json"),
       OPENCLAW_GATEWAY_TOKEN: token,
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      OPENCLAW_NO_RESPAWN: "1",
     };
+    delete env.OPENCLAW_GATEWAY_PORT;
+    delete env.NODE_COMPILE_CACHE;
+    delete env.NODE_COMPILE_CACHE_PORTABLE;
+    delete env.VITEST;
+    delete env.NODE_OPTIONS;
 
     const add = await rpcReq(ws, "cron.add", {
       name: "proof-trigger-once",

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -325,7 +325,7 @@ export function registerCronEditCommand(cron: Command) {
             // stream schedule edits already merge sibling metadata the same way.
             const existing = await readExistingCronJob();
             patch.trigger = {
-              ...(existing.trigger ?? {}),
+              ...existing.trigger,
               script: await readCronTriggerScript(triggerScriptPath),
               ...(opts.triggerOnce ? { once: true } : {}),
             };

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -320,7 +320,12 @@ export function registerCronEditCommand(cron: Command) {
           if (opts.clearTrigger) {
             patch.trigger = null;
           } else if (triggerScriptPath) {
+            // Preserve existing trigger metadata (especially once) when only the
+            // script body changes. Gateway replaces patch.trigger wholesale, and
+            // stream schedule edits already merge sibling metadata the same way.
+            const existing = await readExistingCronJob();
             patch.trigger = {
+              ...(existing.trigger ?? {}),
               script: await readCronTriggerScript(triggerScriptPath),
               ...(opts.triggerOnce ? { once: true } : {}),
             };

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -227,6 +227,18 @@ export function registerCronEditCommand(cron: Command) {
           if (deliveryModeFlagCount > 1) {
             throw new Error("Choose at most one of --announce, --no-deliver, or --webhook.");
           }
+          const triggerScriptPath = normalizeOptionalString(opts.triggerScript);
+          if (typeof opts.triggerScript === "string" && !triggerScriptPath) {
+            throw new Error("--trigger-script must not be blank");
+          }
+          if (opts.clearTrigger && (triggerScriptPath || opts.triggerOnce)) {
+            throw new Error("Use --clear-trigger or trigger options, not both");
+          }
+          // Local input errors must not depend on Gateway availability, even when
+          // another edit field later needs the existing job.
+          const triggerScript = triggerScriptPath
+            ? await readCronTriggerScript(triggerScriptPath)
+            : undefined;
           const patch: Record<string, unknown> = {};
           if (typeof opts.name === "string") {
             patch.name = opts.name;
@@ -313,20 +325,16 @@ export function registerCronEditCommand(cron: Command) {
             };
           }
 
-          const triggerScriptPath = normalizeOptionalString(opts.triggerScript);
-          if (opts.clearTrigger && (triggerScriptPath || opts.triggerOnce)) {
-            throw new Error("Use --clear-trigger or trigger options, not both");
-          }
           if (opts.clearTrigger) {
             patch.trigger = null;
-          } else if (triggerScriptPath) {
+          } else if (triggerScript !== undefined) {
             // Preserve existing trigger metadata (especially once) when only the
             // script body changes. Gateway replaces patch.trigger wholesale, and
             // stream schedule edits already merge sibling metadata the same way.
             const existing = await readExistingCronJob();
             patch.trigger = {
               ...existing.trigger,
-              script: await readCronTriggerScript(triggerScriptPath),
+              script: triggerScript,
               ...(opts.triggerOnce ? { once: true } : {}),
             };
           } else if (opts.triggerOnce) {


### PR DESCRIPTION
## Review feedback addressed

Tip `6e6af0496bb6a14ac1ac99ed6a64c21216091229` is a **narrow, current-main Closes #119916 repair** that keeps #119917's proven CLI-to-Gateway persistence path and absorbs the focused producer-side strengths from draft #120226:

1. **[x] Preserve trigger.once on script-only edits (P2 owner boundary)** — CLI merges existing trigger metadata before Gateway wholesale replacement (sibling to pacing/stream metadata merges).
2. **[x] Narrow the PR to the issue surface** — removed the unrelated plugins.refresh / OPENCLAW_GATEWAY_PORT change that previously made this branch wider than the formal closing candidate.
3. **[x] Fail closed on blank/invalid --trigger-script before Gateway** — blank path, empty/oversized/missing script bodies reject locally without cron.get / ECONNREFUSED (same producer fail-closed shape as #120226).
4. **[x] Exact-head CLI to ephemeral Gateway proof** — register.cron-edit.trigger-once.gateway.test.ts still proves persistence of once:true after a real script-only edit (Claw previously rated this proof path diamond).

Focused vitest on tip `6e6af0496bb6a14ac1ac99ed6a64c21216091229`: src/cli/cron-cli/register.cron-edit.test.ts, src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts → 2 files / 82 tests passed.

**Final PR head:** `6e6af0496bb6a14ac1ac99ed6a64c21216091229` (rebased onto current main; issue-scoped files only)

Closes #119916

## What Problem This Solves

Addresses #119916: cron edit --trigger-script silently clears trigger.once one-shot conditions.

## Why This Change Was Made

Gateway replaces patch.trigger wholesale. A script-only CLI edit that rebuilds only the script field without merging existing trigger metadata durably drops once:true. The CLI producer must preserve sibling trigger fields (matching pacing/stream merge behavior) and reject invalid script inputs before RPC.

## User Impact

Script-only cron edits keep one-shot semantics. Blank or invalid --trigger-script values fail locally with a clear error instead of depending on Gateway availability.

## Evidence

```text
TIP=6e6af0496bb6a14ac1ac99ed6a64c21216091229
node scripts/run-vitest.mjs \
  src/cli/cron-cli/register.cron-edit.test.ts \
  src/cli/cron-cli/register.cron-edit.trigger-once.gateway.test.ts \
  --reporter=verbose

Test Files  2 passed (2)
     Tests  82 passed (82)
```

Coverage includes: preserve once on script-only replace; --trigger-script + --trigger-once; do not invent once for repeatable triggers; clear/script mutex; blank/invalid script fail-closed before Gateway; live ephemeral-Gateway persistence proof.

## AI-assisted development

This change was implemented with an OpenClaw coding agent and published through a guarded human-approval workflow. The exact diff and focused validation evidence were verified before publication.
