### PR TITLE
fix(qa): make profile failure evidence durable

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -106,10 +106,7 @@ import { QaSuiteInfraError } from "./errors.js";
 import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
 import { runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
-import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
 import type { QaProviderModeInput } from "./run-config.js";
-import { expandQaScenarioExecutionCells } from "./scenario-lane.js";
-import type { QaSuiteRunParams } from "./suite.js";
 
 const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
 const QA_PASSING_SUITE_SCENARIO = {
@@ -157,24 +154,12 @@ function makeQaEvidence(entries: unknown[] = []) {
 
 function flowSuiteRuntimeResult(params: {
   evidencePath?: string;
-  expectedCells?: Array<{
-    scenarioId: string;
-    executionKind: "flow" | "script" | "vitest" | "playwright";
-    channel: string | null;
-  }>;
-  observedCells?: Array<{
-    scenarioId: string;
-    executionKind: "flow" | "script" | "vitest" | "playwright";
-    channel: string | null;
-  }>;
   reportPath: string;
   summaryPath: string;
   scenarios?: unknown[];
 }) {
   return {
     executionKind: "flow",
-    expectedCells: params.expectedCells ?? params.observedCells ?? [],
-    observedCells: params.observedCells ?? [],
     result: {
       outputDir: path.dirname(params.reportPath),
       evidencePath:
@@ -190,16 +175,6 @@ function flowSuiteRuntimeResult(params: {
 
 function unifiedSuiteRuntimeResult(params: {
   evidencePath: string;
-  expectedCells?: Array<{
-    scenarioId: string;
-    executionKind: "flow" | "script" | "vitest" | "playwright";
-    channel: string | null;
-  }>;
-  observedCells?: Array<{
-    scenarioId: string;
-    executionKind: "flow" | "script" | "vitest" | "playwright";
-    channel: string | null;
-  }>;
   outputDir: string;
   reportPath: string;
   summaryPath: string;
@@ -207,8 +182,6 @@ function unifiedSuiteRuntimeResult(params: {
 }) {
   return {
     executionKind: "suite",
-    expectedCells: params.expectedCells ?? params.observedCells ?? [],
-    observedCells: params.observedCells ?? [],
     result: {
       outputDir: params.outputDir,
       reportPath: params.reportPath,
@@ -218,31 +191,6 @@ function unifiedSuiteRuntimeResult(params: {
       scenarios: params.scenarios ?? [QA_PASSING_SUITE_SCENARIO],
     },
   };
-}
-
-function executionCellsForSuiteParams(params?: QaSuiteRunParams) {
-  const scenarioIds = new Set(params?.scenarioIds ?? []);
-  const scenarios = readQaScenarioPack().scenarios.filter((scenario) =>
-    scenarioIds.has(scenario.id),
-  );
-  const adapterFactories: readonly QaTransportAdapterFactory[] = params?.adapterFactories ?? [];
-  return expandQaScenarioExecutionCells({
-    scenarios,
-    channelDriver: params?.channelDriver ?? "qa-channel",
-    channel: params?.channelId ?? params?.channelDriverSelection?.channel,
-    defaultChannel:
-      params?.channelDriver === "crabline" ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL : undefined,
-    supportsChannel:
-      params?.channelDriver === "crabline"
-        ? isCrablineServerChannel
-        : params?.channelDriver === "live"
-          ? (channel) =>
-              adapterFactories.some((factory) =>
-                factory.matches({ channelId: channel, driver: "live" }),
-              )
-          : undefined,
-    expandChannels: params?.expandScenarioChannels === true,
-  });
 }
 
 describe("qa cli runtime", () => {
@@ -341,14 +289,12 @@ describe("qa cli runtime", () => {
         defaultQaProviderModelForMode(mode as QaProviderModeInput, options),
     );
     readQaScenarioPack.mockClear();
-    runQaSuite.mockImplementation(async (params) => {
-      const observedCells = executionCellsForSuiteParams(params);
-      return flowSuiteRuntimeResult({
-        observedCells,
+    runQaSuite.mockImplementation(async () =>
+      flowSuiteRuntimeResult({
         reportPath: suiteReportPath,
         summaryPath: suiteSummaryPath,
-      });
-    });
+      }),
+    );
     runQaFlowSuiteFromRuntime.mockResolvedValue({
       outputDir: suiteArtifactsDir,
       evidencePath: suiteEvidencePath,
@@ -717,14 +663,6 @@ describe("qa cli runtime", () => {
           "utf8",
         );
         return flowSuiteRuntimeResult({
-          observedCells: expandQaScenarioExecutionCells({
-            scenarios: [readQaScenarioById("telegram-commands-command")],
-            channelDriver: params?.channelDriver ?? "qa-channel",
-            channel: params?.channelId ?? params?.channelDriverSelection?.channel,
-            defaultChannel: OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
-            supportsChannel: isCrablineServerChannel,
-            expandChannels: true,
-          }),
           reportPath: suiteReportPath,
           summaryPath: suiteSummaryPath,
         });
@@ -758,50 +696,14 @@ describe("qa cli runtime", () => {
         channelDriver: "crabline",
       });
       expect(suiteArgs.scenarioIds).toEqual(["telegram-commands-command"]);
-      expect(process.env.OPENCLAW_QA_PROFILE).toBe("release");
-      const evidence = JSON.parse(await fs.readFile(suiteEvidencePath, "utf8")) as {
-        evidenceMode?: unknown;
-        entries?: unknown[];
-        profile?: unknown;
-        profilePlan?: {
-          counts?: Record<string, unknown>;
-          expectedCells?: unknown[];
-          observedCells?: unknown[];
-        };
-        scorecard?: {
-          run?: { evidenceEntryCount?: unknown };
-          coverageIds?: { fulfilled?: unknown };
-          categoryReports?: Array<{
-            id?: unknown;
-            coverageIds?: { fulfilled?: unknown };
-            missingCoverageIds?: unknown;
-          }>;
-        };
-      };
-      expect(evidence.profile).toBe("smoke-ci");
-      expect(evidence.profilePlan?.counts).toMatchObject({
-        membership: 1,
-        selected: 1,
-        excluded: 0,
-        expectedCells: 1,
-        observedCells: 1,
-        missingCells: 0,
-      });
-      expect(evidence.profilePlan?.observedCells).toEqual(evidence.profilePlan?.expectedCells);
-      expect(evidence.evidenceMode).toBe("slim");
-      expect(evidence.scorecard).toMatchObject({
-        run: {
-          evidenceEntryCount: 1,
+      expect(suiteArgs.profileRunSpec).toMatchObject({
+        profile: "smoke-ci",
+        filters: {
+          surface: "telegram",
+          category: "telegram.native-controls-and-approvals",
         },
       });
-      expect(evidence.scorecard).not.toHaveProperty("kind");
-      expect(evidence.scorecard).not.toHaveProperty("taxonomy");
-      expect(evidence.scorecard).not.toHaveProperty("profile");
-      expect(evidence.scorecard?.categoryReports?.[0]).toMatchObject({
-        id: "telegram.native-controls-and-approvals",
-      });
-      expect(evidence.entries?.[0]).not.toHaveProperty("execution");
-      expect(JSON.stringify(evidence.scorecard)).not.toContain("telegram-commands-command");
+      expect(process.env.OPENCLAW_QA_PROFILE).toBe("release");
       expectWriteContains(stdoutWrite, "QA run profile: smoke-ci; categories: 1; scenarios:");
       expectWriteContains(stdoutWrite, `QA profile scorecard: ${suiteEvidencePath}`);
     } finally {
@@ -894,10 +796,8 @@ describe("qa cli runtime", () => {
         }),
         "utf8",
       );
-      runQaSuite.mockImplementationOnce(async (params) => {
-        const observedCells = executionCellsForSuiteParams(params);
+      runQaSuite.mockImplementationOnce(async () => {
         return flowSuiteRuntimeResult({
-          observedCells,
           reportPath: suiteReportPath,
           summaryPath: suiteSummaryPath,
           scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
@@ -924,11 +824,9 @@ describe("qa cli runtime", () => {
   );
 
   it("filters QA-channel-pinned scenarios from an implicit Crabline smoke profile", async () => {
-    runQaSuite.mockImplementationOnce(async (params) => {
+    runQaSuite.mockImplementationOnce(async () => {
       await fs.writeFile(suiteEvidencePath, JSON.stringify(makeQaEvidence()), "utf8");
-      const observedCells = executionCellsForSuiteParams(params);
       return flowSuiteRuntimeResult({
-        observedCells,
         reportPath: suiteReportPath,
         summaryPath: suiteSummaryPath,
       });

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -47,11 +47,11 @@ import { startQaLabServer } from "./lab-server.js";
 import { listLiveTransportQaAdapterFactories } from "./live-transports/cli.js";
 import { runQaManualLane } from "./manual-lane.runtime.js";
 import { runQaMultipass } from "./multipass.runtime.js";
-import { qaProfileEvidencePlan, type QaProfileEvidencePlan } from "./profile-evidence-plan.js";
 import {
   resolveQaRunProfileExecutionSelection,
   resolveQaRunProfileMembership,
 } from "./profile-planning.js";
+import type { QaProfileRunSpec } from "./profile-run-checkpoint.js";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE, getQaProvider } from "./providers/index.js";
 import {
   QA_FRONTIER_PARITY_BASELINE_LABEL,
@@ -85,7 +85,6 @@ import {
   type QaRuntimePairLane,
 } from "./scenario-catalog.js";
 import { scenarioMatchesQaProviderLane } from "./scenario-lane.js";
-import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
 import {
   qaScorecardChannelDriverSchema,
   readQaScorecardTaxonomyReport,
@@ -168,6 +167,7 @@ export type QaSuiteCommandOptions = QaScenarioRunCommandOptions & {
   credentialSource?: string;
   credentialRole?: string;
   explicitScenarioSelection?: boolean;
+  profileRunSpec?: QaProfileRunSpec;
 };
 
 function normalizeQaSuiteChannelDriver(
@@ -702,8 +702,6 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     `QA run profile: ${profile}; categories: ${categories.length}; scenarios: ${scenarios.length}\n`,
   );
   let evidencePath: string | undefined;
-  let expectedCells: QaProfileEvidencePlan["expectedCells"] = [];
-  let observedCells: QaProfileEvidencePlan["observedCells"] = [];
   await withTemporaryQaProfileEnv(profile, async () => {
     const suiteResult = await runQaSuiteCommand({
       repoRoot,
@@ -721,34 +719,22 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
       allowFailures: opts.allowFailures,
       channelDriver: profileReport.channelDriver,
       expandScenarioChannels: true,
+      profileRunSpec: {
+        profile,
+        membershipScenarios: taxonomyScenarios,
+        selectedScenarios: scenarios,
+        excludedScenarios: executionSelection.excludedScenarios,
+        evidenceMode: opts.evidenceMode,
+        filters: { surface: opts.surface, category: opts.category },
+        categories,
+      },
     });
     evidencePath =
       suiteResult && "evidencePath" in suiteResult ? suiteResult.evidencePath : undefined;
-    expectedCells = suiteResult && "expectedCells" in suiteResult ? suiteResult.expectedCells : [];
-    observedCells = suiteResult && "observedCells" in suiteResult ? suiteResult.observedCells : [];
   });
   if (!evidencePath) {
     throw new Error("qa run --qa-profile did not produce qa-evidence.json.");
   }
-  const profilePlan = qaProfileEvidencePlan.build({
-    profile,
-    membershipScenarios: taxonomyScenarios,
-    selectedScenarios: scenarios,
-    excludedScenarios: executionSelection.excludedScenarios,
-    expectedCells,
-    observedCells,
-  });
-  await attachQaProfileScorecardEvidenceToFile({
-    evidencePath,
-    evidenceMode: opts.evidenceMode,
-    profile,
-    profilePlan,
-    filters: {
-      surface: opts.surface,
-      category: opts.category,
-    },
-    categories,
-  });
   process.stdout.write(`QA profile scorecard: ${evidencePath}\n`);
 }
 
@@ -1049,6 +1035,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
         ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }
         : {}),
     ...(runtimePair ? { runtimePair } : {}),
+    ...(opts.profileRunSpec ? { profileRunSpec: opts.profileRunSpec } : {}),
   });
   switch (runtimeResult.executionKind) {
     case "suite": {
@@ -1069,11 +1056,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       if (!allowFailures && blockingScenarioCount > 0) {
         process.exitCode = 1;
       }
-      return {
-        ...result,
-        expectedCells: runtimeResult.expectedCells,
-        observedCells: runtimeResult.observedCells,
-      };
+      return result;
     }
     case "flow": {
       const result = runtimeResult.result;
@@ -1094,11 +1077,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       if (!allowFailures && blockingScenarioCount > 0) {
         process.exitCode = 1;
       }
-      return {
-        ...result,
-        expectedCells: runtimeResult.expectedCells,
-        observedCells: runtimeResult.observedCells,
-      };
+      return result;
     }
   }
   return undefined;

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -164,6 +164,7 @@ const qaEvidenceSummarySchema = z.strictObject({
   generatedAt: nonEmptyStringSchema,
   evidenceMode: qaScorecardEvidenceModeSchema,
   entries: z.array(qaEvidenceSummaryEntrySchema),
+  profileCell: qaProfileEvidencePlan.schema.shape.expectedCells.element.optional(),
   profile: qaEvidenceProfileIdSchema.optional(),
   profilePlan: qaProfileEvidencePlan.schema.optional(),
   scorecard: qaEvidenceScorecardSchema.optional(),

--- a/extensions/qa-lab/src/profile-run-checkpoint.test.ts
+++ b/extensions/qa-lab/src/profile-run-checkpoint.test.ts
@@ -7,6 +7,7 @@ import { readQaScenarioById } from "./scenario-catalog.js";
 
 const atomicState = vi.hoisted(() => ({
   checkpointFailures: 0,
+  finalEvidenceFailures: 0,
   writes: [] as string[],
 }));
 const cryptoState = vi.hoisted(() => ({ fixedHash: false }));
@@ -40,6 +41,10 @@ vi.mock("openclaw/plugin-sdk/json-store", async (importOriginal) => {
       ) {
         atomicState.checkpointFailures -= 1;
         throw new Error("checkpoint disk full");
+      }
+      if (filePath.endsWith("qa-evidence.json") && atomicState.finalEvidenceFailures > 0) {
+        atomicState.finalEvidenceFailures -= 1;
+        throw new Error("final evidence disk full");
       }
       await actual.writeJsonFileAtomically(filePath, value);
     },
@@ -95,8 +100,8 @@ function emptyEvidence(): QaEvidenceSummaryJson {
 async function createCheckpoint(
   expectedCells: readonly (typeof cell)[] = [cell],
   selectedScenarios = [scenario],
+  outputDir = tempDirs.make("qa-profile-checkpoint-"),
 ) {
-  const outputDir = tempDirs.make("qa-profile-checkpoint-");
   const checkpoint = await createQaProfileRunCheckpoint({
     expectedCells,
     outputDir,
@@ -124,8 +129,44 @@ async function readCheckpoint(outputDir: string) {
 describe("QA profile run checkpoint", () => {
   beforeEach(() => {
     atomicState.checkpointFailures = 0;
+    atomicState.finalEvidenceFailures = 0;
     atomicState.writes.length = 0;
     cryptoState.fixedHash = false;
+  });
+
+  it("removes prior canonical evidence before checkpoint creation", async () => {
+    const outputDir = tempDirs.make("qa-profile-checkpoint-stale-");
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    await fs.writeFile(evidencePath, `${JSON.stringify(evidence(), null, 2)}\n`, "utf8");
+
+    await createCheckpoint([cell], [scenario], outputDir);
+
+    await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.access(path.join(outputDir, "qa-profile-run-checkpoint.json")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("aborts checkpoint creation when canonical evidence cannot be invalidated", async () => {
+    const outputDir = tempDirs.make("qa-profile-checkpoint-invalidation-");
+    await fs.mkdir(path.join(outputDir, "qa-evidence.json"));
+
+    await expect(createCheckpoint([cell], [scenario], outputDir)).rejects.toThrow();
+    await expect(
+      fs.access(path.join(outputDir, "qa-profile-run-checkpoint.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not expose prior canonical evidence when finalization persistence fails", async () => {
+    const outputDir = tempDirs.make("qa-profile-checkpoint-finalize-");
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    await fs.writeFile(evidencePath, `${JSON.stringify(evidence(), null, 2)}\n`, "utf8");
+    const { checkpoint } = await createCheckpoint([cell], [scenario], outputDir);
+    await checkpoint.control([cell]).complete({ scenarioId: scenario.id, evidence: evidence() });
+    atomicState.finalEvidenceFailures = 1;
+
+    await expect(checkpoint.finalize()).rejects.toThrow("final evidence disk full");
+    await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("becomes terminal only after the checkpoint snapshot commits", async () => {

--- a/extensions/qa-lab/src/profile-run-checkpoint.test.ts
+++ b/extensions/qa-lab/src/profile-run-checkpoint.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { validateQaEvidenceSummaryJson, type QaEvidenceSummaryJson } from "./evidence-summary.js";
 import { readQaScenarioById } from "./scenario-catalog.js";
 
@@ -9,6 +9,24 @@ const atomicState = vi.hoisted(() => ({
   checkpointFailures: 0,
   writes: [] as string[],
 }));
+const cryptoState = vi.hoisted(() => ({ fixedHash: false }));
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  return {
+    ...actual,
+    createHash: (...args: Parameters<typeof actual.createHash>) => {
+      if (!cryptoState.fixedHash) {
+        return actual.createHash(...args);
+      }
+      const fixed = {
+        update: () => fixed,
+        digest: () => "0".repeat(64),
+      };
+      return fixed as unknown as ReturnType<typeof actual.createHash>;
+    },
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/json-store", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/json-store")>();
@@ -30,15 +48,24 @@ vi.mock("openclaw/plugin-sdk/json-store", async (importOriginal) => {
 
 import { createQaProfileRunCheckpoint } from "./profile-run-checkpoint.js";
 
-const tempRoots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const scenario = readQaScenarioById("channel-chat-baseline");
+const secondScenario = readQaScenarioById("dm-chat-baseline");
 const cell = {
   scenarioId: scenario.id,
   executionKind: "flow" as const,
   channel: "qa-channel",
 };
+const secondCell = {
+  scenarioId: secondScenario.id,
+  executionKind: "flow" as const,
+  channel: "qa-channel",
+};
 
-function evidence(generatedAt = "2026-08-06T00:00:00.000Z"): QaEvidenceSummaryJson {
+function evidence(
+  generatedAt = "2026-08-06T00:00:00.000Z",
+  testId = scenario.id,
+): QaEvidenceSummaryJson {
   return validateQaEvidenceSummaryJson({
     kind: "openclaw.qa.evidence-summary",
     schemaVersion: 2,
@@ -46,7 +73,7 @@ function evidence(generatedAt = "2026-08-06T00:00:00.000Z"): QaEvidenceSummaryJs
     evidenceMode: "full",
     entries: [
       {
-        test: { kind: "flow", id: scenario.id, title: scenario.title },
+        test: { kind: "flow", id: testId, title: testId },
         coverage: [],
         refs: [],
         result: { status: "pass" },
@@ -55,17 +82,29 @@ function evidence(generatedAt = "2026-08-06T00:00:00.000Z"): QaEvidenceSummaryJs
   });
 }
 
-async function createCheckpoint() {
-  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-profile-checkpoint-"));
-  tempRoots.push(outputDir);
+function emptyEvidence(): QaEvidenceSummaryJson {
+  return validateQaEvidenceSummaryJson({
+    kind: "openclaw.qa.evidence-summary",
+    schemaVersion: 2,
+    generatedAt: "2026-08-06T00:00:00.000Z",
+    evidenceMode: "full",
+    entries: [],
+  });
+}
+
+async function createCheckpoint(
+  expectedCells: readonly (typeof cell)[] = [cell],
+  selectedScenarios = [scenario],
+) {
+  const outputDir = tempDirs.make("qa-profile-checkpoint-");
   const checkpoint = await createQaProfileRunCheckpoint({
-    expectedCells: [cell],
+    expectedCells,
     outputDir,
     retryPhase: async (_phase, run) => await run(),
     spec: {
       profile: "release",
-      membershipScenarios: [scenario],
-      selectedScenarios: [scenario],
+      membershipScenarios: selectedScenarios,
+      selectedScenarios,
       excludedScenarios: [],
       filters: {},
       categories: [],
@@ -86,12 +125,7 @@ describe("QA profile run checkpoint", () => {
   beforeEach(() => {
     atomicState.checkpointFailures = 0;
     atomicState.writes.length = 0;
-  });
-
-  afterEach(async () => {
-    await Promise.all(
-      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
-    );
+    cryptoState.fixedHash = false;
   });
 
   it("becomes terminal only after the checkpoint snapshot commits", async () => {
@@ -108,6 +142,18 @@ describe("QA profile run checkpoint", () => {
     await control.complete({ scenarioId: scenario.id, evidence: evidence() });
     expect(control.hasTerminalEvidence()).toBe(true);
     expect((await readCheckpoint(outputDir)).cells[0]?.evidence?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("keeps generic empty summaries valid but rejects empty profile completion", async () => {
+    expect(validateQaEvidenceSummaryJson(emptyEvidence()).entries).toEqual([]);
+    const { checkpoint, outputDir } = await createCheckpoint();
+    const control = checkpoint.control([cell]);
+
+    await expect(
+      control.complete({ scenarioId: scenario.id, evidence: emptyEvidence() }),
+    ).rejects.toThrow("Invalid QA profile evidence");
+    expect(control.hasTerminalEvidence()).toBe(false);
+    expect((await readCheckpoint(outputDir)).cells[0]).not.toHaveProperty("evidence");
   });
 
   it("binds the canonical qa-channel cell and treats identical completion as idempotent", async () => {
@@ -150,17 +196,68 @@ describe("QA profile run checkpoint", () => {
     const ref = (await readCheckpoint(outputDir)).cells[0]?.evidence;
     await fs.writeFile(path.join(outputDir, ref!.path), "{}\n", "utf8");
 
-    await expect(checkpoint.finalize(evidence())).rejects.toThrow("evidence digest mismatch");
+    await expect(checkpoint.finalize()).rejects.toThrow("evidence digest mismatch");
   });
 
-  it("finalizes strict observed cells without changing authoritative entries", async () => {
+  it("rejects digest-valid empty refs during finalization", async () => {
+    cryptoState.fixedHash = true;
     const { checkpoint, outputDir } = await createCheckpoint();
     await checkpoint.control([cell]).complete({ scenarioId: scenario.id, evidence: evidence() });
-    const authoritative = evidence("2026-08-06T00:00:02.000Z");
+    const ref = (await readCheckpoint(outputDir)).cells[0]?.evidence;
+    const empty = validateQaEvidenceSummaryJson({ ...emptyEvidence(), profileCell: cell });
+    await fs.writeFile(path.join(outputDir, ref!.path), `${JSON.stringify(empty, null, 2)}\n`);
 
-    const finalized = await checkpoint.finalize(authoritative);
+    await expect(checkpoint.finalize()).rejects.toThrow("Invalid QA profile evidence");
+  });
 
-    expect(finalized.entries).toStrictEqual(authoritative.entries);
+  it("finalizes refs in canonical cell order and preserves producer-owned IDs", async () => {
+    const { checkpoint, outputDir } = await createCheckpoint(
+      [secondCell, cell],
+      [secondScenario, scenario],
+    );
+    await checkpoint.control([secondCell]).complete({
+      scenarioId: secondScenario.id,
+      evidence: evidence(undefined, "producer-second"),
+    });
+    await checkpoint
+      .control([cell])
+      .complete({ scenarioId: scenario.id, evidence: evidence(undefined, "producer-first") });
+
+    const finalized = await checkpoint.finalize();
+
+    expect(finalized.entries.map((entry) => entry.test.id)).toEqual([
+      "producer-first",
+      "producer-second",
+    ]);
+    expect(finalized.profileCell).toBeUndefined();
+    expect(finalized.profilePlan?.observedCells).toEqual([cell, secondCell]);
+    expect(
+      validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(path.join(outputDir, "qa-evidence.json"), "utf8")),
+      ),
+    ).toStrictEqual(finalized);
+  });
+
+  it("projects missing cells from the refs-only aggregate", async () => {
+    const { checkpoint } = await createCheckpoint([cell, secondCell], [scenario, secondScenario]);
+    await checkpoint
+      .control([secondCell])
+      .complete({ scenarioId: secondScenario.id, evidence: evidence(undefined, "producer-owned") });
+
+    const finalized = await checkpoint.finalize();
+
+    expect(finalized.entries.map((entry) => entry.test.id)).toEqual(["producer-owned"]);
+    expect(finalized.profilePlan?.observedCells).toEqual([secondCell]);
+    expect(finalized.profilePlan?.missingCells).toEqual([cell]);
+  });
+
+  it("finalizes strict observed cells from refs", async () => {
+    const { checkpoint, outputDir } = await createCheckpoint();
+    await checkpoint.control([cell]).complete({ scenarioId: scenario.id, evidence: evidence() });
+
+    const finalized = await checkpoint.finalize();
+
+    expect(finalized.entries).toStrictEqual(evidence().entries);
     expect(finalized.profilePlan?.observedCells).toEqual([cell]);
     expect(Object.keys(finalized.profilePlan!.observedCells[0]!).toSorted()).toEqual([
       "channel",

--- a/extensions/qa-lab/src/profile-run-checkpoint.test.ts
+++ b/extensions/qa-lab/src/profile-run-checkpoint.test.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { validateQaEvidenceSummaryJson, type QaEvidenceSummaryJson } from "./evidence-summary.js";
+import { readQaScenarioById } from "./scenario-catalog.js";
+
+const atomicState = vi.hoisted(() => ({
+  checkpointFailures: 0,
+  writes: [] as string[],
+}));
+
+vi.mock("openclaw/plugin-sdk/json-store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/json-store")>();
+  return {
+    ...actual,
+    writeJsonFileAtomically: async (filePath: string, value: unknown) => {
+      atomicState.writes.push(filePath);
+      if (
+        filePath.endsWith("qa-profile-run-checkpoint.json") &&
+        atomicState.checkpointFailures > 0
+      ) {
+        atomicState.checkpointFailures -= 1;
+        throw new Error("checkpoint disk full");
+      }
+      await actual.writeJsonFileAtomically(filePath, value);
+    },
+  };
+});
+
+import { createQaProfileRunCheckpoint } from "./profile-run-checkpoint.js";
+
+const tempRoots: string[] = [];
+const scenario = readQaScenarioById("channel-chat-baseline");
+const cell = {
+  scenarioId: scenario.id,
+  executionKind: "flow" as const,
+  channel: "qa-channel",
+};
+
+function evidence(generatedAt = "2026-08-06T00:00:00.000Z"): QaEvidenceSummaryJson {
+  return validateQaEvidenceSummaryJson({
+    kind: "openclaw.qa.evidence-summary",
+    schemaVersion: 2,
+    generatedAt,
+    evidenceMode: "full",
+    entries: [
+      {
+        test: { kind: "flow", id: scenario.id, title: scenario.title },
+        coverage: [],
+        refs: [],
+        result: { status: "pass" },
+      },
+    ],
+  });
+}
+
+async function createCheckpoint() {
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-profile-checkpoint-"));
+  tempRoots.push(outputDir);
+  const checkpoint = await createQaProfileRunCheckpoint({
+    expectedCells: [cell],
+    outputDir,
+    retryPhase: async (_phase, run) => await run(),
+    spec: {
+      profile: "release",
+      membershipScenarios: [scenario],
+      selectedScenarios: [scenario],
+      excludedScenarios: [],
+      filters: {},
+      categories: [],
+    },
+  });
+  return { checkpoint, outputDir };
+}
+
+async function readCheckpoint(outputDir: string) {
+  return JSON.parse(
+    await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
+  ) as {
+    cells: Array<typeof cell & { evidence?: { path: string; sha256: string } }>;
+  };
+}
+
+describe("QA profile run checkpoint", () => {
+  beforeEach(() => {
+    atomicState.checkpointFailures = 0;
+    atomicState.writes.length = 0;
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it("becomes terminal only after the checkpoint snapshot commits", async () => {
+    const { checkpoint, outputDir } = await createCheckpoint();
+    const control = checkpoint.control([cell]);
+    atomicState.checkpointFailures = 1;
+
+    await expect(
+      control.complete({ scenarioId: scenario.id, evidence: evidence() }),
+    ).rejects.toThrow("checkpoint disk full");
+    expect(control.hasTerminalEvidence()).toBe(false);
+    expect((await readCheckpoint(outputDir)).cells[0]).not.toHaveProperty("evidence");
+
+    await control.complete({ scenarioId: scenario.id, evidence: evidence() });
+    expect(control.hasTerminalEvidence()).toBe(true);
+    expect((await readCheckpoint(outputDir)).cells[0]?.evidence?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("binds the canonical qa-channel cell and treats identical completion as idempotent", async () => {
+    const { checkpoint, outputDir } = await createCheckpoint();
+    const control = checkpoint.control([cell]);
+    await control.complete({ scenarioId: scenario.id, evidence: evidence() });
+    const checkpointWrites = atomicState.writes.filter((filePath) =>
+      filePath.endsWith("qa-profile-run-checkpoint.json"),
+    ).length;
+
+    await control.complete({ scenarioId: scenario.id, evidence: evidence() });
+    expect(
+      atomicState.writes.filter((filePath) => filePath.endsWith("qa-profile-run-checkpoint.json")),
+    ).toHaveLength(checkpointWrites);
+
+    const ref = (await readCheckpoint(outputDir)).cells[0]?.evidence;
+    expect(ref).toBeDefined();
+    const stored = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(path.join(outputDir, ref!.path), "utf8")),
+    );
+    expect(stored.profileCell).toEqual(cell);
+  });
+
+  it("rejects replacement evidence after terminal completion", async () => {
+    const { checkpoint } = await createCheckpoint();
+    const control = checkpoint.control([cell]);
+    await control.complete({ scenarioId: scenario.id, evidence: evidence() });
+
+    await expect(
+      control.complete({
+        scenarioId: scenario.id,
+        evidence: evidence("2026-08-06T00:00:01.000Z"),
+      }),
+    ).rejects.toThrow("rejects replacement evidence");
+  });
+
+  it("rejects tampered evidence refs during finalization", async () => {
+    const { checkpoint, outputDir } = await createCheckpoint();
+    await checkpoint.control([cell]).complete({ scenarioId: scenario.id, evidence: evidence() });
+    const ref = (await readCheckpoint(outputDir)).cells[0]?.evidence;
+    await fs.writeFile(path.join(outputDir, ref!.path), "{}\n", "utf8");
+
+    await expect(checkpoint.finalize(evidence())).rejects.toThrow("evidence digest mismatch");
+  });
+
+  it("finalizes strict observed cells without changing authoritative entries", async () => {
+    const { checkpoint, outputDir } = await createCheckpoint();
+    await checkpoint.control([cell]).complete({ scenarioId: scenario.id, evidence: evidence() });
+    const authoritative = evidence("2026-08-06T00:00:02.000Z");
+
+    const finalized = await checkpoint.finalize(authoritative);
+
+    expect(finalized.entries).toStrictEqual(authoritative.entries);
+    expect(finalized.profilePlan?.observedCells).toEqual([cell]);
+    expect(Object.keys(finalized.profilePlan!.observedCells[0]!).toSorted()).toEqual([
+      "channel",
+      "executionKind",
+      "scenarioId",
+    ]);
+    expect(
+      validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(path.join(outputDir, "qa-evidence.json"), "utf8")),
+      ),
+    ).toStrictEqual(finalized);
+  });
+});

--- a/extensions/qa-lab/src/profile-run-checkpoint.ts
+++ b/extensions/qa-lab/src/profile-run-checkpoint.ts
@@ -23,11 +23,6 @@ export type QaProfileRunSpec = Omit<
   categories: readonly QaScorecardCategoryCoverageReport[];
 };
 export type QaProfilePhaseRetry = <T>(phase: string, run: () => Promise<T>) => Promise<T>;
-export const runQaProfilePhase = <T>(
-  retryPhase: QaProfilePhaseRetry | undefined,
-  phase: string,
-  run: () => Promise<T>,
-) => (retryPhase ? retryPhase(phase, run) : run());
 export type QaProfileRunControl = {
   complete(input: { scenarioId: string; evidence: QaEvidenceSummaryJson }): Promise<void>;
   hasTerminalEvidence(): boolean;
@@ -36,6 +31,14 @@ export type QaProfileRunControl = {
 
 const hash = (value: string) => createHash("sha256").update(value).digest("hex");
 const key = (cell: Cell) => `${cell.scenarioId}\0${cell.executionKind}\0${cell.channel ?? ""}`;
+const validateProfileEvidence = (value: unknown, cell: Cell) => {
+  const evidence = validateQaEvidenceSummaryJson(value);
+  const bound = evidence.profileCell && key(evidence.profileCell) === key(cell);
+  if (!bound || evidence.entries.length === 0) {
+    throw new Error(`Invalid QA profile evidence for ${key(cell)}`);
+  }
+  return evidence;
+};
 
 export async function createQaProfileRunCheckpoint(params: {
   expectedCells: readonly Cell[];
@@ -58,12 +61,12 @@ export async function createQaProfileRunCheckpoint(params: {
       evidence: cellKey === next?.[0] ? next[1] : refs.get(cellKey),
     })),
   });
-  const read = async (ref: Ref) => {
+  const read = async (ref: Ref, cell: Cell) => {
     const payload = await fs.readFile(path.join(params.outputDir, ref.path), "utf8");
     if (hash(payload) !== ref.sha256) {
       throw new Error(`QA profile evidence digest mismatch: ${ref.path}`);
     }
-    return validateQaEvidenceSummaryJson(JSON.parse(payload));
+    return validateProfileEvidence(JSON.parse(payload), cell);
   };
   const getCell = (cell: Cell) => {
     const stored = cells.get(key(cell));
@@ -84,7 +87,7 @@ export async function createQaProfileRunCheckpoint(params: {
   const complete = (cell: Cell, input: QaEvidenceSummaryJson) =>
     mutate(async () => {
       const cellKey = key(cell);
-      const evidence = validateQaEvidenceSummaryJson({ ...input, profileCell: cell });
+      const evidence = validateProfileEvidence({ ...input, profileCell: cell }, cell);
       const sha256 = hash(`${JSON.stringify(evidence, null, 2)}\n`);
       const existing = refs.get(cellKey);
       if (existing?.sha256 === sha256) {
@@ -101,6 +104,7 @@ export async function createQaProfileRunCheckpoint(params: {
       refs.set(cellKey, ref);
     });
   return {
+    retryPhase: params.retryPhase,
     control(partitionCells: readonly Cell[]): QaProfileRunControl {
       const partition = new Map(
         partitionCells.map((cell) => [cell.scenarioId, getCell(cell)] as const),
@@ -117,29 +121,32 @@ export async function createQaProfileRunCheckpoint(params: {
         retryPhase: params.retryPhase,
       };
     },
-    finalize: (authoritativeEvidence: QaEvidenceSummaryJson) =>
+    finalize: () =>
       mutate(async () => {
-        const base = validateQaEvidenceSummaryJson(authoritativeEvidence);
         const observed: Cell[] = [];
+        const summaries: QaEvidenceSummaryJson[] = [];
         for (const [cellKey, cell] of cells) {
           const ref = refs.get(cellKey);
           if (!ref) {
             continue;
           }
-          const evidence = await read(ref);
-          if (!evidence.profileCell || key(evidence.profileCell) !== cellKey) {
-            throw new Error(`QA profile evidence ref is not bound to ${cellKey}`);
-          }
-          const { scenarioId, executionKind, channel } = cell;
-          observed.push({ scenarioId, executionKind, channel });
+          const evidence = await read(ref, cell);
+          summaries.push(evidence);
+          observed.push(cell);
         }
+        const latest = summaries.at(-1);
+        if (!latest) {
+          throw new Error("QA profile finalization requires terminal evidence");
+        }
+        const aggregateSummary = { ...latest, entries: summaries.flatMap((item) => item.entries) };
+        delete aggregateSummary.profileCell;
         const aggregate = attachQaEvidenceScorecard({
-          summary: base,
+          summary: aggregateSummary,
           evidenceMode: params.spec.evidenceMode,
           profile: params.spec.profile,
           profilePlan: plan(observed),
           scorecard: buildQaProfileScorecardEvidence({
-            evidence: base,
+            evidence: aggregateSummary,
             filters: params.spec.filters,
             categories: params.spec.categories,
           }),

--- a/extensions/qa-lab/src/profile-run-checkpoint.ts
+++ b/extensions/qa-lab/src/profile-run-checkpoint.ts
@@ -1,0 +1,153 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
+import {
+  QA_EVIDENCE_FILENAME,
+  attachQaEvidenceScorecard,
+  validateQaEvidenceSummaryJson,
+  type QaEvidenceSummaryJson,
+} from "./evidence-summary.js";
+import { qaProfileEvidencePlan, type QaProfileEvidencePlan } from "./profile-evidence-plan.js";
+import { buildQaProfileScorecardEvidence } from "./scorecard-evidence.js";
+import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js";
+
+type Cell = QaProfileEvidencePlan["expectedCells"][number];
+type Ref = { path: string; sha256: string };
+export type QaProfileRunSpec = Omit<
+  Parameters<typeof qaProfileEvidencePlan.build>[0],
+  "expectedCells" | "observedCells"
+> & {
+  evidenceMode?: QaEvidenceSummaryJson["evidenceMode"];
+  filters: { surface?: string; category?: string };
+  categories: readonly QaScorecardCategoryCoverageReport[];
+};
+export type QaProfilePhaseRetry = <T>(phase: string, run: () => Promise<T>) => Promise<T>;
+export const runQaProfilePhase = <T>(
+  retryPhase: QaProfilePhaseRetry | undefined,
+  phase: string,
+  run: () => Promise<T>,
+) => (retryPhase ? retryPhase(phase, run) : run());
+export type QaProfileRunControl = {
+  complete(input: { scenarioId: string; evidence: QaEvidenceSummaryJson }): Promise<void>;
+  hasTerminalEvidence(): boolean;
+  retryPhase: QaProfilePhaseRetry;
+};
+
+const hash = (value: string) => createHash("sha256").update(value).digest("hex");
+const key = (cell: Cell) => `${cell.scenarioId}\0${cell.executionKind}\0${cell.channel ?? ""}`;
+
+export async function createQaProfileRunCheckpoint(params: {
+  expectedCells: readonly Cell[];
+  outputDir: string;
+  retryPhase: QaProfilePhaseRetry;
+  spec: QaProfileRunSpec;
+}) {
+  const plan = (observedCells: readonly Cell[]) =>
+    qaProfileEvidencePlan.build({
+      ...params.spec,
+      expectedCells: params.expectedCells,
+      observedCells,
+    });
+  const cells = new Map(plan([]).expectedCells.map((cell) => [key(cell), cell]));
+  const refs = new Map<string, Ref>();
+  const checkpointPath = path.join(params.outputDir, "qa-profile-run-checkpoint.json");
+  const snapshot = (next?: readonly [string, Ref]) => ({
+    cells: [...cells].map(([cellKey, cell]) => ({
+      ...cell,
+      evidence: cellKey === next?.[0] ? next[1] : refs.get(cellKey),
+    })),
+  });
+  const read = async (ref: Ref) => {
+    const payload = await fs.readFile(path.join(params.outputDir, ref.path), "utf8");
+    if (hash(payload) !== ref.sha256) {
+      throw new Error(`QA profile evidence digest mismatch: ${ref.path}`);
+    }
+    return validateQaEvidenceSummaryJson(JSON.parse(payload));
+  };
+  const getCell = (cell: Cell) => {
+    const stored = cells.get(key(cell));
+    if (!stored) {
+      throw new Error(`QA profile checkpoint does not expect cell ${key(cell)}`);
+    }
+    return stored;
+  };
+  let queue: Promise<unknown> = Promise.resolve();
+  const mutate = <T>(run: () => Promise<T>) => {
+    const next = queue.then(run);
+    queue = next.catch(() => undefined);
+    return next;
+  };
+  await params.retryPhase("checkpoint persistence", () =>
+    writeJsonFileAtomically(checkpointPath, snapshot()),
+  );
+  const complete = (cell: Cell, input: QaEvidenceSummaryJson) =>
+    mutate(async () => {
+      const cellKey = key(cell);
+      const evidence = validateQaEvidenceSummaryJson({ ...input, profileCell: cell });
+      const sha256 = hash(`${JSON.stringify(evidence, null, 2)}\n`);
+      const existing = refs.get(cellKey);
+      if (existing?.sha256 === sha256) {
+        return;
+      }
+      if (existing) {
+        throw new Error(`QA profile checkpoint rejects replacement evidence for ${cellKey}`);
+      }
+      const ref = { path: path.join("qa-profile-evidence", `${sha256}.json`), sha256 };
+      await params.retryPhase("checkpoint persistence", async () => {
+        await writeJsonFileAtomically(path.join(params.outputDir, ref.path), evidence);
+        await writeJsonFileAtomically(checkpointPath, snapshot([cellKey, ref]));
+      });
+      refs.set(cellKey, ref);
+    });
+  return {
+    control(partitionCells: readonly Cell[]): QaProfileRunControl {
+      const partition = new Map(
+        partitionCells.map((cell) => [cell.scenarioId, getCell(cell)] as const),
+      );
+      return {
+        complete: ({ scenarioId, evidence }) => {
+          const cell = partition.get(scenarioId);
+          if (!cell) {
+            throw new Error(`QA profile partition does not expect scenario ${scenarioId}`);
+          }
+          return complete(cell, evidence);
+        },
+        hasTerminalEvidence: () => [...partition.values()].some((cell) => refs.has(key(cell))),
+        retryPhase: params.retryPhase,
+      };
+    },
+    finalize: (authoritativeEvidence: QaEvidenceSummaryJson) =>
+      mutate(async () => {
+        const base = validateQaEvidenceSummaryJson(authoritativeEvidence);
+        const observed: Cell[] = [];
+        for (const [cellKey, cell] of cells) {
+          const ref = refs.get(cellKey);
+          if (!ref) {
+            continue;
+          }
+          const evidence = await read(ref);
+          if (!evidence.profileCell || key(evidence.profileCell) !== cellKey) {
+            throw new Error(`QA profile evidence ref is not bound to ${cellKey}`);
+          }
+          const { scenarioId, executionKind, channel } = cell;
+          observed.push({ scenarioId, executionKind, channel });
+        }
+        const aggregate = attachQaEvidenceScorecard({
+          summary: base,
+          evidenceMode: params.spec.evidenceMode,
+          profile: params.spec.profile,
+          profilePlan: plan(observed),
+          scorecard: buildQaProfileScorecardEvidence({
+            evidence: base,
+            filters: params.spec.filters,
+            categories: params.spec.categories,
+          }),
+        });
+        await params.retryPhase("profile finalization", () =>
+          writeJsonFileAtomically(path.join(params.outputDir, QA_EVIDENCE_FILENAME), aggregate),
+        );
+        return aggregate;
+      }),
+  };
+}

--- a/extensions/qa-lab/src/profile-run-checkpoint.ts
+++ b/extensions/qa-lab/src/profile-run-checkpoint.ts
@@ -103,6 +103,63 @@ export async function createQaProfileRunCheckpoint(params: {
       });
       refs.set(cellKey, ref);
     });
+  const finalize = () =>
+    mutate(async () => {
+      const observed: Cell[] = [];
+      const summaries: QaEvidenceSummaryJson[] = [];
+      for (const [cellKey, cell] of cells) {
+        const ref = refs.get(cellKey);
+        if (!ref) {
+          continue;
+        }
+        const evidence = await read(ref, cell);
+        summaries.push(evidence);
+        observed.push(cell);
+      }
+      const latest = summaries.at(-1);
+      if (!latest) {
+        throw new Error("QA profile finalization requires terminal evidence");
+      }
+      const aggregateSummary = { ...latest, entries: summaries.flatMap((item) => item.entries) };
+      delete aggregateSummary.profileCell;
+      const aggregate = attachQaEvidenceScorecard({
+        summary: aggregateSummary,
+        evidenceMode: params.spec.evidenceMode,
+        profile: params.spec.profile,
+        profilePlan: plan(observed),
+        scorecard: buildQaProfileScorecardEvidence({
+          evidence: aggregateSummary,
+          filters: params.spec.filters,
+          categories: params.spec.categories,
+        }),
+      });
+      await params.retryPhase("profile finalization", () =>
+        writeJsonFileAtomically(path.join(params.outputDir, QA_EVIDENCE_FILENAME), aggregate),
+      );
+      return aggregate;
+    });
+  const finalizeRun = async <T>(run: (finalize: typeof finalize) => Promise<T>) => {
+    let finalization: ReturnType<typeof finalize> | undefined;
+    const finalizeOnce = () => (finalization ??= finalize());
+    try {
+      const result = await run(finalizeOnce);
+      await finalizeOnce();
+      return result;
+    } catch (originalError) {
+      if (!finalization && refs.size > 0) {
+        try {
+          await finalizeOnce();
+        } catch (finalizationError) {
+          throw new AggregateError(
+            [originalError, finalizationError],
+            "QA profile execution and finalization both failed",
+            { cause: originalError },
+          );
+        }
+      }
+      throw originalError;
+    }
+  };
   return {
     retryPhase: params.retryPhase,
     control(partitionCells: readonly Cell[]): QaProfileRunControl {
@@ -121,40 +178,7 @@ export async function createQaProfileRunCheckpoint(params: {
         retryPhase: params.retryPhase,
       };
     },
-    finalize: () =>
-      mutate(async () => {
-        const observed: Cell[] = [];
-        const summaries: QaEvidenceSummaryJson[] = [];
-        for (const [cellKey, cell] of cells) {
-          const ref = refs.get(cellKey);
-          if (!ref) {
-            continue;
-          }
-          const evidence = await read(ref, cell);
-          summaries.push(evidence);
-          observed.push(cell);
-        }
-        const latest = summaries.at(-1);
-        if (!latest) {
-          throw new Error("QA profile finalization requires terminal evidence");
-        }
-        const aggregateSummary = { ...latest, entries: summaries.flatMap((item) => item.entries) };
-        delete aggregateSummary.profileCell;
-        const aggregate = attachQaEvidenceScorecard({
-          summary: aggregateSummary,
-          evidenceMode: params.spec.evidenceMode,
-          profile: params.spec.profile,
-          profilePlan: plan(observed),
-          scorecard: buildQaProfileScorecardEvidence({
-            evidence: aggregateSummary,
-            filters: params.spec.filters,
-            categories: params.spec.categories,
-          }),
-        });
-        await params.retryPhase("profile finalization", () =>
-          writeJsonFileAtomically(path.join(params.outputDir, QA_EVIDENCE_FILENAME), aggregate),
-        );
-        return aggregate;
-      }),
+    finalize,
+    finalizeRun,
   };
 }

--- a/extensions/qa-lab/src/profile-run-checkpoint.ts
+++ b/extensions/qa-lab/src/profile-run-checkpoint.ts
@@ -81,9 +81,10 @@ export async function createQaProfileRunCheckpoint(params: {
     queue = next.catch(() => undefined);
     return next;
   };
-  await params.retryPhase("checkpoint persistence", () =>
-    writeJsonFileAtomically(checkpointPath, snapshot()),
-  );
+  await params.retryPhase("checkpoint persistence", async () => {
+    await fs.rm(path.join(params.outputDir, QA_EVIDENCE_FILENAME), { force: true });
+    await writeJsonFileAtomically(checkpointPath, snapshot());
+  });
   const complete = (cell: Cell, input: QaEvidenceSummaryJson) =>
     mutate(async () => {
       const cellKey = key(cell);
@@ -138,7 +139,7 @@ export async function createQaProfileRunCheckpoint(params: {
       );
       return aggregate;
     });
-  const finalizeRun = async <T>(run: (finalize: typeof finalize) => Promise<T>) => {
+  const finalizeRun = async <T>(run: (finalizeProfile: typeof finalize) => Promise<T>) => {
     let finalization: ReturnType<typeof finalize> | undefined;
     const finalizeOnce = () => (finalization ??= finalize());
     try {

--- a/extensions/qa-lab/src/scorecard-evidence.test.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.test.ts
@@ -1,15 +1,7 @@
 // QA Lab tests cover profile scorecard evidence math.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
-import {
-  validateQaEvidenceSummaryJson,
-  type QaEvidenceSummaryJson,
-  type QaEvidenceSummaryEntry,
-} from "./evidence-summary.js";
-import type { QaProfileEvidencePlan } from "./profile-evidence-plan.js";
-import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
+import { type QaEvidenceSummaryJson, type QaEvidenceSummaryEntry } from "./evidence-summary.js";
+import { buildQaProfileScorecardEvidence as buildScorecard } from "./scorecard-evidence.js";
 import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js";
 
 function evidenceEntry(
@@ -58,46 +50,15 @@ function categoryInventory(coverageIds: string[]): QaScorecardCategoryCoverageRe
   };
 }
 
-async function buildQaProfileScorecardEvidence(params: {
+function buildQaProfileScorecardEvidence(params: {
   evidence: QaEvidenceSummaryJson;
   filters: { surface?: string; category?: string };
   categories: readonly QaScorecardCategoryCoverageReport[];
 }) {
-  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-scorecard-evidence-"));
-  const evidencePath = path.join(tempRoot, "qa-evidence-summary.json");
-  await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence)}\n`, "utf8");
-  try {
-    const scorecard = await attachQaProfileScorecardEvidenceToFile({
-      evidencePath,
-      profile: "release",
-      profilePlan: {
-        profile: "release",
-        membership: [],
-        selected: [],
-        excluded: [],
-        expectedCells: [],
-        observedCells: [],
-        missingCells: [],
-        counts: {
-          membership: 0,
-          selected: 0,
-          excluded: 0,
-          expectedCells: 0,
-          observedCells: 0,
-          missingCells: 0,
-        },
-      } satisfies QaProfileEvidencePlan,
-      filters: params.filters,
-      categories: params.categories,
-    });
-    const writtenEvidence = validateQaEvidenceSummaryJson(
-      JSON.parse(await fs.readFile(evidencePath, "utf8")),
-    );
-    expect(writtenEvidence.profilePlan?.profile).toBe("release");
-    return { scorecard, writtenEvidence };
-  } finally {
-    await fs.rm(tempRoot, { recursive: true, force: true });
-  }
+  return {
+    scorecard: buildScorecard(params),
+    writtenEvidence: params.evidence,
+  };
 }
 
 describe("profile scorecard evidence", () => {

--- a/extensions/qa-lab/src/scorecard-evidence.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.ts
@@ -1,17 +1,10 @@
-// QA Lab plugin module embeds profile scorecard context into QA evidence.
-import fs from "node:fs/promises";
-import {
-  attachQaEvidenceScorecard,
-  validateQaEvidenceSummaryJson,
-  type QaEvidenceScorecardJson,
-  type QaEvidenceSummaryEntry,
-  type QaEvidenceSummaryJson,
-} from "./evidence-summary.js";
-import type { QaProfileEvidencePlan } from "./profile-evidence-plan.js";
+// QA Lab plugin module builds profile scorecard context from authoritative evidence.
 import type {
-  QaScorecardCategoryCoverageReport,
-  QaScorecardEvidenceMode,
-} from "./scorecard-taxonomy.js";
+  QaEvidenceScorecardJson,
+  QaEvidenceSummaryEntry,
+  QaEvidenceSummaryJson,
+} from "./evidence-summary.js";
+import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js";
 
 type QaProfileScorecardFilters = {
   surface?: string;
@@ -85,7 +78,7 @@ function featureCounts(
   };
 }
 
-function buildQaProfileScorecardEvidence(params: {
+export function buildQaProfileScorecardEvidence(params: {
   evidence: QaEvidenceSummaryJson;
   filters: QaProfileScorecardFilters;
   categories: readonly QaScorecardCategoryCoverageReport[];
@@ -171,31 +164,4 @@ function buildQaProfileScorecardEvidence(params: {
     },
     categoryReports,
   };
-}
-
-export async function attachQaProfileScorecardEvidenceToFile(params: {
-  evidencePath: string;
-  evidenceMode?: QaScorecardEvidenceMode;
-  profile: string;
-  profilePlan: QaProfileEvidencePlan;
-  filters: QaProfileScorecardFilters;
-  categories: readonly QaScorecardCategoryCoverageReport[];
-}) {
-  const evidence = validateQaEvidenceSummaryJson(
-    JSON.parse(await fs.readFile(params.evidencePath, "utf8")),
-  );
-  const scorecard = buildQaProfileScorecardEvidence({
-    evidence,
-    filters: params.filters,
-    categories: params.categories,
-  });
-  const nextEvidence = attachQaEvidenceScorecard({
-    summary: evidence,
-    evidenceMode: params.evidenceMode,
-    profile: params.profile,
-    profilePlan: params.profilePlan,
-    scorecard,
-  });
-  await fs.writeFile(params.evidencePath, `${JSON.stringify(nextEvidence, null, 2)}\n`, "utf8");
-  return scorecard;
 }

--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -9,6 +9,11 @@ import {
 } from "./crabline-artifacts.js";
 import { buildQaSuiteEvidenceSummary, QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
 import type { QaProviderMode } from "./model-selection.js";
+import {
+  runQaProfilePhase,
+  type QaProfilePhaseRetry,
+  type QaProfileRunControl,
+} from "./profile-run-checkpoint.js";
 import type { QaTransportDriver } from "./qa-transport-registry.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
@@ -56,6 +61,38 @@ export type QaSuiteGatewayRssSample = NonNullable<
 export type QaSuiteGatewayHeapSnapshot = NonNullable<
   NonNullable<QaSuiteSummaryJson["metrics"]>["gatewayHeapSnapshots"]
 >[number];
+
+export async function persistQaSuiteScenarioEvidence(params: {
+  channelDriver?: QaTransportDriver;
+  channelId: string;
+  evidenceMode?: QaScorecardEvidenceMode;
+  primaryModel: string;
+  profileRun?: QaProfileRunControl;
+  providerMode: QaProviderMode;
+  repoRoot: string;
+  scenarioDefinition: QaSeedScenarioWithSource;
+  scenarioResult: QaSuiteScenarioResult;
+}) {
+  if (!params.profileRun) {
+    return;
+  }
+  await params.profileRun.complete({
+    scenarioId: params.scenarioDefinition.id,
+    evidence: buildQaSuiteEvidenceSummary({
+      artifactPaths: [],
+      evidenceMode: params.evidenceMode,
+      channelDriver: params.channelDriver,
+      channelId: params.channelId,
+      env: process.env,
+      generatedAt: new Date().toISOString(),
+      primaryModel: params.primaryModel,
+      providerMode: params.providerMode,
+      repoRoot: params.repoRoot,
+      scenarioDefinitions: [params.scenarioDefinition],
+      scenarioResults: [params.scenarioResult],
+    }),
+  });
+}
 
 /**
  * Pure-ish JSON builder for qa-suite-summary.json. Exported so the GPT-5.6 Luna
@@ -133,6 +170,7 @@ export async function writeQaSuiteArtifacts(params: {
   scenarioIds?: readonly string[];
   runtimePair?: [RuntimeId, RuntimeId];
   writeEvidenceFile?: boolean;
+  retryPhase?: QaProfilePhaseRetry;
   runCrablineChannelDriverSmoke?: (
     params: Parameters<QaCrablineRuntime["runOpenClawCrablineChannelDriverSmoke"]>[0],
   ) => Promise<QaCrablineChannelDriverSmokeResult>;
@@ -219,71 +257,74 @@ export async function writeQaSuiteArtifacts(params: {
           scenarioResults: params.scenarios,
         })
       : undefined;
-  if (
-    crablineChannelDriverSelection &&
-    crablineChannelDriverSmoke &&
-    !hasQaCrablineArtifactPath(crablineChannelDriverSmoke.capabilityMatrixPath)
-  ) {
-    await fs.writeFile(
-      path.join(params.outputDir, crablineChannelDriverSelection.capabilityMatrixPath),
-      `${JSON.stringify(
-        {
-          version: 1,
-          source: "openclaw/crabline",
-          channelDriver: crablineChannelDriverSelection.channelDriver,
-          selectedChannel: crablineChannelDriverSelection.channel,
-          manifestPath: crablineChannelDriverSmoke.manifestPath,
-          report: crablineChannelDriverSmoke.capabilityReport,
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-  }
-  if (
-    crablineChannelDriverSelection &&
-    crablineChannelDriverSmoke &&
-    !hasQaCrablineArtifactPath(crablineChannelDriverSmoke.smokeArtifactPath)
-  ) {
-    await fs.writeFile(
-      path.join(params.outputDir, crablineChannelDriverSelection.smokeArtifactPath),
-      `${JSON.stringify(
-        {
-          version: 1,
-          source: "openclaw/crabline",
-          channelDriver: crablineChannelDriverSelection.channelDriver,
-          selectedChannel: crablineChannelDriverSelection.channel,
-          manifestPath: crablineChannelDriverSmoke.manifestPath,
-          smoke: crablineChannelDriverSmoke.smoke,
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-  }
   const writeEvidenceFile = params.writeEvidenceFile ?? true;
-  await fs.writeFile(reportPath, report, "utf8");
-  if (evidence && writeEvidenceFile) {
-    await fs.writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
-  }
-  await fs.writeFile(
-    summaryPath,
-    `${JSON.stringify(
-      buildQaSuiteSummaryJson({
-        ...params,
-        channelDriverSelection: effectiveChannelDriverSelection,
-      }),
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
-  await assertQaSuiteArtifactWritten("report", reportPath);
-  await assertQaSuiteArtifactWritten("summary", summaryPath);
-  if (evidence && writeEvidenceFile) {
-    await assertQaSuiteArtifactWritten("evidence", evidencePath);
-  }
+  const persistArtifacts = async () => {
+    if (
+      crablineChannelDriverSelection &&
+      crablineChannelDriverSmoke &&
+      !hasQaCrablineArtifactPath(crablineChannelDriverSmoke.capabilityMatrixPath)
+    ) {
+      await fs.writeFile(
+        path.join(params.outputDir, crablineChannelDriverSelection.capabilityMatrixPath),
+        `${JSON.stringify(
+          {
+            version: 1,
+            source: "openclaw/crabline",
+            channelDriver: crablineChannelDriverSelection.channelDriver,
+            selectedChannel: crablineChannelDriverSelection.channel,
+            manifestPath: crablineChannelDriverSmoke.manifestPath,
+            report: crablineChannelDriverSmoke.capabilityReport,
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+    }
+    if (
+      crablineChannelDriverSelection &&
+      crablineChannelDriverSmoke &&
+      !hasQaCrablineArtifactPath(crablineChannelDriverSmoke.smokeArtifactPath)
+    ) {
+      await fs.writeFile(
+        path.join(params.outputDir, crablineChannelDriverSelection.smokeArtifactPath),
+        `${JSON.stringify(
+          {
+            version: 1,
+            source: "openclaw/crabline",
+            channelDriver: crablineChannelDriverSelection.channelDriver,
+            selectedChannel: crablineChannelDriverSelection.channel,
+            manifestPath: crablineChannelDriverSmoke.manifestPath,
+            smoke: crablineChannelDriverSmoke.smoke,
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+    }
+    await fs.writeFile(reportPath, report, "utf8");
+    if (evidence && writeEvidenceFile) {
+      await fs.writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+    }
+    await fs.writeFile(
+      summaryPath,
+      `${JSON.stringify(
+        buildQaSuiteSummaryJson({
+          ...params,
+          channelDriverSelection: effectiveChannelDriverSelection,
+        }),
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await assertQaSuiteArtifactWritten("report", reportPath);
+    await assertQaSuiteArtifactWritten("summary", summaryPath);
+    if (evidence && writeEvidenceFile) {
+      await assertQaSuiteArtifactWritten("evidence", evidencePath);
+    }
+  };
+  await runQaProfilePhase(params.retryPhase, "suite artifact persistence", persistArtifacts);
   return { evidence, evidencePath, report, reportPath, summaryPath };
 }

--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -9,11 +9,7 @@ import {
 } from "./crabline-artifacts.js";
 import { buildQaSuiteEvidenceSummary, QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
 import type { QaProviderMode } from "./model-selection.js";
-import {
-  runQaProfilePhase,
-  type QaProfilePhaseRetry,
-  type QaProfileRunControl,
-} from "./profile-run-checkpoint.js";
+import type { QaProfilePhaseRetry, QaProfileRunControl } from "./profile-run-checkpoint.js";
 import type { QaTransportDriver } from "./qa-transport-registry.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
@@ -325,6 +321,6 @@ export async function writeQaSuiteArtifacts(params: {
       await assertQaSuiteArtifactWritten("evidence", evidencePath);
     }
   };
-  await runQaProfilePhase(params.retryPhase, "suite artifact persistence", persistArtifacts);
+  await (params.retryPhase?.("suite artifact persistence", persistArtifacts) ?? persistArtifacts());
   return { evidence, evidencePath, report, reportPath, summaryPath };
 }

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2590,7 +2590,16 @@ describe("qa suite runtime launcher", () => {
     expect(checkpoint.cells.every((cell) => cell.evidence)).toBe(true);
   });
 
-  it("does not retry or synthesize over terminal producer evidence", async () => {
+  it.each([
+    {
+      name: "finalizes unified terminal evidence once before rethrowing deterministic cleanup failure",
+      finalEvidenceFailures: 0,
+    },
+    {
+      name: "aggregates unified cleanup and finalization failures without losing the cleanup error",
+      finalEvidenceFailures: 1,
+    },
+  ])("$name", async ({ finalEvidenceFailures }) => {
     const repoRoot = await makeTempRepo("qa-suite-profile-terminal-producer-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-terminal-producer");
     const scenarioIds = ["dm-chat-baseline", "control-ui-chat-flow-playwright"];
@@ -2634,6 +2643,7 @@ describe("qa suite runtime launcher", () => {
       markHigherFailed();
       throw higherError;
     });
+    atomicState.finalEvidenceFailures = finalEvidenceFailures;
 
     const runPromise = runQaSuite({
       repoRoot,
@@ -2658,16 +2668,36 @@ describe("qa suite runtime launcher", () => {
     releaseLower();
     const thrown = await runPromise.catch((error: unknown) => error);
 
-    expect(thrown).toBe(lowerError);
+    if (finalEvidenceFailures > 0) {
+      expect(thrown).toBeInstanceOf(AggregateError);
+      expect((thrown as AggregateError).errors[0]).toBe(lowerError);
+      expect((thrown as AggregateError).errors[1]).toMatchObject({
+        message: "final evidence disk full",
+      });
+      expect((thrown as Error).cause).toBe(lowerError);
+    } else {
+      expect(thrown).toBe(lowerError);
+    }
     expect(attempts).toEqual(
       new Map([
         [scenarioIds[0], 1],
         [scenarioIds[1], 1],
       ]),
     );
-    await expect(fs.access(path.join(outputDir, "qa-evidence.json"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    expect(atomicState.writes.filter((writtenPath) => writtenPath === evidencePath)).toHaveLength(
+      1,
+    );
+    if (finalEvidenceFailures > 0) {
+      await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } else {
+      const finalized = validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(evidencePath, "utf8")),
+      );
+      expect(finalized.entries.map((entry) => entry.test.id).sort()).toEqual(
+        [...scenarioIds].sort(),
+      );
+    }
     const checkpoint = JSON.parse(
       await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
     ) as { cells: Array<{ evidence?: { path: string }; scenarioId: string }> };

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -19,6 +19,25 @@ const { crablineRuntimeLoads, runQaFlowSuite, runQaTestFileScenarios } = vi.hois
   runQaFlowSuite: vi.fn(),
   runQaTestFileScenarios: vi.fn(),
 }));
+const atomicState = vi.hoisted(() => ({
+  finalEvidenceFailures: 0,
+  writes: [] as string[],
+}));
+
+vi.mock("openclaw/plugin-sdk/json-store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/json-store")>();
+  return {
+    ...actual,
+    writeJsonFileAtomically: async (filePath: string, value: unknown) => {
+      atomicState.writes.push(filePath);
+      if (filePath.endsWith("qa-evidence.json") && atomicState.finalEvidenceFailures > 0) {
+        atomicState.finalEvidenceFailures -= 1;
+        throw new Error("final evidence disk full");
+      }
+      await actual.writeJsonFileAtomically(filePath, value);
+    },
+  };
+});
 
 vi.mock("@openclaw/crabline", async (importOriginal) => {
   crablineRuntimeLoads();
@@ -45,13 +64,18 @@ async function makeTempRepo(prefix: string) {
   return repoRoot;
 }
 
-async function writeEvidence(pathLocal: string, writeFile = true) {
+async function writeEvidence(pathLocal: string, writeFile = true, testIds: readonly string[] = []) {
   const evidence = {
     kind: "openclaw.qa.evidence-summary",
     schemaVersion: 2,
     generatedAt: "2026-06-14T00:00:00.000Z",
     evidenceMode: "full",
-    entries: [],
+    entries: testIds.map((testId) => ({
+      test: { kind: "flow", id: testId, title: testId },
+      coverage: [],
+      refs: [],
+      result: { status: "pass" as const },
+    })),
   };
   if (writeFile) {
     await fs.mkdir(path.dirname(pathLocal), { recursive: true });
@@ -129,18 +153,29 @@ function mockFlowPartitionFailures(failuresByScenarioId: ReadonlyMap<string, rea
 
 describe("qa suite runtime launcher", () => {
   beforeEach(() => {
+    atomicState.finalEvidenceFailures = 0;
+    atomicState.writes.length = 0;
     runQaFlowSuite.mockReset();
     runQaTestFileScenarios.mockReset();
     runQaFlowSuite.mockImplementation(
       async (
         params:
-          | { outputDir?: string; scenarioIds?: string[]; writeEvidenceFile?: boolean }
+          | {
+              outputDir?: string;
+              profileRun?: QaProfileRunControl;
+              scenarioIds?: string[];
+              writeEvidenceFile?: boolean;
+            }
           | undefined,
       ) => {
         const outputDir = params?.outputDir ?? "/tmp/qa-flow";
         const evidencePath = path.join(outputDir, "qa-evidence.json");
-        const evidence = await writeEvidence(evidencePath, params?.writeEvidenceFile);
         const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
+        const evidence = await writeEvidence(
+          evidencePath,
+          params?.writeEvidenceFile,
+          params?.profileRun ? scenarioIds : [],
+        );
         return {
           evidence,
           outputDir,
@@ -327,6 +362,9 @@ describe("qa suite runtime launcher", () => {
     if (result.executionKind !== "flow") {
       throw new Error("expected flow suite result");
     }
+    expect(runQaFlowSuite).toHaveBeenCalledWith(
+      expect.objectContaining({ writeEvidenceFile: false }),
+    );
     expect(result.result.evidence?.profilePlan?.observedCells).toEqual([
       {
         scenarioId: "channel-chat-baseline",
@@ -334,6 +372,16 @@ describe("qa suite runtime launcher", () => {
         channel: "qa-channel",
       },
     ]);
+    const evidencePath = path.join(
+      repoRoot,
+      ".artifacts",
+      "qa-e2e",
+      "profile-flow",
+      "qa-evidence.json",
+    );
+    expect(atomicState.writes.filter((writtenPath) => writtenPath === evidencePath)).toHaveLength(
+      1,
+    );
   });
 
   it("retries one preterminal profile partition after another partition completes", async () => {
@@ -396,44 +444,54 @@ describe("qa suite runtime launcher", () => {
     ]);
   });
 
-  it("rethrows post-terminal cleanup failure without replay or synthetic evidence", async () => {
+  it("finalizes direct terminal evidence once before rethrowing the original cleanup failure", async () => {
     const repoRoot = await makeTempRepo("qa-suite-profile-post-terminal-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-post-terminal");
-    const scenarioIds = ["channel-chat-baseline", "control-ui-chat-flow-playwright"];
+    const scenarioIds = ["channel-chat-baseline"];
     const run = runQaFlowSuite.getMockImplementation();
     if (!run) {
       throw new Error("expected default QA flow suite mock implementation");
     }
+    let cleanupFailure: unknown;
     runQaFlowSuite.mockImplementation(async (params) => {
+      expect(params?.writeEvidenceFile).toBe(false);
       const result = await run(params);
       await completeProfileRun(params, result.evidence);
       const cleanupError = Object.assign(new Error("gateway cleanup reset"), {
         code: "ECONNRESET",
       });
-      throwQaSuiteCleanupErrors({
-        cleanupFailures: [{ phase: "gateway stop", error: cleanupError }],
-        runFailed: false,
-        runError: undefined,
-        result,
-        evidenceWritten: true,
-      });
-      return result;
+      try {
+        throwQaSuiteCleanupErrors({
+          cleanupFailures: [{ phase: "gateway stop", error: cleanupError }],
+          runFailed: false,
+          runError: undefined,
+          result,
+          evidenceWritten: false,
+        });
+      } catch (error) {
+        cleanupFailure = error;
+        throw error;
+      }
     });
 
-    await expect(
-      runQaSuite({
-        repoRoot,
-        outputDir: ".artifacts/qa-e2e/profile-post-terminal",
-        providerMode: "mock-openai",
-        scenarioIds,
-        profileRunSpec: profileRunSpec(scenarioIds),
-      }),
-    ).rejects.toThrow("cleanup failed");
+    const thrown = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/profile-post-terminal",
+      providerMode: "mock-openai",
+      scenarioIds,
+      profileRunSpec: profileRunSpec(scenarioIds),
+    }).catch((error: unknown) => error);
 
+    expect(thrown).toBe(cleanupFailure);
     expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
-    await expect(fs.access(path.join(outputDir, "qa-evidence.json"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    expect(atomicState.writes.filter((writtenPath) => writtenPath === evidencePath)).toHaveLength(
+      1,
+    );
+    const finalized = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(evidencePath, "utf8")),
+    );
+    expect(finalized.entries.map((entry) => entry.test.id)).toEqual(scenarioIds);
     const checkpoint = JSON.parse(
       await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
     ) as { cells: Array<{ scenarioId: string; evidence?: { path: string } }> };
@@ -441,7 +499,44 @@ describe("qa suite runtime launcher", () => {
     const stored = validateQaEvidenceSummaryJson(
       JSON.parse(await fs.readFile(path.join(outputDir, terminal!.evidence!.path), "utf8")),
     );
-    expect(stored.entries).toEqual([]);
+    expect(stored.entries.map((entry) => entry.test.id)).toEqual(scenarioIds);
+  });
+
+  it("aggregates direct cleanup and finalization failures without replay", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-profile-finalize-failure-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-finalize-failure");
+    const scenarioIds = ["channel-chat-baseline"];
+    const originalError = new Error("cleanup failed");
+    const run = runQaFlowSuite.getMockImplementation();
+    if (!run) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    runQaFlowSuite.mockImplementation(async (params) => {
+      const result = await run(params);
+      await completeProfileRun(params, result.evidence);
+      throw originalError;
+    });
+    atomicState.finalEvidenceFailures = 1;
+
+    const thrown = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/profile-finalize-failure",
+      providerMode: "mock-openai",
+      scenarioIds,
+      profileRunSpec: profileRunSpec(scenarioIds),
+    }).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect((thrown as AggregateError).errors[0]).toBe(originalError);
+    expect((thrown as AggregateError).errors[1]).toMatchObject({
+      message: "final evidence disk full",
+    });
+    expect((thrown as Error & { cause?: unknown }).cause).toBe(originalError);
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    expect(atomicState.writes.filter((writtenPath) => writtenPath === evidencePath)).toHaveLength(
+      1,
+    );
   });
 
   it("partitions flow-only suites that request isolated workers", async () => {
@@ -2383,6 +2478,8 @@ describe("qa suite runtime launcher", () => {
 
   it("reuses unavailable channel credential evidence across serial partitions", async () => {
     const repoRoot = await makeTempRepo("qa-suite-credential-unavailable-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "credential-unavailable");
+    const scenarioIds = ["whatsapp-status-command", "whatsapp-access-control-dm-open"];
     const poolError = Object.assign(new Error("no WhatsApp credential is available"), {
       code: "POOL_EXHAUSTED",
     });
@@ -2398,11 +2495,9 @@ describe("qa suite runtime launcher", () => {
       providerMode: "mock-openai",
       channelDriver: "live",
       adapterFactories: [{ id: "whatsapp", matches: () => true, create: vi.fn() }],
-      scenarioIds: [
-        "whatsapp-status-command",
-        "whatsapp-access-control-dm-open",
-        "control-ui-chat-flow-playwright",
-      ],
+      runtimePair: ["openclaw", "codex"],
+      scenarioIds,
+      profileRunSpec: profileRunSpec(scenarioIds),
     });
 
     expect(result.executionKind).toBe("suite");
@@ -2421,13 +2516,168 @@ describe("qa suite runtime launcher", () => {
         test?: { id?: string };
       }>;
     };
-    for (const scenarioId of ["whatsapp-status-command", "whatsapp-access-control-dm-open"]) {
+    for (const scenarioId of scenarioIds) {
       const blocked = evidence.entries?.find((entry) => entry.test?.id === scenarioId);
       expect(blocked).toMatchObject({
         execution: { channel: { id: "whatsapp", live: false } },
         result: { status: "blocked" },
       });
       expect(blocked?.execution?.channel?.driver).toBeUndefined();
+    }
+    const checkpoint = JSON.parse(
+      await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
+    ) as { cells: Array<{ evidence?: { path: string }; scenarioId: string }> };
+    expect(checkpoint.cells).toHaveLength(2);
+    for (const cell of checkpoint.cells) {
+      const stored = validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(path.join(outputDir, cell.evidence!.path), "utf8")),
+      );
+      expect(stored.entries.map((entry) => entry.test.id)).toEqual([cell.scenarioId]);
+      expect(stored.entries[0]?.result.status).toBe("blocked");
+    }
+  });
+
+  it("persists exhausted profile retry synthesis through refs and final evidence", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-profile-retry-exhausted-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-retry-exhausted");
+    const scenarioIds = ["channel-chat-baseline", "matrix-allowlist-hot-reload"];
+    const run = runQaFlowSuite.getMockImplementation();
+    if (!run) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    const attempts = new Map<string, number>();
+    runQaFlowSuite.mockImplementation(async (params) => {
+      const scenarioId = params?.scenarioIds?.[0];
+      if (!scenarioId) {
+        throw new Error("expected one scenario per profile partition");
+      }
+      const attempt = (attempts.get(scenarioId) ?? 0) + 1;
+      attempts.set(scenarioId, attempt);
+      if (scenarioId === scenarioIds[1]) {
+        throw new QaSuiteInfraError("agent_wait_failed", "partition wait failed");
+      }
+      const result = await run(params);
+      await completeProfileRun(params, result.evidence);
+      return result;
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/profile-retry-exhausted",
+      concurrency: 1,
+      runtimePair: ["openclaw", "codex"],
+      scenarioIds,
+      profileRunSpec: profileRunSpec(scenarioIds),
+    });
+
+    expect(attempts).toEqual(
+      new Map([
+        [scenarioIds[0], 1],
+        [scenarioIds[1], 2],
+      ]),
+    );
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    const evidence = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")),
+    );
+    expect(evidence.entries.map((entry) => entry.test.id)).toEqual(scenarioIds);
+    expect(evidence.entries.map((entry) => entry.result.status)).toEqual(["pass", "fail"]);
+    const checkpoint = JSON.parse(
+      await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
+    ) as { cells: Array<{ evidence?: { path: string }; scenarioId: string }> };
+    expect(checkpoint.cells.every((cell) => cell.evidence)).toBe(true);
+  });
+
+  it("does not retry or synthesize over terminal producer evidence", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-profile-terminal-producer-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-terminal-producer");
+    const scenarioIds = ["dm-chat-baseline", "control-ui-chat-flow-playwright"];
+    const lowerError = new QaSuiteInfraError("agent_wait_failed", "lower partition failed");
+    const higherError = new QaSuiteInfraError("agent_wait_failed", "higher partition failed");
+    const runFlow = runQaFlowSuite.getMockImplementation();
+    const runTestFile = runQaTestFileScenarios.getMockImplementation();
+    if (!runFlow || !runTestFile) {
+      throw new Error("expected default QA suite mock implementations");
+    }
+    let releaseLower!: () => void;
+    let markHigherFailed!: () => void;
+    const lowerBlocked = new Promise<void>((resolve) => {
+      releaseLower = resolve;
+    });
+    const higherFailed = new Promise<void>((resolve) => {
+      markHigherFailed = resolve;
+    });
+    const attempts = new Map<string, number>();
+    runQaFlowSuite.mockImplementation(async (params) => {
+      const scenarioId = params?.scenarioIds?.[0];
+      if (scenarioId !== scenarioIds[0]) {
+        throw new Error("expected the flow profile partition");
+      }
+      attempts.set(scenarioId, (attempts.get(scenarioId) ?? 0) + 1);
+      const result = await runFlow(params);
+      await completeProfileRun(params, result.evidence);
+      await higherFailed;
+      await lowerBlocked;
+      throw lowerError;
+    });
+    runQaTestFileScenarios.mockImplementation(async (params) => {
+      const scenarioId = params.scenarios[0]?.id;
+      if (scenarioId !== scenarioIds[1] || !params.profileRun) {
+        throw new Error("expected the test-file profile partition");
+      }
+      attempts.set(scenarioId, (attempts.get(scenarioId) ?? 0) + 1);
+      const result = await runTestFile(params);
+      result.evidence = await writeEvidence(result.evidencePath, false, [scenarioId]);
+      await params.profileRun.complete({ scenarioId, evidence: result.evidence });
+      markHigherFailed();
+      throw higherError;
+    });
+
+    const runPromise = runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/profile-terminal-producer",
+      concurrency: 2,
+      scenarioIds,
+      profileRunSpec: profileRunSpec(scenarioIds),
+    });
+    await higherFailed;
+    let settled = false;
+    void runPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseLower();
+    const thrown = await runPromise.catch((error: unknown) => error);
+
+    expect(thrown).toBe(lowerError);
+    expect(attempts).toEqual(
+      new Map([
+        [scenarioIds[0], 1],
+        [scenarioIds[1], 1],
+      ]),
+    );
+    await expect(fs.access(path.join(outputDir, "qa-evidence.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    const checkpoint = JSON.parse(
+      await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
+    ) as { cells: Array<{ evidence?: { path: string }; scenarioId: string }> };
+    for (const cell of checkpoint.cells) {
+      const stored = validateQaEvidenceSummaryJson(
+        JSON.parse(await fs.readFile(path.join(outputDir, cell.evidence!.path), "utf8")),
+      );
+      expect(stored.entries).toMatchObject([
+        { result: { status: "pass" }, test: { id: cell.scenarioId } },
+      ]);
     }
   });
 

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -250,7 +250,11 @@ describe("qa suite runtime launcher", () => {
     });
 
     expect(result.executionKind).toBe("flow");
+    if (result.executionKind !== "flow") {
+      throw new Error("expected flow suite result");
+    }
     expect(result.result.summaryPath).toMatch(/qa-suite-summary\.json$/);
+    expect(result.result.watchUrl).toBe("http://127.0.0.1:43124");
     expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
     expect(runQaFlowSuite).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -338,7 +342,7 @@ describe("qa suite runtime launcher", () => {
     }
   });
 
-  it("finalizes a flow profile with the default qa-channel cell", async () => {
+  it("finalizes a single-flow profile through unified execution", async () => {
     const repoRoot = await makeTempRepo("qa-suite-profile-flow-");
     const run = runQaFlowSuite.getMockImplementation();
     if (!run) {
@@ -358,9 +362,9 @@ describe("qa suite runtime launcher", () => {
       profileRunSpec: profileRunSpec(["channel-chat-baseline"]),
     });
 
-    expect(result.executionKind).toBe("flow");
-    if (result.executionKind !== "flow") {
-      throw new Error("expected flow suite result");
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
     }
     expect(runQaFlowSuite).toHaveBeenCalledWith(
       expect.objectContaining({ writeEvidenceFile: false }),
@@ -382,6 +386,27 @@ describe("qa suite runtime launcher", () => {
     expect(atomicState.writes.filter((writtenPath) => writtenPath === evidencePath)).toHaveLength(
       1,
     );
+  });
+
+  it("does not start a profile run when canonical evidence invalidation fails", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-profile-invalidation-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-invalidation");
+    await fs.mkdir(path.join(outputDir, "qa-evidence.json"), { recursive: true });
+
+    await expect(
+      runQaSuite({
+        repoRoot,
+        outputDir: ".artifacts/qa-e2e/profile-invalidation",
+        providerMode: "mock-openai",
+        scenarioIds: ["channel-chat-baseline"],
+        profileRunSpec: profileRunSpec(["channel-chat-baseline"]),
+      }),
+    ).rejects.toThrow();
+
+    expect(runQaFlowSuite).not.toHaveBeenCalled();
+    await expect(
+      fs.access(path.join(outputDir, "qa-profile-run-checkpoint.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("retries one preterminal profile partition after another partition completes", async () => {
@@ -444,7 +469,7 @@ describe("qa suite runtime launcher", () => {
     ]);
   });
 
-  it("finalizes direct terminal evidence once before rethrowing the original cleanup failure", async () => {
+  it("finalizes unified terminal evidence once before rethrowing the original cleanup failure", async () => {
     const repoRoot = await makeTempRepo("qa-suite-profile-post-terminal-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-post-terminal");
     const scenarioIds = ["channel-chat-baseline"];
@@ -502,7 +527,7 @@ describe("qa suite runtime launcher", () => {
     expect(stored.entries.map((entry) => entry.test.id)).toEqual(scenarioIds);
   });
 
-  it("aggregates direct cleanup and finalization failures without replay", async () => {
+  it("aggregates unified cleanup and finalization failures without replay", async () => {
     const repoRoot = await makeTempRepo("qa-suite-profile-finalize-failure-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-finalize-failure");
     const scenarioIds = ["channel-chat-baseline"];
@@ -2537,57 +2562,112 @@ describe("qa suite runtime launcher", () => {
     }
   });
 
-  it("persists exhausted profile retry synthesis through refs and final evidence", async () => {
+  it("invalidates prior success before exhausted single-flow profile retry publishes failure", async () => {
     const repoRoot = await makeTempRepo("qa-suite-profile-retry-exhausted-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-retry-exhausted");
-    const scenarioIds = ["channel-chat-baseline", "matrix-allowlist-hot-reload"];
+    const scenarioId = "channel-chat-baseline";
     const run = runQaFlowSuite.getMockImplementation();
     if (!run) {
       throw new Error("expected default QA flow suite mock implementation");
     }
-    const attempts = new Map<string, number>();
+    let failing = false;
+    let failureAttempts = 0;
+    let releaseFirstFailure!: () => void;
+    let markFirstFailureStarted!: () => void;
+    const firstFailureBlocked = new Promise<void>((resolve) => {
+      releaseFirstFailure = resolve;
+    });
+    const firstFailureStarted = new Promise<void>((resolve) => {
+      markFirstFailureStarted = resolve;
+    });
     runQaFlowSuite.mockImplementation(async (params) => {
-      const scenarioId = params?.scenarioIds?.[0];
-      if (!scenarioId) {
-        throw new Error("expected one scenario per profile partition");
-      }
-      const attempt = (attempts.get(scenarioId) ?? 0) + 1;
-      attempts.set(scenarioId, attempt);
-      if (scenarioId === scenarioIds[1]) {
+      if (failing) {
+        failureAttempts += 1;
+        if (failureAttempts === 1) {
+          markFirstFailureStarted();
+          await firstFailureBlocked;
+        }
         throw new QaSuiteInfraError("agent_wait_failed", "partition wait failed");
       }
       const result = await run(params);
       await completeProfileRun(params, result.evidence);
       return result;
     });
-
-    const result = await runQaSuite({
+    const runParams = {
       repoRoot,
       outputDir: ".artifacts/qa-e2e/profile-retry-exhausted",
-      concurrency: 1,
-      runtimePair: ["openclaw", "codex"],
-      scenarioIds,
-      profileRunSpec: profileRunSpec(scenarioIds),
-    });
+      providerMode: "mock-openai" as const,
+      scenarioIds: [scenarioId],
+      profileRunSpec: profileRunSpec([scenarioId]),
+    };
 
-    expect(attempts).toEqual(
-      new Map([
-        [scenarioIds[0], 1],
-        [scenarioIds[1], 2],
-      ]),
+    const success = await runQaSuite(runParams);
+    expect(success.executionKind).toBe("suite");
+    const evidencePath = path.join(outputDir, "qa-evidence.json");
+    expect(
+      validateQaEvidenceSummaryJson(JSON.parse(await fs.readFile(evidencePath, "utf8"))).entries[0]
+        ?.result.status,
+    ).toBe("pass");
+    const canonicalWritesAfterSuccess = atomicState.writes.filter(
+      (writtenPath) => writtenPath === evidencePath,
+    ).length;
+
+    failing = true;
+    const failedRun = runQaSuite(runParams);
+    await firstFailureStarted;
+    await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+    releaseFirstFailure();
+    const result = await failedRun;
+
+    expect(failureAttempts).toBe(2);
+    expect(atomicState.writes.filter((writtenPath) => writtenPath === evidencePath)).toHaveLength(
+      canonicalWritesAfterSuccess + 1,
     );
+    expect(result.executionKind).toBe("suite");
     if (result.executionKind !== "suite") {
       throw new Error("expected unified suite result");
     }
     const evidence = validateQaEvidenceSummaryJson(
       JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")),
     );
-    expect(evidence.entries.map((entry) => entry.test.id)).toEqual(scenarioIds);
-    expect(evidence.entries.map((entry) => entry.result.status)).toEqual(["pass", "fail"]);
+    expect(evidence.entries).toMatchObject([
+      {
+        test: { id: scenarioId },
+        result: {
+          status: "fail",
+          failure: { reason: "suite partition failed: partition wait failed" },
+        },
+      },
+    ]);
+    expect(evidence.profilePlan?.observedCells).toEqual([
+      {
+        scenarioId,
+        executionKind: "flow",
+        channel: "qa-channel",
+      },
+    ]);
+    expect(result.result.scenarios).toMatchObject([
+      {
+        status: "fail",
+        details: "suite partition failed: partition wait failed",
+      },
+    ]);
+    const summary = JSON.parse(await fs.readFile(result.result.summaryPath, "utf8")) as {
+      counts: { failed: number; passed: number; total: number };
+    };
+    expect(summary.counts).toMatchObject({ total: 1, passed: 0, failed: 1 });
+    await expect(fs.access(result.result.evidencePath)).resolves.toBeUndefined();
+    await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
+    await expect(fs.access(result.result.summaryPath)).resolves.toBeUndefined();
     const checkpoint = JSON.parse(
       await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
     ) as { cells: Array<{ evidence?: { path: string }; scenarioId: string }> };
-    expect(checkpoint.cells.every((cell) => cell.evidence)).toBe(true);
+    expect(checkpoint.cells).toMatchObject([
+      {
+        scenarioId,
+        evidence: { path: expect.stringMatching(/^qa-profile-evidence\//) },
+      },
+    ]);
   });
 
   it.each([

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QaSuiteInfraError } from "./errors.js";
+import { validateQaEvidenceSummaryJson } from "./evidence-summary.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
+import type { QaProfileRunControl, QaProfileRunSpec } from "./profile-run-checkpoint.js";
+import { readQaScenarioById } from "./scenario-catalog.js";
 import type { QaSuiteScenarioResult } from "./suite.js";
 import { throwQaSuiteCleanupErrors } from "./suite.js";
 import type {
@@ -55,6 +58,29 @@ async function writeEvidence(pathLocal: string, writeFile = true) {
     await fs.writeFile(pathLocal, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
   }
   return evidence;
+}
+
+function profileRunSpec(scenarioIds: readonly string[]): QaProfileRunSpec {
+  const scenarios = scenarioIds.map(readQaScenarioById);
+  return {
+    profile: "release",
+    membershipScenarios: scenarios,
+    selectedScenarios: scenarios,
+    excludedScenarios: [],
+    filters: {},
+    categories: [],
+  };
+}
+
+async function completeProfileRun(
+  params: { profileRun?: QaProfileRunControl; scenarioIds?: string[] },
+  evidence: Awaited<ReturnType<typeof writeEvidence>>,
+) {
+  const scenarioId = params.scenarioIds?.[0];
+  if (!scenarioId || !params.profileRun) {
+    throw new Error("expected profile partition");
+  }
+  await params.profileRun.complete({ scenarioId, evidence });
 }
 
 function trackMaxActiveFlowRuns() {
@@ -188,12 +214,8 @@ describe("qa suite runtime launcher", () => {
       scenarioIds: ["channel-chat-baseline"],
     });
 
-    expect(result).toMatchObject({
-      executionKind: "flow",
-      result: {
-        summaryPath: "/tmp/qa-flow/qa-suite-summary.json",
-      },
-    });
+    expect(result.executionKind).toBe("flow");
+    expect(result.result.summaryPath).toMatch(/qa-suite-summary\.json$/);
     expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
     expect(runQaFlowSuite).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -279,6 +301,147 @@ describe("qa suite runtime launcher", () => {
     } finally {
       stderrWrite.mockRestore();
     }
+  });
+
+  it("finalizes a flow profile with the default qa-channel cell", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-profile-flow-");
+    const run = runQaFlowSuite.getMockImplementation();
+    if (!run) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    runQaFlowSuite.mockImplementation(async (params) => {
+      const result = await run(params);
+      await completeProfileRun(params, result.evidence);
+      return result;
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/profile-flow",
+      providerMode: "mock-openai",
+      scenarioIds: ["channel-chat-baseline"],
+      profileRunSpec: profileRunSpec(["channel-chat-baseline"]),
+    });
+
+    expect(result.executionKind).toBe("flow");
+    if (result.executionKind !== "flow") {
+      throw new Error("expected flow suite result");
+    }
+    expect(result.result.evidence?.profilePlan?.observedCells).toEqual([
+      {
+        scenarioId: "channel-chat-baseline",
+        executionKind: "flow",
+        channel: "qa-channel",
+      },
+    ]);
+  });
+
+  it("retries one preterminal profile partition after another partition completes", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-profile-partition-retry-");
+    const scenarioIds = ["channel-chat-baseline", "matrix-allowlist-hot-reload"];
+    const run = runQaFlowSuite.getMockImplementation();
+    if (!run) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    const attempts = new Map<string, number>();
+    runQaFlowSuite.mockImplementation(async (params) => {
+      const scenarioId = params?.scenarioIds?.[0];
+      if (!scenarioId) {
+        throw new Error("expected one scenario per profile partition");
+      }
+      const attempt = (attempts.get(scenarioId) ?? 0) + 1;
+      attempts.set(scenarioId, attempt);
+      if (scenarioId === scenarioIds[1] && attempt === 1) {
+        throw new QaSuiteInfraError("agent_wait_failed", "second partition wait failed");
+      }
+      const result = await run(params);
+      await completeProfileRun(params, result.evidence);
+      return result;
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/profile-partition-retry",
+      providerMode: "mock-openai",
+      concurrency: 1,
+      runtimePair: ["openclaw", "codex"],
+      scenarioIds,
+      profileRunSpec: profileRunSpec(scenarioIds),
+    });
+
+    expect(attempts).toEqual(
+      new Map([
+        ["channel-chat-baseline", 1],
+        ["matrix-allowlist-hot-reload", 2],
+      ]),
+    );
+    expect(result.executionKind).toBe("suite");
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    const evidence = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(result.result.evidencePath, "utf8")),
+    );
+    expect(evidence.profilePlan?.observedCells).toEqual([
+      {
+        scenarioId: "channel-chat-baseline",
+        executionKind: "flow",
+        channel: "qa-channel",
+      },
+      {
+        scenarioId: "matrix-allowlist-hot-reload",
+        executionKind: "flow",
+        channel: "qa-channel",
+      },
+    ]);
+  });
+
+  it("rethrows post-terminal cleanup failure without replay or synthetic evidence", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-profile-post-terminal-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "profile-post-terminal");
+    const scenarioIds = ["channel-chat-baseline", "control-ui-chat-flow-playwright"];
+    const run = runQaFlowSuite.getMockImplementation();
+    if (!run) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    runQaFlowSuite.mockImplementation(async (params) => {
+      const result = await run(params);
+      await completeProfileRun(params, result.evidence);
+      const cleanupError = Object.assign(new Error("gateway cleanup reset"), {
+        code: "ECONNRESET",
+      });
+      throwQaSuiteCleanupErrors({
+        cleanupFailures: [{ phase: "gateway stop", error: cleanupError }],
+        runFailed: false,
+        runError: undefined,
+        result,
+        evidenceWritten: true,
+      });
+      return result;
+    });
+
+    await expect(
+      runQaSuite({
+        repoRoot,
+        outputDir: ".artifacts/qa-e2e/profile-post-terminal",
+        providerMode: "mock-openai",
+        scenarioIds,
+        profileRunSpec: profileRunSpec(scenarioIds),
+      }),
+    ).rejects.toThrow("cleanup failed");
+
+    expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
+    await expect(fs.access(path.join(outputDir, "qa-evidence.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    const checkpoint = JSON.parse(
+      await fs.readFile(path.join(outputDir, "qa-profile-run-checkpoint.json"), "utf8"),
+    ) as { cells: Array<{ scenarioId: string; evidence?: { path: string } }> };
+    const terminal = checkpoint.cells.find((entry) => entry.scenarioId === "channel-chat-baseline");
+    const stored = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(path.join(outputDir, terminal!.evidence!.path), "utf8")),
+    );
+    expect(stored.entries).toEqual([]);
   });
 
   it("partitions flow-only suites that request isolated workers", async () => {
@@ -440,15 +603,6 @@ describe("qa suite runtime launcher", () => {
     expect(
       result.result.scenarios.find((scenario) => scenario.name === "thread-isolation [matrix]"),
     ).toMatchObject({ status: "fail" });
-    expect(result.observedCells).toEqual(
-      expect.arrayContaining([
-        { scenarioId: "channel-chat-baseline", executionKind: "flow", channel: null },
-        { scenarioId: "telegram-help-command", executionKind: "flow", channel: "telegram" },
-        { scenarioId: "matrix-restart-resume", executionKind: "flow", channel: "matrix" },
-        { scenarioId: "thread-isolation", executionKind: "flow", channel: "slack" },
-        { scenarioId: "thread-isolation", executionKind: "flow", channel: "matrix" },
-      ]),
-    );
   });
 
   it("uses one eligible channel outside profile execution", async () => {
@@ -699,7 +853,6 @@ describe("qa suite runtime launcher", () => {
     expect(evidence.entries).toMatchObject([
       { test: { id: "whatsapp-status-command" }, result: { status: "fail" } },
     ]);
-    expect(result.observedCells).toEqual([]);
     await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
   });
 
@@ -2276,16 +2429,6 @@ describe("qa suite runtime launcher", () => {
       });
       expect(blocked?.execution?.channel?.driver).toBeUndefined();
     }
-    expect(result.observedCells).not.toEqual(
-      expect.arrayContaining([
-        { scenarioId: "whatsapp-status-command", executionKind: "flow", channel: "whatsapp" },
-        {
-          scenarioId: "whatsapp-access-control-dm-open",
-          executionKind: "flow",
-          channel: "whatsapp",
-        },
-      ]),
-    );
   });
 
   it("omits later credential failures after the first failed flow scenario", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -13,6 +13,12 @@ import {
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
 import { isQaFastModeEnabled } from "./model-selection.js";
+import {
+  createQaProfileRunCheckpoint,
+  runQaProfilePhase,
+  type QaProfileRunControl,
+  type QaProfileRunSpec,
+} from "./profile-run-checkpoint.js";
 import { DEFAULT_QA_PROVIDER_MODE } from "./providers/index.js";
 import {
   defaultQaSuiteConcurrencyForTransport,
@@ -55,10 +61,7 @@ import {
   type QaTestFileScenarioRunResult,
 } from "./test-file-scenario-runner.js";
 
-export type QaSuiteRuntimeResult = {
-  expectedCells: QaScenarioExecutionCell[];
-  observedCells: QaScenarioExecutionCell[];
-} & (
+export type QaSuiteRuntimeResult =
   | {
       executionKind: "flow";
       result: QaSuiteResult;
@@ -66,10 +69,10 @@ export type QaSuiteRuntimeResult = {
   | {
       executionKind: "suite";
       result: QaUnifiedSuiteResult;
-    }
-);
+    };
 
 type QaUnifiedSuiteResult = {
+  evidence: QaEvidenceSummaryJson;
   evidencePath: string;
   outputDir: string;
   report: string;
@@ -77,6 +80,13 @@ type QaUnifiedSuiteResult = {
   scenarios: QaSuiteScenarioResult[];
   summaryPath: string;
 };
+
+type QaSuiteLaunchParams = QaSuiteRunParams & {
+  expandScenarioChannels?: boolean;
+  profileRun?: QaProfileRunControl;
+  profileRunSpec?: QaProfileRunSpec;
+};
+type QaProfileCheckpoint = Awaited<ReturnType<typeof createQaProfileRunCheckpoint>>;
 
 type QaSuiteExecutionPlan = {
   expectedCells: QaScenarioExecutionCell[];
@@ -119,6 +129,7 @@ type QaUnifiedPartitionTask = {
   channel?: string;
   channelId: string;
   exclusiveKey?: string;
+  profileRun?: QaProfileRunControl;
   run: () => Promise<QaUnifiedPartitionResult>;
   scenarios: readonly QaSeedScenarioWithSource[];
   weight: number;
@@ -195,16 +206,21 @@ function isQaSuiteInfraRetryableError(error: unknown) {
 export async function runQaSuiteWithInfraRetry<Result>(
   run: () => Promise<Result>,
   maxRetries = QA_SUITE_INFRA_RETRY_LIMIT,
+  options?: { phase?: string; shouldRetry?: () => boolean },
 ) {
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
     try {
       return await run();
     } catch (error) {
-      if (!isQaSuiteInfraRetryableError(error) || attempt >= maxRetries) {
+      if (
+        !isQaSuiteInfraRetryableError(error) ||
+        attempt >= maxRetries ||
+        options?.shouldRetry?.() === false
+      ) {
         throw error;
       }
       process.stderr.write(
-        `[qa-suite] infra retry ${attempt + 1}/${maxRetries}: ${formatErrorMessage(error)}\n`,
+        `[qa-suite] ${options?.phase ?? "infra"} retry ${attempt + 1}/${maxRetries}: ${formatErrorMessage(error)}\n`,
       );
     }
   }
@@ -221,7 +237,7 @@ async function loadQaFlowSuiteRuntime() {
     import("./suite.js"),
     loadQaLabServerRuntime(),
   ]);
-  return async (params: QaSuiteRunParams | undefined) =>
+  return async (params: QaSuiteLaunchParams | undefined) =>
     await runQaFlowSuite({
       ...params,
       startLab: params?.startLab ?? startLab,
@@ -243,7 +259,7 @@ function resolveRequestedScenarios(params: {
 }
 
 async function resolveQaFlowChannelGroups(
-  runParams: QaSuiteRunParams | undefined,
+  runParams: QaSuiteLaunchParams | undefined,
   scenarios: readonly QaSeedScenarioWithSource[],
 ): Promise<QaFlowChannelGroup[]> {
   if (runParams?.adapterFactories) {
@@ -349,7 +365,7 @@ async function resolveQaFlowChannelGroups(
 }
 
 async function resolveSuiteExecutionPlan(
-  params: QaSuiteRunParams | undefined,
+  params: QaSuiteLaunchParams | undefined,
 ): Promise<QaSuiteExecutionPlan> {
   const scenarioIds = params?.scenarioIds ?? [];
   if (scenarioIds.length === 0) {
@@ -408,7 +424,7 @@ async function resolveSuiteExecutionPlan(
   };
 }
 async function runQaTestFileSuiteFromRuntime(params: {
-  runParams: QaSuiteRunParams | undefined;
+  runParams: QaSuiteLaunchParams | undefined;
   scenarios: readonly QaTestFileScenario[];
 }): Promise<QaTestFileScenarioRunResult> {
   const runParams = params.runParams;
@@ -433,11 +449,12 @@ async function runQaTestFileSuiteFromRuntime(params: {
     providerMode,
     primaryModel,
     scenarios: params.scenarios,
+    profileRun: runParams?.profileRun,
     writeEvidenceFile: runParams?.writeEvidenceFile,
   });
 }
 
-function rejectFlowOnlySuiteOptionsForUnifiedRun(runParams: QaSuiteRunParams | undefined) {
+function rejectFlowOnlySuiteOptionsForUnifiedRun(runParams: QaSuiteLaunchParams | undefined) {
   if (runParams?.runtimePair) {
     throw new Error("--runtime-pair requires execution.kind: flow scenarios.");
   }
@@ -700,6 +717,7 @@ async function writeUnifiedQaSuiteArtifacts(params: {
   scenarioIds: readonly string[];
   scenarios: readonly QaSuiteScenarioResult[];
   startedAt: Date;
+  retryPhase?: QaProfileRunControl["retryPhase"];
 }) {
   await fs.mkdir(params.outputDir, { recursive: true });
   const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
@@ -725,10 +743,14 @@ async function writeUnifiedQaSuiteArtifacts(params: {
     scenarios: [...params.scenarios],
     startedAt: params.startedAt,
   }) satisfies QaSuiteSummaryJson;
-  await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
-  await fs.writeFile(reportPath, report, "utf8");
-  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  const persist = async () => {
+    await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
+    await fs.writeFile(reportPath, report, "utf8");
+    await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  };
+  await runQaProfilePhase(params.retryPhase, "unified artifact persistence", persist);
   return {
+    evidence: params.evidence,
     evidencePath,
     outputDir: params.outputDir,
     report,
@@ -740,8 +762,9 @@ async function writeUnifiedQaSuiteArtifacts(params: {
 
 async function runUnifiedQaSuite(params: {
   plan: Extract<QaSuiteExecutionPlan, { kind: "unified" }>;
-  runParams: QaSuiteRunParams | undefined;
-}): Promise<QaUnifiedSuiteResult & { observedCells: QaScenarioExecutionCell[] }> {
+  profileCheckpoint?: QaProfileCheckpoint;
+  runParams: QaSuiteLaunchParams | undefined;
+}): Promise<QaUnifiedSuiteResult> {
   if (params.plan.testFileScenariosByKind.size > 0) {
     rejectFlowOnlySuiteOptionsForUnifiedRun(params.runParams);
   }
@@ -791,20 +814,6 @@ async function runUnifiedQaSuite(params: {
       );
   const evidenceSummaries: QaEvidenceSummaryJson[] = [];
   const scenarioResultsById = new Map<string, QaSuiteScenarioResult[]>();
-  const observedCellsByKey = new Map<string, QaScenarioExecutionCell>();
-  const recordObservedScenarios = (
-    scenarios: readonly QaSeedScenarioWithSource[],
-    channel?: string,
-  ) => {
-    for (const cell of expandQaScenarioExecutionCells({
-      scenarios,
-      channelDriver: params.runParams?.channelDriver ?? "qa-channel",
-      channel,
-      expandChannels: false,
-    })) {
-      observedCellsByKey.set(JSON.stringify(cell), cell);
-    }
-  };
   const sharedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
   const isolatedFlowPartitionTasks: QaUnifiedPartitionTask[] = [];
   const testFilePartitionTasks: QaUnifiedPartitionTask[] = [];
@@ -905,6 +914,14 @@ async function runUnifiedQaSuite(params: {
           channelGroup.channelDriverSelection?.channel ??
           channelGroup.channel ??
           transportId;
+        const profileRun = params.profileCheckpoint?.control(
+          expandQaScenarioExecutionCells({
+            scenarios: partition.scenarios,
+            channelDriver: params.runParams?.channelDriver ?? "qa-channel",
+            channel: channelGroup.channel,
+            expandChannels: false,
+          }),
+        );
         const buildCredentialUnavailableResult = (details: string): QaUnifiedPartitionResult => {
           const blockedResults = partition.scenarios.map((scenario) => ({
             name:
@@ -953,6 +970,7 @@ async function runUnifiedQaSuite(params: {
           exclusiveKey: channelDriverFlowRequiresExclusiveWorkers
             ? `channel:${channelGroup.channel ?? channelGroup.channelId ?? "default"}`
             : undefined,
+          profileRun,
           scenarios: partition.scenarios,
           weight: partition.concurrency,
           run: async () => {
@@ -964,6 +982,7 @@ async function runUnifiedQaSuite(params: {
             }
             const result = await runFlowSuite({
               ...params.runParams,
+              profileRun,
               ...(progress
                 ? {
                     lab: progress.createPartitionLab(
@@ -1011,11 +1030,6 @@ async function runUnifiedQaSuite(params: {
             if ("evidenceSummaries" in result) {
               return result;
             }
-            const startedScenarioIdSet = new Set(result.startedScenarioIds);
-            recordObservedScenarios(
-              partition.scenarios.filter((scenario) => startedScenarioIdSet.has(scenario.id)),
-              channelGroup.channel,
-            );
             const scenarioResults: QaUnifiedPartitionResult["scenarioResults"] = [];
             for (const [index, scenario] of partition.scenarios.entries()) {
               const scenarioResult = result.scenarios[index];
@@ -1057,8 +1071,16 @@ async function runUnifiedQaSuite(params: {
     scenariosByKind: ReadonlyMap<QaTestFileExecutionKind, QaTestFileScenario[]>,
   ) => {
     const taskScenarios = [...scenariosByKind.values()].flat();
+    const profileRun = params.profileCheckpoint?.control(
+      expandQaScenarioExecutionCells({
+        scenarios: taskScenarios,
+        channelDriver: params.runParams?.channelDriver ?? "qa-channel",
+        expandChannels: false,
+      }),
+    );
     return {
       channelId: transportId,
+      profileRun,
       scenarios: taskScenarios,
       weight: 1,
       run: async () => {
@@ -1074,6 +1096,7 @@ async function runUnifiedQaSuite(params: {
           const result = await runQaTestFileSuiteFromRuntime({
             runParams: {
               ...params.runParams,
+              profileRun,
               outputDir: suitePartitionOutputDir(outputDir, kind),
               writeEvidenceFile: false,
               providerMode,
@@ -1112,9 +1135,6 @@ async function runUnifiedQaSuite(params: {
             break;
           }
         }
-        recordObservedScenarios(
-          taskScenarios.filter((scenario) => testFileStartedScenarioIds.includes(scenario.id)),
-        );
         return {
           evidenceSummaries: testFileEvidenceSummaries,
           scenarioResults: testFileScenarioResults,
@@ -1285,8 +1305,13 @@ async function runUnifiedQaSuite(params: {
       ...task,
       run: async () => {
         try {
-          return await runQaSuiteWithInfraRetry(task.run);
+          return await runQaSuiteWithInfraRetry(task.run, QA_SUITE_INFRA_RETRY_LIMIT, {
+            shouldRetry: () => !task.profileRun?.hasTerminalEvidence(),
+          });
         } catch (error) {
+          if (task.profileRun?.hasTerminalEvidence()) {
+            throw error;
+          }
           // Failed partitions still own durable failure evidence; rejecting here would
           // discard completed siblings and prevent the unified artifacts from existing.
           return capturePartitionFailure(task, error);
@@ -1316,10 +1341,13 @@ async function runUnifiedQaSuite(params: {
     evidenceSummaries.push(...partitionResult.evidenceSummaries);
   }
   const finishedAt = new Date();
-  const evidence = mergeQaEvidenceSummaries({
+  const authoritativeEvidence = mergeQaEvidenceSummaries({
     evidenceSummaries,
     generatedAt: finishedAt.toISOString(),
   });
+  const evidence = params.profileCheckpoint
+    ? await params.profileCheckpoint.finalize(authoritativeEvidence)
+    : authoritativeEvidence;
   const channel = summarizeQaEvidenceChannel([evidence]);
   const scenarios = params.plan.scenarios.flatMap((scenario) => {
     const results = scenarioResultsById.get(scenario.id);
@@ -1359,6 +1387,7 @@ async function runUnifiedQaSuite(params: {
     scenarioIds: params.plan.scenarios.map((scenario) => scenario.id),
     scenarios,
     startedAt,
+    retryPhase: params.profileCheckpoint?.retryPhase,
   });
   const progressResults = params.plan.scenarios.flatMap((scenario) => {
     const results = scenarioResultsById.get(scenario.id);
@@ -1402,41 +1431,59 @@ async function runUnifiedQaSuite(params: {
     markdown: unifiedResult.report,
     generatedAt: finishedAt.toISOString(),
   });
-  return {
-    ...unifiedResult,
-    observedCells: [...observedCellsByKey.values()].toSorted((left, right) =>
-      JSON.stringify(left).localeCompare(JSON.stringify(right)),
-    ),
-  };
+  return unifiedResult;
 }
 
-export async function runQaSuite(...args: [QaSuiteRunParams?]): Promise<QaSuiteRuntimeResult> {
-  const runParams = args[0];
+export async function runQaSuite(...args: [QaSuiteLaunchParams?]): Promise<QaSuiteRuntimeResult> {
+  const input = args[0];
+  const repoRoot = path.resolve(input?.repoRoot ?? process.cwd());
+  const outputDir = await resolveQaSuiteOutputDir(repoRoot, input?.outputDir);
+  const runParams = input ? { ...input, repoRoot, outputDir } : input;
   const plan = await resolveSuiteExecutionPlan(runParams);
+  const profileCheckpoint = runParams?.profileRunSpec
+    ? await createQaProfileRunCheckpoint({
+        expectedCells: plan.expectedCells,
+        outputDir,
+        retryPhase: (phase, run) =>
+          runQaSuiteWithInfraRetry(run, QA_SUITE_INFRA_RETRY_LIMIT, { phase }),
+        spec: runParams.profileRunSpec,
+      })
+    : undefined;
   if (plan.kind === "unified") {
-    const { observedCells, ...result } = await runUnifiedQaSuite({
+    const result = await runUnifiedQaSuite({
       runParams,
       plan,
+      profileCheckpoint,
     });
     return {
       executionKind: "suite",
-      expectedCells: plan.expectedCells,
-      observedCells,
       result,
     };
   }
-  const result = await runQaSuiteWithInfraRetry(() => runQaFlowSuiteFromRuntime(...args));
-  const startedScenarioIds = new Set(result.startedScenarioIds);
+  const profileRun = profileCheckpoint?.control(plan.expectedCells);
+  const flowRunParams = {
+    ...runParams,
+    profileRun,
+  };
+  const result = await runQaSuiteWithInfraRetry(
+    () => runQaFlowSuiteFromRuntime(flowRunParams),
+    QA_SUITE_INFRA_RETRY_LIMIT,
+    { shouldRetry: () => !profileRun?.hasTerminalEvidence() },
+  );
+  if (profileCheckpoint) {
+    if (!result.evidence) {
+      throw new Error("QA profile flow completed without authoritative evidence");
+    }
+    result.evidence = await profileCheckpoint.finalize(result.evidence);
+  }
   return {
     executionKind: "flow",
-    expectedCells: plan.expectedCells,
-    observedCells: plan.expectedCells.filter((cell) => startedScenarioIds.has(cell.scenarioId)),
     result,
   };
 }
 
 export async function runQaFlowSuiteFromRuntime(
-  ...args: [QaSuiteRunParams?]
+  ...args: [QaSuiteLaunchParams?]
 ): Promise<QaSuiteResult> {
   return await (
     await loadQaFlowSuiteRuntime()

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -15,7 +15,6 @@ import {
 import { isQaFastModeEnabled } from "./model-selection.js";
 import {
   createQaProfileRunCheckpoint,
-  runQaProfilePhase,
   type QaProfileRunControl,
   type QaProfileRunSpec,
 } from "./profile-run-checkpoint.js";
@@ -499,83 +498,54 @@ async function runWeightedUnifiedPartitionTasks(
   tasks: readonly QaUnifiedPartitionTask[],
   maxWeight: number,
 ) {
-  if (tasks.length === 0) {
-    return [];
-  }
   const limit = Math.max(1, Math.floor(maxWeight));
   const results: QaUnifiedPartitionResult[] = [];
   const pending = tasks.map((task, index) => ({ index, task }));
   const activeExclusiveKeys = new Set<string>();
+  const active = new Set<Promise<void>>();
   let activeWeight = 0;
-  return await new Promise<QaUnifiedPartitionResult[]>((resolve, reject) => {
-    let firstError: Error | undefined;
-    let finished = false;
-    const finishIfSettled = () => {
-      if (finished || activeWeight > 0) {
-        return;
-      }
-      finished = true;
-      if (firstError) {
-        reject(firstError);
-        return;
-      }
-      resolve(results);
-    };
-    const launch = () => {
-      if (firstError) {
-        finishIfSettled();
-        return;
-      }
-      while (pending.length > 0) {
-        const pendingIndex = pending.findIndex(({ task }) => {
-          const taskWeight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
-          return (
-            (activeWeight === 0 || activeWeight + taskWeight <= limit) &&
-            (!task.exclusiveKey || !activeExclusiveKeys.has(task.exclusiveKey))
-          );
-        });
-        if (pendingIndex === -1) {
-          return;
-        }
-        const pendingTask = pending.splice(pendingIndex, 1)[0];
-        if (!pendingTask) {
-          throw new Error("failed to select a pending QA suite partition task");
-        }
-        const { index, task } = pendingTask;
-        const taskWeight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
-        activeWeight += taskWeight;
-        if (task.exclusiveKey) {
-          activeExclusiveKeys.add(task.exclusiveKey);
-        }
-        task.run().then(
-          (result) => {
-            results[index] = result;
-            activeWeight -= taskWeight;
-            if (task.exclusiveKey) {
-              activeExclusiveKeys.delete(task.exclusiveKey);
-            }
-            if (pending.length === 0 && activeWeight === 0) {
-              finishIfSettled();
-              return;
-            }
-            launch();
-          },
-          (error: unknown) => {
-            firstError = error instanceof Error ? error : new Error(String(error));
-            activeWeight -= taskWeight;
-            if (task.exclusiveKey) {
-              activeExclusiveKeys.delete(task.exclusiveKey);
-            }
-            finishIfSettled();
-          },
+  let failure: { error: unknown; index: number } | undefined;
+  while ((!failure && pending.length > 0) || active.size > 0) {
+    while (!failure && pending.length > 0) {
+      const pendingIndex = pending.findIndex(({ task }) => {
+        const weight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
+        return (
+          (activeWeight === 0 || activeWeight + weight <= limit) &&
+          (!task.exclusiveKey || !activeExclusiveKeys.has(task.exclusiveKey))
         );
+      });
+      if (pendingIndex === -1) {
+        break;
       }
-      if (activeWeight === 0) {
-        finishIfSettled();
+      const { index, task } = pending.splice(pendingIndex, 1)[0]!;
+      const weight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
+      activeWeight += weight;
+      if (task.exclusiveKey) {
+        activeExclusiveKeys.add(task.exclusiveKey);
       }
-    };
-    launch();
-  });
+      const run = Promise.resolve()
+        .then(task.run)
+        .then((result) => {
+          results[index] = result;
+        })
+        .catch((error: unknown) => {
+          failure = !failure || index < failure.index ? { error, index } : failure;
+        })
+        .finally(() => {
+          activeWeight -= weight;
+          if (task.exclusiveKey) {
+            activeExclusiveKeys.delete(task.exclusiveKey);
+          }
+          active.delete(run);
+        });
+      active.add(run);
+    }
+    await Promise.race(active);
+  }
+  if (failure) {
+    throw failure.error;
+  }
+  return results;
 }
 
 async function readQaSuiteEvidenceSummary(evidencePath: string) {
@@ -718,6 +688,7 @@ async function writeUnifiedQaSuiteArtifacts(params: {
   scenarios: readonly QaSuiteScenarioResult[];
   startedAt: Date;
   retryPhase?: QaProfileRunControl["retryPhase"];
+  writeEvidenceFile?: boolean;
 }) {
   await fs.mkdir(params.outputDir, { recursive: true });
   const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
@@ -744,11 +715,13 @@ async function writeUnifiedQaSuiteArtifacts(params: {
     startedAt: params.startedAt,
   }) satisfies QaSuiteSummaryJson;
   const persist = async () => {
-    await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
+    if (params.writeEvidenceFile !== false) {
+      await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
+    }
     await fs.writeFile(reportPath, report, "utf8");
     await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
   };
-  await runQaProfilePhase(params.retryPhase, "unified artifact persistence", persist);
+  await (params.retryPhase?.("unified artifact persistence", persist) ?? persist());
   return {
     evidence: params.evidence,
     evidencePath,
@@ -819,6 +792,65 @@ async function runUnifiedQaSuite(params: {
   const testFilePartitionTasks: QaUnifiedPartitionTask[] = [];
   const scriptPartitionTasks: QaUnifiedPartitionTask[] = [];
   const unavailableChannelCredentialDetails = new Map<string, string>();
+  const synthesizePartitionFailure = async (
+    task: QaUnifiedPartitionTask,
+    error: unknown,
+    details: string,
+    options?: { blocked?: boolean; channelLabel?: string },
+  ): Promise<QaUnifiedPartitionResult> => {
+    if (task.profileRun?.hasTerminalEvidence()) {
+      throw error;
+    }
+    const step = options?.blocked ? "Acquire channel credential" : "suite partition";
+    const scenarioResults = task.scenarios.map((scenario) => {
+      const name = options?.channelLabel
+        ? `${scenario.title} [${options.channelLabel}]`
+        : scenario.title;
+      return {
+        scenarioId: scenario.id,
+        result: {
+          name,
+          status: "fail" as const,
+          details,
+          steps: [{ name: step, status: "fail" as const, details }],
+        },
+      };
+    });
+    const evidenceSummaries = task.scenarios.map((scenario, index) =>
+      buildQaSuiteEvidenceSummary({
+        artifactPaths: [],
+        evidenceMode: params.runParams?.evidenceMode,
+        channelId: task.channelId,
+        env: process.env,
+        generatedAt: new Date().toISOString(),
+        primaryModel,
+        providerMode,
+        repoRoot,
+        scenarioDefinitions: [scenario],
+        scenarioResults: [
+          {
+            name: scenarioResults[index]!.result.name,
+            status: options?.blocked ? "blocked" : "fail",
+            details,
+          },
+        ],
+      }),
+    );
+    if (task.profileRun) {
+      for (const [index, scenario] of task.scenarios.entries()) {
+        await task.profileRun.complete({
+          scenarioId: scenario.id,
+          evidence: evidenceSummaries[index]!,
+        });
+      }
+    }
+    return {
+      evidenceSummaries,
+      scenarioResults,
+      startedScenarioIds: task.scenarios.map((scenario) => scenario.id),
+      submittedScenarioIds: task.scenarios.map((scenario) => scenario.id),
+    };
+  };
   if (params.plan.channelGroups.length > 0) {
     const channelGroups = params.plan.channelGroups;
     const runFlowSuite = await loadQaFlowSuiteRuntime();
@@ -922,47 +954,7 @@ async function runUnifiedQaSuite(params: {
             expandChannels: false,
           }),
         );
-        const buildCredentialUnavailableResult = (details: string): QaUnifiedPartitionResult => {
-          const blockedResults = partition.scenarios.map((scenario) => ({
-            name:
-              params.runParams?.expandScenarioChannels && channelGroup.channel
-                ? `${scenario.title} [${channelGroup.channel}]`
-                : scenario.title,
-            status: "blocked" as const,
-            details,
-          }));
-          return {
-            evidenceSummaries: [
-              buildQaSuiteEvidenceSummary({
-                artifactPaths: [],
-                evidenceMode: params.runParams?.evidenceMode,
-                channelId: taskChannelId,
-                env: process.env,
-                generatedAt: new Date().toISOString(),
-                primaryModel,
-                providerMode,
-                repoRoot,
-                scenarioDefinitions: partition.scenarios,
-                scenarioResults: blockedResults,
-              }),
-            ],
-            scenarioResults: partition.scenarios.map((scenario) => ({
-              scenarioId: scenario.id,
-              result: {
-                name:
-                  params.runParams?.expandScenarioChannels && channelGroup.channel
-                    ? `${scenario.title} [${channelGroup.channel}]`
-                    : scenario.title,
-                status: "fail",
-                details,
-                steps: [{ name: "Acquire channel credential", status: "fail", details }],
-              },
-            })),
-            startedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
-            submittedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
-          };
-        };
-        const task = {
+        const task: QaUnifiedPartitionTask = {
           channel: channelGroup.channel,
           channelId: taskChannelId,
           // One channel's credential and Gateway state stay serial unless each adapter create()
@@ -978,7 +970,18 @@ async function runUnifiedQaSuite(params: {
               ? unavailableChannelCredentialDetails.get(channelGroup.channelId)
               : undefined;
             if (unavailableDetails) {
-              return buildCredentialUnavailableResult(unavailableDetails);
+              return await synthesizePartitionFailure(
+                task,
+                new Error(unavailableDetails),
+                unavailableDetails,
+                {
+                  blocked: true,
+                  channelLabel:
+                    params.runParams?.expandScenarioChannels && channelGroup.channel
+                      ? channelGroup.channel
+                      : undefined,
+                },
+              );
             }
             const result = await runFlowSuite({
               ...params.runParams,
@@ -1015,17 +1018,25 @@ async function runUnifiedQaSuite(params: {
                   ))
                 : params.runParams?.workerStartStaggerMs,
               scenarioIds: partition.scenarios.map((scenario) => scenario.id),
-            }).catch((error: unknown) => {
+            }).catch(async (error: unknown) => {
               if (!isChannelCredentialPoolUnavailable(error, channelGroup.channelId)) {
                 throw error;
               }
-              // Preserve other channels' evidence, but keep the suite failed: maturity
-              // docs must not publish until every required channel can run.
+              if (profileRun?.hasTerminalEvidence()) {
+                throw error;
+              }
+              // Preserve sibling evidence, but keep the suite failed.
               const details = `channel credential unavailable: ${formatErrorMessage(error)}`;
               if (channelDriverFlowRequiresExclusiveWorkers && channelGroup.channelId) {
                 unavailableChannelCredentialDetails.set(channelGroup.channelId, details);
               }
-              return buildCredentialUnavailableResult(details);
+              return await synthesizePartitionFailure(task, error, details, {
+                blocked: true,
+                channelLabel:
+                  params.runParams?.expandScenarioChannels && channelGroup.channel
+                    ? channelGroup.channel
+                    : undefined,
+              });
             });
             if ("evidenceSummaries" in result) {
               return result;
@@ -1058,7 +1069,7 @@ async function runUnifiedQaSuite(params: {
               submittedScenarioIds: partition.scenarios.map((scenario) => scenario.id),
             };
           },
-        } satisfies QaUnifiedPartitionTask;
+        };
         if (isolatedPartition) {
           isolatedFlowPartitionTasks.push(task);
         } else {
@@ -1263,41 +1274,6 @@ async function runUnifiedQaSuite(params: {
     );
     return partition.startedScenarioIds.some((scenarioId) => !returnedScenarioIds.has(scenarioId));
   };
-  const capturePartitionFailure = (
-    task: QaUnifiedPartitionTask,
-    error: unknown,
-  ): QaUnifiedPartitionResult => {
-    const scenarios = task.scenarios;
-    const details = `suite partition failed: ${formatErrorMessage(error)}`;
-    const scenarioResults = scenarios.map((scenario) => ({
-      scenarioId: scenario.id,
-      result: {
-        name: scenario.title,
-        status: "fail" as const,
-        details,
-        steps: [{ name: "suite partition", status: "fail" as const, details }],
-      },
-    }));
-    return {
-      evidenceSummaries: [
-        buildQaSuiteEvidenceSummary({
-          artifactPaths: [],
-          evidenceMode: params.runParams?.evidenceMode,
-          channelId: task.channelId,
-          env: process.env,
-          generatedAt: new Date().toISOString(),
-          primaryModel,
-          providerMode,
-          repoRoot,
-          scenarioDefinitions: scenarios,
-          scenarioResults: scenarioResults.map(({ result }) => result),
-        }),
-      ],
-      scenarioResults,
-      startedScenarioIds: scenarios.map((scenario) => scenario.id),
-      submittedScenarioIds: task.scenarios.map((scenario) => scenario.id),
-    };
-  };
   const runPartitionTasks = async (tasks: readonly QaUnifiedPartitionTask[], maxWeight: number) => {
     // Retry inside the scheduled task so its weight and exclusive key stay held;
     // one failed channel must not replay partitions that already completed.
@@ -1312,9 +1288,12 @@ async function runUnifiedQaSuite(params: {
           if (task.profileRun?.hasTerminalEvidence()) {
             throw error;
           }
-          // Failed partitions still own durable failure evidence; rejecting here would
-          // discard completed siblings and prevent the unified artifacts from existing.
-          return capturePartitionFailure(task, error);
+          // Failed partitions still own durable evidence for the unified report.
+          return await synthesizePartitionFailure(
+            task,
+            error,
+            `suite partition failed: ${formatErrorMessage(error)}`,
+          );
         }
       },
     }));
@@ -1341,13 +1320,12 @@ async function runUnifiedQaSuite(params: {
     evidenceSummaries.push(...partitionResult.evidenceSummaries);
   }
   const finishedAt = new Date();
-  const authoritativeEvidence = mergeQaEvidenceSummaries({
-    evidenceSummaries,
-    generatedAt: finishedAt.toISOString(),
-  });
   const evidence = params.profileCheckpoint
-    ? await params.profileCheckpoint.finalize(authoritativeEvidence)
-    : authoritativeEvidence;
+    ? await params.profileCheckpoint.finalize()
+    : mergeQaEvidenceSummaries({
+        evidenceSummaries,
+        generatedAt: finishedAt.toISOString(),
+      });
   const channel = summarizeQaEvidenceChannel([evidence]);
   const scenarios = params.plan.scenarios.flatMap((scenario) => {
     const results = scenarioResultsById.get(scenario.id);
@@ -1388,6 +1366,7 @@ async function runUnifiedQaSuite(params: {
     scenarios,
     startedAt,
     retryPhase: params.profileCheckpoint?.retryPhase,
+    writeEvidenceFile: !params.profileCheckpoint,
   });
   const progressResults = params.plan.scenarios.flatMap((scenario) => {
     const results = scenarioResultsById.get(scenario.id);
@@ -1464,17 +1443,32 @@ export async function runQaSuite(...args: [QaSuiteLaunchParams?]): Promise<QaSui
   const flowRunParams = {
     ...runParams,
     profileRun,
+    ...(profileCheckpoint ? { writeEvidenceFile: false } : {}),
   };
-  const result = await runQaSuiteWithInfraRetry(
-    () => runQaFlowSuiteFromRuntime(flowRunParams),
-    QA_SUITE_INFRA_RETRY_LIMIT,
-    { shouldRetry: () => !profileRun?.hasTerminalEvidence() },
-  );
-  if (profileCheckpoint) {
-    if (!result.evidence) {
-      throw new Error("QA profile flow completed without authoritative evidence");
+  let result: QaSuiteResult;
+  try {
+    result = await runQaSuiteWithInfraRetry(
+      () => runQaFlowSuiteFromRuntime(flowRunParams),
+      QA_SUITE_INFRA_RETRY_LIMIT,
+      { shouldRetry: () => !profileRun?.hasTerminalEvidence() },
+    );
+  } catch (originalError) {
+    if (!profileCheckpoint || !profileRun?.hasTerminalEvidence()) {
+      throw originalError;
     }
-    result.evidence = await profileCheckpoint.finalize(result.evidence);
+    try {
+      await profileCheckpoint.finalize();
+    } catch (finalizationError) {
+      throw new AggregateError(
+        [originalError, finalizationError],
+        "QA profile execution and finalization both failed",
+        { cause: originalError },
+      );
+    }
+    throw originalError;
+  }
+  if (profileCheckpoint) {
+    result.evidence = await profileCheckpoint.finalize();
   }
   return {
     executionKind: "flow",

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -367,7 +367,7 @@ async function resolveSuiteExecutionPlan(
   params: QaSuiteLaunchParams | undefined,
 ): Promise<QaSuiteExecutionPlan> {
   const scenarioIds = params?.scenarioIds ?? [];
-  if (scenarioIds.length === 0) {
+  if (scenarioIds.length === 0 && !params?.profileRunSpec) {
     return { kind: "flow", expectedCells: [], scenarios: [] };
   }
   const selectedScenarios = resolveRequestedScenarios({
@@ -411,7 +411,7 @@ async function resolveSuiteExecutionPlan(
       (scenario) => scenario.execution.kind === "flow" && scenario.execution.runtime !== undefined,
     ) ||
     (flowScenarios.length > 1 && flowScenarios.some(scenarioRequiresIsolatedQaSuiteWorker));
-  if (testFileScenariosByKind.size === 0 && !requiresFlowPartitions) {
+  if (!params?.profileRunSpec && testFileScenariosByKind.size === 0 && !requiresFlowPartitions) {
     return { kind: "flow", expectedCells, scenarios: selectedScenarios };
   }
   return {
@@ -1440,27 +1440,10 @@ export async function runQaSuite(...args: [QaSuiteLaunchParams?]): Promise<QaSui
       result,
     };
   }
-  const profileRun = profileCheckpoint?.control(plan.expectedCells);
-  const flowRunParams = {
-    ...runParams,
-    profileRun,
-    ...(profileCheckpoint ? { writeEvidenceFile: false } : {}),
+  return {
+    executionKind: "flow",
+    result: await runQaSuiteWithInfraRetry(() => runQaFlowSuiteFromRuntime(runParams)),
   };
-  const runFlow = async (finalizeProfile?: QaProfileCheckpoint["finalize"]) => {
-    const result = await runQaSuiteWithInfraRetry(
-      () => runQaFlowSuiteFromRuntime(flowRunParams),
-      QA_SUITE_INFRA_RETRY_LIMIT,
-      { shouldRetry: () => !profileRun?.hasTerminalEvidence() },
-    );
-    if (finalizeProfile) {
-      result.evidence = await finalizeProfile();
-    }
-    return {
-      executionKind: "flow" as const,
-      result,
-    };
-  };
-  return profileCheckpoint ? await profileCheckpoint.finalizeRun(runFlow) : await runFlow();
 }
 
 export async function runQaFlowSuiteFromRuntime(

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -734,6 +734,7 @@ async function writeUnifiedQaSuiteArtifacts(params: {
 }
 
 async function runUnifiedQaSuite(params: {
+  finalizeProfile?: QaProfileCheckpoint["finalize"];
   plan: Extract<QaSuiteExecutionPlan, { kind: "unified" }>;
   profileCheckpoint?: QaProfileCheckpoint;
   runParams: QaSuiteLaunchParams | undefined;
@@ -1320,8 +1321,8 @@ async function runUnifiedQaSuite(params: {
     evidenceSummaries.push(...partitionResult.evidenceSummaries);
   }
   const finishedAt = new Date();
-  const evidence = params.profileCheckpoint
-    ? await params.profileCheckpoint.finalize()
+  const evidence = params.finalizeProfile
+    ? await params.finalizeProfile()
     : mergeQaEvidenceSummaries({
         evidenceSummaries,
         generatedAt: finishedAt.toISOString(),
@@ -1429,11 +1430,11 @@ export async function runQaSuite(...args: [QaSuiteLaunchParams?]): Promise<QaSui
       })
     : undefined;
   if (plan.kind === "unified") {
-    const result = await runUnifiedQaSuite({
-      runParams,
-      plan,
-      profileCheckpoint,
-    });
+    const runUnified = (finalizeProfile?: QaProfileCheckpoint["finalize"]) =>
+      runUnifiedQaSuite({ runParams, plan, profileCheckpoint, finalizeProfile });
+    const result = profileCheckpoint
+      ? await profileCheckpoint.finalizeRun(runUnified)
+      : await runUnified();
     return {
       executionKind: "suite",
       result,
@@ -1445,35 +1446,21 @@ export async function runQaSuite(...args: [QaSuiteLaunchParams?]): Promise<QaSui
     profileRun,
     ...(profileCheckpoint ? { writeEvidenceFile: false } : {}),
   };
-  let result: QaSuiteResult;
-  try {
-    result = await runQaSuiteWithInfraRetry(
+  const runFlow = async (finalizeProfile?: QaProfileCheckpoint["finalize"]) => {
+    const result = await runQaSuiteWithInfraRetry(
       () => runQaFlowSuiteFromRuntime(flowRunParams),
       QA_SUITE_INFRA_RETRY_LIMIT,
       { shouldRetry: () => !profileRun?.hasTerminalEvidence() },
     );
-  } catch (originalError) {
-    if (!profileCheckpoint || !profileRun?.hasTerminalEvidence()) {
-      throw originalError;
+    if (finalizeProfile) {
+      result.evidence = await finalizeProfile();
     }
-    try {
-      await profileCheckpoint.finalize();
-    } catch (finalizationError) {
-      throw new AggregateError(
-        [originalError, finalizationError],
-        "QA profile execution and finalization both failed",
-        { cause: originalError },
-      );
-    }
-    throw originalError;
-  }
-  if (profileCheckpoint) {
-    result.evidence = await profileCheckpoint.finalize();
-  }
-  return {
-    executionKind: "flow",
-    result,
+    return {
+      executionKind: "flow" as const,
+      result,
+    };
   };
+  return profileCheckpoint ? await profileCheckpoint.finalizeRun(runFlow) : await runFlow();
 }
 
 export async function runQaFlowSuiteFromRuntime(

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -250,6 +250,68 @@ describe("qa suite planning helpers", () => {
     expect(sleeps).toEqual([25, 25, 25]);
   });
 
+  it("settles started mappers and stagger gates before rejecting the lowest-index error", async () => {
+    const lowerError = new Error("lower-index failure");
+    const higherError = new Error("higher-index failure");
+    const started: number[] = [];
+    const sleepReleases: Array<() => void> = [];
+    let releaseLower!: () => void;
+    let markHigherFailed!: () => void;
+    const lowerBlocked = new Promise<void>((resolve) => {
+      releaseLower = resolve;
+    });
+    const higherFailed = new Promise<void>((resolve) => {
+      markHigherFailed = resolve;
+    });
+    const outcome = mapQaSuiteWithConcurrency(
+      [0, 1, 2, 3],
+      3,
+      async (item) => {
+        started.push(item);
+        if (item === 0) {
+          await lowerBlocked;
+          throw lowerError;
+        }
+        if (item === 1) {
+          markHigherFailed();
+          throw higherError;
+        }
+        throw new Error(`unexpected producer ${item}`);
+      },
+      {
+        startStaggerMs: 1,
+        sleepImpl: async () =>
+          await new Promise<void>((resolve) => {
+            sleepReleases.push(resolve);
+          }),
+      },
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    let settled = false;
+    void outcome.then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(started).toEqual([0]));
+    sleepReleases.shift()?.();
+    await higherFailed;
+    expect(started).toEqual([0, 1]);
+    expect(settled).toBe(false);
+
+    releaseLower();
+    await vi.waitFor(() => expect(sleepReleases).toHaveLength(1));
+    expect(settled).toBe(false);
+    sleepReleases.shift()?.();
+    await vi.waitFor(() => expect(sleepReleases).toHaveLength(1));
+    expect(settled).toBe(false);
+    sleepReleases.shift()?.();
+
+    await expect(outcome).resolves.toBe(lowerError);
+    expect(started).toEqual([0, 1]);
+  });
+
   it("resolves a default worker startup stagger for concurrent suite workers", () => {
     expect(resolveQaSuiteWorkerStartStaggerMs(1, {})).toBe(0);
     expect(resolveQaSuiteWorkerStartStaggerMs(4, {})).toBe(1500);

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -2,7 +2,6 @@
 import path from "node:path";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import pMap from "p-map";
 import { createQaArtifactRunId } from "./artifact-run-id.js";
 import { ensureRepoBoundDirectory, resolveRepoRelativeOutputDir } from "./cli-paths.js";
 import type { QaCliBackendAuthMode } from "./gateway-child.js";
@@ -371,7 +370,10 @@ async function mapQaSuiteWithConcurrency<T, U>(
   },
 ) {
   let stopped = false;
-  let nextStartGate = Promise.resolve();
+  let failure: { error: unknown; index: number } | undefined;
+  let nextIndex = 0;
+  let startGate = Promise.resolve();
+  const results: Array<U | undefined> = Array.from({ length: items.length });
   const startStaggerMs = Math.max(0, Math.floor(opts?.startStaggerMs ?? 0));
   const sleepImpl =
     opts?.sleepImpl ??
@@ -379,49 +381,40 @@ async function mapQaSuiteWithConcurrency<T, U>(
       new Promise<void>((resolve) => {
         setTimeout(resolve, ms);
       }));
-  async function waitForStartSlot(shouldReleaseNextSlot: boolean) {
-    const currentGate = nextStartGate;
-    let releaseNextSlot: (() => void) | undefined;
-    if (shouldReleaseNextSlot) {
-      nextStartGate = new Promise<void>((resolve) => {
-        releaseNextSlot = resolve;
-      });
-    }
-    await currentGate;
-    if (!releaseNextSlot) {
-      return;
-    }
-    void (async () => {
+  const worker = async () => {
+    while (!stopped && nextIndex < items.length) {
+      const index = nextIndex++;
+      const currentGate = startGate;
+      if (index < items.length - 1) {
+        startGate = currentGate.then(async () => {
+          if (startStaggerMs > 0) {
+            await sleepImpl(startStaggerMs);
+          }
+        });
+      }
+      await currentGate;
+      if (stopped) {
+        return;
+      }
       try {
-        if (startStaggerMs > 0) {
-          await sleepImpl(startStaggerMs);
+        const result = await mapper(items[index]!, index);
+        results[index] = result;
+        if (opts?.shouldStop?.(result, index)) {
+          stopped = true;
         }
-      } finally {
-        releaseNextSlot();
-      }
-    })();
-  }
-  const results = await pMap(
-    items,
-    async (item, index) => {
-      if (stopped) {
-        return undefined;
-      }
-      await waitForStartSlot(index < items.length - 1);
-      if (stopped) {
-        return undefined;
-      }
-      const result = await mapper(item, index);
-      if (opts?.shouldStop?.(result, index)) {
+      } catch (error) {
         stopped = true;
+        failure = !failure || index < failure.index ? { error, index } : failure;
       }
-      return result;
-    },
-    {
-      concurrency: Math.max(1, Math.floor(concurrency)),
-      stopOnError: true,
-    },
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(items.length, Math.max(1, Math.floor(concurrency))) }, worker),
   );
+  await startGate;
+  if (failure) {
+    throw failure.error;
+  }
   const completed: U[] = [];
   for (const result of results) {
     if (result !== undefined) {

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -46,7 +46,8 @@ vi.mock("./gateway-child.js", () => ({
 vi.mock("./providers/server-runtime.js", () => ({
   startQaProviderServer: vi.fn(async () => undefined),
 }));
-vi.mock("./suite-artifacts.js", () => ({
+vi.mock("./suite-artifacts.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./suite-artifacts.js")>()),
   writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
 }));
 vi.mock("./suite-runtime-gateway.js", () => ({

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -220,6 +220,141 @@ describe("isolated QA suite transport cleanup", () => {
     }
   });
 
+  it("drains a blocked partial artifact write before exposing partition failure or cleanup", async () => {
+    const lab = createCleanupTestLab();
+    const context = createCleanupTestContext();
+    context.selectedScenarios = [
+      makeQaSuiteTestScenario("completed-scenario"),
+      makeQaSuiteTestScenario("failed-scenario"),
+    ];
+    context.concurrency = 2;
+    let releaseArtifactWrite!: () => void;
+    let markArtifactWriteStarted!: () => void;
+    const artifactWriteBlocked = new Promise<void>((resolve) => {
+      releaseArtifactWrite = resolve;
+    });
+    const artifactWriteStarted = new Promise<void>((resolve) => {
+      markArtifactWriteStarted = resolve;
+    });
+    mocks.writeQaSuiteArtifacts.mockImplementationOnce(async () => {
+      markArtifactWriteStarted();
+      await artifactWriteBlocked;
+      return {
+        evidence: undefined,
+        evidencePath: "/qa-output/qa-evidence.json",
+        report: "",
+        reportPath: "/qa-output/qa-suite-report.md",
+        summaryPath: "/qa-output/qa-suite-summary.json",
+      };
+    });
+    const partitionError = new Error("partition failed");
+    const runChild = vi.fn<QaSuiteRunner>(async (params) => {
+      const scenarioId = params?.scenarioIds?.[0];
+      if (scenarioId === "failed-scenario") {
+        await artifactWriteStarted;
+        throw partitionError;
+      }
+      return {
+        outputDir: "/qa-child",
+        evidencePath: "/qa-child/qa-evidence.json",
+        reportPath: "/qa-child/qa-suite-report.md",
+        summaryPath: "/qa-child/qa-suite-summary.json",
+        report: "",
+        scenarios: [{ name: "completed-scenario", status: "pass", steps: [] }],
+        startedScenarioIds: ["completed-scenario"],
+        watchUrl: lab.baseUrl,
+      };
+    });
+    const outcome = runQaFlowSuiteIsolated(
+      {
+        profileRun: {
+          complete: async () => {},
+          hasTerminalEvidence: () => false,
+          retryPhase: async (_phase, run) => await run(),
+        },
+        startLab: async () => lab,
+        workerStartStaggerMs: 0,
+      },
+      context,
+      runChild,
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    let settled = false;
+    void outcome.then(() => {
+      settled = true;
+    });
+
+    await artifactWriteStarted;
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(mocks.disposeRegisteredAgentHarnesses).not.toHaveBeenCalled();
+    expect(lab.stop).not.toHaveBeenCalled();
+
+    releaseArtifactWrite();
+    await expect(outcome).resolves.toBe(partitionError);
+    expect(mocks.disposeRegisteredAgentHarnesses).toHaveBeenCalledOnce();
+    expect(lab.stop).toHaveBeenCalledOnce();
+  });
+
+  it("preserves partition failure when the drained artifact write also fails", async () => {
+    const lab = createCleanupTestLab();
+    const context = createCleanupTestContext();
+    context.selectedScenarios = [
+      makeQaSuiteTestScenario("completed-scenario"),
+      makeQaSuiteTestScenario("failed-scenario"),
+    ];
+    context.concurrency = 2;
+    let markArtifactWriteStarted!: () => void;
+    const artifactWriteStarted = new Promise<void>((resolve) => {
+      markArtifactWriteStarted = resolve;
+    });
+    const artifactError = new Error("partial artifact write failed");
+    mocks.writeQaSuiteArtifacts.mockImplementationOnce(async () => {
+      markArtifactWriteStarted();
+      throw artifactError;
+    });
+    const partitionError = new Error("partition failed");
+    const runChild = vi.fn<QaSuiteRunner>(async (params) => {
+      const scenarioId = params?.scenarioIds?.[0];
+      if (scenarioId === "failed-scenario") {
+        await artifactWriteStarted;
+        throw partitionError;
+      }
+      return {
+        outputDir: "/qa-child",
+        evidencePath: "/qa-child/qa-evidence.json",
+        reportPath: "/qa-child/qa-suite-report.md",
+        summaryPath: "/qa-child/qa-suite-summary.json",
+        report: "",
+        scenarios: [{ name: "completed-scenario", status: "pass", steps: [] }],
+        startedScenarioIds: ["completed-scenario"],
+        watchUrl: lab.baseUrl,
+      };
+    });
+
+    const thrown = await runQaFlowSuiteIsolated(
+      {
+        profileRun: {
+          complete: async () => {},
+          hasTerminalEvidence: () => false,
+          retryPhase: async (_phase, run) => await run(),
+        },
+        startLab: async () => lab,
+        workerStartStaggerMs: 0,
+      },
+      context,
+      runChild,
+    ).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).toEqual([partitionError, artifactError]);
+    expect((thrown as Error).cause).toBe(partitionError);
+    expect(mocks.disposeRegisteredAgentHarnesses).toHaveBeenCalledOnce();
+    expect(lab.stop).toHaveBeenCalledOnce();
+  });
+
   it.each(["cleanup", "cleanupAfterGatewayStop"] as const)(
     "retries a failed parent %s phase before disposing its owned lab",
     async (cleanupPhase) => {

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harness";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
+import type { QaProfileRunControl } from "./profile-run-checkpoint.js";
 import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
 import { mapQaSuiteWithConcurrency, resolveQaSuiteWorkerStartStaggerMs } from "./suite-planning.js";
@@ -23,7 +24,7 @@ import {
 } from "./suite.js";
 
 export async function runQaFlowSuiteIsolated(
-  params: QaSuiteRunParams | undefined,
+  params: (QaSuiteRunParams & { profileRun?: QaProfileRunControl }) | undefined,
   context: QaSuiteResolvedRunContext,
   runQaFlowSuite: QaSuiteRunner,
 ): Promise<QaSuiteResult> {
@@ -116,6 +117,7 @@ export async function runQaFlowSuiteIsolated(
           channelDriverSelection: params?.channelDriverSelection,
           isolatedWorkers: true,
           writeEvidenceFile: params?.writeEvidenceFile,
+          retryPhase: params?.profileRun?.retryPhase,
           scenarioIds:
             params?.scenarioIds && params.scenarioIds.length > 0
               ? selectedScenarios.map((scenario) => scenario.id)
@@ -171,8 +173,8 @@ export async function runQaFlowSuiteIsolated(
         try {
           const scenarioOutputDir = path.join(outputDir, "scenarios", scenario.id);
           const childSuiteResult: QaSuiteResult = await runQaFlowSuite(
-            markQaSuiteNestedRun(
-              buildQaIsolatedScenarioWorkerParams({
+            markQaSuiteNestedRun({
+              ...buildQaIsolatedScenarioWorkerParams({
                 repoRoot,
                 outputDir: scenarioOutputDir,
                 providerMode,
@@ -186,7 +188,8 @@ export async function runQaFlowSuiteIsolated(
                 scenario,
                 input: params,
               }),
-            ),
+              profileRun: params?.profileRun,
+            } as QaSuiteRunParams),
           );
           for (const scenarioId of childSuiteResult.startedScenarioIds) {
             startedScenarioIds.add(scenarioId);
@@ -223,6 +226,9 @@ export async function runQaFlowSuiteIsolated(
           writePartialArtifacts();
           return scenarioResult;
         } catch (error) {
+          if (params?.profileRun) {
+            throw error;
+          }
           const details = formatErrorMessage(error);
           const scenarioResult = {
             name: scenario.title,
@@ -300,6 +306,7 @@ export async function runQaFlowSuiteIsolated(
           params?.scenarioIds && params.scenarioIds.length > 0
             ? selectedScenarios.map((scenario) => scenario.id)
             : undefined,
+        retryPhase: params?.profileRun?.retryPhase,
       },
     );
     lab.setLatestReport({
@@ -334,7 +341,10 @@ export async function runQaFlowSuiteIsolated(
     if (ownsLab) {
       cleanupSteps.push({ phase: "lab stop", run: () => lab.stop() });
     }
-    const cleanupFailures = await runQaSuiteCleanupSteps(cleanupSteps);
+    const cleanupFailures = await runQaSuiteCleanupSteps(
+      cleanupSteps,
+      params?.profileRun?.retryPhase,
+    );
     throwQaSuiteCleanupErrors({
       cleanupFailures,
       runFailed: isolatedRunFailed,

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -83,6 +83,7 @@ export async function runQaFlowSuiteIsolated(
   });
   const startedScenarioIds = new Set<string>();
   let artifactWriteQueue = Promise.resolve();
+  let artifactWriteFailure: { error: unknown } | undefined;
   const writePartialArtifacts = () => {
     const partialScenarios = completedScenarioResults.filter(
       (scenario): scenario is QaSuiteScenarioResult => scenario !== undefined,
@@ -130,6 +131,7 @@ export async function runQaFlowSuiteIsolated(
         } satisfies QaLabLatestReport);
       })
       .catch((error: unknown) => {
+        artifactWriteFailure ??= { error };
         writeQaSuiteProgress(
           progressEnabled,
           `partial artifact write failed: ${sanitizeQaSuiteProgressValue(formatErrorMessage(error))}`,
@@ -330,6 +332,15 @@ export async function runQaFlowSuiteIsolated(
   } catch (error) {
     isolatedRunFailed = true;
     isolatedRunError = error;
+    await artifactWriteQueue.catch(() => undefined);
+    if (artifactWriteFailure) {
+      isolatedRunError = new AggregateError(
+        [error, artifactWriteFailure.error],
+        "QA suite execution and partial artifact persistence both failed",
+        { cause: error },
+      );
+      throw isolatedRunError;
+    }
     throw error;
   } finally {
     const cleanupSteps = [

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -61,7 +61,8 @@ vi.mock("./providers/server-runtime.js", () => ({
 vi.mock("./runtime-parity.js", () => ({
   captureRuntimeParityCell: mocks.captureRuntimeParityCell,
 }));
-vi.mock("./suite-artifacts.js", () => ({
+vi.mock("./suite-artifacts.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./suite-artifacts.js")>()),
   writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
 }));
 vi.mock("./suite-runtime-gateway.js", () => ({
@@ -237,6 +238,46 @@ describe("QA runtime parity scenario retry isolation", () => {
         String(message).startsWith("run complete"),
       ),
     ).toHaveLength(0);
+  });
+
+  it("retries cleanup without replaying terminal scenario evidence", async () => {
+    const cleanup = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("cleanup reset"))
+      .mockResolvedValueOnce(undefined);
+    const complete = vi.fn(async () => {});
+    const retryPhase = vi.fn(async (_phase: string, run: () => Promise<unknown>) => {
+      try {
+        return await run();
+      } catch {
+        return await run();
+      }
+    });
+    mocks.runQaFlowSuiteCleanupPlan.mockImplementationOnce(async (params) => {
+      await params.retryPhase?.("cleanup: gateway stop", cleanup);
+      return [];
+    });
+    const runScenario = vi
+      .fn<QaSuiteScenarioRunner>()
+      .mockResolvedValue(makeRetryTestResult("pass"));
+
+    await runQaFlowSuiteStandard(
+      {
+        lab: makeRetryTestLab(),
+        profileRun: {
+          complete,
+          hasTerminalEvidence: () => complete.mock.calls.length > 0,
+          retryPhase,
+        },
+      },
+      makeRetryTestContext(),
+      runScenario,
+    );
+
+    expect(runScenario).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledTimes(2);
+    expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -3,6 +3,7 @@ import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harne
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { startQaGatewayChild } from "./gateway-child.js";
 import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
+import type { QaProfileRunControl } from "./profile-run-checkpoint.js";
 import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
 import { startQaProviderServer } from "./providers/server-runtime.js";
 import {
@@ -13,6 +14,7 @@ import { captureRuntimeParityCell } from "./runtime-parity.js";
 import {
   type QaSuiteGatewayHeapSnapshot,
   type QaSuiteGatewayRssSample,
+  persistQaSuiteScenarioEvidence,
   writeQaSuiteArtifacts,
 } from "./suite-artifacts.js";
 import {
@@ -50,7 +52,7 @@ import {
 import { closeQaWebSessions } from "./web-runtime.js";
 
 export async function runQaFlowSuiteStandard(
-  params: QaSuiteRunParams | undefined,
+  params: (QaSuiteRunParams & { profileRun?: QaProfileRunControl }) | undefined,
   context: QaSuiteResolvedRunContext,
   runScenarioDefinition: QaSuiteScenarioRunner,
 ): Promise<QaSuiteResult> {
@@ -311,6 +313,15 @@ export async function runQaFlowSuiteStandard(
           scenarioFinishedAt: scenarioExecutionFinishedAt,
         });
       }
+      await persistQaSuiteScenarioEvidence({
+        ...context,
+        channelDriver: transportFactoryResult.driver,
+        channelId: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
+        evidenceMode: params?.evidenceMode,
+        profileRun: params?.profileRun,
+        scenarioDefinition: scenario,
+        scenarioResult,
+      });
       sampleGatewayProcessRss(`scenario:${scenario.id}:finish`);
       scenarios.push(scenarioResult);
       writeQaSuiteProgress(
@@ -406,6 +417,7 @@ export async function runQaFlowSuiteStandard(
           params?.scenarioIds && params.scenarioIds.length > 0
             ? selectedScenarios.map((scenario) => scenario.id)
             : undefined,
+        retryPhase: params?.profileRun?.retryPhase,
       },
     );
     const latestReport = {
@@ -461,6 +473,7 @@ export async function runQaFlowSuiteStandard(
               });
             }
           },
+      retryPhase: params?.profileRun?.retryPhase,
     });
     throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result, evidenceWritten });
   }

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { QaProfileRunControl } from "./profile-run-checkpoint.js";
 import {
   defaultQaSuiteConcurrencyForTransport,
   normalizeQaTransportId,
@@ -26,7 +27,9 @@ import {
   writeQaSuiteProgress,
 } from "./suite.js";
 
-export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Promise<QaSuiteResult> {
+export async function runQaFlowSuiteFromRuntime(
+  params?: QaSuiteRunParams & { profileRun?: QaProfileRunControl },
+): Promise<QaSuiteResult> {
   const startedAt = new Date();
   const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
   const catalog = readQaBootstrapScenarioCatalog();
@@ -149,6 +152,7 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
       scenarioIds: params.scenarioIds,
       runtimePair: params.runtimePair,
       writeEvidenceFile: params.writeEvidenceFile,
+      profileRun: params.profileRun,
     });
   }
   return useIsolatedScenarioWorkers

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -73,7 +73,8 @@ vi.mock("./runtime-parity.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./runtime-parity.js")>()),
   captureRuntimeParityCell: mocks.captureRuntimeParityCell,
 }));
-vi.mock("./suite-artifacts.js", () => ({
+vi.mock("./suite-artifacts.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./suite-artifacts.js")>()),
   writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
 }));
 vi.mock("./suite-runtime-gateway.js", () => ({

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -7,6 +7,7 @@ import type {
   QaLabServerHandle,
 } from "./lab-server.types.js";
 import type { QaProviderMode } from "./model-selection.js";
+import type { QaProfileRunControl } from "./profile-run-checkpoint.js";
 import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
 import type { QaThinkingLevel } from "./qa-gateway-config.js";
 import type { QaTransportAdapterFactory, QaTransportId } from "./qa-transport-registry.js";
@@ -17,7 +18,7 @@ import {
 } from "./runtime-parity.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
-import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
+import { persistQaSuiteScenarioEvidence, writeQaSuiteArtifacts } from "./suite-artifacts.js";
 import {
   collectQaSuiteTransportPolicy,
   mapQaSuiteWithConcurrency,
@@ -69,6 +70,7 @@ export async function runQaRuntimeParitySuite(params: {
   scenarioIds?: readonly string[];
   runtimePair: [RuntimeId, RuntimeId];
   writeEvidenceFile?: boolean;
+  profileRun?: QaProfileRunControl;
 }) {
   const ownsLab = !params.lab;
   const startLab = requireQaSuiteStartLab(params.startLab);
@@ -227,6 +229,13 @@ export async function runQaRuntimeParitySuite(params: {
           scenarioName: scenario.title,
           result: parity,
         });
+        await persistQaSuiteScenarioEvidence({
+          ...params,
+          channelDriver: transportFactoryResult.driver,
+          channelId: params.channelId ?? params.channelDriverSelection?.channel ?? transport.id,
+          scenarioDefinition: scenario,
+          scenarioResult: parityScenarioResult,
+        });
         liveScenarioOutcomes[index] = {
           id: scenario.id,
           name: scenario.title,
@@ -278,6 +287,7 @@ export async function runQaRuntimeParitySuite(params: {
             : undefined,
         runtimePair: params.runtimePair,
         writeEvidenceFile: params.writeEvidenceFile,
+        retryPhase: params.profileRun?.retryPhase,
       },
     );
     lab.setLatestReport({
@@ -311,12 +321,20 @@ export async function runQaRuntimeParitySuite(params: {
     runError = error;
     throw error;
   } finally {
-    const cleanupFailures = await runQaSuiteCleanupSteps([
-      ...(!parentTransportCleaned
-        ? [{ phase: "parent transport", run: () => transportFactoryResult.cleanupWithoutGateway() }]
-        : []),
-      ...(ownsLab ? [{ phase: "lab stop", run: () => lab.stop() }] : []),
-    ]);
+    const cleanupFailures = await runQaSuiteCleanupSteps(
+      [
+        ...(!parentTransportCleaned
+          ? [
+              {
+                phase: "parent transport",
+                run: () => transportFactoryResult.cleanupWithoutGateway(),
+              },
+            ]
+          : []),
+        ...(ownsLab ? [{ phase: "lab stop", run: () => lab.stop() }] : []),
+      ],
+      params.profileRun?.retryPhase,
+    );
     throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result, evidenceWritten });
   }
   if (!result) {

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -74,6 +74,51 @@ describe("qa suite", () => {
     ]);
   });
 
+  it("retries only the failed cleanup step without changing cleanup order", async () => {
+    const calls: string[] = [];
+    let gatewayAttempts = 0;
+    const retryPhase = async (_phase: string, run: () => Promise<void>) => {
+      try {
+        await run();
+      } catch {
+        await run();
+      }
+    };
+
+    const failures = await qaSuiteProgressTesting.runQaFlowSuiteCleanupPlan({
+      cleanupTransportBeforeGatewayStop: async () => {
+        calls.push("transport before gateway");
+      },
+      stopGateway: async () => {
+        gatewayAttempts += 1;
+        calls.push(`gateway ${gatewayAttempts}`);
+        if (gatewayAttempts === 1) {
+          throw new Error("gateway stop reset");
+        }
+      },
+      cleanupTransportAfterGatewayStop: async () => {
+        calls.push("transport after gateway");
+      },
+      disposeAgentHarnesses: async () => {
+        calls.push("agent harnesses");
+      },
+      finishLab: async () => {
+        calls.push("lab");
+      },
+      retryPhase,
+    });
+
+    expect(failures).toEqual([]);
+    expect(calls).toEqual([
+      "transport before gateway",
+      "gateway 1",
+      "gateway 2",
+      "transport after gateway",
+      "agent harnesses",
+      "lab",
+    ]);
+  });
+
   it("keeps the primary suite error as the cause of aggregated cleanup failures", () => {
     const runError = new Error("gateway infrastructure failed");
     const cleanupError = new Error("transport cleanup failed");

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -6,29 +6,23 @@ import type { OpenClawCrablineChannelDriverSelection } from "@openclaw/crabline"
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import type { QaEvidenceTiming, QaEvidenceSummaryJson } from "./evidence-summary.js";
-import type { QaCliBackendAuthMode, QaGatewayChildCommand } from "./gateway-child.js";
 import { startQaGatewayChild } from "./gateway-child.js";
 import { discardIgnoredResponseBody } from "./ignored-response-body.js";
-import type { QaLabServerHandle, QaLabServerStartParams } from "./lab-server.types.js";
+import type { QaLabServerHandle } from "./lab-server.types.js";
 import { resolveQaLiveTurnTimeoutMs } from "./live-timeout.js";
-import type { QaProviderMode } from "./model-selection.js";
+import { runQaProfilePhase, type QaProfilePhaseRetry } from "./profile-run-checkpoint.js";
 import {
   parseQaProgressBooleanEnv as parseQaSuiteBooleanEnv,
   sanitizeQaProgressValue as sanitizeQaSuiteProgressValue,
 } from "./progress-format.js";
-import type { QaThinkingLevel } from "./qa-gateway-config.js";
 import {
   createQaTransportAdapter,
   selectQaTransportDriver,
   type QaTransportAdapterFactory,
-  type QaTransportFactoryContext,
   type QaTransportId,
 } from "./qa-transport-registry.js";
-import type { QaReportCheck } from "./report.js";
-import type { RuntimeId, RuntimeParityCell, RuntimeParityResult } from "./runtime-parity.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
-import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
+import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
 import {
   type QaSuiteGatewayHeapSnapshot,
   type QaSuiteGatewayRssSample,
@@ -39,13 +33,11 @@ import {
   shouldUseIsolatedQaSuiteScenarioWorkers,
   splitModelRef,
 } from "./suite-planning.js";
-import type { QaSuiteRoundTripProbe } from "./suite-round-trip.js";
 import {
   createQaSuiteScenarioStepRunner,
   runQaSuiteScenarioDefinition,
   runQaSuiteScenarioSteps,
 } from "./suite-runtime-flow.js";
-import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 import type { QaSuiteSummaryJson } from "./suite-summary.js";
 import {
   appendNodeOption,
@@ -54,6 +46,13 @@ import {
   mergeQaRuntimeEnvPatches,
   remapModelRefForForcedRuntime,
 } from "./suite-support.js";
+import type {
+  QaSuiteEnvironment,
+  QaSuiteResult,
+  QaSuiteRunParams,
+  QaSuiteScenarioResult,
+  QaSuiteStartLabFn,
+} from "./suite-types.js";
 
 function resolveQaSuiteControlUiEnabled(params: {
   explicit?: boolean;
@@ -63,23 +62,6 @@ function resolveQaSuiteControlUiEnabled(params: {
     params.explicit ?? params.scenarios.some((scenario) => scenarioRequiresControlUi(scenario))
   );
 }
-
-export type QaSuiteScenarioResult = {
-  name: string;
-  status: "pass" | "fail" | "skip";
-  steps: QaReportCheck[];
-  details?: string;
-  timing?: QaEvidenceTiming;
-  runtimeParity?: RuntimeParityResult;
-};
-
-type QaSuiteEnvironment = {
-  lab: QaLabServerHandle;
-  runtimeId: RuntimeId;
-  webSessionIds: Set<string>;
-} & QaSuiteRuntimeEnv;
-
-export type QaSuiteStartLabFn = (params?: QaLabServerStartParams) => Promise<QaLabServerHandle>;
 
 export async function createQaSuiteTransportAdapter(params: {
   adapterOptions?: QaSuiteRunParams["adapterOptions"];
@@ -126,44 +108,6 @@ export async function createQaSuiteTransportAdapter(params: {
     throw error;
   }
 }
-
-export type QaSuiteRunParams = {
-  adapterOptions?: QaTransportFactoryContext["adapterOptions"];
-  adapterFactories?: readonly QaTransportAdapterFactory[];
-  channelId?: string;
-  evidenceMode?: QaScorecardEvidenceMode;
-  repoRoot?: string;
-  sutOpenClawCommand?: QaGatewayChildCommand;
-  outputDir?: string;
-  providerMode?: QaProviderMode;
-  transportId?: QaTransportId;
-  channelDriver?: QaScorecardChannelDriver;
-  channelDriverSelection?: OpenClawCrablineChannelDriverSelection | null;
-  primaryModel?: string;
-  alternateModel?: string;
-  fastMode?: boolean;
-  failFast?: boolean;
-  thinkingDefault?: QaThinkingLevel;
-  claudeCliAuthMode?: QaCliBackendAuthMode;
-  scenarioIds?: string[];
-  lab?: QaLabServerHandle;
-  startLab?: QaSuiteStartLabFn;
-  concurrency?: number;
-  enabledPluginIds?: string[];
-  controlUiEnabled?: boolean;
-  transportReadyTimeoutMs?: number;
-  workerStartStaggerMs?: number;
-  forcedRuntime?: RuntimeId;
-  runtimePair?: [RuntimeId, RuntimeId];
-  captureRuntimeParityCell?: boolean;
-  roundTripProbe?: QaSuiteRoundTripProbe;
-  // Profile runs prove every applicable declared channel. Direct channel lanes
-  // still treat execution.channels as an OR eligibility list.
-  expandScenarioChannels?: boolean;
-  // Unified suite partitions consume child evidence in memory; only the
-  // parent should write the aggregate qa-evidence.json artifact.
-  writeEvidenceFile?: boolean;
-};
 
 export function shouldLogQaSuiteProgress(env: NodeJS.ProcessEnv = process.env) {
   const override = parseQaSuiteBooleanEnv(env.OPENCLAW_QA_SUITE_PROGRESS);
@@ -283,11 +227,14 @@ export async function waitForQaLabReadyOrStopOwned(params: {
 type QaSuiteCleanupStep = { phase: string; run: () => Promise<void> };
 type QaSuiteCleanupFailure = { phase: string; error: unknown };
 
-export async function runQaSuiteCleanupSteps(steps: readonly QaSuiteCleanupStep[]) {
+export async function runQaSuiteCleanupSteps(
+  steps: readonly QaSuiteCleanupStep[],
+  retryPhase?: QaProfilePhaseRetry,
+) {
   const failures: QaSuiteCleanupFailure[] = [];
   for (const step of steps) {
     try {
-      await step.run();
+      await runQaProfilePhase(retryPhase, `cleanup: ${step.phase}`, step.run);
     } catch (error) {
       failures.push({ phase: step.phase, error });
     }
@@ -303,6 +250,7 @@ export async function runQaFlowSuiteCleanupPlan(params: {
   disposeAgentHarnesses: () => Promise<void>;
   stopProvider?: () => Promise<void>;
   finishLab: () => Promise<void>;
+  retryPhase?: QaProfilePhaseRetry;
 }) {
   const stopGateway = params.stopGateway;
   let gatewayStopped = !stopGateway;
@@ -315,19 +263,22 @@ export async function runQaFlowSuiteCleanupPlan(params: {
       await params.cleanupTransportAfterGatewayStop();
     }
   };
-  return runQaSuiteCleanupSteps([
-    ...(params.closeWebSessions ? [{ phase: "web sessions", run: params.closeWebSessions }] : []),
-    // Drain transport HTTP work before stopping the gateway; otherwise a completed suite can
-    // emit an unhandled response-close rejection during delivery.
-    { phase: "transport before gateway stop", run: params.cleanupTransportBeforeGatewayStop },
-    ...(stopGateway ? [{ phase: "gateway stop", run: stopGatewayAndMark }] : []),
-    // Never release a credential-backed transport until gateway teardown proves
-    // that the isolated runtime reached its terminal boundary.
-    { phase: "transport after gateway stop", run: cleanupTransportAfterGatewayStop },
-    { phase: "agent harnesses", run: params.disposeAgentHarnesses },
-    ...(params.stopProvider ? [{ phase: "provider stop", run: params.stopProvider }] : []),
-    { phase: "lab finish", run: params.finishLab },
-  ]);
+  return runQaSuiteCleanupSteps(
+    [
+      ...(params.closeWebSessions ? [{ phase: "web sessions", run: params.closeWebSessions }] : []),
+      // Drain transport HTTP work before stopping the gateway; otherwise a completed suite can
+      // emit an unhandled response-close rejection during delivery.
+      { phase: "transport before gateway stop", run: params.cleanupTransportBeforeGatewayStop },
+      ...(stopGateway ? [{ phase: "gateway stop", run: stopGatewayAndMark }] : []),
+      // Never release a credential-backed transport until gateway teardown proves
+      // that the isolated runtime reached its terminal boundary.
+      { phase: "transport after gateway stop", run: cleanupTransportAfterGatewayStop },
+      { phase: "agent harnesses", run: params.disposeAgentHarnesses },
+      ...(params.stopProvider ? [{ phase: "provider stop", run: params.stopProvider }] : []),
+      { phase: "lab finish", run: params.finishLab },
+    ],
+    params.retryPhase,
+  );
 }
 
 export function throwQaSuiteCleanupErrors(params: {
@@ -420,19 +371,6 @@ const QA_IMAGE_UNDERSTANDING_LARGE_PNG_BASE64 =
 
 const QA_IMAGE_UNDERSTANDING_VALID_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAALklEQVR4nO3OoQEAAAyDsP7/9HYGJgJNdtuVDQAAAAAAACAHxH8AAAAAAACAHvBX0fhq85dN7QAAAABJRU5ErkJggg==";
-
-export type QaSuiteResult = {
-  evidence?: QaEvidenceSummaryJson;
-  outputDir: string;
-  evidencePath: string;
-  reportPath: string;
-  summaryPath: string;
-  report: string;
-  scenarios: QaSuiteScenarioResult[];
-  startedScenarioIds: string[];
-  watchUrl: string;
-  runtimeParityCell?: RuntimeParityCell;
-};
 
 export async function runQaSuiteScenarioDefinitionForRuntime(
   env: QaSuiteEnvironment,
@@ -588,6 +526,12 @@ export async function captureGatewayHeapSnapshotCheckpoint(params: {
 export { buildQaSuiteSummaryJson } from "./suite-artifacts.js";
 export type { QaSuiteSummaryJsonParams } from "./suite-artifacts.js";
 export type { QaSuiteSummaryJson } from "./suite-summary.js";
+export type {
+  QaSuiteResult,
+  QaSuiteRunParams,
+  QaSuiteScenarioResult,
+  QaSuiteStartLabFn,
+} from "./suite-types.js";
 
 export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuiteResult> {
   const { runQaFlowSuiteFromRuntime } = await import("./suite-run.runtime.js");

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -10,7 +10,7 @@ import { startQaGatewayChild } from "./gateway-child.js";
 import { discardIgnoredResponseBody } from "./ignored-response-body.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import { resolveQaLiveTurnTimeoutMs } from "./live-timeout.js";
-import { runQaProfilePhase, type QaProfilePhaseRetry } from "./profile-run-checkpoint.js";
+import type { QaProfilePhaseRetry } from "./profile-run-checkpoint.js";
 import {
   parseQaProgressBooleanEnv as parseQaSuiteBooleanEnv,
   sanitizeQaProgressValue as sanitizeQaSuiteProgressValue,
@@ -50,7 +50,6 @@ import type {
   QaSuiteEnvironment,
   QaSuiteResult,
   QaSuiteRunParams,
-  QaSuiteScenarioResult,
   QaSuiteStartLabFn,
 } from "./suite-types.js";
 
@@ -234,7 +233,7 @@ export async function runQaSuiteCleanupSteps(
   const failures: QaSuiteCleanupFailure[] = [];
   for (const step of steps) {
     try {
-      await runQaProfilePhase(retryPhase, `cleanup: ${step.phase}`, step.run);
+      await (retryPhase?.(`cleanup: ${step.phase}`, step.run) ?? step.run());
     } catch (error) {
       failures.push({ phase: step.phase, error });
     }

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -961,12 +961,18 @@ describe("qa test file scenario runner", () => {
       makeDockerE2eScenario("prefix-lane", "gateway"),
       makeDockerE2eScenario("failing-lane", "gateway-network"),
     ];
+    const complete = vi.fn(async () => {});
     const result = await runQaTestFileScenarios({
       repoRoot,
       outputDir,
       providerMode: "mock-openai",
       primaryModel: "mock-openai/gpt-5.6-luna",
       scenarios,
+      profileRun: {
+        complete,
+        hasTerminalEvidence: () => complete.mock.calls.length > 0,
+        retryPhase: async (_phase, run) => await run(),
+      },
       runCommand: async (command) => {
         commands.push(command);
         await expect(fs.access(staleSummaryPath)).rejects.toThrow();
@@ -1019,6 +1025,9 @@ describe("qa test file scenario runner", () => {
       { scenario: { id: "failing-lane" }, status: "fail" },
     ]);
     expect(result.results[3]?.failureMessage).toBe("gateway-network exited with 1");
+    expect(complete.mock.calls.map(([input]) => input.scenarioId)).toEqual(
+      scenarios.map((scenario) => scenario.id),
+    );
   });
 
   it("uses script scenario timeout overrides when running producer commands", async () => {

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -16,7 +16,7 @@ import {
   resolveQaEvidenceProfile,
   validateQaEvidenceSummaryJson,
 } from "./evidence-summary.js";
-import { runQaProfilePhase, type QaProfileRunControl } from "./profile-run-checkpoint.js";
+import type { QaProfileRunControl } from "./profile-run-checkpoint.js";
 import type { QaProviderMode } from "./providers/index.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
@@ -557,11 +557,7 @@ async function writeTestFileEvidenceFile(params: {
       await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
       await assertQaSuiteArtifactWritten("evidence", evidencePath);
     };
-    await runQaProfilePhase(
-      params.profileRun?.retryPhase,
-      "test-file artifact persistence",
-      persist,
-    );
+    await (params.profileRun?.retryPhase?.("test-file artifact persistence", persist) ?? persist());
   }
   return { evidencePath };
 }

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -16,6 +16,7 @@ import {
   resolveQaEvidenceProfile,
   validateQaEvidenceSummaryJson,
 } from "./evidence-summary.js";
+import { runQaProfilePhase, type QaProfileRunControl } from "./profile-run-checkpoint.js";
 import type { QaProviderMode } from "./providers/index.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
@@ -57,6 +58,7 @@ type QaTestFileScenarioRunParams = {
   runCommand?: QaScenarioCommandRunner;
   scenarios: readonly QaSeedScenarioWithSource[];
   writeEvidenceFile?: boolean;
+  profileRun?: QaProfileRunControl;
 };
 
 type QaScenarioCommandRunner = (
@@ -547,13 +549,43 @@ async function writeTestFileEvidenceFile(params: {
   evidence: unknown;
   outputDir: string;
   writeEvidenceFile?: boolean;
+  profileRun?: QaProfileRunControl;
 }): Promise<Pick<QaTestFileScenarioRunResult, "evidencePath">> {
   const evidencePath = path.join(params.outputDir, QA_EVIDENCE_FILENAME);
   if (params.writeEvidenceFile ?? true) {
-    await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
-    await assertQaSuiteArtifactWritten("evidence", evidencePath);
+    const persist = async () => {
+      await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
+      await assertQaSuiteArtifactWritten("evidence", evidencePath);
+    };
+    await runQaProfilePhase(
+      params.profileRun?.retryPhase,
+      "test-file artifact persistence",
+      persist,
+    );
   }
   return { evidencePath };
+}
+
+async function persistTestFileScenarioEvidence(
+  params: QaTestFileScenarioRunParams,
+  env: NodeJS.ProcessEnv,
+  kind: QaTestFileExecutionKind,
+  result: QaTestFileScenarioResult,
+) {
+  if (!params.profileRun) {
+    return;
+  }
+  await params.profileRun.complete({
+    scenarioId: result.scenario.id,
+    evidence: buildTestFileEvidence({
+      ...params,
+      artifactPaths: buildScenarioArtifactPaths({ repoRoot: params.repoRoot, results: [result] }),
+      env,
+      generatedAt: new Date().toISOString(),
+      kind,
+      results: [result],
+    }),
+  });
 }
 
 export async function runQaTestFileScenarios(
@@ -590,16 +622,18 @@ export async function runQaTestFileScenarios(
   for (const [scenarioTimeoutMs, group] of dockerBatchGroups) {
     // A scheduler invocation shares one fallback lane timeout, so timeout overrides
     // stay in separate batches instead of borrowing another scenario's budget.
-    results.push(
-      ...(await runDockerE2eBatch({
-        commandTimeoutMs: scenarioTimeoutMs,
-        env,
-        outputDir: params.outputDir,
-        repoRoot: params.repoRoot,
-        runCommand,
-        scenarios: group,
-      })),
-    );
+    const batchResults = await runDockerE2eBatch({
+      commandTimeoutMs: scenarioTimeoutMs,
+      env,
+      outputDir: params.outputDir,
+      repoRoot: params.repoRoot,
+      runCommand,
+      scenarios: group,
+    });
+    for (const result of batchResults) {
+      await persistTestFileScenarioEvidence(params, env, kind, result);
+      results.push(result);
+    }
   }
   const dockerBatchScenarioIds = new Set(dockerBatchScenarios.map((scenario) => scenario.id));
   for (const scenario of scenarios) {
@@ -614,6 +648,7 @@ export async function runQaTestFileScenarios(
       runCommand,
       scenario,
     });
+    await persistTestFileScenarioEvidence(params, env, kind, result);
     results.push(result);
     if (params.failFast && result.status !== "pass") {
       break;
@@ -643,6 +678,7 @@ export async function runQaTestFileScenarios(
   const paths = await writeTestFileEvidenceFile({
     evidence,
     outputDir: params.outputDir,
+    profileRun: params.profileRun,
     writeEvidenceFile: params.writeEvidenceFile,
   });
   return {


### PR DESCRIPTION
Related: #119761
Related: #119572
Replaces: #119868

## What Problem This Solves

QA profile runs could retain a stale successful `qa-evidence.json` when a replacement run failed before final aggregation. Direct single-profile execution also bypassed the suite retry, checkpoint, and finalization owner used by multi-cell profiles, so retry exhaustion and cleanup failures could end without canonical failure evidence.

## Why This Change Was Made

QA Lab now owns one profile-run lifecycle:

- remove prior canonical evidence before creating the new checkpoint, and abort before execution if invalidation cannot be completed;
- route every profile run, including direct single-flow mode, through one bounded partition retry and finalization path;
- persist content-addressed terminal cell evidence before marking a checkpoint cell complete;
- synthesize durable failure evidence when a profile partition exhausts retries before producing a terminal result;
- finalize authoritative checkpoint refs into one atomic canonical `qa-evidence.json`;
- leave canonical evidence absent if the final atomic write fails, rather than preserving stale success;
- retry individual artifact and cleanup phases without replaying already-terminal producers.

Non-profile direct and `watchUrl` execution keep their existing path and behavior.

This replaces the broader lifecycle draft in #119868. That draft added start/running state and duplicate attempt policy at producer boundaries. The replacement keeps the authoritative facts smaller: expected cells, durable terminal evidence refs, bounded phase retry, and one finalization owner.

## User Impact

QA operators and maturity automation no longer mistake stale success for the result of a failed profile run. Retry exhaustion, direct-profile failure, partial terminal progress, cleanup failure, and final-write failure now have deterministic evidence semantics.

No changelog entry: this is internal QA evidence and validation infrastructure.

## Evidence

- Exact head: `bb6b67a3fe3ed47b5a3b017e7cb4fc4124f16b45`.
- Refreshed live base before push: `913b53ad808772be8c3a8497f7320d93e928b4db`.
- Focused Vitest: 221 tests across 8 files passed.
- Formatting and `git diff --check` passed.
- Independent autoreview: clean; patch correct at 0.98 confidence.
- Hosted exact-head profile failure/retry/evidence proof: pending on direct AWS Crabbox because local Blacksmith Testbox authentication is unavailable.
- Required hosted changed gates and GitHub CI: pending.

## Review Notes

- Production TypeScript: `+718/-515`, net `+203`.
- Tests: `+1166/-196`, net `+970`.
- The production growth is the canonical checkpoint/finalization owner and the phase-retry wiring required to make artifact, cleanup, and final evidence writes durable. It replaces the obsolete file-mutating scorecard finalizer and avoids the broader duplicate lifecycle policy from #119868.
- No config, schema-version, dependency, workflow, release, tag, or publish surface changes.
- Commit attestation: `att_01KZBKZ9EJWF668A8Q9GDFQBB7`.

Punchcard-Session: cobalt-valley-meadow-mg
