### PR TITLE
feat(qa): execute Telegram module flows through the live adapter

### DIFF
--- a/extensions/qa-lab/src/live-transports/live-transport-adapters.test.ts
+++ b/extensions/qa-lab/src/live-transports/live-transport-adapters.test.ts
@@ -68,7 +68,7 @@ describe("live transport adapter factories", () => {
     expect(matrixQaAdapterFactory.supportsModuleFlows).toBe(true);
     expect(slackQaAdapterFactory.supportsModuleFlows).toBe(true);
     expect(whatsappQaAdapterFactory.supportsModuleFlows).toBe(true);
-    expect(telegramQaAdapterFactory.supportsModuleFlows).toBeUndefined();
+    expect(telegramQaAdapterFactory.supportsModuleFlows).toBe(true);
   });
 
   it.each([
@@ -83,9 +83,7 @@ describe("live transport adapter factories", () => {
       const adapterOptions = { sutAccountId: `${channelId}-sut` };
       const state = createQaBusState();
       const adapter: QaTransportAdapter = createQaChannelTransport(state);
-      if (channelId !== "telegram") {
-        adapter.prepareFlow = async () => ({});
-      }
+      adapter.prepareFlow = async () => ({});
       create.mockResolvedValueOnce(adapter);
       const created = await createQaTransportAdapter(
         {

--- a/extensions/qa-lab/src/live-transports/scenario-module-parity.test.ts
+++ b/extensions/qa-lab/src/live-transports/scenario-module-parity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { readQaScenarioPack, type QaSeedScenarioWithSource } from "../scenario-catalog.js";
 import * as discordScenarioRuntime from "./discord/scenario-runtime.js";
 import * as slackScenarioRuntime from "./slack/scenario-runtime.js";
+import * as telegramScenarioRuntime from "./telegram/scenario-runtime.js";
 import * as whatsappScenarioRuntime from "./whatsapp/scenario-runtime.js";
 
 const LANES = [
@@ -107,4 +108,23 @@ describe("live transport scenario module routing", () => {
       }
     },
   );
+
+  it("routes the Telegram help flow through its typed module context", () => {
+    const scenario = readQaScenarioPack().scenarios.find(
+      (candidate) => candidate.id === "telegram-help-command",
+    );
+    expect(scenario).toBeDefined();
+    if (!scenario) {
+      throw new Error("telegram-help-command is missing from the QA catalog");
+    }
+    const call = readScenarioModuleCall(scenario, "./live-transports/telegram/scenario-runtime.js");
+
+    expect(call?.call).toBe("runTelegramHelpCommandScenario");
+    expect(call?.args?.map(readExpression)).toEqual([
+      "telegramScenarioContext",
+      "transport",
+      "config",
+    ]);
+    expect(telegramScenarioRuntime.runTelegramHelpCommandScenario).toBeTypeOf("function");
+  });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
@@ -324,6 +324,33 @@ describe("Telegram QA transport adapter", () => {
         },
       },
     });
+    const prepared = await adapter.prepareFlow?.({
+      scenarioId: "telegram-help-command",
+      scenarioTitle: "Telegram help command reply",
+      timeoutMs: 60_000,
+    } as never);
+    expect(prepared).toMatchObject({
+      telegramScenarioContext: {
+        accountId: "sut",
+        driverIdentity: { id: 1, username: "driver_bot" },
+        groupId: "-100123",
+        scenario: {
+          id: "telegram-help-command",
+          timeoutMs: 60_000,
+          title: "Telegram help command reply",
+        },
+        sutIdentity: { id: 2, username: "openclaw_qa_bot" },
+      },
+    });
+    const telegramScenarioContext = prepared?.telegramScenarioContext as {
+      createNativeCommandInput(command: string): unknown;
+    };
+    expect(telegramScenarioContext.createNativeCommandInput("help")).toMatchObject({
+      command: "help",
+      conversation: { id: "-100123", kind: "group" },
+      senderId: "1",
+      senderName: "driver_bot",
+    });
 
     await vi.waitFor(() => expect(pollResolvers).toHaveLength(1));
     await adapter.sendInbound?.({
@@ -339,11 +366,10 @@ describe("Telegram QA transport adapter", () => {
         text: "@openclaw_qa_bot reply exactly: QA-MARKER",
       }),
     );
-    await adapter.sendInbound?.({
+    await adapter.sendNativeCommand?.({
+      command: "status",
       conversation: { id: "logical-room", kind: "group" },
       senderId: "driver",
-      text: "/status",
-      nativeCommand: { name: "status" },
     });
     expect(mocks.callTelegramApi).toHaveBeenCalledWith(
       "placeholder",

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -9,6 +9,7 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
+import { createTelegramQaScenarioEnvironment } from "./scenario-environment.js";
 import {
   buildTelegramQaConfig,
   callTelegramApi,
@@ -223,6 +224,56 @@ export async function createTelegramQaTransportAdapter(
       observerState.terminalError = error instanceof Error ? error : new Error("unknown error");
     }
   });
+  const resetTransport = () => {
+    logicalConversationId = runtimeEnv.groupId;
+    logicalConversationKind = "channel";
+    nativeMessageIds.clear();
+    busMessageIds.clear();
+    observerState.pollCount = 0;
+    observerState.updateCount = 0;
+    observerState.filteredCount = 0;
+    observerState.matchedCount = 0;
+    observerState.relevantUpdateKinds.clear();
+  };
+  const sendInbound: AdapterDefinition["sendInbound"] = async (input) => {
+    heartbeat.throwIfFailed();
+    logicalConversationId = input.conversation.id;
+    logicalConversationKind = input.conversation.kind;
+    const text = renderTelegramQaInboundText(input, sutUsername);
+    const nativeReplyToId = input.replyToId ? nativeMessageIds.get(input.replyToId) : undefined;
+    const sent = await callTelegramApi<{ message_id: number }>(
+      runtimeEnv.driverToken,
+      "sendMessage",
+      {
+        chat_id: runtimeEnv.groupId,
+        text,
+        disable_notification: true,
+        ...(nativeReplyToId
+          ? {
+              reply_parameters: {
+                message_id: nativeReplyToId,
+                allow_sending_without_reply: true,
+              },
+            }
+          : {}),
+      },
+    );
+    const message = await context.messages.addInboundMessage({
+      ...input,
+      accountId,
+      senderId: String(driverIdentity.id),
+      senderName: driverIdentity.username,
+    });
+    nativeMessageIds.set(message.id, sent.message_id);
+    busMessageIds.set(sent.message_id, message.id);
+    return message;
+  };
+  const scenarioEnvironment = createTelegramQaScenarioEnvironment({
+    accountId,
+    driverIdentity,
+    groupId: runtimeEnv.groupId,
+    sutIdentity,
+  });
   return {
     id: "telegram",
     label: "Telegram live",
@@ -236,50 +287,15 @@ export async function createTelegramQaTransportAdapter(
       heartbeat.throwIfFailed();
     },
     describeTransportState: () => describeTelegramQaObserverState(observerState),
-    async sendInbound(input) {
-      heartbeat.throwIfFailed();
-      logicalConversationId = input.conversation.id;
-      logicalConversationKind = input.conversation.kind;
-      const text = renderTelegramQaInboundText(input, sutUsername);
-      const nativeReplyToId = input.replyToId ? nativeMessageIds.get(input.replyToId) : undefined;
-      const sent = await callTelegramApi<{ message_id: number }>(
-        runtimeEnv.driverToken,
-        "sendMessage",
-        {
-          chat_id: runtimeEnv.groupId,
-          text,
-          disable_notification: true,
-          ...(nativeReplyToId
-            ? {
-                reply_parameters: {
-                  message_id: nativeReplyToId,
-                  allow_sending_without_reply: true,
-                },
-              }
-            : {}),
-        },
-      );
-      const message = await context.messages.addInboundMessage({
+    sendInbound,
+    sendNativeCommand: async ({ command, ...input }) => {
+      await sendInbound({
         ...input,
-        accountId,
-        senderId: String(driverIdentity.id),
-        senderName: driverIdentity.username,
+        text: `/${command}`,
+        nativeCommand: { name: command.split(/\s+/u, 1)[0] ?? command },
       });
-      nativeMessageIds.set(message.id, sent.message_id);
-      busMessageIds.set(sent.message_id, message.id);
-      return message;
     },
-    resetTransport: () => {
-      logicalConversationId = runtimeEnv.groupId;
-      logicalConversationKind = "channel";
-      nativeMessageIds.clear();
-      busMessageIds.clear();
-      observerState.pollCount = 0;
-      observerState.updateCount = 0;
-      observerState.filteredCount = 0;
-      observerState.matchedCount = 0;
-      observerState.relevantUpdateKinds.clear();
-    },
+    resetTransport,
     createGatewayConfig: () =>
       buildTelegramQaConfig({} as OpenClawConfig, {
         groupId: runtimeEnv.groupId,
@@ -300,6 +316,7 @@ export async function createTelegramQaTransportAdapter(
       replyChannel: "telegram",
       replyTo: runtimeEnv.groupId,
     }),
+    prepareFlow: scenarioEnvironment.prepareFlow,
     async handleAction() {
       throw new Error("Telegram live QA adapter does not implement transport actions");
     },

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -173,6 +173,7 @@ export async function runQaTelegramSuite(opts: TelegramQaSuiteOptions) {
     adapterFactories: [
       {
         id: "telegram",
+        supportsModuleFlows: true,
         matches: ({ channelId, driver }) => driver === "live" && channelId === "telegram",
         create: createTelegramQaTransportAdapter,
       },

--- a/extensions/qa-lab/src/live-transports/telegram/cli.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.ts
@@ -19,6 +19,7 @@ export const telegramQaCliRegistration: LiveTransportQaCliRegistration =
     commandName: "telegram",
     adapterFactory: createLiveTransportQaAdapterFactory({
       id: "telegram",
+      supportsModuleFlows: true,
       async create(context) {
         return (await loadTelegramQaAdapterRuntime()).createTelegramQaTransportAdapter(context);
       },

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-environment.ts
@@ -1,0 +1,44 @@
+import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
+import type { QaTransportNativeCommandInput } from "../../qa-transport.js";
+import type { TelegramBotIdentity } from "./telegram-api.runtime.js";
+
+type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
+type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
+type FlowPreparationInput = Parameters<NonNullable<AdapterDefinition["prepareFlow"]>>[0];
+
+export type TelegramQaScenarioEnvironment = {
+  accountId: string;
+  createNativeCommandInput: (command: string) => QaTransportNativeCommandInput;
+  driverIdentity: TelegramBotIdentity;
+  groupId: string;
+  scenario: { id: string; timeoutMs: number; title: string };
+  sutIdentity: TelegramBotIdentity;
+};
+
+export function createTelegramQaScenarioEnvironment(params: {
+  accountId: string;
+  driverIdentity: TelegramBotIdentity;
+  groupId: string;
+  sutIdentity: TelegramBotIdentity;
+}) {
+  const prepareFlow = async (input: FlowPreparationInput) => ({
+    telegramScenarioContext: {
+      accountId: params.accountId,
+      createNativeCommandInput: (command: string) => ({
+        command,
+        conversation: { id: params.groupId, kind: "group" },
+        senderId: String(params.driverIdentity.id),
+        senderName: params.driverIdentity.username,
+      }),
+      driverIdentity: params.driverIdentity,
+      groupId: params.groupId,
+      scenario: {
+        id: input.scenarioId,
+        timeoutMs: input.timeoutMs,
+        title: input.scenarioTitle,
+      },
+      sutIdentity: params.sutIdentity,
+    } satisfies TelegramQaScenarioEnvironment,
+  });
+  return { prepareFlow };
+}

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "../../bus-state.js";
+import type { QaTransportAdapter } from "../../qa-transport.js";
+import type { TelegramQaScenarioEnvironment } from "./scenario-environment.js";
+import { runTelegramHelpCommandScenario } from "./scenario-runtime.js";
+
+function createContext(): TelegramQaScenarioEnvironment {
+  return {
+    accountId: "sut",
+    createNativeCommandInput: (command) => ({
+      command,
+      conversation: { id: "-100123", kind: "group" },
+      senderId: "1",
+      senderName: "driver_bot",
+    }),
+    driverIdentity: {
+      id: 1,
+      is_bot: true,
+      first_name: "Driver",
+      username: "driver_bot",
+    },
+    groupId: "-100123",
+    scenario: { id: "telegram-help-command", timeoutMs: 60_000, title: "Telegram help" },
+    sutIdentity: {
+      id: 2,
+      is_bot: true,
+      first_name: "SUT",
+      username: "openclaw_qa_bot",
+    },
+  };
+}
+
+describe("Telegram module scenarios", () => {
+  it("executes the native command through the active transport and verifies its reply", async () => {
+    const state = createQaBusState();
+    const reset = vi.fn(async () => state.reset());
+    const sendNativeCommand = vi.fn(async () => {
+      state.addOutboundMessage({
+        accountId: "sut",
+        senderId: "2",
+        text: "Use /new to start fresh; use /commands for full list.",
+        to: "group:-100123",
+      });
+    });
+    const transport = {
+      label: "Telegram live",
+      reset,
+      sendNativeCommand,
+      state,
+      waitForOutbound: async () => state.getSnapshot().messages.at(-1),
+    } as unknown as QaTransportAdapter;
+
+    await expect(
+      runTelegramHelpCommandScenario(createContext(), transport, {
+        command: "help",
+        expectedAny: ["/new", "/commands for full list"],
+      }),
+    ).resolves.toContain("/commands for full list");
+    expect(reset).toHaveBeenCalledOnce();
+    expect(sendNativeCommand).toHaveBeenCalledWith({
+      command: "help",
+      conversation: { id: "-100123", kind: "group" },
+      senderId: "1",
+      senderName: "driver_bot",
+    });
+  });
+
+  it("fails honestly when the active transport has no native command operation", async () => {
+    const state = createQaBusState();
+    const transport = {
+      label: "unsupported",
+      reset: vi.fn(),
+      state,
+      waitForOutbound: vi.fn(),
+    } as unknown as QaTransportAdapter;
+
+    await expect(
+      runTelegramHelpCommandScenario(createContext(), transport, {
+        command: "help",
+        expectedAny: ["/new"],
+      }),
+    ).rejects.toThrow("does not implement native Telegram commands");
+  });
+});

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.test.ts
@@ -55,7 +55,7 @@ describe("Telegram module scenarios", () => {
         command: "help",
         expectedAny: ["/new", "/commands for full list"],
       }),
-    ).resolves.toContain("/commands for full list");
+    ).resolves.toEqual({ details: "Use /new to start fresh; use /commands for full list." });
     expect(reset).toHaveBeenCalledOnce();
     expect(sendNativeCommand).toHaveBeenCalledWith({
       command: "help",

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.ts
@@ -44,5 +44,5 @@ export async function runTelegramHelpCommandScenario(
   if (!config.expectedAny.every((needle) => reply.text.includes(needle))) {
     throw new Error(`Telegram help reply missing expected text: ${reply.text}`);
   }
-  return reply.text;
+  return { details: reply.text };
 }

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-runtime.ts
@@ -1,0 +1,48 @@
+import type { QaTransportAdapter } from "../../qa-transport.js";
+import type { TelegramQaScenarioEnvironment } from "./scenario-environment.js";
+
+type TelegramHelpCommandScenarioConfig = {
+  command: string;
+  expectedAny: string[];
+};
+
+function readTelegramHelpCommandScenarioConfig(
+  value: Record<string, unknown>,
+): TelegramHelpCommandScenarioConfig {
+  const command = typeof value.command === "string" ? value.command.trim() : "";
+  const expectedAny = Array.isArray(value.expectedAny)
+    ? value.expectedAny.filter(
+        (entry): entry is string => typeof entry === "string" && entry.length > 0,
+      )
+    : [];
+  if (!command || expectedAny.length === 0) {
+    throw new Error("Telegram help scenario requires a command and expected response markers");
+  }
+  return { command, expectedAny };
+}
+
+export async function runTelegramHelpCommandScenario(
+  context: TelegramQaScenarioEnvironment,
+  transport: QaTransportAdapter,
+  rawConfig: Record<string, unknown>,
+) {
+  const config = readTelegramHelpCommandScenarioConfig(rawConfig);
+  if (!transport.sendNativeCommand) {
+    throw new Error(`${transport.label} does not implement native Telegram commands`);
+  }
+  await transport.reset();
+  const sinceIndex = transport.state
+    .getSnapshot()
+    .messages.filter((message) => message.direction === "outbound").length;
+  await transport.sendNativeCommand(context.createNativeCommandInput(config.command));
+  const reply = await transport.waitForOutbound({
+    conversation: { id: context.groupId, kind: "group" },
+    sinceIndex,
+    textIncludes: config.expectedAny[0],
+    timeoutMs: context.scenario.timeoutMs,
+  });
+  if (!config.expectedAny.every((needle) => reply.text.includes(needle))) {
+    throw new Error(`Telegram help reply missing expected text: ${reply.text}`);
+  }
+  return reply.text;
+}

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts
@@ -12,7 +12,11 @@ export function resolveTelegramQaScenarioIds(params: {
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }): string[] {
-  return resolveLiveTransportQaScenarioIds({ channelId: TELEGRAM_QA_CHANNEL_ID, ...params });
+  return resolveLiveTransportQaScenarioIds({
+    channelId: TELEGRAM_QA_CHANNEL_ID,
+    supportsModuleFlows: true,
+    ...params,
+  });
 }
 
 export function listTelegramQaScenarios(params: {
@@ -21,6 +25,7 @@ export function listTelegramQaScenarios(params: {
 }) {
   return listLiveTransportQaScenarios({
     channelId: TELEGRAM_QA_CHANNEL_ID,
+    supportsModuleFlows: true,
     ...params,
   });
 }

--- a/extensions/qa-lab/src/profile-selection.test.ts
+++ b/extensions/qa-lab/src/profile-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveLiveTransportQaScenarioIds } from "./live-transports/shared/scenario-selection.js";
+import { resolveTelegramQaScenarioIds } from "./live-transports/telegram/scenario-selection.js";
 import {
   resolveQaProfileScenarios,
   resolveQaRunProfileExecutionSelection,
@@ -53,12 +53,10 @@ describe("taxonomy profile scenario selection", () => {
   });
 
   it("derives channel defaults from catalog metadata and lane constraints", () => {
-    const liveTelegram = resolveLiveTransportQaScenarioIds({
-      channelId: "telegram",
+    const liveTelegram = resolveTelegramQaScenarioIds({
       providerMode: "live-frontier",
     });
-    const mockTelegram = resolveLiveTransportQaScenarioIds({
-      channelId: "telegram",
+    const mockTelegram = resolveTelegramQaScenarioIds({
       providerMode: "mock-openai",
     });
 

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -27,7 +27,7 @@ describe("qa scenario catalog channel contracts", () => {
       (scenario) => scenario.execution.flowKind === "module",
     );
 
-    expect(moduleFlows).toHaveLength(143);
+    expect(moduleFlows).toHaveLength(144);
     expect(moduleFlows.every((scenario) => scenario.execution.flow)).toBe(true);
   });
 

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -79,6 +79,8 @@ const qaFlowImportLoaders: Record<string, QaFlowImportLoader> = {
     import("./live-transports/discord/scenario-runtime.js"),
   "./live-transports/slack/scenario-runtime.js": () =>
     import("./live-transports/slack/scenario-runtime.js"),
+  "./live-transports/telegram/scenario-runtime.js": () =>
+    import("./live-transports/telegram/scenario-runtime.js"),
   "./live-transports/whatsapp/scenario-runtime.js": () =>
     import("./live-transports/whatsapp/scenario-runtime.js"),
   "./tool-search-gateway.fixture.js": () => import("./tool-search-gateway.fixture.js"),

--- a/qa/scenarios/channels/telegram-help-command.yaml
+++ b/qa/scenarios/channels/telegram-help-command.yaml
@@ -25,30 +25,9 @@ scenario:
         - /commands for full list
 
 flow:
-  steps:
-    - name: help returns the concise command guide
-      actions:
-        - resetTransport: true
-        - set: startIndex
-          value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
-        - sendInbound:
-            conversation: { id: telegram-command-room, kind: channel }
-            senderId: qa-command-operator
-            senderName: QA Command Operator
-            text:
-              expr: "`/${config.command}`"
-            nativeCommand:
-              name:
-                expr: config.command
-        - waitForOutbound:
-            conversation: { id: telegram-command-room, kind: channel }
-            sinceIndex: { ref: startIndex }
-            textIncludes: { expr: "config.expectedAny[0]" }
-            timeoutMs: 60000
-          saveAs: reply
-        - assert:
-            expr: "config.expectedAny.every((needle) => reply.text.includes(needle))"
-            message:
-              expr: "`help reply missing expected text: ${reply.text}`"
-      detailsExpr: reply.text
+  module: ./live-transports/telegram/scenario-runtime.js
+  call: runTelegramHelpCommandScenario
+  args:
+    - { expr: telegramScenarioContext }
+    - { expr: transport }
+    - { expr: config }


### PR DESCRIPTION
Related: #119934

## What Problem This Solves

Telegram live QA could execute inline flows, but module-authored scenarios were rejected before execution because the adapter did not prepare a real Telegram scenario context. That prevented channel-specific modules from using the credential-leased Bot API ingress and observation path.

## Why This Change Was Made

The Telegram adapter now prepares a typed scenario context from its leased driver/SUT identities and group, and exposes native command execution through the same real ingress used by ordinary Telegram QA messages. The existing `telegram-help-command` taxonomy scenario is preserved but now runs as a module and validates the observed Telegram reply through the active adapter.

Missing native-command support fails explicitly; there is no empty context, no-op, fake client, provider/model special case, or coverage bypass.

The conflict repair preserved current-main Telegram observer diagnostics, retry backoff, cancellation, and terminal health reporting while factoring native sends and resets through one canonical adapter path.

This is stack layer A of four:

1. **This PR:** Telegram module execution (base: `main`)
2. Crabline module execution for every registered transport, including Matrix (base: this PR)
3. QA Channel module execution (base: layer 2)
4. Remove the unreleased `supportsModuleFlows` distinction and stale planning provenance (base: layer 3)

## User Impact

QA operators can select and execute Telegram module-authored scenarios through the live Telegram runner. Channel constraints, credential leasing, provider/model selection, mock/real separation, taxonomy IDs, and realized-driver evidence remain unchanged.

## Evidence

- Repaired head: `9fc8fbdfd8bd8450970e5322969090dba5968668`, rebased onto reviewed `main` `e31a6e29fff724e07e108d7c5cef3ed104dc2354`. GitHub reports the PR mergeable against the live base.
- Exact-final-base focused proof: [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31509558150) — 6 files, 38 tests passed.
- Repository changed gate: [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31506957748) — `tsgo`, format, lint, import cycles, API/boundary, and guard checks passed.
- Packaged build: [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31508837794) — `pnpm build` passed, including runtime postbuild and all 152 public plugin-SDK subpaths.
- The final disjoint rebase preserved stable patch-id `83130e26127b362c1be3cf285ce10122df916fdb`; intervening main commits touched none of the 14 Layer A paths.
- Fresh exact-final-base Codex autoreview: clean, no accepted/actionable findings, patch correct at 0.99.
- ClawSweeper's two source-backed findings remain applied: the module returns structured reply evidence, and profile selection uses Telegram's capability-aware resolver.
- Real Telegram `telegram-help-command` module execution: [Mantis/Crabbox proof](https://github.com/openclaw/openclaw/pull/119947#issuecomment-5205226177) passed the same stable Layer A patch before history refresh, with a redacted desktop transcript, screenshot, GIF/MP4, and raw QA artifacts ([workflow](https://github.com/openclaw/openclaw/actions/runs/31109426921)).
