### PR TITLE
test(docker): shorten Unix socket fixture paths

### DIFF
--- a/src/docker-setup.e2e.test-support.ts
+++ b/src/docker-setup.e2e.test-support.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:net";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "./infra/tmp-openclaw-dir.js";
 import { createSuiteTempRootTracker } from "./test-helpers/temp-dir.js";
 
 export const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
@@ -15,7 +16,10 @@ export type DockerSetupSandbox = {
   binDir: string;
 };
 
-const sandboxRootTracker = createSuiteTempRootTracker({ prefix: "openclaw-docker-setup-" });
+const sandboxRootTracker = createSuiteTempRootTracker({
+  prefix: "openclaw-docker-setup-",
+  parentDir: resolvePreferredOpenClawTmpDir(),
+});
 
 export async function setupDockerSetupSandboxRoot(): Promise<void> {
   await sandboxRootTracker.setup();


### PR DESCRIPTION
Closes #119944

AI-assisted: yes

## What Problem This Solves

Fixes three deterministic macOS failures in the Docker setup E2E suite. The fixture created Unix-domain sockets below a suite root under `os.tmpdir()`; macOS canonicalized that root through `/private/var/folders/...`, producing a 107-character socket path that cannot fit Darwin's `sockaddr_un.sun_path[104]` field.

The failures occurred before Docker setup assertions ran, so normal macOS validation reported 38/41 even though the setup behavior itself was correct.

## Why This Change Was Made

The Docker setup test support now uses the suite tracker's existing `parentDir` seam with `resolvePreferredOpenClawTmpDir()`. That shared owner provides a short, secure OpenClaw temp root on POSIX and the normal scoped fallback on other platforms.

The test still owns one stable suite root and isolated child directory; only the parent location changes. Production Docker setup, config, socket handling, and runtime temp policy are unchanged.

Production LOC: +0/-0. Test support: +5/-1.

## Evidence

Before on macOS current main `b0c368ae34d845ab2ef6a6c6adf160e1edf49442`:

- Default environment: 38/41; three socket-backed cases failed with `listen EINVAL`.
- Example socket address length: 107 characters.
- Installed macOS SDK `usr/include/sys/un.h`: `sun_path[104]`.
- Diagnostic control with `TMPDIR=/tmp`: 41/41.

After:

- Default macOS environment: 41/41; no `TMPDIR` override.
- macOS stress: 20/20 fresh processes passed, totaling 820 assertions.
- Exact rebased head `f63a584124cc8f` on Linux Testbox `tbx_01kzbjfj1ayecar3xq2wh07d40`, [run 31103789509](https://github.com/openclaw/openclaw/actions/runs/31103789509): 41/41 plus complete `pnpm check:changed`, 0 warnings/errors.
- AutoReview on exact rebased head: clean, no accepted/actionable findings, correctness 0.99.
- Public model identifier gate: PASS; the exact diff contains no model identifiers.

## User Impact

Maintainers can run the Docker setup E2E suite on macOS without a global `TMPDIR` workaround or false socket failures. No production behavior changes.

## Docs and Changelog

Not applicable; this is test-support isolation only.
