### PR TITLE
fix(lmstudio): redact upstream error body text in model load error

### DIFF
--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -1,5 +1,5 @@
 // Lmstudio plugin module implements models.fetch behavior.
-import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
+import { createSubsystemLogger, redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonArrayFieldResponse,

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -4,10 +4,10 @@ import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonArrayFieldResponse,
   readProviderJsonResponse,
-  readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { SELF_HOSTED_DEFAULT_COST } from "openclaw/plugin-sdk/provider-setup";
+import { readResponseTextPrefix } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { LMSTUDIO_DEFAULT_LOAD_CONTEXT_LENGTH } from "./defaults.js";
@@ -340,7 +340,15 @@ export async function ensureLmstudioModelLoaded(params: {
     });
     try {
       if (!response.ok) {
-        const body = await readResponseTextLimited(response, LMSTUDIO_ERROR_BODY_LIMIT_BYTES);
+        const bodyRead = await readResponseTextPrefix(response, LMSTUDIO_ERROR_BODY_LIMIT_BYTES, {
+          chunkTimeoutMs: 10_000,
+        });
+        if (bodyRead.truncated) {
+          // A reflected credential split across the byte cap cannot be reliably
+          // redacted, so keep only the status in the operator-visible error.
+          throw new Error(`LM Studio model load failed (${response.status})`);
+        }
+        const body = bodyRead.text;
         throw new Error(
           `LM Studio model load failed (${response.status})${body ? `: ${redactLmstudioErrorBody(body, { apiKey: params.apiKey, headers: params.headers })}` : ""}`,
         );

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -23,6 +23,49 @@ import { buildLmstudioAuthHeaders } from "./runtime.js";
 
 const log = createSubsystemLogger("extensions/lmstudio/models");
 const LMSTUDIO_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const REDACTED_SECRET_PLACEHOLDER = "***";
+
+function collectLmstudioRequestSecrets(params: {
+  apiKey?: string;
+  headers?: Record<string, string>;
+}): string[] {
+  const secrets = new Set<string>();
+  const apiKey = params.apiKey?.trim();
+  if (apiKey) {
+    secrets.add(apiKey);
+    secrets.add(`Bearer ${apiKey}`);
+  }
+  for (const [headerName, headerValue] of Object.entries(params.headers ?? {})) {
+    if (!headerValue) {
+      continue;
+    }
+    secrets.add(headerValue);
+    if (headerName.toLowerCase() === "authorization" && headerValue.startsWith("Bearer ")) {
+      secrets.add(headerValue.slice("Bearer ".length));
+    }
+  }
+  return Array.from(secrets);
+}
+
+/**
+ * Redacts the exact credential values sent in the request before applying the
+ * shared pattern-based redactor. This covers short configured API keys (e.g.
+ * `sk-test`) that the generic standalone-Bearer pattern may miss.
+ */
+function redactLmstudioErrorBody(
+  body: string,
+  params: {
+    apiKey?: string;
+    headers?: Record<string, string>;
+  },
+): string {
+  const secrets = collectLmstudioRequestSecrets(params).toSorted((a, b) => b.length - a.length);
+  let redacted = body;
+  for (const secret of secrets) {
+    redacted = redacted.replaceAll(secret, REDACTED_SECRET_PLACEHOLDER);
+  }
+  return redactToolPayloadText(redacted);
+}
 
 type LmstudioLoadResponse = {
   status?: string;
@@ -299,7 +342,7 @@ export async function ensureLmstudioModelLoaded(params: {
       if (!response.ok) {
         const body = await readResponseTextLimited(response, LMSTUDIO_ERROR_BODY_LIMIT_BYTES);
         throw new Error(
-          `LM Studio model load failed (${response.status})${body ? `: ${body}` : ""}`,
+          `LM Studio model load failed (${response.status})${body ? `: ${redactLmstudioErrorBody(body, { apiKey: params.apiKey, headers: params.headers })}` : ""}`,
         );
       }
       // Read the success body through the shared byte-capped reader so a misbehaving

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -955,6 +955,34 @@ describe("lmstudio-models", () => {
     expect((error as Error).message).toContain("upstream proxy error");
   });
 
+  it("redacts short reflected API keys from model load error body text", async () => {
+    // LM Studio accepts short configured API keys that fall below the generic
+    // standalone-Bearer redactor's length threshold; scrub the exact outbound
+    // credential so a reflected `Bearer <key>` value cannot leak.
+    const body = `upstream proxy error: rejected Bearer sk-test`;
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/api/v1/models")) {
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
+      }
+      if (String(url).endsWith("/api/v1/models/load")) {
+        return new Response(body, { status: 502 });
+      }
+      throw new Error(`Unexpected fetch URL: ${String(url)}`);
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    const error = await ensureLmstudioModelLoaded({
+      baseUrl: "http://localhost:1234/v1",
+      apiKey: "sk-test",
+      modelKey: "qwen3-8b-instruct",
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain("sk-test");
+    expect((error as Error).message).toMatch(/LM Studio model load failed \(502\)/);
+  });
+
   it("reloads model to the clamped default target when already loaded below the default window", async () => {
     const fetchMock = createModelLoadFetchMock({
       loadedContextLength: 4096,

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -925,6 +925,53 @@ describe("lmstudio-models", () => {
     expect(textSpy).not.toHaveBeenCalled();
   });
 
+  it("redacts reflected credentials from model load error body text", async () => {
+    // Upstream proxies may reflect an Authorization header in error bodies.
+    // Sanitize that text through the tool-payload redactor so credentials
+    // never reach the thrown error message.
+    const body = `upstream proxy error: rejected Bearer sk-reflected-secret-abc123xyz`;
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/api/v1/models")) {
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
+      }
+      if (String(url).endsWith("/api/v1/models/load")) {
+        return new Response(body, { status: 502 });
+      }
+      throw new Error(`Unexpected fetch URL: ${String(url)}`);
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    const error = await ensureLmstudioModelLoaded({
+      baseUrl: "http://localhost:1234/v1",
+      modelKey: "qwen3-8b-instruct",
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    // The Bearer credential must be absent from the operator-visible error.
+    expect((error as Error).message).not.toMatch(/sk-reflected-secret/);
+    // Safe diagnostics (status code, upstream error label) must still appear.
+    expect((error as Error).message).toMatch(/LM Studio model load failed \(502\)/);
+    expect((error as Error).message).toContain("upstream proxy error");
+  });
+
+  it("reloads model to the clamped default target when already loaded below the default window", async () => {
+    const fetchMock = createModelLoadFetchMock({
+      loadedContextLength: 4096,
+      maxContextLength: 32768,
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    await expect(
+      ensureLmstudioModelLoaded({
+        baseUrl: "http://localhost:1234/v1",
+        modelKey: "qwen3-8b-instruct",
+      }),
+    ).resolves.toBe("qwen3-8b-instruct");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expectLoadContextLength(fetchMock, 32768);
+  });
   it("loads model with clamped context length and merged headers", async () => {
     const fetchMock = createModelLoadFetchMock({ maxContextLength: 32768 });
     vi.stubGlobal("fetch", asFetch(fetchMock));

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -895,7 +895,7 @@ describe("lmstudio-models", () => {
     expect(bytesEmitted).toBeLessThan(32 * 1024 * 1024);
   });
 
-  it("bounds model load error bodies", async () => {
+  it("suppresses truncated model load error bodies", async () => {
     const body = `${"lmstudio load unavailable ".repeat(512)}tail`;
     const tracked = cancelTrackedResponse(body, { status: 503 });
     const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
@@ -917,9 +917,8 @@ describe("lmstudio-models", () => {
       modelKey: "qwen3-8b-instruct",
     }).catch((caught: unknown) => caught);
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toMatch(
-      /LM Studio model load failed \(503\): lmstudio load unavailable/,
-    );
+    expect((error as Error).message).toBe("LM Studio model load failed (503)");
+    expect((error as Error).message).not.toContain("lmstudio load unavailable");
     expect((error as Error).message).not.toContain("tail");
     expect(tracked.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
@@ -981,6 +980,42 @@ describe("lmstudio-models", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).not.toContain("sk-test");
     expect((error as Error).message).toMatch(/LM Studio model load failed \(502\)/);
+  });
+
+  it("suppresses truncated error bodies so a split credential cannot leak", async () => {
+    // A reflected credential that straddles the 8 KiB byte cap cannot be
+    // reliably redacted, so the whole body must be omitted when truncated.
+    const secret = "split-credential-xyz";
+    const prefix = "x".repeat(8 * 1024 - 5);
+    const tracked = cancelTrackedResponse(`${prefix}Bearer ${secret}${"y".repeat(1000)}`, {
+      status: 502,
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/api/v1/models")) {
+        return jsonResponse({
+          models: [{ type: "llm", key: "qwen3-8b-instruct", loaded_instances: [] }],
+        });
+      }
+      if (String(url).endsWith("/api/v1/models/load")) {
+        return tracked.response;
+      }
+      throw new Error(`Unexpected fetch URL: ${String(url)}`);
+    });
+    vi.stubGlobal("fetch", asFetch(fetchMock));
+
+    const error = await ensureLmstudioModelLoaded({
+      baseUrl: "http://localhost:1234/v1",
+      apiKey: secret,
+      modelKey: "qwen3-8b-instruct",
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("LM Studio model load failed (502)");
+    expect((error as Error).message).not.toContain(secret);
+    expect((error as Error).message).not.toContain("Bearer");
+    expect((error as Error).message).not.toContain(prefix.slice(0, 20));
+    expect(tracked.wasCanceled()).toBe(true);
+    expect(textSpy).not.toHaveBeenCalled();
   });
 
   it("reloads model to the clamped default target when already loaded below the default window", async () => {

--- a/extensions/lmstudio/src/proof-redact.test.ts
+++ b/extensions/lmstudio/src/proof-redact.test.ts
@@ -1,0 +1,190 @@
+// Real HTTP-server proof for LM Studio model-load error-body redaction.
+//
+// This test starts a local HTTP server that emulates LM Studio's discovery and
+// load endpoints. The load endpoint returns a 502 whose body reflects the
+// outbound Authorization header, which is the exact scenario that previously
+// leaked credentials into operator-visible errors.
+//
+// Running this file proves that, after the fix, the reflected Bearer token is
+// scrubbed from the thrown Error.message while safe diagnostics are preserved,
+// and that bodies exceeding the 8 KiB cap are suppressed entirely.
+
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ensureLmstudioModelLoaded } from "./models.fetch.js";
+
+const secretToken = "sk-test-token-proof-abc123";
+const shortApiKey = "sk-test";
+const modelKey = "qwen3-8b-instruct";
+
+let server: http.Server;
+let serverUrl: string;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    if (req.url?.startsWith("/api/v1/models") && req.method !== "POST") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          models: [{ type: "llm", key: modelKey, loaded_instances: [] }],
+        }),
+      );
+      return;
+    }
+
+    if (req.url?.startsWith("/api/v1/models/load")) {
+      const authHeader = (req.headers.authorization as string) ?? "(no auth header)";
+      res.writeHead(502, { "Content-Type": "text/plain" });
+      res.end(`upstream proxy error: reflected ${authHeader}`);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("not found");
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const addr = server.address();
+  if (!addr || typeof addr !== "object") {
+    throw new Error("Proof HTTP server did not bind to a port");
+  }
+  serverUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("proof: LM Studio error body credential redaction (real HTTP)", () => {
+  it("redacts reflected Bearer token from upstream error response", async () => {
+    const error = await ensureLmstudioModelLoaded({
+      baseUrl: serverUrl,
+      modelKey,
+      apiKey: secretToken,
+      timeoutMs: 10_000,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+
+    expect(message).toMatch(/LM Studio model load failed \(502\)/);
+    expect(message).toContain("upstream proxy error");
+    expect(message).not.toContain(secretToken);
+    console.log(`[proof] scene=reflected-bearer status=pass leaked=false`);
+  });
+
+  it("redacts short configured API keys that generic patterns may miss", async () => {
+    const error = await ensureLmstudioModelLoaded({
+      baseUrl: serverUrl,
+      modelKey,
+      apiKey: shortApiKey,
+      timeoutMs: 10_000,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+
+    expect(message).toMatch(/LM Studio model load failed \(502\)/);
+    expect(message).not.toContain(shortApiKey);
+    console.log(`[proof] scene=short-api-key status=pass leaked=false`);
+  });
+
+  it("suppresses truncated error bodies to avoid leaking credential fragments", async () => {
+    const truncServer = http.createServer((req, res) => {
+      if (req.url?.startsWith("/api/v1/models") && req.method !== "POST") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ models: [{ type: "llm", key: modelKey, loaded_instances: [] }] }));
+        return;
+      }
+      if (req.url?.startsWith("/api/v1/models/load")) {
+        const authHeader = (req.headers.authorization as string) ?? "";
+        // Body exceeds the 8 KiB cap so the truncation-aware reader drops it.
+        const body = `upstream proxy error: reflected ${authHeader}\n${"x".repeat(9 * 1024)}`;
+        res.writeHead(502, { "Content-Type": "text/plain" });
+        res.end(body);
+        return;
+      }
+      res.writeHead(404);
+      res.end("not found");
+    });
+
+    await new Promise<void>((resolve) => {
+      truncServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = truncServer.address();
+    if (!addr || typeof addr !== "object") {
+      throw new Error("Truncation proof server did not bind");
+    }
+    const truncUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const error = await ensureLmstudioModelLoaded({
+        baseUrl: truncUrl,
+        modelKey,
+        apiKey: secretToken,
+        timeoutMs: 10_000,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+
+      expect(message).toMatch(/LM Studio model load failed \(502\)/);
+      expect(message).not.toContain(secretToken);
+      expect(message).not.toContain("upstream proxy error");
+      console.log(`[proof] scene=truncated-body status=pass leaked=false`);
+    } finally {
+      truncServer.close();
+    }
+  });
+
+  it("preserves non-sensitive diagnostic text in error bodies", async () => {
+    const plainServer = http.createServer((req, res) => {
+      if (req.url?.startsWith("/api/v1/models") && req.method !== "POST") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            models: [{ type: "llm", key: modelKey, loaded_instances: [] }],
+          }),
+        );
+        return;
+      }
+      if (req.url?.startsWith("/api/v1/models/load")) {
+        res.writeHead(500, { "Content-Type": "text/plain" });
+        res.end("GPU out of memory");
+        return;
+      }
+      res.writeHead(404);
+      res.end("not found");
+    });
+
+    await new Promise<void>((resolve) => {
+      plainServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = plainServer.address();
+    if (!addr || typeof addr !== "object") {
+      throw new Error("Diagnostic proof server did not bind");
+    }
+    const plainUrl = `http://127.0.0.1:${addr.port}`;
+
+    try {
+      const error = await ensureLmstudioModelLoaded({
+        baseUrl: plainUrl,
+        modelKey,
+        apiKey: secretToken,
+        timeoutMs: 10_000,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+
+      expect(message).toContain("GPU out of memory");
+      expect(message).not.toContain(secretToken);
+      console.log(`[proof] scene=preserve-diagnostics status=pass leaked=false`);
+    } finally {
+      plainServer.close();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LM Studio model load errors could leak the configured API
key into log output and error traces. When `ensureLmstudioModelLoaded` receives
a non-2xx response from the upstream LM Studio server, the raw response body
was included verbatim in the thrown Error message. If the upstream server
reflects the `Authorization` header (which carries the API key as `Bearer
<token>`) in its error response, the credential appears unredacted in logs.

## Why This Change Was Made

The upstream error body text is now redacted before being included in the Error
message. In addition to the shared `redactToolPayloadText` pattern-based
sanitizer, the model-load path scrubs the exact outbound credential values it
sent in the request (configured `apiKey` and any sensitive header values).
This covers short configured API keys such as `sk-test`, which LM Studio
accepts but which fall below the generic standalone-Bearer redactor's length
threshold.

To address the ClawSweeper [P1] finding about response truncation, the path now
uses the truncation-aware `readResponseTextPrefix` reader and discards the body
entirely when the 8 KiB byte cap is exceeded. A reflected credential split
across that boundary cannot be reliably redacted by exact-value or pattern-based
sanitizers, so suppressing the truncated body prevents any credential fragment
from reaching the operator-visible error.

The branch has been rebased onto `upstream/main` and conflicts in
`extensions/lmstudio/src/models.test.ts` were resolved. The shared
`redactToolPayloadText` import in `extensions/lmstudio/src/models.fetch.ts` was
restored during rebase.

## User Impact

Operators and developers reading LM Studio error logs or traces will no longer
see unredacted API keys when an upstream error response body contains reflected
credentials, including short API keys that generic patterns can miss. When an
error body is truncated at the 8 KiB cap, the error message now shows only the
HTTP status, ensuring no credential fragment can leak. No user-visible behavioral
change otherwise.

## Evidence

### Before fix

LM Studio model load error messages included raw upstream response bodies
without credential redaction. A reflected `Authorization: Bearer sk-abc123`
header in the error body would appear as:

```
LM Studio model load failed (500): {"error":"...Authorization: Bearer sk-abc123..."}
```

### After fix

For complete (untruncated) error bodies, the body is sanitized through
exact-value redaction followed by the shared `redactToolPayloadText` sanitizer,
which masks known credential patterns:

```
LM Studio model load failed (500): {"error":"...Authorization: Bearer ***..."}
```

For error bodies that exceed the 8 KiB cap, the body is now omitted entirely so
a split credential cannot leak:

```
LM Studio model load failed (500)
```

### Real behavior proof: real HTTP server

`extensions/lmstudio/src/proof-redact.test.ts` starts a local HTTP server that
emulates LM Studio's `/api/v1/models` discovery endpoint and a misbehaving
`/api/v1/models/load` endpoint that reflects the outbound `Authorization`
header in its 502 response body. The full transport pipeline — request header
→ reflected body → bounded reader → redaction → `Error.message` — is exercised
without mocked `fetch` or `Response` objects.

```bash
node scripts/run-vitest.mjs extensions/lmstudio/src/proof-redact.test.ts
```

Output:

```
[test] starting test/vitest/vitest.extension-providers.config.ts

 RUN  v4.1.10 /home/0668000452/codes/开源/openclaw

stdout | extensions/lmstudio/src/proof-redact.test.ts > proof: LM Studio error body credential redaction (real HTTP) > redacts reflected Bearer token from upstream error response
[proof] scene=reflected-bearer status=pass leaked=false

stdout | extensions/lmstudio/src/proof-redact.test.ts > proof: LM Studio error body credential redaction (real HTTP) > redacts short configured API keys that generic patterns may miss
[proof] scene=short-api-key status=pass leaked=false

stdout | extensions/lmstudio/src/proof-redact.test.ts > proof: LM Studio error body credential redaction (real HTTP) > suppresses truncated error bodies to avoid leaking credential fragments
[proof] scene=truncated-body status=pass leaked=false

stdout | extensions/lmstudio/src/proof-redact.test.ts > proof: LM Studio error body credential redaction (real HTTP) > preserves non-sensitive diagnostic text in error bodies
[proof] scene=preserve-diagnostics status=pass leaked=false

 ✓ |extension-providers| extensions/lmstudio/src/proof-redact.test.ts (4 tests) 1008ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Relevant proof scenarios:

- `redacts reflected Bearer token from upstream error response` — a long
  reflected `Bearer sk-test-token-proof-abc123` is absent from the operator-visible
  error while the status code and safe diagnostic text remain.
- `redacts short configured API keys that generic patterns may miss` — the short
  key `sk-test` is scrubbed even though it falls below the generic standalone-Bearer
  redactor's length threshold.
- `suppresses truncated error bodies to avoid leaking credential fragments` — a
  body exceeding the 8 KiB cap is dropped entirely, so no credential fragment
  split across the boundary can leak.
- `preserves non-sensitive diagnostic text in error bodies` — non-sensitive text
  such as `GPU out of memory` survives redaction.

### Regression tests

The LM Studio model test suite also exercises the load path with mocked
`Response` streams and credentials, including the truncation boundary:

```bash
node scripts/run-vitest.mjs extensions/lmstudio/src/models.test.ts
```

Output:

```
[test] starting test/vitest/vitest.extension-providers.config.ts

 RUN  v4.1.10 /home/0668000452/codes/开源/openclaw

 ✓ |extension-providers| extensions/lmstudio/src/models.test.ts (51 tests) 1224ms

 Test Files  1 passed (1)
      Tests  51 passed (51)
```

### Lint / format

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json extensions/lmstudio/src/models.fetch.ts extensions/lmstudio/src/models.test.ts extensions/lmstudio/src/proof-redact.test.ts
./node_modules/.bin/oxfmt --check extensions/lmstudio/src/models.fetch.ts extensions/lmstudio/src/models.test.ts extensions/lmstudio/src/proof-redact.test.ts
```

Output:

```
Found 0 warnings and 0 errors.
All matched files use the correct format.
```

Updated head: `8244906f7f0`
