### PR TITLE
fix(agents): clear emoji/avatar on agents.update empty or null

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13842,9 +13842,9 @@ public struct AgentsUpdateParams: Codable, Sendable {
         agentid: String,
         name: String? = nil,
         workspace: String? = nil,
-        modelvalue: AnyCodable? = nil,
-        emojivalue: AnyCodable? = nil,
-        avatarvalue: AnyCodable? = nil)
+        modelvalue: AnyCodable?,
+        emojivalue: AnyCodable?,
+        avatarvalue: AnyCodable?)
     {
         self.agentid = agentid
         self.name = name

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13877,8 +13877,8 @@ public struct AgentsUpdateParams: Codable, Sendable {
         name: String? = nil,
         workspace: String? = nil,
         modelvalue: AnyCodable?,
-        emoji: String? = nil,
-        avatar: String? = nil)
+        emoji: String?,
+        avatar: String?)
     {
         self.init(
             agentid: agentid,

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13833,16 +13833,16 @@ public struct AgentsUpdateParams: Codable, Sendable {
     public let workspace: String?
     public let modelvalue: AnyCodable?
     public var model: String? { modelvalue?.value as? String }
-    public let emoji: String?
-    public let avatar: String?
+    public let emoji: AnyCodable?
+    public let avatar: AnyCodable?
 
     public init(
         agentid: String,
         name: String? = nil,
         workspace: String? = nil,
         modelvalue: AnyCodable?,
-        emoji: String? = nil,
-        avatar: String? = nil)
+        emoji: AnyCodable? = nil,
+        avatar: AnyCodable? = nil)
     {
         self.agentid = agentid
         self.name = name
@@ -13857,8 +13857,8 @@ public struct AgentsUpdateParams: Codable, Sendable {
         name: String? = nil,
         workspace: String? = nil,
         model: String? = nil,
-        emoji: String? = nil,
-        avatar: String? = nil)
+        emoji: AnyCodable? = nil,
+        avatar: AnyCodable? = nil)
     {
         self.init(
             agentid: agentid,
@@ -13886,8 +13886,8 @@ public struct AgentsUpdateParams: Codable, Sendable {
         self.modelvalue = container.contains(.modelvalue)
             ? try container.decode(AnyCodable.self, forKey: .modelvalue)
             : nil
-        self.emoji = try container.decodeIfPresent(String.self, forKey: .emoji)
-        self.avatar = try container.decodeIfPresent(String.self, forKey: .avatar)
+        self.emoji = try container.decodeIfPresent(AnyCodable.self, forKey: .emoji)
+        self.avatar = try container.decodeIfPresent(AnyCodable.self, forKey: .avatar)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13871,6 +13871,24 @@ public struct AgentsUpdateParams: Codable, Sendable {
             avatarvalue: avatar.map { AnyCodable($0) })
     }
 
+    /// Shipped mixed call shape: raw modelvalue plus String emoji/avatar labels.
+    public init(
+        agentid: String,
+        name: String? = nil,
+        workspace: String? = nil,
+        modelvalue: AnyCodable?,
+        emoji: String? = nil,
+        avatar: String? = nil)
+    {
+        self.init(
+            agentid: agentid,
+            name: name,
+            workspace: workspace,
+            modelvalue: modelvalue,
+            emojivalue: emoji.map { AnyCodable($0) },
+            avatarvalue: avatar.map { AnyCodable($0) })
+    }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case name

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13843,8 +13843,8 @@ public struct AgentsUpdateParams: Codable, Sendable {
         name: String? = nil,
         workspace: String? = nil,
         modelvalue: AnyCodable?,
-        emojivalue: AnyCodable?,
-        avatarvalue: AnyCodable?)
+        emojivalue: AnyCodable? = nil,
+        avatarvalue: AnyCodable? = nil)
     {
         self.agentid = agentid
         self.name = name

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13889,6 +13889,40 @@ public struct AgentsUpdateParams: Codable, Sendable {
             avatarvalue: avatar.map { AnyCodable($0) })
     }
 
+    /// Shipped mixed call shape: raw modelvalue plus String emoji label.
+    public init(
+        agentid: String,
+        name: String? = nil,
+        workspace: String? = nil,
+        modelvalue: AnyCodable?,
+        emoji: String?)
+    {
+        self.init(
+            agentid: agentid,
+            name: name,
+            workspace: workspace,
+            modelvalue: modelvalue,
+            emojivalue: emoji.map { AnyCodable($0) },
+            avatarvalue: nil)
+    }
+
+    /// Shipped mixed call shape: raw modelvalue plus String avatar label.
+    public init(
+        agentid: String,
+        name: String? = nil,
+        workspace: String? = nil,
+        modelvalue: AnyCodable?,
+        avatar: String?)
+    {
+        self.init(
+            agentid: agentid,
+            name: name,
+            workspace: workspace,
+            modelvalue: modelvalue,
+            emojivalue: nil,
+            avatarvalue: avatar.map { AnyCodable($0) })
+    }
+
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case name

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13833,23 +13833,25 @@ public struct AgentsUpdateParams: Codable, Sendable {
     public let workspace: String?
     public let modelvalue: AnyCodable?
     public var model: String? { modelvalue?.value as? String }
-    public let emoji: AnyCodable?
-    public let avatar: AnyCodable?
+    public let emojivalue: AnyCodable?
+    public var emoji: String? { emojivalue?.value as? String }
+    public let avatarvalue: AnyCodable?
+    public var avatar: String? { avatarvalue?.value as? String }
 
     public init(
         agentid: String,
         name: String? = nil,
         workspace: String? = nil,
-        modelvalue: AnyCodable?,
-        emoji: AnyCodable? = nil,
-        avatar: AnyCodable? = nil)
+        modelvalue: AnyCodable? = nil,
+        emojivalue: AnyCodable? = nil,
+        avatarvalue: AnyCodable? = nil)
     {
         self.agentid = agentid
         self.name = name
         self.workspace = workspace
         self.modelvalue = modelvalue
-        self.emoji = emoji
-        self.avatar = avatar
+        self.emojivalue = emojivalue
+        self.avatarvalue = avatarvalue
     }
 
     public init(
@@ -13857,16 +13859,16 @@ public struct AgentsUpdateParams: Codable, Sendable {
         name: String? = nil,
         workspace: String? = nil,
         model: String? = nil,
-        emoji: AnyCodable? = nil,
-        avatar: AnyCodable? = nil)
+        emoji: String? = nil,
+        avatar: String? = nil)
     {
         self.init(
             agentid: agentid,
             name: name,
             workspace: workspace,
             modelvalue: model.map { AnyCodable($0) },
-            emoji: emoji,
-            avatar: avatar)
+            emojivalue: emoji.map { AnyCodable($0) },
+            avatarvalue: avatar.map { AnyCodable($0) })
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -13874,8 +13876,8 @@ public struct AgentsUpdateParams: Codable, Sendable {
         case name
         case workspace
         case modelvalue = "model"
-        case emoji
-        case avatar
+        case emojivalue = "emoji"
+        case avatarvalue = "avatar"
     }
 
     public init(from decoder: Decoder) throws {
@@ -13886,8 +13888,12 @@ public struct AgentsUpdateParams: Codable, Sendable {
         self.modelvalue = container.contains(.modelvalue)
             ? try container.decode(AnyCodable.self, forKey: .modelvalue)
             : nil
-        self.emoji = try container.decodeIfPresent(AnyCodable.self, forKey: .emoji)
-        self.avatar = try container.decodeIfPresent(AnyCodable.self, forKey: .avatar)
+        self.emojivalue = container.contains(.emojivalue)
+            ? try container.decode(AnyCodable.self, forKey: .emojivalue)
+            : nil
+        self.avatarvalue = container.contains(.avatarvalue)
+            ? try container.decode(AnyCodable.self, forKey: .avatarvalue)
+            : nil
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -13896,8 +13902,8 @@ public struct AgentsUpdateParams: Codable, Sendable {
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(workspace, forKey: .workspace)
         try container.encodeIfPresent(modelvalue, forKey: .modelvalue)
-        try container.encodeIfPresent(emoji, forKey: .emoji)
-        try container.encodeIfPresent(avatar, forKey: .avatar)
+        try container.encodeIfPresent(emojivalue, forKey: .emojivalue)
+        try container.encodeIfPresent(avatarvalue, forKey: .avatarvalue)
     }
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -244,8 +244,8 @@ struct GatewayModelsCompatibilityTests {
     func `agent update model keeps legacy source compatibility and nullable wire semantics`() throws {
         let legacyParams = AgentsUpdateParams(agentid: "work", model: "openai/gpt-5.6")
         let omittedParams = AgentsUpdateParams(agentid: "work")
-        // Shipped raw model-null call site: must stay source-compatible without naming
-        // emojivalue/avatarvalue (see AgentsUpdateParams raw initializer defaults).
+        // Shipped raw model-null call site: uniquely matches the raw initializer
+        // because mixed emoji/avatar labels are required (no defaults).
         let clearedParams = AgentsUpdateParams(agentid: "work", modelvalue: AnyCodable(NSNull()))
 
         #expect(legacyParams.model == "openai/gpt-5.6")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -343,27 +343,4 @@ struct GatewayModelsCompatibilityTests {
         #expect(reencodedCleared["emoji"] is NSNull)
         #expect(reencodedCleared["avatar"] is NSNull)
     }
-
-    @Test
-    func `node invoke session envelope preserves omitted null and value states`() throws {
-        let omitted = try JSONDecoder().decode(
-            NodeInvokeRequestEvent.self,
-            from: Data(#"{"id":"invoke-1","nodeId":"node-1","command":"debug.ping"}"#.utf8))
-        let cleared = try JSONDecoder().decode(
-            NodeInvokeRequestEvent.self,
-            from: Data(
-                #"{"id":"invoke-2","nodeId":"node-1","command":"debug.ping","sessionKey":null}"#.utf8))
-        let attributed = try JSONDecoder().decode(
-            NodeInvokeRequestEvent.self,
-            from: Data(
-                #"{"id":"invoke-3","nodeId":"node-1","command":"debug.ping","sessionKey":"agent:main:main"}"#.utf8))
-        let reencodedCleared = try #require(
-            JSONSerialization.jsonObject(with: JSONEncoder().encode(cleared))
-                as? [String: Any])
-
-        #expect(omitted.sessionkey == nil)
-        #expect(cleared.sessionkey?.value is NSNull)
-        #expect(attributed.sessionkey?.value as? String == "agent:main:main")
-        #expect(reencodedCleared["sessionKey"] is NSNull)
-    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -281,6 +281,25 @@ struct GatewayModelsCompatibilityTests {
     }
 
     @Test
+    func `agent update keeps mixed modelvalue plus String emoji avatar call sites`() throws {
+        let mixedParams = AgentsUpdateParams(
+            agentid: "work",
+            modelvalue: AnyCodable(NSNull()),
+            emoji: "🦞",
+            avatar: "https://example.com/a.png")
+        let mixedJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(mixedParams))
+                as? [String: Any])
+
+        #expect(mixedParams.modelvalue?.value is NSNull)
+        #expect(mixedParams.emoji == "🦞")
+        #expect(mixedParams.avatar == "https://example.com/a.png")
+        #expect(mixedJSON["model"] is NSNull)
+        #expect(mixedJSON["emoji"] as? String == "🦞")
+        #expect(mixedJSON["avatar"] as? String == "https://example.com/a.png")
+    }
+
+    @Test
     func `agent update emoji and avatar keep String call sites and nullable clears`() throws {
         let legacyParams = AgentsUpdateParams(agentid: "work", emoji: "🐢", avatar: "https://example.com/a.png")
         let omittedParams = AgentsUpdateParams(agentid: "work")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -244,7 +244,11 @@ struct GatewayModelsCompatibilityTests {
     func `agent update model keeps legacy source compatibility and nullable wire semantics`() throws {
         let legacyParams = AgentsUpdateParams(agentid: "work", model: "openai/gpt-5.6")
         let omittedParams = AgentsUpdateParams(agentid: "work")
-        let clearedParams = AgentsUpdateParams(agentid: "work", modelvalue: AnyCodable(NSNull()))
+        let clearedParams = AgentsUpdateParams(
+            agentid: "work",
+            modelvalue: AnyCodable(NSNull()),
+            emojivalue: nil,
+            avatarvalue: nil)
 
         #expect(legacyParams.model == "openai/gpt-5.6")
         #expect(omittedParams.modelvalue == nil)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -277,4 +277,72 @@ struct GatewayModelsCompatibilityTests {
         #expect(decodedCleared.modelvalue?.value is NSNull)
         #expect(reencodedCleared["model"] is NSNull)
     }
+
+    @Test
+    func `agent update emoji and avatar keep String call sites and nullable clears`() throws {
+        let legacyParams = AgentsUpdateParams(agentid: "work", emoji: "🐢", avatar: "https://example.com/a.png")
+        let omittedParams = AgentsUpdateParams(agentid: "work")
+        let clearedParams = AgentsUpdateParams(
+            agentid: "work",
+            modelvalue: nil,
+            emojivalue: AnyCodable(NSNull()),
+            avatarvalue: AnyCodable(NSNull()))
+
+        #expect(legacyParams.emoji == "🐢")
+        #expect(legacyParams.avatar == "https://example.com/a.png")
+        #expect(omittedParams.emojivalue == nil)
+        #expect(omittedParams.avatarvalue == nil)
+
+        let legacyJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(legacyParams))
+                as? [String: Any])
+        let omittedJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(omittedParams))
+                as? [String: Any])
+        let clearedJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(clearedParams))
+                as? [String: Any])
+
+        #expect(legacyJSON["emoji"] as? String == "🐢")
+        #expect(legacyJSON["avatar"] as? String == "https://example.com/a.png")
+        #expect(omittedJSON["emoji"] == nil)
+        #expect(omittedJSON["avatar"] == nil)
+        #expect(clearedJSON["emoji"] is NSNull)
+        #expect(clearedJSON["avatar"] is NSNull)
+
+        let decodedCleared = try JSONDecoder().decode(
+            AgentsUpdateParams.self,
+            from: Data(#"{"agentId":"work","emoji":null,"avatar":null}"#.utf8))
+        let reencodedCleared = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(decodedCleared))
+                as? [String: Any])
+
+        #expect(decodedCleared.emojivalue?.value is NSNull)
+        #expect(decodedCleared.avatarvalue?.value is NSNull)
+        #expect(reencodedCleared["emoji"] is NSNull)
+        #expect(reencodedCleared["avatar"] is NSNull)
+    }
+
+    @Test
+    func `node invoke session envelope preserves omitted null and value states`() throws {
+        let omitted = try JSONDecoder().decode(
+            NodeInvokeRequestEvent.self,
+            from: Data(#"{"id":"invoke-1","nodeId":"node-1","command":"debug.ping"}"#.utf8))
+        let cleared = try JSONDecoder().decode(
+            NodeInvokeRequestEvent.self,
+            from: Data(
+                #"{"id":"invoke-2","nodeId":"node-1","command":"debug.ping","sessionKey":null}"#.utf8))
+        let attributed = try JSONDecoder().decode(
+            NodeInvokeRequestEvent.self,
+            from: Data(
+                #"{"id":"invoke-3","nodeId":"node-1","command":"debug.ping","sessionKey":"agent:main:main"}"#.utf8))
+        let reencodedCleared = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(cleared))
+                as? [String: Any])
+
+        #expect(omitted.sessionkey == nil)
+        #expect(cleared.sessionkey?.value is NSNull)
+        #expect(attributed.sessionkey?.value as? String == "agent:main:main")
+        #expect(reencodedCleared["sessionKey"] is NSNull)
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -282,15 +282,51 @@ struct GatewayModelsCompatibilityTests {
 
     @Test
     func `agent update keeps mixed modelvalue plus String emoji avatar call sites`() throws {
+        let noneParams = AgentsUpdateParams(
+            agentid: "work",
+            modelvalue: AnyCodable(NSNull()))
+        let emojiOnlyParams = AgentsUpdateParams(
+            agentid: "work",
+            modelvalue: AnyCodable("openai/gpt-5.6-luna"),
+            emoji: "🦞")
+        let avatarOnlyParams = AgentsUpdateParams(
+            agentid: "work",
+            modelvalue: AnyCodable("openai/gpt-5.6-luna"),
+            avatar: "https://example.com/a.png")
         let mixedParams = AgentsUpdateParams(
             agentid: "work",
             modelvalue: AnyCodable(NSNull()),
             emoji: "🦞",
             avatar: "https://example.com/a.png")
+        let noneJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(noneParams))
+                as? [String: Any])
+        let emojiOnlyJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(emojiOnlyParams))
+                as? [String: Any])
+        let avatarOnlyJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(avatarOnlyParams))
+                as? [String: Any])
         let mixedJSON = try #require(
             JSONSerialization.jsonObject(with: JSONEncoder().encode(mixedParams))
                 as? [String: Any])
 
+        #expect(noneParams.modelvalue?.value is NSNull)
+        #expect(noneParams.emoji == nil)
+        #expect(noneParams.avatar == nil)
+        #expect(noneJSON["model"] is NSNull)
+        #expect(noneJSON["emoji"] == nil)
+        #expect(noneJSON["avatar"] == nil)
+        #expect(emojiOnlyParams.model == "openai/gpt-5.6-luna")
+        #expect(emojiOnlyParams.emoji == "🦞")
+        #expect(emojiOnlyParams.avatar == nil)
+        #expect(emojiOnlyJSON["emoji"] as? String == "🦞")
+        #expect(emojiOnlyJSON["avatar"] == nil)
+        #expect(avatarOnlyParams.model == "openai/gpt-5.6-luna")
+        #expect(avatarOnlyParams.emoji == nil)
+        #expect(avatarOnlyParams.avatar == "https://example.com/a.png")
+        #expect(avatarOnlyJSON["emoji"] == nil)
+        #expect(avatarOnlyJSON["avatar"] as? String == "https://example.com/a.png")
         #expect(mixedParams.modelvalue?.value is NSNull)
         #expect(mixedParams.emoji == "🦞")
         #expect(mixedParams.avatar == "https://example.com/a.png")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -244,11 +244,9 @@ struct GatewayModelsCompatibilityTests {
     func `agent update model keeps legacy source compatibility and nullable wire semantics`() throws {
         let legacyParams = AgentsUpdateParams(agentid: "work", model: "openai/gpt-5.6")
         let omittedParams = AgentsUpdateParams(agentid: "work")
-        let clearedParams = AgentsUpdateParams(
-            agentid: "work",
-            modelvalue: AnyCodable(NSNull()),
-            emojivalue: nil,
-            avatarvalue: nil)
+        // Shipped raw model-null call site: must stay source-compatible without naming
+        // emojivalue/avatarvalue (see AgentsUpdateParams raw initializer defaults).
+        let clearedParams = AgentsUpdateParams(agentid: "work", modelvalue: AnyCodable(NSNull()))
 
         #expect(legacyParams.model == "openai/gpt-5.6")
         #expect(omittedParams.modelvalue == nil)

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -207,6 +207,16 @@ describe("AgentsUpdateParamsSchema", () => {
     expectAccepted(AgentsUpdateParamsSchema, { agentId: "work" }, { agentId: "work", model: null });
     expectRejected(AgentsUpdateParamsSchema, { agentId: "work", model: "" });
   });
+
+  it("accepts null or empty emoji/avatar clears", () => {
+    expectAccepted(
+      AgentsUpdateParamsSchema,
+      { agentId: "work", emoji: null },
+      { agentId: "work", emoji: "" },
+      { agentId: "work", avatar: null },
+      { agentId: "work", avatar: "" },
+    );
+  });
 });
 
 describe("ModelsListParamsSchema", () => {

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -165,7 +165,7 @@ export const AgentsUpdateParamsSchema = closedObject({
   name: Type.Optional(NonEmptyString),
   workspace: Type.Optional(NonEmptyString),
   model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-  // Empty string also clears (historical clients); prefer null like model.
+  // Null clears; empty and whitespace strings preserve existing identity values.
   emoji: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   avatar: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 });

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -159,14 +159,15 @@ export const AgentsCreateResultSchema = closedObject({
   model: Type.Optional(NonEmptyString),
 });
 
-/** Updates mutable agent identity, workspace, and model fields; null clears the model override. */
+/** Updates mutable agent identity, workspace, and model fields; null clears overrides. */
 export const AgentsUpdateParamsSchema = closedObject({
   agentId: NonEmptyString,
   name: Type.Optional(NonEmptyString),
   workspace: Type.Optional(NonEmptyString),
   model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
-  emoji: Type.Optional(Type.String()),
-  avatar: Type.Optional(Type.String()),
+  // Empty string also clears (historical clients); prefer null like model.
+  emoji: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  avatar: Type.Optional(Type.Union([Type.String(), Type.Null()])),
 });
 
 /** Result returned after updating an agent. */

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -430,6 +430,14 @@ describe("OpenClaw SDK websocket e2e", () => {
         await oc.agents.update({ agentId: "sdk-agent", model: null }),
       );
       expect(clearAgentModel.params).toEqual({ agentId: "sdk-agent", model: null });
+      const clearAgentEmoji = expectJsonObject(
+        await oc.agents.update({ agentId: "sdk-agent", emoji: null, avatar: null }),
+      );
+      expect(clearAgentEmoji.params).toEqual({
+        agentId: "sdk-agent",
+        emoji: null,
+        avatar: null,
+      });
       const deleteAgent = expectJsonObject(await oc.agents.delete({ agentId: "sdk-agent" }));
       expect(deleteAgent.method).toBe("agents.delete");
       expect(deleteAgent.params).toEqual({ agentId: "sdk-agent" });

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -529,7 +529,10 @@ function emitStructCompatibilityInitializer(
         return `        ${propName}: AnyCodable?`;
       }
       if (agentsUpdateNullableStringKeys.has(key)) {
-        return `        ${safeName(key)}: String? = nil`;
+        // Mixed emoji/avatar omit defaults so
+        // AgentsUpdateParams(agentid:modelvalue:) uniquely matches the raw
+        // initializer instead of this String-label overload.
+        return `        ${safeName(key)}: String?`;
       }
       return `        ${swiftInitializerParam({
         name: propName,

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -523,6 +523,31 @@ function emitStructCompatibilityInitializer(
       }
       return `            ${propName}: ${propName}`;
     });
+    const mixedInitializerParams = Object.entries(props).map(([key, prop]) => {
+      const propName = swiftStoredPropertyName(name, key);
+      if (key === "model") {
+        return `        ${propName}: AnyCodable?`;
+      }
+      if (agentsUpdateNullableStringKeys.has(key)) {
+        return `        ${safeName(key)}: String? = nil`;
+      }
+      return `        ${swiftInitializerParam({
+        name: propName,
+        schema: prop,
+        required: required.has(key),
+      })}`;
+    });
+    const mixedDelegatedArgs = Object.keys(props).map((key) => {
+      const propName = swiftStoredPropertyName(name, key);
+      if (key === "model") {
+        return `            ${propName}: ${propName}`;
+      }
+      if (agentsUpdateNullableStringKeys.has(key)) {
+        const publicName = safeName(key);
+        return `            ${propName}: ${publicName}.map { AnyCodable($0) }`;
+      }
+      return `            ${propName}: ${propName}`;
+    });
     return (
       "\n\n    public init(\n" +
       initializerParams.join(",\n") +
@@ -530,6 +555,15 @@ function emitStructCompatibilityInitializer(
       "    {\n" +
       "        self.init(\n" +
       delegatedArgs.join(",\n") +
+      ")\n" +
+      "    }" +
+      "\n\n    /// Shipped mixed call shape: raw modelvalue plus String emoji/avatar labels.\n" +
+      "    public init(\n" +
+      mixedInitializerParams.join(",\n") +
+      ")\n" +
+      "    {\n" +
+      "        self.init(\n" +
+      mixedDelegatedArgs.join(",\n") +
       ")\n" +
       "    }"
     );

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -523,34 +523,58 @@ function emitStructCompatibilityInitializer(
       }
       return `            ${propName}: ${propName}`;
     });
-    const mixedInitializerParams = Object.entries(props).map(([key, prop]) => {
-      const propName = swiftStoredPropertyName(name, key);
-      if (key === "model") {
-        return `        ${propName}: AnyCodable?`;
-      }
-      if (agentsUpdateNullableStringKeys.has(key)) {
-        // Mixed emoji/avatar omit defaults so
-        // AgentsUpdateParams(agentid:modelvalue:) uniquely matches the raw
-        // initializer instead of this String-label overload.
-        return `        ${safeName(key)}: String?`;
-      }
-      return `        ${swiftInitializerParam({
-        name: propName,
-        schema: prop,
-        required: required.has(key),
-      })}`;
-    });
-    const mixedDelegatedArgs = Object.keys(props).map((key) => {
-      const propName = swiftStoredPropertyName(name, key);
-      if (key === "model") {
+    const emitMixedInitializer = (params: {
+      comment: string;
+      identityLabels: ReadonlySet<string>;
+    }): string => {
+      const mixedInitializerParams = Object.entries(props).flatMap(([key, prop]) => {
+        const propName = swiftStoredPropertyName(name, key);
+        if (key === "model") {
+          return [`        ${propName}: AnyCodable?`];
+        }
+        if (agentsUpdateNullableStringKeys.has(key)) {
+          if (!params.identityLabels.has(key)) {
+            return [];
+          }
+          // Mixed String labels omit defaults so
+          // AgentsUpdateParams(agentid:modelvalue:) uniquely matches the raw
+          // initializer instead of a String-label overload.
+          return [`        ${safeName(key)}: String?`];
+        }
+        return [
+          `        ${swiftInitializerParam({
+            name: propName,
+            schema: prop,
+            required: required.has(key),
+          })}`,
+        ];
+      });
+      const mixedDelegatedArgs = Object.keys(props).map((key) => {
+        const propName = swiftStoredPropertyName(name, key);
+        if (key === "model") {
+          return `            ${propName}: ${propName}`;
+        }
+        if (agentsUpdateNullableStringKeys.has(key)) {
+          if (!params.identityLabels.has(key)) {
+            return `            ${propName}: nil`;
+          }
+          const publicName = safeName(key);
+          return `            ${propName}: ${publicName}.map { AnyCodable($0) }`;
+        }
         return `            ${propName}: ${propName}`;
-      }
-      if (agentsUpdateNullableStringKeys.has(key)) {
-        const publicName = safeName(key);
-        return `            ${propName}: ${publicName}.map { AnyCodable($0) }`;
-      }
-      return `            ${propName}: ${propName}`;
-    });
+      });
+      return (
+        `\n\n    /// ${params.comment}\n` +
+        "    public init(\n" +
+        mixedInitializerParams.join(",\n") +
+        ")\n" +
+        "    {\n" +
+        "        self.init(\n" +
+        mixedDelegatedArgs.join(",\n") +
+        ")\n" +
+        "    }"
+      );
+    };
     return (
       "\n\n    public init(\n" +
       initializerParams.join(",\n") +
@@ -560,15 +584,18 @@ function emitStructCompatibilityInitializer(
       delegatedArgs.join(",\n") +
       ")\n" +
       "    }" +
-      "\n\n    /// Shipped mixed call shape: raw modelvalue plus String emoji/avatar labels.\n" +
-      "    public init(\n" +
-      mixedInitializerParams.join(",\n") +
-      ")\n" +
-      "    {\n" +
-      "        self.init(\n" +
-      mixedDelegatedArgs.join(",\n") +
-      ")\n" +
-      "    }"
+      emitMixedInitializer({
+        comment: "Shipped mixed call shape: raw modelvalue plus String emoji/avatar labels.",
+        identityLabels: new Set(["emoji", "avatar"]),
+      }) +
+      emitMixedInitializer({
+        comment: "Shipped mixed call shape: raw modelvalue plus String emoji label.",
+        identityLabels: new Set(["emoji"]),
+      }) +
+      emitMixedInitializer({
+        comment: "Shipped mixed call shape: raw modelvalue plus String avatar label.",
+        identityLabels: new Set(["avatar"]),
+      })
     );
   }
   if (name !== "ChatSendParams" || !props.fastMode) {

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -101,6 +101,9 @@ function safeName(name: string) {
 }
 
 // Canonical initializer labels must match stored properties; compatibility initializers
+/** AgentsUpdateParams fields that keep String? call sites while wire-encoding null clears. */
+const agentsUpdateNullableStringKeys = new Set(["model", "emoji", "avatar"]);
+
 // declare legacy labels separately.
 function swiftStoredPropertyName(structName: string, key: string): string {
   if (structName === "SessionCompactionCheckpoint" && key === "tokensVersion") {
@@ -112,8 +115,8 @@ function swiftStoredPropertyName(structName: string, key: string): string {
   if (structName === "ChatSendParams" && key === "fastMode") {
     return "fastmodevalue";
   }
-  if (structName === "AgentsUpdateParams" && key === "model") {
-    return "modelvalue";
+  if (structName === "AgentsUpdateParams" && agentsUpdateNullableStringKeys.has(key)) {
+    return `${safeName(key)}value`;
   }
   if (structName === "ChatSendParams" && key === "fast_seconds") {
     return "fastseconds";
@@ -125,8 +128,9 @@ function swiftCompatibilityPropertyLines(structName: string, key: string): strin
   if (structName === "ChatSendParams" && key === "fastMode") {
     return ["    public var fastmode: Bool? { fastmodevalue?.value as? Bool }"];
   }
-  if (structName === "AgentsUpdateParams" && key === "model") {
-    return ["    public var model: String? { modelvalue?.value as? String }"];
+  if (structName === "AgentsUpdateParams" && agentsUpdateNullableStringKeys.has(key)) {
+    const stored = swiftStoredPropertyName(structName, key);
+    return [`    public var ${safeName(key)}: String? { ${stored}?.value as? String }`];
   }
   return [];
 }
@@ -389,10 +393,11 @@ function emitStruct(name: string, schema: JsonSchema): string {
         .map(([key, prop]) => {
           const propName = swiftStoredPropertyName(name, key);
           const req = required.has(key);
-          if (name === "AgentsUpdateParams" && key === "model") {
+          if (name === "AgentsUpdateParams" && agentsUpdateNullableStringKeys.has(key)) {
             // Keep the raw nullable value explicit so the source-compatible initializer stays
-            // unambiguous when callers omit model.
-            return "        modelvalue: AnyCodable?";
+            // unambiguous when callers omit the field. Default nil so raw clears can name
+            // only the field being cleared (e.g. modelvalue: AnyCodable(NSNull())).
+            return `        ${swiftStoredPropertyName(name, key)}: AnyCodable? = nil`;
           }
           return `        ${swiftInitializerParam({
             name: propName,
@@ -449,14 +454,17 @@ function emitStructCustomCodable(
   props: Record<string, JsonSchema>,
   required: Set<string>,
 ): string {
-  if (name !== "AgentsUpdateParams" || !props.model) {
+  const preservesExplicitNull = (key: string) =>
+    (name === "AgentsUpdateParams" && agentsUpdateNullableStringKeys.has(key)) ||
+    (name === "NodeInvokeRequestEvent" && key === "sessionKey");
+  if (!Object.keys(props).some(preservesExplicitNull)) {
     return "";
   }
   const decodedProperties = Object.entries(props).map(([key, propSchema]) => {
     const propName = swiftStoredPropertyName(name, key);
-    if (key === "model") {
+    if (preservesExplicitNull(key)) {
       // decodeIfPresent collapses an explicit JSON null into nil. Presence-aware decoding
-      // preserves the Gateway patch distinction between clearing and omitting the model.
+      // preserves Gateway distinctions between clearing and omitting nullable fields.
       return `        self.${propName} = container.contains(.${propName})\n            ? try container.decode(AnyCodable.self, forKey: .${propName})\n            : nil`;
     }
     if (required.has(key)) {
@@ -488,11 +496,14 @@ function emitStructCompatibilityInitializer(
   props: Record<string, JsonSchema>,
   required: Set<string>,
 ): string {
-  if (name === "AgentsUpdateParams" && props.model) {
+  if (
+    name === "AgentsUpdateParams" &&
+    [...agentsUpdateNullableStringKeys].some((key) => Boolean(props[key]))
+  ) {
     const initializerParams = Object.entries(props).map(([key, prop]) => {
       const propName = swiftStoredPropertyName(name, key);
-      if (key === "model") {
-        return "        model: String? = nil";
+      if (agentsUpdateNullableStringKeys.has(key)) {
+        return `        ${safeName(key)}: String? = nil`;
       }
       return `        ${swiftInitializerParam({
         name: propName,
@@ -502,8 +513,9 @@ function emitStructCompatibilityInitializer(
     });
     const delegatedArgs = Object.keys(props).map((key) => {
       const propName = swiftStoredPropertyName(name, key);
-      if (key === "model") {
-        return "            modelvalue: model.map { AnyCodable($0) }";
+      if (agentsUpdateNullableStringKeys.has(key)) {
+        const publicName = safeName(key);
+        return `            ${propName}: ${publicName}.map { AnyCodable($0) }`;
       }
       return `            ${propName}: ${propName}`;
     });

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -394,9 +394,14 @@ function emitStruct(name: string, schema: JsonSchema): string {
           const propName = swiftStoredPropertyName(name, key);
           const req = required.has(key);
           if (name === "AgentsUpdateParams" && agentsUpdateNullableStringKeys.has(key)) {
-            // No default: otherwise AgentsUpdateParams(agentid:) is ambiguous with the
-            // String?-facing compatibility initializer (same as model-only pattern).
-            return `        ${swiftStoredPropertyName(name, key)}: AnyCodable?`;
+            // modelvalue stays required so AgentsUpdateParams(agentid:) uniquely resolves
+            // to the String?-facing compatibility initializer. emojivalue/avatarvalue keep
+            // defaults so the shipped raw call AgentsUpdateParams(agentid:modelvalue:) still
+            // compiles without naming the newer clearable fields.
+            if (key === "model") {
+              return `        ${swiftStoredPropertyName(name, key)}: AnyCodable?`;
+            }
+            return `        ${swiftStoredPropertyName(name, key)}: AnyCodable? = nil`;
           }
           return `        ${swiftInitializerParam({
             name: propName,

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -394,10 +394,9 @@ function emitStruct(name: string, schema: JsonSchema): string {
           const propName = swiftStoredPropertyName(name, key);
           const req = required.has(key);
           if (name === "AgentsUpdateParams" && agentsUpdateNullableStringKeys.has(key)) {
-            // Keep the raw nullable value explicit so the source-compatible initializer stays
-            // unambiguous when callers omit the field. Default nil so raw clears can name
-            // only the field being cleared (e.g. modelvalue: AnyCodable(NSNull())).
-            return `        ${swiftStoredPropertyName(name, key)}: AnyCodable? = nil`;
+            // No default: otherwise AgentsUpdateParams(agentid:) is ambiguous with the
+            // String?-facing compatibility initializer (same as model-only pattern).
+            return `        ${swiftStoredPropertyName(name, key)}: AnyCodable?`;
           }
           return `        ${swiftInitializerParam({
             name: propName,

--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -138,6 +138,39 @@ Fluent in over six million error messages.
 
     expect(merged).toBe("- Name: New Name\n");
   });
+
+  it("clears parser-accepted unbulleted emoji and avatar labels", () => {
+    const merged = mergeIdentityMarkdownContent(
+      `# IDENTITY.md - Agent Identity
+
+Name: Keep Me
+Emoji: 🤖
+Avatar: https://example.com/a.png
+Creature: Familiar
+`,
+      {},
+      { clearFields: ["emoji", "avatar"] },
+    );
+
+    expect(merged).toContain("Name: Keep Me");
+    expect(merged).toContain("Creature: Familiar");
+    expect(merged).not.toMatch(/Emoji\s*:/);
+    expect(merged).not.toMatch(/Avatar\s*:/);
+  });
+
+  it("clears both bulleted and unbulleted emoji forms", () => {
+    const merged = mergeIdentityMarkdownContent(
+      `- Emoji: 🤖
+Emoji: 🦞
+- Avatar: avatars/a.png
+`,
+      {},
+      { clearFields: ["emoji", "avatar"] },
+    );
+
+    expect(merged).not.toMatch(/Emoji\s*:/);
+    expect(merged).not.toMatch(/Avatar\s*:/);
+  });
 });
 
 describe("loadAgentIdentityFromWorkspace", () => {

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -217,11 +217,23 @@ function resolveIdentityInsertIndex(lines: string[]): number {
 export function mergeIdentityMarkdownContent(
   content: string | undefined,
   identity: Pick<AgentIdentityFile, "name" | "theme" | "emoji" | "avatar">,
+  opts?: { clearFields?: ReadonlyArray<"name" | "theme" | "emoji" | "avatar"> },
 ): string {
   const lines = normalizeIdentityContent(content);
   const nextLines = lines.length > 0 ? [...lines] : ["# IDENTITY.md - Agent Identity", ""];
+  const clearFields = new Set(opts?.clearFields ?? []);
 
   for (const [field, label] of WRITABLE_IDENTITY_FIELDS) {
+    if (clearFields.has(field)) {
+      for (let index = nextLines.length - 1; index >= 0; index -= 1) {
+        const line = nextLines[index];
+        if (line !== undefined && matchesIdentityLabel(line, label)) {
+          nextLines.splice(index, 1);
+        }
+      }
+      continue;
+    }
+
     const value = identity[field]?.trim();
     if (!value) {
       continue;

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -161,11 +161,10 @@ function buildIdentityLine(label: string, value: string): string {
 }
 
 function matchesIdentityLabel(line: string, label: string): boolean {
-  const trimmed = line.trim();
-  if (!trimmed.startsWith("-")) {
-    return false;
-  }
-  const cleaned = trimmed.replace(/^\s*-\s*/, "");
+  // Match the reader: optional leading bullet, then Label: value.
+  // Clearing must remove unbulleted `Emoji:` / `Avatar:` lines too, or a
+  // config tombstone can leave a file-backed identity value active.
+  const cleaned = line.trim().replace(/^\s*-\s*/, "");
   const colonIndex = cleaned.indexOf(":");
   if (colonIndex === -1) {
     return false;

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -129,6 +129,28 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
   });
 }
 
+/** Identity patch for agent config updates; `null` clears a previously set field. */
+export type AgentIdentityPatch = {
+  [K in keyof IdentityConfig]?: IdentityConfig[K] | null;
+};
+
+function mergeAgentIdentity(
+  base: IdentityConfig | undefined,
+  patch: AgentIdentityPatch,
+): IdentityConfig | undefined {
+  const next: IdentityConfig = { ...base };
+  for (const [key, value] of Object.entries(patch) as Array<
+    [keyof IdentityConfig, IdentityConfig[keyof IdentityConfig] | null | undefined]
+  >) {
+    if (value === null || value === undefined || value === "") {
+      delete next[key];
+      continue;
+    }
+    next[key] = value;
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
 export function applyAgentConfig(
   cfg: OpenClawConfig,
   params: {
@@ -137,7 +159,7 @@ export function applyAgentConfig(
     workspace?: string;
     agentDir?: string;
     model?: string | null;
-    identity?: IdentityConfig;
+    identity?: AgentIdentityPatch;
   },
 ): OpenClawConfig {
   const agentId = normalizeAgentId(params.agentId);
@@ -145,14 +167,21 @@ export function applyAgentConfig(
   const list = listAgentEntries(cfg);
   const index = findAgentEntryIndex(list, agentId);
   const base = (index >= 0 ? list[index] : undefined) ?? { id: agentId };
-  const mergedIdentity = params.identity ? { ...base.identity, ...params.identity } : undefined;
+  const mergedIdentity =
+    params.identity !== undefined ? mergeAgentIdentity(base.identity, params.identity) : undefined;
   const nextEntry: AgentEntry = {
     ...base,
     ...(name ? { name } : {}),
     ...(params.workspace ? { workspace: params.workspace } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),
-    ...(mergedIdentity ? { identity: mergedIdentity } : {}),
   };
+  if (params.identity !== undefined) {
+    if (mergedIdentity) {
+      nextEntry.identity = mergedIdentity;
+    } else {
+      delete nextEntry.identity;
+    }
+  }
   // Model is tri-state: omission preserves the override, null restores inheritance.
   if (params.model === null) {
     delete nextEntry.model;

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -134,14 +134,18 @@ export type AgentIdentityPatch = {
   [K in keyof IdentityConfig]?: IdentityConfig[K] | null;
 };
 
+const IDENTITY_PATCH_KEYS = ["name", "theme", "emoji", "avatar"] as const;
+
 function mergeAgentIdentity(
   base: IdentityConfig | undefined,
   patch: AgentIdentityPatch,
 ): IdentityConfig | undefined {
   const next: IdentityConfig = { ...base };
-  for (const [key, value] of Object.entries(patch) as Array<
-    [keyof IdentityConfig, IdentityConfig[keyof IdentityConfig] | null | undefined]
-  >) {
+  for (const key of IDENTITY_PATCH_KEYS) {
+    if (!Object.hasOwn(patch, key)) {
+      continue;
+    }
+    const value = patch[key];
     if (value === null || value === undefined || value === "") {
       delete next[key];
       continue;

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -162,6 +162,23 @@ describe("agents helpers", () => {
     expect(work?.identity?.theme).toBe("chill");
   });
 
+  it("applyAgentConfig clears identity fields with null", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        entries: { work: { identity: { name: "Old", theme: "chill", emoji: "🐢" } } },
+      },
+    };
+
+    const next = applyAgentConfig(cfg, {
+      agentId: "work",
+      identity: { emoji: null },
+    });
+
+    const work = next.agents?.entries?.work;
+    expect(work?.identity).toEqual({ name: "Old", theme: "chill" });
+    expect(work?.identity).not.toHaveProperty("emoji");
+  });
+
   it("applyAgentConfig skips identity when not provided", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -6,11 +6,11 @@ import {
   findAgentEntryIndex,
   listAgentEntries,
   pruneAgentConfig,
+  type AgentIdentityPatch,
 } from "../../commands/agents.config.js";
 import { mutateConfigFileWithRetry } from "../../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions.js";
 import type { AgentConfig } from "../../config/types.agents.js";
-import type { IdentityConfig } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 type AgentDeleteMutationResult = {
@@ -34,7 +34,7 @@ export async function updateAgentConfigEntry(params: {
   name?: string;
   workspace?: string;
   model?: string | null;
-  identity?: IdentityConfig;
+  identity?: AgentIdentityPatch;
 }): Promise<void> {
   await mutateConfigFileWithRetry({
     afterWrite: { mode: "auto" },
@@ -47,7 +47,7 @@ export async function updateAgentConfigEntry(params: {
         ...(params.name ? { name: params.name } : {}),
         ...(params.workspace ? { workspace: params.workspace } : {}),
         ...(params.model !== undefined ? { model: params.model } : {}),
-        ...(params.identity ? { identity: params.identity } : {}),
+        ...(params.identity !== undefined ? { identity: params.identity } : {}),
       });
       Object.assign(draft, latestNextConfig);
     },

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1505,11 +1505,15 @@ describe("agents.update", () => {
   it.each([
     {
       name: "restores IDENTITY.md when it still contains this mutation's write after config commit failure",
-      concurrentEdit: false,
+      concurrentEdit: "none",
     },
     {
       name: "does not restore IDENTITY.md over a concurrent agents.files.set edit after config commit failure",
-      concurrentEdit: true,
+      concurrentEdit: "before-compare",
+    },
+    {
+      name: "does not restore IDENTITY.md over a concurrent agents.files.set edit that lands after the rollback comparison",
+      concurrentEdit: "after-compare",
     },
   ] as const)("$name", async ({ concurrentEdit }) => {
     const identityMarkdown = [
@@ -1529,13 +1533,20 @@ describe("agents.update", () => {
       "",
     ].join("\n");
     let lastWritten: string | undefined;
+    let readsAfterClearedWrite = 0;
     mocks.rootRead.mockImplementation(async () => {
-      const content =
-        lastWritten === undefined
-          ? identityMarkdown
-          : concurrentEdit
-            ? concurrentMarkdown
-            : lastWritten;
+      let content = lastWritten === undefined ? identityMarkdown : lastWritten;
+      if (lastWritten !== undefined && concurrentEdit === "before-compare") {
+        content = concurrentMarkdown;
+      } else if (lastWritten !== undefined && concurrentEdit === "after-compare") {
+        readsAfterClearedWrite += 1;
+        if (readsAfterClearedWrite === 1) {
+          content = lastWritten;
+          lastWritten = concurrentMarkdown;
+        } else {
+          content = lastWritten;
+        }
+      }
       return {
         buffer: Buffer.from(content),
         realPath: "/workspace/test-agent/IDENTITY.md",
@@ -1562,9 +1573,14 @@ describe("agents.update", () => {
     });
     expect(String(clearedWrite.data)).not.toMatch(/Emoji\s*:/);
     expect(String(clearedWrite.data)).not.toMatch(/Avatar\s*:/);
-    if (concurrentEdit) {
+    if (concurrentEdit === "before-compare") {
       expect(mocks.rootWrite).toHaveBeenCalledOnce();
       expect(lastWritten).toBe(String(clearedWrite.data));
+      return;
+    }
+    if (concurrentEdit === "after-compare") {
+      expect(mocks.rootWrite).toHaveBeenCalledOnce();
+      expect(lastWritten).toBe(concurrentMarkdown);
       return;
     }
     const restoredWrite = expectRecordFields(mockCallArg(mocks.rootWrite, 1), {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1028,13 +1028,10 @@ describe("agents.update", () => {
     expect(agent).not.toHaveProperty("model");
   });
 
-  it.each([
-    { label: "empty string", emoji: "" },
-    { label: "null", emoji: null },
-  ])("clears an existing emoji with $label instead of silently keeping it", async ({ emoji }) => {
+  it("clears an existing emoji with null instead of silently keeping it", async () => {
     const { respond, promise } = makeCall("agents.update", {
       agentId: "test-agent",
-      emoji,
+      emoji: null,
     });
     await promise;
 
@@ -1050,6 +1047,30 @@ describe("agents.update", () => {
     );
     expect(agent.identity).toEqual({ name: "Current Agent", theme: "steady" });
     expect(agent.identity).not.toHaveProperty("emoji");
+  });
+
+  it("preserves an existing emoji when agents.update receives an empty string", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        list: [
+          {
+            id: "test-agent",
+            workspace: "/workspace/test-agent",
+            identity: { name: "Current Agent", theme: "steady", emoji: "🦞" },
+          },
+        ],
+      },
+    };
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji: "",
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    const update = expectRecordFields(mockCallArg(mocks.applyAgentConfig, 0, 1), {});
+    expect(update).not.toHaveProperty("identity");
   });
 
   it("preserves an existing emoji when agents.update receives whitespace-only input", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1502,7 +1502,16 @@ describe("agents.update", () => {
     expect(mocks.writeConfigFile).not.toHaveBeenCalled();
   });
 
-  it("restores IDENTITY.md when config commit fails after a successful identity write", async () => {
+  it.each([
+    {
+      name: "restores IDENTITY.md when it still contains this mutation's write after config commit failure",
+      concurrentEdit: false,
+    },
+    {
+      name: "does not restore IDENTITY.md over a concurrent agents.files.set edit after config commit failure",
+      concurrentEdit: true,
+    },
+  ] as const)("$name", async ({ concurrentEdit }) => {
     const identityMarkdown = [
       "# IDENTITY.md - Agent Identity",
       "",
@@ -1512,10 +1521,29 @@ describe("agents.update", () => {
       "Creature: Familiar",
       "",
     ].join("\n");
-    mocks.rootRead.mockResolvedValue({
-      buffer: Buffer.from(identityMarkdown),
-      realPath: "/workspace/test-agent/IDENTITY.md",
-      stat: { size: identityMarkdown.length, mtimeMs: 1 },
+    const concurrentMarkdown = [
+      "# IDENTITY.md - Agent Identity",
+      "",
+      "Name: Concurrent Agent",
+      "Creature: Familiar",
+      "",
+    ].join("\n");
+    let lastWritten: string | undefined;
+    mocks.rootRead.mockImplementation(async () => {
+      const content =
+        lastWritten === undefined
+          ? identityMarkdown
+          : concurrentEdit
+            ? concurrentMarkdown
+            : lastWritten;
+      return {
+        buffer: Buffer.from(content),
+        realPath: "/workspace/test-agent/IDENTITY.md",
+        stat: { size: content.length, mtimeMs: 1 },
+      };
+    });
+    mocks.rootWrite.mockImplementation(async (params?: unknown) => {
+      lastWritten = String((params as { data?: string | Buffer }).data);
     });
     mocks.writeConfigFile.mockRejectedValueOnce(new Error("config write failed"));
 
@@ -1534,6 +1562,11 @@ describe("agents.update", () => {
     });
     expect(String(clearedWrite.data)).not.toMatch(/Emoji\s*:/);
     expect(String(clearedWrite.data)).not.toMatch(/Avatar\s*:/);
+    if (concurrentEdit) {
+      expect(mocks.rootWrite).toHaveBeenCalledOnce();
+      expect(lastWritten).toBe(String(clearedWrite.data));
+      return;
+    }
     const restoredWrite = expectRecordFields(mockCallArg(mocks.rootWrite, 1), {
       rootDir: "/workspace/test-agent",
       relativePath: "IDENTITY.md",

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1049,6 +1049,36 @@ describe("agents.update", () => {
     expect(agent.identity).not.toHaveProperty("emoji");
   });
 
+  it("preserves an existing emoji when agents.update receives whitespace-only input", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        list: [
+          {
+            id: "test-agent",
+            workspace: "/workspace/test-agent",
+            identity: { name: "Current Agent", theme: "steady", emoji: "🦞" },
+          },
+        ],
+      },
+    };
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji: "   ",
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    const update = expectRecordFields(mockCallArg(mocks.applyAgentConfig, 0, 1), {});
+    expect(update).not.toHaveProperty("identity");
+    if (mocks.writeConfigFile.mock.calls.length > 0) {
+      const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
+      const agents = expectRecordFields(persisted.agents, {});
+      const [agent] = agents.list as MockAgentEntry[];
+      expect(agent.identity).toMatchObject({ emoji: "🦞" });
+    }
+  });
+
   it("clears an existing avatar with null", async () => {
     mocks.loadConfigReturn = {
       agents: {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -101,6 +101,7 @@ const mocks = vi.hoisted(() => ({
     size: 0,
   })),
   rootWrite: vi.fn(async (_params?: unknown) => {}),
+  rootRemove: vi.fn(async (_params?: unknown) => {}),
   migrateLegacyMainSessionKeys: vi.fn(),
   purgeAgentSessionStoreEntries: vi.fn(async () => false),
 }));
@@ -336,6 +337,7 @@ vi.mock("../../infra/fs-safe.js", async () => {
           data,
           ...options,
         }),
+      remove: async (relativePath: string) => await mocks.rootRemove({ rootDir, relativePath }),
     })),
   };
 });
@@ -450,6 +452,7 @@ beforeEach(() => {
     };
   });
   mocks.rootWrite.mockResolvedValue(undefined);
+  mocks.rootRemove.mockResolvedValue(undefined);
 });
 
 function makeRootForTest(overrides?: {
@@ -457,6 +460,7 @@ function makeRootForTest(overrides?: {
   read?: (params: Record<string, unknown>) => Promise<unknown>;
   stat?: (params: Record<string, unknown>) => Promise<unknown>;
   write?: (params: Record<string, unknown>) => Promise<unknown>;
+  remove?: (params: Record<string, unknown>) => Promise<unknown>;
 }) {
   return async (rootDir: string) =>
     ({
@@ -478,6 +482,8 @@ function makeRootForTest(overrides?: {
           data,
           ...options,
         }),
+      remove: async (relativePath: string) =>
+        await (overrides?.remove ?? mocks.rootRemove)({ rootDir, relativePath }),
     }) as never;
 }
 
@@ -1494,6 +1500,45 @@ describe("agents.update", () => {
 
     expectRespondErrorContaining(respond, "unsafe workspace file");
     expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("restores IDENTITY.md when config commit fails after a successful identity write", async () => {
+    const identityMarkdown = [
+      "# IDENTITY.md - Agent Identity",
+      "",
+      "Name: Current Agent",
+      "Emoji: 🐢",
+      "Avatar: https://example.com/avatar.png",
+      "Creature: Familiar",
+      "",
+    ].join("\n");
+    mocks.rootRead.mockResolvedValue({
+      buffer: Buffer.from(identityMarkdown),
+      realPath: "/workspace/test-agent/IDENTITY.md",
+      stat: { size: identityMarkdown.length, mtimeMs: 1 },
+    });
+    mocks.writeConfigFile.mockRejectedValueOnce(new Error("config write failed"));
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji: null,
+      avatar: null,
+    });
+
+    await expect(promise).rejects.toThrow("config write failed");
+    expect(respond).not.toHaveBeenCalled();
+    expect(mocks.writeConfigFile).toHaveBeenCalledOnce();
+    const clearedWrite = expectRecordFields(mockCallArg(mocks.rootWrite, 0), {
+      rootDir: "/workspace/test-agent",
+      relativePath: "IDENTITY.md",
+    });
+    expect(String(clearedWrite.data)).not.toMatch(/Emoji\s*:/);
+    expect(String(clearedWrite.data)).not.toMatch(/Avatar\s*:/);
+    const restoredWrite = expectRecordFields(mockCallArg(mocks.rootWrite, 1), {
+      rootDir: "/workspace/test-agent",
+      relativePath: "IDENTITY.md",
+    });
+    expect(String(restoredWrite.data)).toBe(identityMarkdown);
   });
 
   it("treats unsafe IDENTITY.md reads as invalid update requests", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1044,7 +1044,10 @@ describe("agents.update", () => {
     });
     const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
     const agents = expectRecordFields(persisted.agents, {});
-    const [agent] = agents.list as MockAgentEntry[];
+    const agent = expectDefined(
+      (agents.list as MockAgentEntry[])[0],
+      "persisted agent after emoji clear",
+    );
     expect(agent.identity).toEqual({ name: "Current Agent", theme: "steady" });
     expect(agent.identity).not.toHaveProperty("emoji");
   });
@@ -1074,7 +1077,10 @@ describe("agents.update", () => {
     if (mocks.writeConfigFile.mock.calls.length > 0) {
       const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
       const agents = expectRecordFields(persisted.agents, {});
-      const [agent] = agents.list as MockAgentEntry[];
+      const agent = expectDefined(
+        (agents.list as MockAgentEntry[])[0],
+        "persisted agent after whitespace emoji",
+      );
       expect(agent.identity).toMatchObject({ emoji: "🦞" });
     }
   });
@@ -1105,7 +1111,10 @@ describe("agents.update", () => {
     expectRespondOk(respond, { ok: true, agentId: "test-agent" });
     const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
     const agents = expectRecordFields(persisted.agents, {});
-    const [agent] = agents.list as MockAgentEntry[];
+    const agent = expectDefined(
+      (agents.list as MockAgentEntry[])[0],
+      "persisted agent after avatar clear",
+    );
     expect(agent.identity).toEqual({ name: "Current Agent", emoji: "🐢" });
     expect(agent.identity).not.toHaveProperty("avatar");
   });

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1119,6 +1119,64 @@ describe("agents.update", () => {
     expect(agent.identity).not.toHaveProperty("avatar");
   });
 
+  it("does not create IDENTITY.md when clearing emoji with no source file and no remaining identity", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        list: [
+          {
+            id: "test-agent",
+            workspace: "/workspace/test-agent",
+            identity: { emoji: "🐢" },
+          },
+        ],
+      },
+    };
+    mocks.rootRead.mockRejectedValue(new FsSafeError("not-found", "file not found"));
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji: null,
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    expect(mocks.rootWrite).not.toHaveBeenCalled();
+    const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
+    const agents = expectRecordFields(persisted.agents, {});
+    const agent = expectDefined(
+      (agents.list as MockAgentEntry[])[0],
+      "persisted agent after no-file emoji clear",
+    );
+    expect(agent.identity).toBeUndefined();
+  });
+
+  it("does not create IDENTITY.md on workspace move when identity is absent", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        list: [
+          {
+            id: "test-agent",
+            workspace: "/workspace/test-agent",
+          },
+        ],
+      },
+    };
+    mocks.ensureAgentWorkspace.mockResolvedValueOnce({
+      dir: "/resolved/new/workspace",
+      identityPathCreated: true,
+    });
+    mocks.rootRead.mockRejectedValue(new FsSafeError("not-found", "file not found"));
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      workspace: "/new/workspace",
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    expect(mocks.rootWrite).not.toHaveBeenCalled();
+  });
+
   it("clears parser-accepted unbulleted emoji/avatar lines from IDENTITY.md", async () => {
     const identityMarkdown = [
       "# IDENTITY.md - Agent Identity",

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -624,10 +624,24 @@ function mergeAgentConfig(cfg: unknown, opts: unknown): MockConfig {
     ...(params.workspace ? { workspace: params.workspace } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),
     ...(params.model ? { model: params.model } : {}),
-    ...(params.identity ? { identity: { ...base.identity, ...params.identity } } : {}),
   };
   if (params.model === null) {
     delete nextEntry.model;
+  }
+  if (params.identity !== undefined) {
+    const nextIdentity: MockIdentity = { ...base.identity };
+    for (const [key, value] of Object.entries(params.identity)) {
+      if (value === null || value === undefined || value === "") {
+        delete nextIdentity[key as keyof MockIdentity];
+      } else {
+        nextIdentity[key as keyof MockIdentity] = value as string;
+      }
+    }
+    if (Object.keys(nextIdentity).length > 0) {
+      nextEntry.identity = nextIdentity;
+    } else {
+      delete nextEntry.identity;
+    }
   }
   if (index >= 0) {
     list[index] = nextEntry;
@@ -1012,6 +1026,58 @@ describe("agents.update", () => {
     const agents = expectRecordFields(persisted.agents, {});
     const [agent] = agents.list as MockAgentEntry[];
     expect(agent).not.toHaveProperty("model");
+  });
+
+  it.each([
+    { label: "empty string", emoji: "" },
+    { label: "null", emoji: null },
+  ])("clears an existing emoji with $label instead of silently keeping it", async ({ emoji }) => {
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji,
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    expectRecordFields(mockCallArg(mocks.applyAgentConfig, 0, 1), {
+      identity: { emoji: null },
+    });
+    const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
+    const agents = expectRecordFields(persisted.agents, {});
+    const [agent] = agents.list as MockAgentEntry[];
+    expect(agent.identity).toEqual({ name: "Current Agent", theme: "steady" });
+    expect(agent.identity).not.toHaveProperty("emoji");
+  });
+
+  it("clears an existing avatar with null", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        list: [
+          {
+            id: "test-agent",
+            workspace: "/workspace/test-agent",
+            identity: {
+              name: "Current Agent",
+              emoji: "🐢",
+              avatar: "https://example.com/avatar.png",
+            },
+          },
+        ],
+      },
+    };
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      avatar: null,
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
+    const agents = expectRecordFields(persisted.agents, {});
+    const [agent] = agents.list as MockAgentEntry[];
+    expect(agent.identity).toEqual({ name: "Current Agent", emoji: "🐢" });
+    expect(agent.identity).not.toHaveProperty("avatar");
   });
 
   it("ensures workspace when workspace changes", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1080,6 +1080,40 @@ describe("agents.update", () => {
     expect(agent.identity).not.toHaveProperty("avatar");
   });
 
+  it("clears parser-accepted unbulleted emoji/avatar lines from IDENTITY.md", async () => {
+    const identityMarkdown = [
+      "# IDENTITY.md - Agent Identity",
+      "",
+      "Name: Current Agent",
+      "Emoji: 🐢",
+      "Avatar: https://example.com/avatar.png",
+      "Creature: Familiar",
+      "",
+    ].join("\n");
+    mocks.rootRead.mockResolvedValueOnce({
+      buffer: Buffer.from(identityMarkdown),
+      realPath: "/workspace/test-agent/IDENTITY.md",
+      stat: { size: identityMarkdown.length, mtimeMs: 1 },
+    });
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji: null,
+      avatar: null,
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    const write = expectRecordFields(mockCallArg(mocks.rootWrite), {
+      rootDir: "/workspace/test-agent",
+      relativePath: "IDENTITY.md",
+    });
+    expect(String(write.data)).toContain("Name: Current Agent");
+    expect(String(write.data)).toContain("Creature: Familiar");
+    expect(String(write.data)).not.toMatch(/Emoji\s*:/);
+    expect(String(write.data)).not.toMatch(/Avatar\s*:/);
+  });
+
   it("ensures workspace when workspace changes", async () => {
     const { promise } = makeCall("agents.update", {
       agentId: "test-agent",

--- a/src/gateway/server-methods/agents-update-clear-identity.gateway.test.ts
+++ b/src/gateway/server-methods/agents-update-clear-identity.gateway.test.ts
@@ -1,0 +1,89 @@
+// Exact-head Gateway proof: agents.update null/empty clears emoji/avatar in
+// config and removes parser-accepted unbulleted IDENTITY.md labels.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  connectOk,
+  installGatewayTestHooks,
+  rpcReq,
+  startServerWithClient,
+} from "../test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("agents.update clear identity gateway", () => {
+  let started: Awaited<ReturnType<typeof startServerWithClient>> | undefined;
+  let workspaceDir = "";
+  const token = "proof-agents-clear-identity-token";
+
+  beforeAll(async () => {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agents-clear-id-"));
+    started = await startServerWithClient(token);
+    await connectOk(started.ws);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (started) {
+      started.ws.close();
+      await started.server.close().catch(() => undefined);
+      started.envSnapshot.restore();
+    }
+    if (workspaceDir) {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("null emoji/avatar clears config and unbulleted IDENTITY.md fields", async () => {
+    expect(started).toBeDefined();
+    const ws = started!.ws;
+    const agentWorkspace = path.join(workspaceDir, "clear-id-agent");
+    await fs.mkdir(agentWorkspace, { recursive: true });
+
+    const created = await rpcReq<{ ok: boolean; agentId: string }>(ws, "agents.create", {
+      name: "Clear Identity Agent",
+      workspace: agentWorkspace,
+      emoji: "🐢",
+      avatar: "https://example.com/avatar.png",
+    });
+    expect(created.ok).toBe(true);
+    const agentId = created.payload?.agentId;
+    expect(agentId).toBeTruthy();
+
+    // Parser-accepted unbulleted form that the writer previously failed to clear.
+    await fs.writeFile(
+      path.join(agentWorkspace, "IDENTITY.md"),
+      [
+        "# IDENTITY.md - Agent Identity",
+        "",
+        "Name: Clear Identity Agent",
+        "Emoji: 🐢",
+        "Avatar: https://example.com/avatar.png",
+        "Creature: Familiar",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const cleared = await rpcReq<{ ok: boolean; agentId: string }>(ws, "agents.update", {
+      agentId,
+      emoji: null,
+      avatar: null,
+    });
+    expect(cleared.ok).toBe(true);
+
+    const listed = await rpcReq<{
+      agents: Array<{ id: string; identity?: { emoji?: string; avatar?: string; name?: string } }>;
+    }>(ws, "agents.list", {});
+    expect(listed.ok).toBe(true);
+    const agent = listed.payload?.agents.find((entry) => entry.id === agentId);
+    expect(agent?.identity?.emoji).toBeUndefined();
+    expect(agent?.identity?.avatar).toBeUndefined();
+
+    const identityAfter = await fs.readFile(path.join(agentWorkspace, "IDENTITY.md"), "utf8");
+    expect(identityAfter).toContain("Creature: Familiar");
+    expect(identityAfter).not.toMatch(/Emoji\s*:/);
+    expect(identityAfter).not.toMatch(/Avatar\s*:/);
+  }, 120_000);
+});

--- a/src/gateway/server-methods/agents-update-clear-identity.gateway.test.ts
+++ b/src/gateway/server-methods/agents-update-clear-identity.gateway.test.ts
@@ -72,6 +72,12 @@ describe("agents.update clear identity gateway", () => {
       avatar: null,
     });
     expect(cleared.ok).toBe(true);
+    console.log(
+      [
+        "----- rpc-agents-update-clear -----",
+        JSON.stringify({ ok: cleared.ok, agentId, emoji: null, avatar: null }, null, 2),
+      ].join("\n"),
+    );
 
     const listed = await rpcReq<{
       agents: Array<{ id: string; identity?: { emoji?: string; avatar?: string; name?: string } }>;
@@ -80,10 +86,28 @@ describe("agents.update clear identity gateway", () => {
     const agent = listed.payload?.agents.find((entry) => entry.id === agentId);
     expect(agent?.identity?.emoji).toBeUndefined();
     expect(agent?.identity?.avatar).toBeUndefined();
+    console.log(
+      [
+        "----- rpc-agents-list-readback -----",
+        JSON.stringify(
+          {
+            agentId,
+            identity: agent?.identity ?? null,
+            emoji: agent?.identity?.emoji ?? null,
+            avatar: agent?.identity?.avatar ?? null,
+          },
+          null,
+          2,
+        ),
+      ].join("\n"),
+    );
 
     const identityAfter = await fs.readFile(path.join(agentWorkspace, "IDENTITY.md"), "utf8");
     expect(identityAfter).toContain("Creature: Familiar");
     expect(identityAfter).not.toMatch(/Emoji\s*:/);
     expect(identityAfter).not.toMatch(/Avatar\s*:/);
+    console.log(
+      ["----- identity-md-readback -----", identityAfter.trim(), "----- end -----"].join("\n"),
+    );
   }, 120_000);
 });

--- a/src/gateway/server-methods/agents-update-clear-identity.gateway.test.ts
+++ b/src/gateway/server-methods/agents-update-clear-identity.gateway.test.ts
@@ -1,5 +1,6 @@
-// Exact-head Gateway proof: agents.update null/empty clears emoji/avatar in
-// config and removes parser-accepted unbulleted IDENTITY.md labels.
+// Exact-head Gateway proof: agents.update null clears emoji/avatar in config
+// and removes parser-accepted unbulleted IDENTITY.md labels. Empty strings stay
+// non-destructive (preserve stored identity).
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -108,6 +109,50 @@ describe("agents.update clear identity gateway", () => {
     expect(identityAfter).not.toMatch(/Avatar\s*:/);
     console.log(
       ["----- identity-md-readback -----", identityAfter.trim(), "----- end -----"].join("\n"),
+    );
+  }, 120_000);
+
+  test("empty-string emoji/avatar preserve stored identity (null is the clear tombstone)", async () => {
+    expect(started).toBeDefined();
+    const ws = started!.ws;
+    const agentWorkspace = path.join(workspaceDir, "preserve-empty-agent");
+    await fs.mkdir(agentWorkspace, { recursive: true });
+
+    const created = await rpcReq<{ ok: boolean; agentId: string }>(ws, "agents.create", {
+      name: "Preserve Empty Agent",
+      workspace: agentWorkspace,
+      emoji: "🦞",
+      avatar: "https://example.com/keep.png",
+    });
+    expect(created.ok).toBe(true);
+    const agentId = created.payload?.agentId;
+    expect(agentId).toBeTruthy();
+
+    const preserved = await rpcReq<{ ok: boolean; agentId: string }>(ws, "agents.update", {
+      agentId,
+      emoji: "",
+      avatar: "",
+    });
+    expect(preserved.ok).toBe(true);
+    console.log(
+      [
+        "----- rpc-agents-update-empty-preserve -----",
+        JSON.stringify({ ok: preserved.ok, agentId, emoji: "", avatar: "" }, null, 2),
+      ].join("\n"),
+    );
+
+    const listed = await rpcReq<{
+      agents: Array<{ id: string; identity?: { emoji?: string; avatar?: string } }>;
+    }>(ws, "agents.list", {});
+    expect(listed.ok).toBe(true);
+    const agent = listed.payload?.agents.find((entry) => entry.id === agentId);
+    expect(agent?.identity?.emoji).toBe("🦞");
+    expect(agent?.identity?.avatar).toBe("https://example.com/keep.png");
+    console.log(
+      [
+        "----- rpc-agents-list-empty-preserve-readback -----",
+        JSON.stringify({ agentId, identity: agent?.identity ?? null }, null, 2),
+      ].join("\n"),
     );
   }, 120_000);
 });

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -820,8 +820,33 @@ async function restoreWorkspaceFile(params: {
   workspaceDir: string;
   name: string;
   previousContent: string | undefined;
+  expectedCurrentContent: string;
 }): Promise<void> {
   const workspaceRoot = await agentsHandlerDeps.root(params.workspaceDir);
+  const readCurrentIdentityContent = async (): Promise<string | undefined> => {
+    try {
+      const safeRead = await workspaceRoot.read(params.name, {
+        hardlinks: "reject",
+        nonBlockingRead: true,
+      });
+      return safeRead.buffer.toString("utf-8");
+    } catch {
+      // Unreadable current bytes cannot prove this mutation still owns the
+      // file; skip restore rather than overwrite an unknown concurrent edit.
+      return undefined;
+    }
+  };
+  // Two observations are required. The first is the rollback snapshot; the
+  // second is the condition for the mutating syscall. A concurrent IDENTITY.md
+  // write can complete in the await between them; restoring from the first
+  // snapshot would clobber it. Same-process agents.files.set shares the config
+  // lock; this write-time re-read still covers writers outside that lock.
+  if ((await readCurrentIdentityContent()) !== params.expectedCurrentContent) {
+    return;
+  }
+  if ((await readCurrentIdentityContent()) !== params.expectedCurrentContent) {
+    return;
+  }
   if (params.previousContent === undefined) {
     try {
       await workspaceRoot.remove(params.name);
@@ -1102,20 +1127,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
             try {
               await updateAgentConfigEntry(agentConfigUpdate);
             } catch (error) {
-              // Restore only when IDENTITY.md still contains this mutation's
-              // write. agents.files.set can edit the same file without the
-              // config lock; a stale snapshot restore would overwrite that edit.
-              const currentIdentityContent = await readWorkspaceFileContent(
-                identityWorkspaceDir,
-                DEFAULT_IDENTITY_FILENAME,
-              ).catch(() => undefined);
-              if (currentIdentityContent === builtIdentity.content) {
-                await restoreWorkspaceFile({
-                  workspaceDir: identityWorkspaceDir,
-                  name: DEFAULT_IDENTITY_FILENAME,
-                  previousContent: previousIdentityContent,
-                });
-              }
+              await restoreWorkspaceFile({
+                workspaceDir: identityWorkspaceDir,
+                name: DEFAULT_IDENTITY_FILENAME,
+                previousContent: previousIdentityContent,
+                expectedCurrentContent: builtIdentity.content,
+              });
               throw error;
             }
             return true;
@@ -1725,7 +1742,17 @@ export const agentsHandlers: GatewayRequestHandlers = {
     let workspaceRoot: WorkspaceRoot;
     try {
       workspaceRoot = await agentsHandlerDeps.root(workspaceDir);
-      await workspaceRoot.write(name, content, { encoding: "utf8" });
+      const writeWorkspaceFile = async () => {
+        await workspaceRoot.write(name, content, { encoding: "utf8" });
+      };
+      // IDENTITY.md rollback restore runs under the config lock. Taking the
+      // same lock serializes raw files.set with that restore so a concurrent
+      // authorized edit cannot land between the restore snapshot and write.
+      if (name === DEFAULT_IDENTITY_FILENAME) {
+        await withConfigMutationExclusive(writeWorkspaceFile);
+      } else {
+        await writeWorkspaceFile();
+      }
     } catch (err) {
       if (!(err instanceof FsSafeError)) {
         throw err;

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -841,7 +841,7 @@ async function buildIdentityMarkdownForWrite(params: {
   clearFields?: Array<"name" | "theme" | "emoji" | "avatar">;
   fallbackWorkspaceDir?: string;
   preferFallbackWorkspaceContent?: boolean;
-}): Promise<string> {
+}): Promise<{ content: string; hadSourceFile: boolean }> {
   let baseContent: string | undefined;
   if (params.preferFallbackWorkspaceContent && params.fallbackWorkspaceDir) {
     // Workspace moves may create a blank identity file; merge into the previous user-edited file.
@@ -862,9 +862,13 @@ async function buildIdentityMarkdownForWrite(params: {
     }
   }
 
-  return mergeIdentityMarkdownContent(baseContent, params.identity, {
-    clearFields: params.clearFields,
-  });
+  return {
+    content: mergeIdentityMarkdownContent(baseContent, params.identity, {
+      clearFields: params.clearFields,
+    }),
+    // Empty buffers still count as a present file; only not-found is undefined.
+    hadSourceFile: baseContent !== undefined,
+  };
 }
 
 async function buildIdentityMarkdownOrRespondUnsafe(params: {
@@ -874,7 +878,7 @@ async function buildIdentityMarkdownOrRespondUnsafe(params: {
   clearFields?: Array<"name" | "theme" | "emoji" | "avatar">;
   fallbackWorkspaceDir?: string;
   preferFallbackWorkspaceContent?: boolean;
-}): Promise<string | null> {
+}): Promise<{ content: string; hadSourceFile: boolean } | null> {
   try {
     return await buildIdentityMarkdownForWrite(params);
   } catch (err) {
@@ -1036,7 +1040,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
         workspaceDir && identityWorkspaceDir !== previousWorkspaceDir
           ? previousWorkspaceDir
           : undefined;
-      const identityContent = await buildIdentityMarkdownOrRespondUnsafe({
+      const builtIdentity = await buildIdentityMarkdownOrRespondUnsafe({
         respond,
         workspaceDir: identityWorkspaceDir,
         identity: persistedIdentity ?? {},
@@ -1045,15 +1049,20 @@ export const agentsHandlers: GatewayRequestHandlers = {
         preferFallbackWorkspaceContent:
           Boolean(fallbackWorkspaceDir) && ensuredWorkspace?.identityPathCreated === true,
       });
-      if (identityContent === null) {
+      if (builtIdentity === null) {
         return;
       }
+      // Optional IDENTITY.md is intentionally absent when neither a source file nor
+      // persisted identity values exist. Clearing empty/null emoji/avatar must not
+      // synthesize a header-only file in that case.
+      const shouldWriteIdentityFile = builtIdentity.hadSourceFile || Boolean(persistedIdentity);
       if (
+        shouldWriteIdentityFile &&
         !(await writeWorkspaceFileOrRespond({
           respond,
           workspaceDir: identityWorkspaceDir,
           name: DEFAULT_IDENTITY_FILENAME,
-          content: identityContent,
+          content: builtIdentity.content,
         }))
       ) {
         return;

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -839,6 +839,7 @@ async function readWorkspaceFileContent(
 async function buildIdentityMarkdownForWrite(params: {
   workspaceDir: string;
   identity: IdentityConfig;
+  clearFields?: Array<"name" | "theme" | "emoji" | "avatar">;
   fallbackWorkspaceDir?: string;
   preferFallbackWorkspaceContent?: boolean;
 }): Promise<string> {
@@ -862,13 +863,16 @@ async function buildIdentityMarkdownForWrite(params: {
     }
   }
 
-  return mergeIdentityMarkdownContent(baseContent, params.identity);
+  return mergeIdentityMarkdownContent(baseContent, params.identity, {
+    clearFields: params.clearFields,
+  });
 }
 
 async function buildIdentityMarkdownOrRespondUnsafe(params: {
   respond: RespondFn;
   workspaceDir: string;
   identity: IdentityConfig;
+  clearFields?: Array<"name" | "theme" | "emoji" | "avatar">;
   fallbackWorkspaceDir?: string;
   preferFallbackWorkspaceContent?: boolean;
 }): Promise<string | null> {
@@ -967,19 +971,44 @@ export const agentsHandlers: GatewayRequestHandlers = {
         ? sanitizeAgentIdentityLine(params.name.trim())
         : undefined;
 
-    const identity = createAgentIdentityConfig({
-      name: safeName,
-      emoji: params.emoji,
-      avatar: params.avatar,
-    });
-    const hasIdentityFields = Boolean(identity);
+    // Identity fields are tri-state like model: omit preserves, null/"" clears,
+    // non-empty sets. createAgentIdentityConfig compacting empties would omit the
+    // patch entirely and silently keep the previous emoji/avatar.
+    const identityPatch: {
+      name?: string;
+      emoji?: string | null;
+      avatar?: string | null;
+    } = {};
+    const clearedIdentityFields: Array<"emoji" | "avatar"> = [];
+    if (safeName) {
+      identityPatch.name = safeName;
+    }
+    if ("emoji" in params) {
+      const emoji = resolveOptionalStringParam(params.emoji);
+      if (params.emoji === null || !emoji) {
+        identityPatch.emoji = null;
+        clearedIdentityFields.push("emoji");
+      } else {
+        identityPatch.emoji = sanitizeAgentIdentityLine(emoji);
+      }
+    }
+    if ("avatar" in params) {
+      const avatar = resolveOptionalStringParam(params.avatar);
+      if (params.avatar === null || !avatar) {
+        identityPatch.avatar = null;
+        clearedIdentityFields.push("avatar");
+      } else {
+        identityPatch.avatar = sanitizeAgentIdentityLine(avatar);
+      }
+    }
+    const hasIdentityFields = Object.keys(identityPatch).length > 0;
 
     const agentConfigUpdate: Parameters<typeof updateAgentConfigEntry>[0] = {
       agentId,
       ...(safeName ? { name: safeName } : {}),
       ...(workspaceDir ? { workspace: workspaceDir } : {}),
       ...(model !== undefined ? { model } : {}),
-      ...(identity ? { identity } : {}),
+      ...(hasIdentityFields ? { identity: identityPatch } : {}),
     };
     const nextConfig = applyAgentConfig(cfg, agentConfigUpdate);
 
@@ -994,7 +1023,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
 
     const persistedIdentity = normalizeIdentityForFile(resolveAgentIdentity(nextConfig, agentId));
-    if (persistedIdentity && (workspaceDir || hasIdentityFields)) {
+    if (workspaceDir || hasIdentityFields) {
       const identityWorkspaceDir = resolveAgentWorkspaceDir(nextConfig, agentId);
       const previousWorkspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
       const fallbackWorkspaceDir =
@@ -1004,7 +1033,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
       const identityContent = await buildIdentityMarkdownOrRespondUnsafe({
         respond,
         workspaceDir: identityWorkspaceDir,
-        identity: persistedIdentity,
+        identity: persistedIdentity ?? {},
+        clearFields: clearedIdentityFields,
         fallbackWorkspaceDir,
         preferFallbackWorkspaceContent:
           Boolean(fallbackWorkspaceDir) && ensuredWorkspace?.identityPathCreated === true,

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1102,11 +1102,20 @@ export const agentsHandlers: GatewayRequestHandlers = {
             try {
               await updateAgentConfigEntry(agentConfigUpdate);
             } catch (error) {
-              await restoreWorkspaceFile({
-                workspaceDir: identityWorkspaceDir,
-                name: DEFAULT_IDENTITY_FILENAME,
-                previousContent: previousIdentityContent,
-              });
+              // Restore only when IDENTITY.md still contains this mutation's
+              // write. agents.files.set can edit the same file without the
+              // config lock; a stale snapshot restore would overwrite that edit.
+              const currentIdentityContent = await readWorkspaceFileContent(
+                identityWorkspaceDir,
+                DEFAULT_IDENTITY_FILENAME,
+              ).catch(() => undefined);
+              if (currentIdentityContent === builtIdentity.content) {
+                await restoreWorkspaceFile({
+                  workspaceDir: identityWorkspaceDir,
+                  name: DEFAULT_IDENTITY_FILENAME,
+                  previousContent: previousIdentityContent,
+                });
+              }
               throw error;
             }
             return true;

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1034,12 +1034,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
         if (!isConfiguredAgent(lockedConfig, agentId)) {
           throw new AgentConfigPreconditionError(`agent "${agentId}" not found`);
         }
-        const nextConfig = applyAgentConfig(lockedConfig, agentConfigUpdate);
+        const lockedNextConfig = applyAgentConfig(lockedConfig, agentConfigUpdate);
         const persistedIdentity = normalizeIdentityForFile(
-          resolveAgentIdentity(nextConfig, agentId),
+          resolveAgentIdentity(lockedNextConfig, agentId),
         );
         if (workspaceDir || hasIdentityFields) {
-          const identityWorkspaceDir = resolveAgentWorkspaceDir(nextConfig, agentId);
+          const identityWorkspaceDir = resolveAgentWorkspaceDir(lockedNextConfig, agentId);
           const previousWorkspaceDir = resolveAgentWorkspaceDir(lockedConfig, agentId);
           const fallbackWorkspaceDir =
             workspaceDir && identityWorkspaceDir !== previousWorkspaceDir

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1019,7 +1019,6 @@ export const agentsHandlers: GatewayRequestHandlers = {
       ...(hasIdentityFields ? { identity: identityPatch } : {}),
     };
     const nextConfig = applyAgentConfig(cfg, agentConfigUpdate);
-
     let ensuredWorkspace: Awaited<ReturnType<typeof ensureAgentWorkspace>> | undefined;
     if (workspaceDir) {
       const skipBootstrap = Boolean(nextConfig.agents?.defaults?.skipBootstrap);
@@ -1030,45 +1029,56 @@ export const agentsHandlers: GatewayRequestHandlers = {
       });
     }
 
-    const persistedIdentity = normalizeIdentityForFile(resolveAgentIdentity(nextConfig, agentId));
-    if (workspaceDir || hasIdentityFields) {
-      const identityWorkspaceDir = resolveAgentWorkspaceDir(nextConfig, agentId);
-      const previousWorkspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-      const fallbackWorkspaceDir =
-        workspaceDir && identityWorkspaceDir !== previousWorkspaceDir
-          ? previousWorkspaceDir
-          : undefined;
-      const builtIdentity = await buildIdentityMarkdownOrRespondUnsafe({
-        respond,
-        workspaceDir: identityWorkspaceDir,
-        identity: persistedIdentity ?? {},
-        clearFields: clearedIdentityFields,
-        fallbackWorkspaceDir,
-        preferFallbackWorkspaceContent:
-          Boolean(fallbackWorkspaceDir) && ensuredWorkspace?.identityPathCreated === true,
-      });
-      if (builtIdentity === null) {
-        return;
-      }
-      // Optional IDENTITY.md is intentionally absent when neither a source file nor
-      // persisted identity values exist. Clearing empty/null emoji/avatar must not
-      // synthesize a header-only file in that case.
-      const shouldWriteIdentityFile = builtIdentity.hadSourceFile || Boolean(persistedIdentity);
-      if (
-        shouldWriteIdentityFile &&
-        !(await writeWorkspaceFileOrRespond({
-          respond,
-          workspaceDir: identityWorkspaceDir,
-          name: DEFAULT_IDENTITY_FILENAME,
-          content: builtIdentity.content,
-        }))
-      ) {
-        return;
-      }
-    }
-
     try {
-      await updateAgentConfigEntry(agentConfigUpdate);
+      const mutationCompleted = await withConfigMutationExclusive(async (lockedConfig) => {
+        if (!isConfiguredAgent(lockedConfig, agentId)) {
+          throw new AgentConfigPreconditionError(`agent "${agentId}" not found`);
+        }
+        const nextConfig = applyAgentConfig(lockedConfig, agentConfigUpdate);
+        const persistedIdentity = normalizeIdentityForFile(
+          resolveAgentIdentity(nextConfig, agentId),
+        );
+        if (workspaceDir || hasIdentityFields) {
+          const identityWorkspaceDir = resolveAgentWorkspaceDir(nextConfig, agentId);
+          const previousWorkspaceDir = resolveAgentWorkspaceDir(lockedConfig, agentId);
+          const fallbackWorkspaceDir =
+            workspaceDir && identityWorkspaceDir !== previousWorkspaceDir
+              ? previousWorkspaceDir
+              : undefined;
+          const builtIdentity = await buildIdentityMarkdownOrRespondUnsafe({
+            respond,
+            workspaceDir: identityWorkspaceDir,
+            identity: persistedIdentity ?? {},
+            clearFields: clearedIdentityFields,
+            fallbackWorkspaceDir,
+            preferFallbackWorkspaceContent:
+              Boolean(fallbackWorkspaceDir) && ensuredWorkspace?.identityPathCreated === true,
+          });
+          if (builtIdentity === null) {
+            return false;
+          }
+          // Optional IDENTITY.md is intentionally absent when neither a source file nor
+          // persisted identity values exist. Clearing empty/null emoji/avatar must not
+          // synthesize a header-only file in that case.
+          const shouldWriteIdentityFile = builtIdentity.hadSourceFile || Boolean(persistedIdentity);
+          if (
+            shouldWriteIdentityFile &&
+            !(await writeWorkspaceFileOrRespond({
+              respond,
+              workspaceDir: identityWorkspaceDir,
+              name: DEFAULT_IDENTITY_FILENAME,
+              content: builtIdentity.content,
+            }))
+          ) {
+            return false;
+          }
+        }
+        await updateAgentConfigEntry(agentConfigUpdate);
+        return true;
+      });
+      if (!mutationCompleted) {
+        return;
+      }
     } catch (error) {
       if (error instanceof AgentConfigPreconditionError) {
         respondAgentNotFound(respond, agentId);

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -974,9 +974,10 @@ export const agentsHandlers: GatewayRequestHandlers = {
         ? sanitizeAgentIdentityLine(params.name.trim())
         : undefined;
 
-    // Identity fields are tri-state like model: omit preserves, null/"" clears,
-    // non-empty sets. createAgentIdentityConfig compacting empties would omit the
-    // patch entirely and silently keep the previous emoji/avatar.
+    // Identity fields are tri-state like model: omit preserves, null clears,
+    // non-empty sets. Literal empty / whitespace strings stay non-destructive so
+    // existing clients that send "" keep stored identity; Control UI already
+    // converts Remove-avatar drafts to an explicit null tombstone.
     const identityPatch: {
       name?: string;
       emoji?: string | null;
@@ -987,10 +988,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
       identityPatch.name = safeName;
     }
     if ("emoji" in params) {
-      // Clear contract: null or literal "" tombstones. Whitespace-only must not
-      // destroy stored identity (resolveOptionalStringParam would otherwise
-      // treat it as absent and fall into the clear branch).
-      if (params.emoji === null || params.emoji === "") {
+      if (params.emoji === null) {
         identityPatch.emoji = null;
         clearedIdentityFields.push("emoji");
       } else if (typeof params.emoji === "string") {
@@ -1001,7 +999,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
       }
     }
     if ("avatar" in params) {
-      if (params.avatar === null || params.avatar === "") {
+      if (params.avatar === null) {
         identityPatch.avatar = null;
         clearedIdentityFields.push("avatar");
       } else if (typeof params.avatar === "string") {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -52,7 +52,6 @@ import {
 } from "../../agents/auth-profiles/path-resolve.js";
 import { resolveAuthProfileDatabasePath } from "../../agents/auth-profiles/sqlite.js";
 import {
-  createAgentIdentityConfig,
   mergeIdentityMarkdownContent,
   normalizeIdentityForFile,
   sanitizeAgentIdentityLine,

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -983,21 +983,28 @@ export const agentsHandlers: GatewayRequestHandlers = {
       identityPatch.name = safeName;
     }
     if ("emoji" in params) {
-      const emoji = resolveOptionalStringParam(params.emoji);
-      if (params.emoji === null || !emoji) {
+      // Clear contract: null or literal "" tombstones. Whitespace-only must not
+      // destroy stored identity (resolveOptionalStringParam would otherwise
+      // treat it as absent and fall into the clear branch).
+      if (params.emoji === null || params.emoji === "") {
         identityPatch.emoji = null;
         clearedIdentityFields.push("emoji");
-      } else {
-        identityPatch.emoji = sanitizeAgentIdentityLine(emoji);
+      } else if (typeof params.emoji === "string") {
+        const emoji = resolveOptionalStringParam(params.emoji);
+        if (emoji) {
+          identityPatch.emoji = sanitizeAgentIdentityLine(emoji);
+        }
       }
     }
     if ("avatar" in params) {
-      const avatar = resolveOptionalStringParam(params.avatar);
-      if (params.avatar === null || !avatar) {
+      if (params.avatar === null || params.avatar === "") {
         identityPatch.avatar = null;
         clearedIdentityFields.push("avatar");
-      } else {
-        identityPatch.avatar = sanitizeAgentIdentityLine(avatar);
+      } else if (typeof params.avatar === "string") {
+        const avatar = resolveOptionalStringParam(params.avatar);
+        if (avatar) {
+          identityPatch.avatar = sanitizeAgentIdentityLine(avatar);
+        }
       }
     }
     const hasIdentityFields = Object.keys(identityPatch).length > 0;

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -816,6 +816,25 @@ async function writeWorkspaceFileOrRespond(params: {
   return true;
 }
 
+async function restoreWorkspaceFile(params: {
+  workspaceDir: string;
+  name: string;
+  previousContent: string | undefined;
+}): Promise<void> {
+  const workspaceRoot = await agentsHandlerDeps.root(params.workspaceDir);
+  if (params.previousContent === undefined) {
+    try {
+      await workspaceRoot.remove(params.name);
+    } catch (err) {
+      if (!isMissingPathError(err)) {
+        throw err;
+      }
+    }
+    return;
+  }
+  await workspaceRoot.write(params.name, params.previousContent, { encoding: "utf8" });
+}
+
 async function readWorkspaceFileContent(
   workspaceDir: string,
   name: string,
@@ -1061,16 +1080,36 @@ export const agentsHandlers: GatewayRequestHandlers = {
           // persisted identity values exist. Clearing empty/null emoji/avatar must not
           // synthesize a header-only file in that case.
           const shouldWriteIdentityFile = builtIdentity.hadSourceFile || Boolean(persistedIdentity);
-          if (
-            shouldWriteIdentityFile &&
-            !(await writeWorkspaceFileOrRespond({
-              respond,
-              workspaceDir: identityWorkspaceDir,
-              name: DEFAULT_IDENTITY_FILENAME,
-              content: builtIdentity.content,
-            }))
-          ) {
-            return false;
+          if (shouldWriteIdentityFile) {
+            // Snapshot destination bytes before rewrite so a later config-commit
+            // failure can restore IDENTITY.md. File-first keeps unsafe writes from
+            // publishing config; without restore, config retains identity while the
+            // file is already cleared.
+            const previousIdentityContent = await readWorkspaceFileContent(
+              identityWorkspaceDir,
+              DEFAULT_IDENTITY_FILENAME,
+            );
+            if (
+              !(await writeWorkspaceFileOrRespond({
+                respond,
+                workspaceDir: identityWorkspaceDir,
+                name: DEFAULT_IDENTITY_FILENAME,
+                content: builtIdentity.content,
+              }))
+            ) {
+              return false;
+            }
+            try {
+              await updateAgentConfigEntry(agentConfigUpdate);
+            } catch (error) {
+              await restoreWorkspaceFile({
+                workspaceDir: identityWorkspaceDir,
+                name: DEFAULT_IDENTITY_FILENAME,
+                previousContent: previousIdentityContent,
+              });
+              throw error;
+            }
+            return true;
           }
         }
         await updateAgentConfigEntry(agentConfigUpdate);

--- a/ui/src/e2e/agents-identity-avatar-clear.e2e.test.ts
+++ b/ui/src/e2e/agents-identity-avatar-clear.e2e.test.ts
@@ -1,0 +1,136 @@
+// Control UI proof: avatar Remove → Save sends agents.update avatar:null and refreshes.
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI agents identity avatar clear mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected object value");
+  }
+  return value as Record<string, unknown>;
+}
+
+function requestParams(request: MockGatewayRequest): Record<string, unknown> {
+  return requireRecord(request.params);
+}
+
+suite.define(() => {
+  it("Remove → Save clears avatar through agents.update null and refreshes identity", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const avatarUrl = "https://example.com/avatar.png";
+        const withAvatarList = {
+          agents: [
+            {
+              id: "main",
+              name: "Main agent",
+              identity: { name: "Main agent", avatar: avatarUrl, emoji: "🦞" },
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        };
+        const clearedList = {
+          agents: [
+            {
+              id: "main",
+              name: "Main agent",
+              identity: { name: "Main agent", emoji: "🦞" },
+            },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        };
+        const identityGet = {
+          agentId: "main",
+          name: "Main agent",
+          emoji: "🦞",
+          avatar: avatarUrl,
+          avatarStatus: "external",
+        };
+        const gateway = await installMockGateway(page, {
+          assistantName: "Main agent",
+          defaultAgentId: "main",
+          // Advertise agents.update so canUpdateIdentity enables Remove/Save.
+          featureMethods: [
+            "chat.abort",
+            "chat.metadata",
+            "chat.startup",
+            "config.apply",
+            "config.patch",
+            "config.set",
+            "agents.list",
+            "agent.identity.get",
+            "agents.update",
+            "agents.files.list",
+            "agents.files.get",
+            "agents.files.set",
+          ],
+          methodResponses: {
+            "agents.list": withAvatarList,
+            "agent.identity.get": identityGet,
+            "agents.update": { ok: true, agentId: "main" },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}agents`);
+        expect(response?.status()).toBe(200);
+        await page.locator("button.agents-refresh-btn").waitFor({ state: "visible" });
+        await page.locator("wa-tab.hub-tab", { hasText: "Overview" }).first().click();
+        await page.locator(".agent-identity-editor").waitFor({ state: "visible" });
+
+        const remove = page.getByTestId("agent-identity-avatar-remove");
+        await remove.waitFor({ state: "visible", timeout: 15_000 });
+        await expect.poll(async () => remove.isEnabled()).toBe(true);
+        const updatePromise = gateway.waitForRequest("agents.update");
+        await remove.click();
+        const save = page.locator(".agent-identity-editor__actions button.btn.primary");
+        await expect.poll(async () => save.isEnabled()).toBe(true);
+        await save.click();
+
+        const updateRequest = await updatePromise;
+        const params = requestParams(updateRequest);
+        expect(params).toMatchObject({ agentId: "main", avatar: null });
+
+        await gateway.setMethodResponse("agents.list", clearedList);
+        await gateway.setMethodResponse("agent.identity.get", {
+          agentId: "main",
+          name: "Main agent",
+          emoji: "🦞",
+          avatar: "",
+          avatarStatus: "none",
+        });
+        await page.goto(`${suite.server.baseUrl}agents`);
+        await page.locator("button.agents-refresh-btn").waitFor({ state: "visible" });
+        await page.locator("wa-tab.hub-tab", { hasText: "Overview" }).first().click();
+        await page.locator(".agent-identity-editor").waitFor({ state: "visible" });
+        await page.getByTestId("agent-identity-avatar-remove").waitFor({ state: "detached" });
+        expect(await page.getByTestId("agent-identity-avatar-remove").count()).toBe(0);
+        console.log(
+          [
+            "----- control-ui-avatar-remove-save -----",
+            `url=${suite.server.baseUrl}agents`,
+            "action=Remove → Save",
+            `gateway_request=${JSON.stringify({ method: "agents.update", params })}`,
+            `gateway_result=${JSON.stringify({ ok: true, agentId: "main" })}`,
+            "refreshed_state=Remove control absent after cleared agents.list / agent.identity.get",
+          ].join("\n"),
+        );
+      },
+    );
+  });
+});

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -208,8 +208,10 @@ export async function setDefaultAgent(
 type AgentIdentityUpdate = {
   agentId: string;
   name?: string;
-  emoji?: string;
-  avatar?: string;
+  /** Set a value, or pass `null` to clear the override. */
+  emoji?: string | null;
+  /** Set a value, or pass `null` to clear the override. */
+  avatar?: string | null;
 };
 
 /** Persist identity fields through the gateway; the handler also rewrites the
@@ -221,8 +223,8 @@ export async function updateAgentIdentity(
   await client.request("agents.update", {
     agentId: update.agentId,
     ...(update.name ? { name: update.name } : {}),
-    ...(update.emoji ? { emoji: update.emoji } : {}),
-    ...(update.avatar ? { avatar: update.avatar } : {}),
+    ...(update.emoji !== undefined ? { emoji: update.emoji } : {}),
+    ...(update.avatar !== undefined ? { avatar: update.avatar } : {}),
   });
 }
 

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -54,6 +54,7 @@ import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { loadAgentFileContent, saveAgentFile } from "./files.ts";
 import { GitHubIdentityController } from "./github-identity-controller.ts";
 import {
+  clearIdentityAvatar,
   resetIdentityDraft,
   saveIdentityDraft,
   selectIdentityAvatar,
@@ -1085,6 +1086,11 @@ class AgentsPage
           onIdentityAvatarSelect: (file) => {
             if (this.canCall("agents.update", "operator.admin")) {
               selectIdentityAvatar(this, file);
+            }
+          },
+          onIdentityAvatarClear: () => {
+            if (this.canCall("agents.update", "operator.admin")) {
+              clearIdentityAvatar(this);
             }
           },
           onIdentitySave: () => this.saveIdentityDraft(),

--- a/ui/src/pages/agents/agents-view.test-helpers.ts
+++ b/ui/src/pages/agents/agents-view.test-helpers.ts
@@ -124,6 +124,7 @@ export function createAgentViewTestProps(
     onSetDefault: () => undefined,
     onIdentityFieldChange: () => undefined,
     onIdentityAvatarSelect: () => undefined,
+    onIdentityAvatarClear: () => undefined,
     onIdentitySave: () => undefined,
     onTogglePinnedAgent: () => undefined,
     onOpenAgentDefaults: () => undefined,

--- a/ui/src/pages/agents/identity-actions.test.ts
+++ b/ui/src/pages/agents/identity-actions.test.ts
@@ -56,9 +56,9 @@ describe("agent identity actions", () => {
     expect(state.identityDraft.name).toBe("  ");
   });
 
-  it("sends null emoji tombstone when the emoji draft is cleared", async () => {
+  it("sends null emoji tombstone when the emoji draft is explicitly emptied", async () => {
     const state = host();
-    state.identityDraft.emoji = "  ";
+    state.identityDraft.emoji = "";
     const request = vi.fn(async () => ({}));
     const expectedClient = { request } as unknown as GatewayBrowserClient;
     const runtimeConfig = {
@@ -92,6 +92,43 @@ describe("agent identity actions", () => {
       agentId: "main",
       emoji: null,
     });
+  });
+
+  it("omits whitespace-only emoji drafts so stored emoji is preserved", async () => {
+    const state = host();
+    state.identityDraft.emoji = "  ";
+    const request = vi.fn(async () => ({}));
+    const expectedClient = { request } as unknown as GatewayBrowserClient;
+    const runExternalMutation = vi.fn(async (task) => ({
+      ok: true as const,
+      value: await task(expectedClient),
+      refresh: { ok: true as const },
+    }));
+    const runtimeConfig = {
+      runExternalMutation,
+    } as unknown as ApplicationContext["runtimeConfig"];
+    const agents = {
+      refreshList: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agents"];
+    const agentIdentity = {
+      invalidate: vi.fn(),
+      ensure: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agentIdentity"];
+
+    await saveIdentityDraft({
+      host: state,
+      expectedClient,
+      agentId: "main",
+      agents,
+      agentIdentity,
+      runtimeConfig,
+      canDispatch: () => true,
+      isCurrent: () => true,
+      onSaved: vi.fn(),
+    });
+
+    expect(runExternalMutation).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("sends null avatar tombstone after clearIdentityAvatar", async () => {

--- a/ui/src/pages/agents/identity-actions.test.ts
+++ b/ui/src/pages/agents/identity-actions.test.ts
@@ -4,7 +4,12 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { createRuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import * as avatarImage from "./avatar-image.ts";
-import { resetIdentityDraft, saveIdentityDraft, selectIdentityAvatar } from "./identity-actions.ts";
+import {
+  clearIdentityAvatar,
+  resetIdentityDraft,
+  saveIdentityDraft,
+  selectIdentityAvatar,
+} from "./identity-actions.ts";
 
 const fileToAvatarDataUrlMock = vi.fn<typeof avatarImage.fileToAvatarDataUrl>();
 
@@ -27,7 +32,7 @@ function host(): Parameters<typeof resetIdentityDraft>[0] {
 }
 
 describe("agent identity actions", () => {
-  it("keeps unsupported blank edits visible without sending an update", async () => {
+  it("keeps unsupported blank name edits visible without sending an update", async () => {
     const state = host();
     state.identityDraft.name = "  ";
     const runExternalMutation = vi.fn();
@@ -49,6 +54,83 @@ describe("agent identity actions", () => {
 
     expect(runExternalMutation).not.toHaveBeenCalled();
     expect(state.identityDraft.name).toBe("  ");
+  });
+
+  it("sends null emoji tombstone when the emoji draft is cleared", async () => {
+    const state = host();
+    state.identityDraft.emoji = "  ";
+    const request = vi.fn(async () => ({}));
+    const expectedClient = { request } as unknown as GatewayBrowserClient;
+    const runtimeConfig = {
+      runExternalMutation: vi.fn(async (task) => ({
+        ok: true as const,
+        value: await task(expectedClient),
+        refresh: { ok: true as const },
+      })),
+    } as unknown as ApplicationContext["runtimeConfig"];
+    const agents = {
+      refreshList: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agents"];
+    const agentIdentity = {
+      invalidate: vi.fn(),
+      ensure: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agentIdentity"];
+
+    await saveIdentityDraft({
+      host: state,
+      expectedClient,
+      agentId: "main",
+      agents,
+      agentIdentity,
+      runtimeConfig,
+      canDispatch: () => true,
+      isCurrent: () => true,
+      onSaved: vi.fn(),
+    });
+
+    expect(request).toHaveBeenCalledWith("agents.update", {
+      agentId: "main",
+      emoji: null,
+    });
+  });
+
+  it("sends null avatar tombstone after clearIdentityAvatar", async () => {
+    const state = host();
+    clearIdentityAvatar(state);
+    expect(state.identityDraft.avatar).toBe("");
+    const request = vi.fn(async () => ({}));
+    const expectedClient = { request } as unknown as GatewayBrowserClient;
+    const runtimeConfig = {
+      runExternalMutation: vi.fn(async (task) => ({
+        ok: true as const,
+        value: await task(expectedClient),
+        refresh: { ok: true as const },
+      })),
+    } as unknown as ApplicationContext["runtimeConfig"];
+    const agents = {
+      refreshList: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agents"];
+    const agentIdentity = {
+      invalidate: vi.fn(),
+      ensure: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agentIdentity"];
+
+    await saveIdentityDraft({
+      host: state,
+      expectedClient,
+      agentId: "main",
+      agents,
+      agentIdentity,
+      runtimeConfig,
+      canDispatch: () => true,
+      isCurrent: () => true,
+      onSaved: vi.fn(),
+    });
+
+    expect(request).toHaveBeenCalledWith("agents.update", {
+      agentId: "main",
+      avatar: null,
+    });
   });
 
   it("drops an avatar decode that completes after the selected agent resets", async () => {

--- a/ui/src/pages/agents/identity-actions.ts
+++ b/ui/src/pages/agents/identity-actions.ts
@@ -75,16 +75,29 @@ export async function saveIdentityDraft(params: {
   const { host, expectedClient, agentId, agents, agentIdentity, runtimeConfig } = params;
   const draft = host.identityDraft;
   // Name stays set-only (blank name edits stay local). Emoji/avatar are
-  // tri-state like model: omit preserves, null clears. A blank emoji draft or
-  // an explicit empty avatar draft sends the null tombstone.
+  // tri-state like model: omit preserves, null clears. Literal empty drafts
+  // (including Remove-avatar's "") send the null tombstone; whitespace-only
+  // drafts omit so Gateway keeps the stored value.
   const name = draft.name?.trim();
   if (draft.name !== null && !name) {
     return;
   }
   const emojiUpdate =
-    draft.emoji === null ? undefined : draft.emoji.trim() ? draft.emoji.trim() : null;
+    draft.emoji === null
+      ? undefined
+      : draft.emoji.trim()
+        ? draft.emoji.trim()
+        : draft.emoji === ""
+          ? null
+          : undefined;
   const avatarUpdate =
-    draft.avatar === null ? undefined : draft.avatar.trim() ? draft.avatar : null;
+    draft.avatar === null
+      ? undefined
+      : draft.avatar.trim()
+        ? draft.avatar
+        : draft.avatar === ""
+          ? null
+          : undefined;
   if (!name && emojiUpdate === undefined && avatarUpdate === undefined) {
     resetIdentityDraft(host);
     return;

--- a/ui/src/pages/agents/identity-actions.ts
+++ b/ui/src/pages/agents/identity-actions.ts
@@ -52,6 +52,13 @@ export function selectIdentityAvatar(host: AgentIdentityEditorHost, file: File) 
   });
 }
 
+/** Mark avatar for clear on next save (`null` tombstone via agents.update). */
+export function clearIdentityAvatar(host: AgentIdentityEditorHost) {
+  advanceAvatarSelectionEpoch(host);
+  host.identityDraft = { ...host.identityDraft, avatar: "" };
+  host.identityError = null;
+}
+
 /** Persist the draft via agents.update, then refresh the roster and the
     identity cache so the sidebar chip and page pick up the new identity. */
 export async function saveIdentityDraft(params: {
@@ -67,15 +74,18 @@ export async function saveIdentityDraft(params: {
 }) {
   const { host, expectedClient, agentId, agents, agentIdentity, runtimeConfig } = params;
   const draft = host.identityDraft;
-  // Set/replace only: agents.update has no explicit clear operation. Keep a
-  // blank edit visible and unsaved instead of pretending it removed a field.
+  // Name stays set-only (blank name edits stay local). Emoji/avatar are
+  // tri-state like model: omit preserves, null clears. A blank emoji draft or
+  // an explicit empty avatar draft sends the null tombstone.
   const name = draft.name?.trim();
-  const emoji = draft.emoji?.trim();
-  const avatar = draft.avatar ?? undefined;
-  if ((draft.name !== null && !name) || (draft.emoji !== null && !emoji)) {
+  if (draft.name !== null && !name) {
     return;
   }
-  if (!name && !emoji && !avatar) {
+  const emojiUpdate =
+    draft.emoji === null ? undefined : draft.emoji.trim() ? draft.emoji.trim() : null;
+  const avatarUpdate =
+    draft.avatar === null ? undefined : draft.avatar.trim() ? draft.avatar : null;
+  if (!name && emojiUpdate === undefined && avatarUpdate === undefined) {
     resetIdentityDraft(host);
     return;
   }
@@ -87,7 +97,12 @@ export async function saveIdentityDraft(params: {
         if (client !== expectedClient) {
           throw new Error("Connection changed before the agent identity update started.");
         }
-        return updateAgentIdentity(client, { agentId, name, emoji, avatar });
+        return updateAgentIdentity(client, {
+          agentId,
+          ...(name ? { name } : {}),
+          ...(emojiUpdate !== undefined ? { emoji: emojiUpdate } : {}),
+          ...(avatarUpdate !== undefined ? { avatar: avatarUpdate } : {}),
+        });
       },
       {
         canDispatch: params.canDispatch,

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -122,8 +122,8 @@ export function renderAgentOverview(params: {
     identityDraft.avatar === null ? hasStoredAvatar : Boolean(identityDraft.avatar.trim());
   const identityDirty =
     identityDraft.name !== null || identityDraft.emoji !== null || identityDraft.avatar !== null;
-  // Blank emoji/avatar drafts are clear intents (null tombstone). Only blank
-  // name edits stay invalid / unsaved.
+  // Literal-empty emoji/avatar drafts are clear intents (null tombstone).
+  // Whitespace-only drafts omit on save. Only blank name edits stay invalid.
   const identityInvalid = identityDraft.name !== null && !identityDraft.name.trim();
   const identityBusy = params.identitySaving || !params.canUpdateIdentity;
 

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -25,6 +25,7 @@ import {
 } from "../../lib/agents/display.ts";
 import type { AgentsPanel } from "../../lib/agents/index.ts";
 import { deriveAvatarInitial, resolveAgentAvatarUrl } from "../../lib/avatar.ts";
+import { normalizeOptionalString } from "../../lib/string-coerce.ts";
 
 export type AgentIdentityDraft = {
   name: string | null;
@@ -110,6 +111,15 @@ export function renderAgentOverview(params: {
   const identityAvatarText =
     resolveAgentTextAvatar(agent, params.agentIdentity) ??
     (deriveAvatarInitial(identityName || agent.id) || "?");
+  // Previewable URLs may be empty while Gateway still stores a raw avatar
+  // (e.g. https://…). Gate Remove on stored/draft presence, not previewability.
+  const hasStoredAvatar = Boolean(
+    normalizeOptionalString(params.agentIdentity?.avatar) ||
+    normalizeOptionalString(agent.identity?.avatar) ||
+    normalizeOptionalString(agent.identity?.avatarUrl),
+  );
+  const canRemoveAvatar =
+    identityDraft.avatar === null ? hasStoredAvatar : Boolean(identityDraft.avatar.trim());
   const identityDirty =
     identityDraft.name !== null || identityDraft.emoji !== null || identityDraft.avatar !== null;
   // Blank emoji/avatar drafts are clear intents (null tombstone). Only blank
@@ -190,7 +200,7 @@ export function renderAgentOverview(params: {
             : nothing}
           <div class="agent-identity-editor__actions">
             <label class="btn btn--sm">
-              ${identityAvatarUrl
+              ${canRemoveAvatar || identityAvatarUrl
                 ? t("agents.identity.replaceImage")
                 : t("agents.identity.chooseImage")}
               <input
@@ -201,10 +211,11 @@ export function renderAgentOverview(params: {
                 @change=${handleAvatarFileSelect}
               />
             </label>
-            ${identityAvatarUrl
+            ${canRemoveAvatar
               ? html`<button
                   type="button"
                   class="btn btn--sm"
+                  data-testid="agent-identity-avatar-remove"
                   ?disabled=${identityBusy}
                   @click=${() => params.onIdentityAvatarClear()}
                 >

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -55,6 +55,7 @@ export function renderAgentOverview(params: {
   onConfigSave: () => void;
   onIdentityFieldChange: (field: "name" | "emoji", value: string) => void;
   onIdentityAvatarSelect: (file: File) => void;
+  onIdentityAvatarClear: () => void;
   onIdentitySave: () => void;
   onModelChange: (agentId: string, modelId: string | null) => void;
   onModelFallbacksChange: (agentId: string, fallbacks: string[]) => void;
@@ -111,9 +112,9 @@ export function renderAgentOverview(params: {
     (deriveAvatarInitial(identityName || agent.id) || "?");
   const identityDirty =
     identityDraft.name !== null || identityDraft.emoji !== null || identityDraft.avatar !== null;
-  const identityInvalid =
-    (identityDraft.name !== null && !identityDraft.name.trim()) ||
-    (identityDraft.emoji !== null && !identityDraft.emoji.trim());
+  // Blank emoji/avatar drafts are clear intents (null tombstone). Only blank
+  // name edits stay invalid / unsaved.
+  const identityInvalid = identityDraft.name !== null && !identityDraft.name.trim();
   const identityBusy = params.identitySaving || !params.canUpdateIdentity;
 
   const handleAvatarFileSelect = (e: Event) => {
@@ -200,6 +201,16 @@ export function renderAgentOverview(params: {
                 @change=${handleAvatarFileSelect}
               />
             </label>
+            ${identityAvatarUrl
+              ? html`<button
+                  type="button"
+                  class="btn btn--sm"
+                  ?disabled=${identityBusy}
+                  @click=${() => params.onIdentityAvatarClear()}
+                >
+                  ${t("common.remove")}
+                </button>`
+              : nothing}
             <button
               type="button"
               class="btn btn--sm primary"

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -1,4 +1,5 @@
 // Control UI view renders agents panels overview screen content.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeCsvOrLooseStringList } from "@openclaw/normalization-core/string-normalization";
 import { html, nothing } from "lit";
 import type {
@@ -25,7 +26,6 @@ import {
 } from "../../lib/agents/display.ts";
 import type { AgentsPanel } from "../../lib/agents/index.ts";
 import { deriveAvatarInitial, resolveAgentAvatarUrl } from "../../lib/avatar.ts";
-import { normalizeOptionalString } from "../../lib/string-coerce.ts";
 
 export type AgentIdentityDraft = {
   name: string | null;

--- a/ui/src/pages/agents/view.identity-avatar.test.ts
+++ b/ui/src/pages/agents/view.identity-avatar.test.ts
@@ -1,0 +1,64 @@
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { createAgentViewTestProps as createProps } from "./agents-view.test-helpers.ts";
+import { renderAgents } from "./view.ts";
+
+describe("renderAgents identity avatar controls", () => {
+  it("prefills the identity editor from the fetched agent identity", () => {
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        createProps({
+          agentIdentityById: {
+            beta: { agentId: "beta", name: "Fetched Beta", avatar: "" },
+          },
+        }),
+      ),
+      container,
+    );
+
+    expect(
+      container.querySelector<HTMLInputElement>(".agent-identity-editor__fields input")?.value,
+    ).toBe("Fetched Beta");
+  });
+
+  it("offers Remove for a stored non-previewable avatar", () => {
+    const onIdentityAvatarClear = vi.fn();
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        createProps({
+          agentsList: {
+            defaultId: "alpha",
+            mainKey: "main",
+            scope: "workspace",
+            agents: [
+              { id: "alpha", name: "Alpha" } as never,
+              {
+                id: "beta",
+                name: "Beta",
+                identity: { avatar: "https://example.com/avatar.png" },
+              } as never,
+            ],
+          },
+          agentIdentityById: {
+            beta: {
+              agentId: "beta",
+              name: "Beta",
+              avatar: "https://example.com/avatar.png",
+            },
+          },
+          onIdentityAvatarClear,
+        }),
+      ),
+      container,
+    );
+
+    const remove = container.querySelector<HTMLButtonElement>(
+      '[data-testid="agent-identity-avatar-remove"]',
+    );
+    expect(remove).not.toBeNull();
+    remove?.click();
+    expect(onIdentityAvatarClear).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/pages/agents/view.identity-avatar.test.ts
+++ b/ui/src/pages/agents/view.identity-avatar.test.ts
@@ -28,19 +28,6 @@ describe("renderAgents identity avatar controls", () => {
     render(
       renderAgents(
         createProps({
-          agentsList: {
-            defaultId: "alpha",
-            mainKey: "main",
-            scope: "workspace",
-            agents: [
-              { id: "alpha", name: "Alpha" } as never,
-              {
-                id: "beta",
-                name: "Beta",
-                identity: { avatar: "https://example.com/avatar.png" },
-              } as never,
-            ],
-          },
           agentIdentityById: {
             beta: {
               agentId: "beta",

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -103,65 +103,6 @@ describe("renderAgents", () => {
     expect(onSelectPanel).toHaveBeenCalledWith("tools");
   });
 
-  it("prefills the identity editor from the fetched agent identity", () => {
-    const container = document.createElement("div");
-    render(
-      renderAgents(
-        createProps({
-          agentIdentityById: {
-            beta: { agentId: "beta", name: "Fetched Beta", avatar: "", emoji: "🦊" },
-          },
-        }),
-      ),
-      container,
-    );
-
-    expect(
-      container.querySelector<HTMLInputElement>(".agent-identity-editor__fields input")?.value,
-    ).toBe("Fetched Beta");
-    expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("🦊");
-  });
-
-  it("offers Remove for a stored non-previewable avatar", () => {
-    const onIdentityAvatarClear = vi.fn();
-    const container = document.createElement("div");
-    render(
-      renderAgents(
-        createProps({
-          agentsList: {
-            defaultId: "alpha",
-            mainKey: "main",
-            scope: "workspace",
-            agents: [
-              { id: "alpha", name: "Alpha" } as never,
-              {
-                id: "beta",
-                name: "Beta",
-                identity: { avatar: "https://example.com/avatar.png" },
-              } as never,
-            ],
-          },
-          agentIdentityById: {
-            beta: {
-              agentId: "beta",
-              name: "Beta",
-              avatar: "https://example.com/avatar.png",
-            },
-          },
-          onIdentityAvatarClear,
-        }),
-      ),
-      container,
-    );
-
-    const remove = container.querySelector<HTMLButtonElement>(
-      '[data-testid="agent-identity-avatar-remove"]',
-    );
-    expect(remove).not.toBeNull();
-    remove?.click();
-    expect(onIdentityAvatarClear).toHaveBeenCalledOnce();
-  });
-
   it("shows a model-catalog failure and lets the operator retry", () => {
     const container = document.createElement("div");
     const onModelCatalogRetry = vi.fn();

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -122,6 +122,46 @@ describe("renderAgents", () => {
     expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("🦊");
   });
 
+  it("offers Remove for a stored non-previewable avatar", () => {
+    const onIdentityAvatarClear = vi.fn();
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        createProps({
+          agentsList: {
+            defaultId: "alpha",
+            mainKey: "main",
+            scope: "workspace",
+            agents: [
+              { id: "alpha", name: "Alpha" } as never,
+              {
+                id: "beta",
+                name: "Beta",
+                identity: { avatar: "https://example.com/avatar.png" },
+              } as never,
+            ],
+          },
+          agentIdentityById: {
+            beta: {
+              agentId: "beta",
+              name: "Beta",
+              avatar: "https://example.com/avatar.png",
+            },
+          },
+          onIdentityAvatarClear,
+        }),
+      ),
+      container,
+    );
+
+    const remove = container.querySelector<HTMLButtonElement>(
+      '[data-testid="agent-identity-avatar-remove"]',
+    );
+    expect(remove).not.toBeNull();
+    remove?.click();
+    expect(onIdentityAvatarClear).toHaveBeenCalledOnce();
+  });
+
   it("shows a model-catalog failure and lets the operator retry", () => {
     const container = document.createElement("div");
     const onModelCatalogRetry = vi.fn();

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -145,6 +145,7 @@ type AgentsProps = {
   onConfigSave: () => void;
   onIdentityFieldChange: (field: "name" | "emoji", value: string) => void;
   onIdentityAvatarSelect: (file: File) => void;
+  onIdentityAvatarClear: () => void;
   onIdentitySave: () => void;
   onModelChange: (agentId: string, modelId: string | null) => void;
   onModelFallbacksChange: (agentId: string, fallbacks: string[]) => void;
@@ -369,6 +370,7 @@ export function renderAgents(props: AgentsProps) {
                         onConfigSave: props.onConfigSave,
                         onIdentityFieldChange: props.onIdentityFieldChange,
                         onIdentityAvatarSelect: props.onIdentityAvatarSelect,
+                        onIdentityAvatarClear: props.onIdentityAvatarClear,
                         onIdentitySave: props.onIdentitySave,
                         onModelChange: props.onModelChange,
                         onModelFallbacksChange: props.onModelFallbacksChange,


### PR DESCRIPTION
<!-- maintainer-local-candidate-119930 -->
## Maintainer status — local candidate, not published

**This PR remains open at contributor head `a86cfd4e370614dfbbaffc05b23a26dd9710af0c`.** The integration described here is an uncommitted, unpublished maintainer candidate (staged tree `4862cde3fbe12995820c4fc4b088fe9988ce170b`), not the current PR branch. Original work and contributor ancestry from @zyw02 are preserved.

### Proposed repair and user impact

Related: #119929. Remove → Save clears a stored avatar; clearing the custom emoji input clears that stored value. The proposed API clear contract is explicit `null`; empty, whitespace, and omitted API fields preserve existing values.

On a configuration-write failure after the identity file changes, the candidate saves the previous bytes (or a prior-absence marker) and returns an actionable pending-recovery error. It never restores or deletes the current identity file, which may contain a newer external edit. Operators must compare the recovery artifact, current file, and configuration before retrying and remove the artifact after reconciliation. **This is not automatic rollback or a multi-file transaction.** The earlier conditional-rollback claims below are historical contributor notes, not an accepted correctness claim.

Current ownership checks, authenticated avatar rendering, generated protocol declarations, and legacy Swift initializer call shapes are retained. Text-only default avatars do not expose a misleading Remove action after reload.

### Candidate validation

- The unchanged baseline reproduced the null-schema failure and all four failed-config recovery cases.
- Focused protocol, identity-file, agent-config, Gateway, and UI suite: 221 tests passed before the final UI regression additions.
- Final acceptance passed all four selected Vitest shards: Gateway mutation coverage, 38 UI tests, a real Gateway serving the built Control UI, and SDK coverage. One optional external-live SDK test was skipped; this is not authenticated external-service proof.
- The real served-UI test verifies empty/omitted RPC preservation, Remove → Save, persisted config/file clearing, unrelated Markdown preservation, and browser reload with no remaining Remove action.
- 16 final validation lanes passed. Unavailable/failing final lanes: FINAL-LINT-APPS, FINAL-MACOS-CI. See limitations below. Task-file lint and Swift generated-output consistency passed. These are local results, not exact-head CI.

### Inspected served-UI proof

These sanitized, synthetic-state screenshots are from the **unpublished candidate** and a real local Gateway, not a mocked Gateway.

Before removing the stored avatar and custom emoji:

![Before Remove and Save — unpublished maintainer candidate](https://github.com/user-attachments/assets/9c4beb5b-4ef2-4896-a437-51dbd9f7e1df)

After Save and browser reload (generic avatar and default emoji placeholder, no saved custom values):

![After Save and reload — unpublished maintainer candidate](https://github.com/user-attachments/assets/ee70a744-4b3b-4a29-bbf1-e2540589eed0)

### Remaining gates

Independent source-bound review remains unavailable under the inherited quota hold; no unchanged retry or provider switch was made. Explicit additive-null/pending-recovery contract acceptance and current required owner review remain pending. Swift compatibility compilation/tests, app lint, and the macOS CI lane (142 passed, 10 failed) are blocked by this host's unaccepted Xcode license/SourceKit setup; generated-output consistency is not compilation or lint proof. Originating-chat screenshot delivery is not established by this PR update. Reviewed publication, exact-head CI, and native landing remain pending.

<details>
<summary>Historical contributor notes for the published head (not current maintainer validation)</summary>

## Review feedback addressed

Follow-up on `479698f24256882db910081831bc1e9ce4d0fe12`. New head: `a86cfd4e370614dfbbaffc05b23a26dd9710af0c`.

ClawSweeper review on `479698f` required the IDENTITY.md rollback to be conditional at its final write, not only before an awaited restore. This tip:

1. **[x] Make the rollback conditional at its final write (P1)** — `restoreWorkspaceFile` re-reads current IDENTITY.md bytes immediately before write/delete and skips when the file is no longer this mutation's content. Same-process `agents.files.set` of IDENTITY.md now takes `withConfigMutationExclusive`, serializing it with `agents.update` rollback. Regression: `does not restore IDENTITY.md over a concurrent agents.files.set edit that lands after the rollback comparison`.
2. **[x] Prevent rollback from overwriting concurrent IDENTITY.md edits (P1)** — after a config-commit failure, restore the previous file only when IDENTITY.md still contains this mutation's write at the mutating syscall. A concurrent `agents.files.set` edit is left in place. Also covered: `does not restore IDENTITY.md over a concurrent agents.files.set edit after config commit failure`.
3. **[x] Preserve partial raw Swift identity initializers (P1)** — generated mixed `AgentsUpdateParams` overloads now cover none (`agentid:modelvalue:`), emoji-only, avatar-only, and both String labels. Mixed labels still omit defaults so the raw initializer stays unique. Compile-oriented coverage is in `GatewayModelsCompatibilityTests`.
4. **[x] Make file and config identity updates failure-safe (P2)** — snapshot destination `IDENTITY.md` before rewrite, write rebuilt content, then commit config. If that later commit throws and the file is still this mutation's write, restore the previous file bytes (or remove a newly created file) before rethrowing. Regression: `restores IDENTITY.md when it still contains this mutation's write after config commit failure`.
5. **[x] Current-head CI caused by this diff** — Control UI Remove-avatar fixture no longer uses `agentsList.scope: "workspace"` (`check-test-types-core-2`); `mergeAgentIdentity` iterates `IDENTITY_PATCH_KEYS` instead of an uncommented `Object.entries` assertion (`checks-fast-baseline-ratchets`); dropped invalid `NodeInvokeRequestEvent.sessionKey` Swift coverage (`macos-swift`). `android-ktlint` 429 / promisor fetch on the previous head was infrastructure. Current-head `macos-swift` failure on `479698f` was `CronJobsStoreTests` (`GatewayProcessManager.shared.status → .starting == .stopped`), unrelated to this identity-clear diff.
6. **[x] Resolve merge conflicts (P1)** — replayed on `42f5717` from `2db308f06b9` onto `671e41a8773bb9df6f044372fe227f7415a45b38`. Conflict files: `src/gateway/server-methods/agents.ts`, `src/commands/agents.config.ts`, `packages/sdk/src/types.ts`, `ui/src/pages/agents/panels-overview.ts`, `ui/src/pages/agents/view.test.ts`.
7. **[x] Preserve current agent ownership safeguards** — `agents.delete` still uses `agentOwnsSharedAuthStore`, `isInheritedAuthStoreOwner`, `tryResolveSoleAgentId`, and `normalizeAgentIdStrict`. Roster updates still pin `ownership: "explicit"` and `pinLegacyInheritedAuthOwnerForRosterTransition`.
8. **[x] Keep SDK types on the protocol contract** — `AgentsUpdateParams` stays a re-export from `@openclaw/gateway-protocol` (nullable emoji/avatar live in the schema, not a local SDK duplicate).
9. **[x] Make Swift raw-model overloads non-overlapping** — mixed String-label initializers omit defaults so `AgentsUpdateParams(agentid:modelvalue:)` uniquely matches the raw initializer.
10. **[ ] Served Control UI proof** — still outstanding: redacted Remove → Save against a real Gateway. The existing UI E2E remains mock-gateway and is not claimed as served-UI proof.

Empty-string vs null remains the existing null-only tombstone contract (ClawSweeper recommendation: keep null-only clearing). Direct empty/whitespace requests still preserve stored identity.

## What Problem This Solves

Addresses #119929: agents.update empty/null emoji/avatar handling must clear intentionally without breaking shipped Swift call shapes or turning legacy empty-string requests into destructive clears.

## Why This Change Was Made

Null is the additive clear tombstone. Empty-string requests remain non-destructive for compatibility. Generated Swift keeps String-facing and raw AnyCodable initializers, including mixed modelvalue plus none / emoji-only / avatar-only / both String labels, without overlapping `agentid:modelvalue:` call sites. File-first identity writes stay unsafe-write gated; config-commit failures restore the previous IDENTITY.md bytes only when the file is still this mutation's write at the final syscall, so a concurrent `agents.files.set` edit is not overwritten.

## User Impact

Explicit null clears identity fields through config and IDENTITY.md. Empty-string updates no longer wipe stored emoji/avatar. Existing Swift clients compiling mixed update initializers, including emoji-only and avatar-only raw-model calls, keep working. `AgentsUpdateParams(agentid:modelvalue:)` compiles as the raw initializer. A failed config commit after a successful identity rewrite no longer leaves a cleared IDENTITY.md against the retained roster identity, and no longer clobbers a concurrent authorized IDENTITY.md write that lands after the rollback snapshot.

## Evidence

```text
PREV=479698f24256882db910081831bc1e9ce4d0fe12
TIP=a86cfd4e370614dfbbaffc05b23a26dd9710af0c

git diff --check
./node_modules/.bin/oxfmt src/gateway/server-methods/agents.ts \
  src/gateway/server-methods/agents-mutate.test.ts
node scripts/run-oxlint.mjs \
  src/gateway/server-methods/agents.ts \
  src/gateway/server-methods/agents-mutate.test.ts
node --import tsx scripts/protocol-gen-swift.ts --check

node scripts/run-vitest.mjs \
  src/gateway/server-methods/agents-mutate.test.ts \
  src/gateway/server-methods/agents-update-clear-identity.gateway.test.ts \
  src/agents/identity-file.test.ts \
  --reporter=verbose
```

Focused validation on `a86cfd4e370`: gateway mutate + clear-identity 116 tests and identity-file 15 tests passed (including still-ours restore, before-compare skip, after-compare files.set win, and the exact-head Gateway transcript). `git diff --check`, oxfmt, oxlint, and `protocol:check:swift` passed. `swift test --filter GatewayModelsCompatibilityTests` was skipped locally (no Swift toolchain on this Linux runner); please use exact-head `macos-swift`.

Exact-head Gateway transcript excerpts (clear vs empty-string preserve, still valid on this tip):

```text
----- rpc-agents-update-clear -----
{
  "ok": true,
  "agentId": "clear-identity-agent",
  "emoji": null,
  "avatar": null
}

----- rpc-agents-list-readback -----
{
  "agentId": "clear-identity-agent",
  "identity": {
    "name": "Clear Identity Agent"
  },
  "emoji": null,
  "avatar": null
}

----- identity-md-readback -----
# IDENTITY.md - Agent Identity

- Name: Clear Identity Agent
Creature: Familiar
----- end -----

----- rpc-agents-update-empty-preserve -----
{
  "ok": true,
  "agentId": "preserve-empty-agent",
  "emoji": "",
  "avatar": ""
}

----- rpc-agents-list-empty-preserve-readback -----
{
  "agentId": "preserve-empty-agent",
  "identity": {
    "name": "Preserve Empty Agent",
    "emoji": "🦞",
    "avatar": "https://example.com/keep.png",
    "avatarUrl": "https://example.com/keep.png"
  }
}
```

## AI-assisted development

This change was implemented with an OpenClaw coding agent and published through a guarded human-approval workflow. The exact diff and exact-head validation evidence were verified before publication.

</details>
