### PR TITLE
fix(qa): restore Matrix provider-selection fixture

### DIFF
--- a/extensions/qa-lab/src/suite-provider-selection.test.ts
+++ b/extensions/qa-lab/src/suite-provider-selection.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
 import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
 import { runQaSuite } from "./suite-launch.runtime.js";
 import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
@@ -76,8 +77,18 @@ describe("qa suite provider selection", () => {
       scenarioId: "matrix-room-block-streaming",
       channelDriver: "live" as const,
       channelId: "matrix",
+      adapterFactories: [
+        {
+          id: "matrix",
+          supportsModuleFlows: true,
+          matches: ({ driver, channelId }) => driver === "live" && channelId === "matrix",
+          create: async () => {
+            throw new Error("Matrix adapter creation must remain unreachable");
+          },
+        } satisfies QaTransportAdapterFactory,
+      ],
     },
-    { scenarioId: "goal-context-next-turn" },
+    { scenarioId: "goal-context-next-turn", adapterFactories: undefined },
   ])("adopts the provider requirement for directly selected $scenarioId", async (selection) => {
     const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-provider-lane-"));
     const startLab = vi.fn(async () => {
@@ -92,6 +103,7 @@ describe("qa suite provider selection", () => {
           ...("channelDriver" in selection
             ? { channelDriver: selection.channelDriver, channelId: selection.channelId }
             : {}),
+          adapterFactories: selection.adapterFactories,
           startLab,
         }),
       ).rejects.toThrow("selected provider lane reached lab startup");


### PR DESCRIPTION
Related: #119491
Related: #118069
Related: #118005
Related: #119934
Related: #119908

## What Problem This Solves

Resolves a problem where the QA Lab provider-selection test fails on current `main` for the Matrix module-backed scenario after module-flow eligibility became implementation-owned in #118069.

## Why This Change Was Made

The stale test fixture now supplies the minimal Matrix adapter factory contract used by production planning: a matching live Matrix factory with `supportsModuleFlows: true`. Its `create` method throws if reached, preserving the test's real boundary that provider selection must reach the injected lab startup without constructing a transport.

This is intentionally test-only. Production Matrix registration already declares the same capability and production behavior is correct, so no runtime, configuration, documentation, or changelog change is warranted.

## User Impact

No user-visible product behavior changes. QA maintainers regain a green provider-selection regression test, and #119908 can resume its separate exact-head scenario proof after incorporating this landed fixture.

## Evidence

- Current live `main` (`913b53ad808772be8c3a8497f7320d93e928b4db`): focused test reproduces 1 failure / 7 passes. The Matrix row is rejected with `module flow unsupported by implementation=live:matrix` before lab startup.
- Candidate `4f668b956ba8ffef95512af56bb93e034f56cc6e`: focused test passes 8/8.
- `git diff --check origin/main...HEAD`: passed.
- `node_modules/.bin/oxfmt --check extensions/qa-lab/src/suite-provider-selection.test.ts`: passed.
- Autoreview: clean, no accepted/actionable findings; correctness confidence 0.99.
- LOC: production +0/-0; tests +13/-1.
- Overlap: #119491 introduced the provider-selection fixture; #118069 and #118005 established the implementation-owned module-flow contract; #119934 proposes future universal module-flow support but does not remove the current contract yet; #119908 is separate provider-metadata work and is not fixed by this PR.

Punchcard-Session: cobalt-valley-meadow-mg
