### PR TITLE
fix: preserve paired tool results across reset replay

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -65,6 +65,18 @@ function createProjectedEntry(
     : { ...common, type, fromId: common.parentId ?? common.id, summary: content };
 }
 
+const RESET_COMPACTION_VARIANTS: Array<{
+  blockType: "toolCall" | "toolUse" | "functionCall";
+  resultField: string;
+}> = [
+  { blockType: "toolCall", resultField: "toolUseId" },
+  { blockType: "toolCall", resultField: "call_id" },
+  { blockType: "toolUse", resultField: "toolUseId" },
+  { blockType: "toolUse", resultField: "tool_use_id" },
+  { blockType: "functionCall", resultField: "callId" },
+  { blockType: "functionCall", resultField: "call_id" },
+];
+
 describe("calculateContextTokens", () => {
   it("prefers the final-iteration context snapshot over aggregate billing usage", () => {
     expect(
@@ -419,6 +431,71 @@ describe("session-entry compaction budgeting", () => {
     expect(JSON.stringify(result.value.turnPrefixMessages)).not.toContain("orphan tool result");
     expect(["entry-7", "entry-8"]).toContain(result.value.firstKeptEntryId);
   });
+
+  it.each(RESET_COMPACTION_VARIANTS)(
+    "retains paired reset tool rows for $blockType/$resultField in compaction input",
+    ({ blockType, resultField }) => {
+      const entries: SessionTreeEntry[] = [
+        createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),
+        createMessageEntry({ role: "user", content: "kept question", timestamp: 2 }, 1),
+        createMessageEntry(
+          {
+            ...createAssistant("", createUsage(2), 3),
+            content: [{ type: blockType, id: "call-1", name: "read", arguments: {} }],
+            stopReason: "toolUse",
+          },
+          2,
+        ),
+        createMessageEntry(
+          {
+            role: "toolResult",
+            [resultField]: "call-1",
+            toolName: "read",
+            content: [{ type: "text", text: "paired tool result" }],
+            isError: false,
+            timestamp: 4,
+          } as unknown as AgentMessage,
+          3,
+        ),
+        createMessageEntry(
+          {
+            role: "toolResult",
+            toolCallId: "orphan-call",
+            toolName: "read",
+            content: [{ type: "text", text: "orphan tool result" }],
+            isError: false,
+            timestamp: 5,
+          },
+          4,
+        ),
+        createMessageEntry(createAssistant("kept answer", createUsage(2), 6), 5),
+        {
+          type: "reset",
+          id: "entry-6",
+          parentId: "entry-5",
+          timestamp: new Date(7).toISOString(),
+          reason: "new",
+          firstKeptEntryId: "entry-1",
+        },
+        createMessageEntry({ role: "user", content: "post reset", timestamp: 8 }, 7),
+        createMessageEntry(createAssistant("new answer", createUsage(2), 9), 8),
+      ];
+
+      const result = prepareCompaction(entries, {
+        enabled: true,
+        reserveTokens: 0,
+        keepRecentTokens: 1,
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || !result.value) {
+        throw new Error("expected reset transcript to be compactable");
+      }
+      expect(JSON.stringify(result.value.messagesToSummarize)).toContain("paired tool result");
+      expect(JSON.stringify(result.value.messagesToSummarize)).not.toContain("orphan tool result");
+      expect(JSON.stringify(result.value.turnPrefixMessages)).not.toContain("orphan tool result");
+    },
+  );
 
   it("keeps unpaired reset tool rows out of later compaction input", () => {
     const entries: SessionTreeEntry[] = [

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -357,7 +357,70 @@ describe("session-entry compaction budgeting", () => {
     expect(result.value.messagesToSummarize.length).toBeGreaterThan(0);
   });
 
-  it("keeps reset-filtered tool rows out of later compaction input", () => {
+  it("retains paired reset tool rows while filtering orphan rows from later compaction input", () => {
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),
+      createMessageEntry({ role: "user", content: "kept question", timestamp: 2 }, 1),
+      createMessageEntry(
+        {
+          ...createAssistant("", createUsage(2), 3),
+          content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+          stopReason: "toolUse",
+        },
+        2,
+      ),
+      createMessageEntry(
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "paired tool result" }],
+          isError: false,
+          timestamp: 4,
+        },
+        3,
+      ),
+      createMessageEntry(
+        {
+          role: "toolResult",
+          toolCallId: "orphan-call",
+          toolName: "read",
+          content: [{ type: "text", text: "orphan tool result" }],
+          isError: false,
+          timestamp: 5,
+        },
+        4,
+      ),
+      createMessageEntry(createAssistant("kept answer", createUsage(2), 6), 5),
+      {
+        type: "reset",
+        id: "entry-6",
+        parentId: "entry-5",
+        timestamp: new Date(7).toISOString(),
+        reason: "new",
+        firstKeptEntryId: "entry-1",
+      },
+      createMessageEntry({ role: "user", content: "post reset", timestamp: 8 }, 7),
+      createMessageEntry(createAssistant("new answer", createUsage(2), 9), 8),
+    ];
+
+    const result = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 0,
+      keepRecentTokens: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || !result.value) {
+      throw new Error("expected reset transcript to be compactable");
+    }
+    expect(JSON.stringify(result.value.messagesToSummarize)).toContain("paired tool result");
+    expect(JSON.stringify(result.value.messagesToSummarize)).not.toContain("orphan tool result");
+    expect(JSON.stringify(result.value.turnPrefixMessages)).not.toContain("orphan tool result");
+    expect(["entry-7", "entry-8"]).toContain(result.value.firstKeptEntryId);
+  });
+
+  it("keeps unpaired reset tool rows out of later compaction input", () => {
     const entries: SessionTreeEntry[] = [
       createMessageEntry({ role: "user", content: "discarded", timestamp: 1 }, 0),
       createMessageEntry({ role: "user", content: "kept question", timestamp: 2 }, 1),

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -441,7 +441,9 @@ describe("session-entry compaction budgeting", () => {
         createMessageEntry(
           {
             ...createAssistant("", createUsage(2), 3),
-            content: [{ type: blockType, id: "call-1", name: "read", arguments: {} }],
+            content: [
+              { type: blockType, id: "call-1", name: "read", arguments: {} },
+            ] as unknown as AssistantMessage["content"],
             stopReason: "toolUse",
           },
           2,

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -17,7 +17,11 @@ import {
 } from "../../runtime-deps.js";
 import type { AgentMessage, ThinkingLevel } from "../../types.js";
 import { convertToLlm, type HarnessMessage } from "../messages.js";
-import { buildSessionContext, projectSessionEntryMessage } from "../session/session.js";
+import {
+  buildSessionContext,
+  projectSessionEntryMessage,
+  selectResetKeptEntries,
+} from "../session/session.js";
 import {
   type CompactionEntry,
   CompactionError,
@@ -70,13 +74,6 @@ function getMessageFromEntryForCompaction(entry: SessionTreeEntry): AgentMessage
     return undefined;
   }
   return projectSessionEntryMessage(entry);
-}
-
-function isResetReplayableEntry(entry: SessionTreeEntry): boolean {
-  return (
-    entry.type === "message" &&
-    (entry.message.role === "user" || entry.message.role === "assistant")
-  );
 }
 
 /** Generated compaction data ready to be persisted as a compaction entry. */
@@ -693,7 +690,7 @@ export function prepareCompaction(
     if (prevBoundary?.type === "reset") {
       const keptEntries =
         firstKeptEntryIndex >= 0
-          ? pathEntries.slice(firstKeptEntryIndex, prevBoundaryIndex).filter(isResetReplayableEntry)
+          ? selectResetKeptEntries(pathEntries.slice(firstKeptEntryIndex, prevBoundaryIndex))
           : [];
       resetPreludeMessages = keptEntries.flatMap((entry) => {
         const message = getMessageFromEntryForCompaction(entry);

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -14,6 +14,19 @@ function userEntry(id: string, parentId: string | null, content: string): Sessio
   };
 }
 
+const RESET_TOOL_CALL_TYPES = ["toolCall", "toolUse", "functionCall"] as const;
+const RESET_TOOL_RESULT_ID_FIELDS = [
+  "toolCallId",
+  "toolUseId",
+  "tool_call_id",
+  "tool_use_id",
+  "callId",
+  "call_id",
+] as const;
+const RESET_PAIR_VARIANTS = RESET_TOOL_CALL_TYPES.flatMap((blockType) =>
+  RESET_TOOL_RESULT_ID_FIELDS.map((resultField) => ({ blockType, resultField })),
+);
+
 describe("buildSessionContext", () => {
   it("replays only the retained tail and newer entries after compaction", () => {
     const entries: SessionTreeEntry[] = [
@@ -161,6 +174,205 @@ describe("buildSessionContext", () => {
     expect(JSON.stringify(context.messages)).toContain("new turn");
     expect(JSON.stringify(context.messages)).not.toContain("discarded");
     expect(JSON.stringify(context.messages)).not.toContain("orphan tool result");
+  });
+
+  it.each(RESET_PAIR_VARIANTS)(
+    "retains a paired $blockType/$resultField tool result across reset replay and excludes orphans",
+    ({ blockType, resultField }) => {
+      const entries: SessionTreeEntry[] = [
+        userEntry("discarded", null, "discarded"),
+        userEntry("kept-user", "discarded", "kept question"),
+        {
+          type: "message",
+          id: "kept-assistant-tool",
+          parentId: "kept-user",
+          timestamp,
+          message: {
+            role: "assistant",
+            api: "anthropic-messages",
+            content: [{ type: blockType, id: "call-1", name: "read", arguments: {} }],
+            provider: "test-provider",
+            model: "test-model",
+            usage: {
+              input: 1,
+              output: 1,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 2,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: Date.parse(timestamp),
+          },
+        },
+        {
+          type: "message",
+          id: "kept-tool",
+          parentId: "kept-assistant-tool",
+          timestamp,
+          message: {
+            role: "toolResult",
+            [resultField]: "call-1",
+            toolName: "read",
+            content: [{ type: "text", text: "paired tool result" }],
+            isError: false,
+            timestamp: Date.parse(timestamp),
+          } as unknown as SessionTreeEntry["message"],
+        },
+        {
+          type: "message",
+          id: "kept-orphan-tool",
+          parentId: "kept-tool",
+          timestamp,
+          message: {
+            role: "toolResult",
+            toolCallId: "orphan-call",
+            toolName: "read",
+            content: [{ type: "text", text: "orphan tool result" }],
+            isError: false,
+            timestamp: Date.parse(timestamp),
+          },
+        },
+        {
+          type: "reset",
+          id: "reset",
+          parentId: "kept-orphan-tool",
+          timestamp,
+          reason: "new",
+          firstKeptEntryId: "kept-user",
+        },
+        userEntry("new", "reset", "new turn"),
+      ];
+
+      const context = buildSessionContext(entries);
+
+      expect(context.messages.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+        "toolResult",
+        "user",
+      ]);
+      expect(JSON.stringify(context.messages)).toContain("paired tool result");
+      expect(JSON.stringify(context.messages)).not.toContain("orphan tool result");
+      expect(JSON.stringify(context.messages)).not.toContain("discarded");
+    },
+  );
+
+  it("matches repeated aliased tool-call ids by occurrence across reset replay", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("kept-user", null, "kept question"),
+      {
+        type: "message",
+        id: "kept-assistant-tool-1",
+        parentId: "kept-user",
+        timestamp,
+        message: {
+          role: "assistant",
+          api: "anthropic-messages",
+          content: [{ type: "toolUse", id: "call-1", name: "read", input: {} }],
+          provider: "test-provider",
+          model: "test-model",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "toolUse",
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "kept-tool-1",
+        parentId: "kept-assistant-tool-1",
+        timestamp,
+        message: {
+          role: "toolResult",
+          tool_use_id: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "first paired result" }],
+          isError: false,
+          timestamp: Date.parse(timestamp),
+        } as unknown as SessionTreeEntry["message"],
+      },
+      {
+        type: "message",
+        id: "kept-assistant-tool-2",
+        parentId: "kept-tool-1",
+        timestamp,
+        message: {
+          role: "assistant",
+          api: "anthropic-messages",
+          content: [{ type: "functionCall", id: "call-1", name: "read", arguments: {} }],
+          provider: "test-provider",
+          model: "test-model",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "toolUse",
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "kept-tool-2",
+        parentId: "kept-assistant-tool-2",
+        timestamp,
+        message: {
+          role: "toolResult",
+          call_id: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "second paired result" }],
+          isError: false,
+          timestamp: Date.parse(timestamp),
+        } as unknown as SessionTreeEntry["message"],
+      },
+      {
+        type: "message",
+        id: "kept-orphan-tool",
+        parentId: "kept-tool-2",
+        timestamp,
+        message: {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "third orphan result" }],
+          isError: false,
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "kept-orphan-tool",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "kept-user",
+      },
+      userEntry("new", "reset", "new turn"),
+    ];
+
+    const context = buildSessionContext(entries);
+
+    expect(context.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(JSON.stringify(context.messages)).toContain("first paired result");
+    expect(JSON.stringify(context.messages)).toContain("second paired result");
+    expect(JSON.stringify(context.messages)).not.toContain("third orphan result");
   });
 
   it("lets the latest compaction shadow an earlier reset boundary", () => {

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -203,7 +203,7 @@ describe("buildSessionContext", () => {
             },
             stopReason: "toolUse",
             timestamp: Date.parse(timestamp),
-          },
+          } as unknown as Extract<SessionTreeEntry, { type: "message" }>["message"],
         },
         {
           type: "message",
@@ -217,7 +217,7 @@ describe("buildSessionContext", () => {
             content: [{ type: "text", text: "paired tool result" }],
             isError: false,
             timestamp: Date.parse(timestamp),
-          } as unknown as SessionTreeEntry["message"],
+          } as unknown as Extract<SessionTreeEntry, { type: "message" }>["message"],
         },
         {
           type: "message",
@@ -282,7 +282,7 @@ describe("buildSessionContext", () => {
           },
           stopReason: "toolUse",
           timestamp: Date.parse(timestamp),
-        },
+        } as unknown as Extract<SessionTreeEntry, { type: "message" }>["message"],
       },
       {
         type: "message",
@@ -296,7 +296,7 @@ describe("buildSessionContext", () => {
           content: [{ type: "text", text: "first paired result" }],
           isError: false,
           timestamp: Date.parse(timestamp),
-        } as unknown as SessionTreeEntry["message"],
+        } as unknown as Extract<SessionTreeEntry, { type: "message" }>["message"],
       },
       {
         type: "message",
@@ -319,7 +319,7 @@ describe("buildSessionContext", () => {
           },
           stopReason: "toolUse",
           timestamp: Date.parse(timestamp),
-        },
+        } as unknown as Extract<SessionTreeEntry, { type: "message" }>["message"],
       },
       {
         type: "message",
@@ -333,7 +333,7 @@ describe("buildSessionContext", () => {
           content: [{ type: "text", text: "second paired result" }],
           isError: false,
           timestamp: Date.parse(timestamp),
-        } as unknown as SessionTreeEntry["message"],
+        } as unknown as Extract<SessionTreeEntry, { type: "message" }>["message"],
       },
       {
         type: "message",

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -57,20 +57,57 @@ describe("buildSessionContext", () => {
     ]);
   });
 
-  it("treats the latest reset as a hard cut with a user/assistant-only kept tail", () => {
+  it("treats the latest reset as a hard cut with pairing-aware kept tool results", () => {
     const entries: SessionTreeEntry[] = [
       userEntry("discarded", null, "discarded"),
       userEntry("kept-user", "discarded", "kept question"),
       {
         type: "message",
-        id: "kept-tool",
+        id: "kept-assistant-tool",
         parentId: "kept-user",
+        timestamp,
+        message: {
+          role: "assistant",
+          api: "openai-responses",
+          content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+          provider: "test-provider",
+          model: "test-model",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "toolUse",
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "kept-tool",
+        parentId: "kept-assistant-tool",
         timestamp,
         message: {
           role: "toolResult",
           toolCallId: "call-1",
           toolName: "read",
-          content: [{ type: "text", text: "hidden tool result" }],
+          content: [{ type: "text", text: "paired tool result" }],
+          isError: false,
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "kept-orphan-tool",
+        parentId: "kept-tool",
+        timestamp,
+        message: {
+          role: "toolResult",
+          toolCallId: "orphan-call",
+          toolName: "read",
+          content: [{ type: "text", text: "orphan tool result" }],
           isError: false,
           timestamp: Date.parse(timestamp),
         },
@@ -78,7 +115,7 @@ describe("buildSessionContext", () => {
       {
         type: "message",
         id: "kept-assistant",
-        parentId: "kept-tool",
+        parentId: "kept-orphan-tool",
         timestamp,
         message: {
           role: "assistant",
@@ -111,12 +148,19 @@ describe("buildSessionContext", () => {
 
     const context = buildSessionContext(entries);
 
-    expect(context.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(context.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+      "user",
+    ]);
     expect(JSON.stringify(context.messages)).toContain("kept question");
+    expect(JSON.stringify(context.messages)).toContain("paired tool result");
     expect(JSON.stringify(context.messages)).toContain("kept answer");
     expect(JSON.stringify(context.messages)).toContain("new turn");
     expect(JSON.stringify(context.messages)).not.toContain("discarded");
-    expect(JSON.stringify(context.messages)).not.toContain("hidden tool result");
+    expect(JSON.stringify(context.messages)).not.toContain("orphan tool result");
   });
 
   it("lets the latest compaction shadow an earlier reset boundary", () => {

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -9,6 +9,62 @@ import type { CompactionEntry, ResetEntry, SessionContext, SessionTreeEntry } fr
 
 type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
+const RESET_TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+
+/** Extract tool-call ids using the persisted pairing contract's supported block types. */
+function extractResetToolCallIds(message: Extract<AgentMessage, { role: "assistant" }>): string[] {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  const ids: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as { type?: unknown; id?: unknown };
+    if (
+      typeof record.type === "string" &&
+      RESET_TOOL_CALL_TYPES.has(record.type) &&
+      typeof record.id === "string" &&
+      record.id
+    ) {
+      ids.push(record.id);
+    }
+  }
+  return ids;
+}
+
+/** Extract the tool-result id using the persisted pairing contract's accepted aliases. */
+function extractResetToolResultId(
+  message: Extract<AgentMessage, { role: "toolResult" }>,
+): string | null {
+  const record = message as {
+    toolCallId?: unknown;
+    toolUseId?: unknown;
+    tool_call_id?: unknown;
+    tool_use_id?: unknown;
+    callId?: unknown;
+    call_id?: unknown;
+  };
+  for (const value of [
+    record.toolCallId,
+    record.toolUseId,
+    record.tool_call_id,
+    record.tool_use_id,
+    record.callId,
+    record.call_id,
+  ]) {
+    if (typeof value === "string") {
+      const id = value.trim();
+      if (id) {
+        return id;
+      }
+    }
+  }
+  return null;
+}
 
 /** Project persisted session entries into the message shared by replay and summarization. */
 export function projectSessionEntryMessage(entry: SessionTreeEntry): AgentMessage | undefined {
@@ -60,11 +116,8 @@ export function selectResetKeptEntries(entries: readonly SessionTreeEntry[]): Se
 
     const message = entry.message;
     if (message.role === "assistant") {
-      for (const block of message.content) {
-        if (block.type !== "toolCall") {
-          continue;
-        }
-        pendingToolCalls.set(block.id, (pendingToolCalls.get(block.id) ?? 0) + 1);
+      for (const id of extractResetToolCallIds(message)) {
+        pendingToolCalls.set(id, (pendingToolCalls.get(id) ?? 0) + 1);
       }
       retainedEntries.push(entry);
       continue;
@@ -76,14 +129,18 @@ export function selectResetKeptEntries(entries: readonly SessionTreeEntry[]): Se
     }
 
     if (message.role === "toolResult") {
-      const pendingCount = pendingToolCalls.get(message.toolCallId) ?? 0;
+      const toolCallId = extractResetToolResultId(message);
+      if (!toolCallId) {
+        continue;
+      }
+      const pendingCount = pendingToolCalls.get(toolCallId) ?? 0;
       if (pendingCount === 0) {
         continue;
       }
       if (pendingCount === 1) {
-        pendingToolCalls.delete(message.toolCallId);
+        pendingToolCalls.delete(toolCallId);
       } else {
-        pendingToolCalls.set(message.toolCallId, pendingCount - 1);
+        pendingToolCalls.set(toolCallId, pendingCount - 1);
       }
       retainedEntries.push(entry);
     }

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -48,17 +48,70 @@ function appendContextMessage(messages: AgentMessage[], entry: SessionTreeEntry)
   }
 }
 
+/** Select reset-tail entries that are safe to replay into model-visible context. */
+export function selectResetKeptEntries(entries: readonly SessionTreeEntry[]): SessionTreeEntry[] {
+  const pendingToolCalls = new Map<string, number>();
+  const retainedEntries: SessionTreeEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.type !== "message") {
+      continue;
+    }
+
+    const message = entry.message;
+    if (message.role === "assistant") {
+      for (const block of message.content) {
+        if (block.type !== "toolCall") {
+          continue;
+        }
+        pendingToolCalls.set(block.id, (pendingToolCalls.get(block.id) ?? 0) + 1);
+      }
+      retainedEntries.push(entry);
+      continue;
+    }
+
+    if (message.role === "user") {
+      retainedEntries.push(entry);
+      continue;
+    }
+
+    if (message.role === "toolResult") {
+      const pendingCount = pendingToolCalls.get(message.toolCallId) ?? 0;
+      if (pendingCount === 0) {
+        continue;
+      }
+      if (pendingCount === 1) {
+        pendingToolCalls.delete(message.toolCallId);
+      } else {
+        pendingToolCalls.set(message.toolCallId, pendingCount - 1);
+      }
+      retainedEntries.push(entry);
+    }
+  }
+
+  return retainedEntries;
+}
+
 function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntry): void {
-  if (
-    entry.type === "message" &&
-    (entry.message.role === "user" || entry.message.role === "assistant")
-  ) {
-    const message = { ...entry.message } as AgentMessage & { [SESSION_HISTORY_PRELUDE]?: true };
-    Object.defineProperty(message, SESSION_HISTORY_PRELUDE, {
+  if (entry.type !== "message") {
+    return;
+  }
+
+  const message = entry.message;
+  if (message.role === "user" || message.role === "assistant") {
+    const retainedMessage = { ...message } as AgentMessage & {
+      [SESSION_HISTORY_PRELUDE]?: true;
+    };
+    Object.defineProperty(retainedMessage, SESSION_HISTORY_PRELUDE, {
       configurable: true,
       enumerable: false,
       value: true,
     });
+    messages.push(retainedMessage);
+    return;
+  }
+
+  if (message.role === "toolResult") {
     messages.push(message);
   }
 }
@@ -90,16 +143,27 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
       }
     }
     const boundaryIdx = pathEntries.findIndex((entry) => entry.id === boundary.id);
-    // A reset kept tail mirrors the old cross-log replay contract: only user/assistant
-    // rows survive. Compaction keeps its existing richer retained-tail behavior.
     let foundFirstKept = false;
-    for (const entry of pathEntries.slice(0, boundaryIdx)) {
+    const entriesBeforeBoundary = pathEntries.slice(0, boundaryIdx);
+    const firstKeptEntryIndex = entriesBeforeBoundary.findIndex(
+      (entry) => entry.id === boundary.firstKeptEntryId,
+    );
+    const resetKeptEntries =
+      boundary.type === "reset" && firstKeptEntryIndex >= 0
+        ? selectResetKeptEntries(entriesBeforeBoundary.slice(firstKeptEntryIndex))
+        : undefined;
+    for (const entry of entriesBeforeBoundary) {
       if (entry.id === boundary.firstKeptEntryId) {
         foundFirstKept = true;
       }
       if (foundFirstKept) {
         if (boundary.type === "reset") {
-          appendResetKeptMessage(messages, entry);
+          // A reset kept tail is a model-context projection: retain user/assistant rows and only
+          // tool results paired with retained assistant tool calls. Display/history projections
+          // keep their separate user/assistant-only visibility contract.
+          if (resetKeptEntries?.includes(entry)) {
+            appendResetKeptMessage(messages, entry);
+          }
         } else {
           appendContextMessage(messages, entry);
         }

--- a/src/agents/sessions/session-manager.tool-result-replay.test.ts
+++ b/src/agents/sessions/session-manager.tool-result-replay.test.ts
@@ -158,6 +158,112 @@ describe("SessionManager tool-result replay", () => {
     );
   });
 
+  it("replays reset-retained paired tool results without restoring orphan results", () => {
+    const timestamp = "2026-07-01T00:00:00.000Z";
+    const timestampMs = Date.parse(timestamp);
+    const sessionManager = SessionManager.fromEntries([
+      {
+        type: "session",
+        version: 3,
+        id: "reset-tool-result-session",
+        timestamp,
+        cwd: "/tmp/reset-tool-result-replay",
+      },
+      {
+        type: "message",
+        id: "discarded",
+        parentId: null,
+        timestamp,
+        message: { role: "user", content: "discarded", timestamp: timestampMs },
+      },
+      {
+        type: "message",
+        id: "kept-user",
+        parentId: "discarded",
+        timestamp,
+        message: { role: "user", content: "kept question", timestamp: timestampMs },
+      },
+      {
+        type: "message",
+        id: "kept-assistant-tool",
+        parentId: "kept-user",
+        timestamp,
+        message: {
+          role: "assistant",
+          api: "openai-responses",
+          content: [{ type: "toolCall", id: "call-1", name: "lookup", arguments: {} }],
+          provider: "test-provider",
+          model: "test-model",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "toolUse",
+          timestamp: timestampMs,
+        },
+      },
+      {
+        type: "message",
+        id: "kept-tool-result",
+        parentId: "kept-assistant-tool",
+        timestamp,
+        message: {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "lookup",
+          content: [{ type: "text", text: "paired result" }],
+          isError: false,
+          timestamp: timestampMs,
+        },
+      },
+      {
+        type: "message",
+        id: "kept-orphan-result",
+        parentId: "kept-tool-result",
+        timestamp,
+        message: {
+          role: "toolResult",
+          toolCallId: "orphan-call",
+          toolName: "lookup",
+          content: [{ type: "text", text: "orphan result" }],
+          isError: false,
+          timestamp: timestampMs,
+        },
+      },
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "kept-orphan-result",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "kept-user",
+      },
+      {
+        type: "message",
+        id: "new-user",
+        parentId: "reset",
+        timestamp,
+        message: { role: "user", content: "new turn", timestamp: timestampMs },
+      },
+    ]);
+
+    const messages = sessionManager.buildSessionContext().messages;
+
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(JSON.stringify(messages)).toContain("paired result");
+    expect(JSON.stringify(messages)).not.toContain("orphan result");
+    expect(JSON.stringify(messages)).not.toContain("discarded");
+  });
+
   it("normalizes string tool-result content loaded from JSONL", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/sessions/session-manager.tool-result-replay.test.ts
+++ b/src/agents/sessions/session-manager.tool-result-replay.test.ts
@@ -264,6 +264,123 @@ describe("SessionManager tool-result replay", () => {
     expect(JSON.stringify(messages)).not.toContain("discarded");
   });
 
+  it.each([
+    { blockType: "toolCall", resultField: "toolCallId" },
+    { blockType: "toolCall", resultField: "call_id" },
+    { blockType: "toolUse", resultField: "toolUseId" },
+    { blockType: "toolUse", resultField: "tool_use_id" },
+    { blockType: "functionCall", resultField: "callId" },
+    { blockType: "functionCall", resultField: "call_id" },
+  ] as const)(
+    "replays a reset-retained persisted $blockType assistant with an aliased $resultField result",
+    ({ blockType, resultField }) => {
+      const timestamp = "2026-07-01T00:00:00.000Z";
+      const timestampMs = Date.parse(timestamp);
+      const sessionManager = SessionManager.fromEntries([
+        {
+          type: "session",
+          version: 3,
+          id: "reset-tool-result-session",
+          timestamp,
+          cwd: "/tmp/reset-tool-result-replay",
+        },
+        {
+          type: "message",
+          id: "discarded",
+          parentId: null,
+          timestamp,
+          message: { role: "user", content: "discarded", timestamp: timestampMs },
+        },
+        {
+          type: "message",
+          id: "kept-user",
+          parentId: "discarded",
+          timestamp,
+          message: { role: "user", content: "kept question", timestamp: timestampMs },
+        },
+        {
+          type: "message",
+          id: "kept-assistant-tool",
+          parentId: "kept-user",
+          timestamp,
+          message: {
+            role: "assistant",
+            api: "anthropic-messages",
+            content: [{ type: blockType, id: "call-1", name: "lookup", arguments: {} }],
+            provider: "test-provider",
+            model: "test-model",
+            usage: {
+              input: 1,
+              output: 1,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 2,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: timestampMs,
+          } as unknown as AgentMessage,
+        },
+        {
+          type: "message",
+          id: "kept-tool-result",
+          parentId: "kept-assistant-tool",
+          timestamp,
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            [resultField]: "call-1",
+            toolName: "lookup",
+            content: [{ type: "text", text: "paired result" }],
+            isError: false,
+            timestamp: timestampMs,
+          } as unknown as AgentMessage,
+        },
+        {
+          type: "message",
+          id: "kept-orphan-result",
+          parentId: "kept-tool-result",
+          timestamp,
+          message: {
+            role: "toolResult",
+            toolCallId: "orphan-call",
+            toolName: "lookup",
+            content: [{ type: "text", text: "orphan result" }],
+            isError: false,
+            timestamp: timestampMs,
+          },
+        },
+        {
+          type: "reset",
+          id: "reset",
+          parentId: "kept-orphan-result",
+          timestamp,
+          reason: "new",
+          firstKeptEntryId: "kept-user",
+        },
+        {
+          type: "message",
+          id: "new-user",
+          parentId: "reset",
+          timestamp,
+          message: { role: "user", content: "new turn", timestamp: timestampMs },
+        },
+      ]);
+
+      const messages = sessionManager.buildSessionContext().messages;
+
+      expect(messages.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+        "toolResult",
+        "user",
+      ]);
+      expect(JSON.stringify(messages)).toContain("paired result");
+      expect(JSON.stringify(messages)).not.toContain("orphan result");
+      expect(JSON.stringify(messages)).not.toContain("discarded");
+    },
+  );
+
   it("normalizes string tool-result content loaded from JSONL", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");


### PR DESCRIPTION
## What Problem This Solves

When a session reset retained an assistant tool call, OpenClaw could drop its persisted tool result from model context and create a missing-result repair on the next turn. A later compaction could also lose the same result.

Fixes #116588

## Why This Change Was Made

Reset model and compaction projections now share one pairing-aware selector: user/assistant entries are retained, and tool results are retained only when matched to a preceding retained assistant tool call, including repeated IDs by occurrence. Display/history projections keep their existing user/assistant-only contract, so orphan tool results remain hidden.

The pairing rule follows the existing `repairToolUseResultPairing` invariant in `src/agents/session-transcript-repair.ts`; the selector recognizes the same supported persisted shapes — `toolCall`, `toolUse`, and `functionCall` blocks plus the accepted result-ID aliases (`toolCallId`, `toolUseId`, `tool_call_id`, `tool_use_id`, `callId`, `call_id`). The related #115912 work is a partial recovery safeguard and does not cover normal reset replay.

## User Impact

Reset sessions preserve real tool outputs across the next model turn and compaction instead of fabricating missing-result failures, including for legacy/provider-shaped persisted entries, while unrelated tool results remain excluded.

## Evidence

- Real call chain proof (production module boundary fallback): `node --import tsx proof-live.mts` exercised the public `SessionManager.fromEntries(...).buildSessionContext()` boundary, `repairToolUseResultPairing()`, and `prepareCompaction()` against the same fixed transcript fixtures on the validation base and exact head. The base dropped the canonical, `toolUse`, and `functionCall` pairs and added one repair; the head retained all three pairs, added no repair, and retained the `toolUse` pair through compaction. The orphan negative control stayed excluded.
- Alias-only result IDs were proven at the changed module boundary: the head's `selectResetKeptEntries` retained `toolUse/toolUseId`, `functionCall/call_id`, `toolCall/tool_call_id`, `toolCall/callId`, and `toolUse/tool_use_id` pairs and excluded the orphan. The base does not export the selector, so `selectorAliasCases` is head-only.

```text
$ node --import tsx proof-live.mts
entrypoint: SessionManager.fromEntries(...).buildSessionContext() -> repairToolUseResultPairing() and prepareCompaction()
dependency-boundary: fixed persisted-session entry fixture
base (f5add8197fa990890d3f96142cba1523e9c6c0df):
{"canonical":{"projectedRoles":["user","assistant","user"],"pairedResultRetained":false,"repairAdded":1},"toolUse":{"projectedRoles":["user","assistant","user"],"pairedResultRetained":false},"functionCall":{"projectedRoles":["user","assistant","user"],"pairedResultRetained":false},"compaction":{"toolUsePairedResultRetained":false,"orphanResultRetained":false},"negativeControl":{"projectedRoles":["user","assistant","user"],"orphanResultRetained":false},"selectorAliasCases":{}}
head (5bd77dd5ae8):
{"canonical":{"projectedRoles":["user","assistant","toolResult","user"],"pairedResultRetained":true,"repairAdded":0},"toolUse":{"projectedRoles":["user","assistant","toolResult","user"],"pairedResultRetained":true},"functionCall":{"projectedRoles":["user","assistant","toolResult","user"],"pairedResultRetained":true},"compaction":{"toolUsePairedResultRetained":true,"orphanResultRetained":false},"negativeControl":{"projectedRoles":["user","assistant","user"],"orphanResultRetained":false},"selectorAliasCases":{"toolUse/toolUseId":{"retained":true,"orphanExcluded":true},"functionCall/call_id":{"retained":true,"orphanExcluded":true},"toolCall/tool_call_id":{"retained":true,"orphanExcluded":true},"toolCall/callId":{"retained":true,"orphanExcluded":true},"toolUse/tool_use_id":{"retained":true,"orphanExcluded":true}}}
negative-control: orphan-only reset tail -> projectedRoles ["user","assistant","user"], orphanResultRetained false
before-fix: canonical pairedResultRetained false, repairAdded 1
after-fix: canonical pairedResultRetained true, repairAdded 0
```

- Focused validation passed:
  - `node scripts/run-vitest.mjs packages/agent-core/src/harness/session/session-context.test.ts packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts src/agents/sessions/session-manager.tool-result-replay.test.ts`
  - `node scripts/run-oxlint.mjs packages/agent-core/src/harness/session/session.ts packages/agent-core/src/harness/session/session-context.test.ts packages/agent-core/src/harness/compaction/compaction.ts packages/agent-core/src/harness/compaction/compaction.test.ts src/agents/sessions/session-manager.tool-result-replay.test.ts`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit`
  - `git diff --check`

<details>
<summary>proof-live.mts</summary>

```ts
import { repairToolUseResultPairing } from "./src/agents/session-transcript-repair.js";
import { SessionManager } from "./src/agents/sessions/session-manager.js";
import { prepareCompaction } from "./packages/agent-core/src/harness/compaction/compaction.js";

const timestamp = "2026-07-01T00:00:00.000Z";
const timestampMs = Date.parse(timestamp);
const messageEntry = (id: string, parentId: string | null, message: unknown) => ({
  type: "message",
  id,
  parentId,
  timestamp,
  message,
});
const header = {
  type: "session",
  version: 3,
  id: "reset-tool-result-proof",
  timestamp,
  cwd: "proof-workspace",
};
const usage = {
  input: 1,
  output: 1,
  cacheRead: 0,
  cacheWrite: 0,
  totalTokens: 2,
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
};
const assistantWithToolCall = (type: string) => ({
  role: "assistant",
  api: "openai-responses",
  provider: "test-provider",
  model: "test-model",
  usage,
  stopReason: "toolUse",
  content: [{ type, id: "call-1", name: "lookup", arguments: {} }],
  timestamp: timestampMs,
});
const resultWith = (fields: Record<string, unknown>, text = "paired result") => ({
  role: "toolResult",
  toolName: "lookup",
  content: [{ type: "text", text }],
  isError: false,
  timestamp: timestampMs,
  ...fields,
});
const orphanResult = resultWith({ toolCallId: "orphan-call" }, "orphan result");

const resetEntries = (assistant: unknown, result: unknown, orphan = orphanResult) => [
  header,
  messageEntry("discarded", null, { role: "user", content: "discarded" }),
  messageEntry("kept-user", "discarded", { role: "user", content: "kept question" }),
  messageEntry("kept-assistant", "kept-user", assistant),
  messageEntry("kept-result", "kept-assistant", result),
  messageEntry("kept-orphan", "kept-result", orphan),
  {
    type: "reset",
    id: "reset",
    parentId: "kept-orphan",
    timestamp,
    reason: "new",
    firstKeptEntryId: "kept-user",
  },
  messageEntry("new-user", "reset", { role: "user", content: "new turn" }),
];

const canonicalAssistant = assistantWithToolCall("toolCall");
const canonicalResult = resultWith({ toolCallId: "call-1" });
const toolUseResult = resultWith({ toolCallId: "call-1", toolUseId: "call-1" });
const functionCallResult = resultWith({ toolCallId: "call-1", call_id: "call-1" });

const canonicalProjected = SessionManager.fromEntries(
  resetEntries(canonicalAssistant, canonicalResult),
).buildSessionContext().messages;
const canonicalRepair = repairToolUseResultPairing(canonicalProjected);
const toolUseProjected = SessionManager.fromEntries(
  resetEntries(assistantWithToolCall("toolUse"), toolUseResult),
).buildSessionContext().messages;
const functionCallProjected = SessionManager.fromEntries(
  resetEntries(assistantWithToolCall("functionCall"), functionCallResult),
).buildSessionContext().messages;

const compactionEntries = [
  messageEntry("old", null, { role: "user", content: "old", timestamp: timestampMs }),
  messageEntry("kept-user", "old", {
    role: "user",
    content: "kept question",
    timestamp: timestampMs,
  }),
  messageEntry("kept-assistant", "kept-user", assistantWithToolCall("toolUse")),
  messageEntry("kept-result", "kept-assistant", toolUseResult),
  messageEntry("kept-orphan", "kept-result", orphanResult),
  messageEntry("kept-answer", "kept-orphan", {
    role: "assistant",
    api: "openai-responses",
    provider: "test-provider",
    model: "test-model",
    usage,
    stopReason: "stop",
    content: [{ type: "text", text: "kept answer" }],
    timestamp: timestampMs,
  }),
  {
    type: "reset",
    id: "compaction-reset",
    parentId: "kept-answer",
    timestamp,
    reason: "new",
    firstKeptEntryId: "kept-user",
  },
  messageEntry("post-reset-user", "compaction-reset", {
    role: "user",
    content: "post reset",
    timestamp: timestampMs,
  }),
  messageEntry("post-reset-answer", "post-reset-user", {
    role: "assistant",
    api: "openai-responses",
    provider: "test-provider",
    model: "test-model",
    usage,
    stopReason: "stop",
    content: [{ type: "text", text: "new answer" }],
    timestamp: timestampMs,
  }),
];
const compaction = prepareCompaction(compactionEntries, {
  enabled: true,
  reserveTokens: 0,
  keepRecentTokens: 1,
});
const messagesToSummarize =
  compaction.ok && compaction.value ? compaction.value.messagesToSummarize : [];

const negativeProjected = SessionManager.fromEntries(
  resetEntries(canonicalAssistant, orphanResult),
).buildSessionContext().messages;

const selectorAliasCases: Record<string, unknown> = {};
try {
  const { selectResetKeptEntries } = await import(
    "./packages/agent-core/src/harness/session/session.js"
  );
  for (const [name, assistant, result] of [
    ["toolUse/toolUseId", assistantWithToolCall("toolUse"), resultWith({ toolUseId: "call-1" })],
    [
      "functionCall/call_id",
      assistantWithToolCall("functionCall"),
      resultWith({ call_id: "call-1" }),
    ],
    [
      "toolCall/tool_call_id",
      assistantWithToolCall("toolCall"),
      resultWith({ tool_call_id: "call-1" }),
    ],
    ["toolCall/callId", assistantWithToolCall("toolCall"), resultWith({ callId: "call-1" })],
    [
      "toolUse/tool_use_id",
      assistantWithToolCall("toolUse"),
      resultWith({ tool_use_id: "call-1" }),
    ],
  ] as const) {
    const selected = selectResetKeptEntries(
      resetEntries(assistant, result) as unknown as Parameters<
        typeof selectResetKeptEntries
      >[0],
    );
    selectorAliasCases[name] = {
      retained: selected.some(
        (entry) => entry.type === "message" && entry.message.role === "toolResult",
      ),
      orphanExcluded: !selected.some(
        (entry) => entry.type === "message" && entry.message.role === "toolResult" &&
          entry.message.toolCallId === "orphan-call",
      ),
    };
  }
} catch {
  // selectResetKeptEntries does not exist on the validation base; reported as head-only.
}

console.log(
  JSON.stringify({
    entrypoint:
      "SessionManager.fromEntries(...).buildSessionContext() -> repairToolUseResultPairing() and prepareCompaction()",
    dependencyBoundary: "fixed persisted-session entry fixture",
    canonical: {
      projectedRoles: canonicalProjected.map((message) => message.role),
      pairedResultRetained: JSON.stringify(canonicalProjected).includes("paired result"),
      repairAdded: canonicalRepair.added.length,
    },
    toolUse: {
      projectedRoles: toolUseProjected.map((message) => message.role),
      pairedResultRetained: JSON.stringify(toolUseProjected).includes("paired result"),
    },
    functionCall: {
      projectedRoles: functionCallProjected.map((message) => message.role),
      pairedResultRetained: JSON.stringify(functionCallProjected).includes("paired result"),
    },
    compaction: {
      toolUsePairedResultRetained: JSON.stringify(messagesToSummarize).includes("paired result"),
      orphanResultRetained: JSON.stringify(messagesToSummarize).includes("orphan result"),
    },
    negativeControl: {
      projectedRoles: negativeProjected.map((message) => message.role),
      orphanResultRetained: JSON.stringify(negativeProjected).includes("orphan result"),
    },
    selectorAliasCases,
  }),
);
```

</details>

AI-assisted: built with Codex
