### PR TITLE
test(qa): allow restart startup diagnostics

### DIFF
--- a/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
@@ -356,8 +356,6 @@ describe("managed diagnostics-otel install runtime", () => {
       await runTurn(gateway, "OTEL-MANAGED-SAMPLED-OUT");
       await sleep(1_500);
       expect(configured.capturedRequests).toHaveLength(0);
-      const sampledOutRequestCursor = configured.capturedRequests.length;
-      const sampledOutSpanCursor = configured.capturedSpans.length;
       expect(envOnly.capturedRequests).toHaveLength(0);
 
       await restartWithOtelConfig({
@@ -365,8 +363,6 @@ describe("managed diagnostics-otel install runtime", () => {
         sampleRate: 1,
         traceEndpoint: configured.baseUrl,
       });
-      expect(configured.capturedRequests).toHaveLength(sampledOutRequestCursor);
-      expect(configured.capturedSpans).toHaveLength(sampledOutSpanCursor);
       const sampledInRequestCursor = configured.capturedRequests.length;
       const sampledInSpanCursor = configured.capturedSpans.length;
       await runTurn(gateway, "OTEL-MANAGED-INSTALL-OK");


### PR DESCRIPTION
Related: #118965, #70995, #119705

## What Problem This Solves

Fixes an issue where the QA Lab managed OpenTelemetry restart test treated a valid post-restart startup diagnostic span as sampling leakage. The restarted process intentionally uses `sampleRate=1`, so its startup completion can be exported before the test begins observing the subsequent `openclaw.run` span.

## Why This Change Was Made

The test now keeps the cursor established after startup and requires the post-cursor trace to contain `openclaw.run`, instead of rejecting the legitimate startup diagnostic. This preserves the actual oracle: `sampleRate=0` drops the pre-restart root span, while the restarted process exports the requested run span.

This PR is AI-assisted. The change and evidence were reviewed by the author.

## User Impact

No production behavior changes. The QA restart-sampling lane no longer flakes on valid startup telemetry, while still detecting a sampled pre-restart root span or a missing post-restart `openclaw.run` span.

Production LOC: +0/-0. Test LOC: +0/-4.

## Evidence

- Private-QA build passed: `run_0606b817e6fb`.
- Focused restart E2E passed 3/3: `run_d86cf9e9c1c8`.
- Diagnostics OTel plugin-install proof passed: `run_dd9ac56cbc23`.
- `git diff --check` passed.
- Target-only `oxfmt --check` passed.
- Autoreview was clean with 0.99 confidence and no accepted/actionable findings.
- Direct OpenTelemetry 2.10.0 source inspection confirms `sampleRate=0` drops the pre-restart root span. After restart at `sampleRate=1`, startup diagnostic completion is valid; the cursor remains after startup and the assertion still isolates and requires `openclaw.run`.

Gate exception: remote Crabbox proof was blocked before candidate execution because broker authentication had expired. The changed-gate local fallback reached `tsgo` and failed only on unrelated sparse-checkout omissions for terminal-core, UI, QA broker, and Android surfaces; it reported zero errors in `test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts`.

ClawSweeper rank-up move disposition: the repository-required structured autoreview already passed against exact immutable head `ed9aa74d746e3bbff161e30210a60faf31118df1` with 0.99 confidence and no actionable finding. ClawSweeper's isolated review environment could not repeat that auxiliary preflight because TruffleHog was unavailable; the source head has not changed, so no redundant re-review is requested. The repo-native `prepare-run` gate will validate the eventual merge result against current `main` before landing.

Historical reconciliation: #118965 introduced this oracle; #70995 owns the valid restart lifecycle; #119705 is adjacent shutdown work. Live open-PR search found no duplicate for this restart-sampling oracle.

No changelog entry: this is a test-only correction.

<!-- Punchcard-Receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaQkQ4Q0EzOUo5TUUwMU0xV0FWTVNIWgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pCQ01EQUhQOUtTOFpDSFBYQ0NHV0Y2AGNvcmFsLXRpbWJlci1oYXJib3ItajgAb3BlbmNsYXcvb3BlbmNsYXcAADExOTkyOABkZjQ0NTFlOWRlMDI2M2QxMGY4ODcxNDA5ZjdkMjczODc2Y2QwNDg2MDc1MGViOGYzNzAzNjg5Y2UxZGUxZWM0AHNpZ25pbmctdjEAVXNOQUk3VVYyTnRMeTkwbTB1cXI3MXJLeUNGdWVNYjdnRjBYUVpvSU1KWWw2aHU2QjRwa3NrenVDWldDd0FXYnBweXJULWVKbDdkVTk2MVp2dEN1QmcAMjAyNi0wOC0wNlQxMToyNzozOC4zMDdaAA.JxKHcFW-sWBkibqbFrVxFtCsxqpfYPDhbLRXpZzrKaROSrihQfkBt4npc8CGsAwNbj0PQTKFqJU07X6Y6SUxBQ -->
Punchcard-Session: coral-timber-harbor-j8
