### PR TITLE
fix(googlechat): redact reflected credentials in API errors

### DIFF
--- a/extensions/googlechat/src/api.fetchok.transport.test.ts
+++ b/extensions/googlechat/src/api.fetchok.transport.test.ts
@@ -216,9 +216,16 @@ describe("deleteGoogleChatMessage real guarded transport", () => {
   });
 
   it("preserves Google Chat errors without exposing the bearer token", async () => {
-    const server = createServer((_request, response) => {
+    let receivedAuthorization: string | undefined;
+    const server = createServer((request, response) => {
+      receivedAuthorization = request.headers.authorization;
       response.writeHead(403, { "Content-Type": "application/json" });
-      response.end(JSON.stringify({ error: { message: "Chat permission denied" } }));
+      response.end(
+        JSON.stringify({
+          error: { message: "Chat permission denied" },
+          reflectedHeader: `Authorization: ${receivedAuthorization}`,
+        }),
+      );
     });
 
     loopback.baseUrl = await listen(server);
@@ -230,8 +237,10 @@ describe("deleteGoogleChatMessage real guarded transport", () => {
         ),
       );
       expect(outcome).toBeInstanceOf(Error);
+      expect(receivedAuthorization).toBe(`Bearer ${proofToken}`);
       expect((outcome as Error).message).toContain("Google Chat API 403");
       expect((outcome as Error).message).toContain("Chat permission denied");
+      expect((outcome as Error).message).toContain("Authorization: Bearer");
       expect((outcome as Error).message).not.toContain(proofToken);
       expect(loopback.releases).toEqual([{ bodyIsNull: false, bodyUsed: true }]);
     } finally {

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -1,5 +1,6 @@
 // Googlechat API module exposes the plugin public contract.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   MediaFetchError,
   parseMediaContentLength,
@@ -46,15 +47,17 @@ async function readGoogleChatJsonResponse<T>(response: Response, label: string):
 }
 
 async function readGoogleChatErrorResponse(response: Response, label: string): Promise<string> {
-  return (
+  const text =
     (await readResponseTextSnippet(response, {
       maxBytes: GOOGLECHAT_ERROR_BODY_MAX_BYTES,
       maxChars: GOOGLECHAT_ERROR_BODY_MAX_BYTES,
       chunkTimeoutMs: GOOGLECHAT_RESPONSE_READ_IDLE_TIMEOUT_MS,
       onIdleTimeout: ({ chunkTimeoutMs }) =>
         new Error(`${label} error response stalled after ${chunkTimeoutMs}ms`),
-    })) ?? ""
-  );
+    })) ?? "";
+  // Remote API errors can reflect the request's Authorization header. Force
+  // tool-payload redaction before the text enters any surfaced error message.
+  return redactToolPayloadText(text);
 }
 
 const headersToObject = (headers?: HeadersInit): Record<string, string> =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Chat users could have a bearer token exposed in surfaced API errors when an upstream service or proxy reflected the request's Authorization header in its response body.

## Why This Change Was Made

The shared Google Chat error-response reader now applies forced tool-payload redaction before returning remote text to the API error boundary. This protects every send, update, delete, lookup, and media request that uses the shared response path without changing status handling, retries, or error types.

## User Impact

Google Chat API failures retain useful status and provider details without returning reflected request credentials to users, agents, logs, or downstream error consumers.

## Evidence

- Strengthened `extensions/googlechat/src/api.fetchok.transport.test.ts` so its real guarded loopback transport reflects the actual Bearer Authorization header and verifies the complete token is absent from the surfaced error.
- The same transport case verifies the safe provider message and dispatcher release behavior remain intact.
- [Exact-head changed-test output](https://github.com/openclaw/openclaw/actions/runs/31109420455/job/92643157694) shows the guarded loopback transport file passed 6/6 tests. The linked transport assertions verify the reflected bearer token is absent from the surfaced error while the safe provider detail and dispatcher release behavior remain intact.
- `git diff --check` passed.
- `oxfmt 0.60.0 --check extensions/googlechat/src/api.ts extensions/googlechat/src/api.fetchok.transport.test.ts` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` passed with no accepted or actionable findings.
- [Exact-head GitHub CI](https://github.com/openclaw/openclaw/actions/runs/31109420455) passed all selected checks (47 passed, 37 skipped, 0 failed).

AI-assisted: developed with Codex; the author reviewed the complete change and its shared error-response behavior.
