### PR TITLE
fix(nextcloud-talk): redact upstream error body text in send and bot-preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
+- **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/extensions/nextcloud-talk/src/bot-preflight.test.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.test.ts
@@ -90,31 +90,21 @@ describe("probeNextcloudTalkBotResponseFeature", () => {
     hoisted.fetchWithSsrFGuard.mockReset();
   });
 
-  it("passes when the matching bot has the response feature bit", async () => {
-    mockBotAdmin(1 | 2 | 8);
+  it.each([1 | 2 | 8, "+011"])(
+    "accepts numeric or signed decimal response features: %j",
+    async (features) => {
+      mockBotAdmin(features);
 
-    await expect(probeNextcloudTalkBotResponseFeature({ account: account() })).resolves.toEqual({
-      ok: true,
-      code: "ok",
-      botId: "7",
-      botName: "OpenClaw",
-      features: 11,
-      message: 'Nextcloud Talk bot "OpenClaw" has the response feature.',
-    });
-  });
-
-  it("normalizes signed decimal bot feature strings through the shared parser", async () => {
-    mockBotAdmin("+011");
-
-    await expect(probeNextcloudTalkBotResponseFeature({ account: account() })).resolves.toEqual({
-      ok: true,
-      code: "ok",
-      botId: "7",
-      botName: "OpenClaw",
-      features: 11,
-      message: 'Nextcloud Talk bot "OpenClaw" has the response feature.',
-    });
-  });
+      await expect(probeNextcloudTalkBotResponseFeature({ account: account() })).resolves.toEqual({
+        ok: true,
+        code: "ok",
+        botId: "7",
+        botName: "OpenClaw",
+        features: 11,
+        message: 'Nextcloud Talk bot "OpenClaw" has the response feature.',
+      });
+    },
+  );
 
   it("reports missing response feature for the matching webhook bot", async () => {
     mockBotAdmin(1 | 8);
@@ -130,31 +120,21 @@ describe("probeNextcloudTalkBotResponseFeature", () => {
     });
   });
 
-  it("does not coerce partial bot feature strings", async () => {
-    mockBotAdmin("2response");
+  it.each(["2response", -1])(
+    "rejects malformed or negative response features: %j",
+    async (features) => {
+      mockBotAdmin(features);
 
-    await expect(probeNextcloudTalkBotResponseFeature({ account: account() })).resolves.toEqual({
-      ok: false,
-      code: "missing_response_feature",
-      botId: "7",
-      botName: "OpenClaw",
-      message:
-        'Nextcloud Talk bot "OpenClaw" (7) is missing the response feature; outbound replies will fail. Run ./occ talk:bot:state --feature webhook --feature response --feature reaction 7 1 or reinstall the bot with --feature response.',
-    });
-  });
-
-  it("does not treat negative feature masks as having every feature", async () => {
-    mockBotAdmin(-1);
-
-    await expect(probeNextcloudTalkBotResponseFeature({ account: account() })).resolves.toEqual({
-      ok: false,
-      code: "missing_response_feature",
-      botId: "7",
-      botName: "OpenClaw",
-      message:
-        'Nextcloud Talk bot "OpenClaw" (7) is missing the response feature; outbound replies will fail. Run ./occ talk:bot:state --feature webhook --feature response --feature reaction 7 1 or reinstall the bot with --feature response.',
-    });
-  });
+      await expect(probeNextcloudTalkBotResponseFeature({ account: account() })).resolves.toEqual({
+        ok: false,
+        code: "missing_response_feature",
+        botId: "7",
+        botName: "OpenClaw",
+        message:
+          'Nextcloud Talk bot "OpenClaw" (7) is missing the response feature; outbound replies will fail. Run ./occ talk:bot:state --feature webhook --feature response --feature reaction 7 1 or reinstall the bot with --feature response.',
+      });
+    },
+  );
 
   it("reports malformed bot admin JSON with a stable channel error", async () => {
     hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
@@ -190,9 +170,7 @@ describe("probeNextcloudTalkBotResponseFeature", () => {
       ok: false,
       code: "api_error",
       status: 503,
-      message: expect.stringContaining(
-        "Nextcloud Talk bot response feature probe failed (503): nextcloud bot admin failure",
-      ),
+      message: "Nextcloud Talk bot response feature probe failed (503)",
     });
     expect(textSpy).not.toHaveBeenCalled();
     expect(tracked.wasCanceled()).toBe(true);

--- a/extensions/nextcloud-talk/src/bot-preflight.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.ts
@@ -1,18 +1,17 @@
 // Nextcloud Talk plugin module implements bot preflight behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import {
-  readProviderJsonResponse,
-  readResponseTextLimited,
-} from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { resolveNextcloudTalkApiCredentials } from "./api-credentials.js";
-import { releaseNextcloudTalkGuardedResponse } from "./guarded-response.js";
+import {
+  readNextcloudTalkErrorBody,
+  releaseNextcloudTalkGuardedResponse,
+} from "./guarded-response.js";
 import { ssrfPolicyFromPrivateNetworkOptIn } from "./send.runtime.js";
 
 const BOT_FEATURE_RESPONSE = 2;
-const BOT_PREFLIGHT_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
 type NextcloudTalkBotAdminEntry = {
   id?: number | string;
@@ -130,10 +129,7 @@ export async function probeNextcloudTalkBotResponseFeature(params: {
     });
     try {
       if (!response.ok) {
-        const body = await readResponseTextLimited(
-          response,
-          BOT_PREFLIGHT_ERROR_BODY_LIMIT_BYTES,
-        ).catch(() => "");
+        const body = await readNextcloudTalkErrorBody(response, auth, credentials.apiPassword);
         return {
           ok: false,
           code: "api_error",

--- a/extensions/nextcloud-talk/src/bot-preflight.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.ts
@@ -1,5 +1,6 @@
 // Nextcloud Talk plugin module implements bot preflight behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonResponse,
@@ -138,7 +139,7 @@ export async function probeNextcloudTalkBotResponseFeature(params: {
           ok: false,
           code: "api_error",
           status: response.status,
-          message: `Nextcloud Talk bot response feature probe failed (${response.status})${body ? `: ${body}` : ""}`,
+          message: `Nextcloud Talk bot response feature probe failed (${response.status})${body ? `: ${redactToolPayloadText(body)}` : ""}`,
         };
       }
 

--- a/extensions/nextcloud-talk/src/guarded-response.ts
+++ b/extensions/nextcloud-talk/src/guarded-response.ts
@@ -1,3 +1,6 @@
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
+import { readProviderTextResponse } from "openclaw/plugin-sdk/provider-http";
+
 // Nextcloud Talk guarded fetches own their dispatcher until the response body
 // settles. Cancel unread bodies before release so streaming responses cannot
 // keep the dispatcher alive after an early return.
@@ -9,4 +12,22 @@ export async function releaseNextcloudTalkGuardedResponse(params: {
     await params.response.body?.cancel().catch(() => undefined);
   }
   await params.release();
+}
+export async function readNextcloudTalkErrorBody(
+  response: Response,
+  ...credentials: string[]
+): Promise<string> {
+  try {
+    // Never expose a truncated credential: redact only complete, bounded bodies.
+    let body = await readProviderTextResponse(response, "Nextcloud Talk error", {
+      maxBytes: 8 * 1024,
+      chunkTimeoutMs: 10_000,
+    });
+    for (const credential of credentials) {
+      body = body.replaceAll(credential, "***");
+    }
+    return redactToolPayloadText(body);
+  } catch {
+    return "";
+  }
 }

--- a/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
+++ b/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
@@ -140,52 +140,60 @@ describe("nextcloud-talk send cfg threading", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
-  it("uses provided cfg for sendMessage and skips runtime loadConfig", async () => {
-    const cfg = { source: "provided" } as const;
-    mockNextcloudMessageResponse(12345, 1_706_000_000);
+  it.each([true, false])(
+    "preserves cfg and receipts with runtime initialized=%s",
+    async (initialized) => {
+      const cfg = { source: "provided" } as const;
+      if (!initialized) {
+        hoisted.record.mockImplementation(() => {
+          throw new Error("Nextcloud Talk runtime not initialized");
+        });
+      }
+      mockNextcloudMessageResponse(12345, 1_706_000_000);
 
-    const result = await sendMessageNextcloudTalk("room:abc123", "hello", {
-      cfg,
-      accountId: "work",
-    });
+      const result = await sendMessageNextcloudTalk("room:abc123", "hello", {
+        cfg,
+        accountId: "work",
+      });
 
-    expectProvidedMessageCfgThreading(cfg);
-    expect(hoisted.record).toHaveBeenCalledWith({
-      channel: "nextcloud-talk",
-      accountId: "default",
-      direction: "outbound",
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({
-      messageId: "12345",
-      receipt: {
-        platformMessageIds: ["12345"],
-        primaryPlatformMessageId: "12345",
-        parts: [
-          {
-            index: 0,
-            kind: "text",
-            platformMessageId: "12345",
-            raw: {
+      expectProvidedMessageCfgThreading(cfg);
+      expect(hoisted.record).toHaveBeenCalledWith({
+        channel: "nextcloud-talk",
+        accountId: "default",
+        direction: "outbound",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        messageId: "12345",
+        receipt: {
+          platformMessageIds: ["12345"],
+          primaryPlatformMessageId: "12345",
+          parts: [
+            {
+              index: 0,
+              kind: "text",
+              platformMessageId: "12345",
+              raw: {
+                channel: "nextcloud-talk",
+                conversationId: "abc123",
+                messageId: "12345",
+              },
+            },
+          ],
+          raw: [
+            {
               channel: "nextcloud-talk",
               conversationId: "abc123",
               messageId: "12345",
             },
-          },
-        ],
-        raw: [
-          {
-            channel: "nextcloud-talk",
-            conversationId: "abc123",
-            messageId: "12345",
-          },
-        ],
-        sentAt: fixedSentAt,
-      },
-      roomToken: "abc123",
-      timestamp: 1_706_000_000,
-    });
-  });
+          ],
+          sentAt: fixedSentAt,
+        },
+        roomToken: "abc123",
+        timestamp: 1_706_000_000,
+      });
+    },
+  );
 
   it("strips mixed-case provider and room prefixes before sending", async () => {
     const cfg = { source: "provided" } as const;
@@ -227,50 +235,6 @@ describe("nextcloud-talk send cfg threading", () => {
     expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(
       JSON.stringify({ message: text, replyTo: "parent-1" }),
     );
-  });
-
-  it("sends with provided cfg even when the runtime store is not initialized", async () => {
-    const cfg = { source: "provided" } as const;
-    hoisted.record.mockImplementation(() => {
-      throw new Error("Nextcloud Talk runtime not initialized");
-    });
-    mockNextcloudMessageResponse(12346, 1_706_000_001);
-
-    const result = await sendMessageNextcloudTalk("room:abc123", "hello", {
-      cfg,
-      accountId: "work",
-    });
-
-    expectProvidedMessageCfgThreading(cfg);
-    expect(result).toEqual({
-      messageId: "12346",
-      receipt: {
-        platformMessageIds: ["12346"],
-        primaryPlatformMessageId: "12346",
-        parts: [
-          {
-            index: 0,
-            kind: "text",
-            platformMessageId: "12346",
-            raw: {
-              channel: "nextcloud-talk",
-              conversationId: "abc123",
-              messageId: "12346",
-            },
-          },
-        ],
-        raw: [
-          {
-            channel: "nextcloud-talk",
-            conversationId: "abc123",
-            messageId: "12346",
-          },
-        ],
-        sentAt: fixedSentAt,
-      },
-      roomToken: "abc123",
-      timestamp: 1_706_000_001,
-    });
   });
 
   it("preserves reply ids in receipts", async () => {
@@ -531,7 +495,7 @@ describe("nextcloud-talk send bounded response reads", () => {
     expect(result.timestamp).toBeUndefined();
   });
 
-  it("bounds an oversized error body into a short send-failure snippet", async () => {
+  it("omits an oversized error body from the send failure", async () => {
     fetchMock.mockResolvedValueOnce(
       streamingResponse({
         status: 400,
@@ -543,10 +507,10 @@ describe("nextcloud-talk send bounded response reads", () => {
 
     await expect(
       sendMessageNextcloudTalk("room:abc", "hello", { cfg: { source: "provided" } }),
-    ).rejects.toThrow(/Nextcloud Talk: bad request/);
+    ).rejects.toThrow(new Error("Nextcloud Talk: bad request - invalid message format"));
   });
 
-  it("bounds an oversized reaction error body into a short snippet", async () => {
+  it("omits an oversized error body from the reaction failure", async () => {
     fetchMock.mockResolvedValueOnce(
       streamingResponse({
         status: 500,
@@ -556,31 +520,8 @@ describe("nextcloud-talk send bounded response reads", () => {
       }),
     );
 
-    let caught: unknown;
-    try {
-      await sendReactionNextcloudTalk("room:abc", "m-1", "👍", { cfg: { source: "provided" } });
-    } catch (error) {
-      caught = error;
-    }
-
-    expect(caught).toBeInstanceOf(Error);
-    // The collapsed snippet caps the message far below the streamed 17 MiB body.
-    expect((caught as Error).message.length).toBeLessThan(4_000);
-  });
-
-  it("still parses a normal small success body", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ocs: { data: { id: 99, timestamp: 1_700_000_000 } } }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-
-    const result = await sendMessageNextcloudTalk("room:abc", "hello", {
-      cfg: { source: "provided" },
-    });
-
-    expect(result.messageId).toBe("99");
-    expect(result.timestamp).toBe(1_700_000_000);
+    await expect(
+      sendReactionNextcloudTalk("room:abc", "m-1", "👍", { cfg: { source: "provided" } }),
+    ).rejects.toThrow(new Error("Nextcloud Talk reaction failed: 500"));
   });
 });

--- a/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
@@ -1,5 +1,7 @@
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
+import { resolveNextcloudTalkAccount } from "./accounts.js";
+import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";
 import { sendMessageNextcloudTalk, sendReactionNextcloudTalk } from "./send.js";
 import type { CoreConfig } from "./types.js";
 
@@ -11,6 +13,9 @@ function createTalkConfig(baseUrl: string): CoreConfig {
       "nextcloud-talk": {
         baseUrl,
         botSecret: "test-secret",
+        apiUser: "test-admin",
+        apiPassword: "test-password",
+        webhookPublicUrl: "https://bot.example.test/hook",
         network: { dangerouslyAllowPrivateNetwork: true },
       },
     },
@@ -47,6 +52,69 @@ async function expectHangingTalkRequestTimesOut(params: {
 }
 
 describe("nextcloud-talk send error responses", () => {
+  it.each(["message", "reaction", "preflight"])(
+    "redacts reflected credentials and drops incomplete %s error bodies",
+    async (operation) => {
+      for (const mode of ["complete", "display-boundary", "oversized", "stalled"]) {
+        let credential = "";
+        await withServer(
+          (request, response) => {
+            request.resume();
+            credential = String(
+              request.headers["x-nextcloud-talk-bot-signature"] ??
+                request.headers.authorization?.replace(/^Basic /, ""),
+            );
+            expect(credential).not.toBe("undefined");
+            response.writeHead(500, { "content-type": "text/plain" });
+            // Put a secret across the read cap: exposing a prefix defeats exact redaction.
+            const body =
+              mode === "oversized"
+                ? `${"x".repeat(8192 - 16)}${credential}`
+                : `upstream rejected ${mode === "display-boundary" ? "x".repeat(160) : ""}${credential}; password=fixture-private-value${
+                    request.headers.authorization ? "; decoded test-password" : ""
+                  }`;
+            if (mode === "stalled") {
+              response.write(body);
+            } else {
+              response.end(body);
+            }
+          },
+          async (baseUrl) => {
+            const cfg = createTalkConfig(baseUrl);
+            const result =
+              operation === "preflight"
+                ? await probeNextcloudTalkBotResponseFeature({
+                    account: resolveNextcloudTalkAccount({ cfg }),
+                  })
+                : await (
+                    operation === "message"
+                      ? sendMessageNextcloudTalk("room:abc123", "hello", { cfg })
+                      : sendReactionNextcloudTalk("room:abc123", "m-1", "ok", { cfg })
+                  ).catch((error: unknown) => error);
+            const message =
+              typeof result === "object" && result !== null && "message" in result
+                ? result.message
+                : undefined;
+            expect(message).toBeTypeOf("string");
+            expect(message).not.toContain(credential);
+            expect(message).not.toContain(credential.slice(0, 16));
+            expect(message).not.toContain("fixture-private-value");
+            expect(message).not.toContain("test-password");
+            if (mode === "oversized" || mode === "stalled") {
+              expect(message).not.toContain("xxxxxxxx");
+              expect(message).not.toContain("upstream rejected");
+              expect(message).toContain("500");
+            } else {
+              expect(message).toContain("upstream rejected");
+              expect(message).toContain("***");
+            }
+          },
+        );
+      }
+    },
+    15_000,
+  );
+
   it("keeps send error body snippets UTF-16 safe", async () => {
     const prefix = "e".repeat(199);
     const errorBody = `${prefix}\u{1F600}tail`;

--- a/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
@@ -1,5 +1,5 @@
 import { withServer } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { sendMessageNextcloudTalk, sendReactionNextcloudTalk } from "./send.js";
 import type { CoreConfig } from "./types.js";
 
@@ -98,7 +98,7 @@ describe("nextcloud-talk send error responses", () => {
     // header must have the signature hex replaced with [redacted].
     await withServer(
       (request, response) => {
-        const sig = request.headers["x-nextcloud-talk-bot-signature"] ?? "";
+        const sig = String(request.headers["x-nextcloud-talk-bot-signature"] ?? "");
         expect(request.url).toBe("/ocs/v2.php/apps/spreed/api/v1/bot/abc123/message");
         request.resume();
         response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
@@ -139,7 +139,7 @@ describe("nextcloud-talk send error responses", () => {
   it("redacts reflected HMAC signature from short reaction error bodies", async () => {
     await withServer(
       (request, response) => {
-        const sig = request.headers["x-nextcloud-talk-bot-signature"] ?? "";
+        const sig = String(request.headers["x-nextcloud-talk-bot-signature"] ?? "");
         expect(request.url).toBe("/ocs/v2.php/apps/spreed/api/v1/bot/abc123/reaction/m-1");
         request.resume();
         response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
@@ -156,6 +156,44 @@ describe("nextcloud-talk send error responses", () => {
     );
   });
 });
+
+async function expectHeadersThenStallTimesOut(params: {
+  path: string;
+  run: (baseUrl: string) => Promise<unknown>;
+  expectedMessage: string | RegExp;
+}): Promise<void> {
+  let received = false;
+  await withServer(
+    (request, response) => {
+      received = true;
+      expect(request.method).toBe("POST");
+      expect(request.url).toBe(params.path);
+      request.resume();
+      // Send headers (4xx) then hold the body open indefinitely. flushHeaders
+      // ensures the status line reaches the client so the test exercises the
+      // error-body idle timeout, not the outer request timeout.
+      response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+      response.flushHeaders();
+    },
+    async (baseUrl) => {
+      let thrown: unknown;
+      try {
+        await params.run(baseUrl);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(received).toBe(true);
+      if (!(thrown instanceof Error)) {
+        throw new Error(`expected request timeout, received ${String(thrown)}`);
+      }
+      // The error-body idle timeout fires before the outer request timeout,
+      // so the snippet is suppressed and the caller falls back to a generic
+      // status-only error message.
+      expect(thrown.message).toMatch(params.expectedMessage);
+    },
+  );
+}
 
 describe("nextcloud-talk send fetch timeouts", () => {
   it("bounds hanging message and reaction sends", async () => {
@@ -174,6 +212,47 @@ describe("nextcloud-talk send fetch timeouts", () => {
           cfg: createTalkConfig(baseUrl),
           timeoutMs: REQUEST_TIMEOUT_MS,
         }),
+    });
+  });
+
+  describe("with a short error-body idle timeout", () => {
+    const IDLE_TIMEOUT_ENV = "OPENCLAW_TEST_NEXTCLOUD_TALK_ERROR_IDLE_TIMEOUT_MS";
+    const previousIdleTimeout = process.env[IDLE_TIMEOUT_ENV];
+
+    beforeAll(() => {
+      process.env[IDLE_TIMEOUT_ENV] = "50";
+    });
+
+    afterAll(() => {
+      if (previousIdleTimeout === undefined) {
+        delete process.env[IDLE_TIMEOUT_ENV];
+      } else {
+        process.env[IDLE_TIMEOUT_ENV] = previousIdleTimeout;
+      }
+    });
+
+    it("bounds message sends where a 4xx response header is followed by a stalled body", async () => {
+      await expectHeadersThenStallTimesOut({
+        path: "/ocs/v2.php/apps/spreed/api/v1/bot/abc123/message",
+        run: async (baseUrl) =>
+          sendMessageNextcloudTalk("room:abc123", "hello", {
+            cfg: createTalkConfig(baseUrl),
+            timeoutMs: 500,
+          }),
+        expectedMessage: "Nextcloud Talk: bad request - invalid message format",
+      });
+    });
+
+    it("bounds reaction sends where a 4xx response header is followed by a stalled body", async () => {
+      await expectHeadersThenStallTimesOut({
+        path: "/ocs/v2.php/apps/spreed/api/v1/bot/abc123/reaction/m-1",
+        run: async (baseUrl) =>
+          sendReactionNextcloudTalk("room:abc123", "m-1", "ok", {
+            cfg: createTalkConfig(baseUrl),
+            timeoutMs: 500,
+          }),
+        expectedMessage: "Nextcloud Talk reaction failed: 400",
+      });
     });
   });
 });

--- a/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
@@ -69,6 +69,92 @@ describe("nextcloud-talk send error responses", () => {
       },
     );
   });
+
+  it("omits send error body snippet when body exceeds 8 KiB limit", async () => {
+    // A body larger than the 8 KiB (8192) cap triggers the truncated path,
+    // which must suppress the snippet so no boundary-straddling secret prefix leaks.
+    const body = "X".repeat(8300);
+
+    await withServer(
+      (request, response) => {
+        expect(request.url).toBe("/ocs/v2.php/apps/spreed/api/v1/bot/abc123/message");
+        request.resume();
+        response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        response.end(body);
+      },
+      async (baseUrl) => {
+        await expect(
+          sendMessageNextcloudTalk("room:abc123", "hello", {
+            cfg: createTalkConfig(baseUrl),
+            timeoutMs: REQUEST_TIMEOUT_MS,
+          }),
+        ).rejects.toThrow("Nextcloud Talk: bad request - invalid message format");
+      },
+    );
+  });
+
+  it("redacts reflected HMAC signature from short send error bodies", async () => {
+    // A body under 8 KiB that echoes the X-Nextcloud-Talk-Bot-Signature
+    // header must have the signature hex replaced with [redacted].
+    await withServer(
+      (request, response) => {
+        const sig = request.headers["x-nextcloud-talk-bot-signature"] ?? "";
+        expect(request.url).toBe("/ocs/v2.php/apps/spreed/api/v1/bot/abc123/message");
+        request.resume();
+        response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        response.end(`error: ${sig} is not valid`);
+      },
+      async (baseUrl) => {
+        await expect(
+          sendMessageNextcloudTalk("room:abc123", "hello", {
+            cfg: createTalkConfig(baseUrl),
+            timeoutMs: REQUEST_TIMEOUT_MS,
+          }),
+        ).rejects.toThrow(/\[redacted\]/);
+      },
+    );
+  });
+
+  it("omits reaction error body snippet when body exceeds 8 KiB limit", async () => {
+    const body = "Y".repeat(8300);
+
+    await withServer(
+      (request, response) => {
+        expect(request.url).toBe("/ocs/v2.php/apps/spreed/api/v1/bot/abc123/reaction/m-1");
+        request.resume();
+        response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        response.end(body);
+      },
+      async (baseUrl) => {
+        await expect(
+          sendReactionNextcloudTalk("room:abc123", "m-1", "👍", {
+            cfg: createTalkConfig(baseUrl),
+            timeoutMs: REQUEST_TIMEOUT_MS,
+          }),
+        ).rejects.toThrow("Nextcloud Talk reaction failed: 400");
+      },
+    );
+  });
+
+  it("redacts reflected HMAC signature from short reaction error bodies", async () => {
+    await withServer(
+      (request, response) => {
+        const sig = request.headers["x-nextcloud-talk-bot-signature"] ?? "";
+        expect(request.url).toBe("/ocs/v2.php/apps/spreed/api/v1/bot/abc123/reaction/m-1");
+        request.resume();
+        response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        response.end(`error: ${sig} is not valid`);
+      },
+      async (baseUrl) => {
+        await expect(
+          sendReactionNextcloudTalk("room:abc123", "m-1", "👍", {
+            cfg: createTalkConfig(baseUrl),
+            timeoutMs: REQUEST_TIMEOUT_MS,
+          }),
+        ).rejects.toThrow(/\[redacted\]/);
+      },
+    );
+  });
 });
 
 describe("nextcloud-talk send fetch timeouts", () => {

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -1,15 +1,15 @@
 // Nextcloud Talk plugin module implements send behavior.
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
-import {
-  readProviderJsonResponse,
-  readResponseTextLimited,
-} from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   FormatCapabilityProfile,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { releaseNextcloudTalkGuardedResponse } from "./guarded-response.js";
+import {
+  readNextcloudTalkErrorBody,
+  releaseNextcloudTalkGuardedResponse,
+} from "./guarded-response.js";
 import { stripNextcloudTalkTargetPrefix } from "./normalize.js";
 import {
   convertMarkdownTables,
@@ -23,11 +23,6 @@ import {
 } from "./send.runtime.js";
 import type { CoreConfig, NextcloudTalkSendResult } from "./types.js";
 
-// Nextcloud Talk runs against self-hosted servers whose responses are not
-// trusted to be small. Cap error bodies so a hostile or misbehaving endpoint
-// cannot stream an unbounded body into memory. (Success JSON is bounded by the
-// shared readProviderJsonResponse helper.)
-const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES = 8 * 1024;
 const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_CHARS = 200;
 const NEXTCLOUD_TALK_SEND_TIMEOUT_MS = 30_000;
 
@@ -44,27 +39,13 @@ function renderNextcloudTalkMarkdown(markdown: string): string {
   );
 }
 
-/** Collapses whitespace and caps an error-body prefix to a short, log-safe snippet. */
+/** Collapses and caps an already-redacted error body for display. */
 function collapseErrorSnippet(text: string): string {
   const collapsed = text.replace(/\s+/g, " ").trim();
   if (collapsed.length > NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_CHARS) {
     return `${truncateUtf16Safe(collapsed, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_CHARS)}…`;
   }
   return collapsed;
-}
-
-/** Reads a bounded, collapsed error-body snippet without buffering hostile responses. */
-async function readNextcloudTalkErrorSnippet(response: Response): Promise<string> {
-  try {
-    // readResponseTextLimited caps the read at the byte budget and cancels the
-    // upstream stream once full, so a hostile endpoint cannot stream an
-    // unbounded body into memory. Collapse the bounded prefix locally to keep a
-    // short, log-safe error snippet (no new plugin SDK surface required).
-    const text = await readResponseTextLimited(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
-    return collapseErrorSnippet(text);
-  } catch {
-    return "";
-  }
 }
 
 type NextcloudTalkSendOpts = {
@@ -217,7 +198,7 @@ export async function sendMessageNextcloudTalk(
 
   try {
     if (!response.ok) {
-      const errorBody = await readNextcloudTalkErrorSnippet(response);
+      const errorBody = collapseErrorSnippet(await readNextcloudTalkErrorBody(response, signature));
       const status = response.status;
       let errorMsg = `Nextcloud Talk send failed (${status})`;
 
@@ -317,7 +298,7 @@ export async function sendReactionNextcloudTalk(
 
   try {
     if (!response.ok) {
-      const errorBody = await readNextcloudTalkErrorSnippet(response);
+      const errorBody = collapseErrorSnippet(await readNextcloudTalkErrorBody(response, signature));
       throw new Error(`Nextcloud Talk reaction failed: ${response.status} ${errorBody}`.trim());
     }
 

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -1,10 +1,8 @@
 // Nextcloud Talk plugin module implements send behavior.
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
-import {
-  readProviderJsonResponse,
-  readResponseTextLimited,
-} from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readResponseTextPrefix } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   FormatCapabilityProfile,
   renderMarkdownWithMarkers,
@@ -60,11 +58,17 @@ async function readNextcloudTalkErrorSnippet(
   opts?: { extraRedactions?: readonly string[] },
 ): Promise<string> {
   try {
-    // readResponseTextLimited caps the read at the byte budget and cancels the
+    // readResponseTextPrefix caps the read at the byte budget and cancels the
     // upstream stream once full, so a hostile endpoint cannot stream an
-    // unbounded body into memory. Collapse the bounded prefix locally to keep a
-    // short, log-safe error snippet (no new plugin SDK surface required).
-    let text = await readResponseTextLimited(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
+    // unbounded body into memory. Use the full result (not just .text) so we
+    // can detect truncation: an exact-value replacement below cannot match a
+    // secret that straddles the byte-cap boundary, so omit the snippet when
+    // the read was incomplete.
+    const prefix = await readResponseTextPrefix(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
+    if (prefix.truncated) {
+      return "";
+    }
+    let text = prefix.text;
     // Scrub plugin-generated secret values that a misbehaving upstream may
     // reflect in error bodies (e.g. the HMAC signature sent in
     // X-Nextcloud-Talk-Bot-Signature). Scrub before generic redaction so exact

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -55,13 +55,28 @@ function collapseErrorSnippet(text: string): string {
 }
 
 /** Reads a bounded, collapsed error-body snippet without buffering hostile responses. */
-async function readNextcloudTalkErrorSnippet(response: Response): Promise<string> {
+async function readNextcloudTalkErrorSnippet(
+  response: Response,
+  opts?: { extraRedactions?: readonly string[] },
+): Promise<string> {
   try {
     // readResponseTextLimited caps the read at the byte budget and cancels the
     // upstream stream once full, so a hostile endpoint cannot stream an
     // unbounded body into memory. Collapse the bounded prefix locally to keep a
     // short, log-safe error snippet (no new plugin SDK surface required).
-    const text = await readResponseTextLimited(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
+    let text = await readResponseTextLimited(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
+    // Scrub plugin-generated secret values that a misbehaving upstream may
+    // reflect in error bodies (e.g. the HMAC signature sent in
+    // X-Nextcloud-Talk-Bot-Signature). Scrub before generic redaction so exact
+    // known values are removed even when the generic redactor has no pattern
+    // for this header.
+    if (opts?.extraRedactions) {
+      for (const value of opts.extraRedactions) {
+        if (value) {
+          text = text.replaceAll(value, "[redacted]");
+        }
+      }
+    }
     // Redact credentials that a misbehaving upstream may reflect in error bodies
     // (e.g. Authorization headers echoed back in the response).
     // Redact before collapsing so a credential that crosses the snippet-length
@@ -222,7 +237,9 @@ export async function sendMessageNextcloudTalk(
 
   try {
     if (!response.ok) {
-      const errorBody = await readNextcloudTalkErrorSnippet(response);
+      const errorBody = await readNextcloudTalkErrorSnippet(response, {
+        extraRedactions: [signature],
+      });
       const status = response.status;
       let errorMsg = `Nextcloud Talk send failed (${status})`;
 
@@ -322,7 +339,9 @@ export async function sendReactionNextcloudTalk(
 
   try {
     if (!response.ok) {
-      const errorBody = await readNextcloudTalkErrorSnippet(response);
+      const errorBody = await readNextcloudTalkErrorSnippet(response, {
+        extraRedactions: [signature],
+      });
       throw new Error(`Nextcloud Talk reaction failed: ${response.status} ${errorBody}`.trim());
     }
 

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -30,6 +30,17 @@ const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES = 8 * 1024;
 const NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_CHARS = 200;
 const NEXTCLOUD_TALK_SEND_TIMEOUT_MS = 30_000;
 
+// Internal test hook: allows fast regression tests for the error-body idle
+// timeout without waiting the full 10 seconds in CI. Evaluated at call time so
+// tests can set it after module load.
+function getErrorSnippetIdleTimeoutMs(): number {
+  const override = process.env.OPENCLAW_TEST_NEXTCLOUD_TALK_ERROR_IDLE_TIMEOUT_MS;
+  if (override) {
+    return Number(override);
+  }
+  return 10_000;
+}
+
 const NEXTCLOUD_TALK_FORMAT_PROFILE = FormatCapabilityProfile.define({
   mechanism: "markdown",
   chunk: { limit: 4000, unit: "chars", hardCap: 32_000 },
@@ -63,8 +74,14 @@ async function readNextcloudTalkErrorSnippet(
     // unbounded body into memory. Use the full result (not just .text) so we
     // can detect truncation: an exact-value replacement below cannot match a
     // secret that straddles the byte-cap boundary, so omit the snippet when
-    // the read was incomplete.
-    const prefix = await readResponseTextPrefix(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
+    // the read was incomplete. Preserve the prior 10-second chunk idle timeout
+    // so a server that sends a 4xx header and then holds the body open cannot
+    // delay send/reaction failures until the outer request timeout.
+    const prefix = await readResponseTextPrefix(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES, {
+      chunkTimeoutMs: getErrorSnippetIdleTimeoutMs(),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`Nextcloud Talk error body read stalled for ${chunkTimeoutMs}ms`),
+    });
     if (prefix.truncated) {
       return "";
     }

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -1,5 +1,6 @@
 // Nextcloud Talk plugin module implements send behavior.
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderJsonResponse,
   readResponseTextLimited,
@@ -61,7 +62,9 @@ async function readNextcloudTalkErrorSnippet(response: Response): Promise<string
     // unbounded body into memory. Collapse the bounded prefix locally to keep a
     // short, log-safe error snippet (no new plugin SDK surface required).
     const text = await readResponseTextLimited(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
-    return collapseErrorSnippet(text);
+    // Redact credentials that a misbehaving upstream may reflect in error bodies
+    // (e.g. Authorization headers echoed back in the response).
+    return redactToolPayloadText(collapseErrorSnippet(text));
   } catch {
     return "";
   }

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -64,7 +64,9 @@ async function readNextcloudTalkErrorSnippet(response: Response): Promise<string
     const text = await readResponseTextLimited(response, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_BYTES);
     // Redact credentials that a misbehaving upstream may reflect in error bodies
     // (e.g. Authorization headers echoed back in the response).
-    return redactToolPayloadText(collapseErrorSnippet(text));
+    // Redact before collapsing so a credential that crosses the snippet-length
+    // cutoff is fully matched and scrubbed, not left as a raw partial prefix.
+    return collapseErrorSnippet(redactToolPayloadText(text));
   } catch {
     return "";
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators sending messages or reactions, or probing their Nextcloud Talk bot, could receive reflected request credentials in upstream error diagnostics. A configured server or reverse proxy can echo the generated bot signature or Basic-auth value, and simply limiting the error text does not redact it.

## Why This Change Was Made

Maintainer rewrite of @xialonglee's repair, preserving contributor credit. One plugin-owned error reader now serves all three paths through existing public SDK helpers. It accepts only complete bodies within 8 KiB, retains the existing ten-second idle deadline, removes exact request credentials (including decoded preflight passwords), then applies tools-mode redaction before send/reaction whitespace collapse and UTF-16 display truncation. Oversized, stalled, and unreadable bodies use the existing status/actionable fallback.

This removes the separate send-only reader and duplicated preflight byte-limit policy. No configuration, schema, dependency, or Plugin SDK surface changes. Request signing, successful sends and their unknown-receipt behavior, feature-mask interpretation, SSRF policy, and dispatcher cleanup remain unchanged.

## User Impact

Useful complete diagnostics remain visible without reflected credentials; incomplete bodies cannot expose a credential fragment introduced by our own read/display limits. Existing 400/401/403/404 guidance remains intact.

## Evidence

Maintainer proof head: `7a97ad361010063631b2fcef2d1ddc3f4f2f57e6`; mechanically rebased head: `628b2f8de9b7d347550d97d134b6b3622c31fa0a`. Only the changelog conflict needed resolution; all six changed TypeScript files are byte-identical to the proven head. Fresh structured review of the rebased diff is clean. Exact-head CI run **33097850637 passed**, including `openclaw/ci-gate`. AI-assisted with Codex.

- Failure-first real HTTP regression on baseline `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`: all three credential-reflection cases failed; both pre-existing tests passed. No contributor scripts or configuration were executed locally.
- Repaired owner/sibling tests: 31 passed. Full Nextcloud Talk plugin suite: 158 passed. Final strengthened real-HTTP matrix and bounded-response assertions rerun separately: 5 and 15 passed. Cases cover unlabelled request credentials, generic password fields, decoded Basic passwords, the 200-character display boundary, the 8-KiB read boundary, real ten-second stalled bodies, request timeouts, UTF-16, receipts, and cancellation.
- After the changelog-only conflict resolution, the full Nextcloud suite passed again on `628b2f8de9b7`: **160 tests across 26 files**, including current-main logout coverage. GitHub's first new-head CI attempt hit `startup_failure` before jobs; close/reopen recovery started [CI run 33097850637](https://github.com/openclaw/openclaw/actions/runs/33097850637) on the unchanged head.
- Duplicate initialized/uninitialized receipt and numeric/string feature-mask fixtures were consolidated without dropping their cases. Only the weaker small-success id/timestamp test was removed; the retained full-receipt equality protects the same decoding and more. Oversize assertions now require the exact status-only fallback instead of only a loose length limit.
- Fresh structured Codex review: no actionable P0 findings. Manual owner/caller/sibling review includes the shared body reader and tools-mode redactor; the normal Nextcloud API contract was checked against upstream bot documentation and controller source.
- Full `pnpm build` and the local changed gate passed. Hosted exact-head [CI run 33077998739](https://github.com/openclaw/openclaw/actions/runs/33077998739) passed. Automatic remote changed-gate attempts failed during source sync, before checks executed; these are not counted as passing proof. Server-fixture setup and source-checkout/plugin-inventory attempts are likewise not passing product proof.
- Authentic disposable Nextcloud **32.0.14 / Talk 22.0.17** proof passed with a freshly built, canonically packed and npm-installed host at exact head/tree `7a97ad361010063631b2fcef2d1ddc3f4f2f57e6` / `5b664988b1607d494beeab5c9290cdbe9aec448f`. Baseline and candidate plugin tarballs were installed through the existing loopback prepublish registry fixture. This was not public npm publication and did not bypass official-plugin trust or capability consent.
- Both variants sent a unique message through the CLI and added a reaction through Gateway `/tools/invoke`; independent Nextcloud chat/reaction readback confirmed the bot actor and expected content. Bot preflight reported response features and a ready channel. The upstream bot API's null/201 response explains the unchanged `messageId: unknown`; actual server readback proves delivery.
- A fault proxy reflected each actual request signature or Basic credential through complete and oversized responses. Baseline leaked credentials in message/preflight output and the reaction Gateway log; oversized baseline preflight also retained a credential prefix. All six candidate fault cases removed the active credential, tested prefix, decoded password and full generic-password value. Complete-body guidance remained; oversized bodies fell back to status-only errors. The shared generic redactor may retain its existing abbreviated form, so this does not claim all characters of arbitrary generic values are removed. Real ten-second stalls and display truncation are covered by the separate local HTTP matrix, not claimed as repeated live-server cases.
- Host tarball SHA-256: `b0fe3af6b0189d6830b4ac4fe8f159b441aefe1be03a5e58b1939f8a436662c3`; candidate plugin: `65d5ff1c1477aa0c66fe4df98b8d5be195d9393c94ab56951c9bb83ed90e023b`. Both Gateways, fixture registries, Nextcloud container/volume/network, and isolated state were cleaned up. Source hashes were independently checked against the PR head.
- The completed paired proof is bound by the original wrapper result to [environment run 33082910646](https://github.com/openclaw/openclaw/actions/runs/33082910646): command exit 0, 526,986 ms, exact lease and source/tree recorded. The lease's later displayed creation timestamp is inconsistent with the retained allocation/run records; no clock-skew explanation is claimed. All owned leases are stopped.

Production LOC: **+35/-37 (net -2)**. Tests: **+151/-164 (net -13)**. Changelog: **+1**. **Total: +187/-201 (net -14)**.

The unsafe interpolation is also present in stable `v2026.7.1-2`. Earlier bounding repairs #96031 (author @Alix-007, merged by @sallyom) and #97811 (author @Pick-cat, merged by @vincentkoc) carried the unredacted diagnostics forward; they are not established as the original introduction. Local blame stops at a shallow-history boundary, so no unsupported introduction claim is made.

The August 27 Sweeper review and rank-up moves were read. The changelog-removal suggestion is intentionally not applied: the maintainer's explicit landing instructions require a user-facing changelog entry and contributor thanks, and this is maintainer-added bookkeeping. The review's pending-CI observation is superseded by the completed exact-head run above. Its separate terminal probe stopped waiting after 30 seconds; the retained stalled-body matrix deliberately exercises three real ten-second idle deadlines and completed in our full runs. No production timeout or assertion was weakened to fit that probe.

Current matching branch rules require the Actions-owned CI gate and no independent approval rule; classic branch protection is absent, and these plugin-local paths have no restricted CODEOWNERS entry. No approval bypass will be used. The existing ten-second idle bound is preserved, not newly introduced.

Named follow-up: **packaged Nextcloud CLI reaction activation**. `message react --channel nextcloud-talk` reported unsupported on both baseline and candidate, while the real Gateway `/tools/invoke` reaction path worked on both. Its entrypoint/activation root cause is not established or repaired by this PR. The Gateway HTTP response already sanitizes unexpected tool errors; the reaction leak comparison above is specifically its operator log.
