### PR TITLE
feat(admin-http-rpc): allowlist deterministic send method

### DIFF
--- a/docs/plugins/admin-http-rpc.md
+++ b/docs/plugins/admin-http-rpc.md
@@ -108,6 +108,7 @@ Treat this plugin as a full Gateway operator surface.
 - Trusted identity-bearing HTTP modes honor `x-openclaw-scopes` when present.
 - `gateway.auth.mode="none"` means this route is unauthenticated if the plugin is enabled. Use that only behind a private ingress you fully trust.
 - Requests dispatch through the same Gateway method handlers and scope checks as WebSocket RPC after the plugin route auth passes.
+- The `send` method can post to any channel/target the Gateway's configured accounts can reach. Treat it the same as any other `operator.write` capability on this surface — anyone who can reach this route can send messages as the bot.
 - Keep this route on loopback, tailnet, or a private trusted ingress. Do not expose it directly to the public internet.
 - Plugin manifest contracts are not a sandbox. They prevent accidental use of reserved SDK helpers; trusted plugins still run in the Gateway process.
 
@@ -171,6 +172,8 @@ HTTP status follows the Gateway error when possible. For example, `INVALID_REQUE
 - gateway: `health`, `status`, `logs.tail`, `usage.status`, `usage.cost`, `gateway.restart.request`
 - config: `config.get`, `config.schema`, `config.schema.lookup`, `config.set`, `config.patch`, `config.apply`
 - channels: `channels.status`, `channels.start`, `channels.stop`, `channels.logout`
+- messaging: `send`
+  Deterministic outbound delivery — `{to, message, channel}` posted directly through the same non-agent-turn path the Gateway WebSocket RPC client uses. Does not open or use an agent session.
 - web: `web.login.start`, `web.login.wait`
 - models: `models.list`, `models.authStatus`
 - agents: `agents.list`, `agents.create`, `agents.update`, `agents.delete`

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -133,6 +133,37 @@ describe("admin-http-rpc plugin handler", () => {
     },
   );
 
+  it("allows the deterministic send method through the authenticated plugin request scope", async () => {
+    dispatchGatewayMethod.mockResolvedValueOnce({
+      ok: true,
+      payload: { runId: "abc", messageId: "123", channel: "discord" },
+    });
+
+    const result = await invoke({
+      id: "send-1",
+      method: "send",
+      params: {
+        to: "channel:1534761366391492679",
+        message: "post-mortem card text",
+        channel: "discord",
+        idempotencyKey: "pm-38",
+      },
+    });
+
+    expect(dispatchGatewayMethod).toHaveBeenCalledWith("send", {
+      to: "channel:1534761366391492679",
+      message: "post-mortem card text",
+      channel: "discord",
+      idempotencyKey: "pm-38",
+    });
+    expect(result.captured.statusCode).toBe(200);
+    expect(result.json).toEqual({
+      id: "send-1",
+      ok: true,
+      payload: { runId: "abc", messageId: "123", channel: "discord" },
+    });
+  });
+
   it("rejects methods outside the admin HTTP RPC allowlist", async () => {
     const result = await invoke({ id: "bad", method: "sessions.send" });
 

--- a/extensions/admin-http-rpc/src/methods.ts
+++ b/extensions/admin-http-rpc/src/methods.ts
@@ -21,6 +21,12 @@ const ADMIN_HTTP_RPC_ALLOWED_METHOD_GROUPS = {
     "config.apply",
   ],
   channels: ["channels.status", "channels.start", "channels.stop", "channels.logout"],
+  // `send` is the same deterministic, non-agent-turn outbound delivery path the
+  // Gateway WebSocket RPC client uses (src/gateway/server-methods/send.ts) — a
+  // literal {to, message, channel} send, not an LLM-mediated one. Exposing it
+  // here lets trusted host automation post to a channel by id without opening
+  // an agent session for it.
+  messaging: ["send"],
   web: ["web.login.start", "web.login.wait"],
   models: ["models.list", "models.authStatus"],
   agents: ["agents.list", "agents.create", "agents.update", "agents.delete"],


### PR DESCRIPTION
## What Problem This Solves

There is currently no deterministic way for an external automation (a cron job, a script, another service) to have OpenClaw post an exact, pre-composed message — including a file attachment — to a channel. The only existing path is routing the request through an LLM agent turn (e.g. a scheduled prompt), which is non-deterministic and unsuitable when the caller needs to post exact numbers/content verbatim (for example, a generated report or chart with specific figures).

## Why This Change Was Made

The gateway's `send` method already exists (`src/gateway/server-methods/send.ts`) and is used internally for operator/tool-originated messages, but it was not in `admin-http-rpc`'s method allowlist, so external callers using the admin HTTP RPC surface couldn't reach it. This change adds `send` to that allowlist under a new `messaging` group. No new gateway capability is introduced — this only exposes an existing, already-scoped (`operator.write`) method through the existing admin HTTP RPC surface, which itself stays opt-in (`admin-http-rpc.enabled`) and requires the gateway operator's bearer token.

## User Impact

Operators who enable `admin-http-rpc` can now have external automations call `send` over HTTP to post an exact message (with an optional attachment) to a channel, without needing an LLM-mediated agent turn in the loop. No impact for anyone who doesn't enable the plugin (default: disabled).

## Evidence

- Added a handler test covering the `send` method reaching the gateway via the admin HTTP RPC bridge, following the existing `web.login.start` test pattern:
  ```
  node scripts/run-vitest.mjs extensions/admin-http-rpc/src/handler.test.ts
  Test Files  1 passed (1)
       Tests  9 passed (9)
  ```
- `docs/plugins/admin-http-rpc.md` updated: `send` added to the allowed-methods list, plus a security-model callout noting it inherits the existing full-operator-access model for this admin surface (same as every other allowlisted method).
- Diff is narrow and additive: `methods.ts` (+6), `handler.test.ts` (+31), docs (+3) — no changes to the underlying `send` method itself, its scope requirements, or any other gateway behavior.
