### PR TITLE
fix: contain structured subagent failure reports

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1287,6 +1287,32 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(content.length).toBeLessThanOrEqual(4_096);
   });
 
+  it("does not mirror a structured internal failure report as direct completion text", async () => {
+    const callGateway = createPayloadGatewayMock();
+    const sendMessage = createSendMessageMock();
+
+    await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        result: [
+          "## Result: blocked — could not finish",
+          "",
+          "**Blocker:** The source handoff was unavailable.",
+          "**Needed from main agent:** Retry the parent workflow.",
+        ].join("\n"),
+      }),
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content:
+          "The background task finished, but I couldn't prepare a safe final reply. Please try again.",
+      }),
+    );
+  });
+
   it("reports direct completion delivery before post-send transcript mirroring settles", async () => {
     const callGateway = createPayloadGatewayMock();
     let releaseMirror!: () => void;

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -697,6 +697,13 @@ function resolveTextCompletionDirectFallback(events: readonly AgentInternalEvent
         ? sanitizeAgentRunTerminalReplyText(sanitizePendingFinalDeliveryText(event.result))
         : "";
     if (result && result !== "(no output)") {
+      if (
+        /^\s*##\s+Result:\s*(?:blocked|failed|error)\b[\s\S]{0,4000}^\s*(?:\*\*)?(?:Blocker|Needed from (?:the )?main agent|Not completed)(?:\*\*)?:/im.test(
+          result,
+        )
+      ) {
+        return "The background task finished, but I couldn't prepare a safe final reply. Please try again.";
+      }
       return result;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could receive a structured internal subagent failure
report when announcement synthesis produced no visible response and direct
completion fallback ran.

## Why This Change Was Made

The existing sanitized fallback remains unchanged for ordinary completion text.
Only a high-confidence internal report shape—`## Result: blocked|failed|error`
plus an operator-only blocker or main-agent section—is replaced with fixed
user-safe copy. This is a narrow delivery-boundary invariant rather than a broad
content rewrite.

## User Impact

Users no longer see internal blocker reports or instructions meant for the
requesting agent, while legitimate plain-text subagent completions continue to
be delivered normally.

## Evidence

- AI-assisted; I reviewed and understand the implementation.
- Added the observed structured report shape as a synthetic regression while
  preserving all existing ordinary fallback expectations.
- Focused announcement suite: 150 tests passed.
- `pnpm tsgo:core` passed.
- `pnpm tsgo:test:src` passed.
- `pnpm build` passed, including all nine unified bundle passes and Control UI
  performance checks.
- `oxfmt --check` passed for both changed files.
- The repository preflight guards completed successfully; the unrelated
  repository-wide npm package-lock regeneration lane was not used as evidence.
