### PR TITLE
fix(cli): refresh running gateway auth state after models auth order set/clear

### DIFF
--- a/src/commands/models/auth-order.test.ts
+++ b/src/commands/models/auth-order.test.ts
@@ -1,0 +1,117 @@
+// Covers `models auth order set/clear`: store writes and running-gateway refresh.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  ensureAuthProfileStore: vi.fn(),
+  setAuthProfileOrder: vi.fn(),
+  loadModelsConfig: vi.fn(),
+  refreshRunningGatewayAuthState: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+  setAuthProfileOrder: mocks.setAuthProfileOrder,
+  externalCliDiscoveryForProviderAuth: () => undefined,
+  resolveAuthStatePathForDisplay: (agentDir: string) => `${agentDir}/auth-profiles.json`,
+}));
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfig: mocks.loadModelsConfig,
+}));
+
+vi.mock("./shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./shared.js")>();
+  return {
+    ...actual,
+    resolveModelsTargetAgent: (_cfg: OpenClawConfig, rawAgentId?: string) => ({
+      agentId: rawAgentId ?? "main",
+      agentDir: `/tmp/agent-${rawAgentId ?? "main"}`,
+    }),
+  };
+});
+
+vi.mock("./auth-refresh.js", () => ({
+  refreshRunningGatewayAuthState: mocks.refreshRunningGatewayAuthState,
+}));
+
+const { modelsAuthOrderClearCommand, modelsAuthOrderSetCommand } = await import("./auth-order.js");
+
+function createRuntime(): RuntimeEnv & { logs: string[] } {
+  const logs: string[] = [];
+  return {
+    logs,
+    log: (message: string) => {
+      logs.push(message);
+    },
+    error: () => {},
+  } as unknown as RuntimeEnv & { logs: string[] };
+}
+
+function storeWith(profileIds: string[], order?: string[]): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: Object.fromEntries(
+      profileIds.map((profileId) => [
+        profileId,
+        { type: "oauth" as const, provider: profileId.split(":")[0] ?? "anthropic", access: "tok" },
+      ]),
+    ),
+    ...(order ? { order: { anthropic: order } } : {}),
+  } as unknown as AuthProfileStore;
+}
+
+describe("models auth order", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadModelsConfig.mockResolvedValue({} as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(
+      storeWith(["anthropic:a", "anthropic:b"], ["anthropic:a"]),
+    );
+    mocks.setAuthProfileOrder.mockResolvedValue(
+      storeWith(["anthropic:a", "anthropic:b"], ["anthropic:b", "anthropic:a"]),
+    );
+  });
+
+  it("set writes the store order and refreshes a running gateway", async () => {
+    const runtime = createRuntime();
+    await modelsAuthOrderSetCommand(
+      { provider: "anthropic", order: ["anthropic:b", "anthropic:a"] },
+      runtime,
+    );
+
+    expect(mocks.setAuthProfileOrder).toHaveBeenCalledWith({
+      agentDir: "/tmp/agent-main",
+      provider: "anthropic",
+      order: ["anthropic:b", "anthropic:a"],
+    });
+    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledTimes(1);
+    expect(runtime.logs).toContain("Auth profile order override: anthropic:b, anthropic:a");
+  });
+
+  it("clear removes the store order and refreshes a running gateway", async () => {
+    const runtime = createRuntime();
+    await modelsAuthOrderClearCommand({ provider: "anthropic" }, runtime);
+
+    expect(mocks.setAuthProfileOrder).toHaveBeenCalledWith({
+      agentDir: "/tmp/agent-main",
+      provider: "anthropic",
+      order: null,
+    });
+    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledTimes(1);
+    expect(
+      runtime.logs.some((line) => line.includes("Auth profile order override cleared")),
+    ).toBe(true);
+  });
+
+  it("does not refresh the gateway when the store update fails", async () => {
+    mocks.setAuthProfileOrder.mockResolvedValue(null);
+
+    await expect(
+      modelsAuthOrderSetCommand({ provider: "anthropic", order: ["anthropic:a"] }, createRuntime()),
+    ).rejects.toThrow("Failed to update auth state");
+    expect(mocks.refreshRunningGatewayAuthState).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/models/auth-order.test.ts
+++ b/src/commands/models/auth-order.test.ts
@@ -101,9 +101,9 @@ describe("models auth order", () => {
       order: null,
     });
     expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledTimes(1);
-    expect(
-      runtime.logs.some((line) => line.includes("Auth profile order override cleared")),
-    ).toBe(true);
+    expect(runtime.logs.some((line) => line.includes("Auth profile order override cleared"))).toBe(
+      true,
+    );
   });
 
   it("does not refresh the gateway when the store update fails", async () => {

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -13,6 +13,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
+import { refreshRunningGatewayAuthState } from "./auth-refresh.js";
 import { loadModelsConfig } from "./load-config.js";
 import { resolveModelsTargetAgent } from "./shared.js";
 
@@ -103,6 +104,7 @@ export async function modelsAuthOrderClearCommand(
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
   runtime.log(`Auth profile order override cleared; ${describeOrderFallback(cfg, provider)}.`);
+  await refreshRunningGatewayAuthState();
 }
 
 /** Sets the provider auth profile priority order after validating each profile id. */
@@ -149,4 +151,5 @@ export async function modelsAuthOrderSetCommand(
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
   runtime.log(`Auth profile order override: ${describeOrder(updated, provider).join(", ")}`);
+  await refreshRunningGatewayAuthState();
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw models auth order set --provider anthropic ...` writes the new order successfully (`models auth order get` confirms it), but a **running Gateway keeps its stale auth-profile snapshot** and the runtime continues selecting profiles by the old order until the Gateway is restarted. Same for `models auth order clear`. Reported in #114989.

Fixes #114989

## Why This Change Was Made

- `modelsAuthOrderSetCommand` and `modelsAuthOrderClearCommand` in `src/commands/models/auth-order.ts` write the agent auth-profile store and then only `runtime.log(...)` — unlike every sibling auth write command, they never tell a running Gateway to refresh its auth state.
- The established pattern already exists: `refreshRunningGatewayAuthState()` in `src/commands/models/auth-refresh.ts` does a best-effort `callGateway({ method: "models.authStatus", params: { refresh: true }, timeoutMs: 3000 })` and is already used by `auth-logout.ts:110` and `auth.ts:491,713,773`.
- This PR adds the same single refresh call after each successful store write. Production change is 3 lines (1 import + 2 call sites).

### Addressing the `store.order` vs `cfg.auth.order` question

The reopened investigation on #114989 hypothesized that `models auth order set` writes the persisted `store.order` while the runtime alias selection reads configured `auth.order`, so the two would never meet. That mismatch does not hold for the main resolution path: `src/agents/auth-profiles/order.ts:296-307` resolves `directStoredOrder ?? directConfiguredOrder` — the persisted `store.order` is consumed **first**, ahead of `cfg.auth.order`. So once the running Gateway refreshes its auth snapshot, the CLI-written order takes effect without any config change; the stale-snapshot gap this PR closes is the reported symptom.

One genuine `cfg.auth.order`-only consumer remains at `src/agents/model-runtime-aliases.ts:237` (runtime alias selection). That path does not read `store.order` and is a separate concern; aligning it is deliberately out of scope here.

## User Impact

Operators who run `models auth order set/clear` while the Gateway is up no longer need to restart the Gateway for the new profile order to take effect. When no Gateway is running, behavior is unchanged (the refresh is best-effort and swallows connection errors, as with `auth logout`).

## Evidence

- New focused regression tests in `src/commands/models/auth-order.test.ts` (file did not exist before):
  - `set` writes the store order and calls the gateway refresh hook once.
  - `clear` removes the store order and calls the gateway refresh hook once.
  - failed store write (`setAuthProfileOrder` → `null`) throws and does **not** refresh.
- Test command: `node scripts/run-vitest.mjs src/commands/models/auth-order.test.ts src/commands/models/auth-logout.test.ts src/commands/models/auth.test.ts src/commands/models/auth-list.test.ts src/commands/models/auth.login-profiles.test.ts`
- Result: all selected files green — `auth-order.test.ts` 3/3 (new), `auth-logout.test.ts` 10/10, `auth.test.ts` + `auth-list.test.ts` + `auth.login-profiles.test.ts` passed across all 3 vitest shards, 0 failures. Run on a clean Linux box (Node v22.23.2) against this branch.
- Production diff: `src/commands/models/auth-order.ts` only, +3 lines (import + 2 refresh calls); no behavior change when the write fails or no Gateway is reachable.

- Live proof on a real running Gateway (no restart), addressing the ClawSweeper rank-up ask for production-boundary evidence. Full redacted terminal trace at the bottom of this section.
  - Environment: isolated `OPENCLAW_STATE_DIR=/root/proof-114989/state` on a clean Linux box (Node v22.23.2, OpenClaw 2026.7.2 built from this branch @ `8e734a1`). One Gateway process (PID 8360, `127.0.0.1:19531`, token auth) serves the whole trace and is never restarted. A custom provider `proofprov` points at a local mock OpenAI-compatible endpoint (`http://127.0.0.1:19532/v1`) that logs the `Authorization` header of every request, so the credential the running Gateway actually selects is directly observable at the transport boundary. Agent `main` holds two `api_key` auth profiles, `proofprov:alpha` and `proofprov:beta` (fake keys, redacted below). Each probe is `openclaw infer model run --gateway --model proofprov/proof-model --prompt ...`, i.e. the model call is executed by the Gateway process, not the CLI.
  - Baseline (no override): the Gateway selects `alpha`.
  - `models auth order set --provider proofprov proofprov:beta proofprov:alpha`: without restart, subsequent Gateway runs select `beta`. The new order propagates within ~10s of the CLI returning (the refresh drops the stale runtime snapshot; the Gateway then re-warms its prepared provider-auth state off the main thread, so a probe fired in the first ~5s can still show the previous order).
  - `models auth order clear --provider proofprov`: without restart, automatic selection resumes immediately — probes alternate `alpha`/`beta` (round-robin by `lastUsed`), confirming the running Gateway dropped the override.
  - Control (bug repro): writing the flipped order directly into the SQLite auth store (no CLI, no `models.authStatus` refresh) changes nothing in the running Gateway — it keeps selecting by its stale in-memory order for 50s+ of probing. The identical change through the fixed CLI flips selection within ~10s. This isolates the CLI's `models.authStatus {refresh:true}` call as the cause of the flip (no disk polling is involved).

Redacted trace (mock-provider log = the `Authorization` header the running Gateway sent; `sk-proof-alpha-***` = profile `proofprov:alpha`, `sk-proof-beta-***` = profile `proofprov:beta`):

```text
### environment
openclaw: OpenClaw 2026.7.2   node: v22.23.2
code: branch fix/models-auth-order-gateway-refresh @ 8e734a1c98e5d66b29f1a53ef1303edb7c316f28
OPENCLAW_STATE_DIR=/root/proof-114989/state (isolated, created for this proof only)
GATEWAY_PID=8360  (single gateway for the whole trace; never restarted)
gateway: 127.0.0.1:19531 (token auth); mock provider: http://127.0.0.1:19532/v1

### auth profiles on agent 'main' (SQLite auth store)
  proofprov:alpha  type=api_key  key=sk-proof-alpha-***
  proofprov:beta   type=api_key  key=sk-proof-beta-***
  store.order = null

### 1. baseline: no override -> automatic selection
$ openclaw models auth order get --provider proofprov
Auth profile order override: none (selecting automatically)
  -> 16:00:44Z gateway run used credential: sk-proof-alpha-***

### 2. models auth order set proofprov:beta proofprov:alpha  (gateway NOT restarted)
$ openclaw models auth order set --provider proofprov proofprov:beta proofprov:alpha
Auth profile order override: proofprov:beta, proofprov:alpha
probes immediately after set (+0s/+5s/+10s/+15s):
  -> 16:00:56Z gateway run used credential: sk-proof-beta-***
  -> 16:01:07Z gateway run used credential: sk-proof-beta-***
  -> 16:01:18Z gateway run used credential: sk-proof-beta-***
  -> 16:01:29Z gateway run used credential: sk-proof-beta-***

### 3. models auth order clear  (gateway NOT restarted)
$ openclaw models auth order clear --provider proofprov
Auth profile order override cleared; selecting automatically.
$ openclaw models auth order get --provider proofprov
Auth profile order override: none (selecting automatically)
probes after clear: automatic selection = round-robin across profiles (alternation expected)
  -> 16:01:46Z gateway run used credential: sk-proof-beta-***
  -> 16:01:54Z gateway run used credential: sk-proof-alpha-***
  -> 16:02:02Z gateway run used credential: sk-proof-beta-***
  -> 16:02:10Z gateway run used credential: sk-proof-alpha-***

### 4. control: arm order beta,alpha via CLI, then flip the order on disk DIRECTLY
###    (SQLite write, no CLI, no gateway refresh) — the reported bug, reproduced
$ openclaw models auth order set --provider proofprov proofprov:beta proofprov:alpha
Auth profile order override: proofprov:beta, proofprov:alpha
  -> 16:06:12Z gateway run used credential: sk-proof-alpha-***   (old order still warm, ~5s after set)
direct disk write: store.order.proofprov = proofprov:alpha,proofprov:beta
probes +5s/+20s/+35s/+50s after the direct write:
  -> 16:06:23Z gateway run used credential: sk-proof-beta-***
  -> 16:06:44Z gateway run used credential: sk-proof-beta-***
  -> 16:07:05Z gateway run used credential: sk-proof-beta-***
  -> 16:07:26Z gateway run used credential: sk-proof-beta-***
  => disk says alpha first, but the running gateway keeps its stale in-memory order (beta)

### 5. identical change through the fixed CLI (set -> models.authStatus {refresh:true})
$ openclaw models auth order set --provider proofprov proofprov:alpha proofprov:beta
Auth profile order override: proofprov:alpha, proofprov:beta
probes +5s/+10s/+15s after CLI set:
  -> 16:07:43Z gateway run used credential: sk-proof-beta-***   (previous order still warm)
  -> 16:07:54Z gateway run used credential: sk-proof-alpha-***
  -> 16:08:05Z gateway run used credential: sk-proof-alpha-***

GATEWAY_PID=8360  (never restarted)
```
