### PR TITLE
fix(release): avoid ENOBUFS during JSON preparation

### DIFF
--- a/scripts/release-prepare.ts
+++ b/scripts/release-prepare.ts
@@ -281,20 +281,11 @@ export function runReleasePrepareStep(
   progressStream.write(`\n[release-prepare] ${step.name}\n`);
   const result = spawnSync(step.command, step.args, {
     cwd,
-    encoding: json ? "utf8" : undefined,
     env: process.env,
-    stdio: json ? ["ignore", "pipe", "pipe"] : "inherit",
+    stdio: json ? ["ignore", process.stderr.fd, process.stderr.fd] : "inherit",
   });
   if (result.error) {
     throw result.error;
-  }
-  if (json) {
-    if (typeof result.stdout === "string" && result.stdout) {
-      process.stderr.write(result.stdout);
-    }
-    if (typeof result.stderr === "string" && result.stderr) {
-      process.stderr.write(result.stderr);
-    }
   }
   return result.status ?? 1;
 }

--- a/test/scripts/release-prepare.test.ts
+++ b/test/scripts/release-prepare.test.ts
@@ -1,16 +1,15 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 // Release prepare tests cover shadow planning, cutover commands, and candidate manifests.
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   buildReleasePreparationManifest,
   createReleasePrepareSteps,
   parseReleasePrepareArgs,
   readWorktreeState,
-  runReleasePrepareStep,
   runReleasePrepareSteps,
 } from "../../scripts/release-prepare.ts";
 
@@ -125,41 +124,41 @@ describe("release preparation plan", () => {
     expect(results.map((result) => result.status)).toEqual(["failed", "skipped"]);
   });
 
-  it("keeps JSON mode child output off stdout", () => {
-    const stdout: string[] = [];
-    const stderr: string[] = [];
-    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
-      stdout.push(String(chunk));
-      return true;
-    });
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
-      stderr.push(String(chunk));
-      return true;
-    });
-    try {
+  it("streams large JSON-mode child output to stderr without buffering", () => {
+    const childScript = [
+      'const { writeSync } = require("node:fs");',
+      'writeSync(1, "child stdout begin\\n" + "x".repeat(2 * 1024 * 1024) + "\\nchild stdout end\\n");',
+      'writeSync(2, "child stderr sentinel\\n");',
+      "process.exit(23);",
+    ].join("");
+    const harness = `
+      import { runReleasePrepareStep } from ${JSON.stringify(new URL("../../scripts/release-prepare.ts", import.meta.url).href)};
       const status = runReleasePrepareStep(
-        {
-          args: [
-            "-e",
-            'process.stdout.write("child stdout\\n"); process.stderr.write("child stderr\\n");',
-          ],
-          command: process.execPath,
-          id: "release-version",
-          name: "JSON child",
-        },
+        { args: ["-e", ${JSON.stringify(childScript)}], command: process.execPath, id: "release-version", name: "JSON child" },
         process.cwd(),
         { json: true },
       );
+      process.exitCode = status;
+    `;
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", harness],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        maxBuffer: 4 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
 
-      expect(status).toBe(0);
-      expect(stdout.join("")).toBe("");
-      expect(stderr.join("")).toContain("[release-prepare] JSON child");
-      expect(stderr.join("")).toContain("child stdout");
-      expect(stderr.join("")).toContain("child stderr");
-    } finally {
-      stdoutSpy.mockRestore();
-      stderrSpy.mockRestore();
-    }
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(23);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("[release-prepare] JSON child");
+    expect(result.stderr).toContain("child stdout begin");
+    expect(result.stderr).toContain("child stdout end");
+    expect(result.stderr).toContain("child stderr sentinel");
+    expect(Buffer.byteLength(result.stderr)).toBeGreaterThan(2 * 1024 * 1024);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running release preparation with `--json` could hit `spawnSync ENOBUFS` when a version-owned child command emitted more than Node's default child-process buffer.

## Why This Change Was Made

JSON-mode child stdout and stderr now stream directly to the parent stderr descriptor, preserving stdout for the final machine-readable manifest without imposing another output ceiling. Non-JSON inheritance, child exit status, and spawn-error behavior are unchanged.

## User Impact

Release preparation can process large generated-metadata output without failing or contaminating its JSON stdout.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-prepare.test.ts` (8 tests passed)
- Regression covers 2 MiB of child stdout, child stderr diagnostics, exit status 23, and empty parent stdout
- `git diff --check`
- Exact-head autoreview at `22d828280fd4ee2ee6f995b8956a7557135ad083`: clean, no actionable findings
- First Testbox `tbx_01kzbjz66yse8pxk9vsr9bk9mj` caught an unused test import during root-test typechecking; that import was removed before the current head
- Exact-head Testbox `tbx_01kzbka2xyqmw1f49qmbjfb7ck` timed out while syncing and did not execute the changed lanes: https://github.com/openclaw/openclaw/actions/runs/31104910938
- Trusted-source local fallback passed conflict, attribution, dependency, formatting, patch, temp-file, and script-declaration checks; it stopped in script typechecking on unrelated shared-install errors in untouched files
- Exact-head hosted CI passed with a clean install, including build, lint, production/test types, and all Node test shards: https://github.com/openclaw/openclaw/actions/runs/31105277948
- Exact-head ClawSweeper found no blocking patch defect: https://github.com/openclaw/clawsweeper/actions/runs/31104586410
- ClawSweeper's generic refresh-against-main move is intentionally skipped: this release fix remains on the frozen `cd009e72f0bc336a6c454c28611fd7fc50394652` cut by release-owner direction; the PR is mergeable, exact-head CI is green, and there is no code conflict

AI-assisted: yes. The implementation and regression were reviewed against the release failure and repository subprocess contracts.
