### PR TITLE
fix(sessions): zero highWaterBytes no longer deletes all session history

### DIFF
--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -139,6 +139,11 @@ function resolveHighWaterBytes(
   }
   try {
     const parsed = parseByteSize(normalized, { defaultUnit: "b" });
+    // A zero or negative high-water mark is not a usable target; fall back to
+    // the default ratio so disk budget enforcement does not delete every session.
+    if (parsed <= 0) {
+      return computeDefault();
+    }
     return Math.min(parsed, maxDiskBytes);
   } catch {
     return computeDefault();

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -987,6 +987,20 @@ describe("resolveMaintenanceConfigFromInput", () => {
     expect(maintenance.highWaterBytes).toBeNull();
   });
 
+  it("falls back to default high-water ratio when highWaterBytes is 0", () => {
+    const maintenance = resolveMaintenanceConfigFromInput({ highWaterBytes: 0 });
+
+    expect(maintenance.maxDiskBytes).toBe(10 * 1024 * 1024 * 1024);
+    expect(maintenance.highWaterBytes).toBe(Math.floor(10 * 1024 * 1024 * 1024 * 0.8));
+  });
+
+  it("falls back to default high-water ratio when highWaterBytes is the string '0'", () => {
+    const maintenance = resolveMaintenanceConfigFromInput({ highWaterBytes: "0" });
+
+    expect(maintenance.maxDiskBytes).toBe(10 * 1024 * 1024 * 1024);
+    expect(maintenance.highWaterBytes).toBe(Math.floor(10 * 1024 * 1024 * 1024 * 0.8));
+  });
+
   it("force-gates the unset model-run prune default to the cap-eviction threshold", () => {
     const defaultMaintenance = resolveMaintenanceConfigFromInput({ maxEntries: 50 });
     expect(resolveSessionEntryMaintenanceHighWater(50)).toBe(75);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where setting `session.maintenance.highWaterBytes` to `0` (or `"0"`) in `openclaw.json` causes the disk budget maintenance loop to delete **all** session history until the store is completely empty.

The bug is independent of the `maxDiskBytes` value — even with a valid `maxDiskBytes` default (10GB), `Math.min(0, 10 * 1024^3) = 0`, so the cleanup target becomes 0 bytes and every session gets evicted.

## Why This Change Was Made

`resolveHighWaterBytes` parsed the explicit zero value but passed it straight through `Math.min(parsed, maxDiskBytes)`, returning 0 as the high-water mark. The disk budget enforcement code then looped until `usage.totalBytes <= 0`, deleting everything.

The fix adds a `<= 0` guard after `parseByteSize`, falling back to `computeDefault()` — the same pattern already applied in `computeDefault()` itself and planned for `resolveMaxDiskBytes` in PR #119422. A zero high-water mark is never a usable target, so the config resolution layer should never produce one.

## User Impact

Operators who set `highWaterBytes: 0` (intentionally or accidentally) will no longer lose all session data. The value is treated as unset, and the default high-water ratio (80% of the disk budget) applies instead.

## Evidence

### Before fix

`resolveMaintenanceConfigFromInput({ highWaterBytes: 0 })` returns `highWaterBytes: 0`, which flows into the disk budget enforcement path and causes total session deletion.

### After fix

`resolveMaintenanceConfigFromInput({ highWaterBytes: 0 })` falls back to the default ratio:

```
highWaterBytes = Math.floor(10 * 1024 * 1024 * 1024 * 0.8)  // = 8,589,934,592 (~8GB)
```

### Test results

```
✓ falls back to default high-water ratio when highWaterBytes is 0
✓ falls back to default high-water ratio when highWaterBytes is the string '0'

 Test Files  55 passed (55)
      Tests  744 passed (744)  — zero regressions
```
