### PR TITLE
fix(cli): warn on JSON5 parse failure in config set value

### DIFF
--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -169,6 +169,7 @@ export function parseConfigSetValue(raw: string, strictJson: boolean): unknown {
   try {
     return JSON5.parse(trimmed);
   } catch {
+    console.warn(`JSON5 parse failed for value '${raw}'; using as raw string`);
     return raw;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw config set` silently accepts invalid JSON5 values like `"{invalid json5"` and writes them verbatim to the config file — giving exit code 0 with no warning. The user sees a success message, but the config now contains a malformed value that causes silent failures at startup.

## Why This Change Was Made

The `parseConfigSetValue` function catches JSON5 parse failures and returns the raw string without any user feedback. The `strictJson` code path already throws a descriptive error on parse failure; this change adds a `console.warn` to the JSON5 path so users get a visible warning that parsing failed and the raw value is being used.

## User Impact

When `openclaw config set` encounters a value that fails JSON5 parsing, users now see a warning message like:

```
JSON5 parse failed for value '{invalid json5'; using as raw string
```

This lets operators immediately know the value wasn't parsed as intended, before the invalid config silently breaks later.

## Evidence

### Before fix

```
$ openclaw config set agents.defaults.model "{invalid json5"
# exit 0, no warning, "{invalid json5" is written to config
# Next startup: model name is invalid, user doesn't know why
```

### After fix

```
$ openclaw config set agents.defaults.model "{invalid json5"
JSON5 parse failed for value '{invalid json5'; using as raw string
# exit 0, warning emitted — user knows the value was used as-is
```
