### PR TITLE
fix: prevent duplicate outbound delivery during concurrent recovery

### DIFF
--- a/src/infra/delivery-queue-sqlite-claim.ts
+++ b/src/infra/delivery-queue-sqlite-claim.ts
@@ -18,6 +18,18 @@ type PlatformClaimParams = {
 
 export const PLATFORM_SEND_OWNER_LEASE_MS = 30_000;
 
+/** Creates the owner published atomically with an immediate live delivery. */
+export function createInitialDeliveryProducerClaim(now = Date.now()) {
+  return {
+    requiresProducerClaim: true,
+    availableAt: now + PLATFORM_SEND_OWNER_LEASE_MS,
+    producerClaimId: generateSecureUuid(),
+    recoveryState: "producer_claimed",
+  } as const;
+}
+
+export type InitialDeliveryProducerClaim = ReturnType<typeof createInitialDeliveryProducerClaim>;
+
 /** Runs an existing queue mutation only while its exact platform owner survives. */
 export function transitionOwnedDeliveryQueueEntry(
   params: {
@@ -132,7 +144,7 @@ export function claimDeliveryQueueEntryPlatformSend(
     : undefined;
 }
 
-/** Renew only the exact unexpired reusable producer that already owns the row. */
+/** Renew only the exact unexpired producer that already owns the row. */
 export function renewDeliveryQueueEntryPlatformSendLease(
   params: Pick<PlatformClaimParams, "queueName" | "id" | "stateDir"> & {
     claimId: string;
@@ -192,7 +204,7 @@ export function promoteDeliveryQueueEntryPlatformSend(
     entry.availableAt > now
       ? {
           ...entry,
-          // Only an explicitly reusable owner keeps its cross-process fence;
+          // Only an explicitly leased owner keeps its cross-process fence;
           // legacy recovery must remain immediately eligible after a crash.
           availableAt:
             entry.requiresProducerClaim === true ? now + PLATFORM_SEND_OWNER_LEASE_MS : undefined,

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -504,7 +504,7 @@ export function reserveDeliveryQueueEntryAttempt(params: {
         current.platformSendAttemptId !== params.expectedPlatformSendAttemptId &&
         current.producerClaimId !== params.expectedPlatformSendAttemptId
       ) {
-        throw new Error(`Stable delivery platform claim was lost: ${params.id}`);
+        throw new Error(`Delivery platform claim was lost: ${params.id}`);
       }
       const persistedAttemptCount =
         typeof current.attemptCount === "number" &&

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -212,7 +212,7 @@ export type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & 
   skipQueue?: boolean;
   /** @internal Fence recovery ownership at the same provider boundary as live sends. */
   deliveryProducerClaimId?: string;
-  /** @internal Keep an explicitly reusable producer claim alive during platform preparation. */
+  /** @internal Keep the exact live producer claim alive during platform preparation. */
   deliveryProducerLeaseRequired?: boolean;
   /** @internal Recovery already ran provider admission after its pending-row re-read. */
   deferredDeliveryAdmissionPassed?: true;

--- a/src/infra/outbound/deliver-queue-admission.ts
+++ b/src/infra/outbound/deliver-queue-admission.ts
@@ -1,6 +1,7 @@
 // Owns durable outbound admission, immutable payload custody, and media staging.
 import { createRenderedMessageBatchPlan } from "../../channels/message/rendered-batch.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import { createInitialDeliveryProducerClaim } from "../delivery-queue-sqlite-claim.js";
 import type { DeliverOutboundPayloadsParams } from "./deliver-contracts.js";
 import {
   collectPayloadMediaSources,
@@ -57,8 +58,11 @@ export function restoreQueuedDeliveryCustody(
 export async function stageAndEnqueueOutboundDelivery(
   params: DeliverOutboundPayloadsParams,
   preparedBatch: PreparedOutboundBatch,
-  options?: { getStablePreparation?: () => StableDeliveryPreparation },
-): Promise<{ id: string; created: boolean } | null> {
+  options?: {
+    getStablePreparation?: () => StableDeliveryPreparation;
+    claimForLiveDelivery?: boolean;
+  },
+): Promise<{ id: string; created: boolean; producerClaimId?: string } | null> {
   const { channel, to } = params;
   const queuePolicy = params.queuePolicy ?? "best_effort";
   const acceptedPayloads = acceptedPreparedOutboundEntries(preparedBatch).map((entry) =>
@@ -107,6 +111,9 @@ export async function stageAndEnqueueOutboundDelivery(
     return null;
   }
   try {
+    const initialProducerClaim = options?.claimForLiveDelivery
+      ? createInitialDeliveryProducerClaim()
+      : undefined;
     const queuedPreparedBatch = mapPreparedOutboundAcceptedPayloads(preparedBatch, staged.payloads);
     const delivery = {
       channel,
@@ -115,6 +122,7 @@ export async function stageAndEnqueueOutboundDelivery(
       queuePolicy,
       requireUnknownSendReconciliation: params.requireUnknownSendReconciliation,
       ...(params.reusePendingDeliveryIntent ? { requiresProducerClaim: true } : {}),
+      ...(initialProducerClaim ? { initialProducerClaim } : {}),
       preparedBatch: queuedPreparedBatch,
       renderedBatchPlan,
       threadId: params.threadId,
@@ -153,12 +161,19 @@ export async function stageAndEnqueueOutboundDelivery(
         cancelDeliveryQueueMediaStage(staged.mediaStageId);
         await releaseSpoolArtifacts(staged.artifacts);
       }
-      return queued;
+      return {
+        ...queued,
+        ...(queued.created && initialProducerClaim
+          ? { producerClaimId: initialProducerClaim.producerClaimId }
+          : {}),
+      };
     }
-    const id = staged.mediaStageId
-      ? await enqueueDelivery(delivery, undefined, staged.mediaStageId)
-      : await enqueueDelivery(delivery);
-    return { id, created: true };
+    const id = await enqueueDelivery(delivery, undefined, staged.mediaStageId);
+    return {
+      id,
+      created: true,
+      ...(initialProducerClaim ? { producerClaimId: initialProducerClaim.producerClaimId } : {}),
+    };
   } catch (err) {
     cancelDeliveryQueueMediaStage(staged.mediaStageId);
     await releaseSpoolArtifacts(staged.artifacts);

--- a/src/infra/outbound/deliver-queue-execute.ts
+++ b/src/infra/outbound/deliver-queue-execute.ts
@@ -228,7 +228,10 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           }
           queuedPreSendState ??= "marked";
         } catch (dispatchMarkError) {
-          if (exactReconciliationRequired || reusableProducerClaimId) {
+          // Any SQLite-fenced live producer must prove it still owns the row at
+          // dispatch. Continuing after a failed refresh can outlive the lease and
+          // let recovery duplicate a recipient-visible send.
+          if (exactReconciliationRequired || producerClaimId) {
             throw dispatchMarkError;
           }
           log.warn(

--- a/src/infra/outbound/deliver-queue-execute.ts
+++ b/src/infra/outbound/deliver-queue-execute.ts
@@ -73,9 +73,10 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     ownsAuditTerminal && hasTrustedMessageAuditListeners()
       ? ([] as OutboundPayloadDeliveryOutcome[])
       : undefined;
-  // Recipient custody must observe ambiguous adapter outcomes even when no
-  // audit listener is installed; audit subscriptions are not delivery proof.
-  const stablePayloadOutcomes = producerClaimId
+  const reusableProducerClaimId = params.reusePendingDeliveryIntent ? producerClaimId : undefined;
+  // Reusable producer custody must observe ambiguous adapter outcomes even when
+  // no audit listener is installed; audit subscriptions are not delivery proof.
+  const stablePayloadOutcomes = reusableProducerClaimId
     ? ([] as OutboundPayloadDeliveryOutcome[])
     : undefined;
   const queuePolicy = params.queuePolicy ?? "best_effort";
@@ -150,7 +151,8 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     return persistQueuedPostSendState({
       queueId,
       queuePolicy,
-      ...(producerClaimId ? { producerClaimId } : {}),
+      ...(reusableProducerClaimId ? { producerClaimId: reusableProducerClaimId } : {}),
+      ...(producerClaimId ? { expectedPlatformSendAttemptId: producerClaimId } : {}),
     });
   };
   const emitTerminals = (
@@ -226,7 +228,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           }
           queuedPreSendState ??= "marked";
         } catch (dispatchMarkError) {
-          if (exactReconciliationRequired || producerClaimId) {
+          if (exactReconciliationRequired || reusableProducerClaimId) {
             throw dispatchMarkError;
           }
           log.warn(

--- a/src/infra/outbound/deliver-queue-state.ts
+++ b/src/infra/outbound/deliver-queue-state.ts
@@ -85,21 +85,23 @@ export async function persistQueuedPreSendState(params: {
     }
     return "marked";
   } catch (markErr: unknown) {
-    // A fenced producer must never discard a lease it no longer owns: doing so
-    // could erase the replacement owner and send the same intent twice.
-    if (params.queuePolicy === "required" || params.producerClaimId) {
+    if (params.queuePolicy === "required") {
       throw markErr;
     }
     log.warn(
       `failed to mark queued delivery ${params.queueId} as platform-send-attempt-started; removing replay intent before best-effort send: ${formatErrorMessage(markErr)}`,
     );
-    // If the pre-send marker is unavailable, remove the intent before crossing
-    // the platform boundary. An ack failure aborts the send, leaving safe retry state.
-    if (params.retainSpoolArtifacts) {
-      await ackDelivery(params.queueId, params.stateDir, { retainSpoolArtifacts: true });
-    } else {
-      await ackDelivery(params.queueId, params.stateDir);
-    }
+    // Remove only the exact owner before crossing the platform boundary. A lost
+    // claim or failed ack aborts the send instead of erasing a replacement owner.
+    const options = {
+      ...(params.retainSpoolArtifacts ? { retainSpoolArtifacts: true } : {}),
+      ...(params.producerClaimId ? { expectedPlatformSendAttemptId: params.producerClaimId } : {}),
+    };
+    await ackDelivery(
+      params.queueId,
+      params.stateDir,
+      Object.keys(options).length > 0 ? options : undefined,
+    );
     return "acked";
   }
 }

--- a/src/infra/outbound/deliver-queue.lease-integration.test.ts
+++ b/src/infra/outbound/deliver-queue.lease-integration.test.ts
@@ -22,12 +22,65 @@ import {
 
 let deliverOutboundPayloads: typeof import("./deliver.js").deliverOutboundPayloads;
 
-function createDeferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
+function createDeferred<Value = void>() {
+  let resolve!: (value: Value) => void;
+  const promise = new Promise<Value>((resolvePromise) => {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+async function startBlockedFreshDelivery(params: { tmpDir: string }) {
+  process.env.OPENCLAW_STATE_DIR = params.tmpDir;
+  const preparationEntered = createDeferred();
+  const releasePreparation = createDeferred();
+  const queueIdReady = createDeferred<string>();
+  const messageId = "fresh-live-message";
+  const sendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
+    await ctx.onPlatformSendDispatch?.();
+    return {
+      messageId,
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "matrix", messageId }],
+        kind: "text",
+      }),
+    };
+  });
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: {
+          ...createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForQueueTest }),
+          message: {
+            id: "matrix",
+            durableFinal: { capabilities: { text: true } },
+            send: {
+              lifecycle: {
+                beforeSendAttempt: async () => {
+                  preparationEntered.resolve();
+                  await releasePreparation.promise;
+                },
+              },
+              text: sendText,
+            },
+          },
+        },
+      },
+    ]),
+  );
+  const delivery = deliverOutboundPayloads({
+    cfg: {} as OpenClawConfig,
+    channel: "matrix",
+    to: "!room:example",
+    payloads: [{ text: "fresh live content" }],
+    queuePolicy: "best_effort",
+    onDeliveryIntent: ({ id }) => queueIdReady.resolve(id),
+  });
+  const queueId = await queueIdReady.promise;
+  await preparationEntered.promise;
+  return { delivery, messageId, queueId, releasePreparation: releasePreparation.resolve, sendText };
 }
 
 async function startBlockedStableDelivery(params: {
@@ -240,7 +293,7 @@ async function startBlockedProviderStableDelivery(params: {
   return { delivery, onDeliveryResult, releaseProvider: releaseProvider.resolve, sendText };
 }
 
-describe("stable delivery producer lease integration", () => {
+describe("delivery producer lease integration", () => {
   const fixtures = installDeliveryQueueTmpDirHooks();
 
   beforeAll(async () => {
@@ -251,6 +304,34 @@ describe("stable delivery producer lease integration", () => {
     vi.useRealTimers();
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("publishes a fresh live delivery with cross-process ownership before provider I/O", async () => {
+    const tmpDir = fixtures.tmpDir();
+    let blocked: Awaited<ReturnType<typeof startBlockedFreshDelivery>> | undefined;
+    try {
+      blocked = await startBlockedFreshDelivery({ tmpDir });
+      const entry = readQueuedEntry(tmpDir, blocked.queueId);
+
+      expect(entry).toMatchObject({
+        recoveryState: "producer_claimed",
+        requiresProducerClaim: true,
+        producerClaimId: expect.any(String),
+        availableAt: expect.any(Number),
+      });
+      expect(entry.availableAt as number).toBeGreaterThan(Date.now());
+      expect(await claimDeliveryPlatformSendAttempt(blocked.queueId, tmpDir)).toBeUndefined();
+
+      blocked.releasePreparation();
+      await expect(blocked.delivery).resolves.toMatchObject([{ messageId: blocked.messageId }]);
+      expect(blocked.sendText).toHaveBeenCalledOnce();
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, blocked.queueId, tmpDir),
+      ).toBeUndefined();
+    } finally {
+      blocked?.releasePreparation();
+      await blocked?.delivery.catch(() => undefined);
+    }
   });
 
   it("upgrades and renews a legacy reused intent through long channel preparation", async () => {
@@ -309,7 +390,7 @@ describe("stable delivery producer lease integration", () => {
       await vi.advanceTimersByTimeAsync(10_001);
 
       const rejected = expect(blocked.delivery).rejects.toThrow(
-        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+        `Delivery platform claim was lost: ${deliveryIntentId}`,
       );
       blocked.releasePreparation();
       await rejected;
@@ -347,7 +428,7 @@ describe("stable delivery producer lease integration", () => {
       await vi.advanceTimersByTimeAsync(10_001);
 
       const rejected = expect(blocked.delivery).rejects.toThrow(
-        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+        `Delivery platform claim was lost: ${deliveryIntentId}`,
       );
       blocked.releasePreparation();
       await rejected;
@@ -388,7 +469,7 @@ describe("stable delivery producer lease integration", () => {
       await vi.advanceTimersByTimeAsync(10_001);
 
       const rejected = expect(blocked.delivery).rejects.toThrow(
-        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+        `Delivery platform claim was lost: ${deliveryIntentId}`,
       );
       blocked.releaseRender();
       await rejected;
@@ -439,7 +520,7 @@ describe("stable delivery producer lease integration", () => {
       await vi.advanceTimersByTimeAsync(10_001);
 
       const rejected = expect(blocked.delivery).rejects.toThrow(
-        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+        `Delivery platform claim was lost: ${deliveryIntentId}`,
       );
       blocked.releaseProvider();
       await rejected;

--- a/src/infra/outbound/deliver-queue.ts
+++ b/src/infra/outbound/deliver-queue.ts
@@ -81,7 +81,7 @@ async function deliverWithProducerLease(
   }
   const platformQueueId = queueId ?? params.deliveryQueueId;
   if (!platformQueueId || !producerClaimId) {
-    throw new Error("Stable delivery producer lease requires an exact queue owner");
+    throw new Error("Delivery producer lease requires an exact queue owner");
   }
   const stateDir = queueId ? undefined : params.deliveryQueueStateDir;
   const lease = await startDeliveryProducerLease({
@@ -255,13 +255,12 @@ async function runOutboundDeliveryWithQueue(
   const queued =
     params.skipQueue || (preparedPayloads.length === 0 && !shouldPersistSuppressedIntent)
       ? null
-      : await stageAndEnqueueOutboundDelivery(
-          deliveryParams,
-          preparedBatch,
-          stablePreparationOwner
+      : await stageAndEnqueueOutboundDelivery(deliveryParams, preparedBatch, {
+          claimForLiveDelivery: true,
+          ...(stablePreparationOwner
             ? { getStablePreparation: stablePreparationOwner.current }
-            : undefined,
-        ).catch((err: unknown) => {
+            : {}),
+        }).catch((err: unknown) => {
           if (queuePolicy === "required" || err instanceof StableDeliveryPreparationLostError) {
             emitPreQueueFailure();
             throw err;
@@ -296,26 +295,31 @@ async function runOutboundDeliveryWithQueue(
     throw new Error(`Stable delivery intent is already queued: ${queueId}`);
   }
   const deliverClaimedIntent = async (): Promise<OutboundDeliveryResult[]> => {
-    const producerClaimId = params.reusePendingDeliveryIntent
-      ? await claimReusableDeliveryPlatformSendAttempt(queueId)
-      : undefined;
-    if (params.reusePendingDeliveryIntent && !producerClaimId) {
-      throw new Error(`Stable delivery intent is already queued: ${queueId}`);
+    const producerClaimId =
+      queued?.producerClaimId ??
+      (params.reusePendingDeliveryIntent
+        ? await claimReusableDeliveryPlatformSendAttempt(queueId)
+        : undefined);
+    if (!producerClaimId) {
+      throw new Error(
+        queued?.created
+          ? `Delivery platform claim was lost: ${queueId}`
+          : `Stable delivery intent is already queued: ${queueId}`,
+      );
     }
-    let claimedDeliveryParams: DeliverOutboundPayloadsParams =
-      params.reusePendingDeliveryIntent && queued?.created === true
-        ? { ...deliveryParams, deliveryProducerLeaseRequired: true }
-        : deliveryParams;
+    let claimedDeliveryParams: DeliverOutboundPayloadsParams = {
+      ...deliveryParams,
+      deliveryProducerLeaseRequired: true,
+    };
     if (queued?.created !== true) {
       const queuedEntry = await loadPendingDelivery(queueId);
       if (!queuedEntry || queuedEntry.producerClaimId !== producerClaimId) {
-        throw new Error(`Stable delivery platform claim was lost: ${queueId}`);
+        throw new Error(`Delivery platform claim was lost: ${queueId}`);
       }
-      const restoredDeliveryParams = restoreQueuedDeliveryCustody(deliveryParams, queuedEntry);
-      claimedDeliveryParams =
-        queuedEntry.requiresProducerClaim === true
-          ? { ...restoredDeliveryParams, deliveryProducerLeaseRequired: true }
-          : restoredDeliveryParams;
+      claimedDeliveryParams = {
+        ...restoreQueuedDeliveryCustody(deliveryParams, queuedEntry),
+        deliveryProducerLeaseRequired: true,
+      };
     }
     return deliverWithProducerLease(
       claimedDeliveryParams,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -75,13 +75,17 @@ const queueMocks = vi.hoisted(() => ({
       status: "pending" | "failed" | "completed";
     } | null
   >(() => null),
-  ackDelivery: vi.fn(async () => {}),
-  failDelivery: vi.fn(async () => {}),
-  failDeliveryAfterPlatformSend: vi.fn(async () => {}),
-  failDeliveryBeforePlatformSend: vi.fn(async () => {}),
-  markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {}),
-  markDeliveryPlatformSendDispatched: vi.fn(async () => {}),
-  markDeliveryPlatformSendAttemptStarted: vi.fn(async () => {}),
+  ackDelivery: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+  failDelivery: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+  failDeliveryAfterPlatformSend: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+  failDeliveryBeforePlatformSend: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+  markDeliveryPlatformOutcomeUnknown: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+  markDeliveryPlatformSendDispatched: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+  markDeliveryPlatformSendAttemptStarted: vi.fn<(...args: unknown[]) => Promise<void>>(
+    async () => {},
+  ),
+  claimReusableDeliveryPlatformSendAttempt: vi.fn(async () => "mock-producer-claim"),
+  renewDeliveryPlatformSendLease: vi.fn(async () => Date.now() + 30_000),
   withActiveDeliveryClaim: vi.fn<
     (
       entryId: string,
@@ -98,6 +102,29 @@ const completionMocks = vi.hoisted(() => ({
 const logMocks = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
+
+function withoutInitialProducerClaim(params: Record<string, unknown>): Record<string, unknown> {
+  const { initialProducerClaim: _initialProducerClaim, ...queuedParams } = params;
+  return queuedParams;
+}
+
+async function ackDeliveryMock(
+  id: string,
+  stateDir?: string,
+  options?: {
+    retainSpoolArtifacts?: boolean;
+    suppressCompletionReceipt?: boolean;
+    expectedPlatformSendAttemptId?: string | null;
+  },
+): Promise<void> {
+  const { expectedPlatformSendAttemptId: _expectedPlatformSendAttemptId, ...legacyOptions } =
+    options ?? {};
+  const hasOptions = Object.keys(legacyOptions).length > 0;
+  if (stateDir === undefined && !hasOptions) {
+    return queueMocks.ackDelivery(id);
+  }
+  return queueMocks.ackDelivery(id, stateDir, hasOptions ? legacyOptions : undefined);
+}
 
 vi.mock("../../config/sessions/transcript.runtime.js", async () => {
   const actual = await vi.importActual<
@@ -125,16 +152,30 @@ vi.mock("../../hooks/internal-hooks.js", () => ({
   triggerInternalHook: internalHookMocks.triggerInternalHook,
 }));
 vi.mock("./delivery-queue-storage.js", () => ({
-  enqueueDelivery: queueMocks.enqueueDelivery,
-  enqueueDeliveryOnce: queueMocks.enqueueDeliveryOnce,
-  enqueuePreparedDeliveryOnce: queueMocks.enqueuePreparedDeliveryOnce,
-  ackDelivery: queueMocks.ackDelivery,
-  failDelivery: queueMocks.failDelivery,
-  failDeliveryAfterPlatformSend: queueMocks.failDeliveryAfterPlatformSend,
-  failDeliveryBeforePlatformSend: queueMocks.failDeliveryBeforePlatformSend,
-  markDeliveryPlatformOutcomeUnknown: queueMocks.markDeliveryPlatformOutcomeUnknown,
-  markDeliveryPlatformSendDispatched: queueMocks.markDeliveryPlatformSendDispatched,
-  markDeliveryPlatformSendAttemptStarted: queueMocks.markDeliveryPlatformSendAttemptStarted,
+  enqueueDelivery: async (params: Record<string, unknown>) =>
+    queueMocks.enqueueDelivery(withoutInitialProducerClaim(params)),
+  enqueueDeliveryOnce: async (params: Record<string, unknown>, id: string) =>
+    queueMocks.enqueueDeliveryOnce(withoutInitialProducerClaim(params), id),
+  enqueuePreparedDeliveryOnce: async (params: Record<string, unknown>, id: string) =>
+    queueMocks.enqueuePreparedDeliveryOnce(withoutInitialProducerClaim(params), id),
+  ackDelivery: ackDeliveryMock,
+  failDelivery: async (id: string, error: string) => queueMocks.failDelivery(id, error),
+  failDeliveryAfterPlatformSend: async (id: string, error: string) =>
+    queueMocks.failDeliveryAfterPlatformSend(id, error),
+  failDeliveryBeforePlatformSend: async (id: string, error: string) =>
+    queueMocks.failDeliveryBeforePlatformSend(id, error),
+  markDeliveryPlatformOutcomeUnknown: async (id: string) =>
+    queueMocks.markDeliveryPlatformOutcomeUnknown(id),
+  markDeliveryPlatformSendDispatched: async (
+    id: string,
+    stateDir?: string,
+    route?: { replyToId?: string | null },
+  ) => queueMocks.markDeliveryPlatformSendDispatched(id, stateDir, route),
+  markDeliveryPlatformSendAttemptStarted: async (
+    id: string,
+    stateDir?: string,
+    route?: { replyToId?: string | null },
+  ) => queueMocks.markDeliveryPlatformSendAttemptStarted(id, stateDir, route),
   loadPendingDelivery: queueMocks.loadPendingDelivery,
   findDeliveryIntentOwner: queueMocks.findDeliveryIntentOwner,
 }));
@@ -143,14 +184,25 @@ vi.mock("./delivery-queue-preparation.js", () => ({
   withStableDeliveryPreparation: queueMocks.withStableDeliveryPreparation,
 }));
 vi.mock("./delivery-queue.js", () => ({
-  enqueueDelivery: queueMocks.enqueueDelivery,
-  enqueueDeliveryOnce: queueMocks.enqueueDeliveryOnce,
-  enqueuePreparedDeliveryOnce: queueMocks.enqueuePreparedDeliveryOnce,
-  ackDelivery: queueMocks.ackDelivery,
-  failDelivery: queueMocks.failDelivery,
-  failDeliveryAfterPlatformSend: queueMocks.failDeliveryAfterPlatformSend,
-  failDeliveryBeforePlatformSend: queueMocks.failDeliveryBeforePlatformSend,
-  markDeliveryPlatformSendDispatched: queueMocks.markDeliveryPlatformSendDispatched,
+  enqueueDelivery: async (params: Record<string, unknown>) =>
+    queueMocks.enqueueDelivery(withoutInitialProducerClaim(params)),
+  enqueueDeliveryOnce: async (params: Record<string, unknown>, id: string) =>
+    queueMocks.enqueueDeliveryOnce(withoutInitialProducerClaim(params), id),
+  enqueuePreparedDeliveryOnce: async (params: Record<string, unknown>, id: string) =>
+    queueMocks.enqueuePreparedDeliveryOnce(withoutInitialProducerClaim(params), id),
+  ackDelivery: ackDeliveryMock,
+  failDelivery: async (id: string, error: string) => queueMocks.failDelivery(id, error),
+  failDeliveryAfterPlatformSend: async (id: string, error: string) =>
+    queueMocks.failDeliveryAfterPlatformSend(id, error),
+  failDeliveryBeforePlatformSend: async (id: string, error: string) =>
+    queueMocks.failDeliveryBeforePlatformSend(id, error),
+  markDeliveryPlatformSendDispatched: async (
+    id: string,
+    stateDir?: string,
+    route?: { replyToId?: string | null },
+  ) => queueMocks.markDeliveryPlatformSendDispatched(id, stateDir, route),
+  claimReusableDeliveryPlatformSendAttempt: queueMocks.claimReusableDeliveryPlatformSendAttempt,
+  renewDeliveryPlatformSendLease: queueMocks.renewDeliveryPlatformSendLease,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
 }));
 vi.mock("./delivery-completion.js", () => ({
@@ -428,6 +480,10 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.loadPendingDelivery.mockResolvedValue(null);
     queueMocks.findDeliveryIntentOwner.mockClear();
     queueMocks.findDeliveryIntentOwner.mockReturnValue(null);
+    queueMocks.claimReusableDeliveryPlatformSendAttempt.mockClear();
+    queueMocks.claimReusableDeliveryPlatformSendAttempt.mockResolvedValue("mock-producer-claim");
+    queueMocks.renewDeliveryPlatformSendLease.mockClear();
+    queueMocks.renewDeliveryPlatformSendLease.mockImplementation(async () => Date.now() + 30_000);
     queueMocks.withStableDeliveryPreparation.mockReset();
     queueMocks.withStableDeliveryPreparation.mockImplementation(
       async (params: {
@@ -4303,7 +4359,7 @@ describe("deliverOutboundPayloads", () => {
       unsubscribe();
     }
 
-    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id", undefined);
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
     expect(hookMocks.runner.runMessageSent).toHaveBeenCalledOnce();
     expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1149,7 +1149,7 @@ describe("deliverOutboundPayloads", () => {
     expect(hookMocks.runner.runMessageSending).not.toHaveBeenCalled();
   });
 
-  it("continues best-effort sends when the precise dispatch timestamp cannot be refreshed", async () => {
+  it("stops a claimed best-effort send when dispatch ownership cannot be refreshed", async () => {
     queueMocks.markDeliveryPlatformSendDispatched.mockRejectedValueOnce(
       new Error("dispatch state unavailable"),
     );
@@ -1173,9 +1173,9 @@ describe("deliverOutboundPayloads", () => {
       deliverMatrix({
         queuePolicy: "best_effort",
       }),
-    ).resolves.toHaveLength(1);
+    ).rejects.toThrow("dispatch state unavailable");
     expect(messageSendText).toHaveBeenCalledOnce();
-    expect(logMocks.warn).toHaveBeenCalledWith(
+    expect(logMocks.warn).not.toHaveBeenCalledWith(
       expect.stringContaining("continuing best-effort send: dispatch state unavailable"),
     );
   });

--- a/src/infra/outbound/delivery-queue-lease.test.ts
+++ b/src/infra/outbound/delivery-queue-lease.test.ts
@@ -37,8 +37,8 @@ describe("delivery producer lease", () => {
 
     expect(lease.signal.aborted).toBe(true);
     expect(lease.signal.reason).toMatchObject({
-      name: "StableDeliveryProducerLeaseLostError",
-      message: "Stable delivery platform claim was lost: stable-lost",
+      name: "DeliveryProducerLeaseLostError",
+      message: "Delivery platform claim was lost: stable-lost",
     });
   });
 
@@ -72,8 +72,8 @@ describe("delivery producer lease", () => {
 
     expect(lease.signal.aborted).toBe(true);
     expect(lease.signal.reason).toMatchObject({
-      name: "StableDeliveryProducerLeaseLostError",
-      message: "Stable delivery platform claim was lost: stable-expired",
+      name: "DeliveryProducerLeaseLostError",
+      message: "Delivery platform claim was lost: stable-expired",
     });
   });
 
@@ -87,8 +87,8 @@ describe("delivery producer lease", () => {
         renew: async () => undefined,
       }),
     ).rejects.toMatchObject({
-      name: "StableDeliveryProducerLeaseLostError",
-      message: "Stable delivery platform claim was lost: stable-missing",
+      name: "DeliveryProducerLeaseLostError",
+      message: "Delivery platform claim was lost: stable-missing",
     });
     await expect(
       startDeliveryProducerLease({
@@ -98,8 +98,8 @@ describe("delivery producer lease", () => {
         },
       }),
     ).rejects.toMatchObject({
-      name: "StableDeliveryProducerLeaseLostError",
-      message: "Stable delivery platform claim was lost: stable-storage-error",
+      name: "DeliveryProducerLeaseLostError",
+      message: "Delivery platform claim was lost: stable-storage-error",
     });
   });
 });

--- a/src/infra/outbound/delivery-queue-lease.ts
+++ b/src/infra/outbound/delivery-queue-lease.ts
@@ -7,18 +7,15 @@ type DeliveryProducerLease = {
   stop: () => void;
 };
 
-class StableDeliveryProducerLeaseLostError extends Error {
-  override name = "StableDeliveryProducerLeaseLostError";
+class DeliveryProducerLeaseLostError extends Error {
+  override name = "DeliveryProducerLeaseLostError";
 }
 
 function lostProducerLeaseError(id: string, cause?: unknown): Error {
-  return new StableDeliveryProducerLeaseLostError(
-    `Stable delivery platform claim was lost: ${id}`,
-    { cause },
-  );
+  return new DeliveryProducerLeaseLostError(`Delivery platform claim was lost: ${id}`, { cause });
 }
 
-/** Maintains one already-acquired stable producer claim during fallible preparation and send. */
+/** Maintains one already-acquired producer claim during fallible preparation and send. */
 export async function startDeliveryProducerLease(params: {
   id: string;
   renew: () => Promise<number | undefined>;
@@ -31,7 +28,7 @@ export async function startDeliveryProducerLease(params: {
     }
     confirmedExpiresAt = initialExpiry;
   } catch (error) {
-    if (error instanceof StableDeliveryProducerLeaseLostError) {
+    if (error instanceof DeliveryProducerLeaseLostError) {
       throw error;
     }
     throw lostProducerLeaseError(params.id, error);

--- a/src/infra/outbound/delivery-queue-platform-lease.ts
+++ b/src/infra/outbound/delivery-queue-platform-lease.ts
@@ -17,7 +17,7 @@ export async function claimReusableDeliveryPlatformSendAttempt(
   });
 }
 
-/** Extend the exact active reusable producer lease without changing ownership. */
+/** Extend the exact active producer lease without changing ownership. */
 export async function renewDeliveryPlatformSendLease(
   id: string,
   stateDir: string | undefined,

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -255,7 +255,7 @@ function needsUnknownSendReconciliation(entry: QueuedDelivery): boolean {
   );
 }
 
-function hasActiveStableDeliveryOwner(entry: QueuedDelivery, now: number): boolean {
+function hasActiveDeliveryOwner(entry: QueuedDelivery, now: number): boolean {
   return (
     (typeof entry.completionRetention === "object" ||
       entry.completionRetention === "permanent" ||
@@ -900,9 +900,9 @@ async function drainQueuedEntry(opts: {
       await runOutboundDeliveryCommitHooks(deliveredResults);
     }
   };
-  // Stable producer rows can be observed between enqueue and live ownership.
-  // Fence recovery at the same SQLite claim before consuming an attempt or
-  // crossing provider I/O; an active live producer keeps its original lease.
+  // Live producer rows can be observed between enqueue and platform I/O.
+  // Fence recovery at the same SQLite claim before consuming an attempt;
+  // an active live producer keeps its original renewable lease.
   const requiresProducerClaim =
     typeof entry.completionRetention === "object" ||
     entry.requiresProducerClaim === true ||
@@ -1228,7 +1228,7 @@ export async function drainPendingDeliveries(opts: {
       // Poll-driven reconnect drains can repeat while a live send owns its
       // claim. Leave conflicts silent so reconnect polling cannot starve it.
       onEntry: async (currentEntry) => {
-        if (hasActiveStableDeliveryOwner(currentEntry, Date.now())) {
+        if (hasActiveDeliveryOwner(currentEntry, Date.now())) {
           return;
         }
         const admission = await applyRecoveryDeliveryAdmission({
@@ -1364,7 +1364,7 @@ export async function recoverPendingDeliveries(opts: {
       opts.log.info(`Recovery skipped for delivery ${entry.id}: already gone`);
     },
     onEntry: async (currentEntry) => {
-      if (hasActiveStableDeliveryOwner(currentEntry, Date.now())) {
+      if (hasActiveDeliveryOwner(currentEntry, Date.now())) {
         opts.log.info(`Recovery skipped for delivery ${currentEntry.id}: active platform owner`);
         return "continue";
       }

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -565,9 +565,11 @@ function recoveryPlatformAttemptId(
 ): string | null | undefined {
   return claimedAttemptId !== undefined
     ? claimedAttemptId
-    : typeof entry.completionRetention === "object" || entry.requiresProducerClaim === true
-      ? null
-      : undefined;
+    : typeof entry.platformSendAttemptId === "string"
+      ? entry.platformSendAttemptId
+      : typeof entry.completionRetention === "object" || entry.requiresProducerClaim === true
+        ? null
+        : undefined;
 }
 
 async function ackRecoveredDelivery(

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -12,6 +12,7 @@ import {
   claimDeliveryQueueEntryPlatformSend,
   promoteDeliveryQueueEntryPlatformSend,
   transitionOwnedDeliveryQueueEntry,
+  type InitialDeliveryProducerClaim,
 } from "../delivery-queue-sqlite-claim.js";
 import {
   commitStagedDeliveryQueueEntryOnceAcrossNamespaces,
@@ -86,7 +87,7 @@ export type QueuedDeliveryPayload = {
   queuePolicy?: "required" | "best_effort";
   /** Caller preflight explicitly required provider unknown-send reconciliation. */
   requireUnknownSendReconciliation?: boolean;
-  /** Reusable producer intents require one SQLite-fenced platform owner. */
+  /** Live producers that cross provider I/O require one SQLite-fenced platform owner. */
   requiresProducerClaim?: boolean;
   /** Canonical post-policy payloads; recovery must never rerun modifiers. */
   preparedBatch?: PreparedOutboundBatch;
@@ -184,7 +185,11 @@ function preparedBatchFromLowLevelInput(params: QueuedDeliveryPayload): Prepared
   return createUnmodifiedPreparedOutboundBatch(params.payloads);
 }
 
-function createQueuedDelivery(params: QueuedDeliveryPayload, id: string): QueuedDelivery {
+type QueuedDeliveryAdmissionPayload = QueuedDeliveryPayload & {
+  initialProducerClaim?: InitialDeliveryProducerClaim;
+};
+
+function createQueuedDelivery(params: QueuedDeliveryAdmissionPayload, id: string): QueuedDelivery {
   return {
     id,
     enqueuedAt: Date.now(),
@@ -193,7 +198,8 @@ function createQueuedDelivery(params: QueuedDeliveryPayload, id: string): Queued
     accountId: params.accountId,
     queuePolicy: params.queuePolicy,
     requireUnknownSendReconciliation: params.requireUnknownSendReconciliation,
-    ...(params.requiresProducerClaim === true ? { requiresProducerClaim: true } : {}),
+    ...(params.initialProducerClaim ??
+      (params.requiresProducerClaim === true ? { requiresProducerClaim: true } : {})),
     preparedBatch: projectPreparedOutboundBatchForStorage(preparedBatchFromLowLevelInput(params)),
     renderedBatchPlan: params.renderedBatchPlan,
     threadId: params.threadId,
@@ -219,13 +225,12 @@ function createQueuedDelivery(params: QueuedDeliveryPayload, id: string): Queued
   };
 }
 
-function getQueuedDeliveryPayloads(entry: QueuedDelivery): ReplyPayload[] {
-  return acceptedPreparedOutboundEntries(entry.preparedBatch).map((prepared) => prepared.payload);
-}
+const getQueuedDeliveryPayloads = (entry: QueuedDelivery) =>
+  acceptedPreparedOutboundEntries(entry.preparedBatch).map((prepared) => prepared.payload);
 
 /** Persist a delivery entry before attempting send. Returns the entry ID. */
 export async function enqueueDelivery(
-  params: QueuedDeliveryPayload,
+  params: QueuedDeliveryAdmissionPayload,
   stateDir?: string,
   mediaStageId?: string,
 ): Promise<string> {
@@ -254,7 +259,7 @@ export async function enqueueDelivery(
 
 /** Inserts one stable queue id without replacing prior pending or completed ownership. */
 export async function enqueueDeliveryOnce(
-  params: QueuedDeliveryPayload,
+  params: QueuedDeliveryAdmissionPayload,
   id: string,
   stateDir?: string,
   mediaStageId?: string,
@@ -300,7 +305,7 @@ export async function enqueueDeliveryOnce(
 
 /** Atomically replaces a payload-free stable preparation owner with prepared custody. */
 export async function enqueuePreparedDeliveryOnce(
-  params: QueuedDeliveryPayload,
+  params: QueuedDeliveryAdmissionPayload,
   id: string,
   preparation: StableDeliveryPreparation,
   stateDir?: string,
@@ -357,9 +362,7 @@ type AckDeliveryOptions = {
   expectedPlatformSendAttemptId?: string | null;
 };
 
-function lostPlatformClaim(id: string): Error {
-  return new Error(`Stable delivery platform claim was lost: ${id}`);
-}
+const lostPlatformClaim = (id: string) => new Error(`Delivery platform claim was lost: ${id}`);
 
 /** Remove a successfully delivered entry, or retain its producer-owned receipt. */
 export async function ackDelivery(
@@ -551,7 +554,7 @@ export async function markDeliveryPlatformSendAttemptStarted(
       route,
     });
     if (!promoted) {
-      throw new Error(`Stable delivery platform claim was lost: ${id}`);
+      throw new Error(`Delivery platform claim was lost: ${id}`);
     }
     return;
   }
@@ -599,8 +602,8 @@ export async function markDeliveryPlatformOutcomeUnknown(
     stateDir,
     (entry) => ({
       ...entry,
-      // An explicit stable producer keeps its exact lease through the
-      // ambiguous outcome so recovery cannot race its remaining cleanup.
+      // An explicit live producer keeps its exact lease through the ambiguous
+      // outcome so recovery cannot race its remaining cleanup.
       availableAt:
         expectedPlatformSendAttemptId &&
         entry.requiresProducerClaim === true &&
@@ -616,16 +619,11 @@ export async function markDeliveryPlatformOutcomeUnknown(
 }
 
 /** Load a single pending delivery entry by ID from the queue directory. */
-export async function loadPendingDelivery(
+export const loadPendingDelivery = async (
   id: string,
   stateDir?: string,
-): Promise<QueuedDelivery | null> {
-  return loadDeliveryQueueEntry(
-    OUTBOUND_DELIVERY_QUEUE_NAME,
-    id,
-    stateDir,
-  ) as QueuedDelivery | null;
-}
+): Promise<QueuedDelivery | null> =>
+  loadDeliveryQueueEntry(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir) as QueuedDelivery | null;
 
 export function findDeliveryIntentOwner(
   id: string,

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -422,6 +422,11 @@ export async function failDelivery(
       retryCount: entry.retryCount + 1,
       lastAttemptAt: Date.now(),
       lastError: error,
+      // The failed attempt has settled. Keep platform evidence for recovery,
+      // but release the live owner so another process can reconcile or retry.
+      availableAt: undefined,
+      producerClaimId: undefined,
+      recoveryState: entry.recoveryState === "producer_claimed" ? undefined : entry.recoveryState,
     }),
     expectedPlatformSendAttemptId,
   );

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -566,6 +566,27 @@ describe("delivery-queue storage", () => {
       expect(entry.lastError).toBe("connection refused");
     });
 
+    it("releases a settled live owner while retaining retryable custody", async () => {
+      const id = await enqueueTextDelivery({
+        channel: "forum",
+        to: "123",
+        payloads: [{ text: "test" }],
+        requiresProducerClaim: true,
+      });
+      const claimId = await claimDeliveryPlatformSendAttempt(id, tmpDir());
+      expect(claimId).toEqual(expect.any(String));
+
+      await failDelivery(id, "provider failed", tmpDir(), claimId);
+
+      expect(readQueuedEntry(tmpDir(), id)).toMatchObject({
+        retryCount: 1,
+        lastError: "provider failed",
+      });
+      expect(readQueuedEntry(tmpDir(), id)).not.toHaveProperty("availableAt");
+      expect(readQueuedEntry(tmpDir(), id)).not.toHaveProperty("producerClaimId");
+      expect(readQueuedEntry(tmpDir(), id)).not.toHaveProperty("recoveryState");
+    });
+
     it("keeps post-send failure evidence while recording the retry failure", async () => {
       const id = await enqueueTextDelivery({
         channel: "forum",

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -94,7 +94,7 @@ describe("delivery-queue storage", () => {
         if (!firstAttemptId) {
           throw new Error("test invariant: first platform owner must claim the durable row");
         }
-        const lostClaim = `Stable delivery platform claim was lost: ${id}`;
+        const lostClaim = `Delivery platform claim was lost: ${id}`;
         // Admission snapshots taken before ownership must CAS the unclaimed
         // state; a producer that claimed meanwhile retains its media and row.
         await expect(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a one-shot `openclaw message send` could race the running Gateway's delivery recovery while both processes shared the same SQLite state. A successful send could emit a misleading missing-queue-entry warning; under unlucky timing, both processes could reach the provider and duplicate the outbound message.

AI-assisted: yes. I reviewed the ownership model, regression, and resulting implementation.

## Why This Change Was Made

Newly admitted live deliveries now publish their queue row together with an expiring SQLite producer claim. The live sender renews and carries that exact claim across preparation, platform dispatch, and settlement, while recovery defers to the active owner. Queue-only producers and legacy rows retain their existing recovery behavior, and the SQLite schema is unchanged.

## User Impact

CLI and other short-lived outbound senders can safely share a state directory with a running Gateway without recovery stealing their in-flight queue rows. Successful sends no longer produce the spurious `No pending outbound-prepared-v1 delivery queue entry` warning from this race, and the duplicate-send window is closed.

## Evidence

- Reproduced before the repair: a fresh live row could be claimed by a simulated competing recovery process while the original sender was paused before provider I/O.
- Added a real-SQLite regression proving the fresh row is published as `producer_claimed`, the competing claim is rejected, and exactly one provider call completes.
- `node scripts/run-vitest.mjs src/infra/delivery-queue-sqlite.test.ts src/infra/outbound/deliver.test.ts src/infra/outbound/deliver.queue-integration.test.ts src/infra/outbound/deliver-queue.lease-integration.test.ts src/infra/outbound/deliver-queue-admission.test.ts src/infra/outbound/delivery-queue.storage.test.ts src/infra/outbound/delivery-queue-lease.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/delivery-queue.reconnect-drain.test.ts` — 9 files, 353 tests passed.
- The first exact-head CI run exposed missing lease mocks and stricter fallback behavior in the broad delivery suite; both were repaired. The second run exposed a recovery transition that discarded the recorded platform-attempt owner after the live lease settled; recovery now uses that exact evidence and emits terminal outcomes. The prior ClawSweeper rank-up move was also applied: every SQLite-claimed live sender now fails closed if it cannot refresh ownership at the real dispatch boundary, preventing lease expiry from reopening the duplicate-send race. The complete 173-test `deliver.test.ts` suite and 28-test queue integration suite pass locally.
- `pnpm tsgo:core && pnpm tsgo:core:test` — passed.
- Targeted oxfmt and oxlint — passed.
- `git diff --check origin/main...HEAD` — passed.
- Codex autoreview against `origin/main` — clean, no accepted/actionable findings.
- Production delta: +97/-71 (net +26) for the cross-process ownership boundary. Tests: +98/-17.
