### PR TITLE
fix(skills): add file size guard to session skill loading

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -391,6 +391,9 @@ vi.mock("../../sessions/index.js", () => {
     constructor(...args: unknown[]) {
       hoisted.defaultResourceLoaderInitMock(...args);
     }
+    getSkillFileSizeLimit() {
+      return 256_000;
+    }
     async reload() {}
   }
   function ModelRegistry() {}

--- a/src/agents/sessions/agent-session-loop-resource-loader.test-support.ts
+++ b/src/agents/sessions/agent-session-loop-resource-loader.test-support.ts
@@ -31,6 +31,7 @@ export function createResourceLoader(
   return {
     getExtensions: () => extensionsResult,
     getSkills: () => ({ skills: [], diagnostics: [] }),
+    getSkillFileSizeLimit: () => 256_000,
     getPrompts: () => ({ prompts: [], diagnostics: [] }),
     getThemes: () => ({ themes: [], diagnostics: [] }),
     getAgentsFiles: () => ({ agentsFiles: [] }),

--- a/src/agents/sessions/agent-session-prompting.import-boundary.test.ts
+++ b/src/agents/sessions/agent-session-prompting.import-boundary.test.ts
@@ -1,0 +1,47 @@
+// Import-boundary test: agent-session-prompting must not statically import
+// from the session loader, which pulls in the workshop curator and SQLite
+// runtime.  The bounded skill reader lives in a separate dependency-light
+// leaf module shared by both discovery and prompt-expansion callers.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("agent-session-prompting import boundary", () => {
+  const promptingSource = readSource("src/agents/sessions/agent-session-prompting.ts");
+
+  it("imports readBoundedSkillFile from the leaf module, not the session loader", () => {
+    // Must use the lightweight leaf module — not session.js which transitively
+    // loads workshop/curator, SQLite state, ignore rules, skill-contract, etc.
+    expect(promptingSource).not.toMatch(
+      /import\s+\{[^}]*readBoundedSkillFile[^}]*\}\s+from\s+["'][^"']*session\.js["']/,
+    );
+    expect(promptingSource).toContain(
+      'import { readBoundedSkillFile } from "../../skills/loading/bounded-skill-read.js"',
+    );
+  });
+
+  it("does not pull in workshop curator, SQLite runtime, or ignore-rules", () => {
+    expect(promptingSource).not.toMatch(/from\s+["'][^"']*workshop\/curator/);
+    expect(promptingSource).not.toMatch(/from\s+["'][^"']*sqlite/);
+    expect(promptingSource).not.toMatch(/from\s+["'][^"']*shared\/ignore-rules/);
+    expect(promptingSource).not.toMatch(/from\s+["'][^"']*skill-contract/);
+  });
+
+  it("bounded-skill-read leaf module has no session-loader or workshop deps", () => {
+    const leafSource = readSource("src/skills/loading/bounded-skill-read.ts");
+    expect(leafSource).not.toMatch(/from\s+["'][^"']*session\.js/);
+    expect(leafSource).not.toMatch(/from\s+["'][^"']*workshop/);
+    expect(leafSource).not.toMatch(/from\s+["'][^"']*sqlite/);
+    expect(leafSource).not.toMatch(/from\s+["'][^"']*ignore-rules/);
+    expect(leafSource).not.toMatch(/from\s+["'][^"']*curator/);
+    expect(leafSource).not.toMatch(/from\s+["'][^"']*skill-contract/);
+    // Only allowed heavy import is the boundary-file-read infra module.
+    expect(leafSource).toContain("boundary-file-read.js");
+  });
+});

--- a/src/agents/sessions/agent-session-prompting.skill-expansion.test.ts
+++ b/src/agents/sessions/agent-session-prompting.skill-expansion.test.ts
@@ -1,0 +1,151 @@
+// Focused behavior coverage for `/skill:` expansion honoring the configured size limit.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { DEFAULT_MAX_SKILL_FILE_BYTES } from "../../skills/loading/bounded-skill-read.js";
+import type { Skill } from "../../skills/loading/session.js";
+import { AgentSessionPrompting } from "./agent-session-prompting.js";
+import type { AgentSessionConfig } from "./agent-session-types.js";
+import { createExtensionRuntime } from "./extensions/loader.js";
+import type { ExtensionRunner, LoadExtensionsResult, ResourceLoader } from "./index.js";
+import { createSyntheticSourceInfo } from "./source-info.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+class TestPrompting extends AgentSessionPrompting {
+  // Stubs for abstract members declared in AgentSessionBase.
+  protected isRetryableError(): boolean {
+    return false;
+  }
+
+  protected async prepareRetry(): Promise<boolean> {
+    return false;
+  }
+
+  protected async checkCompaction(): Promise<boolean> {
+    return false;
+  }
+
+  abortRetry(): void {}
+
+  abortCompaction(): void {}
+
+  abortBranchSummary(): void {}
+
+  abortBash(): void {}
+
+  protected flushPendingBashMessages(): void {}
+
+  public expand(text: string): string {
+    // expandSkillCommand is private to AgentSessionPrompting; bypass via any
+    // so this focused test can exercise the expansion path without wiring a
+    // full Agent runtime.
+    return (this as unknown as { expandSkillCommand(text: string): string }).expandSkillCommand(
+      text,
+    );
+  }
+
+  public setExtensionRunnerForTest(runner: ExtensionRunner): void {
+    (this as unknown as { currentExtensionRunner: ExtensionRunner }).currentExtensionRunner =
+      runner;
+  }
+}
+
+function createEmptyResourceLoader(
+  skills: Skill[] = [],
+  skillFileSizeLimit = DEFAULT_MAX_SKILL_FILE_BYTES,
+): ResourceLoader {
+  const extensionsResult: LoadExtensionsResult = {
+    extensions: [],
+    errors: [],
+    runtime: createExtensionRuntime(),
+  };
+  return {
+    getExtensions: () => extensionsResult,
+    getSkills: () => ({ skills, diagnostics: [] }),
+    getSkillFileSizeLimit: () => skillFileSizeLimit,
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => undefined,
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function createTestPrompting(resourceLoader: ResourceLoader): TestPrompting {
+  const config: AgentSessionConfig = {
+    agent: {} as AgentSessionConfig["agent"],
+    sessionManager: {} as AgentSessionConfig["sessionManager"],
+    settingsManager: {} as AgentSessionConfig["settingsManager"],
+    resourceLoader,
+    modelRegistry: {} as AgentSessionConfig["modelRegistry"],
+    cwd: process.cwd(),
+  };
+  const prompting = new TestPrompting(config);
+  const emitError = vi.fn();
+  prompting.setExtensionRunnerForTest({ emitError } as unknown as ExtensionRunner);
+  return prompting;
+}
+
+async function writeSkillFile(dir: string, name: string, bodyBytes: number): Promise<string> {
+  await fs.mkdir(dir, { recursive: true });
+  const skillFile = path.join(dir, "SKILL.md");
+  await fs.writeFile(
+    skillFile,
+    `---\nname: ${name}\ndescription: expansion probe\n---\n${"x".repeat(bodyBytes)}`,
+    "utf-8",
+  );
+  return skillFile;
+}
+
+function createSkill(filePath: string): Skill {
+  return {
+    name: "test",
+    description: "expansion probe",
+    filePath,
+    baseDir: path.dirname(filePath),
+    source: "path",
+    sourceInfo: createSyntheticSourceInfo(filePath, { source: "local" }),
+    disableModelInvocation: false,
+  };
+}
+
+describe("AgentSessionPrompting /skill: expansion limit", () => {
+  it("expands a skill file that is under the configured limit", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-expansion-ok-");
+    const skillFile = await writeSkillFile(tempDir, "test", 1_000);
+    const prompting = createTestPrompting(
+      createEmptyResourceLoader([createSkill(skillFile)], 10_000),
+    );
+
+    const expanded = prompting.expand("/skill:test");
+
+    expect(expanded).toContain('<skill name="test"');
+    expect(expanded).toContain("x".repeat(100));
+  });
+
+  it("rejects an oversized skill file using the configured limit and returns the original command", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-expansion-oversized-");
+    const skillFile = await writeSkillFile(tempDir, "test", 2_000);
+    const prompting = createTestPrompting(
+      createEmptyResourceLoader([createSkill(skillFile)], 1_000),
+    );
+
+    const expanded = prompting.expand("/skill:test extra args");
+
+    expect(expanded).toBe("/skill:test extra args");
+    const runner = (
+      prompting as unknown as { currentExtensionRunner: { emitError: ReturnType<typeof vi.fn> } }
+    ).currentExtensionRunner;
+    expect(runner.emitError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extensionPath: skillFile,
+        event: "skill_expansion",
+        error: expect.stringContaining("exceeds"),
+      }),
+    );
+  });
+});

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import type { ImageContent, TextContent } from "../../llm/types.js";
 import { attachRuntimePromptMediaFacts, type MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
@@ -8,6 +7,7 @@ import type {
   PersistedUserTurnMessage,
   UserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.types.js";
+import { readBoundedSkillFile } from "../../skills/loading/bounded-skill-read.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
 import { AgentSessionBase } from "./agent-session-base.js";
@@ -307,7 +307,10 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     } // Unknown skill, pass through
 
     try {
-      const content = readFileSync(skill.filePath, "utf-8");
+      const content = readBoundedSkillFile(
+        skill.filePath,
+        this.sessionResourceLoader.getSkillFileSizeLimit(),
+      );
       const body = stripFrontmatter(content).trim();
       const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
       return args ? `${skillBlock}\n\n${args}` : skillBlock;

--- a/src/agents/sessions/agent-session.live.test.ts
+++ b/src/agents/sessions/agent-session.live.test.ts
@@ -56,6 +56,7 @@ function createResourceLoader(handlers: ExtensionHandlers = new Map()): Resource
   return {
     getExtensions: () => extensionsResult,
     getSkills: () => ({ skills: [], diagnostics: [] }),
+    getSkillFileSizeLimit: () => 256_000,
     getPrompts: () => ({ prompts: [], diagnostics: [] }),
     getThemes: () => ({ themes: [], diagnostics: [] }),
     getAgentsFiles: () => ({ agentsFiles: [] }),

--- a/src/agents/sessions/agent-session.openai-compaction.live.test.ts
+++ b/src/agents/sessions/agent-session.openai-compaction.live.test.ts
@@ -54,6 +54,7 @@ function createResourceLoader(): ResourceLoader {
   return {
     getExtensions: () => extensionsResult,
     getSkills: () => ({ skills: [], diagnostics: [] }),
+    getSkillFileSizeLimit: () => 256_000,
     getPrompts: () => ({ prompts: [], diagnostics: [] }),
     getThemes: () => ({ themes: [], diagnostics: [] }),
     getAgentsFiles: () => ({ agentsFiles: [] }),

--- a/src/agents/sessions/resource-loader.ts
+++ b/src/agents/sessions/resource-loader.ts
@@ -7,6 +7,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import chalk from "chalk";
+import { DEFAULT_MAX_SKILL_FILE_BYTES } from "../../skills/loading/bounded-skill-read.js";
 import type { Skill } from "../../skills/loading/session.js";
 import { loadSkills } from "../../skills/loading/session.js";
 import { CONFIG_DIR_NAME } from "../config.js";
@@ -41,6 +42,7 @@ export interface ResourceExtensionPaths {
 export interface ResourceLoader {
   getExtensions(): LoadExtensionsResult;
   getSkills(): { skills: Skill[]; diagnostics: ResourceDiagnostic[] };
+  getSkillFileSizeLimit(): number;
   getPrompts(): { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] };
   getThemes(): { themes: Theme[]; diagnostics: ResourceDiagnostic[] };
   getAgentsFiles(): { agentsFiles: Array<{ path: string; content: string }> };
@@ -153,6 +155,8 @@ interface DefaultResourceLoaderOptions {
   noPromptTemplates?: boolean;
   noThemes?: boolean;
   noContextFiles?: boolean;
+  /** Configured byte limit for a single SKILL.md file. */
+  maxSkillFileBytes?: number;
   systemPrompt?: string;
   appendSystemPrompt?: string[];
   extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
@@ -191,6 +195,7 @@ export class DefaultResourceLoader implements ResourceLoader {
   private noPromptTemplates: boolean;
   private noThemes: boolean;
   private noContextFiles: boolean;
+  private maxSkillFileBytes: number;
   private systemPromptSource?: string;
   private appendSystemPromptSource?: string[];
   private extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
@@ -256,6 +261,7 @@ export class DefaultResourceLoader implements ResourceLoader {
     this.noPromptTemplates = options.noPromptTemplates ?? false;
     this.noThemes = options.noThemes ?? false;
     this.noContextFiles = options.noContextFiles ?? false;
+    this.maxSkillFileBytes = options.maxSkillFileBytes ?? DEFAULT_MAX_SKILL_FILE_BYTES;
     this.systemPromptSource = options.systemPrompt;
     this.appendSystemPromptSource = options.appendSystemPrompt;
     this.extensionsOverride = options.extensionsOverride;
@@ -289,6 +295,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 
   getSkills(): { skills: Skill[]; diagnostics: ResourceDiagnostic[] } {
     return { skills: this.skills, diagnostics: this.skillDiagnostics };
+  }
+
+  getSkillFileSizeLimit(): number {
+    return this.maxSkillFileBytes;
   }
 
   getPrompts(): { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] } {
@@ -562,6 +572,7 @@ export class DefaultResourceLoader implements ResourceLoader {
         agentDir: this.agentDir,
         skillPaths,
         includeDefaults: false,
+        maxSkillFileBytes: this.maxSkillFileBytes,
       });
     }
     const resolvedSkills = this.skillsOverride ? this.skillsOverride(skillsResult) : skillsResult;

--- a/src/agents/sessions/sdk.fallback-resource-loader.test.ts
+++ b/src/agents/sessions/sdk.fallback-resource-loader.test.ts
@@ -1,0 +1,95 @@
+// Fallback resource-loader tests: config I/O is loaded lazily only when the SDK
+// has to construct its own DefaultResourceLoader.
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { Model } from "../../llm/types.js";
+import { AuthStorage } from "./auth-storage.js";
+import { createExtensionRuntime } from "./extensions/loader.js";
+import type { LoadExtensionsResult } from "./extensions/types.js";
+import { ModelRegistry } from "./model-registry.js";
+import type { ResourceLoader } from "./resource-loader.js";
+import { createAgentSession } from "./sdk.js";
+import { SessionManager } from "./session-manager.js";
+import { SettingsManager } from "./settings-manager.js";
+
+const configIoMocks = vi.hoisted(() => ({
+  readBestEffortConfig: vi.fn(() => ({ skills: { limits: { maxSkillFileBytes: 123_456 } } })),
+}));
+
+vi.mock("../../config/io.runtime.js", () => ({
+  readBestEffortConfig: configIoMocks.readBestEffortConfig,
+}));
+
+const sdkSessionTempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const testModel = {
+  id: "test-model",
+  name: "Test Model",
+  api: "openai-responses",
+  provider: "test-provider",
+  baseUrl: "https://example.test",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1000,
+  maxTokens: 1000,
+} as Model;
+
+function createEmptyResourceLoader(): ResourceLoader {
+  const extensionsResult: LoadExtensionsResult = {
+    extensions: [],
+    errors: [],
+    runtime: createExtensionRuntime(),
+  };
+  return {
+    getExtensions: () => extensionsResult,
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getSkillFileSizeLimit: () => 256_000,
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => undefined,
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+describe("createAgentSession fallback resource loader", () => {
+  it("loads config I/O lazily only for the fallback resource loader", async () => {
+    configIoMocks.readBestEffortConfig.mockClear();
+
+    await createAgentSession({
+      model: testModel,
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(configIoMocks.readBestEffortConfig).not.toHaveBeenCalled();
+  });
+
+  it("uses the fallback resource loader when none is provided", async () => {
+    const root = sdkSessionTempDirs.make("openclaw-sdk-fallback-loader-");
+    const agentDir = path.join(root, "agent");
+    const cwd = path.join(root, "cwd");
+
+    const { session } = await createAgentSession({
+      agentDir,
+      cwd,
+      model: testModel,
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(configIoMocks.readBestEffortConfig).toHaveBeenCalledWith({
+      skipPluginValidation: true,
+      isolateEnv: true,
+      observe: false,
+    });
+    expect(session.resourceLoader).toBeDefined();
+  });
+});

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -212,6 +212,7 @@ function createResourceLoaderWithHandlers(
   return {
     getExtensions: () => extensionsResult,
     getSkills: () => ({ skills: [], diagnostics: [] }),
+    getSkillFileSizeLimit: () => 256_000,
     getPrompts: () => ({ prompts: [], diagnostics: [] }),
     getThemes: () => ({ themes: [], diagnostics: [] }),
     getAgentsFiles: () => ({ agentsFiles: [] }),

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -296,7 +296,20 @@ async function createAgentSessionImpl(
     options.sessionManager ?? (await createDefaultSdkSessionManager(cwd, agentDir));
 
   if (!resourceLoader) {
-    resourceLoader = new DefaultResourceLoader({ cwd, agentDir, settingsManager });
+    // Load config I/O lazily so SDK consumers that supply their own resource loader
+    // do not pay for the config runtime.
+    const { readBestEffortConfig } = await import("../../config/io.runtime.js");
+    const cfg = await readBestEffortConfig({
+      skipPluginValidation: true,
+      isolateEnv: true,
+      observe: false,
+    });
+    resourceLoader = new DefaultResourceLoader({
+      cwd,
+      agentDir,
+      settingsManager,
+      maxSkillFileBytes: cfg.skills?.limits?.maxSkillFileBytes,
+    });
     await resourceLoader.reload();
     modelRegistry.refresh();
   }

--- a/src/skills/loading/bounded-skill-read.ts
+++ b/src/skills/loading/bounded-skill-read.ts
@@ -1,0 +1,43 @@
+import { closeSync, fstatSync, openSync } from "node:fs";
+import { readFileDescriptorBoundedSync } from "../../infra/boundary-file-read.js";
+
+/** Default max file size for a single SKILL.md. Matches workspace skill loading limit. */
+export const DEFAULT_MAX_SKILL_FILE_BYTES = 256_000;
+
+/**
+ * Read SKILL.md content through a pinned descriptor to avoid TOCTOU races
+ * and bound memory on oversized files.
+ * Emits an operator-visible warning and throws on oversized input.
+ *
+ * Kept in a dependency-light leaf module so prompt-expansion callers
+ * do not pull in the full session loader graph (workshop curator,
+ * SQLite runtime, archive, ignore rules, etc.).
+ */
+export function readBoundedSkillFile(
+  filePath: string,
+  maxBytes: number = DEFAULT_MAX_SKILL_FILE_BYTES,
+): string {
+  const fd = openSync(filePath, "r");
+  try {
+    const stats = fstatSync(fd);
+    if (stats.size > maxBytes) {
+      console.warn(`Skill file rejected (exceeds ${maxBytes} bytes): ${filePath}`);
+      throw Object.assign(new Error(`skill file exceeds ${maxBytes} bytes (${stats.size} bytes)`), {
+        code: "E2BIG",
+      });
+    }
+    try {
+      return readFileDescriptorBoundedSync(fd, maxBytes).toString("utf-8");
+    } catch (error) {
+      if (error instanceof RangeError) {
+        console.warn(`Skill file rejected (exceeds ${maxBytes} bytes): ${filePath}`);
+        throw Object.assign(new Error(`skill file exceeds ${maxBytes} bytes`), {
+          code: "E2BIG",
+        });
+      }
+      throw error;
+    }
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -1,14 +1,22 @@
+import { closeSync, fstatSync, mkdirSync, openSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { readFileDescriptorBoundedSync } from "../../infra/boundary-file-read.js";
 import { parseSkillFrontmatter, resolveSkillManifestMetadata } from "./frontmatter.js";
 import { loadSkills } from "./session.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function loadSkillsFromPath(dir: string) {
-  return loadSkills({ cwd: dir, agentDir: dir, skillPaths: [dir], includeDefaults: false });
+function loadSkillsFromPath(dir: string, maxSkillFileBytes?: number) {
+  return loadSkills({
+    cwd: dir,
+    agentDir: dir,
+    skillPaths: [dir],
+    includeDefaults: false,
+    maxSkillFileBytes,
+  });
 }
 
 describe("loadSkills", () => {
@@ -125,5 +133,106 @@ description: Valid sibling
         message: expect.stringContaining("invalid frontmatter: BAD_INDENT"),
       }),
     ]);
+  });
+
+  it("rejects oversized SKILL.md files and emits a diagnostic", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-scan-");
+    const skillDir = path.join(tempDir, "oversized");
+    await fs.mkdir(skillDir);
+    const skillFile = path.join(skillDir, "SKILL.md");
+    // Write content exceeding the default size limit (256 KB).
+    const oversizeBody = "x".repeat(260_000);
+    await fs.writeFile(
+      skillFile,
+      `---\nname: oversized\ndescription: This file is too big\n---\n${oversizeBody}`,
+      "utf-8",
+    );
+
+    const result = loadSkillsFromPath(tempDir);
+
+    expect(result.skills).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "warning",
+        path: skillFile,
+        message: expect.stringContaining("exceeds"),
+      }),
+    ]);
+  });
+
+  it("honors a custom maxSkillFileBytes limit for discovery", async () => {
+    const tempDir = tempDirs.make("openclaw-skill-custom-limit-");
+    const acceptedDir = path.join(tempDir, "accepted");
+    const rejectedDir = path.join(tempDir, "rejected");
+    await fs.mkdir(acceptedDir);
+    await fs.mkdir(rejectedDir);
+    const acceptedFile = path.join(acceptedDir, "SKILL.md");
+    const rejectedFile = path.join(rejectedDir, "SKILL.md");
+    // 200 KB body is under a 300 KB custom limit but over a 100 KB one.
+    const body = "x".repeat(200_000);
+    const skillFrontmatter = (name: string) =>
+      `---\nname: ${name}\ndescription: limit probe\n---\n`;
+    await fs.writeFile(acceptedFile, `${skillFrontmatter("accepted")}${body}`, "utf-8");
+    await fs.writeFile(rejectedFile, `${skillFrontmatter("rejected")}${body}`, "utf-8");
+
+    const acceptedResult = loadSkillsFromPath(tempDir, 300_000);
+    expect(acceptedResult.skills).toHaveLength(2);
+    expect(acceptedResult.skills.map((skill) => skill.name)).toEqual(
+      expect.arrayContaining(["accepted", "rejected"]),
+    );
+    expect(acceptedResult.diagnostics).toEqual([]);
+
+    const rejectedResult = loadSkillsFromPath(tempDir, 100_000);
+    expect(rejectedResult.skills).toEqual([]);
+    expect(rejectedResult.diagnostics).toHaveLength(2);
+    expect(rejectedResult.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "warning",
+          path: acceptedFile,
+          message: expect.stringContaining("exceeds"),
+        }),
+        expect.objectContaining({
+          type: "warning",
+          path: rejectedFile,
+          message: expect.stringContaining("exceeds"),
+        }),
+      ]),
+    );
+  });
+
+  it("rejects files that grew after stat via the bounded descriptor reader (growth-race regression)", () => {
+    const tempDir = tempDirs.make("openclaw-skill-scan-");
+    const skillDir = path.join(tempDir, "grow-race");
+    mkdirSync(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, "SKILL.md");
+
+    // Write a file under the limit.
+    writeFileSync(
+      skillFile,
+      `---\nname: grow\ndescription: Grows post-stat\n---\n${"x".repeat(50_000)}`,
+      "utf-8",
+    );
+
+    // Open a read-only descriptor and verify the file is under the limit at
+    // open time — this mirrors what readBoundedSkillFile does internally.
+    const fd = openSync(skillFile, "r");
+    try {
+      const stats = fstatSync(fd);
+      expect(stats.size).toBeLessThan(256_000);
+
+      // Grow the file past the limit after the stat check. On Linux the
+      // kernel page cache is coherent, so the original read fd sees the new
+      // data; the bounded reader catches the growth and throws RangeError.
+      writeFileSync(
+        skillFile,
+        `---\nname: grow\ndescription: Grows post-stat\n---\n${"x".repeat(512_000)}`,
+        "utf-8",
+      );
+
+      expect(() => readFileDescriptorBoundedSync(fd, 256_000)).toThrow(RangeError);
+    } finally {
+      closeSync(fd);
+    }
   });
 });

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir } from "../../agents/config.js";
 import type { ResourceDiagnostic } from "../../agents/sessions/diagnostics.js";
@@ -11,6 +11,7 @@ import {
 } from "../../shared/ignore-rules.js";
 // Session skill helpers resolve skills attached to a session and its transcript state.
 import { expandTildePath } from "../../shared/tilde-path.js";
+import { DEFAULT_MAX_SKILL_FILE_BYTES, readBoundedSkillFile } from "./bounded-skill-read.js";
 import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
 import { resolveSkillDisplayName } from "./skill-contract.js";
 import { formatSkillsForPromptBounded } from "./skill-prompt-limits.js";
@@ -111,6 +112,7 @@ function loadSkillsFromDirInternal(
   includeRootFiles: boolean,
   ignoreMatcher?: IgnoreMatcher,
   rootDir?: string,
+  maxSkillFileBytes?: number,
 ): LoadSkillsResult {
   const skills: Skill[] = [];
   const diagnostics: ResourceDiagnostic[] = [];
@@ -148,7 +150,7 @@ function loadSkillsFromDirInternal(
         continue;
       }
 
-      const result = loadSkillFromFile(fullPath, source);
+      const result = loadSkillFromFile(fullPath, source, maxSkillFileBytes);
       if (result.skill) {
         skills.push(result.skill);
       }
@@ -189,7 +191,14 @@ function loadSkillsFromDirInternal(
       }
 
       if (isDirectory) {
-        const subResult = loadSkillsFromDirInternal(fullPath, source, false, ig, root);
+        const subResult = loadSkillsFromDirInternal(
+          fullPath,
+          source,
+          false,
+          ig,
+          root,
+          maxSkillFileBytes,
+        );
         skills.push(...subResult.skills);
         diagnostics.push(...subResult.diagnostics);
         continue;
@@ -199,7 +208,7 @@ function loadSkillsFromDirInternal(
         continue;
       }
 
-      const result = loadSkillFromFile(fullPath, source);
+      const result = loadSkillFromFile(fullPath, source, maxSkillFileBytes);
       if (result.skill) {
         skills.push(result.skill);
       }
@@ -216,11 +225,13 @@ function loadSkillsFromDirInternal(
 function loadSkillFromFile(
   filePath: string,
   source: string,
+  maxSkillFileBytes?: number,
 ): { skill: Skill | null; diagnostics: ResourceDiagnostic[] } {
   const diagnostics: ResourceDiagnostic[] = [];
 
   try {
-    const rawContent = readFileSync(filePath, "utf-8");
+    const resolvedMaxBytes = maxSkillFileBytes ?? DEFAULT_MAX_SKILL_FILE_BYTES;
+    const rawContent = readBoundedSkillFile(filePath, resolvedMaxBytes);
     const frontmatter = parseSkillFrontmatter(rawContent);
     const invocation = resolveSkillInvocationPolicy(frontmatter);
     const skillDir = dirname(filePath);
@@ -288,6 +299,8 @@ interface LoadSkillsOptions {
   skillPaths: string[];
   /** Include default skills directories. */
   includeDefaults: boolean;
+  /** Configured byte limit for a single SKILL.md file. */
+  maxSkillFileBytes?: number;
 }
 
 function resolveSkillPath(p: string, cwd: string): string {
@@ -300,7 +313,7 @@ function resolveSkillPath(p: string, cwd: string): string {
  * Returns skills and any validation diagnostics.
  */
 export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
-  const { cwd, agentDir, skillPaths, includeDefaults } = options;
+  const { cwd, agentDir, skillPaths, includeDefaults, maxSkillFileBytes } = options;
 
   // Resolve agentDir - if not provided, use default from config
   const resolvedAgentDir = agentDir ?? getAgentDir();
@@ -342,8 +355,26 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
   }
 
   if (includeDefaults) {
-    addSkills(loadSkillsFromDirInternal(join(resolvedAgentDir, "skills"), "user", true));
-    addSkills(loadSkillsFromDirInternal(resolve(cwd, CONFIG_DIR_NAME, "skills"), "project", true));
+    addSkills(
+      loadSkillsFromDirInternal(
+        join(resolvedAgentDir, "skills"),
+        "user",
+        true,
+        undefined,
+        undefined,
+        maxSkillFileBytes,
+      ),
+    );
+    addSkills(
+      loadSkillsFromDirInternal(
+        resolve(cwd, CONFIG_DIR_NAME, "skills"),
+        "project",
+        true,
+        undefined,
+        undefined,
+        maxSkillFileBytes,
+      ),
+    );
   }
 
   const userSkillsDir = join(resolvedAgentDir, "skills");
@@ -385,9 +416,18 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
       const stats = statSync(resolvedPath);
       const source = getSource(resolvedPath);
       if (stats.isDirectory()) {
-        addSkills(loadSkillsFromDirInternal(resolvedPath, source, true));
+        addSkills(
+          loadSkillsFromDirInternal(
+            resolvedPath,
+            source,
+            true,
+            undefined,
+            undefined,
+            maxSkillFileBytes,
+          ),
+        );
       } else if (stats.isFile() && resolvedPath.endsWith(".md")) {
-        const result = loadSkillFromFile(resolvedPath, source);
+        const result = loadSkillFromFile(resolvedPath, source, maxSkillFileBytes);
         if (result.skill) {
           addSkills({ skills: [result.skill], diagnostics: result.diagnostics });
         } else {


### PR DESCRIPTION

## What Problem This Solves

Fixes an issue where a large SKILL.md file (e.g. 100 MB) placed in a session or project skills directory would be read entirely into memory during agent skill loading, causing memory bloat with no guard. Also protects `/skill:` command expansion from the same unbounded read.

## Why This Change Was Made

Rebased onto the latest `upstream/main` and replaced the stale branch contents with a clean, current-main implementation:

- A new dependency-light leaf module, `src/skills/loading/bounded-skill-read.ts`, provides a pinned-descriptor bounded reader (`readBoundedSkillFile`) using the existing canonical `readFileDescriptorBoundedSync` from `boundary-file-read.ts`. This enforces the size bound even when a file grows between the `fstatSync` size check and the actual read.
- The bounded reader is applied to both session/project skill discovery (`loadSkillFromFile` in `src/skills/loading/session.ts`) and prompt-time `/skill:` expansion (`expandSkillCommand` in `src/agents/sessions/agent-session-prompting.ts`).
- The resolved `skills.limits.maxSkillFileBytes` value from `openclaw.json` is threaded through `loadSkills` → `DefaultResourceLoader`, and exposed to the prompt-expansion path via the internal `ResourceLoader.getSkillFileSizeLimit()` method. The limit is **not** stored on the exported `Skill` type, keeping loader policy out of the Plugin SDK contract.
- `createAgentSession` dynamically imports `readBestEffortConfig` only inside the fallback `DefaultResourceLoader` branch, so callers that supply their own `resourceLoader` do not pull in the config runtime.
- The retired `docs/.generated/plugin-sdk-api-baseline.sha256` file was dropped during the rebase and is no longer touched.

Oversized-skill rejections are surfaced via `console.warn` for operator visibility plus diagnostic propagation through existing error channels.

## User Impact

Operators who have large files named `SKILL.md` in session or project skill directories now get a visible warning instead of unbounded memory consumption. Session/project skills now honor the same `skills.limits.maxSkillFileBytes` setting as workspace skill loading. No impact on normal usage.

## Evidence

### Rebase resolution

- Branch rebased onto `upstream/main` at `1cb914d6bff`.
- Conflicts on the retired generated SDK hash manifest were resolved by taking the upstream deletion (the file is removed from the branch diff).
- The exported `Skill` type no longer contains a `maxSkillFileBytes` field; the configured limit is carried by the loader/read boundary only.

### Unit tests

```bash
$ node scripts/run-vitest.mjs \
    src/skills/loading/session.test.ts \
    src/agents/sessions/agent-session-prompting.skill-expansion.test.ts \
    src/agents/sessions/agent-session-prompting.import-boundary.test.ts \
    src/agents/sessions/sdk.fallback-resource-loader.test.ts
```

Results:

- `src/skills/loading/session.test.ts` — 7 passed (includes oversized rejection, custom `maxSkillFileBytes` limit, and growth-race regression)
- `src/agents/sessions/agent-session-prompting.skill-expansion.test.ts` — 2 passed (non-default limit honored during `/skill:` expansion)
- `src/agents/sessions/agent-session-prompting.import-boundary.test.ts` — 3 passed (prompt-expansion does not pull in session-loader heavy deps)
- `src/agents/sessions/sdk.fallback-resource-loader.test.ts` — 2 passed (config I/O is lazy and only loaded for the fallback loader)

### Lint, format, and SDK surface

```bash
$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
    src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts \
    src/agents/sessions/agent-session-loop-resource-loader.test-support.ts \
    src/agents/sessions/agent-session-prompting.ts \
    src/agents/sessions/agent-session.live.test.ts \
    src/agents/sessions/agent-session.openai-compaction.live.test.ts \
    src/agents/sessions/resource-loader.ts \
    src/agents/sessions/sdk.test.ts \
    src/agents/sessions/sdk.ts \
    src/agents/sessions/sdk.fallback-resource-loader.test.ts \
    src/skills/loading/session.test.ts \
    src/skills/loading/session.ts \
    src/agents/sessions/agent-session-prompting.import-boundary.test.ts \
    src/agents/sessions/agent-session-prompting.skill-expansion.test.ts \
    src/skills/loading/bounded-skill-read.ts
Found 0 warnings and 0 errors.

$ pnpm format:check <changed-files>
All matched files use the correct format.

$ pnpm plugin-sdk:surface:check
# passed
```

### Real behavior proof (rebased head)

```bash
$ node --import tsx .tmp/proof-skill-size.mts
```

Output on rebased head `882efbea484`:

```
[proof] temp root: /tmp/openclaw-skill-size-proof-zqkCdP
Skill file rejected (exceeds 256000 bytes): /tmp/openclaw-skill-size-proof-zqkCdP/oversized/SKILL.md
[proof] scene=discovery behavior= rejected
[proof] discovery diagnostics: [ 'skill file exceeds 256000 bytes (260049 bytes)' ]
[proof] scene=initial-load behavior= accepted
Skill file rejected (exceeds 10000 bytes): /tmp/openclaw-skill-size-proof-zqkCdP/grow/SKILL.md
[proof] scene=growth-expansion behavior= rejected message= skill file exceeds 10000 bytes (20044 bytes)
```

This confirms:

- `scene=discovery`: an oversized `SKILL.md` is rejected during session/project skill discovery.
- `scene=growth-expansion`: a file that was accepted at discovery time is rejected when it grows past the configured limit before the `/skill:`-style read.

### Resolved ClawSweeper findings

- [P1] Remove the retired SDK hash manifest — resolved by dropping `docs/.generated/plugin-sdk-api-baseline.sha256` from the branch.
- [P1] Keep the byte limit out of the exported `Skill` contract — resolved by moving the limit to `ResourceLoader.getSkillFileSizeLimit()` and threading it as a loader argument.
