### PR TITLE
fix(device-pair): keep notifier poll off Gateway startup

### DIFF
--- a/extensions/device-pair/notify.test.ts
+++ b/extensions/device-pair/notify.test.ts
@@ -96,12 +96,11 @@ describe("device-pair notify persistence", () => {
     });
   }
 
-  it("keeps one notify poll in flight across service recreation", async () => {
+  it("defers the first notify poll and keeps one in flight across service recreation", async () => {
     vi.useFakeTimers();
     const firstPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
     const failedPoll = createDeferred<Awaited<ReturnType<typeof listDevicePairingMock>>>();
     listDevicePairingMock
-      .mockResolvedValueOnce({ pending: [], paired: [] })
       .mockImplementationOnce(() => firstPoll.promise)
       .mockImplementationOnce(() => failedPoll.promise)
       .mockResolvedValue({ pending: [], paired: [] });
@@ -109,29 +108,30 @@ describe("device-pair notify persistence", () => {
     let service = createPairingNotifierService(api);
 
     await service.start({} as never);
-    expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
+    expect(listDevicePairingMock).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(10_000);
-    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(20_000);
-    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
 
     await service.stop?.({} as never);
     service = createPairingNotifierService(createApi());
     await service.start({} as never);
-    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
 
     firstPoll.resolve({ pending: [], paired: [] });
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(10_000);
-    expect(listDevicePairingMock).toHaveBeenCalledTimes(3);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
     await vi.advanceTimersByTimeAsync(20_000);
-    expect(listDevicePairingMock).toHaveBeenCalledTimes(3);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(2);
 
     failedPoll.reject(new Error("poll failed"));
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(10_000);
-    expect(listDevicePairingMock).toHaveBeenCalledTimes(4);
+    expect(listDevicePairingMock).toHaveBeenCalledTimes(3);
 
     await service.stop?.({} as never);
   });
@@ -166,9 +166,7 @@ describe("device-pair notify persistence", () => {
       },
       action: "on",
     });
-    listDevicePairingMock
-      .mockResolvedValueOnce({ pending: [], paired: [] })
-      .mockResolvedValue({ pending: [firstRequest], paired: [] });
+    listDevicePairingMock.mockResolvedValue({ pending: [firstRequest], paired: [] });
     let service = createPairingNotifierService(api);
 
     await service.start({} as never);
@@ -211,7 +209,7 @@ describe("device-pair notify persistence", () => {
       ctx: { channel: "telegram", senderId: "old-chat" },
       action: "on",
     });
-    listDevicePairingMock.mockResolvedValueOnce({ pending: [], paired: [] }).mockResolvedValue({
+    listDevicePairingMock.mockResolvedValue({
       pending: [
         {
           requestId: "request-1",
@@ -261,7 +259,7 @@ describe("device-pair notify persistence", () => {
       ctx: { channel: "telegram", senderId: "chat-123" },
       action: "once",
     });
-    listDevicePairingMock.mockResolvedValueOnce({ pending: [], paired: [] }).mockResolvedValue({
+    listDevicePairingMock.mockResolvedValue({
       pending: [
         {
           requestId: "request-1",
@@ -325,6 +323,7 @@ describe("device-pair notify persistence", () => {
     const service = createPairingNotifierService(api);
 
     await service.start({} as never);
+    await vi.advanceTimersByTimeAsync(10_000);
 
     expect(sendText).not.toHaveBeenCalled();
     await expect(
@@ -367,6 +366,7 @@ describe("device-pair notify persistence", () => {
     });
     const service = createPairingNotifierService(api);
     await service.start({} as never);
+    await vi.advanceTimersByTimeAsync(10_000);
 
     expect(sendText).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringContaining("ID: request-same-ms") }),
@@ -404,6 +404,7 @@ describe("device-pair notify persistence", () => {
     const service = createPairingNotifierService(api);
 
     await service.start({} as never);
+    await vi.advanceTimersByTimeAsync(10_000);
 
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(sendText).toHaveBeenCalledWith(

--- a/extensions/device-pair/notify.ts
+++ b/extensions/device-pair/notify.ts
@@ -454,14 +454,13 @@ export function createPairingNotifierService(api: OpenClawPluginApi): OpenClawPl
 
   return {
     id: "device-pair-notifier",
-    start: async () => {
+    start: () => {
       const tick = async () => {
         await runNotifyPoll(api);
       };
 
-      await tick().catch((err: unknown) => {
-        api.logger.warn(`device-pair: initial notify poll failed: ${formatErrorMessage(err)}`);
-      });
+      // Pairing notifications are eventual background work. Starting on the
+      // existing interval keeps SQLite pairing scans out of Gateway readiness.
       notifyInterval = setInterval(() => {
         tick().catch((err: unknown) => {
           api.logger.warn(`device-pair: notify poll failed: ${formatErrorMessage(err)}`);


### PR DESCRIPTION
Related: #119087

## What Problem This Solves

Resolves a problem where Gateway startup waited for the optional device-pair notification poll to scan SQLite before readiness, even though pairing notifications are periodic background work.

## Why This Change Was Made

The notifier now starts only its existing unref'd 10-second interval. The first poll runs on that interval instead of inside service startup, while the existing overlap lock, service reload behavior, and notification delivery flow remain unchanged.

This removes the notifier-owned startup cost, but it does not close #119087. Residual post-ready HTTP/event-loop serviceability remains and needs separate investigation.

## User Impact

Gateway readiness no longer waits on an optional pairing-notification scan. Pairing notifications keep the same 10-second steady-state cadence and may first arrive within that interval after startup.

## Evidence

- Rebased byte-identically onto `b0c368ae34d845ab2ef6a6c6adf160e1edf49442`; neither touched file changed between the frozen proof base and this base.
- Production LOC: `+3/-4` (net `-1`); tests: `+15/-14` (net `+1`).
- `node scripts/run-vitest.mjs extensions/device-pair/notify.test.ts`: 9/9 passed.
- `pnpm format extensions/device-pair/notify.ts extensions/device-pair/notify.test.ts`: clean/no patch change.
- `git diff --check`: clean.
- Local autoreview: clean, no accepted/actionable findings.
- No `CHANGELOG.md` change; normal PR release notes are carried here.

Exact-package five-pair CPU0 proof was run against the frozen source base `8c64ca24b17fbd4e180395f972cd7bf2c955cff0`. The selected patch remained byte-identical after rebasing, so remote proof was intentionally not rerun during publication prep.

| Surface | Before p50 | After p50 | Delta |
| --- | ---: | ---: | ---: |
| Device-pair notifier | 1268.7 ms | 6.0 ms | -99.53% |
| Gateway-ready log | 7596.2 ms | 6435.8 ms | -15.28% |
| Real `/readyz` | 7941.7 ms | 7870.8 ms | -0.89% |

All 10 device runs returned HTTP 200 from both `/healthz` and `/readyz` and exited cleanly on `SIGTERM`.

- Proof run: https://crabbox.openclaw.ai/portal/runs/run_9a114010e2e9
- Finalizer: https://crabbox.openclaw.ai/portal/runs/run_40ec275640ea

### Exact-head review closeout

Reviewed head: `a38abdd2a84000ecc5343644c9ee16fb3ba62bb6`.

- Maintainer review found no source or security defect. The device-pair plugin owns the optional scan; Gateway readiness remains truthful.
- Exact-head focused proof passed 103 tests: 94 Gateway startup/readiness tests and 9 notifier tests. Formatting, `git diff --check`, and fresh branch autoreview also passed.
- The first notification may arrive within the existing 10-second interval after restart. This is the intentional background-service contract already documented under User Impact.
- The Crabbox links above resolve to the authenticated portal. ClawSweeper's runner could not retrieve them because its environment lacked DNS access; the packaged results remain explicitly scoped to frozen base `8c64ca24b17fbd4e180395f972cd7bf2c955cff0`.
- The optional exact-head packaged rerun rank-up move is skipped: no source or test finding changed the immutable head, the two-file patch remained byte-identical, and exact-head source/readiness proof plus required CI are the landing gates.
- This maintainer review satisfies the requested ordinary human review. Issue #119087 remains open for residual post-ready HTTP/event-loop serviceability.

## AI-Assisted Disclosure

This PR was prepared with Codex assistance. The author reviewed the implementation, preserved the selected patch byte-for-byte through rebase, and verified the focused tests and review result above.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":56,"toolOutputsDropped":55,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":11}

[user]
You own publication prep for the one selected OpenClaw fix. Worktrees: device=[LOCAL_PATH] dropped monitor=[LOCAL_PATH] You are not alone; do not touch other worktrees. Read root/scoped AGENTS, CONTRIBUTING, PR template, punchcard, openclaw-pr-maintainer, clawsweeper, autoreview, agent-transcript, and GitHub publication rules fresh. Use Punchcard session ID from line 1 of /tmp/openclaw-startup-owner-punchcard.session and alias line 2; poll before commit and every GitHub mutation. First fetch origin/main and record exact SHA. Drop the monitor candidate safely by restoring only its task-owned modified files to its branch HEAD, then fast-forward/rebase its clean branch to origin/main; verify clean. For device, preserve the byte-identical two-file patch, rebase onto exact latest origin/main, verify no relevant conflicts, symlinked node_modules, focused 9 tests, format, diff-check, and local autoreview clean; do not rerun remote proof. Commit only the two device files with semantic message `fix(device-pair): keep notifier poll off Gateway startup` and trailer `Punchcard-Session: frost-harbor-willow-ev`; in a Codex worktree use noninteractive git commit after equivalent proof, not scripts/committer. Attest the commit through Punchcard. Push the exact branch and open a DRAFT PR using ghx, assign vincentkoc. PR title same semantic message. Use `Related: #119087`, never Closes/Fixes, because residual readyz delay remains and the issue must stay open. Complete the PR template honestly: optional SQLite pairing poll blocked startup; interval-only solution preserves 10s cadence/overlap/reload; production LOC net -1, tests net +1; focused 9/9 and autoreview clean; exact package five-pair CPU0 proof at frozen 8c64ca24 with run https://crabbox.openclaw.ai/portal/runs/run_9a114010e2e9 and finalizer https://crabbox.openclaw.ai/portal/runs/run_40ec275640ea; notifier p50 1268.7->6.0ms (-99.53%), gateway-ready log 7596.2->6435.8ms (-15.28%), real readyz 7941.7->7870.8ms (-0.89%); all 10 device runs healthz/readyz 200 and clean SIGTERM. Explicitly state this removes the notifier-owned startup cost but does not close #119087; residual post-ready HTTP/event-loop serviceability remains. No CHANGELOG. Include required AI-assisted disclosure and redacted agent transcript section per skill. Never pass GitHub text via stdin: write real temp files, pass paths, then read every live body/comment back with ghx --no-cache and fail on empty/mismatch. Attest PR, add returned compact receipt marker to PR body, verify live readback. Do not mark ready, request ClawSweeper review, enable automerge, merge, or close issue yet. Return latest base, commit SHA/attestation, PR URL/head/body verification, transcript/receipt status, monitor cleanup, and proof summary.

[assistant]
hi, i’m anchoring publication prep to the live base first. i’ll keep both worktrees isolated and poll Punchcard before every commit or GitHub mutation.

the live base is `d5668d83c0362380cc787b1f7b4e459fa20946b4`. next i’m reading the exact publication/review contracts and mapping the two-file patch before touching either branch.

the candidate shape is clean: both branches are zero commits ahead of the frozen `8c64ca24` base, and the device diff is exactly two files. i’m polling the existing Punchcard session now, then i’ll discard only the monitor-owned three-file diff and advance that branch.

the monitor worktree is clean and exactly at `d5668d83`. i’m freezing a binary/full-index copy and checksum of the selected two-file diff, checking whether latest `main` touched either file, then rebasing and restoring the patch byte-for-byte.

the rebase was conflict-free and the full-index patch checksum stayed identical through formatting. `node_modules` is still the required symlink; i’m running the single focused file now, which contains exactly nine tests.

focused proof is green: 9/9 tests, formatter no-op, diff-check clean, and autoreview returned no findings. before committing, i’m refreshing `origin/main` once more and checking the linked issue plus the notifier’s registration path so the PR body stays exact.

`origin/main` is still exactly `d5668d83`, and the issue is open and already assigned to `vincentkoc`. the pre-commit patch checksum is unchanged; i’m polling Punchcard immediately before the scoped commit now.

the commit is `6fb203b74237670ebe541b668954d16dfb324df4`, with Punchcard attestation `att_01KZBG7R3VFBNHGPAN8MTPNY0H`. i’m checking for any pre-existing remote branch/PR, then i’ll build the template-complete body and sanitized transcript before the first GitHub write.

the transcript helper found this exact session and produced a clean, scoped redaction with local paths and raw tool output removed. i’m assembling the PR body now; it will state the frozen remote proof separately from the byte-identical rebase and keep #119087 explicitly open.

[tool summary]
21 read, 4 write, 31 execute; raw tool outputs dropped: 55
````

</details>
<!-- agent-transcript:end -->

<!-- Punchcard-Receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaQkdEUlo4M1RUOFk4NUdLRTE4WFFUNgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkIzNkhHWlRUOVRNRTc1SFA2WVNBRTYAc2VzXzAxS1pCMzZIU0pLUFBNRDk3RlpYUlNGRTY2AGZyb3N0LWhhcmJvci13aWxsb3ctZXYAb3BlbmNsYXcvb3BlbmNsYXcAADExOTkzNgA4NjZkNmI3NTkyNGU2NTE5MTgzMWVjYWJlY2UxMjM3MmFjYTYwNjRmZjVlZmRhNzE4YjhiYTkwNTc5ZGQxODNiAHNpZ25pbmctdjEAby1NV1VyUlVFMFhsTkpWZHNQcDZsdFdra3JBZHZQX0lpNkMzUDcyT081bEoxYkI0anZkYU9sYVdjenMxVUhmdmVfSWU5alVaQzBwY25vT0V6c2N1RFEAMjAyNi0wOC0wNlQxMjoyMzowMC44NDBaAA.xN-NQPLwZmkeKB6L765MRof34WunLhYi35PAyGG6zUMcPbS0W0S4L0DIBXfkCu7fENV693yADQ-XsAqh3cvZDQ -->
Punchcard-Session: frost-harbor-willow-ev
