### PR TITLE
refactor(test): table-drive duplicated test blocks in worst-offender files

### DIFF
--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -281,60 +281,57 @@ describe("markdownToMatrixHtml", () => {
     );
   });
 
-  it("renders qualified Matrix user mentions as matrix.to links and m.mentions metadata", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+  it.each([
+    {
+      name: "renders qualified Matrix user mentions as matrix.to links and m.mentions metadata",
       markdown: "hello @alice:example.org",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe(
-      '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a></p>',
-    );
-    expect(result.mentions).toEqual({
-      user_ids: ["@alice:example.org"],
-    });
-  });
-
-  it("url-encodes matrix.to hrefs for valid mxids with path characters", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a></p>',
+      userId: "@alice:example.org",
+    },
+    {
+      name: "url-encodes matrix.to hrefs for valid mxids with path characters",
       markdown: "hello @foo/bar:example.org",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe(
-      '<p>hello <a href="https://matrix.to/#/%40foo%2Fbar%3Aexample.org">@foo/bar:example.org</a></p>',
-    );
-    expect(result.mentions).toEqual({
-      user_ids: ["@foo/bar:example.org"],
-    });
-  });
-
-  it("treats mxids that begin with room as user mentions", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: '<p>hello <a href="https://matrix.to/#/%40foo%2Fbar%3Aexample.org">@foo/bar:example.org</a></p>',
+      userId: "@foo/bar:example.org",
+    },
+    {
+      name: "treats mxids that begin with room as user mentions",
       markdown: "hello @room:example.org",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe(
-      '<p>hello <a href="https://matrix.to/#/%40room%3Aexample.org">@room:example.org</a></p>',
-    );
-    expect(result.mentions).toEqual({
-      user_ids: ["@room:example.org"],
-    });
-  });
-
-  it("treats hyphenated room-prefixed mxids as user mentions", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: '<p>hello <a href="https://matrix.to/#/%40room%3Aexample.org">@room:example.org</a></p>',
+      userId: "@room:example.org",
+    },
+    {
+      name: "treats hyphenated room-prefixed mxids as user mentions",
       markdown: "hello @room-admin:example.org",
+      html: '<p>hello <a href="https://matrix.to/#/%40room-admin%3Aexample.org">@room-admin:example.org</a></p>',
+      userId: "@room-admin:example.org",
+    },
+    {
+      name: "trims punctuation before storing mentioned user ids",
+      markdown: "hello @alice:example.org.",
+      html: '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a>.</p>',
+      userId: "@alice:example.org",
+    },
+    {
+      name: "accepts bracketed homeservers in matrix mentions",
+      markdown: "hello @alice:[2001:db8::1]",
+      html: '<p>hello <a href="https://matrix.to/#/%40alice%3A%5B2001%3Adb8%3A%3A1%5D">@alice:[2001:db8::1]</a></p>',
+      userId: "@alice:[2001:db8::1]",
+    },
+    {
+      name: "accepts bracketed homeservers with ports in matrix mentions",
+      markdown: "hello @alice:[2001:db8::1]:8448.",
+      html: '<p>hello <a href="https://matrix.to/#/%40alice%3A%5B2001%3Adb8%3A%3A1%5D%3A8448">@alice:[2001:db8::1]:8448</a>.</p>',
+      userId: "@alice:[2001:db8::1]:8448",
+    },
+  ])("$name", async ({ markdown, html, userId }) => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown,
       client: createMentionClient(),
     });
 
-    expect(result.html).toBe(
-      '<p>hello <a href="https://matrix.to/#/%40room-admin%3Aexample.org">@room-admin:example.org</a></p>',
-    );
-    expect(result.mentions).toEqual({
-      user_ids: ["@room-admin:example.org"],
-    });
+    expect(result.html).toBe(html);
+    expect(result.mentions).toEqual({ user_ids: [userId] });
   });
 
   it("keeps explicit room mentions as room mentions", async () => {
@@ -373,157 +370,69 @@ describe("markdownToMatrixHtml", () => {
     });
   });
 
-  it("trims punctuation before storing mentioned user ids", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
-      markdown: "hello @alice:example.org.",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe(
-      '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a>.</p>',
-    );
-    expect(result.mentions).toEqual({
-      user_ids: ["@alice:example.org"],
-    });
-  });
-
-  it("does not emit mentions for mxid-like tokens with path suffixes", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+  it.each([
+    {
+      name: "does not emit mentions for mxid-like tokens with path suffixes",
       markdown: "hello @alice:example.org/path",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<p>hello @alice:example.org/path</p>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("does not emit mentions for filename-embedded mxids with trailing hyphens", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p>hello @alice:example.org/path</p>",
+    },
+    {
+      name: "does not emit mentions for filename-embedded mxids with trailing hyphens",
       markdown: "read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe(
-      "<p>read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt</p>",
-    );
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("accepts bracketed homeservers in matrix mentions", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
-      markdown: "hello @alice:[2001:db8::1]",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe(
-      '<p>hello <a href="https://matrix.to/#/%40alice%3A%5B2001%3Adb8%3A%3A1%5D">@alice:[2001:db8::1]</a></p>',
-    );
-    expect(result.mentions).toEqual({
-      user_ids: ["@alice:[2001:db8::1]"],
-    });
-  });
-
-  it("accepts bracketed homeservers with ports in matrix mentions", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
-      markdown: "hello @alice:[2001:db8::1]:8448.",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe(
-      '<p>hello <a href="https://matrix.to/#/%40alice%3A%5B2001%3Adb8%3A%3A1%5D%3A8448">@alice:[2001:db8::1]:8448</a>.</p>',
-    );
-    expect(result.mentions).toEqual({
-      user_ids: ["@alice:[2001:db8::1]:8448"],
-    });
-  });
-
-  it("leaves bare localpart text unmentioned", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p>read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt</p>",
+    },
+    {
+      name: "leaves bare localpart text unmentioned",
       markdown: "hello @alice",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<p>hello @alice</p>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("does not convert escaped qualified mentions", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p>hello @alice</p>",
+    },
+    {
+      name: "does not convert escaped qualified mentions",
       markdown: "\\@alice:example.org",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<p>@alice:example.org</p>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("does not convert escaped room mentions", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p>@alice:example.org</p>",
+    },
+    {
+      name: "does not convert escaped room mentions",
       markdown: "\\@room",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<p>@room</p>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("keeps escaped mentions literal after escaped backticks", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p>@room</p>",
+    },
+    {
+      name: "keeps escaped mentions literal after escaped backticks",
       markdown: "\\`literal then \\@alice:example.org",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<p>`literal then @alice:example.org</p>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("restores escaped mentions in markdown link labels without linking them", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p>`literal then @alice:example.org</p>",
+    },
+    {
+      name: "restores escaped mentions in markdown link labels without linking them",
       markdown: "[\\@alice:example.org](https://example.com)",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe('<p><a href="https://example.com">@alice:example.org</a></p>');
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("keeps backslashes inside code spans", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: '<p><a href="https://example.com">@alice:example.org</a></p>',
+    },
+    {
+      name: "keeps backslashes inside code spans",
       markdown: "`\\@alice:example.org`",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<p><code>\\@alice:example.org</code></p>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("does not convert mentions inside code spans", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p><code>\\@alice:example.org</code></p>",
+    },
+    {
+      name: "does not convert mentions inside code spans",
       markdown: "`@alice:example.org`",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<p><code>@alice:example.org</code></p>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("keeps backslashes inside tilde fenced code blocks", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<p><code>@alice:example.org</code></p>",
+    },
+    {
+      name: "keeps backslashes inside tilde fenced code blocks",
       markdown: "~~~\n\\@alice:example.org\n~~~",
-      client: createMentionClient(),
-    });
-
-    expect(result.html).toBe("<pre><code>\\@alice:example.org\n</code></pre>");
-    expect(result.mentions).toStrictEqual({});
-  });
-
-  it("keeps backslashes inside indented code blocks", async () => {
-    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      html: "<pre><code>\\@alice:example.org\n</code></pre>",
+    },
+    {
+      name: "keeps backslashes inside indented code blocks",
       markdown: "    \\@alice:example.org",
+      html: "<pre><code>\\@alice:example.org\n</code></pre>",
+    },
+  ])("$name", async ({ markdown, html }) => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown,
       client: createMentionClient(),
     });
 
-    expect(result.html).toBe("<pre><code>\\@alice:example.org\n</code></pre>");
+    expect(result.html).toBe(html);
     expect(result.mentions).toStrictEqual({});
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -1226,9 +1226,57 @@ describe("wrapStreamFnTrimToolCallNames", () => {
     expect(finalToolCall.name).toBe("read");
   });
 
-  it("recovers malformed non-blank names when id is missing", async () => {
-    const finalToolCall = { type: "toolCall", name: "functionsread3" };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
+  it.each([
+    {
+      name: "recovers malformed non-blank names when id is missing",
+      toolCall: { type: "toolCall", name: "functionsread3" },
+      allowedTools: ["read", "write"],
+      expectedName: "read",
+    },
+    {
+      name: "recovers canonical tool names from canonical ids when name is empty",
+      toolCall: { type: "toolCall", id: "read", name: "" },
+      allowedTools: ["read", "write"],
+      expectedName: "read",
+    },
+    {
+      name: "recovers tool names from ids when name is whitespace-only",
+      toolCall: { type: "toolCall", id: "functionswrite4", name: "   " },
+      allowedTools: ["read", "write"],
+      expectedName: "write",
+    },
+    {
+      name: "prefers explicit trimmed canonical names over conflicting malformed ids",
+      toolCall: { type: "toolCall", id: "functionswrite4", name: " read " },
+      allowedTools: ["read", "write"],
+      expectedName: "read",
+    },
+    {
+      name: "does not rewrite composite names that mention multiple tools",
+      toolCall: { type: "toolCall", id: "functionsread3", name: "read write" },
+      allowedTools: ["read", "write"],
+      expectedName: "read write",
+    },
+    {
+      name: "fails closed for malformed non-blank names that are ambiguous",
+      toolCall: { type: "toolCall", id: "functions.exec2", name: "functions.exec2" },
+      allowedTools: ["exec", "exec2"],
+      expectedName: "functions.exec2",
+    },
+    {
+      name: "matches malformed ids case-insensitively across common separators",
+      toolCall: { type: "toolCall", id: "Functions.Read_7", name: "" },
+      allowedTools: ["read", "write"],
+      expectedName: "read",
+    },
+    {
+      name: "does not override explicit non-blank tool names with inferred ids",
+      toolCall: { type: "toolCall", id: "functionswrite4", name: "someOtherTool" },
+      allowedTools: ["read", "write"],
+      expectedName: "someOtherTool",
+    },
+  ])("$name", async ({ toolCall, allowedTools, expectedName }) => {
+    const finalMessage = { role: "assistant", content: [toolCall] };
     const baseFn = vi.fn(() =>
       createFakeStream({
         events: [],
@@ -1236,42 +1284,10 @@ describe("wrapStreamFnTrimToolCallNames", () => {
       }),
     );
 
-    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
+    const stream = await invokeWrappedStream(baseFn, new Set(allowedTools));
     await stream.result();
 
-    expect(finalToolCall.name).toBe("read");
-  });
-
-  it("recovers canonical tool names from canonical ids when name is empty", async () => {
-    const finalToolCall = { type: "toolCall", id: "read", name: "" };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
-    const baseFn = vi.fn(() =>
-      createFakeStream({
-        events: [],
-        resultMessage: finalMessage,
-      }),
-    );
-
-    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
-    await stream.result();
-
-    expect(finalToolCall.name).toBe("read");
-  });
-
-  it("recovers tool names from ids when name is whitespace-only", async () => {
-    const finalToolCall = { type: "toolCall", id: "functionswrite4", name: "   " };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
-    const baseFn = vi.fn(() =>
-      createFakeStream({
-        events: [],
-        resultMessage: finalMessage,
-      }),
-    );
-
-    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
-    await stream.result();
-
-    expect(finalToolCall.name).toBe("write");
+    expect(toolCall.name).toBe(expectedName);
   });
 
   it("stops final blank tool names before dispatch and still assigns fallback ids", async () => {
@@ -1352,85 +1368,6 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 
     expect(finalToolCall.name).toBe("read");
     expect(finalToolCall.id).toBe("write");
-  });
-
-  it("prefers explicit trimmed canonical names over conflicting malformed ids", async () => {
-    const finalToolCall = { type: "toolCall", id: "functionswrite4", name: " read " };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
-    const baseFn = vi.fn(() =>
-      createFakeStream({
-        events: [],
-        resultMessage: finalMessage,
-      }),
-    );
-
-    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
-    await stream.result();
-
-    expect(finalToolCall.name).toBe("read");
-  });
-
-  it("does not rewrite composite names that mention multiple tools", async () => {
-    const finalToolCall = { type: "toolCall", id: "functionsread3", name: "read write" };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
-    const baseFn = vi.fn(() =>
-      createFakeStream({
-        events: [],
-        resultMessage: finalMessage,
-      }),
-    );
-
-    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
-    await stream.result();
-
-    expect(finalToolCall.name).toBe("read write");
-  });
-
-  it("fails closed for malformed non-blank names that are ambiguous", async () => {
-    const finalToolCall = { type: "toolCall", id: "functions.exec2", name: "functions.exec2" };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
-    const baseFn = vi.fn(() =>
-      createFakeStream({
-        events: [],
-        resultMessage: finalMessage,
-      }),
-    );
-
-    const stream = await invokeWrappedStream(baseFn, new Set(["exec", "exec2"]));
-    await stream.result();
-
-    expect(finalToolCall.name).toBe("functions.exec2");
-  });
-
-  it("matches malformed ids case-insensitively across common separators", async () => {
-    const finalToolCall = { type: "toolCall", id: "Functions.Read_7", name: "" };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
-    const baseFn = vi.fn(() =>
-      createFakeStream({
-        events: [],
-        resultMessage: finalMessage,
-      }),
-    );
-
-    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
-    await stream.result();
-
-    expect(finalToolCall.name).toBe("read");
-  });
-  it("does not override explicit non-blank tool names with inferred ids", async () => {
-    const finalToolCall = { type: "toolCall", id: "functionswrite4", name: "someOtherTool" };
-    const finalMessage = { role: "assistant", content: [finalToolCall] };
-    const baseFn = vi.fn(() =>
-      createFakeStream({
-        events: [],
-        resultMessage: finalMessage,
-      }),
-    );
-
-    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write"]));
-    await stream.result();
-
-    expect(finalToolCall.name).toBe("someOtherTool");
   });
 
   it("fails closed when malformed ids could map to multiple allowlisted tools", async () => {

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -1090,112 +1090,67 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
-  it("strips literal synthetic run prefixes without stripping semantic run summaries", () => {
-    const genericPayloads = buildPayloads({
+  it.each([
+    {
+      name: "strips a literal synthetic run prefix",
+      meta: "run make build",
+      error: "Command failed with exit code 2",
+      expected: "⚠️ 🛠️ Exec failed: `make build` (exit 2)",
+    },
+    {
+      name: "preserves a semantic test summary",
+      meta: "run tests",
+      error: "Command failed with exit code 1",
+      expected: "⚠️ 🛠️ Exec failed: `run tests` (exit 1)",
+    },
+    {
+      name: "preserves a semantic deploy summary",
+      meta: "run deploy",
+      error: "Command failed with exit code 1",
+      expected: "⚠️ 🛠️ Exec failed: `run deploy` (exit 1)",
+    },
+    {
+      name: "preserves a compound summary",
+      meta: "run tests → install dependencies",
+      error: "Command failed with exit code 1",
+      expected: "⚠️ 🛠️ Exec failed: `run tests → install dependencies` (exit 1)",
+    },
+    {
+      name: "preserves an inline-script summary",
+      meta: "run node inline script",
+      error: "Command failed with exit code 1",
+      expected: "⚠️ 🛠️ Exec failed: `run node inline script` (exit 1)",
+    },
+    {
+      name: "preserves a heredoc summary",
+      meta: "run python3 inline script (heredoc)",
+      error: "Command failed with exit code 1",
+      expected: "⚠️ 🛠️ Exec failed: `run python3 inline script (heredoc)` (exit 1)",
+    },
+    {
+      name: "preserves a sed summary",
+      meta: "run sed on file",
+      error: "Command failed with exit code 1",
+      expected: "⚠️ 🛠️ Exec failed: `run sed on file` (exit 1)",
+    },
+    {
+      name: "preserves a pipeline summary",
+      meta: "run tests -> show first 3 lines",
+      error: "Command failed with exit code 1",
+      expected: "⚠️ 🛠️ Exec failed: `run tests -> show first 3 lines` (exit 1)",
+    },
+  ])("formats exec metadata: $name", ({ meta, error, expected }) => {
+    const payloads = buildPayloads({
       lastToolError: {
         toolName: "exec",
-        meta: "run make build",
-        error: "Command failed with exit code 2",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-    const semanticPayloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run tests",
-        error: "Command failed with exit code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-    const scriptPayloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run deploy",
-        error: "Command failed with exit code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-    const compoundPayloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run tests → install dependencies",
-        error: "Command failed with exit code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-    const inlineScriptPayloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run node inline script",
-        error: "Command failed with exit code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-    const heredocPayloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run python3 inline script (heredoc)",
-        error: "Command failed with exit code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-    const sedSummaryPayloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run sed on file",
-        error: "Command failed with exit code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-    const pipelineSummaryPayloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run tests -> show first 3 lines",
-        error: "Command failed with exit code 1",
+        meta,
+        error,
         mutatingAction: true,
       },
       toolResultFormat: "markdown",
     });
 
-    expectSinglePayloadSummary(genericPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `make build` (exit 2)",
-      isError: true,
-    });
-    expectSinglePayloadSummary(semanticPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `run tests` (exit 1)",
-      isError: true,
-    });
-    expectSinglePayloadSummary(scriptPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `run deploy` (exit 1)",
-      isError: true,
-    });
-    expectSinglePayloadSummary(compoundPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `run tests → install dependencies` (exit 1)",
-      isError: true,
-    });
-    expectSinglePayloadSummary(inlineScriptPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `run node inline script` (exit 1)",
-      isError: true,
-    });
-    expectSinglePayloadSummary(heredocPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `run python3 inline script (heredoc)` (exit 1)",
-      isError: true,
-    });
-    expectSinglePayloadSummary(sedSummaryPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `run sed on file` (exit 1)",
-      isError: true,
-    });
-    expectSinglePayloadSummary(pipelineSummaryPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `run tests -> show first 3 lines` (exit 1)",
-      isError: true,
-    });
+    expectSinglePayloadSummary(payloads, { text: expected, isError: true });
   });
 
   it("keeps arbitrary exec cwd suffixes inside markdown command text", () => {

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -25,16 +25,71 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(false);
   });
 
-  it("returns true for ACP slash commands", () => {
+  it.each([
+    {
+      name: "ACP slash commands",
+      provider: "discord",
+      command: "/acp cancel",
+      expected: true,
+    },
+    {
+      name: "ACP slash commands addressed to another bot",
+      provider: "discord",
+      command: "/acp@otherbot cancel",
+      expected: false,
+    },
+    {
+      name: "local status commands",
+      provider: "discord",
+      command: "/status",
+      expected: true,
+    },
+    {
+      name: "local status plugin commands",
+      provider: "discord",
+      command: "/STATUS plugins",
+      expected: true,
+    },
+    {
+      name: "registry-backed local help commands",
+      provider: "whatsapp",
+      command: "/help",
+      expected: true,
+    },
+    {
+      name: "local unfocus commands",
+      provider: "discord",
+      command: "/unfocus",
+      expected: true,
+    },
+    {
+      name: "local verbose commands",
+      provider: "discord",
+      command: "/verbose on",
+      expected: true,
+    },
+    {
+      name: "local verbose alias commands",
+      provider: "discord",
+      command: "/v off",
+      expected: true,
+    },
+    {
+      name: "bare ACP reset slash commands",
+      provider: "discord",
+      command: "/reset",
+      expected: true,
+    },
+  ])("returns $expected for $name", ({ provider, command, expected }) => {
     const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/acp cancel",
-      BodyForCommands: "/acp cancel",
-      BodyForAgent: "/acp cancel",
+      Provider: provider,
+      Surface: provider,
+      CommandBody: command,
+      BodyForCommands: command,
+      BodyForAgent: command,
     });
 
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(expected);
   });
 
   it("returns true for native ACP slash commands", () => {
@@ -50,54 +105,6 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
-  it("returns false for ACP slash commands addressed to another bot", () => {
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/acp@otherbot cancel",
-      BodyForCommands: "/acp@otherbot cancel",
-      BodyForAgent: "/acp@otherbot cancel",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(false);
-  });
-
-  it("returns true for local status commands", () => {
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/status",
-      BodyForCommands: "/status",
-      BodyForAgent: "/status",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
-  });
-
-  it("returns true for local status plugin commands", () => {
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/STATUS plugins",
-      BodyForCommands: "/STATUS plugins",
-      BodyForAgent: "/STATUS plugins",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
-  });
-
-  it("returns true for registry-backed local help commands", () => {
-    const ctx = buildTestCtx({
-      Provider: "whatsapp",
-      Surface: "whatsapp",
-      CommandBody: "/help",
-      BodyForCommands: "/help",
-      BodyForAgent: "/help",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
-  });
-
   it("prefers clean command text over channel envelopes", () => {
     const ctx = buildTestCtx({
       Provider: "whatsapp",
@@ -105,42 +112,6 @@ describe("shouldBypassAcpDispatchForCommand", () => {
       CommandBody: "[WhatsApp +15551234567 +1m Fri 2026-05-08 16:12 UTC] /status",
       BodyForCommands: "/status",
       BodyForAgent: "/status",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
-  });
-
-  it("returns true for local unfocus commands", () => {
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/unfocus",
-      BodyForCommands: "/unfocus",
-      BodyForAgent: "/unfocus",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
-  });
-
-  it("returns true for local verbose commands", () => {
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/verbose on",
-      BodyForCommands: "/verbose on",
-      BodyForAgent: "/verbose on",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
-  });
-
-  it("returns true for local verbose alias commands", () => {
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/v off",
-      BodyForCommands: "/v off",
-      BodyForAgent: "/v off",
     });
 
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
@@ -169,18 +140,6 @@ describe("shouldBypassAcpDispatchForCommand", () => {
       CommandBody: "/new continue with deployment",
       BodyForCommands: "/new continue with deployment",
       BodyForAgent: "/new continue with deployment",
-    });
-
-    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
-  });
-
-  it("returns true for bare ACP reset slash commands", () => {
-    const ctx = buildTestCtx({
-      Provider: "discord",
-      Surface: "discord",
-      CommandBody: "/reset",
-      BodyForCommands: "/reset",
-      BodyForAgent: "/reset",
     });
 
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -64,111 +64,127 @@ describe("handlePendingApprovalRequest", () => {
     hasApprovalTurnSourceRouteMock.mockClear();
   });
 
-  it("allows operator.admin clients to see requester-bound approvals", () => {
-    const manager = new ExecApprovalManager();
-    const record = manager.create(
-      {
-        command: "echo ok",
-      },
-      60_000,
-      "approval-admin-visible",
-    );
-    record.requestedByDeviceId = "device-owner";
-    record.requestedByConnId = "conn-owner";
-    record.requestedByClientId = "client-owner";
-
-    expect(
-      isApprovalRecordVisibleToClient({
-        record,
-        client: createApprovalClient({
-          connId: "conn-admin",
-          clientId: "client-admin",
-          deviceId: "device-admin",
-          scopes: ["operator.admin"],
-        }),
-      }),
-    ).toBe(true);
-  });
-
-  it("does not allow approval-scoped clients to see no-device gateway-client approvals from another connection", () => {
-    const manager = new ExecApprovalManager();
-    const record = manager.create(
-      {
-        command: "echo ok",
-      },
-      60_000,
-      "approval-gateway-client-visible",
-    );
-    record.requestedByConnId = "conn-gateway";
-    record.requestedByClientId = GATEWAY_CLIENT_IDS.GATEWAY_CLIENT;
-
-    expect(
-      isApprovalRecordVisibleToClient({
-        record,
-        client: createApprovalClient({
-          connId: "conn-mobile",
-          clientId: GATEWAY_CLIENT_IDS.IOS_APP,
-          scopes: ["operator.approvals"],
-        }),
-      }),
-    ).toBe(false);
-  });
-
   it.each([
-    ["Control UI", GATEWAY_CLIENT_IDS.CONTROL_UI],
-    ["WebChat UI", GATEWAY_CLIENT_IDS.WEBCHAT_UI],
-    ["WebChat", GATEWAY_CLIENT_IDS.WEBCHAT],
-  ])(
-    "does not allow approval-scoped clients to see no-device %s approvals from another connection",
-    (_label, clientId) => {
-      const manager = new ExecApprovalManager();
-      const record = manager.create(
-        {
-          command: "echo ok",
-        },
-        60_000,
-        `approval-${clientId}-visible`,
-      );
-      record.requestedByConnId = "conn-browser-ui";
-      record.requestedByClientId = clientId;
-
-      expect(
-        isApprovalRecordVisibleToClient({
-          record,
-          client: createApprovalClient({
-            connId: "conn-mobile",
-            clientId: GATEWAY_CLIENT_IDS.IOS_APP,
-            scopes: ["operator.approvals"],
-          }),
-        }),
-      ).toBe(false);
-    },
-  );
-
-  it("does not allow approval-scoped clients to see device-bound gateway-client approvals from another device", () => {
-    const manager = new ExecApprovalManager();
-    const record = manager.create(
-      {
-        command: "echo ok",
+    {
+      name: "allows operator.admin clients to see requester-bound approvals",
+      recordId: "approval-admin-visible",
+      requestedBy: {
+        requestedByDeviceId: "device-owner",
+        requestedByConnId: "conn-owner",
+        requestedByClientId: "client-owner",
       },
-      60_000,
-      "approval-gateway-device-visible",
-    );
-    record.requestedByDeviceId = "device-gateway";
-    record.requestedByConnId = "conn-gateway";
-    record.requestedByClientId = GATEWAY_CLIENT_IDS.GATEWAY_CLIENT;
+      client: {
+        connId: "conn-admin",
+        clientId: "client-admin",
+        deviceId: "device-admin",
+        scopes: ["operator.admin"],
+      },
+      expected: true,
+    },
+    {
+      name: "does not allow approval-scoped clients to see no-device gateway-client approvals from another connection",
+      recordId: "approval-gateway-client-visible",
+      requestedBy: {
+        requestedByConnId: "conn-gateway",
+        requestedByClientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+      },
+      client: {
+        connId: "conn-mobile",
+        clientId: GATEWAY_CLIENT_IDS.IOS_APP,
+        scopes: ["operator.approvals"],
+      },
+      expected: false,
+    },
+    ...[
+      ["Control UI", GATEWAY_CLIENT_IDS.CONTROL_UI],
+      ["WebChat UI", GATEWAY_CLIENT_IDS.WEBCHAT_UI],
+      ["WebChat", GATEWAY_CLIENT_IDS.WEBCHAT],
+    ].map(([label, clientId]) => ({
+      name: `does not allow approval-scoped clients to see no-device ${label} approvals from another connection`,
+      recordId: `approval-${clientId}-visible`,
+      requestedBy: {
+        requestedByConnId: "conn-browser-ui",
+        requestedByClientId: clientId,
+      },
+      client: {
+        connId: "conn-mobile",
+        clientId: GATEWAY_CLIENT_IDS.IOS_APP,
+        scopes: ["operator.approvals"],
+      },
+      expected: false,
+    })),
+    {
+      name: "does not allow approval-scoped clients to see device-bound gateway-client approvals from another device",
+      recordId: "approval-gateway-device-visible",
+      requestedBy: {
+        requestedByDeviceId: "device-gateway",
+        requestedByConnId: "conn-gateway",
+        requestedByClientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+      },
+      client: {
+        connId: "conn-mobile",
+        clientId: GATEWAY_CLIENT_IDS.IOS_APP,
+        deviceId: "device-mobile",
+        scopes: ["operator.approvals"],
+      },
+      expected: false,
+    },
+    {
+      name: "allows gateway-client approval runtimes to see requester-bound approvals",
+      recordId: "approval-delivery-runtime-visible",
+      requestedBy: {
+        requestedByDeviceId: "device-owner",
+        requestedByConnId: "conn-owner",
+        requestedByClientId: "client-owner",
+      },
+      client: {
+        connId: "conn-delivery-runtime",
+        clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        scopes: ["operator.approvals"],
+        approvalRuntime: true,
+      },
+      expected: true,
+    },
+    {
+      name: "does not trust gateway-client ids without the approval runtime marker",
+      recordId: "approval-delivery-runtime-spoof-hidden",
+      requestedBy: {
+        requestedByDeviceId: "device-owner",
+        requestedByConnId: "conn-owner",
+        requestedByClientId: "client-owner",
+      },
+      client: {
+        connId: "conn-spoofed-runtime",
+        clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        scopes: ["operator.approvals"],
+      },
+      expected: false,
+    },
+    {
+      name: "does not widen non-gateway no-device approvals to matching client ids",
+      recordId: "approval-other-client-hidden",
+      requestedBy: {
+        requestedByConnId: "conn-requester",
+        requestedByClientId: "client-owner",
+      },
+      client: {
+        connId: "conn-mobile",
+        clientId: "client-owner",
+        scopes: ["operator.approvals"],
+      },
+      expected: false,
+    },
+  ])("$name", ({ recordId, requestedBy, client, expected }) => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, recordId);
+    Object.assign(record, requestedBy);
 
     expect(
       isApprovalRecordVisibleToClient({
         record,
-        client: createApprovalClient({
-          connId: "conn-mobile",
-          clientId: GATEWAY_CLIENT_IDS.IOS_APP,
-          deviceId: "device-mobile",
-          scopes: ["operator.approvals"],
-        }),
+        client: createApprovalClient(client),
       }),
-    ).toBe(false);
+    ).toBe(expected);
   });
 
   it("allows approval-scoped reviewer devices to see approvals requested by the backend runtime", () => {
@@ -247,81 +263,6 @@ describe("handlePendingApprovalRequest", () => {
           connId: "conn-other",
           clientId: GATEWAY_CLIENT_IDS.IOS_APP,
           deviceId: "device-other",
-          scopes: ["operator.approvals"],
-        }),
-      }),
-    ).toBe(false);
-  });
-
-  it("allows gateway-client approval runtimes to see requester-bound approvals", () => {
-    const manager = new ExecApprovalManager();
-    const record = manager.create(
-      {
-        command: "echo ok",
-      },
-      60_000,
-      "approval-delivery-runtime-visible",
-    );
-    record.requestedByDeviceId = "device-owner";
-    record.requestedByConnId = "conn-owner";
-    record.requestedByClientId = "client-owner";
-
-    expect(
-      isApprovalRecordVisibleToClient({
-        record,
-        client: createApprovalClient({
-          connId: "conn-delivery-runtime",
-          clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-          scopes: ["operator.approvals"],
-          approvalRuntime: true,
-        }),
-      }),
-    ).toBe(true);
-  });
-
-  it("does not trust gateway-client ids without the approval runtime marker", () => {
-    const manager = new ExecApprovalManager();
-    const record = manager.create(
-      {
-        command: "echo ok",
-      },
-      60_000,
-      "approval-delivery-runtime-spoof-hidden",
-    );
-    record.requestedByDeviceId = "device-owner";
-    record.requestedByConnId = "conn-owner";
-    record.requestedByClientId = "client-owner";
-
-    expect(
-      isApprovalRecordVisibleToClient({
-        record,
-        client: createApprovalClient({
-          connId: "conn-spoofed-runtime",
-          clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-          scopes: ["operator.approvals"],
-        }),
-      }),
-    ).toBe(false);
-  });
-
-  it("does not widen non-gateway no-device approvals to matching client ids", () => {
-    const manager = new ExecApprovalManager();
-    const record = manager.create(
-      {
-        command: "echo ok",
-      },
-      60_000,
-      "approval-other-client-hidden",
-    );
-    record.requestedByConnId = "conn-requester";
-    record.requestedByClientId = "client-owner";
-
-    expect(
-      isApprovalRecordVisibleToClient({
-        record,
-        client: createApprovalClient({
-          connId: "conn-mobile",
-          clientId: "client-owner",
           scopes: ["operator.approvals"],
         }),
       }),

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -138,30 +138,25 @@ describe("scripts/test-extension.mjs", () => {
     expect(plan.hasTests).toBe(true);
   });
 
-  it("resolves acpx onto the acpx vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "acpx", cwd: process.cwd() });
+  it.each([
+    { extensionId: "acpx" },
+    { extensionId: "diffs" },
+    { extensionId: "feishu" },
+    { extensionId: "matrix" },
+    { extensionId: "telegram" },
+    { extensionId: "whatsapp" },
+    { extensionId: "voice-call" },
+    { extensionId: "mattermost" },
+    { extensionId: "irc" },
+    { extensionId: "zalo" },
+    { extensionId: "msteams" },
+    { extensionId: "codex" },
+  ])("resolves $extensionId onto the $extensionId vitest config", ({ extensionId }) => {
+    const plan = resolveExtensionTestPlan({ targetArg: extensionId, cwd: process.cwd() });
 
-    expect(plan.extensionId).toBe("acpx");
-    expect(plan.config).toBe("test/vitest/vitest.extension-acpx.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("acpx"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves diffs onto the diffs vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "diffs", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("diffs");
-    expect(plan.config).toBe("test/vitest/vitest.extension-diffs.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("diffs"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves feishu onto the feishu vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "feishu", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("feishu");
-    expect(plan.config).toBe("test/vitest/vitest.extension-feishu.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("feishu"));
+    expect(plan.extensionId).toBe(extensionId);
+    expect(plan.config).toBe(`test/vitest/vitest.extension-${extensionId}.config.ts`);
+    expect(plan.roots).toContain(bundledPluginRoot(extensionId));
     expect(plan.hasTests).toBe(true);
   });
 
@@ -171,15 +166,6 @@ describe("scripts/test-extension.mjs", () => {
     expect(plan.extensionId).toBe("openai");
     expect(plan.config).toBe("test/vitest/vitest.extension-provider-openai.config.ts");
     expect(plan.roots).toContain(bundledPluginRoot("openai"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves matrix onto the matrix vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "matrix", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("matrix");
-    expect(plan.config).toBe("test/vitest/vitest.extension-matrix.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("matrix"));
     expect(plan.hasTests).toBe(true);
   });
 
@@ -240,75 +226,12 @@ describe("scripts/test-extension.mjs", () => {
     ).toEqual([[root]]);
   });
 
-  it("resolves telegram onto the telegram vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "telegram", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("telegram");
-    expect(plan.config).toBe("test/vitest/vitest.extension-telegram.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("telegram"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves whatsapp onto the whatsapp vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "whatsapp", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("whatsapp");
-    expect(plan.config).toBe("test/vitest/vitest.extension-whatsapp.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("whatsapp"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves voice-call onto the voice-call vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "voice-call", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("voice-call");
-    expect(plan.config).toBe("test/vitest/vitest.extension-voice-call.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("voice-call"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves mattermost onto the mattermost vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "mattermost", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("mattermost");
-    expect(plan.config).toBe("test/vitest/vitest.extension-mattermost.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("mattermost"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves irc onto the irc vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "irc", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("irc");
-    expect(plan.config).toBe("test/vitest/vitest.extension-irc.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("irc"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves zalo onto the zalo vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "zalo", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("zalo");
-    expect(plan.config).toBe("test/vitest/vitest.extension-zalo.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("zalo"));
-    expect(plan.hasTests).toBe(true);
-  });
-
   it("resolves memory extensions onto the memory vitest config", () => {
     const plan = resolveExtensionTestPlan({ targetArg: "memory-core", cwd: process.cwd() });
 
     expect(plan.extensionId).toBe("memory-core");
     expect(plan.config).toBe("test/vitest/vitest.extension-memory.config.ts");
     expect(plan.roots).toContain(bundledPluginRoot("memory-core"));
-    expect(plan.hasTests).toBe(true);
-  });
-
-  it("resolves msteams onto the msteams vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "msteams", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("msteams");
-    expect(plan.config).toBe("test/vitest/vitest.extension-msteams.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("msteams"));
     expect(plan.hasTests).toBe(true);
   });
 
@@ -325,15 +248,6 @@ describe("scripts/test-extension.mjs", () => {
     expect(resolveExtensionTestPlan({ targetArg: "firecrawl", cwd: process.cwd() }).config).toBe(
       "test/vitest/vitest.extension-misc.config.ts",
     );
-  });
-
-  it("resolves codex onto the codex vitest config", () => {
-    const plan = resolveExtensionTestPlan({ targetArg: "codex", cwd: process.cwd() });
-
-    expect(plan.extensionId).toBe("codex");
-    expect(plan.config).toBe("test/vitest/vitest.extension-codex.config.ts");
-    expect(plan.roots).toContain(bundledPluginRoot("codex"));
-    expect(plan.hasTests).toBe(true);
   });
 
   it("omits src/<extension> when no paired core root exists", () => {


### PR DESCRIPTION
## What Problem This Solves

Repeated longhand test setup made several high-duplication suites harder to scan and maintain. Equivalent scenarios could drift because the inputs and expected values were spread across copied blocks rather than expressed as an explicit case matrix.

## Why This Change Was Made

This AI-assisted refactor converts only structurally identical test bodies into `it.each` tables with scenario-specific row names. Cases with distinct setup or extra assertions remain longhand; production code and behavior are unchanged.

Current `main` had fewer approval visibility duplicates than the task estimate: nine structurally identical cases (including an existing three-row mini-table), not roughly 25 longhand cases. Reviewer-binding cases with extra setup/assertions were intentionally left alone.

## User Impact

No user-visible behavior changes. Developers get smaller test suites with clearer per-scenario failures and one canonical assertion body for each duplicated case family.

## Evidence

Case coverage and Vitest expansion:

| File | Old cases | New rows | Vitest before | Vitest after |
| --- | ---: | ---: | ---: | ---: |
| `test/scripts/test-extension.test.ts` | 12 | 12 | 161 | 161 |
| `src/agents/embedded-agent-runner/run/payloads.errors.test.ts` | 8 scenarios inside 1 test | 8 | 73 | 80 |
| `src/auto-reply/reply/dispatch-acp-command-bypass.test.ts` | 9 | 9 | 23 | 23 |
| `extensions/matrix/src/matrix/format.test.ts` | 18 | 18 | 56 | 56 |
| `src/agents/embedded-agent-runner/run/attempt.test.ts` | 8 | 8 | 120 | 120 |
| `src/gateway/server-methods/approval-shared.test.ts` | 9 | 9 | 37 | 37 |

The payload test count increases by seven because one old test manually ran and asserted eight independent metadata scenarios; each scenario is now its own named Vitest row. All other totals are unchanged.

Focused tests were run before and after the refactor, all green:

- `node scripts/run-vitest.mjs test/scripts/test-extension.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-acp-command-bypass.test.ts`
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/format.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-methods/approval-shared.test.ts`

Additional validation:

- `pnpm format test/scripts/test-extension.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/auto-reply/reply/dispatch-acp-command-bypass.test.ts extensions/matrix/src/matrix/format.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/gateway/server-methods/approval-shared.test.ts` — passed
- `node scripts/check-changed.mjs` — remote routing reached an Azure broker 403 after Blacksmith/Daytona were unavailable; the documented trusted-source local fallback passed with `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings
- `git diff --check` — passed

`git diff origin/main...HEAD --numstat`: production `+0/-0` (net 0); tests `+392/-777` (net -385).
