### PR TITLE
fix: prevent stale image edit completion delivery

### DIFF
--- a/src/agents/image-generation-task-status.test.ts
+++ b/src/agents/image-generation-task-status.test.ts
@@ -190,6 +190,52 @@ describe("image generation task status", () => {
     );
   });
 
+  it("allows a new reference request key to replace an active edit with the same prompt", () => {
+    const now = Date.now();
+    recordRecentMediaGenerationTaskStartForSession({
+      sessionKey: "agent:main",
+      taskKind: IMAGE_GENERATION_TASK_KIND,
+      sourcePrefix: "image_generate",
+      taskId: "task-old-reference",
+      runId: "run-old-reference",
+      taskLabel: "make it crisper",
+      requestKey: "image-request:old-reference",
+      providerId: "openai",
+      progressSummary: "Generating image",
+      nowMs: now,
+    });
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
+      {
+        taskId: "task-old-reference",
+        runId: "run-old-reference",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "make it crisper",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: now,
+      },
+    ]);
+
+    expect(
+      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+        prompt: "make it crisper",
+        requestKey: "image-request:old-reference",
+      })?.taskId,
+    ).toBe("task-old-reference");
+    expect(
+      findDuplicateGuardImageGenerationTaskForSession("agent:main", {
+        prompt: "make it crisper",
+        requestKey: "image-request:new-reference",
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not use a delivery-blocked image task as a succeeded duplicate guard", () => {
     // If completion delivery failed, suppressing a retry would strand the
     // requester without an image even though the provider task succeeded.

--- a/src/agents/media-generation-task-status-shared.ts
+++ b/src/agents/media-generation-task-status-shared.ts
@@ -235,6 +235,7 @@ function findRecentStartedMediaGenerationTaskForSession(params: {
   const retainedEntries: RecentMediaGenerationTaskStart[] = [];
   for (const entry of entries.toReversed()) {
     const task = entry.task;
+    const requestKeyMatches = !params.requestKey || entry.requestKey === params.requestKey;
     const persistedTask = findPersistedTaskForRecentMediaGenerationStart({
       sessionKey,
       cachedTask: task,
@@ -244,7 +245,11 @@ function findRecentStartedMediaGenerationTaskForSession(params: {
     if (persistedTask) {
       const persistedTaskLabelMatches =
         !taskLabel || mediaGenerationTaskLabelMatches(persistedTask, taskLabel);
-      if (isTaskStillBlockingDuplicateGuard(persistedTask) && persistedTaskLabelMatches) {
+      if (
+        requestKeyMatches &&
+        isTaskStillBlockingDuplicateGuard(persistedTask) &&
+        persistedTaskLabelMatches
+      ) {
         return persistedTask;
       }
       if (
@@ -265,7 +270,7 @@ function findRecentStartedMediaGenerationTaskForSession(params: {
     }
     if (isRecentMediaGenerationTaskRecord({ task, maxAgeMs, nowMs })) {
       const cachedTaskLabelMatches = !taskLabel || mediaGenerationTaskLabelMatches(task, taskLabel);
-      if (isTaskStillBlockingDuplicateGuard(task) && cachedTaskLabelMatches) {
+      if (requestKeyMatches && isTaskStillBlockingDuplicateGuard(task) && cachedTaskLabelMatches) {
         return { ...task };
       }
       retainedEntries.push(entry);
@@ -366,16 +371,16 @@ function findDuplicateGuardMediaGenerationTaskForSession(params: {
   requestKey?: string;
   maxAgeMs: number;
 }): TaskRecord | undefined {
-  return (
-    findRecentStartedMediaGenerationTaskForSession(params) ??
-    findActiveMediaGenerationTaskForSession({
-      sessionKey: params.sessionKey,
-      taskKind: params.taskKind,
-      sourcePrefix: params.sourcePrefix,
-      taskLabel: params.taskLabel,
-    }) ??
-    undefined
-  );
+  const recentMatch = findRecentStartedMediaGenerationTaskForSession(params);
+  if (recentMatch || params.requestKey) {
+    return recentMatch;
+  }
+  return findActiveMediaGenerationTaskForSession({
+    sessionKey: params.sessionKey,
+    taskKind: params.taskKind,
+    sourcePrefix: params.sourcePrefix,
+    taskLabel: params.taskLabel,
+  });
 }
 
 /** Builds structured status details for one media generation task. */

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -38,6 +38,7 @@ import { getImageMetadata } from "../../media/media-services.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
+import { supersedeGeneratedMediaTaskActivity } from "../../tasks/generated-media-task-activity.js";
 import { resolveUserPath } from "../../utils.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
@@ -46,6 +47,7 @@ import {
   sanitizeGeneratedMediaDisplayText,
   type AgentGeneratedAttachment,
 } from "../generated-attachments.js";
+import { findActiveImageGenerationTaskForSession } from "../image-generation-task-status.js";
 import {
   buildMediaGenerationRequestKey,
   recordRecentMediaGenerationTaskStartForSession,
@@ -910,7 +912,7 @@ export function createImageGenerateTool(options?: {
     label: "Image Generation",
     name: "image_generate",
     description:
-      'Create/edit images. Batch via count; aspectRatio and resolution up to 4K. Session chat runs background: call once/request, await completion, then visible reply with structured media attachment. Transparent: outputFormat png|webp + background="transparent"; OpenAI also openai.background, default gpt-image-1.5. action=list providers/models/readiness/auth; status active task.',
+      'Create/edit images. For an inbound-image edit, use the current turn attachment path; a new reference image supersedes an active edit with the same prompt. Batch via count; aspectRatio and resolution up to 4K. Session chat runs background: call once/request, await completion, then visible reply with structured media attachment. Transparent: outputFormat png|webp + background="transparent"; OpenAI also openai.background, default gpt-image-1.5. action=list providers/models/readiness/auth; status active task.',
     parameters: ImageGenerateToolSchema,
     execute: async (_toolCallId, args, signal) => {
       const params = args as Record<string, unknown>;
@@ -946,14 +948,6 @@ export function createImageGenerateTool(options?: {
         applyImageGenerationModelConfigDefaults(cfg, imageGenerationModelConfig) ?? cfg;
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
       const prompt = readStringParam(params, "prompt", { required: true });
-
-      const activeDuplicateGuardResult = createImageGenerateDuplicateGuardResult(
-        options?.agentSessionKey,
-        { prompt },
-      );
-      if (activeDuplicateGuardResult) {
-        return activeDuplicateGuardResult;
-      }
 
       const imageInputs = normalizeReferenceImages(params);
       const filename = readStringParam(params, "filename");
@@ -1023,6 +1017,10 @@ export function createImageGenerateTool(options?: {
       if (duplicateGuardResult) {
         return duplicateGuardResult;
       }
+      const supersededTask =
+        imageInputs.length > 0
+          ? findActiveImageGenerationTaskForSession(options?.agentSessionKey, { prompt })
+          : undefined;
       validateImageGenerationCapabilities({
         provider: selectedProvider,
         count,
@@ -1077,6 +1075,9 @@ export function createImageGenerateTool(options?: {
         prompt,
         providerId: selectedProvider?.id,
       });
+      if (taskHandle && supersededTask?.runId) {
+        supersedeGeneratedMediaTaskActivity(supersededTask.runId, taskHandle.runId);
+      }
       const shouldDetach = Boolean(
         taskHandle && shouldDetachMediaGenerationTask(options?.agentSessionKey),
       );

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -6,6 +6,10 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../config/sessions/transcript-write-context.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import {
+  registerGeneratedMediaTaskActivity,
+  supersedeGeneratedMediaTaskActivity,
+} from "../../tasks/generated-media-task-activity.js";
 import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { hasPendingGeneratedMediaTaskForSessionKey } from "../../tasks/task-status-access.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
@@ -117,6 +121,59 @@ describe("shouldDetachMediaGenerationTask", () => {
       },
     });
     expect(shouldDetachMediaGenerationTask(sessionKey)).toBe(true);
+  });
+});
+
+describe("superseded media completion", () => {
+  it("records the old task without delivering its stale output", async () => {
+    const scheduled: Array<() => Promise<void>> = [];
+    const lifecycle = {
+      createTaskRun: vi.fn(),
+      recordTaskProgress: vi.fn(),
+      completeTaskRun: vi.fn(),
+      failTaskRun: vi.fn(),
+      wakeTaskCompletion: vi.fn(async () => ({ status: "delivered" as const })),
+    };
+    const handle = {
+      taskId: "task-old-source",
+      runId: "tool:image_generate:old-source",
+      requesterSessionKey: "agent:cadence:imessage:direct:contact",
+      taskLabel: "make it crisper",
+    };
+    registerGeneratedMediaTaskActivity(handle.runId, handle.requesterSessionKey);
+    registerGeneratedMediaTaskActivity(
+      "tool:image_generate:new-source",
+      handle.requesterSessionKey,
+    );
+    supersedeGeneratedMediaTaskActivity(handle.runId, "tool:image_generate:new-source");
+
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle,
+      scheduleBackgroundWork: (work) => scheduled.push(work),
+      progressSummary: "Generating image",
+      toolName: "Image generation",
+      onWakeFailure: vi.fn(),
+      run: async () => ({
+        provider: "openai",
+        model: "gpt-image-1",
+        count: 1,
+        paths: ["/tmp/stale-output.png"],
+        wakeResult: "generated stale output",
+      }),
+    });
+
+    await scheduled[0]?.();
+
+    expect(lifecycle.wakeTaskCompletion).not.toHaveBeenCalled();
+    expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalResult: expect.objectContaining({
+          terminalOutcome: "blocked",
+          terminalSummary: expect.stringContaining("superseded"),
+        }),
+      }),
+    );
   });
 });
 

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -21,6 +21,7 @@ import {
 } from "../../tasks/detached-task-runtime.js";
 import {
   clearGeneratedMediaTaskActivity,
+  getGeneratedMediaTaskSupersedingRunId,
   registerGeneratedMediaTaskActivity,
 } from "../../tasks/generated-media-task-activity.js";
 import {
@@ -494,6 +495,13 @@ export function scheduleMediaGenerationTaskCompletion<
         run: params.run,
       });
     } catch (error) {
+      const supersedingRunId = params.handle
+        ? getGeneratedMediaTaskSupersedingRunId(params.handle.runId)
+        : undefined;
+      if (supersedingRunId) {
+        params.lifecycle.failTaskRun({ handle: params.handle, error });
+        return;
+      }
       try {
         const wakeOutcome = await wakeMediaGenerationTaskCompletionWithRetry({
           wake: async () =>
@@ -519,6 +527,24 @@ export function scheduleMediaGenerationTaskCompletion<
         });
       }
       params.lifecycle.failTaskRun({ handle: params.handle, error });
+      return;
+    }
+
+    const supersedingRunId = params.handle
+      ? getGeneratedMediaTaskSupersedingRunId(params.handle.runId)
+      : undefined;
+    if (supersedingRunId) {
+      params.lifecycle.completeTaskRun({
+        handle: params.handle,
+        provider: executed.provider,
+        model: executed.model,
+        count: executed.count,
+        paths: executed.paths,
+        terminalResult: {
+          terminalOutcome: "blocked",
+          terminalSummary: `Completion intentionally withheld because newer media run ${supersedingRunId} superseded this request.`,
+        },
+      });
       return;
     }
 

--- a/src/tasks/generated-media-task-activity.ts
+++ b/src/tasks/generated-media-task-activity.ts
@@ -3,6 +3,7 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 const GENERATED_MEDIA_TASK_ACTIVITY_KEY = Symbol.for("openclaw.generatedMediaTaskActivity");
 const GENERATED_MEDIA_TASK_ADMISSIONS_KEY = Symbol.for("openclaw.generatedMediaTaskAdmissions");
+const SUPERSEDED_GENERATED_MEDIA_TASKS_KEY = Symbol.for("openclaw.supersededGeneratedMediaTasks");
 const GENERATED_MEDIA_TASK_ADMISSIONS_MAX_ENTRIES = 2_048;
 
 function getActiveGeneratedMediaTasks(): Map<string, string> {
@@ -12,6 +13,13 @@ function getActiveGeneratedMediaTasks(): Map<string, string> {
 function getLatestGeneratedMediaTaskAdmissions(): Map<string, string> {
   return resolveGlobalSingleton(
     GENERATED_MEDIA_TASK_ADMISSIONS_KEY,
+    () => new Map<string, string>(),
+  );
+}
+
+function getSupersededGeneratedMediaTasks(): Map<string, string> {
+  return resolveGlobalSingleton(
+    SUPERSEDED_GENERATED_MEDIA_TASKS_KEY,
     () => new Map<string, string>(),
   );
 }
@@ -34,6 +42,22 @@ export function registerGeneratedMediaTaskActivity(runId: string, sessionKey: st
 /** Clears in-process generated-media activity after terminal task bookkeeping. */
 export function clearGeneratedMediaTaskActivity(runId: string): void {
   getActiveGeneratedMediaTasks().delete(runId);
+  getSupersededGeneratedMediaTasks().delete(runId);
+}
+
+/** Marks an active generated-media run as replaced by a newer admitted run. */
+export function supersedeGeneratedMediaTaskActivity(runId: string, replacementRunId: string): void {
+  if (!runId || !replacementRunId || runId === replacementRunId) {
+    return;
+  }
+  if (getActiveGeneratedMediaTasks().has(runId)) {
+    getSupersededGeneratedMediaTasks().set(runId, replacementRunId);
+  }
+}
+
+/** Returns the newer run that owns delivery after this run was superseded. */
+export function getGeneratedMediaTaskSupersedingRunId(runId: string): string | undefined {
+  return getSupersededGeneratedMediaTasks().get(runId);
 }
 
 /** Lists active generated-media run ids for one exact requester session. */
@@ -62,6 +86,7 @@ export function getLatestGeneratedMediaTaskAdmissionIdForSessionKey(
 function resetGeneratedMediaTaskActivityForTests(): void {
   getActiveGeneratedMediaTasks().clear();
   getLatestGeneratedMediaTaskAdmissions().clear();
+  getSupersededGeneratedMediaTasks().clear();
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/tasks/task-status-access.test.ts
+++ b/src/tasks/task-status-access.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearGeneratedMediaTaskActivity,
+  getGeneratedMediaTaskSupersedingRunId,
   registerGeneratedMediaTaskActivity,
+  supersedeGeneratedMediaTaskActivity,
 } from "./generated-media-task-activity.js";
 import { resetGeneratedMediaTaskActivityForTests } from "./task-runtime.test-helpers.js";
 import {
@@ -75,6 +77,18 @@ describe("generated media task snapshots", () => {
     clearGeneratedMediaTaskActivity("tool:image_generate:run-1");
     expect(hasNewGeneratedMediaTaskForSessionKey(sessionKey, before)).toBe(true);
     expect(hasPendingGeneratedMediaTaskForSessionKey(sessionKey)).toBe(false);
+  });
+
+  it("tracks supersession only while the replaced media run remains active", () => {
+    registerGeneratedMediaTaskActivity("tool:image_generate:old", sessionKey);
+    registerGeneratedMediaTaskActivity("tool:image_generate:new", sessionKey);
+    supersedeGeneratedMediaTaskActivity("tool:image_generate:old", "tool:image_generate:new");
+
+    expect(getGeneratedMediaTaskSupersedingRunId("tool:image_generate:old")).toBe(
+      "tool:image_generate:new",
+    );
+    clearGeneratedMediaTaskActivity("tool:image_generate:old");
+    expect(getGeneratedMediaTaskSupersedingRunId("tool:image_generate:old")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a second image edit with a newer reference
image could still receive the older in-flight edit when both requests used the
same prompt.

## Why This Change Was Made

Image-edit duplicate admission now includes the normalized reference-image
request key. When a different reference is admitted for the same prompt, the
new run becomes the delivery owner and the superseded run records a terminal
blocked outcome without waking or publishing its completion.

The positive production LOC establishes one generic task-ownership boundary;
it is shared by image admission and detached completion rather than adding
channel- or provider-specific suppression.

## User Impact

The most recently admitted image edit owns delivery. A slower edit using an
obsolete reference can no longer overwrite or precede the requested result.

## Evidence

- AI-assisted; I reviewed and understand the implementation.
- Added regression coverage for same-prompt/different-reference admission,
  activity ownership, and suppression of both success and error wakes.
- Focused suites: 48 tests passed across task status, image generation status,
  and background media delivery.
- `pnpm tsgo:core` passed.
- `pnpm tsgo:test:src` passed.
- `pnpm build` passed, including all nine unified bundle passes and Control UI
  performance checks.
- `oxfmt --check` passed for all changed files.
- The repository preflight guards completed successfully; the unrelated
  repository-wide npm package-lock regeneration lane was not used as evidence.
