### PR TITLE
fix(gateway): distinguish still-starting from failed restart health waits

### DIFF
--- a/src/cli/daemon-cli/lifecycle.external-supervision.test.ts
+++ b/src/cli/daemon-cli/lifecycle.external-supervision.test.ts
@@ -228,6 +228,7 @@ describe("external gateway supervision lifecycle", () => {
       delayMs: 500,
       previousLockIdentity: lockIdentity,
       waitIndefinitelyForPreviousOwner: false,
+      previousOwnerPid: 4200,
     });
   });
 
@@ -245,7 +246,31 @@ describe("external gateway supervision lifecycle", () => {
       delayMs: 500,
       previousLockIdentity: gatewayLockIdentity,
       waitIndefinitelyForPreviousOwner: false,
+      previousOwnerPid: 4200,
     });
+  });
+
+  it("reports a slow in-process restart as still starting instead of failing", async () => {
+    waitForGatewayHealthyListener.mockResolvedValue({
+      healthy: false,
+      portUsage: { port: 18_789, status: "free", listeners: [], hints: [] },
+      waitOutcome: "still-starting",
+      elapsedMs: 65_000,
+    });
+    const { defaultRuntime } = await import("../../runtime.js");
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+
+    await expect(runDaemonRestart({ json: true, force: true })).resolves.toBe(true);
+
+    expect(writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "restart",
+        ok: true,
+        message: expect.stringContaining("still in progress after 65s"),
+      }),
+    );
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Timed out after"));
   });
 
   it("uses targeted in-gateway restart transport on Windows", async () => {
@@ -277,6 +302,7 @@ describe("external gateway supervision lifecycle", () => {
       delayMs: 500,
       previousLockIdentity: gatewayLockIdentity,
       waitIndefinitelyForPreviousOwner: false,
+      previousOwnerPid: 4200,
     });
   });
 

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -875,6 +875,7 @@ describe("runDaemonRestart health checks", () => {
         port: 18_789,
       },
       waitIndefinitelyForPreviousOwner: false,
+      previousOwnerPid: 4200,
     });
   });
 
@@ -917,6 +918,7 @@ describe("runDaemonRestart health checks", () => {
         port: 18_789,
       },
       waitIndefinitelyForPreviousOwner: false,
+      previousOwnerPid: 4200,
     });
   });
 

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -109,6 +109,27 @@ function formatRestartFailure(params: {
   };
 }
 
+/**
+ * Renders the "still starting" note for in-process (SIGUSR1) gateway restarts:
+ * the PID is unchanged and the process is alive while the port is still free,
+ * so the restart is progressing rather than failed. Explicitly non-failure
+ * language — failure here would push operators toward destructive recovery of
+ * a healthy, booting process.
+ */
+function formatGatewayStillStartingMessage(params: {
+  elapsedMs?: number;
+  pid: number;
+  fallbackTimeoutSeconds: number;
+}): string {
+  const elapsedSeconds = Math.max(
+    1,
+    Math.round(
+      params.elapsedMs === undefined ? params.fallbackTimeoutSeconds : params.elapsedMs / 1000,
+    ),
+  );
+  return `Gateway restart is still in progress after ${elapsedSeconds}s: process PID ${params.pid} is alive and booting (in-process restart keeps the PID). Poll readiness with "openclaw gateway status --deep".`;
+}
+
 async function resolveGatewayLifecycleContext(service = resolveGatewayService()): Promise<{
   port: number;
   env: NodeJS.ProcessEnv;
@@ -442,11 +463,29 @@ async function runExternalSupervisorRestart(opts: DaemonLifecycleOptions): Promi
     delayMs: POST_RESTART_HEALTH_DELAY_MS,
     previousLockIdentity: signaled.previousLockIdentity,
     waitIndefinitelyForPreviousOwner: healthWait.waitIndefinitelyForPreviousOwner,
+    previousOwnerPid: signaled.pid,
   });
-  if (!health.healthy) {
+  if (!health.healthy && health.waitOutcome !== "still-starting") {
     const message = `Gateway restart timed out after ${healthWait.timeoutSeconds}s waiting for health checks.`;
     fail(message, renderGatewayPortHealthDiagnostics(health));
     return false;
+  }
+
+  if (health.waitOutcome === "still-starting") {
+    const stillStartingMessage = formatGatewayStillStartingMessage({
+      elapsedMs: health.elapsedMs,
+      pid: signaled.pid,
+      fallbackTimeoutSeconds: healthWait.timeoutSeconds,
+    });
+    emit({
+      ok: true,
+      result: signaled.result,
+      message: stillStartingMessage,
+    });
+    if (!json) {
+      defaultRuntime.log(theme.info(stillStartingMessage));
+    }
+    return true;
   }
 
   emit({
@@ -582,6 +621,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   let unmanagedRestartHealthAttempts = restartHealthAttempts;
   let unmanagedRestartWaitIndefinitely = false;
   let unmanagedRestartWaitSeconds = restartWaitSeconds;
+  let unmanagedRestartPid: number | undefined;
 
   return await runServiceRestart({
     serviceNoun: "Gateway",
@@ -626,12 +666,15 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       const handled = await restartUnmanaged(unmanagedPort, restartIntent, !mutationError);
       if (handled) {
         restartedWithoutServiceManager = true;
-        if (isGatewaySignalRestartResult(handled) && handled.previousLockIdentity) {
-          unmanagedPreviousLockIdentity = handled.previousLockIdentity;
-          const healthWait = await resolveRestartListenerHealthWait(restartIntent);
-          unmanagedRestartHealthAttempts = healthWait.attempts;
-          unmanagedRestartWaitIndefinitely = healthWait.waitIndefinitelyForPreviousOwner;
-          unmanagedRestartWaitSeconds = healthWait.timeoutSeconds;
+        if (isGatewaySignalRestartResult(handled)) {
+          unmanagedRestartPid = handled.pid;
+          if (handled.previousLockIdentity) {
+            unmanagedPreviousLockIdentity = handled.previousLockIdentity;
+            const healthWait = await resolveRestartListenerHealthWait(restartIntent);
+            unmanagedRestartHealthAttempts = healthWait.attempts;
+            unmanagedRestartWaitIndefinitely = healthWait.waitIndefinitelyForPreviousOwner;
+            unmanagedRestartWaitSeconds = healthWait.timeoutSeconds;
+          }
         }
         return handled;
       }
@@ -654,8 +697,22 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
                 waitIndefinitelyForPreviousOwner: unmanagedRestartWaitIndefinitely,
               }
             : {}),
+          ...(unmanagedRestartPid !== undefined ? { previousOwnerPid: unmanagedRestartPid } : {}),
         });
         if (health.healthy) {
+          return undefined;
+        }
+        if (health.waitOutcome === "still-starting" && unmanagedRestartPid !== undefined) {
+          const stillStartingLine = formatGatewayStillStartingMessage({
+            elapsedMs: health.elapsedMs,
+            pid: unmanagedRestartPid,
+            fallbackTimeoutSeconds: unmanagedRestartWaitSeconds,
+          });
+          if (!jsonOutput) {
+            defaultRuntime.log(theme.info(stillStartingLine));
+          } else {
+            warnings.push(stillStartingLine);
+          }
           return undefined;
         }
 

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -58,10 +58,10 @@ import {
   resolveGatewayRestartIntentOptions,
 } from "./lifecycle-safe-restart.js";
 import { createDaemonActionContext, createNullWriter } from "./response.js";
+import { formatRestartFailure, resolveStillStartingMessage } from "./restart-health-diagnostics.js";
 import {
   DEFAULT_RESTART_HEALTH_ATTEMPTS,
   DEFAULT_RESTART_HEALTH_DELAY_MS,
-  type GatewayRestartSnapshot,
   renderGatewayPortHealthDiagnostics,
   renderRestartDiagnostics,
   terminateStaleGatewayPids,
@@ -80,54 +80,6 @@ function postRestartHealthAttempts(): number {
   return process.platform === "win32"
     ? Math.ceil(WINDOWS_POST_RESTART_HEALTH_TIMEOUT_MS / POST_RESTART_HEALTH_DELAY_MS)
     : POST_RESTART_HEALTH_ATTEMPTS;
-}
-
-function formatRestartFailure(params: {
-  health: GatewayRestartSnapshot;
-  port: number;
-  defaultTimeoutSeconds: number;
-}): { statusLine: string; failMessage: string } {
-  if (params.health.waitOutcome === "stopped-free") {
-    const elapsedSeconds = Math.max(1, Math.round((params.health.elapsedMs ?? 0) / 1000));
-    return {
-      statusLine: `Gateway restart failed after ${elapsedSeconds}s: service stayed stopped and port ${params.port} stayed free.`,
-      failMessage: `Gateway restart failed after ${elapsedSeconds}s: service stayed stopped and health checks never came up.`,
-    };
-  }
-
-  const timeoutSeconds = Math.max(
-    1,
-    Math.round(
-      params.health.elapsedMs === undefined
-        ? params.defaultTimeoutSeconds
-        : params.health.elapsedMs / 1000,
-    ),
-  );
-  return {
-    statusLine: `Timed out after ${timeoutSeconds}s waiting for gateway port ${params.port} to become healthy.`,
-    failMessage: `Gateway restart timed out after ${timeoutSeconds}s waiting for health checks.`,
-  };
-}
-
-/**
- * Renders the "still starting" note for in-process (SIGUSR1) gateway restarts:
- * the PID is unchanged and the process is alive while the port is still free,
- * so the restart is progressing rather than failed. Explicitly non-failure
- * language — failure here would push operators toward destructive recovery of
- * a healthy, booting process.
- */
-function formatGatewayStillStartingMessage(params: {
-  elapsedMs?: number;
-  pid: number;
-  fallbackTimeoutSeconds: number;
-}): string {
-  const elapsedSeconds = Math.max(
-    1,
-    Math.round(
-      params.elapsedMs === undefined ? params.fallbackTimeoutSeconds : params.elapsedMs / 1000,
-    ),
-  );
-  return `Gateway restart is still in progress after ${elapsedSeconds}s: process PID ${params.pid} is alive and booting (in-process restart keeps the PID). Poll readiness with "openclaw gateway status --deep".`;
 }
 
 async function resolveGatewayLifecycleContext(service = resolveGatewayService()): Promise<{
@@ -471,30 +423,13 @@ async function runExternalSupervisorRestart(opts: DaemonLifecycleOptions): Promi
     return false;
   }
 
-  if (health.waitOutcome === "still-starting") {
-    const stillStartingMessage = formatGatewayStillStartingMessage({
-      elapsedMs: health.elapsedMs,
-      pid: signaled.pid,
-      fallbackTimeoutSeconds: healthWait.timeoutSeconds,
-    });
-    emit({
-      ok: true,
-      result: signaled.result,
-      message: stillStartingMessage,
-    });
-    if (!json) {
-      defaultRuntime.log(theme.info(stillStartingMessage));
-    }
-    return true;
-  }
-
-  emit({
-    ok: true,
-    result: signaled.result,
-    message: signaled.message,
-  });
+  const message =
+    health.waitOutcome === "still-starting"
+      ? resolveStillStartingMessage(health, signaled.pid, healthWait.timeoutSeconds)
+      : signaled.message;
+  emit({ ok: true, result: signaled.result, message });
   if (!json) {
-    defaultRuntime.log(signaled.message);
+    defaultRuntime.log(theme.info(message));
   }
   return true;
 }
@@ -703,11 +638,11 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           return undefined;
         }
         if (health.waitOutcome === "still-starting" && unmanagedRestartPid !== undefined) {
-          const stillStartingLine = formatGatewayStillStartingMessage({
-            elapsedMs: health.elapsedMs,
-            pid: unmanagedRestartPid,
-            fallbackTimeoutSeconds: unmanagedRestartWaitSeconds,
-          });
+          const stillStartingLine = resolveStillStartingMessage(
+            health,
+            unmanagedRestartPid,
+            unmanagedRestartWaitSeconds,
+          );
           if (!jsonOutput) {
             defaultRuntime.log(theme.info(stillStartingLine));
           } else {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -643,10 +643,12 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
             unmanagedRestartPid,
             unmanagedRestartWaitSeconds,
           );
-          if (!jsonOutput) {
-            defaultRuntime.log(theme.info(stillStartingLine));
-          } else {
-            warnings.push(stillStartingLine);
+          if (stillStartingLine !== undefined) {
+            if (!jsonOutput) {
+              defaultRuntime.log(theme.info(stillStartingLine));
+            } else {
+              warnings.push(stillStartingLine);
+            }
           }
           return undefined;
         }

--- a/src/cli/daemon-cli/restart-health-diagnostics.ts
+++ b/src/cli/daemon-cli/restart-health-diagnostics.ts
@@ -54,3 +54,52 @@ export function renderRestartDiagnostics(snapshot: GatewayRestartSnapshot): stri
 export function renderGatewayPortHealthDiagnostics(snapshot: GatewayPortHealthSnapshot): string[] {
   return renderPortUsageDiagnostics(snapshot);
 }
+
+export function formatRestartFailure(params: {
+  health: GatewayRestartSnapshot;
+  port: number;
+  defaultTimeoutSeconds: number;
+}): { statusLine: string; failMessage: string } {
+  if (params.health.waitOutcome === "stopped-free") {
+    const elapsedSeconds = Math.max(1, Math.round((params.health.elapsedMs ?? 0) / 1000));
+    return {
+      statusLine: `Gateway restart failed after ${elapsedSeconds}s: service stayed stopped and port ${params.port} stayed free.`,
+      failMessage: `Gateway restart failed after ${elapsedSeconds}s: service stayed stopped and health checks never came up.`,
+    };
+  }
+
+  const timeoutSeconds = Math.max(
+    1,
+    Math.round(
+      params.health.elapsedMs === undefined
+        ? params.defaultTimeoutSeconds
+        : params.health.elapsedMs / 1000,
+    ),
+  );
+  return {
+    statusLine: `Timed out after ${timeoutSeconds}s waiting for gateway port ${params.port} to become healthy.`,
+    failMessage: `Gateway restart timed out after ${timeoutSeconds}s waiting for health checks.`,
+  };
+}
+
+/**
+ * Renders the "still starting" note for in-process (SIGUSR1) gateway restarts:
+ * the PID is unchanged and the process is alive while the port is still free,
+ * so the restart is progressing rather than failed. Explicitly non-failure
+ * language — failure here would push operators toward destructive recovery of
+ * a healthy, booting process.
+ */
+export function resolveStillStartingMessage(
+  health: GatewayPortHealthSnapshot,
+  pid: number | undefined,
+  fallbackTimeoutSeconds: number,
+): string | undefined {
+  if (health.waitOutcome !== "still-starting" || pid === undefined) {
+    return undefined;
+  }
+  const elapsedSeconds = Math.max(
+    1,
+    Math.round(health.elapsedMs === undefined ? fallbackTimeoutSeconds : health.elapsedMs / 1000),
+  );
+  return `Gateway restart is still in progress after ${elapsedSeconds}s: process PID ${pid} is alive and booting (in-process restart keeps the PID). Poll readiness with "openclaw gateway status --deep".`;
+}

--- a/src/cli/daemon-cli/restart-health-diagnostics.ts
+++ b/src/cli/daemon-cli/restart-health-diagnostics.ts
@@ -1,7 +1,9 @@
 import { formatPortDiagnostics } from "../../infra/ports.js";
 import type { GatewayPortHealthSnapshot, GatewayRestartSnapshot } from "./restart-health.types.js";
 
-function renderPortUsageDiagnostics(snapshot: GatewayPortHealthSnapshot): string[] {
+function renderPortUsageDiagnostics(
+  snapshot: Pick<GatewayPortHealthSnapshot, "portUsage">,
+): string[] {
   const lines: string[] = [];
   if (snapshot.portUsage.status === "busy") {
     lines.push(...formatPortDiagnostics(snapshot.portUsage));

--- a/src/cli/daemon-cli/restart-health-external.test.ts
+++ b/src/cli/daemon-cli/restart-health-external.test.ts
@@ -147,6 +147,54 @@ describe("restart health", () => {
     expect(snapshot.waitOutcome).toBe("timeout");
   });
 
+  it("reports timeout instead of still-starting when the boot lifecycle recorded startup_failed", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const { readLatestGatewayBootOutcome } = await import("./restart-health.test-helpers.js");
+    readLatestGatewayBootOutcome.mockReturnValue("startup_failed");
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      attempts: 1,
+      delayMs: 500,
+      previousOwnerPid: 4200,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.waitOutcome).toBe("timeout");
+    expect(killSpy).toHaveBeenCalledWith(4200, 0);
+    expect(readLatestGatewayBootOutcome).toHaveBeenCalled();
+  });
+
+  it("keeps still-starting when the boot lifecycle has no recorded failure", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    const { readLatestGatewayBootOutcome } = await import("./restart-health.test-helpers.js");
+    readLatestGatewayBootOutcome.mockReturnValue(null);
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      attempts: 1,
+      delayMs: 500,
+      previousOwnerPid: 4200,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.waitOutcome).toBe("still-starting");
+  });
+
   it("keeps the healthy outcome for a reachable listener", async () => {
     inspectPortUsage.mockResolvedValue({
       port: 18789,

--- a/src/cli/daemon-cli/restart-health-external.test.ts
+++ b/src/cli/daemon-cli/restart-health-external.test.ts
@@ -106,7 +106,7 @@ describe("restart health", () => {
       listeners: [],
       hints: [],
     });
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => undefined);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     const { waitForGatewayHealthyListener } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyListener({

--- a/src/cli/daemon-cli/restart-health-external.test.ts
+++ b/src/cli/daemon-cli/restart-health-external.test.ts
@@ -1,5 +1,5 @@
 // Externally supervised gateway restart polling tests.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   inspectPortUsage,
   mockGatewayLockReplacement,
@@ -97,5 +97,78 @@ describe("restart health", () => {
     expect(readActiveGatewayLockIdentity).toHaveBeenCalledTimes(2);
     expect(inspectPortUsage).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports still-starting when the restarted process is alive and the port is free", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => undefined);
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      attempts: 1,
+      delayMs: 500,
+      previousOwnerPid: 4200,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.waitOutcome).toBe("still-starting");
+    expect(snapshot.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(killSpy).toHaveBeenCalledWith(4200, 0);
+  });
+
+  it("reports timeout when the restarted process is no longer alive", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const error = new Error("ESRCH") as NodeJS.ErrnoException;
+      error.code = "ESRCH";
+      throw error;
+    });
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      attempts: 1,
+      delayMs: 500,
+      previousOwnerPid: 4200,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.waitOutcome).toBe("timeout");
+  });
+
+  it("keeps the healthy outcome for a reachable listener", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 4200, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: { version: "2026.7.16", connId: "gateway" },
+    });
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      attempts: 1,
+      delayMs: 500,
+      previousOwnerPid: 4200,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.waitOutcome).toBe("healthy");
   });
 });

--- a/src/cli/daemon-cli/restart-health-external.test.ts
+++ b/src/cli/daemon-cli/restart-health-external.test.ts
@@ -195,6 +195,34 @@ describe("restart health", () => {
     expect(snapshot.waitOutcome).toBe("still-starting");
   });
 
+  it("reports timeout when no boot lifecycle row exists instead of still-starting", async () => {
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const { readLatestGatewayBootOutcome } = await import("./restart-health.test-helpers.js");
+    // undefined = no boot row recorded or lifecycle storage unreadable:
+    // there is no evidence of an in-progress boot, so the gateway must not
+    // be reported as still starting.
+    readLatestGatewayBootOutcome.mockReturnValue(undefined);
+
+    const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyListener({
+      port: 18789,
+      attempts: 1,
+      delayMs: 500,
+      previousOwnerPid: 4200,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.waitOutcome).toBe("timeout");
+    expect(killSpy).toHaveBeenCalledWith(4200, 0);
+    expect(readLatestGatewayBootOutcome).toHaveBeenCalled();
+  });
+
   it("keeps the healthy outcome for a reachable listener", async () => {
     inspectPortUsage.mockResolvedValue({
       port: 18789,

--- a/src/cli/daemon-cli/restart-health-external.ts
+++ b/src/cli/daemon-cli/restart-health-external.ts
@@ -1,4 +1,5 @@
 import { performance } from "node:perf_hooks";
+import { readLatestGatewayBootOutcome } from "../../infra/gateway-boot-lifecycle.js";
 import type { GatewayLockIdentity } from "../../infra/gateway-lock.js";
 import { sleep } from "../../utils.js";
 import {
@@ -37,7 +38,12 @@ function withWaitOutcome(
   if (
     previousOwnerPid !== undefined &&
     snapshot.portUsage.status === "free" &&
-    isProcessAlive(previousOwnerPid)
+    isProcessAlive(previousOwnerPid) &&
+    // The boot lifecycle also records terminal failures: a restart loop that
+    // already recorded startup_failed keeps the process alive (so the port
+    // stays free) but is NOT still starting — report it as a timeout so
+    // operators see the failed restart instead of a false success.
+    readLatestGatewayBootOutcome() !== "startup_failed"
   ) {
     return { ...snapshot, waitOutcome: "still-starting", elapsedMs };
   }

--- a/src/cli/daemon-cli/restart-health-external.ts
+++ b/src/cli/daemon-cli/restart-health-external.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import type { GatewayLockIdentity } from "../../infra/gateway-lock.js";
 import { sleep } from "../../utils.js";
 import {
@@ -11,16 +12,56 @@ import {
 import type { GatewayPortHealthSnapshot } from "./restart-health.types.js";
 import { waitForGatewayLockReplacement } from "./restart-lock-replacement.js";
 
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function withWaitOutcome(
+  snapshot: GatewayPortHealthSnapshot,
+  startedAtMs: number,
+  previousOwnerPid?: number,
+): GatewayPortHealthSnapshot {
+  const elapsedMs = Math.max(0, performance.now() - startedAtMs);
+  if (snapshot.healthy) {
+    return { ...snapshot, waitOutcome: "healthy", elapsedMs };
+  }
+  // In-process (SIGUSR1) restarts keep the same PID, so an alive process with
+  // a free port means the gateway is still booting — not dead. Reporting that
+  // as failure language pushes operators toward destructive recovery of a
+  // healthy process, so surface it as a distinct "still starting" outcome.
+  if (
+    previousOwnerPid !== undefined &&
+    snapshot.portUsage.status === "free" &&
+    isProcessAlive(previousOwnerPid)
+  ) {
+    return { ...snapshot, waitOutcome: "still-starting", elapsedMs };
+  }
+  return { ...snapshot, waitOutcome: "timeout", elapsedMs };
+}
+
 export async function waitForGatewayHealthyListener(params: {
   port: number;
   attempts?: number;
   delayMs?: number;
   previousLockIdentity?: GatewayLockIdentity;
   waitIndefinitelyForPreviousOwner?: boolean;
+  /**
+   * PID of the gateway process that received the restart signal. In-process
+   * (SIGUSR1) restarts keep the same PID; combined with a free port, an alive
+   * PID means the gateway is still booting rather than dead.
+   */
+  previousOwnerPid?: number;
 }): Promise<GatewayPortHealthSnapshot> {
+  const startedAtMs = performance.now();
   const attempts = params.attempts ?? DEFAULT_RESTART_HEALTH_ATTEMPTS;
   const delayMs = params.delayMs ?? DEFAULT_RESTART_HEALTH_DELAY_MS;
   const previousLockIdentity = params.previousLockIdentity;
+  const previousOwnerPid = params.previousOwnerPid;
 
   const probeAuth = await resolveGatewayRestartProbeAuth(undefined).catch(() => undefined);
   let snapshot: GatewayPortHealthSnapshot = previousLockIdentity
@@ -51,7 +92,7 @@ export async function waitForGatewayHealthyListener(params: {
       waitIndefinitelyForPreviousOwner: params.waitIndefinitelyForPreviousOwner === true,
     });
     if (replacement.status === "timeout") {
-      return snapshot;
+      return withWaitOutcome(snapshot, startedAtMs, previousOwnerPid);
     }
     attempt = replacement.attemptsUsed;
     expectedListenerPid = replacement.lockIdentity.pid;
@@ -63,7 +104,7 @@ export async function waitForGatewayHealthyListener(params: {
   }
 
   if (snapshot.healthy) {
-    return snapshot;
+    return withWaitOutcome(snapshot, startedAtMs, previousOwnerPid);
   }
   while (attempt < attempts) {
     attempt += 1;
@@ -74,9 +115,9 @@ export async function waitForGatewayHealthyListener(params: {
       expectedListenerPid,
     });
     if (snapshot.healthy) {
-      return snapshot;
+      return withWaitOutcome(snapshot, startedAtMs, previousOwnerPid);
     }
   }
 
-  return snapshot;
+  return withWaitOutcome(snapshot, startedAtMs, previousOwnerPid);
 }

--- a/src/cli/daemon-cli/restart-health-external.ts
+++ b/src/cli/daemon-cli/restart-health-external.ts
@@ -39,11 +39,13 @@ function withWaitOutcome(
     previousOwnerPid !== undefined &&
     snapshot.portUsage.status === "free" &&
     isProcessAlive(previousOwnerPid) &&
-    // The boot lifecycle also records terminal failures: a restart loop that
-    // already recorded startup_failed keeps the process alive (so the port
-    // stays free) but is NOT still starting — report it as a timeout so
-    // operators see the failed restart instead of a false success.
-    readLatestGatewayBootOutcome() !== "startup_failed"
+    // Only claim still-starting on positive evidence: the boot lifecycle
+    // recorded an in-progress (open) boot row. A recorded terminal failure
+    // (startup_failed) means the restart already failed, and an unreadable
+    // or empty lifecycle (undefined) means there is no evidence the gateway
+    // is still starting — report those as a timeout so operators see the
+    // unavailable gateway instead of a false success.
+    readLatestGatewayBootOutcome() === null
   ) {
     return { ...snapshot, waitOutcome: "still-starting", elapsedMs };
   }

--- a/src/cli/daemon-cli/restart-health.test-helpers.ts
+++ b/src/cli/daemon-cli/restart-health.test-helpers.ts
@@ -25,6 +25,9 @@ export const readActiveGatewayLockIdentity = vi.fn();
 export const resolveGatewayServiceProbeHosts = vi.fn<
   (_params?: unknown) => Promise<readonly string[]>
 >(async () => ["127.0.0.1"]);
+export const readLatestGatewayBootOutcome = vi.fn<
+  (_env?: NodeJS.ProcessEnv) => string | null | undefined
+>(() => null);
 
 vi.mock("../../infra/ports.js", () => ({
   classifyPortListener: (listener: unknown, port: number) => classifyPortListener(listener, port),
@@ -63,6 +66,10 @@ vi.mock("../../infra/gateway-lock.js", () => ({
       : previous.pid === current.pid &&
         previous.createdAt === current.createdAt &&
         previous.startTime === current.startTime,
+}));
+
+vi.mock("../../infra/gateway-boot-lifecycle.js", () => ({
+  readLatestGatewayBootOutcome: (env?: NodeJS.ProcessEnv) => readLatestGatewayBootOutcome(env),
 }));
 
 vi.mock("../../daemon/gateway-service-probe-hosts.js", () => ({
@@ -225,6 +232,8 @@ export function resetRestartHealthMocks() {
   hasActiveStartupMigrationLease.mockReturnValue(false);
   readActiveGatewayLockIdentity.mockReset();
   readActiveGatewayLockIdentity.mockResolvedValue(undefined);
+  readLatestGatewayBootOutcome.mockReset();
+  readLatestGatewayBootOutcome.mockReturnValue(null);
   resolveGatewayServiceProbeHosts.mockReset();
   resolveGatewayServiceProbeHosts.mockResolvedValue(["127.0.0.1"]);
 }

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -33,6 +33,7 @@ export {
 export { waitForGatewayHealthyListener } from "./restart-health-external.js";
 export type {
   GatewayPortHealthSnapshot,
+  GatewayPortHealthWaitOutcome,
   GatewayRestartSnapshot,
   GatewayRestartWaitOutcome,
 } from "./restart-health.types.js";

--- a/src/cli/daemon-cli/restart-health.types.ts
+++ b/src/cli/daemon-cli/restart-health.types.ts
@@ -28,7 +28,11 @@ export type GatewayRestartSnapshot = {
   elapsedMs?: number;
 };
 
+export type GatewayPortHealthWaitOutcome = "healthy" | "timeout" | "still-starting";
+
 export type GatewayPortHealthSnapshot = {
   portUsage: PortUsage;
   healthy: boolean;
+  waitOutcome?: GatewayPortHealthWaitOutcome;
+  elapsedMs?: number;
 };

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -274,6 +274,39 @@ export function completeGatewayBootLifecycle(
   }
 }
 
+/**
+ * Reads the most recently recorded boot lifecycle outcome for the current
+ * state directory. Returns `null` when the newest boot row is still open
+ * (in progress), the outcome string otherwise, and `undefined` when the
+ * lifecycle table cannot be read (fail-open — callers keep their default
+ * behavior when lifecycle state is unavailable).
+ */
+export function readLatestGatewayBootOutcome(
+  env: NodeJS.ProcessEnv = process.env,
+): GatewayBootLifecycleOutcome | null | undefined {
+  try {
+    const { db } = openOpenClawStateDatabase({ env });
+    const kysely = getNodeSqliteKysely<GatewayBootLifecycleDatabase>(db);
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("gateway_boot_lifecycle")
+        .select("outcome")
+        .orderBy("started_at_ms", "desc")
+        .limit(1),
+    );
+    const outcome = row?.outcome;
+    return outcome === null || outcome === undefined
+      ? null
+      : (outcome as GatewayBootLifecycleOutcome);
+  } catch (err) {
+    gatewayLifecycleLog.warn(
+      `failed to read latest gateway boot outcome; fail-open: ${String(err)}`,
+    );
+    return undefined;
+  }
+}
+
 export function repairGatewayAgentMediaMigrationStartupFailures(params: {
   databasePaths: readonly string[];
   env?: NodeJS.ProcessEnv;

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -276,10 +276,12 @@ export function completeGatewayBootLifecycle(
 
 /**
  * Reads the most recently recorded boot lifecycle outcome for the current
- * state directory. Returns `null` when the newest boot row is still open
- * (in progress), the outcome string otherwise, and `undefined` when the
- * lifecycle table cannot be read (fail-open — callers keep their default
- * behavior when lifecycle state is unavailable).
+ * state directory. Returns `null` only when the newest boot row is still open
+ * (in progress — a positive still-starting signal), the outcome string
+ * otherwise, and `undefined` when no boot row has been recorded or the
+ * lifecycle table cannot be read. Callers must treat only `null` as
+ * still-starting: `undefined` means there is no evidence of an in-progress
+ * boot, so the gateway must not be reported as still starting.
  */
 export function readLatestGatewayBootOutcome(
   env: NodeJS.ProcessEnv = process.env,
@@ -295,13 +297,17 @@ export function readLatestGatewayBootOutcome(
         .orderBy("started_at_ms", "desc")
         .limit(1),
     );
-    const outcome = row?.outcome;
+    if (!row) {
+      // No boot has been recorded for this state dir: not in progress.
+      return undefined;
+    }
+    const outcome = row.outcome;
     return outcome === null || outcome === undefined
       ? null
       : (outcome as GatewayBootLifecycleOutcome);
   } catch (err) {
     gatewayLifecycleLog.warn(
-      `failed to read latest gateway boot outcome; fail-open: ${String(err)}`,
+      `failed to read latest gateway boot outcome; fail-closed for still-starting: ${String(err)}`,
     );
     return undefined;
   }


### PR DESCRIPTION
Fixes #119958

## What Problem This Solves

`openclaw gateway restart` (and the externally-supervised restart path) waits a fixed 60 s for the gateway port to become healthy, then reports failure. On a gateway whose startup legitimately takes 240 s+ (heavy plugin loads, shared host), this declares a *successful* in-process (SIGUSR1) restart to be a failed one. The PID does not change during an in-process restart, so the natural next step — destructive recovery (`docker restart`, SIGKILL, rollback) — gets applied to a healthy process mid-boot.

## Why

The unmanaged restart path (`waitForGatewayHealthyListener`) polls only port health. A free port during boot is indistinguishable from a dead process, so the loop exhausts its 120×500 ms budget and the caller emits unambiguous failure language ("Timed out … failed") plus "Gateway port status: free" — which, together, actively mislead the operator. The managed path has the same shape through `waitOutcome: "timeout"`.

## User Impact

- A slow but healthy restart now exits 0 with an explicit note: `Gateway restart is still in progress after Ns: process PID <pid> is alive and booting (in-process restart keeps the PID). Poll readiness with "openclaw gateway status --deep".` Failure language is reserved for an actually dead or non-progressing process.
- The PID note also kills the "did it even restart?" confusion: the same-PID observation is now explained instead of looking like the restart never happened.
- The signal is exact: `still-starting` requires the previously-signaled gateway PID to be **alive** *and* the port to be **free** *and* no `startup_failed` recorded in the boot lifecycle. Any other timeout shape (dead PID, busy-but-unreachable port, stale listeners, recorded startup failure) still reports failure with the existing diagnostics — a restart loop that already recorded `startup_failed` keeps the process alive but is a failed restart, not a starting one.

## Evidence

### Boundary repair (ClawSweeper P1: require recorded boot progress before reporting still-starting)

The `still-starting` classification now consults the boot lifecycle's latest recorded outcome (`readLatestGatewayBootOutcome` in `src/infra/gateway-boot-lifecycle.ts`, newest `gateway_boot_lifecycle` row by `started_at_ms`). When the run loop already recorded `startup_failed` — which happens after it releases the lock and deliberately keeps the process alive (`src/cli/gateway-cli/run-loop.ts:1076-1111`) — the live-PID/free-port shape is no longer reported as a successful restart; it falls through to `timeout` so operators and automation see the failed restart. Read failures fail open to the previous behavior (still-starting preserved).

### Local runs (Node v24.15.0)

```text
$ ./node_modules/.bin/vitest run src/cli/daemon-cli/restart-health-external.test.ts
✓ does not accept listener health until the gateway lock owner changes
✓ reports still-starting when the restarted process is alive and the port is free
✓ reports timeout instead of still-starting when the boot lifecycle recorded startup_failed
✓ keeps still-starting when the boot lifecycle has no recorded failure
Test Files  1 passed (1)
     Tests  9 passed (9)

$ ./node_modules/.bin/vitest run src/cli/daemon-cli/lifecycle.external-supervision.test.ts src/infra/gateway-boot-lifecycle.test.ts
Test Files  2 passed (2)
     Tests  21 passed (21)
```

New regression tests prove both sides:

```text
reports timeout instead of still-starting when the boot lifecycle recorded startup_failed
  → readLatestGatewayBootOutcome() = "startup_failed", alive PID, free port
  → waitOutcome: "timeout"

keeps still-starting when the boot lifecycle has no recorded failure
  → readLatestGatewayBootOutcome() = null, alive PID, free port
  → waitOutcome: "still-starting"
```

### Code shape (production)

- `src/infra/gateway-boot-lifecycle.ts`: added `readLatestGatewayBootOutcome(env)` — newest lifecycle row's outcome, `null` when the newest boot is still open, `undefined` fail-open on read error.
- `src/cli/daemon-cli/restart-health-external.ts`: `withWaitOutcome` now requires `readLatestGatewayBootOutcome() !== "startup_failed"` before classifying free-port + alive-PID as `still-starting`.
- `src/cli/daemon-cli/restart-health.test-helpers.ts`: mockable `readLatestGatewayBootOutcome` for the health suites.
- Both `waitForGatewayHealthyListener` call sites pass `previousOwnerPid` (the PID that received SIGUSR1 — unchanged across in-process restarts) and treat `waitOutcome === "still-starting"` as success-with-note instead of failure.

[AI-assisted]
