### PR TITLE
refactor(ui): adopt shared control-ui e2e suite bootstrap

### DIFF
--- a/ui/src/e2e/about.e2e.test.ts
+++ b/ui/src/e2e/about.e2e.test.ts
@@ -1,40 +1,20 @@
 // Control UI tests cover About artifact identity against a mocked Gateway.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI About mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const COMMIT = "0123456789abcdef0123456789abcdef01234567";
 const BUILT_AT = "2026-07-10T12:34:56.000Z";
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI About mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("shows and copies browser artifact identity, separately from the Gateway version", async () => {
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
@@ -55,7 +35,7 @@ describeControlUiE2e("Control UI About mocked Gateway E2E", () => {
     await installMockGateway(page);
 
     try {
-      const response = await page.goto(`${server.baseUrl}settings/about`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/about`);
       expect(response?.status()).toBe(200);
       await page.getByRole("heading", { name: "Settings" }).waitFor();
 

--- a/ui/src/e2e/activity-answer-candidates.e2e.test.ts
+++ b/ui/src/e2e/activity-answer-candidates.e2e.test.ts
@@ -1,20 +1,18 @@
 // Control UI E2E tests cover Codex final-answer candidate Activity rendering.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Codex answer candidates",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(
   process.cwd(),
@@ -22,9 +20,6 @@ const proofDir = path.join(
   "control-ui-e2e",
   "codex-answer-candidates",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
@@ -38,74 +33,60 @@ async function screenshot(page: Page, name: string) {
   });
 }
 
-describeControlUiE2e("Control UI Codex answer candidates", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("shows superseded and authoritative selected answers only in Activity", async () => {
     if (captureUiProof) {
       await mkdir(proofDir, { recursive: true });
     }
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, { sessionKey: "main" });
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, { sessionKey: "main" });
 
-    try {
-      await page.goto(`${server.baseUrl}activity`);
-      await page.getByText("No activity yet.", { exact: true }).waitFor();
-      await screenshot(page, "01-before-empty-activity.png");
+        await page.goto(`${suite.server.baseUrl}activity`);
+        await page.getByText("No activity yet.", { exact: true }).waitFor();
+        await screenshot(page, "01-before-empty-activity.png");
 
-      const emitCandidate = async (
-        seq: number,
-        itemId: string,
-        status: "candidate" | "superseded" | "selected",
-        progressText: string,
-      ) => {
-        await gateway.emitGatewayEvent("agent", {
-          runId: "run-proof",
-          seq,
-          stream: "item",
-          ts: Date.now(),
-          sessionKey: "main",
-          data: { kind: "answer_candidate", itemId, progressText, status },
-        });
-      };
+        const emitCandidate = async (
+          seq: number,
+          itemId: string,
+          status: "candidate" | "superseded" | "selected",
+          progressText: string,
+        ) => {
+          await gateway.emitGatewayEvent("agent", {
+            runId: "run-proof",
+            seq,
+            stream: "item",
+            ts: Date.now(),
+            sessionKey: "main",
+            data: { kind: "answer_candidate", itemId, progressText, status },
+          });
+        };
 
-      await emitCandidate(1, "answer-1", "candidate", "Initial bounded answer.");
-      await emitCandidate(2, "answer-1", "superseded", "Initial bounded answer.");
-      await emitCandidate(3, "answer-2", "candidate", "Authoritative bounded answer.");
-      await emitCandidate(4, "answer-2", "selected", "Authoritative bounded answer.");
+        await emitCandidate(1, "answer-1", "candidate", "Initial bounded answer.");
+        await emitCandidate(2, "answer-1", "superseded", "Initial bounded answer.");
+        await emitCandidate(3, "answer-2", "candidate", "Authoritative bounded answer.");
+        await emitCandidate(4, "answer-2", "selected", "Authoritative bounded answer.");
 
-      await expect.poll(() => page.locator(".activity-entry").count()).toBe(2);
-      await page.getByText("Superseded answer", { exact: true }).waitFor();
-      await page.getByText("Selected answer", { exact: true }).waitFor();
-      const selected = page.locator(".activity-entry").filter({ hasText: "Selected answer" });
-      await selected.locator("summary").click();
-      await selected.getByText("Authoritative bounded answer.", { exact: true }).waitFor();
-      await screenshot(page, "02-after-selected-answer.png");
+        await expect.poll(() => page.locator(".activity-entry").count()).toBe(2);
+        await page.getByText("Superseded answer", { exact: true }).waitFor();
+        await page.getByText("Selected answer", { exact: true }).waitFor();
+        const selected = page.locator(".activity-entry").filter({ hasText: "Selected answer" });
+        await selected.locator("summary").click();
+        await selected.getByText("Authoritative bounded answer.", { exact: true }).waitFor();
+        await screenshot(page, "02-after-selected-answer.png");
 
-      await page.goto(`${server.baseUrl}chat`);
-      await expect
-        .poll(() => page.getByText("Authoritative bounded answer.", { exact: true }).count())
-        .toBe(0);
-      await page.goto(`${server.baseUrl}activity`);
-      await page.getByText("No activity yet.", { exact: true }).waitFor();
-    } finally {
-      await context.close();
-    }
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await expect
+          .poll(() => page.getByText("Authoritative bounded answer.", { exact: true }).count())
+          .toBe(0);
+        await page.goto(`${suite.server.baseUrl}activity`);
+        await page.getByText("No activity yet.", { exact: true }).waitFor();
+      },
+    );
   });
 });

--- a/ui/src/e2e/activity-summaries.e2e.test.ts
+++ b/ui/src/e2e/activity-summaries.e2e.test.ts
@@ -1,114 +1,98 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Activity summaries mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-activity-summaries");
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI Activity summaries mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("updates one visible tool summary from running to completed output", async () => {
     if (captureUiProof) {
       await mkdir(path.join(proofDir, "video"), { recursive: true });
     }
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-      ...(captureUiProof
-        ? { recordVideo: { dir: path.join(proofDir, "video"), size: { height: 900, width: 1280 } } }
-        : {}),
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, { sessionKey: "main" });
-    const startedAt = Date.now();
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: path.join(proofDir, "video"),
+                size: { height: 900, width: 1280 },
+              },
+            }
+          : {}),
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, { sessionKey: "main" });
+        const startedAt = Date.now();
 
-    try {
-      await page.goto(`${server.baseUrl}activity`);
-      await page.getByText("No activity yet.", { exact: true }).waitFor();
+        await page.goto(`${suite.server.baseUrl}activity`);
+        await page.getByText("No activity yet.", { exact: true }).waitFor();
 
-      await gateway.emitGatewayEvent("agent", {
-        runId: "run-diagnostics",
-        seq: 1,
-        stream: "tool",
-        ts: startedAt,
-        sessionKey: "main",
-        data: {
-          phase: "start",
-          name: "web_search",
-          toolCallId: "tool-diagnostics",
-          args: { query: "operator diagnostics" },
-        },
-      });
-
-      const entry = page.locator(".activity-entry").filter({ hasText: "web_search" });
-      await entry.waitFor();
-      await expect.poll(() => page.locator(".activity-entry").count()).toBe(1);
-      await entry.getByText("Running", { exact: true }).waitFor();
-      await entry
-        .locator(".activity-entry__summary .activity-entry__text")
-        .getByText("1 argument hidden", { exact: true })
-        .waitFor();
-
-      await gateway.emitGatewayEvent("agent", {
-        runId: "run-diagnostics",
-        seq: 2,
-        stream: "tool",
-        ts: startedAt + 250,
-        sessionKey: "main",
-        data: {
-          phase: "result",
-          name: "web_search",
-          toolCallId: "tool-diagnostics",
-          result: {
-            content: [{ type: "text", text: "Indexed 3 diagnostic sources." }],
+        await gateway.emitGatewayEvent("agent", {
+          runId: "run-diagnostics",
+          seq: 1,
+          stream: "tool",
+          ts: startedAt,
+          sessionKey: "main",
+          data: {
+            phase: "start",
+            name: "web_search",
+            toolCallId: "tool-diagnostics",
+            args: { query: "operator diagnostics" },
           },
-        },
-      });
-
-      await entry.getByText("Done", { exact: true }).waitFor();
-      await expect.poll(() => page.locator(".activity-entry").count()).toBe(1);
-      await page.getByText("1 of 1", { exact: true }).waitFor();
-      await entry.locator("summary").click();
-      await entry.getByText("Indexed 3 diagnostic sources.", { exact: true }).waitFor();
-      await entry.getByText("Run: run-diagnostics", { exact: true }).waitFor();
-
-      if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(proofDir, "completed-tool-summary.png"),
         });
-      }
-    } finally {
-      await context.close();
-    }
+
+        const entry = page.locator(".activity-entry").filter({ hasText: "web_search" });
+        await entry.waitFor();
+        await expect.poll(() => page.locator(".activity-entry").count()).toBe(1);
+        await entry.getByText("Running", { exact: true }).waitFor();
+        await entry
+          .locator(".activity-entry__summary .activity-entry__text")
+          .getByText("1 argument hidden", { exact: true })
+          .waitFor();
+
+        await gateway.emitGatewayEvent("agent", {
+          runId: "run-diagnostics",
+          seq: 2,
+          stream: "tool",
+          ts: startedAt + 250,
+          sessionKey: "main",
+          data: {
+            phase: "result",
+            name: "web_search",
+            toolCallId: "tool-diagnostics",
+            result: {
+              content: [{ type: "text", text: "Indexed 3 diagnostic sources." }],
+            },
+          },
+        });
+
+        await entry.getByText("Done", { exact: true }).waitFor();
+        await expect.poll(() => page.locator(".activity-entry").count()).toBe(1);
+        await page.getByText("1 of 1", { exact: true }).waitFor();
+        await entry.locator("summary").click();
+        await entry.getByText("Indexed 3 diagnostic sources.", { exact: true }).waitFor();
+        await entry.getByText("Run: run-diagnostics", { exact: true }).waitFor();
+
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDir, "completed-tool-summary.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/agent-channel-runtime-status.e2e.test.ts
+++ b/ui/src/e2e/agent-channel-runtime-status.e2e.test.ts
@@ -1,25 +1,20 @@
 // Control UI E2E tests cover Agents channel runtime-status precedence.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Agents channel status",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "channel-runtime-status");
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 async function screenshot(page: Page) {
   if (!captureUiProof) {
@@ -33,84 +28,72 @@ async function screenshot(page: Page) {
   });
 }
 
-describeControlUiE2e("Control UI Agents channel status", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps an explicit stopped runtime in warning state when its API probe succeeds", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      assistantName: "Main agent",
-      defaultAgentId: "main",
-      methodResponses: {
-        "agents.list": {
-          agents: [{ id: "main", name: "Main agent" }],
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
-        },
-        "channels.status": {
-          ts: Date.now(),
-          channelOrder: ["discord"],
-          channelLabels: { discord: "Discord" },
-          channelMeta: [{ id: "discord", label: "Discord", detailLabel: "Discord Bot" }],
-          channels: {},
-          channelAccounts: {
-            discord: [
-              {
-                accountId: "default",
-                configured: true,
-                connected: false,
-                enabled: true,
-                probe: { ok: true },
-                running: false,
-              },
-            ],
-          },
-          channelDefaultAccountId: { discord: "default" },
-        },
-        "config.get": {
-          config: { agents: { entries: { main: { default: true } } } },
-          hash: "hash-1",
-          issues: [],
-          raw: '{"agents":{"list":[{"id":"main"}]}}',
-          valid: true,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          assistantName: "Main agent",
+          defaultAgentId: "main",
+          methodResponses: {
+            "agents.list": {
+              agents: [{ id: "main", name: "Main agent" }],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+            },
+            "channels.status": {
+              ts: Date.now(),
+              channelOrder: ["discord"],
+              channelLabels: { discord: "Discord" },
+              channelMeta: [{ id: "discord", label: "Discord", detailLabel: "Discord Bot" }],
+              channels: {},
+              channelAccounts: {
+                discord: [
+                  {
+                    accountId: "default",
+                    configured: true,
+                    connected: false,
+                    enabled: true,
+                    probe: { ok: true },
+                    running: false,
+                  },
+                ],
+              },
+              channelDefaultAccountId: { discord: "default" },
+            },
+            "config.get": {
+              config: { agents: { entries: { main: { default: true } } } },
+              hash: "hash-1",
+              issues: [],
+              raw: '{"agents":{"list":[{"id":"main"}]}}',
+              valid: true,
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/agents/main/channels`);
-      expect(response?.status()).toBe(200);
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/main/channels");
-      await page.getByRole("tab", { name: /^Channels/ }).click();
+        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/channels`);
+        expect(response?.status()).toBe(200);
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe("/settings/agents/main/channels");
+        await page.getByRole("tab", { name: /^Channels/ }).click();
 
-      const discordRow = page.locator(".settings-row").filter({ hasText: "Discord" });
-      await expect.poll(() => discordRow.count()).toBe(1);
+        const discordRow = page.locator(".settings-row").filter({ hasText: "Discord" });
+        await expect.poll(() => discordRow.count()).toBe(1);
 
-      const status = discordRow.locator(".settings-status");
-      await expect.poll(async () => (await status.textContent())?.trim()).toBe("0/1 connected");
-      await expect
-        .poll(async () => await status.getAttribute("class"))
-        .toContain("settings-status--warn");
-      await screenshot(page);
-    } finally {
-      await context.close();
-    }
+        const status = discordRow.locator(".settings-status");
+        await expect.poll(async () => (await status.textContent())?.trim()).toBe("0/1 connected");
+        await expect
+          .poll(async () => await status.getAttribute("class"))
+          .toContain("settings-status--warn");
+        await screenshot(page);
+      },
+    );
   });
 });

--- a/ui/src/e2e/agent-config-save.e2e.test.ts
+++ b/ui/src/e2e/agent-config-save.e2e.test.ts
@@ -1,25 +1,18 @@
 // Control UI E2E proves per-agent config writes use the canonical keyed shape.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI agent config save",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "agent-config-save");
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function requireRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -28,132 +21,118 @@ function requireRecord(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-describeControlUiE2e("Control UI agent config save", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("submits keyed entries and surfaces Gateway validation failures", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const config = {
-      agents: {
-        entries: {
-          main: {
-            default: true,
-            tools: { profile: "full" },
-          },
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    };
-    const gateway = await installMockGateway(page, {
-      assistantName: "Main agent",
-      defaultAgentId: "main",
-      methodResponses: {
-        "agents.list": {
-          agents: [{ id: "main", name: "Main agent" }],
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
-        },
-        "config.get": {
-          config,
-          sourceConfig: config,
-          runtimeConfig: config,
-          hash: "agent-config-hash-1",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
-        "tools.catalog": {
-          agentId: "main",
-          profiles: [{ id: "full", label: "Full" }],
-          groups: [
-            {
-              id: "fs",
-              label: "Files",
-              source: "core",
-              tools: [
+      async ({ page }) => {
+        const config = {
+          agents: {
+            entries: {
+              main: {
+                default: true,
+                tools: { profile: "full" },
+              },
+            },
+          },
+        };
+        const gateway = await installMockGateway(page, {
+          assistantName: "Main agent",
+          defaultAgentId: "main",
+          methodResponses: {
+            "agents.list": {
+              agents: [{ id: "main", name: "Main agent" }],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+            },
+            "config.get": {
+              config,
+              sourceConfig: config,
+              runtimeConfig: config,
+              hash: "agent-config-hash-1",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+            "tools.catalog": {
+              agentId: "main",
+              profiles: [{ id: "full", label: "Full" }],
+              groups: [
                 {
-                  id: "read",
-                  label: "read",
-                  description: "Read files",
+                  id: "fs",
+                  label: "Files",
                   source: "core",
-                  defaultProfiles: ["full"],
+                  tools: [
+                    {
+                      id: "read",
+                      label: "read",
+                      description: "Read files",
+                      source: "core",
+                      defaultProfiles: ["full"],
+                    },
+                  ],
                 },
               ],
             },
-          ],
-        },
-        "tools.effective": {
-          agentId: "main",
-          profile: "full",
-          groups: [],
-          notices: [],
-        },
-      },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/agents/main/tools`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("agents.list");
-      await gateway.waitForRequest("config.get");
-      await gateway.waitForRequest("tools.catalog");
-
-      await page
-        .locator(".agent-tools-group")
-        .filter({ hasText: "Files" })
-        .locator(".agent-tools-group__summary")
-        .click();
-      await gateway.deferNext("config.set");
-      await page.locator("#agent-tool-read wa-switch").click();
-
-      const request = await gateway.waitForRequest("config.set");
-      const params = requireRecord(request.params);
-      const raw = requireRecord(JSON.parse(String(params.raw)));
-      expect(raw).toEqual({
-        agents: {
-          entries: {
-            main: {
-              default: true,
-              tools: { profile: "full", deny: ["read"] },
+            "tools.effective": {
+              agentId: "main",
+              profile: "full",
+              groups: [],
+              notices: [],
             },
           },
-        },
-      });
-      expect(requireRecord(raw.agents)).not.toHaveProperty("list");
-      expect(params.baseHash).toBe("agent-config-hash-1");
-
-      await gateway.rejectDeferred("config.set", {
-        code: "INVALID_REQUEST",
-        message: "mock validation failure",
-      });
-      await page.getByRole("alert").filter({ hasText: "mock validation failure" }).waitFor();
-
-      if (captureUiProof) {
-        await mkdir(proofDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(proofDir, "01-save-error.png"),
         });
-      }
-    } finally {
-      await context.close();
-    }
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("agents.list");
+        await gateway.waitForRequest("config.get");
+        await gateway.waitForRequest("tools.catalog");
+
+        await page
+          .locator(".agent-tools-group")
+          .filter({ hasText: "Files" })
+          .locator(".agent-tools-group__summary")
+          .click();
+        await gateway.deferNext("config.set");
+        await page.locator("#agent-tool-read wa-switch").click();
+
+        const request = await gateway.waitForRequest("config.set");
+        const params = requireRecord(request.params);
+        const raw = requireRecord(JSON.parse(String(params.raw)));
+        expect(raw).toEqual({
+          agents: {
+            entries: {
+              main: {
+                default: true,
+                tools: { profile: "full", deny: ["read"] },
+              },
+            },
+          },
+        });
+        expect(requireRecord(raw.agents)).not.toHaveProperty("list");
+        expect(params.baseHash).toBe("agent-config-hash-1");
+
+        await gateway.rejectDeferred("config.set", {
+          code: "INVALID_REQUEST",
+          message: "mock validation failure",
+        });
+        await page.getByRole("alert").filter({ hasText: "mock validation failure" }).waitFor();
+
+        if (captureUiProof) {
+          await mkdir(proofDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDir, "01-save-error.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
+++ b/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
@@ -1,39 +1,18 @@
 // Real browser proof that agent model fallbacks follow the Gateway's ownership contract.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI agent model fallback ownership",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 const primaryModel = "openai/gpt-5.4";
 const inheritedFallback = "anthropic/claude-sonnet-4-6";
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI agent model fallback ownership", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it.each([
     {
       name: "inherits global fallbacks when the agent has no model override",
@@ -61,78 +40,77 @@ describeControlUiE2e("Control UI agent model fallback ownership", () => {
       expectedFallbacks: ["google/gemini-3-pro"],
     },
   ])("$name", async ({ model, expectedFallbacks }) => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const config = {
-      agents: {
-        defaults: { model: { primary: primaryModel, fallbacks: [inheritedFallback] } },
-        entries: {
-          main: { default: true },
-          writer: model === undefined ? {} : { model },
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "agents.list": {
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
-          agents: [
-            { id: "main", identity: { name: "Main" }, name: "Main" },
-            { id: "writer", identity: { name: "Writer" }, name: "Writer" },
-          ],
-        },
-        "config.get": {
-          config,
-          sourceConfig: config,
-          hash: "agent-model-fallback-ownership",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
+      async ({ page }) => {
+        const config = {
+          agents: {
+            defaults: { model: { primary: primaryModel, fallbacks: [inheritedFallback] } },
+            entries: {
+              main: { default: true },
+              writer: model === undefined ? {} : { model },
+            },
+          },
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+              agents: [
+                { id: "main", identity: { name: "Main" }, name: "Main" },
+                { id: "writer", identity: { name: "Writer" }, name: "Writer" },
+              ],
+            },
+            "config.get": {
+              config,
+              sourceConfig: config,
+              hash: "agent-model-fallback-ownership",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("agents.list");
+        await gateway.waitForRequest("config.get");
+        const agentPicker = page.locator("openclaw-agents-page openclaw-agent-select");
+        await agentPicker.locator(".agent-select__trigger").click();
+        // Switching agents is the user action under test; the Tools panel must survive it.
+        await agentPicker
+          .locator("wa-dropdown-item[data-agent-option]")
+          .filter({ hasText: "Writer" })
+          .evaluate((item) => (item as HTMLElement).click());
+        await expect
+          .poll(() =>
+            agentPicker.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+          )
+          .toBe("writer");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/writer/tools");
+        await page.getByRole("tab", { name: "Overview", exact: true }).click();
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe("/settings/agents/writer/overview");
+
+        const fallbackInput = page.locator(".agent-chip-input");
+        await fallbackInput.waitFor({ timeout: 10_000 });
+        await expect
+          .poll(async () =>
+            (await fallbackInput.locator(".chip").allTextContents()).map((value) =>
+              value.replace("×", "").trim(),
+            ),
+          )
+          .toEqual(expectedFallbacks);
+        expect(await gateway.getRequests("config.set")).toHaveLength(0);
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/agents/main/tools`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("agents.list");
-      await gateway.waitForRequest("config.get");
-      const agentPicker = page.locator("openclaw-agents-page openclaw-agent-select");
-      await agentPicker.locator(".agent-select__trigger").click();
-      // Switching agents is the user action under test; the Tools panel must survive it.
-      await agentPicker
-        .locator("wa-dropdown-item[data-agent-option]")
-        .filter({ hasText: "Writer" })
-        .evaluate((item) => (item as HTMLElement).click());
-      await expect
-        .poll(() =>
-          agentPicker.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
-        )
-        .toBe("writer");
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/writer/tools");
-      await page.getByRole("tab", { name: "Overview", exact: true }).click();
-      await expect
-        .poll(() => new URL(page.url()).pathname)
-        .toBe("/settings/agents/writer/overview");
-
-      const fallbackInput = page.locator(".agent-chip-input");
-      await fallbackInput.waitFor({ timeout: 10_000 });
-      await expect
-        .poll(async () =>
-          (await fallbackInput.locator(".chip").allTextContents()).map((value) =>
-            value.replace("×", "").trim(),
-          ),
-        )
-        .toEqual(expectedFallbacks);
-      expect(await gateway.getRequests("config.set")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+    );
   });
 });

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -1,26 +1,20 @@
 // Control UI E2E tests cover chip-selected page scope and the all-agents escape.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayControls,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI agent page scope",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "agent-page-scope");
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function requestParams(request: { params?: unknown }): Record<string, unknown> {
   return request.params && typeof request.params === "object"
@@ -73,192 +67,177 @@ const multiAgentRoster = [
   { id: "writer", identity: { name: "Writer" }, name: "Writer" },
 ];
 
-describeControlUiE2e("Control UI agent page scope", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("scopes pages from the chip and keeps Agents settings independent", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "agents.list": {
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
-          agents: multiAgentRoster,
-        },
-        "chat.startup": {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
-            agents: multiAgentRoster,
-          },
-          messages: [],
-          metadata: { models: [] },
-          sessionId: "control-ui-e2e-session",
-          thinkingLevel: null,
-        },
-        "sessions.list": {
-          count: 0,
-          defaults: { contextTokens: null, model: null, modelProvider: null },
-          path: "",
-          sessions: [],
-          ts: Date.now(),
-        },
-        "sessions.usage": emptyUsage,
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+              agents: multiAgentRoster,
+            },
+            "chat.startup": {
+              agentsList: {
+                defaultId: "main",
+                mainKey: "main",
+                scope: "agent",
+                agents: multiAgentRoster,
+              },
+              messages: [],
+              metadata: { models: [] },
+              sessionId: "control-ui-e2e-session",
+              thinkingLevel: null,
+            },
+            "sessions.list": {
+              count: 0,
+              defaults: { contextTokens: null, model: null, modelProvider: null },
+              path: "",
+              sessions: [],
+              ts: Date.now(),
+            },
+            "sessions.usage": emptyUsage,
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}usage`);
-      await gateway.waitForRequest("agents.list");
-      const sidebar = page.locator("openclaw-app-sidebar");
-      await sidebar.getByRole("button", { name: /Switch agent/ }).click();
-      const agentMenu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
-      // The card sits at the top of the sidebar: the menu drops below it so the
-      // agent you clicked (and its checkmark row) stays visible.
-      await expect
-        .poll(async () => {
-          const [card, menu] = await Promise.all([
-            sidebar.locator(".sidebar-agent-card__main").boundingBox(),
-            agentMenu.locator('[part~="menu"], .wa-dropdown__menu').first().boundingBox(),
-          ]);
-          if (!card || !menu) {
-            return null;
-          }
-          return { belowCard: menu.y >= card.y + card.height, leftAligned: menu.x <= card.x + 4 };
-        })
-        .toEqual({ belowCard: true, leftAligned: true });
-      await agentMenu.locator('wa-dropdown-item[value="agent:writer"]').click();
-      await waitForRequest(gateway, "sessions.list", (params) => params.agentId === "writer");
-      await expect
-        .poll(async () =>
-          (await sidebar.locator(".sidebar-agent-card__name").textContent())?.trim(),
-        )
-        .toBe("Writer");
+        await page.goto(`${suite.server.baseUrl}usage`);
+        await gateway.waitForRequest("agents.list");
+        const sidebar = page.locator("openclaw-app-sidebar");
+        await sidebar.getByRole("button", { name: /Switch agent/ }).click();
+        const agentMenu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
+        // The card sits at the top of the sidebar: the menu drops below it so the
+        // agent you clicked (and its checkmark row) stays visible.
+        await expect
+          .poll(async () => {
+            const [card, menu] = await Promise.all([
+              sidebar.locator(".sidebar-agent-card__main").boundingBox(),
+              agentMenu.locator('[part~="menu"], .wa-dropdown__menu').first().boundingBox(),
+            ]);
+            if (!card || !menu) {
+              return null;
+            }
+            return { belowCard: menu.y >= card.y + card.height, leftAligned: menu.x <= card.x + 4 };
+          })
+          .toEqual({ belowCard: true, leftAligned: true });
+        await agentMenu.locator('wa-dropdown-item[value="agent:writer"]').click();
+        await waitForRequest(gateway, "sessions.list", (params) => params.agentId === "writer");
+        await expect
+          .poll(async () =>
+            (await sidebar.locator(".sidebar-agent-card__name").textContent())?.trim(),
+          )
+          .toBe("Writer");
 
-      await sidebar.getByRole("link", { name: "Home" }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/writer");
-      await sidebar.locator(".sidebar-identity-card").click();
-      await sidebar
-        .locator('wa-dropdown.sidebar-identity-menu wa-dropdown-item[value="command:usage"]')
-        .click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/usage");
-      await waitForRequest(gateway, "sessions.usage", (params) => params.agentId === "writer");
-      const pageScope = page.locator(".agent-scope-control openclaw-agent-select");
-      await expect
-        .poll(() =>
-          pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
-        )
-        .toBe("writer");
-      await screenshot(page, "01-writer-usage.png");
+        await sidebar.getByRole("link", { name: "Home" }).click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/writer");
+        await sidebar.locator(".sidebar-identity-card").click();
+        await sidebar
+          .locator('wa-dropdown.sidebar-identity-menu wa-dropdown-item[value="command:usage"]')
+          .click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/usage");
+        await waitForRequest(gateway, "sessions.usage", (params) => params.agentId === "writer");
+        const pageScope = page.locator(".agent-scope-control openclaw-agent-select");
+        await expect
+          .poll(() =>
+            pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+          )
+          .toBe("writer");
+        await screenshot(page, "01-writer-usage.png");
 
-      await sidebar.getByRole("button", { name: /Switch agent/ }).click();
-      await sidebar
-        .locator("wa-dropdown.sidebar-agent-menu")
-        .locator('wa-dropdown-item[value="command:agent-settings"]')
-        .click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/writer");
-      expect(new URL(page.url()).searchParams.get("agent")).toBeNull();
-      await screenshot(page, "03-writer-settings.png");
-    } finally {
-      await context.close();
-    }
+        await sidebar.getByRole("button", { name: /Switch agent/ }).click();
+        await sidebar
+          .locator("wa-dropdown.sidebar-agent-menu")
+          .locator('wa-dropdown-item[value="command:agent-settings"]')
+          .click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/writer");
+        expect(new URL(page.url()).searchParams.get("agent")).toBeNull();
+        await screenshot(page, "03-writer-settings.png");
+      },
+    );
   });
 
   it("updates the compact session scope label and exposes All agents", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "agents.list": {
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
-          agents: multiAgentRoster,
-        },
-        "sessions.list": {
-          count: 0,
-          defaults: { contextTokens: null, model: null, modelProvider: null },
-          path: "",
-          sessions: [],
-          ts: Date.now(),
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+              agents: multiAgentRoster,
+            },
+            "sessions.list": {
+              count: 0,
+              defaults: { contextTokens: null, model: null, modelProvider: null },
+              path: "",
+              sessions: [],
+              ts: Date.now(),
+            },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}sessions`);
-      await gateway.waitForRequest("agents.list");
-      const pageScope = page.locator(".agent-scope-control openclaw-agent-select");
-      await expect
-        .poll(() =>
-          pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
-        )
-        .toBe("main");
+        await page.goto(`${suite.server.baseUrl}sessions`);
+        await gateway.waitForRequest("agents.list");
+        const pageScope = page.locator(".agent-scope-control openclaw-agent-select");
+        await expect
+          .poll(() =>
+            pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+          )
+          .toBe("main");
 
-      await pageScope.locator(".agent-select__trigger").click();
-      await pageScope
-        .locator("wa-dropdown-item[data-agent-option]")
-        .filter({ hasText: "Writer" })
-        .click();
+        await pageScope.locator(".agent-select__trigger").click();
+        await pageScope
+          .locator("wa-dropdown-item[data-agent-option]")
+          .filter({ hasText: "Writer" })
+          .click();
 
-      await waitForRequest(gateway, "sessions.list", (params) => params.agentId === "writer");
-      await expect
-        .poll(() =>
-          pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
-        )
-        .toBe("writer");
-      await expect
-        .poll(async () => (await pageScope.locator(".agent-select__label").textContent())?.trim())
-        .toBe("Writer");
-      await screenshot(page, "05-first-session-scope-switch.png");
+        await waitForRequest(gateway, "sessions.list", (params) => params.agentId === "writer");
+        await expect
+          .poll(() =>
+            pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+          )
+          .toBe("writer");
+        await expect
+          .poll(async () => (await pageScope.locator(".agent-select__label").textContent())?.trim())
+          .toBe("Writer");
+        await screenshot(page, "05-first-session-scope-switch.png");
 
-      const sessionRequestsBeforeAll = (await gateway.getRequests("sessions.list")).length;
-      await pageScope.locator(".agent-select__trigger").click();
-      await pageScope
-        .locator("wa-dropdown-item[data-agent-option]")
-        .filter({ hasText: "All agents" })
-        .evaluate((item) => (item as HTMLElement).click());
-      await expect
-        .poll(async () => {
-          const requests = await gateway.getRequests("sessions.list");
-          return requests
-            .slice(sessionRequestsBeforeAll)
-            .some((request) => !Object.hasOwn(requestParams(request), "agentId"));
-        })
-        .toBe(true);
-      await expect
-        .poll(() =>
-          pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
-        )
-        .toBe("");
-      await expect
-        .poll(async () => (await pageScope.locator(".agent-select__label").textContent())?.trim())
-        .toBe("All agents");
-      await screenshot(page, "06-all-agents-session-scope.png");
-    } finally {
-      await context.close();
-    }
+        const sessionRequestsBeforeAll = (await gateway.getRequests("sessions.list")).length;
+        await pageScope.locator(".agent-select__trigger").click();
+        await pageScope
+          .locator("wa-dropdown-item[data-agent-option]")
+          .filter({ hasText: "All agents" })
+          .evaluate((item) => (item as HTMLElement).click());
+        await expect
+          .poll(async () => {
+            const requests = await gateway.getRequests("sessions.list");
+            return requests
+              .slice(sessionRequestsBeforeAll)
+              .some((request) => !Object.hasOwn(requestParams(request), "agentId"));
+          })
+          .toBe(true);
+        await expect
+          .poll(() =>
+            pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+          )
+          .toBe("");
+        await expect
+          .poll(async () => (await pageScope.locator(".agent-select__label").textContent())?.trim())
+          .toBe("All agents");
+        await screenshot(page, "06-all-agents-session-scope.png");
+      },
+    );
   });
 });

--- a/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
+++ b/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
@@ -1,20 +1,18 @@
 // Control UI tests cover bounded authenticated agent-picker avatar fetches.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI agent picker avatar timeout",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(
   process.cwd(),
@@ -22,9 +20,6 @@ const proofDir = path.join(
   "control-ui-e2e",
   "agent-select-avatar-timeout",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
@@ -38,82 +33,68 @@ async function screenshot(page: Page, name: string) {
   });
 }
 
-describeControlUiE2e("Control UI agent picker avatar timeout", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("aborts a stalled authenticated avatar request and keeps the text fallback", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await page.clock.install();
-
-    let avatarRequestCount = 0;
-    let avatarAuthorization: string | undefined;
-    const failedAvatarRequests: string[] = [];
-    page.on("requestfailed", (request) => {
-      if (new URL(request.url()).pathname === "/avatar/main") {
-        failedAvatarRequests.push(request.failure()?.errorText ?? "unknown");
-      }
-    });
-    await page.route(/\/avatar\/main$/, (route) => {
-      avatarRequestCount += 1;
-      avatarAuthorization = route.request().headers().authorization;
-      // Leave the route unanswered. The page-owned deadline must cancel it.
-    });
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "agent.identity.get": {
-          agentId: "main",
-          avatar: "/avatar/main",
-          avatarStatus: "local",
-          name: "Main agent",
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        await page.clock.install();
 
-    try {
-      const response = await page.goto(`${server.baseUrl}agents`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("agent.identity.get");
-      await expect.poll(() => avatarRequestCount).toBe(1);
-      const picker = page.locator("openclaw-agent-select");
-      await expect
-        .poll(() =>
-          picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
-        )
-        .toBe("O");
-      expect(avatarAuthorization).toBe("Bearer e2e-device-token");
-      await screenshot(page, "01-request-stalled.png");
+        let avatarRequestCount = 0;
+        let avatarAuthorization: string | undefined;
+        const failedAvatarRequests: string[] = [];
+        page.on("requestfailed", (request) => {
+          if (new URL(request.url()).pathname === "/avatar/main") {
+            failedAvatarRequests.push(request.failure()?.errorText ?? "unknown");
+          }
+        });
+        await page.route(/\/avatar\/main$/, (route) => {
+          avatarRequestCount += 1;
+          avatarAuthorization = route.request().headers().authorization;
+          // Leave the route unanswered. The page-owned deadline must cancel it.
+        });
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agent.identity.get": {
+              agentId: "main",
+              avatar: "/avatar/main",
+              avatarStatus: "local",
+              name: "Main agent",
+            },
+          },
+        });
 
-      await page.clock.runFor(30_000);
-      await expect.poll(() => failedAvatarRequests.length).toBe(1);
-      await expect.poll(() => picker.locator("img.agent-select__avatar").count()).toBe(0);
-      await expect
-        .poll(() =>
-          picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
-        )
-        .toBe("O");
+        const response = await page.goto(`${suite.server.baseUrl}agents`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("agent.identity.get");
+        await expect.poll(() => avatarRequestCount).toBe(1);
+        const picker = page.locator("openclaw-agent-select");
+        await expect
+          .poll(() =>
+            picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
+          )
+          .toBe("O");
+        expect(avatarAuthorization).toBe("Bearer e2e-device-token");
+        await screenshot(page, "01-request-stalled.png");
 
-      // A later render must use the cached miss instead of launching another fetch.
-      await picker.locator(".agent-select__trigger").click();
-      expect(avatarRequestCount).toBe(1);
-      await screenshot(page, "02-timeout-fallback.png");
-    } finally {
-      await context.close();
-    }
+        await page.clock.runFor(30_000);
+        await expect.poll(() => failedAvatarRequests.length).toBe(1);
+        await expect.poll(() => picker.locator("img.agent-select__avatar").count()).toBe(0);
+        await expect
+          .poll(() =>
+            picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
+          )
+          .toBe("O");
+
+        // A later render must use the cached miss instead of launching another fetch.
+        await picker.locator(".agent-select__trigger").click();
+        expect(avatarRequestCount).toBe(1);
+        await screenshot(page, "02-timeout-fallback.png");
+      },
+    );
   });
 });

--- a/ui/src/e2e/agents-set-default-persistence.e2e.test.ts
+++ b/ui/src/e2e/agents-set-default-persistence.e2e.test.ts
@@ -1,22 +1,14 @@
 // Control UI tests cover Agents page Set Default persistence behavior.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayRequest,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI agents Set Default mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 function requireRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -29,87 +21,71 @@ function requestParams(request: MockGatewayRequest): Record<string, unknown> {
   return requireRecord(request.params);
 }
 
-describeControlUiE2e("Control UI agents Set Default mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("persists Set Default through config.set instead of only staging the form draft", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const initialConfig = {
-      agents: { entries: { main: { default: true }, kimi: {} } },
-    };
-    const savedConfig = {
-      agents: { entries: { main: {}, kimi: { default: true } } },
-    };
-    const gateway = await installMockGateway(page, {
-      assistantName: "Main agent",
-      defaultAgentId: "main",
-      methodResponses: {
-        "agents.list": {
-          agents: [
-            { id: "main", name: "Main agent" },
-            { id: "kimi", name: "Kimi agent" },
-          ],
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
-        },
-        "config.get": {
-          config: initialConfig,
-          sourceConfig: initialConfig,
-          hash: "hash-1",
-          issues: [],
-          raw: JSON.stringify(initialConfig),
-          valid: true,
-        },
-        "config.set": {
-          config: savedConfig,
-          sourceConfig: savedConfig,
-          hash: "hash-2",
-          issues: [],
-          raw: JSON.stringify(savedConfig),
-          valid: true,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const initialConfig = {
+          agents: { entries: { main: { default: true }, kimi: {} } },
+        };
+        const savedConfig = {
+          agents: { entries: { main: {}, kimi: { default: true } } },
+        };
+        const gateway = await installMockGateway(page, {
+          assistantName: "Main agent",
+          defaultAgentId: "main",
+          methodResponses: {
+            "agents.list": {
+              agents: [
+                { id: "main", name: "Main agent" },
+                { id: "kimi", name: "Kimi agent" },
+              ],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+            },
+            "config.get": {
+              config: initialConfig,
+              sourceConfig: initialConfig,
+              hash: "hash-1",
+              issues: [],
+              raw: JSON.stringify(initialConfig),
+              valid: true,
+            },
+            "config.set": {
+              config: savedConfig,
+              sourceConfig: savedConfig,
+              hash: "hash-2",
+              issues: [],
+              raw: JSON.stringify(savedConfig),
+              valid: true,
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}agents`);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(`${suite.server.baseUrl}agents`);
+        expect(response?.status()).toBe(200);
 
-      // Click auto-waits for the elements to be actionable (enabled), so
-      // these implicitly assert the dropdown loaded and Set Default is clickable for a
-      // non-default agent.
-      const agentSelect = page.locator("wa-dropdown.agent-select");
-      await agentSelect.locator(".agent-select__trigger").click();
-      await agentSelect.getByRole("menuitemradio", { name: "Kimi agent", exact: true }).click();
-      await page.getByRole("button", { name: "Set Default", exact: true }).click();
+        // Click auto-waits for the elements to be actionable (enabled), so
+        // these implicitly assert the dropdown loaded and Set Default is clickable for a
+        // non-default agent.
+        const agentSelect = page.locator("wa-dropdown.agent-select");
+        await agentSelect.locator(".agent-select__trigger").click();
+        await agentSelect.getByRole("menuitemradio", { name: "Kimi agent", exact: true }).click();
+        await page.getByRole("button", { name: "Set Default", exact: true }).click();
 
-      // The fix routes Set Default through the canonical save path; without it the click
-      // only stages a form draft and never emits config.set, so this request never arrives.
-      const setRequest = await gateway.waitForRequest("config.set");
-      const raw = requestParams(setRequest).raw;
-      expect(JSON.parse(String(raw))).toEqual(savedConfig);
-      expect(requireRecord(JSON.parse(String(raw))).agents).not.toHaveProperty("list");
-    } finally {
-      await context.close();
-    }
+        // The fix routes Set Default through the canonical save path; without it the click
+        // only stages a form draft and never emits config.set, so this request never arrives.
+        const setRequest = await gateway.waitForRequest("config.set");
+        const raw = requestParams(setRequest).raw;
+        expect(JSON.parse(String(raw))).toEqual(savedConfig);
+        expect(requireRecord(JSON.parse(String(raw))).agents).not.toHaveProperty("list");
+      },
+    );
   });
 });

--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -1,20 +1,18 @@
 // Control UI tests cover contextual scrollbars and native-style text selection.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI app chrome interaction mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -22,9 +20,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "app-chrome-interaction",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 async function dragAcross(page: Page, locator: Locator): Promise<string> {
   await locator.scrollIntoViewIfNeeded();
@@ -51,126 +46,110 @@ async function captureUiProof(page: Page, fileName: string) {
   });
 }
 
-describeControlUiE2e("Control UI app chrome interaction mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("uses compact sidebar scrollbars and keeps selection in chat and inputs", async () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
-      locale: "en-US",
-      recordVideo: captureUiProofEnabled
-        ? { dir: path.join(uiProofArtifactDir, "video"), size: { height: 900, width: 1440 } }
-        : undefined,
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      historyMessages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "Selectable transcript content" }],
-        },
-      ],
-    });
+    await suite.withPage(
+      {
+        locale: "en-US",
+        recordVideo: captureUiProofEnabled
+          ? { dir: path.join(uiProofArtifactDir, "video"), size: { height: 900, width: 1440 } }
+          : undefined,
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          historyMessages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Selectable transcript content" }],
+            },
+          ],
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
-      const transcript = page.getByText("Selectable transcript content", { exact: true });
-      await transcript.waitFor();
-      const chatStyles = await page.evaluate(() => {
-        const sidebar = document.querySelector<HTMLElement>(".sidebar");
-        const sessions = document.querySelector<HTMLElement>(".sidebar-shell__body");
-        const thread = document.querySelector<HTMLElement>(".chat-thread");
-        if (!sidebar || !sessions || !thread) {
-          throw new Error("Missing chat interaction surface");
-        }
-        return {
-          chatSelection: getComputedStyle(thread).userSelect,
-          chatScrollbar: getComputedStyle(thread, "::-webkit-scrollbar").width,
-          sidebarSelection: getComputedStyle(sidebar).userSelect,
-          sidebarScrollbar: getComputedStyle(sessions, "::-webkit-scrollbar").width,
-        };
-      });
-      expect(chatStyles).toEqual({
-        chatSelection: "text",
-        chatScrollbar: "12px",
-        sidebarSelection: "none",
-        sidebarScrollbar: "6px",
-      });
-      expect(await dragAcross(page, transcript)).toContain("Selectable transcript");
-      await captureUiProof(page, "01-chat-selectable-transcript.png");
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const transcript = page.getByText("Selectable transcript content", { exact: true });
+        await transcript.waitFor();
+        const chatStyles = await page.evaluate(() => {
+          const sidebar = document.querySelector<HTMLElement>(".sidebar");
+          const sessions = document.querySelector<HTMLElement>(".sidebar-shell__body");
+          const thread = document.querySelector<HTMLElement>(".chat-thread");
+          if (!sidebar || !sessions || !thread) {
+            throw new Error("Missing chat interaction surface");
+          }
+          return {
+            chatSelection: getComputedStyle(thread).userSelect,
+            chatScrollbar: getComputedStyle(thread, "::-webkit-scrollbar").width,
+            sidebarSelection: getComputedStyle(sidebar).userSelect,
+            sidebarScrollbar: getComputedStyle(sessions, "::-webkit-scrollbar").width,
+          };
+        });
+        expect(chatStyles).toEqual({
+          chatSelection: "text",
+          chatScrollbar: "12px",
+          sidebarSelection: "none",
+          sidebarScrollbar: "6px",
+        });
+        expect(await dragAcross(page, transcript)).toContain("Selectable transcript");
+        await captureUiProof(page, "01-chat-selectable-transcript.png");
 
-      await page.setViewportSize({ height: 650, width: 1440 });
-      // Appearance renders schema-independent theme/UI sections that overflow
-      // 650px even against the mock gateway's tiny config fixture; General
-      // became short enough to fit once the host panel moved to Gateway.
-      await page.goto(`${server.baseUrl}settings/appearance`);
-      const settingsSidebar = page.locator(".settings-sidebar");
-      const settingsTitle = settingsSidebar.locator(".settings-sidebar__title");
-      const settingsSearch = settingsSidebar.locator(".settings-sidebar__search-input");
-      const content = page.locator(".content");
-      await settingsSidebar.waitFor();
-      await expect
-        .poll(() => content.evaluate((element) => element.scrollHeight))
-        .toBeGreaterThan(await content.evaluate((element) => element.clientHeight));
+        await page.setViewportSize({ height: 650, width: 1440 });
+        // Appearance renders schema-independent theme/UI sections that overflow
+        // 650px even against the mock gateway's tiny config fixture; General
+        // became short enough to fit once the host panel moved to Gateway.
+        await page.goto(`${suite.server.baseUrl}settings/appearance`);
+        const settingsSidebar = page.locator(".settings-sidebar");
+        const settingsTitle = settingsSidebar.locator(".settings-sidebar__title");
+        const settingsSearch = settingsSidebar.locator(".settings-sidebar__search-input");
+        const content = page.locator(".content");
+        await settingsSidebar.waitFor();
+        await expect
+          .poll(() => content.evaluate((element) => element.scrollHeight))
+          .toBeGreaterThan(await content.evaluate((element) => element.clientHeight));
 
-      const settingsStyles = await page.evaluate(() => {
-        const contentNode = document.querySelector<HTMLElement>(".content");
-        const nav = document.querySelector<HTMLElement>(".settings-sidebar__nav");
-        const search = document.querySelector<HTMLElement>(".settings-sidebar__search-input");
-        const sidebar = document.querySelector<HTMLElement>(".settings-sidebar");
-        if (!contentNode || !nav || !search || !sidebar) {
-          throw new Error("Missing settings interaction surface");
-        }
-        return {
-          contentScrollbar: getComputedStyle(contentNode, "::-webkit-scrollbar").width,
-          contentSelection: getComputedStyle(contentNode).userSelect,
-          inputSelection: getComputedStyle(search).userSelect,
-          sidebarScrollbar: getComputedStyle(nav, "::-webkit-scrollbar").width,
-          sidebarSelection: getComputedStyle(sidebar).userSelect,
-        };
-      });
-      expect(settingsStyles).toEqual({
-        contentScrollbar: "12px",
-        contentSelection: "none",
-        inputSelection: "text",
-        sidebarScrollbar: "6px",
-        sidebarSelection: "none",
-      });
+        const settingsStyles = await page.evaluate(() => {
+          const contentNode = document.querySelector<HTMLElement>(".content");
+          const nav = document.querySelector<HTMLElement>(".settings-sidebar__nav");
+          const search = document.querySelector<HTMLElement>(".settings-sidebar__search-input");
+          const sidebar = document.querySelector<HTMLElement>(".settings-sidebar");
+          if (!contentNode || !nav || !search || !sidebar) {
+            throw new Error("Missing settings interaction surface");
+          }
+          return {
+            contentScrollbar: getComputedStyle(contentNode, "::-webkit-scrollbar").width,
+            contentSelection: getComputedStyle(contentNode).userSelect,
+            inputSelection: getComputedStyle(search).userSelect,
+            sidebarScrollbar: getComputedStyle(nav, "::-webkit-scrollbar").width,
+            sidebarSelection: getComputedStyle(sidebar).userSelect,
+          };
+        });
+        expect(settingsStyles).toEqual({
+          contentScrollbar: "12px",
+          contentSelection: "none",
+          inputSelection: "text",
+          sidebarScrollbar: "6px",
+          sidebarSelection: "none",
+        });
 
-      await page.evaluate(() => globalThis.getSelection()?.removeAllRanges());
-      expect(await dragAcross(page, settingsTitle)).toBe("");
-      await settingsSearch.selectText();
-      expect(
-        await settingsSearch.evaluate(
-          (element) =>
-            element instanceof HTMLInputElement &&
-            element.selectionStart === 0 &&
-            element.selectionEnd === element.value.length,
-        ),
-      ).toBe(true);
-      await content.evaluate((element) => {
-        element.scrollTop = Math.min(160, element.scrollHeight - element.clientHeight);
-      });
-      await captureUiProof(page, "02-settings-contextual-scrollbars.png");
-    } finally {
-      await context.close();
-    }
+        await page.evaluate(() => globalThis.getSelection()?.removeAllRanges());
+        expect(await dragAcross(page, settingsTitle)).toBe("");
+        await settingsSearch.selectText();
+        expect(
+          await settingsSearch.evaluate(
+            (element) =>
+              element instanceof HTMLInputElement &&
+              element.selectionStart === 0 &&
+              element.selectionEnd === element.value.length,
+          ),
+        ).toBe(true);
+        await content.evaluate((element) => {
+          element.scrollTop = Math.min(160, element.scrollHeight - element.clientHeight);
+        });
+        await captureUiProof(page, "02-settings-contextual-scrollbars.png");
+      },
+    );
   });
 });

--- a/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
@@ -1,27 +1,27 @@
 // Control UI tests cover Appearance override provenance and restoring product defaults.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
 import { importCustomThemeFromUrl } from "../app/custom-theme.ts";
 import {
-  canRunPlaywrightChromium,
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
   waitForControlUiSettingsTakeover,
-  type ControlUiE2eServer,
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createTweakcnThemePayload } from "../test-helpers/custom-theme.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Appearance defaults mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -29,11 +29,8 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "appearance-settings-defaults",
 );
-let browser: Browser;
-let server: ControlUiE2eServer;
-
 function settingsStorageKey(): string {
-  return controlUiBundledSettingsStorageKey(server.baseUrl);
+  return controlUiBundledSettingsStorageKey(suite.server.baseUrl);
 }
 
 function configResponse(prefs: Record<string, unknown>, hash: string) {
@@ -150,24 +147,9 @@ async function captureViewport(page: Page, filename: string): Promise<void> {
   });
 }
 
-describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("removes synced and browser-local overrides, then reloads inherited defaults", async () => {
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
       serviceWorkers: "block",
@@ -188,7 +170,7 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
           }),
         );
       },
-      { gatewayUrl: controlUiBundledGatewayUrl(server.baseUrl), key: settingsStorageKey() },
+      { gatewayUrl: controlUiBundledGatewayUrl(suite.server.baseUrl), key: settingsStorageKey() },
     );
     const page = await context.newPage();
     const initialPrefs: Record<string, unknown> = {
@@ -205,7 +187,7 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
       expect(response?.status()).toBe(200);
       await waitForControlUiSettingsTakeover(page);
       await gateway.waitForRequest("config.get");
@@ -375,116 +357,121 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
   });
 
   it("keeps rejected edits browser-local and resets them without another server write", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const initialPrefs = {
-      locale: "en",
-      theme: "claw",
-      chatFollowUpMode: "queue",
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse(initialPrefs, "appearance-rejected-1"),
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const initialPrefs = {
+          locale: "en",
+          theme: "claw",
+          chatFollowUpMode: "queue",
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse(initialPrefs, "appearance-rejected-1"),
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
-      expect(response?.status()).toBe(200);
-      await waitForControlUiSettingsTakeover(page);
-      await gateway.waitForRequest("config.get");
+        const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
+        expect(response?.status()).toBe(200);
+        await waitForControlUiSettingsTakeover(page);
+        await gateway.waitForRequest("config.get");
 
-      const languageRow = page.locator("#settings-language .settings-row");
-      const languageSelect = languageRow.locator("wa-select");
-      const themeSection = page.locator("#settings-appearance-theme");
-      const themeDescription = themeSection.locator(":scope > .settings-section__desc");
-      const followUpSelect = page.locator("[data-settings-follow-up-mode]");
-      const followUpRow = page.locator(".settings-row").filter({ has: followUpSelect });
+        const languageRow = page.locator("#settings-language .settings-row");
+        const languageSelect = languageRow.locator("wa-select");
+        const themeSection = page.locator("#settings-appearance-theme");
+        const themeDescription = themeSection.locator(":scope > .settings-section__desc");
+        const followUpSelect = page.locator("[data-settings-follow-up-mode]");
+        const followUpRow = page.locator(".settings-row").filter({ has: followUpSelect });
 
-      await expect.poll(() => selectValue(languageSelect)).toBe("en");
-      await expect
-        .poll(() => themeSection.locator(".settings-theme-card--claw").getAttribute("aria-pressed"))
-        .toBe("true");
-      await expect.poll(() => followUpSelect.inputValue()).toBe("queue");
+        await expect.poll(() => selectValue(languageSelect)).toBe("en");
+        await expect
+          .poll(() =>
+            themeSection.locator(".settings-theme-card--claw").getAttribute("aria-pressed"),
+          )
+          .toBe("true");
+        await expect.poll(() => followUpSelect.inputValue()).toBe("queue");
 
-      await gateway.deferNext("config.patch");
-      await themeSection.locator(".settings-theme-card--knot").click();
-      await waitForRequestCount(gateway, "config.patch", 1);
-      expect(
-        patchPrefs((await gateway.getRequests("config.patch"))[0] as MockGatewayRequest),
-      ).toEqual({ theme: "knot" });
-      await gateway.rejectDeferred("config.patch", {
-        code: "INVALID_REQUEST",
-        message: "mock validation failure",
-      });
+        await gateway.deferNext("config.patch");
+        await themeSection.locator(".settings-theme-card--knot").click();
+        await waitForRequestCount(gateway, "config.patch", 1);
+        expect(
+          patchPrefs((await gateway.getRequests("config.patch"))[0] as MockGatewayRequest),
+        ).toEqual({ theme: "knot" });
+        await gateway.rejectDeferred("config.patch", {
+          code: "INVALID_REQUEST",
+          message: "mock validation failure",
+        });
 
-      await expect
-        .poll(() => themeSection.locator(".settings-theme-card--knot").getAttribute("aria-pressed"))
-        .toBe("true");
-      await expect.poll(() => themeDescription.textContent()).toContain("Default: Claw");
-      await expect
-        .poll(() => themeDescription.textContent())
-        .toContain("Stored in this browser only");
+        await expect
+          .poll(() =>
+            themeSection.locator(".settings-theme-card--knot").getAttribute("aria-pressed"),
+          )
+          .toBe("true");
+        await expect.poll(() => themeDescription.textContent()).toContain("Default: Claw");
+        await expect
+          .poll(() => themeDescription.textContent())
+          .toContain("Stored in this browser only");
 
-      await gateway.deferNext("config.patch");
-      await languageSelect.evaluate((element) => {
-        const select = element as HTMLElement & { value: string };
-        select.value = "fr";
-        select.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
-      });
-      await waitForRequestCount(gateway, "config.patch", 2);
-      expect(
-        patchPrefs((await gateway.getRequests("config.patch"))[1] as MockGatewayRequest),
-      ).toEqual({ locale: "fr" });
-      await gateway.rejectDeferred("config.patch", {
-        code: "INVALID_REQUEST",
-        message: "mock validation failure",
-      });
+        await gateway.deferNext("config.patch");
+        await languageSelect.evaluate((element) => {
+          const select = element as HTMLElement & { value: string };
+          select.value = "fr";
+          select.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+        });
+        await waitForRequestCount(gateway, "config.patch", 2);
+        expect(
+          patchPrefs((await gateway.getRequests("config.patch"))[1] as MockGatewayRequest),
+        ).toEqual({ locale: "fr" });
+        await gateway.rejectDeferred("config.patch", {
+          code: "INVALID_REQUEST",
+          message: "mock validation failure",
+        });
 
-      await expect.poll(() => selectValue(languageSelect)).toBe("fr");
-      await expect.poll(() => languageRow.textContent()).toContain("Par défaut : Anglais");
-      await expect
-        .poll(() => languageRow.textContent())
-        .toContain("Stocké uniquement dans ce navigateur");
+        await expect.poll(() => selectValue(languageSelect)).toBe("fr");
+        await expect.poll(() => languageRow.textContent()).toContain("Par défaut : Anglais");
+        await expect
+          .poll(() => languageRow.textContent())
+          .toContain("Stocké uniquement dans ce navigateur");
 
-      await gateway.deferNext("config.patch");
-      await followUpSelect.selectOption("steer");
-      await waitForRequestCount(gateway, "config.patch", 3);
-      expect(
-        patchPrefs((await gateway.getRequests("config.patch"))[2] as MockGatewayRequest),
-      ).toEqual({ chatFollowUpMode: "steer" });
-      await gateway.rejectDeferred("config.patch", {
-        code: "INVALID_REQUEST",
-        message: "mock validation failure",
-      });
+        await gateway.deferNext("config.patch");
+        await followUpSelect.selectOption("steer");
+        await waitForRequestCount(gateway, "config.patch", 3);
+        expect(
+          patchPrefs((await gateway.getRequests("config.patch"))[2] as MockGatewayRequest),
+        ).toEqual({ chatFollowUpMode: "steer" });
+        await gateway.rejectDeferred("config.patch", {
+          code: "INVALID_REQUEST",
+          message: "mock validation failure",
+        });
 
-      await expect.poll(() => followUpSelect.inputValue()).toBe("steer");
-      await expect
-        .poll(() => followUpRow.textContent())
-        .toContain("Stocké uniquement dans ce navigateur");
+        await expect.poll(() => followUpSelect.inputValue()).toBe("steer");
+        await expect
+          .poll(() => followUpRow.textContent())
+          .toContain("Stocké uniquement dans ce navigateur");
 
-      await themeSection
-        .locator(":scope > .settings-section__header")
-        .locator("button.btn--icon")
-        .click();
-      await languageRow.locator("button.btn--icon").click();
-      await followUpRow.locator("button.btn--sm").click();
+        await themeSection
+          .locator(":scope > .settings-section__header")
+          .locator("button.btn--icon")
+          .click();
+        await languageRow.locator("button.btn--icon").click();
+        await followUpRow.locator("button.btn--sm").click();
 
-      await expect
-        .poll(() => themeSection.locator(".settings-theme-card--claw").getAttribute("aria-pressed"))
-        .toBe("true");
-      await expect.poll(() => selectValue(languageSelect)).toBe("en");
-      await expect.poll(() => followUpSelect.inputValue()).toBe("queue");
-      await expect.poll(() => page.locator("html").getAttribute("lang")).toBe("en");
-      await page.waitForTimeout(100);
-      expect(await gateway.getRequests("config.patch")).toHaveLength(3);
-    } finally {
-      await context.close();
-    }
+        await expect
+          .poll(() =>
+            themeSection.locator(".settings-theme-card--claw").getAttribute("aria-pressed"),
+          )
+          .toBe("true");
+        await expect.poll(() => selectValue(languageSelect)).toBe("en");
+        await expect.poll(() => followUpSelect.inputValue()).toBe("queue");
+        await expect.poll(() => page.locator("html").getAttribute("lang")).toBe("en");
+        await page.waitForTimeout(100);
+        expect(await gateway.getRequests("config.patch")).toHaveLength(3);
+      },
+    );
   });
 
   it("keeps every read-only preference surface browser-local across reload", async () => {
@@ -623,7 +610,7 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
     const replacementGate = new Promise<void>((resolve) => {
       releaseReplacement = resolve;
     });
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
       serviceWorkers: "block",
@@ -641,7 +628,7 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
         );
       },
       {
-        gatewayUrl: controlUiBundledGatewayUrl(server.baseUrl),
+        gatewayUrl: controlUiBundledGatewayUrl(suite.server.baseUrl),
         key: settingsStorageKey(),
         theme: existingTheme,
       },
@@ -659,7 +646,7 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
       expect(response?.status()).toBe(200);
       await waitForControlUiSettingsTakeover(page);
       await gateway.waitForRequest("config.get");
@@ -745,7 +732,7 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
     const importGate = new Promise<void>((resolve) => {
       releaseImport = resolve;
     });
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
       serviceWorkers: "block",
@@ -764,7 +751,7 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
       expect(response?.status()).toBe(200);
       await waitForControlUiSettingsTakeover(page);
       await gateway.waitForRequest("config.get");

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -1,24 +1,15 @@
 // Control UI E2E tests cover approval queue behavior through the Gateway WebSocket.
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { afterEach, expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI approval flow",
+});
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
-let browser: Browser;
 let page: Page | undefined;
-let server: ControlUiE2eServer | undefined;
-
 function approval(id: string, command: string, createdAtMs: number) {
   return {
     id,
@@ -35,17 +26,7 @@ function requireRecord(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-describeControlUiE2e("Control UI approval flow", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await page
       ?.context()
@@ -54,18 +35,13 @@ describeControlUiE2e("Control UI approval flow", () => {
     page = undefined;
   });
 
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
   it("keeps a resolve failure scoped to its approval when a newer one arrives", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage);
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await gateway.waitForRequest("sessions.list");
     await gateway.deferNext("exec.approval.resolve");
     await gateway.emitGatewayEvent(
@@ -104,12 +80,12 @@ describeControlUiE2e("Control UI approval flow", () => {
   });
 
   it("sends a typed approval command immediately while the active run waits", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage);
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await gateway.waitForRequest("sessions.list");
 
     const composer = currentPage.locator(".agent-chat__composer-combobox textarea");

--- a/ui/src/e2e/approval-page.e2e.test.ts
+++ b/ui/src/e2e/approval-page.e2e.test.ts
@@ -1,24 +1,19 @@
 import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page, type Video } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Browser, BrowserContext, Page, Video } from "playwright";
+import { afterEach, expect, it } from "vitest";
 import type {
   AllowedApprovalSnapshot,
   PendingApprovalSnapshot,
 } from "../../../packages/gateway-protocol/src/index.js";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayControls,
-} from "../test-helpers/control-ui-e2e.ts";
+import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI standalone approval page",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 const APPROVAL_ID = "Approval:Mobile/東京 100% 🦞";
 const APPROVAL_NOW_MS = Date.UTC(2026, 6, 10, 18, 0, 0);
@@ -35,8 +30,6 @@ type ApprovalSurface = {
   rawVideoDir?: string;
 };
 
-let browser: Browser | undefined;
-let server: ControlUiE2eServer | undefined;
 const openContexts = new Set<BrowserContext>();
 const rawVideoDirs = new Set<string>();
 
@@ -45,7 +38,7 @@ function approvalPath(basePath: string): string {
 }
 
 function approvalUrl(basePath: string): string {
-  return new URL(approvalPath(basePath), server?.baseUrl ?? "http://127.0.0.1/").href;
+  return new URL(approvalPath(basePath), suite.server?.baseUrl ?? "http://127.0.0.1/").href;
 }
 
 function pendingApproval(basePath: string): PendingApprovalSnapshot {
@@ -84,10 +77,10 @@ function allowedApproval(pending: PendingApprovalSnapshot): AllowedApprovalSnaps
 }
 
 function requireBrowser(): Browser {
-  if (!browser) {
+  if (!suite.browser) {
     throw new Error("Control UI E2E browser is not running");
   }
-  return browser;
+  return suite.browser;
 }
 
 async function createSurface(params: {
@@ -238,15 +231,7 @@ async function expectMobilePendingLayout(page: Page): Promise<void> {
   expect(metrics.backLinkTop).toBeGreaterThanOrEqual(metrics.cardBottom + 10);
 }
 
-describeControlUiE2e("Control UI standalone approval page", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
     openContexts.clear();
@@ -254,11 +239,6 @@ describeControlUiE2e("Control UI standalone approval page", () => {
       [...rawVideoDirs].map((rawVideoDir) => rm(rawVideoDir, { force: true, recursive: true })),
     );
     rawVideoDirs.clear();
-  });
-
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
   });
 
   it("keeps one canonical winner across conflicting surfaces and terminal reload", async () => {
@@ -428,7 +408,7 @@ describeControlUiE2e("Control UI standalone approval page", () => {
       pending,
       viewport: MOBILE_VIEWPORT,
     });
-    const appUrl = new URL(server?.baseUrl ?? "http://127.0.0.1/");
+    const appUrl = new URL(suite.server?.baseUrl ?? "http://127.0.0.1/");
     const pageGatewayScope = `ws://${appUrl.host}`;
     const selectionKey = `openclaw.control.currentGateway.v1:${pageGatewayScope}`;
     const pageGateway = pageGatewayScope;

--- a/ui/src/e2e/avatar-initial-emoji.e2e.test.ts
+++ b/ui/src/e2e/avatar-initial-emoji.e2e.test.ts
@@ -2,20 +2,18 @@
 // live agent-avatar fallback surface.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI grapheme-aware avatar initials",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "avatar-initial-emoji");
 
@@ -41,9 +39,6 @@ const agentIdentities = {
   ],
 };
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
 async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
@@ -56,164 +51,152 @@ async function screenshot(page: Page, name: string) {
   });
 }
 
-describeControlUiE2e("Control UI grapheme-aware avatar initials", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders the emoji grapheme initial in the sidebar chip and agent menu row", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      defaultAgentId: "main",
-      methodResponses: {
-        "agent.identity.get": agentIdentities,
-        "agents.list": agentsList,
-        "chat.startup": {
-          agentsList,
-          messages: [],
-          metadata: { models: [] },
-          sessionId: "control-ui-e2e-session",
-          thinkingLevel: null,
-        },
-        "sessions.list": {
-          count: 0,
-          defaults: { contextTokens: null, model: null, modelProvider: null },
-          path: "",
-          sessions: [],
-          ts: Date.now(),
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          defaultAgentId: "main",
+          methodResponses: {
+            "agent.identity.get": agentIdentities,
+            "agents.list": agentsList,
+            "chat.startup": {
+              agentsList,
+              messages: [],
+              metadata: { models: [] },
+              sessionId: "control-ui-e2e-session",
+              thinkingLevel: null,
+            },
+            "sessions.list": {
+              count: 0,
+              defaults: { contextTokens: null, model: null, modelProvider: null },
+              path: "",
+              sessions: [],
+              ts: Date.now(),
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}usage`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("agents.list");
-      const sidebar = page.locator("openclaw-app-sidebar");
+        const response = await page.goto(`${suite.server.baseUrl}usage`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("agents.list");
+        const sidebar = page.locator("openclaw-app-sidebar");
 
-      await sidebar.getByRole("button", { name: /Switch agent/ }).click();
-      const emojiRow = sidebar
-        .locator("wa-dropdown.sidebar-agent-menu")
-        .getByRole("menuitemradio", { name: "🚀Rocket", exact: true });
-      const menuAvatar = emojiRow.locator(".agent-select__avatar--text");
-      await expect.poll(() => menuAvatar.getAttribute("data-avatar")).toBe(emojiGrapheme);
-      // The shared picker paints its text through CSS, not a text node.
-      await expect
-        .poll(() => menuAvatar.evaluate((element) => getComputedStyle(element, "::before").content))
-        .toContain(emojiGrapheme);
-      await screenshot(page, "01-sidebar-menu-emoji.png");
+        await sidebar.getByRole("button", { name: /Switch agent/ }).click();
+        const emojiRow = sidebar
+          .locator("wa-dropdown.sidebar-agent-menu")
+          .getByRole("menuitemradio", { name: "🚀Rocket", exact: true });
+        const menuAvatar = emojiRow.locator(".agent-select__avatar--text");
+        await expect.poll(() => menuAvatar.getAttribute("data-avatar")).toBe(emojiGrapheme);
+        // The shared picker paints its text through CSS, not a text node.
+        await expect
+          .poll(() =>
+            menuAvatar.evaluate((element) => getComputedStyle(element, "::before").content),
+          )
+          .toContain(emojiGrapheme);
+        await screenshot(page, "01-sidebar-menu-emoji.png");
 
-      await emojiRow.click();
-      await expect
-        .poll(async () =>
-          (await gateway.getRequests("sessions.list")).some(
-            (request) =>
-              request.params && (request.params as { agentId?: string }).agentId === "emoji",
-          ),
-        )
-        .toBe(true);
-      await expect
-        .poll(() => sidebar.locator(".sidebar-agent-card__avatar-text").textContent())
-        .toBe(emojiGrapheme);
-      await screenshot(page, "01-sidebar-chip-emoji.png");
-    } finally {
-      await context.close();
-    }
+        await emojiRow.click();
+        await expect
+          .poll(async () =>
+            (await gateway.getRequests("sessions.list")).some(
+              (request) =>
+                request.params && (request.params as { agentId?: string }).agentId === "emoji",
+            ),
+          )
+          .toBe(true);
+        await expect
+          .poll(() => sidebar.locator(".sidebar-agent-card__avatar-text").textContent())
+          .toBe(emojiGrapheme);
+        await screenshot(page, "01-sidebar-chip-emoji.png");
+      },
+    );
   });
 
   it("renders the emoji grapheme initial in the agent selector dropdown", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      defaultAgentId: "main",
-      methodResponses: {
-        "agent.identity.get": agentIdentities,
-        "agents.list": agentsList,
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          defaultAgentId: "main",
+          methodResponses: {
+            "agent.identity.get": agentIdentities,
+            "agents.list": agentsList,
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}agents`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("agents.list");
-      const agentSelect = page.locator("openclaw-agents-page openclaw-agent-select");
-      await agentSelect.locator(".agent-select__trigger").click();
-      const emojiItem = agentSelect.getByRole("menuitemradio", {
-        name: "🚀Rocket",
-        exact: true,
-      });
-      const pickerAvatar = emojiItem.locator(".agent-select__avatar--text");
-      await expect.poll(() => pickerAvatar.getAttribute("data-avatar")).toBe(emojiGrapheme);
-      await expect
-        .poll(() =>
-          pickerAvatar.evaluate((element) => getComputedStyle(element, "::before").content),
-        )
-        .toContain(emojiGrapheme);
-      await screenshot(page, "02-agent-selector-emoji.png");
-    } finally {
-      await context.close();
-    }
+        const response = await page.goto(`${suite.server.baseUrl}agents`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("agents.list");
+        const agentSelect = page.locator("openclaw-agents-page openclaw-agent-select");
+        await agentSelect.locator(".agent-select__trigger").click();
+        const emojiItem = agentSelect.getByRole("menuitemradio", {
+          name: "🚀Rocket",
+          exact: true,
+        });
+        const pickerAvatar = emojiItem.locator(".agent-select__avatar--text");
+        await expect.poll(() => pickerAvatar.getAttribute("data-avatar")).toBe(emojiGrapheme);
+        await expect
+          .poll(() =>
+            pickerAvatar.evaluate((element) => getComputedStyle(element, "::before").content),
+          )
+          .toContain(emojiGrapheme);
+        await screenshot(page, "02-agent-selector-emoji.png");
+      },
+    );
   });
 
   it("renders the emoji grapheme initial in the agents overview identity editor", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const config = { agents: { list: [{ id: "main" }, { id: "emoji" }] } };
-    const gateway = await installMockGateway(page, {
-      defaultAgentId: "main",
-      methodResponses: {
-        "agent.identity.get": agentIdentities,
-        "agents.list": agentsList,
-        "config.get": {
-          config,
-          sourceConfig: config,
-          hash: "hash-1",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const config = { agents: { list: [{ id: "main" }, { id: "emoji" }] } };
+        const gateway = await installMockGateway(page, {
+          defaultAgentId: "main",
+          methodResponses: {
+            "agent.identity.get": agentIdentities,
+            "agents.list": agentsList,
+            "config.get": {
+              config,
+              sourceConfig: config,
+              hash: "hash-1",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/agents/main/tools`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("agents.list");
-      await gateway.waitForRequest("config.get");
-      const agentSelect = page.locator("openclaw-agents-page openclaw-agent-select");
-      await agentSelect.locator(".agent-select__trigger").click();
-      await agentSelect.getByRole("menuitemradio", { name: "🚀Rocket", exact: true }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/emoji/tools");
-      await page.getByRole("tab", { name: "Overview", exact: true }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/emoji/overview");
-      await expect
-        .poll(() => page.locator(".agent-identity-editor__avatar-text").textContent())
-        .toBe(emojiGrapheme);
-      await screenshot(page, "03-agents-overview-emoji.png");
-    } finally {
-      await context.close();
-    }
+        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("agents.list");
+        await gateway.waitForRequest("config.get");
+        const agentSelect = page.locator("openclaw-agents-page openclaw-agent-select");
+        await agentSelect.locator(".agent-select__trigger").click();
+        await agentSelect.getByRole("menuitemradio", { name: "🚀Rocket", exact: true }).click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/emoji/tools");
+        await page.getByRole("tab", { name: "Overview", exact: true }).click();
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe("/settings/agents/emoji/overview");
+        await expect
+          .poll(() => page.locator(".agent-identity-editor__avatar-text").textContent())
+          .toBe(emojiGrapheme);
+        await screenshot(page, "03-agents-overview-emoji.png");
+      },
+    );
   });
 });

--- a/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
+++ b/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
@@ -1,219 +1,199 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI browser screenshot failed-body E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.resolve(
   process.cwd(),
   ".artifacts/control-ui-e2e/browser-screenshot-body-cancel",
 );
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI browser screenshot failed-body E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps the status error visible and cancels the unread media body", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await page.addInitScript(() => {
-      localStorage.removeItem("openclaw.browser.panel.v1");
-      const originalFetch = window.fetch.bind(window);
-      window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-        const response = await originalFetch(input, init);
-        const url =
-          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-        if (!url.includes("/__openclaw__/assistant-media")) {
-          return response;
-        }
-        const source = response.body;
-        if (!source) {
-          return response;
-        }
-        type ScreenshotProof = {
-          cancelCount: number;
-          cancelResolvedCount: number;
-          fetchCount: number;
-          statuses: number[];
-        };
-        const proofWindow = window as Window & { openclawScreenshotProof?: ScreenshotProof };
-        const proof = (proofWindow.openclawScreenshotProof ??= {
-          cancelCount: 0,
-          cancelResolvedCount: 0,
-          fetchCount: 0,
-          statuses: [],
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await page.addInitScript(() => {
+          localStorage.removeItem("openclaw.browser.panel.v1");
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+            const response = await originalFetch(input, init);
+            const url =
+              typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+            if (!url.includes("/__openclaw__/assistant-media")) {
+              return response;
+            }
+            const source = response.body;
+            if (!source) {
+              return response;
+            }
+            type ScreenshotProof = {
+              cancelCount: number;
+              cancelResolvedCount: number;
+              fetchCount: number;
+              statuses: number[];
+            };
+            const proofWindow = window as Window & { openclawScreenshotProof?: ScreenshotProof };
+            const proof = (proofWindow.openclawScreenshotProof ??= {
+              cancelCount: 0,
+              cancelResolvedCount: 0,
+              fetchCount: 0,
+              statuses: [],
+            });
+            proof.fetchCount += 1;
+            proof.statuses.push(response.status);
+            const originalCancel = source.cancel.bind(source);
+            source.cancel = async (reason) => {
+              proof.cancelCount += 1;
+              await originalCancel(reason);
+              proof.cancelResolvedCount += 1;
+            };
+            return response;
+          };
         });
-        proof.fetchCount += 1;
-        proof.statuses.push(response.status);
-        const originalCancel = source.cancel.bind(source);
-        source.cancel = async (reason) => {
-          proof.cancelCount += 1;
-          await originalCancel(reason);
-          proof.cancelResolvedCount += 1;
-        };
-        return response;
-      };
-    });
-    let mediaRequest: { authorization: string; source: string | null } | null = null;
-    await page.route("**/__openclaw__/assistant-media**", (route) => {
-      const request = route.request();
-      mediaRequest = {
-        authorization: request.headers().authorization ?? "",
-        source: new URL(request.url()).searchParams.get("source"),
-      };
-      return route.fulfill({
-        body: "screenshot unavailable",
-        contentType: "text/plain; charset=utf-8",
-        status: 404,
-      });
-    });
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "browser.request"],
-      methodResponses: {
-        "browser.request": {
-          cases: [
-            {
-              match: { method: "GET", path: "/tabs" },
-              response: {
-                running: true,
-                tabs: [
-                  {
+        let mediaRequest: { authorization: string; source: string | null } | null = null;
+        await page.route("**/__openclaw__/assistant-media**", (route) => {
+          const request = route.request();
+          mediaRequest = {
+            authorization: request.headers().authorization ?? "",
+            source: new URL(request.url()).searchParams.get("source"),
+          };
+          return route.fulfill({
+            body: "screenshot unavailable",
+            contentType: "text/plain; charset=utf-8",
+            status: 404,
+          });
+        });
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "browser.request"],
+          methodResponses: {
+            "browser.request": {
+              cases: [
+                {
+                  match: { method: "GET", path: "/tabs" },
+                  response: {
+                    running: true,
+                    tabs: [
+                      {
+                        targetId: "target-1",
+                        tabId: "t1",
+                        title: "Example",
+                        url: "https://example.test/",
+                      },
+                    ],
+                  },
+                },
+                {
+                  match: { method: "POST", path: "/screenshot" },
+                  response: {
+                    path: "/proof/missing.png",
                     targetId: "target-1",
-                    tabId: "t1",
-                    title: "Example",
                     url: "https://example.test/",
                   },
-                ],
-              },
+                },
+              ],
             },
-            {
-              match: { method: "POST", path: "/screenshot" },
-              response: {
-                path: "/proof/missing.png",
-                targetId: "target-1",
-                url: "https://example.test/",
-              },
-            },
-          ],
-        },
-      },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}chat`);
-      expect(response?.status()).toBe(200);
-      const showFiles = page.getByRole("button", { name: "Show thread files", exact: true });
-      await showFiles.waitFor();
-      await showFiles.click();
-      const toggle = page.getByRole("button", { name: "Toggle browser panel", exact: true });
-      await toggle.waitFor();
-      await toggle.click();
-
-      const panel = page.locator("section.bp");
-      await panel.waitFor();
-      const alert = panel.getByRole("alert");
-      await alert.waitFor();
-      expect(await alert.textContent()).toBe(
-        "Browser request failed: Screenshot fetch failed (404).",
-      );
-      await expect
-        .poll(() =>
-          page.evaluate(
-            () =>
-              (
-                window as Window & {
-                  openclawScreenshotProof?: {
-                    cancelCount?: number;
-                    cancelResolvedCount?: number;
-                    fetchCount?: number;
-                    statuses?: number[];
-                  };
-                }
-              ).openclawScreenshotProof,
-          ),
-        )
-        .toEqual({
-          cancelCount: 1,
-          cancelResolvedCount: 1,
-          fetchCount: 1,
-          statuses: [404],
+          },
         });
 
-      const requests = await gateway.getRequests("browser.request");
-      expect(requests.map((request) => request.params)).toEqual([
-        { method: "GET", path: "/tabs" },
-        {
-          body: { targetId: "t1", type: "png" },
-          method: "POST",
-          path: "/screenshot",
-        },
-      ]);
-      expect(mediaRequest).toEqual({
-        authorization: "Bearer e2e-device-token",
-        source: "/proof/missing.png",
-      });
+        const response = await page.goto(`${suite.server.baseUrl}chat`);
+        expect(response?.status()).toBe(200);
+        const showFiles = page.getByRole("button", { name: "Show thread files", exact: true });
+        await showFiles.waitFor();
+        await showFiles.click();
+        const toggle = page.getByRole("button", { name: "Toggle browser panel", exact: true });
+        await toggle.waitFor();
+        await toggle.click();
 
-      if (captureUiProofEnabled) {
-        await mkdir(proofDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(proofDir, "failed-screenshot.png"),
-        });
-        const stream = await page.evaluate(
-          () => (window as Window & { openclawScreenshotProof?: unknown }).openclawScreenshotProof,
+        const panel = page.locator("section.bp");
+        await panel.waitFor();
+        const alert = panel.getByRole("alert");
+        await alert.waitFor();
+        expect(await alert.textContent()).toBe(
+          "Browser request failed: Screenshot fetch failed (404).",
         );
-        await writeFile(
-          path.join(proofDir, "proof.json"),
-          `${JSON.stringify(
-            {
+        await expect
+          .poll(() =>
+            page.evaluate(
+              () =>
+                (
+                  window as Window & {
+                    openclawScreenshotProof?: {
+                      cancelCount?: number;
+                      cancelResolvedCount?: number;
+                      fetchCount?: number;
+                      statuses?: number[];
+                    };
+                  }
+                ).openclawScreenshotProof,
+            ),
+          )
+          .toEqual({
+            cancelCount: 1,
+            cancelResolvedCount: 1,
+            fetchCount: 1,
+            statuses: [404],
+          });
+
+        const requests = await gateway.getRequests("browser.request");
+        expect(requests.map((request) => request.params)).toEqual([
+          { method: "GET", path: "/tabs" },
+          {
+            body: { targetId: "t1", type: "png" },
+            method: "POST",
+            path: "/screenshot",
+          },
+        ]);
+        expect(mediaRequest).toEqual({
+          authorization: "Bearer e2e-device-token",
+          source: "/proof/missing.png",
+        });
+
+        if (captureUiProofEnabled) {
+          await mkdir(proofDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "failed-screenshot.png"),
+          });
+          const stream = await page.evaluate(
+            () =>
+              (window as Window & { openclawScreenshotProof?: unknown }).openclawScreenshotProof,
+          );
+          await writeFile(
+            path.join(proofDir, "proof.json"),
+            `${JSON.stringify(
+              {
+                error: (await alert.textContent())?.trim() ?? "",
+                mediaRequest,
+                requests,
+                stream,
+              },
+              null,
+              2,
+            )}\n`,
+          );
+          console.log(
+            `CONTROL_UI_BROWSER_SCREENSHOT_PROOF=${JSON.stringify({
               error: (await alert.textContent())?.trim() ?? "",
               mediaRequest,
-              requests,
+              requests: requests.map((request) => request.params),
               stream,
-            },
-            null,
-            2,
-          )}\n`,
-        );
-        console.log(
-          `CONTROL_UI_BROWSER_SCREENSHOT_PROOF=${JSON.stringify({
-            error: (await alert.textContent())?.trim() ?? "",
-            mediaRequest,
-            requests: requests.map((request) => request.params),
-            stream,
-          })}`,
-        );
-      }
-    } finally {
-      await context.close();
-    }
+            })}`,
+          );
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -1,13 +1,6 @@
 // Control UI E2E tests cover browser Talk start and stop through a real page.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
   captureComposerProof,
   captureVideoTalkProof,
@@ -16,64 +9,44 @@ import {
   installTalkBrowserFixtures,
   videoTalkCatalog,
 } from "./browser-talk-start-stop.fixtures.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI browser Talk",
+  browserLaunchOptions: {
+    args: ["--use-fake-device-for-media-stream", "--use-fake-ui-for-media-stream"],
+  },
+});
 
-let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
-let browser: Browser;
-
-describeControlUiE2e("Control UI browser Talk", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({
-      executablePath: chromiumExecutablePath,
-      args: ["--use-fake-device-for-media-stream", "--use-fake-ui-for-media-stream"],
-    });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("starts a provider WebSocket session and stops browser audio resources", async () => {
-    const context = await browser.newContext({ permissions: ["microphone"] });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "talk.client.create": {
-          provider: "google",
-          voiceSessionId: "voice-browser-talk-e2e",
-          transport: "provider-websocket",
-          protocol: "google-live-bidi",
-          clientSecret: "auth_tokens/browser-talk-e2e",
-          websocketUrl:
-            "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
-          audio: {
-            inputEncoding: "pcm16",
-            inputSampleRateHz: 16_000,
-            outputEncoding: "pcm16",
-            outputSampleRateHz: 24_000,
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.client.create": {
+            provider: "google",
+            voiceSessionId: "voice-browser-talk-e2e",
+            transport: "provider-websocket",
+            protocol: "google-live-bidi",
+            clientSecret: "auth_tokens/browser-talk-e2e",
+            websocketUrl:
+              "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
           },
         },
-      },
-    });
-    await installTalkBrowserFixtures(page);
+      });
+      await installTalkBrowserFixtures(page);
 
-    try {
       await page.emulateMedia({ reducedMotion: "reduce" });
       // The microphone picker lives on the Settings appearance page; the
       // selection persists and applies to talk sessions started from chat.
-      await page.goto(`${server.baseUrl}settings/appearance`);
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
       const microphoneSelect = page.locator("[data-settings-microphone]");
       await expect
         .poll(async () =>
@@ -81,7 +54,7 @@ describeControlUiE2e("Control UI browser Talk", () => {
         )
         .toEqual(["System default", "Built-in Microphone", "USB Audio Interface"]);
       await microphoneSelect.selectOption("usb");
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.setViewportSize({ width: 320, height: 720 });
       await page.getByRole("button", { name: "Start voice input" }).click();
 
@@ -221,39 +194,35 @@ describeControlUiE2e("Control UI browser Talk", () => {
         .poll(() => page.getByRole("button", { name: "Start voice input" }).isVisible())
         .toBe(true);
       console.info("[video-talk-e2e] ordinary_voice=start-stop-passed");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("keeps stop-voice and stop-run controls visually distinct while both are active", async () => {
-    const context = await browser.newContext({ permissions: ["microphone"] });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["chat.send"],
-      methodResponses: {
-        "talk.client.create": {
-          provider: "google",
-          voiceSessionId: "voice-controls-e2e",
-          transport: "provider-websocket",
-          protocol: "google-live-bidi",
-          // Fake harness token, assembled so secret scanners do not flag it.
-          clientSecret: ["auth_tokens", "browser-talk-e2e"].join("/"),
-          websocketUrl:
-            "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
-          audio: {
-            inputEncoding: "pcm16",
-            inputSampleRateHz: 16_000,
-            outputEncoding: "pcm16",
-            outputSampleRateHz: 24_000,
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["chat.send"],
+        methodResponses: {
+          "talk.client.create": {
+            provider: "google",
+            voiceSessionId: "voice-controls-e2e",
+            transport: "provider-websocket",
+            protocol: "google-live-bidi",
+            // Fake harness token, assembled so secret scanners do not flag it.
+            clientSecret: ["auth_tokens", "browser-talk-e2e"].join("/"),
+            websocketUrl:
+              "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
           },
         },
-      },
-    });
-    await installTalkBrowserFixtures(page);
+      });
+      await installTalkBrowserFixtures(page);
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.setViewportSize({ width: 1366, height: 900 });
 
       await page.getByRole("button", { name: "Start voice input" }).click();
@@ -340,118 +309,114 @@ describeControlUiE2e("Control UI browser Talk", () => {
       await expect.poll(() => stopVoice.count()).toBe(0);
       await expect.poll(() => stopRun.isVisible()).toBe(true);
       expect(await gateway.getRequests("chat.abort")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("starts OpenAI Talk, enables a fake camera, and submits describe_view", async () => {
-    const context = await browser.newContext({ permissions: ["camera", "microphone"] });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "talk.catalog": videoTalkCatalog("openai"),
-        "talk.client.create": {
-          provider: "openai",
-          voiceSessionId: "voice-openai-video-e2e",
-          transport: "webrtc",
-          clientSecret: "test-client-secret",
-          offerUrl: "https://api.openai.com/v1/realtime/calls",
-        },
-      },
-    });
-    await page.addInitScript(() => {
-      const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-      Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
-        configurable: true,
-        value: async (constraints: MediaStreamConstraints) => {
-          const stream = await getUserMedia(constraints);
-          (
-            window as Window & {
-              openclawVideoTalkTracks?: MediaStreamTrack[];
-            }
-          ).openclawVideoTalkTracks = [
-            ...((window as Window & { openclawVideoTalkTracks?: MediaStreamTrack[] })
-              .openclawVideoTalkTracks ?? []),
-            ...stream.getTracks(),
-          ];
-          return stream;
+    await suite.withPage({ permissions: ["camera", "microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.catalog": videoTalkCatalog("openai"),
+          "talk.client.create": {
+            provider: "openai",
+            voiceSessionId: "voice-openai-video-e2e",
+            transport: "webrtc",
+            clientSecret: "test-client-secret",
+            offerUrl: "https://api.openai.com/v1/realtime/calls",
+          },
         },
       });
-      class FakeDataChannel extends EventTarget {
-        readyState = "open";
-        sent: unknown[] = [];
+      await page.addInitScript(() => {
+        const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+        Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+          configurable: true,
+          value: async (constraints: MediaStreamConstraints) => {
+            const stream = await getUserMedia(constraints);
+            (
+              window as Window & {
+                openclawVideoTalkTracks?: MediaStreamTrack[];
+              }
+            ).openclawVideoTalkTracks = [
+              ...((window as Window & { openclawVideoTalkTracks?: MediaStreamTrack[] })
+                .openclawVideoTalkTracks ?? []),
+              ...stream.getTracks(),
+            ];
+            return stream;
+          },
+        });
+        class FakeDataChannel extends EventTarget {
+          readyState = "open";
+          sent: unknown[] = [];
 
-        send(payload: string) {
-          this.sent.push(JSON.parse(payload));
-        }
-
-        close() {
-          this.readyState = "closed";
-        }
-      }
-
-      class FakePeerConnection extends EventTarget {
-        connectionState = "new";
-        channel = new FakeDataChannel();
-        localDescription: RTCSessionDescriptionInit | null = null;
-        remoteDescription: RTCSessionDescriptionInit | null = null;
-
-        constructor() {
-          super();
-          (
-            window as Window & {
-              openclawVideoTalkE2e?: {
-                dataChannelCreated: boolean;
-                peer: FakePeerConnection;
-              };
-            }
-          ).openclawVideoTalkE2e = { dataChannelCreated: false, peer: this };
-        }
-
-        addTrack() {}
-
-        createDataChannel() {
-          const harness = (
-            window as Window & {
-              openclawVideoTalkE2e?: { dataChannelCreated: boolean };
-            }
-          ).openclawVideoTalkE2e;
-          if (harness) {
-            harness.dataChannelCreated = true;
+          send(payload: string) {
+            this.sent.push(JSON.parse(payload));
           }
-          return this.channel;
+
+          close() {
+            this.readyState = "closed";
+          }
         }
 
-        async createOffer() {
-          return { type: "offer" as const, sdp: "offer-sdp" };
+        class FakePeerConnection extends EventTarget {
+          connectionState = "new";
+          channel = new FakeDataChannel();
+          localDescription: RTCSessionDescriptionInit | null = null;
+          remoteDescription: RTCSessionDescriptionInit | null = null;
+
+          constructor() {
+            super();
+            (
+              window as Window & {
+                openclawVideoTalkE2e?: {
+                  dataChannelCreated: boolean;
+                  peer: FakePeerConnection;
+                };
+              }
+            ).openclawVideoTalkE2e = { dataChannelCreated: false, peer: this };
+          }
+
+          addTrack() {}
+
+          createDataChannel() {
+            const harness = (
+              window as Window & {
+                openclawVideoTalkE2e?: { dataChannelCreated: boolean };
+              }
+            ).openclawVideoTalkE2e;
+            if (harness) {
+              harness.dataChannelCreated = true;
+            }
+            return this.channel;
+          }
+
+          async createOffer() {
+            return { type: "offer" as const, sdp: "offer-sdp" };
+          }
+
+          async setLocalDescription(description: RTCSessionDescriptionInit) {
+            this.localDescription = description;
+          }
+
+          async setRemoteDescription(description: RTCSessionDescriptionInit) {
+            this.remoteDescription = description;
+          }
+
+          close() {
+            this.connectionState = "closed";
+          }
         }
 
-        async setLocalDescription(description: RTCSessionDescriptionInit) {
-          this.localDescription = description;
-        }
-
-        async setRemoteDescription(description: RTCSessionDescriptionInit) {
-          this.remoteDescription = description;
-        }
-
-        close() {
-          this.connectionState = "closed";
-        }
-      }
-
-      Object.defineProperty(window, "RTCPeerConnection", {
-        configurable: true,
-        value: FakePeerConnection,
+        Object.defineProperty(window, "RTCPeerConnection", {
+          configurable: true,
+          value: FakePeerConnection,
+        });
       });
-    });
-    await page.route("https://api.openai.com/v1/realtime/calls", async (route) => {
-      await route.fulfill({ status: 200, contentType: "application/sdp", body: "answer-sdp" });
-    });
+      await page.route("https://api.openai.com/v1/realtime/calls", async (route) => {
+        await route.fulfill({ status: 200, contentType: "application/sdp", body: "answer-sdp" });
+      });
 
-    try {
       await page.setViewportSize({ width: 1366, height: 900 });
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await captureVideoTalkProof(page, "01-before-video-talk.png");
 
       await page.getByRole("button", { name: "Start voice input" }).click();
@@ -577,83 +542,79 @@ describeControlUiE2e("Control UI browser Talk", () => {
       expect(trackStates?.every((state) => state === "ended")).toBe(true);
       await captureVideoTalkProof(page, "04-after-video-talk-stop.png");
       console.info("[video-talk-e2e] stop=preview-removed,tracks:ended+ended");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("starts Gemini Live Talk, enables a fake camera, and handles describe_view", async () => {
-    const context = await browser.newContext({ permissions: ["camera", "microphone"] });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "talk.catalog": videoTalkCatalog("google"),
-        "talk.client.create": {
-          provider: "google",
-          voiceSessionId: "voice-google-video-e2e",
-          transport: "provider-websocket",
-          protocol: "google-live-bidi",
-          // Fake harness token, assembled so secret scanners do not flag it.
-          clientSecret: ["auth_tokens", "browser-video-e2e"].join("/"),
-          websocketUrl:
-            "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
-          audio: {
-            inputEncoding: "pcm16",
-            inputSampleRateHz: 16_000,
-            outputEncoding: "pcm16",
-            outputSampleRateHz: 24_000,
+    await suite.withPage({ permissions: ["camera", "microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.catalog": videoTalkCatalog("google"),
+          "talk.client.create": {
+            provider: "google",
+            voiceSessionId: "voice-google-video-e2e",
+            transport: "provider-websocket",
+            protocol: "google-live-bidi",
+            // Fake harness token, assembled so secret scanners do not flag it.
+            clientSecret: ["auth_tokens", "browser-video-e2e"].join("/"),
+            websocketUrl:
+              "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
           },
         },
-      },
-    });
-    const googleLiveMessages: unknown[] = [];
-    let describeViewSent = false;
-    await page.routeWebSocket("wss://generativelanguage.googleapis.com/**", (ws) => {
-      ws.onMessage((message) => {
-        const parsed = JSON.parse(typeof message === "string" ? message : message.toString()) as {
-          setup?: unknown;
-          realtimeInput?: { video?: unknown };
-        };
-        googleLiveMessages.push(parsed);
-        if (parsed.setup) {
-          ws.send(JSON.stringify({ setupComplete: {} }));
-          return;
-        }
-        if (parsed.realtimeInput?.video && !describeViewSent) {
-          describeViewSent = true;
-          ws.send(
-            JSON.stringify({
-              toolCall: {
-                functionCalls: [{ id: "call-camera", name: "describe_view", args: {} }],
-              },
-            }),
-          );
-        }
       });
-    });
-    await page.addInitScript(() => {
-      const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-      Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
-        configurable: true,
-        value: async (constraints: MediaStreamConstraints) => {
-          const stream = await getUserMedia(constraints);
-          (
-            window as Window & {
-              openclawGeminiVideoTalkTracks?: MediaStreamTrack[];
-            }
-          ).openclawGeminiVideoTalkTracks = [
-            ...((window as Window & { openclawGeminiVideoTalkTracks?: MediaStreamTrack[] })
-              .openclawGeminiVideoTalkTracks ?? []),
-            ...stream.getTracks(),
-          ];
-          return stream;
-        },
+      const googleLiveMessages: unknown[] = [];
+      let describeViewSent = false;
+      await page.routeWebSocket("wss://generativelanguage.googleapis.com/**", (ws) => {
+        ws.onMessage((message) => {
+          const parsed = JSON.parse(typeof message === "string" ? message : message.toString()) as {
+            setup?: unknown;
+            realtimeInput?: { video?: unknown };
+          };
+          googleLiveMessages.push(parsed);
+          if (parsed.setup) {
+            ws.send(JSON.stringify({ setupComplete: {} }));
+            return;
+          }
+          if (parsed.realtimeInput?.video && !describeViewSent) {
+            describeViewSent = true;
+            ws.send(
+              JSON.stringify({
+                toolCall: {
+                  functionCalls: [{ id: "call-camera", name: "describe_view", args: {} }],
+                },
+              }),
+            );
+          }
+        });
       });
-    });
+      await page.addInitScript(() => {
+        const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+        Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+          configurable: true,
+          value: async (constraints: MediaStreamConstraints) => {
+            const stream = await getUserMedia(constraints);
+            (
+              window as Window & {
+                openclawGeminiVideoTalkTracks?: MediaStreamTrack[];
+              }
+            ).openclawGeminiVideoTalkTracks = [
+              ...((window as Window & { openclawGeminiVideoTalkTracks?: MediaStreamTrack[] })
+                .openclawGeminiVideoTalkTracks ?? []),
+              ...stream.getTracks(),
+            ];
+            return stream;
+          },
+        });
+      });
 
-    try {
       await page.setViewportSize({ width: 1366, height: 900 });
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.getByRole("button", { name: "Start voice input" }).click();
       const request = await gateway.waitForRequest("talk.client.create");
       expect(request.params).toMatchObject({
@@ -723,50 +684,46 @@ describeControlUiE2e("Control UI browser Talk", () => {
       expect(trackStates).toHaveLength(2);
       expect(trackStates?.every((state) => state === "ended")).toBe(true);
       console.info("[video-talk-e2e] gemini_stop=preview-removed,tracks:ended+ended");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("shows actionable guidance when Video Talk camera permission is blocked", async () => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "talk.catalog": videoTalkCatalog("google"),
-        "talk.client.create": {
-          provider: "google",
-          voiceSessionId: "voice-blocked-camera-e2e",
-          transport: "provider-websocket",
-          protocol: "google-live-bidi",
-          // Fake harness token, assembled so secret scanners do not flag it.
-          clientSecret: ["auth_tokens", "browser-video-denied"].join("/"),
-          websocketUrl:
-            "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
-          audio: {
-            inputEncoding: "pcm16",
-            inputSampleRateHz: 16_000,
-            outputEncoding: "pcm16",
-            outputSampleRateHz: 24_000,
+    await suite.withPage(undefined, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.catalog": videoTalkCatalog("google"),
+          "talk.client.create": {
+            provider: "google",
+            voiceSessionId: "voice-blocked-camera-e2e",
+            transport: "provider-websocket",
+            protocol: "google-live-bidi",
+            // Fake harness token, assembled so secret scanners do not flag it.
+            clientSecret: ["auth_tokens", "browser-video-denied"].join("/"),
+            websocketUrl:
+              "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained",
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
           },
         },
-      },
-    });
-    await page.routeWebSocket("wss://generativelanguage.googleapis.com/**", (ws) => {
-      ws.onMessage((message) => {
-        const parsed = JSON.parse(typeof message === "string" ? message : message.toString()) as {
-          setup?: unknown;
-        };
-        if (parsed.setup) {
-          ws.send(JSON.stringify({ setupComplete: {} }));
-        }
       });
-    });
-    await installBlockedVideoTalkFixture(page);
+      await page.routeWebSocket("wss://generativelanguage.googleapis.com/**", (ws) => {
+        ws.onMessage((message) => {
+          const parsed = JSON.parse(typeof message === "string" ? message : message.toString()) as {
+            setup?: unknown;
+          };
+          if (parsed.setup) {
+            ws.send(JSON.stringify({ setupComplete: {} }));
+          }
+        });
+      });
+      await installBlockedVideoTalkFixture(page);
 
-    try {
       await page.setViewportSize({ width: 1366, height: 900 });
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.getByRole("button", { name: "Start voice input" }).click();
       await gateway.waitForRequest("talk.client.create");
       const turnCameraOn = page.getByRole("button", { name: "Turn camera on" });
@@ -781,36 +738,32 @@ describeControlUiE2e("Control UI browser Talk", () => {
         .toBe(true);
       await captureVideoTalkProof(page, "03-camera-permission-blocked.png");
       console.info("[video-talk-e2e] camera_denial=actionable,no-audio-fallback");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("renders streamed relay assistant transcript deltas as readable text", async () => {
-    const context = await browser.newContext({ permissions: ["microphone"] });
-    const page = await context.newPage();
-    const relaySessionId = "relay-e2e-transcript";
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "talk.client.create": {
-          provider: "openai",
-          transport: "gateway-relay",
-          relaySessionId,
-          audio: {
-            inputEncoding: "pcm16",
-            inputSampleRateHz: 16_000,
-            outputEncoding: "pcm16",
-            outputSampleRateHz: 24_000,
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const relaySessionId = "relay-e2e-transcript";
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.client.create": {
+            provider: "openai",
+            transport: "gateway-relay",
+            relaySessionId,
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
           },
+          "talk.session.appendAudio": {},
+          "talk.session.close": {},
         },
-        "talk.session.appendAudio": {},
-        "talk.session.close": {},
-      },
-    });
-    await installTalkBrowserFixtures(page);
+      });
+      await installTalkBrowserFixtures(page);
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.setViewportSize({ width: 1366, height: 900 });
       await page.getByRole("button", { name: "Start voice input" }).click();
       await gateway.waitForRequest("talk.client.create");
@@ -869,37 +822,33 @@ describeControlUiE2e("Control UI browser Talk", () => {
       // A collapsed turn renders one character per line (tall, sliver-wide box).
       expect(turnBounds?.width ?? 0).toBeGreaterThanOrEqual(500);
       expect(turnBounds?.height ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(120);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("closes a stale relay when stop and restart race its create response", async () => {
-    const context = await browser.newContext({ locale: "en-US", permissions: ["microphone"] });
-    const page = await context.newPage();
-    const currentRelaySessionId = "relay-current-e2e";
-    const staleRelaySessionId = "relay-stale-e2e";
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "talk.client.create": {
-          provider: "openai",
-          transport: "gateway-relay",
-          relaySessionId: currentRelaySessionId,
-          audio: {
-            inputEncoding: "pcm16",
-            inputSampleRateHz: 16_000,
-            outputEncoding: "pcm16",
-            outputSampleRateHz: 24_000,
+    await suite.withPage({ locale: "en-US", permissions: ["microphone"] }, async ({ page }) => {
+      const currentRelaySessionId = "relay-current-e2e";
+      const staleRelaySessionId = "relay-stale-e2e";
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.client.create": {
+            provider: "openai",
+            transport: "gateway-relay",
+            relaySessionId: currentRelaySessionId,
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
           },
+          "talk.session.appendAudio": {},
+          "talk.session.close": {},
         },
-        "talk.session.appendAudio": {},
-        "talk.session.close": {},
-      },
-    });
-    await installTalkBrowserFixtures(page);
+      });
+      await installTalkBrowserFixtures(page);
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.deferNext("talk.client.create");
 
       await page.getByRole("button", { name: "Start voice input" }).click();
@@ -986,20 +935,16 @@ describeControlUiE2e("Control UI browser Talk", () => {
             .then((requests) => requests.map((request) => request.params)),
         )
         .toEqual([{ sessionId: staleRelaySessionId }, { sessionId: currentRelaySessionId }]);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("keeps blocked microphone guidance readable in a narrow viewport", async () => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await installMockGateway(page);
-    await installBlockedMicrophoneFixture(page);
+    await suite.withPage(undefined, async ({ page }) => {
+      await installMockGateway(page);
+      await installBlockedMicrophoneFixture(page);
 
-    try {
       await page.setViewportSize({ width: 320, height: 720 });
-      await page.goto(`${server.baseUrl}settings/appearance`);
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
       await page.getByRole("button", { name: "Refresh: Microphone input" }).click();
 
       const permissionAlert = page.getByRole("alert");
@@ -1011,8 +956,6 @@ describeControlUiE2e("Control UI browser Talk", () => {
       await expect
         .poll(() => permissionAlert.textContent())
         .toContain("Microphone access is blocked.");
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/e2e/build-info-unicode.e2e.test.ts
+++ b/ui/src/e2e/build-info-unicode.e2e.test.ts
@@ -1,20 +1,29 @@
 // Control UI tests keep build identity readable at UTF-16 truncation boundaries.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Unicode build identity mocked Gateway E2E",
+  startServer: () =>
+    startControlUiE2eServer({
+      version: "2026.7.10",
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      commitAt: "2026-07-10T11:22:33.000Z",
+      builtAt: "2026-07-10T12:34:56.000Z",
+      branch: RAW_BRANCH,
+      dirty: true,
+      release: false,
+      buildId: "build-info-unicode-e2e",
+    }),
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -26,9 +35,6 @@ const uiProofArtifactDir = path.join(
 const RAW_BRANCH = `${"a".repeat(12)}😀${"b".repeat(85)}😀suffix`;
 const NORMALIZED_BRANCH = `${"a".repeat(12)}😀${"b".repeat(85)}`;
 const COMPACT_BRANCH = `${"a".repeat(12)}😀…`;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function containsBrokenSurrogate(value: string): boolean {
   for (let index = 0; index < value.length; index += 1) {
@@ -71,57 +77,32 @@ async function assertFullBranchLabel(page: Page) {
   expect(containsBrokenSurrogate(fullText)).toBe(false);
 }
 
-describeControlUiE2e("Control UI Unicode build identity mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer({
-      version: "2026.7.10",
-      commit: "0123456789abcdef0123456789abcdef01234567",
-      commitAt: "2026-07-10T11:22:33.000Z",
-      builtAt: "2026-07-10T12:34:56.000Z",
-      branch: RAW_BRANCH,
-      dirty: true,
-      release: false,
-      buildId: "build-info-unicode-e2e",
-    });
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders intact emoji at compact and metadata boundaries across navigation and reload", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page);
 
-    try {
-      const response = await page.goto(`${server.baseUrl}chat`);
-      expect(response?.status()).toBe(200);
-      await openBuildDetails(page);
-      await assertFullBranchLabel(page);
-      await page.reload();
-      await assertFullBranchLabel(page);
+        const response = await page.goto(`${suite.server.baseUrl}chat`);
+        expect(response?.status()).toBe(200);
+        await openBuildDetails(page);
+        await assertFullBranchLabel(page);
+        await page.reload();
+        await assertFullBranchLabel(page);
 
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "01-about-build-identity.png"),
-        });
-      }
-    } finally {
-      await context.close();
-    }
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "01-about-build-identity.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -1,193 +1,169 @@
 // Control UI tests cover WhatsApp logout feedback against a mocked Gateway.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI WhatsApp logout mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 const QR_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=";
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI WhatsApp logout mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps the QR visible and explains a no-op logout", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "channels.status": {
-          ts: Date.now(),
-          channelOrder: ["whatsapp"],
-          channelLabels: { whatsapp: "WhatsApp" },
-          channels: {
-            whatsapp: {
-              configured: true,
-              linked: true,
-              running: true,
-              connected: true,
-              reconnectAttempts: 0,
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "channels.status": {
+              ts: Date.now(),
+              channelOrder: ["whatsapp"],
+              channelLabels: { whatsapp: "WhatsApp" },
+              channels: {
+                whatsapp: {
+                  configured: true,
+                  linked: true,
+                  running: true,
+                  connected: true,
+                  reconnectAttempts: 0,
+                },
+              },
+              channelAccounts: {},
+              channelDefaultAccountId: {},
+            },
+            "channels.pairing.list": {
+              accounts: [],
+              requests: [],
+              commandOwnerConfigured: true,
+              limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+            },
+            "web.login.start": {
+              connected: false,
+              message: "Scan this QR.",
+              qrDataUrl: QR_DATA_URL,
+            },
+            "channels.logout": {
+              channel: "whatsapp",
+              accountId: "default",
+              cleared: false,
+              loggedOut: false,
             },
           },
-          channelAccounts: {},
-          channelDefaultAccountId: {},
-        },
-        "channels.pairing.list": {
-          accounts: [],
-          requests: [],
-          commandOwnerConfigured: true,
-          limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
-        },
-        "web.login.start": {
-          connected: false,
-          message: "Scan this QR.",
-          qrDataUrl: QR_DATA_URL,
-        },
-        "channels.logout": {
-          channel: "whatsapp",
-          accountId: "default",
-          cleared: false,
-          loggedOut: false,
-        },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/channels`);
+        expect(response?.status()).toBe(200);
+        const channel = page.locator(".channels-item", { hasText: "WhatsApp" }).first();
+        await channel.click();
+        const detail = page.locator(".channels-detail");
+        await detail.waitFor();
+
+        await detail.getByRole("button", { name: "Relink" }).click();
+        const qr = detail.getByRole("img", { name: "WhatsApp QR" });
+        await qr.waitFor();
+        await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
+
+        await detail.getByRole("button", { name: "Logout" }).click();
+        await expect
+          .poll(async () => detail.locator(".settings-row__desc").allTextContents())
+          .toContain(
+            "No stored WhatsApp session was cleared. It may already be absent, or its auth directory may require manual cleanup.",
+          );
+        await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
+        await expect(detail.getByText("Logged out.", { exact: true }).count()).resolves.toBe(0);
+        await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(1);
+        await expect.poll(async () => gateway.getRequests("channels.status")).toHaveLength(3);
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/channels`);
-      expect(response?.status()).toBe(200);
-      const channel = page.locator(".channels-item", { hasText: "WhatsApp" }).first();
-      await channel.click();
-      const detail = page.locator(".channels-detail");
-      await detail.waitFor();
-
-      await detail.getByRole("button", { name: "Relink" }).click();
-      const qr = detail.getByRole("img", { name: "WhatsApp QR" });
-      await qr.waitFor();
-      await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
-
-      await detail.getByRole("button", { name: "Logout" }).click();
-      await expect
-        .poll(async () => detail.locator(".settings-row__desc").allTextContents())
-        .toContain(
-          "No stored WhatsApp session was cleared. It may already be absent, or its auth directory may require manual cleanup.",
-        );
-      await expect(qr.getAttribute("src")).resolves.toBe(QR_DATA_URL);
-      await expect(detail.getByText("Logged out.", { exact: true }).count()).resolves.toBe(0);
-      await expect.poll(async () => gateway.getRequests("channels.logout")).toHaveLength(1);
-      await expect.poll(async () => gateway.getRequests("channels.status")).toHaveLength(3);
-    } finally {
-      await context.close();
-    }
+    );
   });
 
   it("preserves standard channel details and the complete Telegram setup wizard", async () => {
-    const context = await browser.newContext({ locale: "en-US", serviceWorkers: "block" });
-    const page = await context.newPage();
-    const channelEntries = [
-      ["discord", "Discord"],
-      ["googlechat", "Google Chat"],
-      ["imessage", "iMessage"],
-      ["signal", "Signal"],
-      ["slack", "Slack"],
-      ["telegram", "Telegram"],
-    ] as const;
-    const running = { configured: true, running: true };
-    const details: Record<string, Record<string, unknown>> = {
-      googlechat: {
-        credentialSource: "service-account",
-        audienceType: "url",
-        audience: "https://chat.example.test",
-      },
-      signal: { baseUrl: "https://signal.example.test" },
-    };
-    const bot = (accountId: string, username: string) => ({
-      accountId,
-      ...running,
-      probe: { bot: { username } },
-    });
-    const step = (id: string, type: string, values: Record<string, unknown> = {}) => ({
-      done: false,
-      status: "running",
-      step: { id, type, ...values },
-    });
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["channels.status", "channels.pairing.list", "wizard.start", "wizard.next"],
-      methodResponses: {
-        "channels.status": {
-          ts: Date.now(),
-          channelOrder: channelEntries.map(([id]) => id),
-          channelLabels: Object.fromEntries(channelEntries),
-          channelMeta: channelEntries.map(([id, label]) => ({ id, label })),
-          channels: Object.fromEntries(
-            channelEntries.map(([id]) => [id, { ...running, ...details[id] }]),
-          ),
-          channelAccounts: { telegram: [bot("personal", "alpha_bot"), bot("work", "work_bot")] },
-          channelDefaultAccountId: { telegram: "personal" },
+    await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
+      const channelEntries = [
+        ["discord", "Discord"],
+        ["googlechat", "Google Chat"],
+        ["imessage", "iMessage"],
+        ["signal", "Signal"],
+        ["slack", "Slack"],
+        ["telegram", "Telegram"],
+      ] as const;
+      const running = { configured: true, running: true };
+      const details: Record<string, Record<string, unknown>> = {
+        googlechat: {
+          credentialSource: "service-account",
+          audienceType: "url",
+          audience: "https://chat.example.test",
         },
-        "channels.pairing.list": {
-          accounts: [],
-          requests: [],
-          commandOwnerConfigured: true,
-          limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
-        },
-        "wizard.start": {
-          sessionId: "channel-standard-proof",
-          ...step("account", "select", {
-            message: "Choose Telegram account",
-            initialValue: "personal",
-            options: ["personal", "work"].map((value) => ({
-              value,
-              label: value === "work" ? "Work bot" : "Personal bot",
-            })),
-          }),
-        },
-        "wizard.next": {
-          sequence: [
-            step("token", "text", { message: "Telegram bot token", sensitive: true }),
-            step("features", "multiselect", {
-              initialValue: ["alpha"],
-              options: ["alpha", "beta"].map((value) => ({
+        signal: { baseUrl: "https://signal.example.test" },
+      };
+      const bot = (accountId: string, username: string) => ({
+        accountId,
+        ...running,
+        probe: { bot: { username } },
+      });
+      const step = (id: string, type: string, values: Record<string, unknown> = {}) => ({
+        done: false,
+        status: "running",
+        step: { id, type, ...values },
+      });
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["channels.status", "channels.pairing.list", "wizard.start", "wizard.next"],
+        methodResponses: {
+          "channels.status": {
+            ts: Date.now(),
+            channelOrder: channelEntries.map(([id]) => id),
+            channelLabels: Object.fromEntries(channelEntries),
+            channelMeta: channelEntries.map(([id, label]) => ({ id, label })),
+            channels: Object.fromEntries(
+              channelEntries.map(([id]) => [id, { ...running, ...details[id] }]),
+            ),
+            channelAccounts: { telegram: [bot("personal", "alpha_bot"), bot("work", "work_bot")] },
+            channelDefaultAccountId: { telegram: "personal" },
+          },
+          "channels.pairing.list": {
+            accounts: [],
+            requests: [],
+            commandOwnerConfigured: true,
+            limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+          },
+          "wizard.start": {
+            sessionId: "channel-standard-proof",
+            ...step("account", "select", {
+              message: "Choose Telegram account",
+              initialValue: "personal",
+              options: ["personal", "work"].map((value) => ({
                 value,
-                label: value === "alpha" ? "Alpha" : "Beta",
+                label: value === "work" ? "Work bot" : "Personal bot",
               })),
             }),
-            step("confirm", "confirm", { message: "Apply Telegram settings?" }),
-            step("progress", "progress", { executor: "gateway", message: "Finish preparation" }),
-            { done: true, status: "done", channels: ["telegram"], accounts: [] },
-          ],
+          },
+          "wizard.next": {
+            sequence: [
+              step("token", "text", { message: "Telegram bot token", sensitive: true }),
+              step("features", "multiselect", {
+                initialValue: ["alpha"],
+                options: ["alpha", "beta"].map((value) => ({
+                  value,
+                  label: value === "alpha" ? "Alpha" : "Beta",
+                })),
+              }),
+              step("confirm", "confirm", { message: "Apply Telegram settings?" }),
+              step("progress", "progress", { executor: "gateway", message: "Finish preparation" }),
+              { done: true, status: "done", channels: ["telegram"], accounts: [] },
+            ],
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}settings/channels`);
+      await page.goto(`${suite.server.baseUrl}settings/channels`);
       const expectedFields: Record<string, string[]> = {
         googlechat: ["service-account", "url · https://chat.example.test"],
         signal: ["https://signal.example.test"],
@@ -243,8 +219,6 @@ describeControlUiE2e("Control UI WhatsApp logout mocked Gateway E2E", () => {
         })),
         { sessionId: "channel-standard-proof" },
       ]);
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -1,18 +1,14 @@
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  controlUiSessionUrl,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat attachment read lifecycle",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const ONE_PIXEL_PNG_B64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
 
@@ -53,126 +49,110 @@ async function pastePng(composer: Locator): Promise<void> {
   }, ONE_PIXEL_PNG_B64);
 }
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI chat attachment read lifecycle", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("waits for a pasted image before sending its complete gateway payload", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installDeferredAttachmentReader(page);
-    const gateway = await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installDeferredAttachmentReader(page);
+        const gateway = await installMockGateway(page);
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
-      const composer = page.locator(".agent-chat__composer-combobox textarea");
-      const send = page.getByRole("button", { name: "Send message" });
-      await composer.fill("Include the image that is still loading");
-      await pastePng(composer);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        const send = page.getByRole("button", { name: "Send message" });
+        await composer.fill("Include the image that is still loading");
+        await pastePng(composer);
 
-      await expect.poll(() => send.isDisabled()).toBe(true);
-      await composer.press("Enter");
-      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+        await expect.poll(() => send.isDisabled()).toBe(true);
+        await composer.press("Enter");
+        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 
-      await page.evaluate(() => {
-        const proof = (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
-          .attachmentReadProof;
-        if (!proof.finish) {
-          throw new Error("Pasted image read was not started");
-        }
-        proof.finish();
-      });
-      await page.locator('.chat-attachment-thumb img[alt="Attachment preview"]').waitFor();
-      await expect.poll(() => send.isEnabled()).toBe(true);
-      await send.click();
+        await page.evaluate(() => {
+          const proof = (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
+            .attachmentReadProof;
+          if (!proof.finish) {
+            throw new Error("Pasted image read was not started");
+          }
+          proof.finish();
+        });
+        await page.locator('.chat-attachment-thumb img[alt="Attachment preview"]').waitFor();
+        await expect.poll(() => send.isEnabled()).toBe(true);
+        await send.click();
 
-      const request = await gateway.waitForRequest("chat.send");
-      expect(request.params).toMatchObject({
-        attachments: [{ content: ONE_PIXEL_PNG_B64, fileName: "pixel.png", mimeType: "image/png" }],
-        message: "Include the image that is still loading",
-      });
-    } finally {
-      await context.close();
-    }
+        const request = await gateway.waitForRequest("chat.send");
+        expect(request.params).toMatchObject({
+          attachments: [
+            { content: ONE_PIXEL_PNG_B64, fileName: "pixel.png", mimeType: "image/png" },
+          ],
+          message: "Include the image that is still loading",
+        });
+      },
+    );
   });
 
   it("aborts a session's pending image before the pane adopts another session", async () => {
     const firstSession = "agent:main:attachment-session-a";
     const secondSession = "agent:main:attachment-session-b";
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installDeferredAttachmentReader(page);
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "sessions.list": {
-          count: 2,
-          defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
-          path: "",
-          sessions: [
-            { key: firstSession, kind: "direct", updatedAt: 2 },
-            { key: secondSession, kind: "direct", updatedAt: 1 },
-          ],
-          ts: Date.now(),
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-      sessionKey: firstSession,
-    });
+      async ({ page }) => {
+        await installDeferredAttachmentReader(page);
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.list": {
+              count: 2,
+              defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+              path: "",
+              sessions: [
+                { key: firstSession, kind: "direct", updatedAt: 2 },
+                { key: secondSession, kind: "direct", updatedAt: 1 },
+              ],
+              ts: Date.now(),
+            },
+          },
+          sessionKey: firstSession,
+        });
 
-    try {
-      await page.goto(controlUiSessionUrl(server.baseUrl, firstSession));
-      const composer = page.locator(".agent-chat__composer-combobox textarea");
-      await composer.fill("Private session A attachment");
-      await pastePng(composer);
-      await expect
-        .poll(() => page.getByRole("button", { name: "Send message" }).isDisabled())
-        .toBe(true);
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, firstSession));
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.fill("Private session A attachment");
+        await pastePng(composer);
+        await expect
+          .poll(() => page.getByRole("button", { name: "Send message" }).isDisabled())
+          .toBe(true);
 
-      await page.locator("openclaw-chat-pane").evaluate((pane, sessionKey) => {
-        (pane as HTMLElement & { sessionKey: string }).sessionKey = sessionKey;
-      }, secondSession);
+        await page.locator("openclaw-chat-pane").evaluate((pane, sessionKey) => {
+          (pane as HTMLElement & { sessionKey: string }).sessionKey = sessionKey;
+        }, secondSession);
 
-      await expect
-        .poll(() =>
-          page.evaluate(
-            () =>
-              (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
-                .attachmentReadProof.aborts,
-          ),
-        )
-        .toBe(1);
-      await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(0);
+        await expect
+          .poll(() =>
+            page.evaluate(
+              () =>
+                (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
+                  .attachmentReadProof.aborts,
+            ),
+          )
+          .toBe(1);
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(0);
 
-      await composer.fill("Safe session B message");
-      await composer.press("Enter");
-      const request = await gateway.waitForRequest("chat.send");
-      expect(request.params).toMatchObject({
-        message: "Safe session B message",
-        sessionKey: secondSession,
-      });
-      expect((request.params as { attachments?: unknown }).attachments).toBeUndefined();
-    } finally {
-      await context.close();
-    }
+        await composer.fill("Safe session B message");
+        await composer.press("Enter");
+        const request = await gateway.waitForRequest("chat.send");
+        expect(request.params).toMatchObject({
+          message: "Safe session B message",
+          sessionKey: secondSession,
+        });
+        expect((request.params as { attachments?: unknown }).attachments).toBeUndefined();
+      },
+    );
   });
 });

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -1,24 +1,15 @@
 // Control UI E2E tests cover attributed chat identity placement.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, expect, type Browser, type Page } from "playwright/test";
-import { afterAll, beforeAll, describe, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  controlUiSessionUrl,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, type Page } from "playwright/test";
+import { it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI attributed chat identity",
+  startServerBeforeBrowser: true,
+});
 
 function resolveArtifactDir(): string | undefined {
   return process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() || undefined;
@@ -36,23 +27,13 @@ async function captureProof(page: Page, name: string) {
   });
 }
 
-describeControlUiE2e("Control UI attributed chat identity", () => {
-  beforeAll(async () => {
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("uses one avatar placement and keeps shared-thread authors readable", async () => {
     const artifactDir = resolveArtifactDir();
     if (artifactDir) {
       await fs.mkdir(artifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       viewport: { height: 760, width: 1180 },
       ...(artifactDir
         ? { recordVideo: { dir: artifactDir, size: { height: 760, width: 1180 } } }
@@ -102,7 +83,7 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
       ],
     });
 
-    await page.goto(controlUiSessionUrl(server.baseUrl, "agent:main:main"));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
     await page.getByText("This is much easier to scan in a team conversation.").waitFor();
 
     const userGroups = page.locator(".chat-group.user");
@@ -145,7 +126,7 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
   });
 
   it("keeps missing same-origin avatar initials through a live rerender", async () => {
-    const context = await browser.newContext({ viewport: { height: 760, width: 1180 } });
+    const context = await suite.browser.newContext({ viewport: { height: 760, width: 1180 } });
     const page = await context.newPage();
     const sender = {
       id: "dd7c98e2-f51d-4590-b588-fa0682e165b7",
@@ -205,7 +186,7 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
     });
 
     try {
-      await page.goto(controlUiSessionUrl(server.baseUrl, "agent:main:main"));
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
       await page.getByText("Please keep my fallback avatar readable.").waitFor();
 
       const userGroup = page.locator(".chat-group.user", {

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -1,22 +1,12 @@
 // Control UI E2E coverage proves the composer capability menu against a mocked Gateway.
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayControls,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let server: ControlUiE2eServer;
-let browser: Browser;
+const suite = createControlUiE2eSuite({
+  name: "Control UI composer capability menu",
+});
 
 function skill(
   name: string,
@@ -188,52 +178,35 @@ async function openMenu(page: Page) {
   return composer;
 }
 
-describeControlUiE2e("Control UI composer capability menu", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders the root stack, proxies attachments, patches sparse overrides, and clears the pill", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse({
-          github: { url: "https://mcp.example.test", enabled: true },
-          notion: { command: "notion-mcp", enabled: false },
-        }),
-        "sessions.list": sessionsList({
-          mcpServers: { github: false },
-          mcpToolsDeny: { notion: ["delete_page"] },
-          skills: { docs: false },
-          webSearch: false,
-        }),
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [
-            skill("Docs"),
-            skill("Deploy", { disabled: true }),
-            skill("Broken", { missingDeps: true }),
-            skill("Private", { blocked: true }),
-          ],
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "config.get": configResponse({
+            github: { url: "https://mcp.example.test", enabled: true },
+            notion: { command: "notion-mcp", enabled: false },
+          }),
+          "sessions.list": sessionsList({
+            mcpServers: { github: false },
+            mcpToolsDeny: { notion: ["delete_page"] },
+            skills: { docs: false },
+            webSearch: false,
+          }),
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [
+              skill("Docs"),
+              skill("Deploy", { disabled: true }),
+              skill("Broken", { missingDeps: true }),
+              skill("Private", { blocked: true }),
+            ],
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       const pill = page.locator(".agent-chat__session-overrides-pill");
       await expect
@@ -354,30 +327,26 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       expect(themeBackgrounds[0]).not.toBe("");
       expect(themeBackgrounds[1]).not.toBe("");
       expect(themeBackgrounds[0]).not.toBe(themeBackgrounds[1]);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("shows per-connector tool access and preserves raw MCP tool identity", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "tools.effective"],
-      methodResponses: {
-        "config.get": configResponse({
-          github: { url: "https://mcp.example.test", enabled: true },
-          notion: { command: "notion-mcp", enabled: true },
-        }),
-        "sessions.list": sessionsList({
-          mcpToolsDeny: { github: ["search_items"] },
-        }),
-        "tools.effective": effectiveToolsResponse(),
-      },
-    });
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "tools.effective"],
+        methodResponses: {
+          "config.get": configResponse({
+            github: { url: "https://mcp.example.test", enabled: true },
+            notion: { command: "notion-mcp", enabled: true },
+          }),
+          "sessions.list": sessionsList({
+            mcpToolsDeny: { github: ["search_items"] },
+          }),
+          "tools.effective": effectiveToolsResponse(),
+        },
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const composer = await openMenu(page);
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
@@ -432,29 +401,25 @@ describeControlUiE2e("Control UI composer capability menu", () => {
 
       await menu.getByRole("menuitem", { name: "Back" }).click();
       await expect.poll(() => menu.getAttribute("data-view")).toBe("connectors");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it('renders tool access for a server named "constructor"', async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
-      methodResponses: {
-        "config.get": configResponse({
-          constructor: { url: "https://mcp.example.test", enabled: true },
-        }),
-        "sessions.list": sessionsList({
-          mcpToolsDeny: { github: ["search_items"] },
-        }),
-        "tools.effective": effectiveToolsResponse("constructor"),
-      },
-    });
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+        methodResponses: {
+          "config.get": configResponse({
+            constructor: { url: "https://mcp.example.test", enabled: true },
+          }),
+          "sessions.list": sessionsList({
+            mcpToolsDeny: { github: ["search_items"] },
+          }),
+          "tools.effective": effectiveToolsResponse("constructor"),
+        },
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const composer = await openMenu(page);
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
@@ -463,28 +428,24 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:constructor");
       await expect.poll(() => menu.getByText("3 of 3 tools on").isVisible()).toBe(true);
       await expect.poll(() => menu.locator('wa-dropdown-item[value^="mcp-tool:"]').count()).toBe(3);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("scopes effective-tools discovery notices to their connector", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
-      methodResponses: {
-        "config.get": configResponse({
-          github: { url: "https://mcp.example.test", enabled: true },
-          notion: { command: "notion-mcp", enabled: true },
-        }),
-        "sessions.list": sessionsList(),
-        "tools.effective": undiscoveredMcpToolsResponse(),
-      },
-    });
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+        methodResponses: {
+          "config.get": configResponse({
+            github: { url: "https://mcp.example.test", enabled: true },
+            notion: { command: "notion-mcp", enabled: true },
+          }),
+          "sessions.list": sessionsList(),
+          "tools.effective": undiscoveredMcpToolsResponse(),
+        },
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const composer = await openMenu(page);
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
@@ -515,27 +476,23 @@ describeControlUiE2e("Control UI composer capability menu", () => {
         .poll(() => menu.getByText("No tools available for this connector.").isVisible())
         .toBe(true);
       await expect.poll(() => menu.getByText("0 of 0 tools on").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("uses the generic empty state for an unscoped discovery notice", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
-      methodResponses: {
-        "config.get": configResponse({
-          github: { url: "https://mcp.example.test", enabled: true },
-        }),
-        "sessions.list": sessionsList(),
-        "tools.effective": undiscoveredMcpToolsResponse("github", false),
-      },
-    });
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+        methodResponses: {
+          "config.get": configResponse({
+            github: { url: "https://mcp.example.test", enabled: true },
+          }),
+          "sessions.list": sessionsList(),
+          "tools.effective": undiscoveredMcpToolsResponse("github", false),
+        },
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const composer = await openMenu(page);
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
@@ -551,27 +508,23 @@ describeControlUiE2e("Control UI composer capability menu", () => {
         )
         .toBe(0);
       await expect.poll(() => menu.getByText("0 of 0 tools on").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("blocks tool mutations until the session, runtime config, and catalog are ready", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "tools.effective"],
-      deferredMethods: ["sessions.list", "tools.effective"],
-      methodResponses: {
-        "config.get": configResponse({
-          github: { url: "https://mcp.example.test", enabled: true },
-        }),
-        "tools.effective": effectiveToolsResponse(),
-      },
-    });
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "tools.effective"],
+        deferredMethods: ["sessions.list", "tools.effective"],
+        methodResponses: {
+          "config.get": configResponse({
+            github: { url: "https://mcp.example.test", enabled: true },
+          }),
+          "tools.effective": effectiveToolsResponse(),
+        },
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("sessions.list");
       const composer = await openMenu(page);
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
@@ -602,29 +555,25 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       await expect
         .poll(() => latestToolOverrides(gateway))
         .toEqual({ mcpToolsDeny: { github: ["list-issues"] } });
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("disables capability mutations and admin rows for a read-only operator", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      operatorScopes: ["operator.read"],
-      methodResponses: {
-        "config.get": configResponse({ github: { url: "https://mcp.example.test" } }),
-        "sessions.list": sessionsList({ webSearch: false }),
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [skill("Docs")],
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        operatorScopes: ["operator.read"],
+        methodResponses: {
+          "config.get": configResponse({ github: { url: "https://mcp.example.test" } }),
+          "sessions.list": sessionsList({ webSearch: false }),
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [skill("Docs")],
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const composer = await openMenu(page);
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       const clear = composer.getByRole("button", { name: "Clear session overrides" });
@@ -648,27 +597,23 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       const addServer = menu.getByRole("menuitem", { name: /Add MCP server/ });
       await expect.poll(() => addServer.isDisabled()).toBe(true);
       await expect.poll(() => addServer.getAttribute("title")).toContain("Admin access");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("blocks capability mutations until the session row and runtime config load", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["sessions.list", "config.get"],
-      methodResponses: {
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [skill("Docs")],
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["sessions.list", "config.get"],
+        methodResponses: {
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [skill("Docs")],
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await Promise.all([
         gateway.waitForRequest("sessions.list"),
         gateway.waitForRequest("config.get"),
@@ -704,28 +649,24 @@ describeControlUiE2e("Control UI composer capability menu", () => {
         .toEqual({
           mcpToolsDeny: { notion: ["delete_page"] },
         });
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("shows empty skills and connector states", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse({}, false),
-        "sessions.list": sessionsList(),
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [],
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        methodResponses: {
+          "config.get": configResponse({}, false),
+          "sessions.list": sessionsList(),
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [],
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const composer = await openMenu(page);
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       await expect
@@ -736,28 +677,24 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       await menu.getByRole("menuitem", { name: "Back" }).click();
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
       await expect.poll(() => menu.getByText("No MCP servers configured.").isVisible()).toBe(true);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("validates and adds MCP servers for session and everywhere scopes", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse({}, false),
-        "sessions.list": sessionsList({ skills: { docs: false } }),
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [],
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "config.get": configResponse({}, false),
+          "sessions.list": sessionsList({ skills: { docs: false } }),
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [],
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       let composer = await openMenu(page);
       let menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
@@ -874,8 +811,6 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       await expect
         .poll(() => menu.getByRole("menuitem", { name: /^global-docs.*Enabled/ }).isVisible())
         .toBe(true);
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -1,117 +1,89 @@
 // Control UI E2E tests cover the redesigned chat composer.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  controlUiSessionUrl,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat composer redesign",
+});
 
-let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
-let browser: Browser;
-
-describeControlUiE2e("Control UI chat composer redesign", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps model and settings in the bottom bar and switches the primary action with input state", async () => {
-    const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      assistantName: "Rosita",
-      deferredMethods: ["chat.send"],
-      models: [
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-        {
-          id: "gpt-5.4-pro",
-          name: "GPT-5.4 Pro",
-          provider: "openai",
-          available: true,
-        },
-        {
-          id: "gpt-5.3-codex-spark",
-          name: "GPT-5.3 Codex Spark",
-          provider: "codex",
-          available: false,
-        },
-        {
-          id: "claude-sonnet-4-6",
-          name: "Claude Sonnet 4.6",
-          provider: "anthropic",
-        },
-      ],
-      methodResponses: {
-        "models.authStatus": {
-          ts: Date.now(),
-          providers: [
-            {
-              provider: "openai",
-              displayName: "Codex",
-              status: "ok",
-              profiles: [{ profileId: "codex", type: "oauth", status: "ok" }],
-              usage: { providerId: "openai", windows: [{ label: "Week", usedPercent: 72 }] },
-            },
-          ],
-        },
-        "sessions.list": {
-          count: 1,
-          defaults: {
-            contextTokens: 200_000,
-            model: "gpt-5.5",
-            modelProvider: "openai",
-            thinkingDefault: "high",
-            thinkingLevels: [
-              { id: "off", label: "off" },
-              { id: "low", label: "low" },
-              { id: "medium", label: "medium" },
-              { id: "high", label: "high" },
+    await suite.withPage({ viewport: { width: 1920, height: 1080 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        assistantName: "Rosita",
+        deferredMethods: ["chat.send"],
+        models: [
+          { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+          {
+            id: "gpt-5.4-pro",
+            name: "GPT-5.4 Pro",
+            provider: "openai",
+            available: true,
+          },
+          {
+            id: "gpt-5.3-codex-spark",
+            name: "GPT-5.3 Codex Spark",
+            provider: "codex",
+            available: false,
+          },
+          {
+            id: "claude-sonnet-4-6",
+            name: "Claude Sonnet 4.6",
+            provider: "anthropic",
+          },
+        ],
+        methodResponses: {
+          "models.authStatus": {
+            ts: Date.now(),
+            providers: [
+              {
+                provider: "openai",
+                displayName: "Codex",
+                status: "ok",
+                profiles: [{ profileId: "codex", type: "oauth", status: "ok" }],
+                usage: { providerId: "openai", windows: [{ label: "Week", usedPercent: 72 }] },
+              },
             ],
           },
-          path: "",
-          sessions: [
-            {
+          "sessions.list": {
+            count: 1,
+            defaults: {
               contextTokens: 200_000,
-              displayName: "Main",
-              hasActiveRun: false,
-              key: "main",
-              kind: "direct",
-              label: "Main",
               model: "gpt-5.5",
               modelProvider: "openai",
-              status: "done",
-              totalTokens: 46_000,
-              totalTokensFresh: true,
-              updatedAt: Date.now(),
+              thinkingDefault: "high",
+              thinkingLevels: [
+                { id: "off", label: "off" },
+                { id: "low", label: "low" },
+                { id: "medium", label: "medium" },
+                { id: "high", label: "high" },
+              ],
             },
-          ],
-          ts: Date.now(),
+            path: "",
+            sessions: [
+              {
+                contextTokens: 200_000,
+                displayName: "Main",
+                hasActiveRun: false,
+                key: "main",
+                kind: "direct",
+                label: "Main",
+                model: "gpt-5.5",
+                modelProvider: "openai",
+                status: "done",
+                totalTokens: 46_000,
+                totalTokensFresh: true,
+                updatedAt: Date.now(),
+              },
+            ],
+            ts: Date.now(),
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
 
       const composer = page.locator(".agent-chat__input");
@@ -559,79 +531,75 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
           path: `${artifactDir}/voice-picker-disabled-background.png`,
         });
       }
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("refreshes the configured usable catalog after advertised chat metadata", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      agentModel: "openai/gpt-5.3-codex-spark",
-      models: [
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true },
-        {
-          id: "gpt-5.3-codex-spark",
-          name: "GPT-5.3 Codex Spark",
-          provider: "codex",
-          available: false,
-        },
-      ],
-      methodResponses: {
-        "chat.startup": {
-          agentsList: {
-            agents: [{ id: "main", name: "OpenClaw" }],
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        agentModel: "openai/gpt-5.3-codex-spark",
+        models: [
+          { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true },
+          {
+            id: "gpt-5.3-codex-spark",
+            name: "GPT-5.3 Codex Spark",
+            provider: "codex",
+            available: false,
           },
-          messages: [],
-          sessionId: "control-ui-e2e-session",
-          thinkingLevel: null,
-        },
-        "chat.metadata": {
-          commands: [],
-          models: [
-            { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true },
-            {
-              id: "gpt-5.3-codex-spark",
-              name: "GPT-5.3 Codex Spark",
-              provider: "codex",
-              available: false,
+        ],
+        methodResponses: {
+          "chat.startup": {
+            agentsList: {
+              agents: [{ id: "main", name: "OpenClaw" }],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
             },
-          ],
-        },
-        "sessions.list": {
-          count: 1,
-          defaults: {
-            contextTokens: 200_000,
-            model: "gpt-5.3-codex-spark",
-            modelProvider: "openai",
+            messages: [],
+            sessionId: "control-ui-e2e-session",
+            thinkingLevel: null,
           },
-          path: "",
-          sessions: [
-            {
+          "chat.metadata": {
+            commands: [],
+            models: [
+              { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true },
+              {
+                id: "gpt-5.3-codex-spark",
+                name: "GPT-5.3 Codex Spark",
+                provider: "codex",
+                available: false,
+              },
+            ],
+          },
+          "sessions.list": {
+            count: 1,
+            defaults: {
               contextTokens: 200_000,
-              displayName: "Main",
-              hasActiveRun: false,
-              key: "main",
-              kind: "direct",
-              label: "Main",
-              model: "gpt-5.5",
+              model: "gpt-5.3-codex-spark",
               modelProvider: "openai",
-              status: "done",
-              totalTokens: 0,
-              updatedAt: Date.now(),
             },
-          ],
-          ts: Date.now(),
+            path: "",
+            sessions: [
+              {
+                contextTokens: 200_000,
+                displayName: "Main",
+                hasActiveRun: false,
+                key: "main",
+                kind: "direct",
+                label: "Main",
+                model: "gpt-5.5",
+                modelProvider: "openai",
+                status: "done",
+                totalTokens: 0,
+                updatedAt: Date.now(),
+              },
+            ],
+            ts: Date.now(),
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.metadata");
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
 
@@ -650,84 +618,80 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       // marked as the default and no synthetic empty row is introduced.
       await expect.poll(() => composer.locator('[data-chat-model-default="true"]').count()).toBe(0);
       await expect.poll(() => composer.locator('[data-chat-model-option=""]').count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("refreshes agent-scoped models when the pane switches sessions", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      defaultAgentId: "work",
-      sessionKey: "agent:work:main",
-      methodResponses: {
-        "chat.metadata": {
-          cases: [
-            {
-              match: { agentId: "work" },
-              response: {
-                commands: [],
-                models: [
-                  {
-                    id: "work-model",
-                    name: "Work Model",
-                    provider: "openai",
-                    available: true,
-                  },
-                ],
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        defaultAgentId: "work",
+        sessionKey: "agent:work:main",
+        methodResponses: {
+          "chat.metadata": {
+            cases: [
+              {
+                match: { agentId: "work" },
+                response: {
+                  commands: [],
+                  models: [
+                    {
+                      id: "work-model",
+                      name: "Work Model",
+                      provider: "openai",
+                      available: true,
+                    },
+                  ],
+                },
               },
-            },
-            {
-              match: { agentId: "other" },
-              response: {
-                commands: [],
-                models: [
-                  {
-                    id: "other-model",
-                    name: "Other Model",
-                    provider: "anthropic",
-                    available: true,
-                  },
-                ],
+              {
+                match: { agentId: "other" },
+                response: {
+                  commands: [],
+                  models: [
+                    {
+                      id: "other-model",
+                      name: "Other Model",
+                      provider: "anthropic",
+                      available: true,
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        },
-        "sessions.list": {
-          count: 2,
-          defaults: {
-            contextTokens: 200_000,
-            model: "other-model",
-            modelProvider: "anthropic",
+            ],
           },
-          path: "",
-          sessions: [
-            {
-              key: "agent:work:main",
-              kind: "direct",
-              model: "work-model",
-              modelProvider: "openai",
-              status: "done",
-              updatedAt: Date.now(),
-            },
-            {
-              key: "agent:other:main",
-              kind: "direct",
+          "sessions.list": {
+            count: 2,
+            defaults: {
+              contextTokens: 200_000,
               model: "other-model",
               modelProvider: "anthropic",
-              status: "done",
-              updatedAt: Date.now(),
             },
-          ],
-          ts: Date.now(),
+            path: "",
+            sessions: [
+              {
+                key: "agent:work:main",
+                kind: "direct",
+                model: "work-model",
+                modelProvider: "openai",
+                status: "done",
+                updatedAt: Date.now(),
+              },
+              {
+                key: "agent:other:main",
+                kind: "direct",
+                model: "other-model",
+                modelProvider: "anthropic",
+                status: "done",
+                updatedAt: Date.now(),
+              },
+            ],
+            ts: Date.now(),
+          },
         },
-      },
-      models: [{ id: "work-model", name: "Work Model", provider: "openai", available: true }],
-    });
+        models: [{ id: "work-model", name: "Work Model", provider: "openai", available: true }],
+      });
 
-    try {
-      await page.goto(controlUiSessionUrl(server.baseUrl, "agent:work:main"));
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:work:main"));
       await gateway.waitForRequest("chat.startup");
       // The initial work-agent catalog is complete in chat.startup, so only the
       // later switch to the other agent should require chat.metadata.
@@ -761,21 +725,17 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       expect((metadataRequests[0]?.params as { agentId?: string } | undefined)?.agentId).toBe(
         "other",
       );
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("keeps startup models when an explicit metadata refresh fails", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["chat.metadata"],
-      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true }],
-    });
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["chat.metadata"],
+        models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true }],
+      });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       const composer = page.locator(".agent-chat__input");
       await expect
@@ -798,33 +758,29 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
         .poll(() => composer.locator('[data-chat-model-provider-group="openai"]').textContent())
         .toContain("GPT-5.5");
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("does not substitute default-agent models when scoped metadata fails", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["chat.startup"],
-      methodResponses: {
-        "chat.metadata": {
-          cases: [
-            {
-              match: { agentId: "work" },
-              response: {
-                __mockError: { code: "UNAVAILABLE", message: "metadata unavailable" },
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["chat.startup"],
+        methodResponses: {
+          "chat.metadata": {
+            cases: [
+              {
+                match: { agentId: "work" },
+                response: {
+                  __mockError: { code: "UNAVAILABLE", message: "metadata unavailable" },
+                },
               },
-            },
-          ],
+            ],
+          },
         },
-      },
-      models: [{ id: "gpt-default", name: "GPT Default", provider: "openai", available: true }],
-    });
+        models: [{ id: "gpt-default", name: "GPT Default", provider: "openai", available: true }],
+      });
 
-    try {
-      await page.goto(controlUiSessionUrl(server.baseUrl, "agent:main:main"));
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
       await gateway.waitForRequest("chat.startup");
       await page.locator("openclaw-chat-pane").evaluate((pane) => {
         (pane as HTMLElement & { sessionKey: string }).sessionKey = "agent:work:main";
@@ -903,58 +859,54 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
         ),
       ).toBe(true);
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("does not request unscoped models when chat metadata is unavailable", async () => {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      models: [{ id: "gpt-default", name: "GPT Default", provider: "openai", available: true }],
-      methodResponses: {
-        connect: {
-          auth: {
-            deviceToken: "e2e-device-token",
-            role: "operator",
-            scopes: [
-              "operator.admin",
-              "operator.read",
-              "operator.write",
-              "operator.approvals",
-              "operator.pairing",
-            ],
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        models: [{ id: "gpt-default", name: "GPT Default", provider: "openai", available: true }],
+        methodResponses: {
+          connect: {
+            auth: {
+              deviceToken: "e2e-device-token",
+              role: "operator",
+              scopes: [
+                "operator.admin",
+                "operator.read",
+                "operator.write",
+                "operator.approvals",
+                "operator.pairing",
+              ],
+            },
+            features: { events: [], methods: ["chat.startup"] },
+            protocol: 4,
+            server: { connId: "control-ui-e2e", version: "e2e" },
+            snapshot: {
+              sessionDefaults: {
+                defaultAgentId: "main",
+                mainKey: "main",
+                mainSessionKey: "agent:work:main",
+                scope: "agent",
+              },
+            },
+            type: "hello-ok",
           },
-          features: { events: [], methods: ["chat.startup"] },
-          protocol: 4,
-          server: { connId: "control-ui-e2e", version: "e2e" },
-          snapshot: {
-            sessionDefaults: {
-              defaultAgentId: "main",
+          "chat.startup": {
+            agentsList: {
+              agents: [{ id: "work", name: "Work" }],
+              defaultId: "main",
               mainKey: "main",
-              mainSessionKey: "agent:work:main",
               scope: "agent",
             },
+            messages: [],
+            sessionId: "control-ui-e2e-session",
+            thinkingLevel: null,
           },
-          type: "hello-ok",
         },
-        "chat.startup": {
-          agentsList: {
-            agents: [{ id: "work", name: "Work" }],
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
-          },
-          messages: [],
-          sessionId: "control-ui-e2e-session",
-          thinkingLevel: null,
-        },
-      },
-    });
+      });
 
-    try {
-      await page.goto(controlUiSessionUrl(server.baseUrl, "agent:work:main"));
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:work:main"));
       const startupRequest = await gateway.waitForRequest("chat.startup");
       expect(startupRequest.params).toEqual(
         expect.objectContaining({ sessionKey: "agent:work:main" }),
@@ -971,8 +923,6 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
         .not.toContain("GPT Default");
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/e2e/chat-panel-reflow.e2e.test.ts
+++ b/ui/src/e2e/chat-panel-reflow.e2e.test.ts
@@ -1,19 +1,15 @@
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "chat transcript panel reflow",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-panel-reflow");
 const chatSessionKey = "agent:main:main";
 
@@ -63,123 +59,106 @@ async function expectMessagesNotToOverlap(page: import("playwright").Page): Prom
     .toEqual([]);
 }
 
-let server: ControlUiE2eServer;
-let browser: Browser;
-
-describeControlUiE2e("chat transcript panel reflow", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps transcript rows separate across background-task, file, and diff panel toggles", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     await mkdir(artifactDir, { recursive: true });
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    try {
-      await installMockGateway(page, {
-        featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
-        historyMessages,
-        methodResponses: {
-          "artifacts.list": { artifacts: [] },
-          "sessions.diff": {
-            additions: 1,
-            baseRef: "main",
-            branch: "feature/reflow",
-            deletions: 0,
-            files: [
-              {
-                additions: 1,
-                deletions: 0,
-                patch: [
-                  "diff --git a/src/app.ts b/src/app.ts",
-                  "--- a/src/app.ts",
-                  "+++ b/src/app.ts",
-                  "@@ -1 +1,2 @@",
-                  " current line",
-                  "+new line",
-                  "",
-                ].join("\n"),
-                path: "src/app.ts",
-                status: "modified",
-              },
-            ],
-            root: "/workspace",
-            sessionKey: "main",
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+          historyMessages,
+          methodResponses: {
+            "artifacts.list": { artifacts: [] },
+            "sessions.diff": {
+              additions: 1,
+              baseRef: "main",
+              branch: "feature/reflow",
+              deletions: 0,
+              files: [
+                {
+                  additions: 1,
+                  deletions: 0,
+                  patch: [
+                    "diff --git a/src/app.ts b/src/app.ts",
+                    "--- a/src/app.ts",
+                    "+++ b/src/app.ts",
+                    "@@ -1 +1,2 @@",
+                    " current line",
+                    "+new line",
+                    "",
+                  ].join("\n"),
+                  path: "src/app.ts",
+                  status: "modified",
+                },
+              ],
+              root: "/workspace",
+              sessionKey: "main",
+            },
+            "sessions.files.list": {
+              browser: { entries: [], path: "" },
+              files: [
+                {
+                  kind: "modified",
+                  missing: false,
+                  name: "AGENTS.md",
+                  path: "/workspace/AGENTS.md",
+                  size: 2048,
+                },
+              ],
+              root: "/workspace",
+              sessionKey: "main",
+            },
+            "tasks.list": {
+              tasks: [
+                {
+                  agentId: "main",
+                  createdAt: Date.now() - 5_000,
+                  id: "task-reflow",
+                  kind: "subagent",
+                  ownerKey: chatSessionKey,
+                  progressSummary: "Checking transcript layout",
+                  runtime: "subagent",
+                  startedAt: Date.now() - 4_000,
+                  status: "running",
+                  taskId: "task-reflow",
+                  title: "Reflow proof",
+                  updatedAt: Date.now(),
+                },
+              ],
+            },
           },
-          "sessions.files.list": {
-            browser: { entries: [], path: "" },
-            files: [
-              {
-                kind: "modified",
-                missing: false,
-                name: "AGENTS.md",
-                path: "/workspace/AGENTS.md",
-                size: 2048,
-              },
-            ],
-            root: "/workspace",
-            sessionKey: "main",
-          },
-          "tasks.list": {
-            tasks: [
-              {
-                agentId: "main",
-                createdAt: Date.now() - 5_000,
-                id: "task-reflow",
-                kind: "subagent",
-                ownerKey: chatSessionKey,
-                progressSummary: "Checking transcript layout",
-                runtime: "subagent",
-                startedAt: Date.now() - 4_000,
-                status: "running",
-                taskId: "task-reflow",
-                title: "Reflow proof",
-                updatedAt: Date.now(),
-              },
-            ],
-          },
-        },
-      });
+        });
 
-      const response = await page.goto(`${server.baseUrl}chat`);
-      expect(response?.status()).toBe(200);
-      await expect.poll(() => page.locator(".chat-group").count()).toBe(historyMessageCount);
-      await page.locator(".chat-thread").evaluate((element) => {
-        element.scrollTop = Math.max(0, element.scrollHeight / 2);
-      });
-      await expectMessagesNotToOverlap(page);
-      await page.screenshot({ path: path.join(artifactDir, "00-closed.png") });
+        const response = await page.goto(`${suite.server.baseUrl}chat`);
+        expect(response?.status()).toBe(200);
+        await expect.poll(() => page.locator(".chat-group").count()).toBe(historyMessageCount);
+        await page.locator(".chat-thread").evaluate((element) => {
+          element.scrollTop = Math.max(0, element.scrollHeight / 2);
+        });
+        await expectMessagesNotToOverlap(page);
+        await page.screenshot({ path: path.join(artifactDir, "00-closed.png") });
 
-      await page.getByRole("button", { name: "Show background tasks" }).click();
-      await page.locator(".chat-tasks-rail").waitFor({ state: "visible" });
-      await expectMessagesNotToOverlap(page);
-      await page.screenshot({ path: path.join(artifactDir, "01-background-tasks.png") });
+        await page.getByRole("button", { name: "Show background tasks" }).click();
+        await page.locator(".chat-tasks-rail").waitFor({ state: "visible" });
+        await expectMessagesNotToOverlap(page);
+        await page.screenshot({ path: path.join(artifactDir, "01-background-tasks.png") });
 
-      await page.getByRole("button", { name: "Show thread files", exact: true }).click();
-      await page.locator(".chat-workspace-rail").waitFor({ state: "visible" });
-      await expectMessagesNotToOverlap(page);
-      await page.screenshot({ path: path.join(artifactDir, "02-thread-files.png") });
+        await page.getByRole("button", { name: "Show thread files", exact: true }).click();
+        await page.locator(".chat-workspace-rail").waitFor({ state: "visible" });
+        await expectMessagesNotToOverlap(page);
+        await page.screenshot({ path: path.join(artifactDir, "02-thread-files.png") });
 
-      await page.locator(".chat-session-diff-toggle").first().click();
-      await page.locator(".session-diff").waitFor({ state: "visible" });
-      await expectMessagesNotToOverlap(page);
-      await page.screenshot({ path: path.join(artifactDir, "03-thread-changes.png") });
-    } finally {
-      await context.close();
-    }
+        await page.locator(".chat-session-diff-toggle").first().click();
+        await page.locator(".session-diff").waitFor({ state: "visible" });
+        await expectMessagesNotToOverlap(page);
+        await page.screenshot({ path: path.join(artifactDir, "03-thread-changes.png") });
+      },
+    );
   });
 });

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -1,19 +1,14 @@
 // Real-browser proof + regression for #93041: provider usage from models.authStatus remains
 // available in the desktop composer's context popover. Screenshots go to the ignored artifacts tree.
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const describeE2e = chromiumAvailable ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI #93041 desktop chat quota popover (mocked Gateway E2E)",
+});
 
 const baseTime = 1_700_000_000_000;
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-quota-pill-93041");
@@ -91,9 +86,6 @@ const claudeSubscriptionSessions = {
   ts: Date.now(),
 };
 
-let server: ControlUiE2eServer;
-let browser: Browser;
-
 async function openChat(
   authStatus: unknown,
   extraMethodResponses: Record<string, unknown> = {},
@@ -104,7 +96,7 @@ async function openChat(
   let context: BrowserContext | undefined;
   let page: Page | undefined;
   try {
-    context = await browser.newContext({
+    context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
@@ -114,7 +106,7 @@ async function openChat(
     const gateway = await installMockGateway(page, {
       methodResponses: { "models.authStatus": authStatus, ...extraMethodResponses },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await gateway.waitForRequest("models.authStatus");
     return { context, page };
   } catch (error) {
@@ -129,22 +121,7 @@ async function closeChat(fixture: { context: BrowserContext; page: Page }): Prom
   await fixture.context.close().catch(() => {});
 }
 
-describeE2e("Control UI #93041 desktop chat quota popover (mocked Gateway E2E)", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close().catch(() => {});
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders provider usage inside the desktop context popover", async () => {
     const fixture = await openChat(authStatusWithUsage);
     const { page } = fixture;

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -1,42 +1,23 @@
 // Control UI E2E tests cover chat run lifecycle behavior through the Gateway WebSocket.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Page } from "playwright";
+import { afterEach, expect, it } from "vitest";
 import { CHAT_RUN_STATUS_TOAST_DURATION_MS } from "../pages/chat/run-lifecycle.ts";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  pauseVirtualClock,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { installMockGateway, pauseVirtualClock } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat run lifecycle",
+});
+
 // Home mirrors the sidebar leading-slot contract: an active run rings the Home
 // glyph instead of adding a trailing spinner (see app-sidebar-render.ts).
 const HOME_RUN_RING_SELECTOR = ".session-glyph--running .session-glyph__ring";
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
-let browser: Browser;
 let page: Page | undefined;
-let server: ControlUiE2eServer | undefined;
-
-describeControlUiE2e("Control UI chat run lifecycle", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await page
       ?.context()
@@ -45,13 +26,8 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     page = undefined;
   });
 
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
   it("keeps a continuing run inside its latest assistant reply", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     await installMockGateway(currentPage, {
@@ -70,7 +46,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     const assistantGroup = currentPage.locator(".chat-group.assistant");
     await assistantGroup.getByText("First result is ready.", { exact: true }).waitFor();
     await assistantGroup.locator(".chat-working-indicator--continuation").waitFor();
@@ -93,7 +69,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     if (captureProof) {
       await mkdir(artifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureProof
         ? { recordVideo: { dir: artifactDir, size: { height: 800, width: 1200 } } }
@@ -117,7 +93,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("Saved opening.", { exact: true }).waitFor();
     const stream = currentPage.locator(".chat-bubble.streaming", {
       hasText: "Still working after reconnect.",
@@ -136,7 +112,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
   });
 
   it("shows compaction savings and live working time", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     await currentPage.clock.install();
@@ -155,7 +131,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       ],
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("saved 875.3k tokens", { exact: true }).waitFor();
     await currentPage.locator(".agent-chat__input textarea").fill("keep working");
     // The working timer starts at the send click; pause first so the elapsed
@@ -182,7 +158,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
   });
 
   it("clears shared session activity when chat final arrives first", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     await currentPage.clock.install();
@@ -196,7 +172,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       ],
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage
       .getByText("Ready for run lifecycle verification.")
       .waitFor({ timeout: 10_000 });
@@ -327,7 +303,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
   });
 
   it("does not announce Done when a yielded parent is waiting for continuation", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, {
@@ -340,7 +316,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       ],
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage
       .getByText("Ready for yielded lifecycle verification.")
       .waitFor({ timeout: 10_000 });
@@ -402,12 +378,12 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     if (captureProof) {
       await mkdir(artifactDir, { recursive: true });
     }
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage);
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.locator(".agent-chat__input textarea").fill("run the edit");
     await currentPage.getByRole("button", { name: "Send message" }).click();
     const send = await gateway.waitForRequest("chat.send");

--- a/ui/src/e2e/chat-send-pending-handoff.e2e.test.ts
+++ b/ui/src/e2e/chat-send-pending-handoff.e2e.test.ts
@@ -1,24 +1,14 @@
 // Control UI E2E tests cover the pending-send bubble handoff to authoritative history.
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayControls,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { afterEach, expect, it } from "vitest";
+import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat send pending handoff",
+});
 
-let browser: Browser;
 let page: Page | undefined;
-let server: ControlUiE2eServer | undefined;
-
 type FrameSample = {
   t: number;
   present: boolean;
@@ -106,7 +96,7 @@ async function openChatAndSubmitProbe(
   gateway: MockGatewayControls,
   opts?: { deferSend?: boolean },
 ): Promise<string> {
-  await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+  await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
   await currentPage.getByText("Ready.").waitFor({ timeout: 10_000 });
   await gateway.waitForRequest("sessions.list");
   if (opts?.deferSend) {
@@ -193,17 +183,7 @@ async function finishRunAndSettle(
   return stopFrameSampler(currentPage);
 }
 
-describeControlUiE2e("Control UI chat send pending handoff", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await page
       ?.context()
@@ -212,13 +192,8 @@ describeControlUiE2e("Control UI chat send pending handoff", () => {
     page = undefined;
   });
 
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
   it("keeps the submitted user turn visible through run completion and history reload", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, { historyMessages: BASE_HISTORY });
@@ -243,7 +218,7 @@ describeControlUiE2e("Control UI chat send pending handoff", () => {
   });
 
   it("keeps the submitted user turn visible when the session echo lands before the send ack", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, { historyMessages: BASE_HISTORY });

--- a/ui/src/e2e/chat-skill-references.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-references.e2e.test.ts
@@ -1,137 +1,111 @@
 // Control UI E2E tests cover composable skill references in the chat composer.
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI skill references",
+});
 
-let server: ControlUiE2eServer;
-let browser: Browser;
-
-describeControlUiE2e("Control UI skill references", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("references multiple skills inside a normal prompt and sends the visible tokens", async () => {
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    const context = await browser.newContext({
-      viewport: { width: 1280, height: 900 },
-      ...(artifactDir
-        ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
-        : {}),
-    });
-    const page = await context.newPage();
-    const commands = [
+    await suite.withPage(
       {
-        acceptsArgs: true,
-        description: "Pre-commit and ship code review.",
-        name: "autoreview",
-        scope: "both",
-        source: "skill",
-        skillModelVisible: true,
-        textAliases: ["/autoreview"],
+        viewport: { width: 1280, height: 900 },
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
+          : {}),
       },
-      {
-        acceptsArgs: true,
-        description: "Build and review technical documentation.",
-        name: "technical_documentation",
-        scope: "both",
-        source: "skill",
-        skillModelVisible: true,
-        textAliases: ["/technical_documentation"],
-      },
-      {
-        acceptsArgs: false,
-        description: "Show gateway status.",
-        name: "status",
-        scope: "both",
-        source: "native",
-        textAliases: ["/status"],
-      },
-    ];
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["chat.send"],
-      methodResponses: {
-        "chat.startup": {
-          agentsList: {
-            agents: [{ id: "main", name: "OpenClaw" }],
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
+      async ({ page }) => {
+        const commands = [
+          {
+            acceptsArgs: true,
+            description: "Pre-commit and ship code review.",
+            name: "autoreview",
+            scope: "both",
+            source: "skill",
+            skillModelVisible: true,
+            textAliases: ["/autoreview"],
           },
-          messages: [],
-          metadata: { commands, models: [] },
-          sessionId: "skill-reference-session",
-          thinkingLevel: null,
-        },
-        "commands.list": { commands },
-      },
-    });
-
-    try {
-      await page.goto(`${server.baseUrl}chat`);
-      await gateway.waitForRequest("chat.startup");
-      const composer = page.locator(".agent-chat__composer-combobox textarea");
-      await composer.fill("Review this with $auto");
-
-      const picker = page.getByRole("listbox", { name: "Skill references" });
-      await picker.waitFor({ state: "visible" });
-      await expect.poll(() => picker.getByRole("option").count()).toBe(1);
-      await expect
-        .poll(() => picker.getByRole("option").first().textContent())
-        .toContain("$autoreview");
-      await composer.press("Enter");
-      await expect.poll(() => composer.inputValue()).toBe("Review this with $autoreview ");
-
-      await composer.fill(`${await composer.inputValue()}and $technical`);
-      await expect.poll(() => picker.getByRole("option").count()).toBe(1);
-      await composer.press("Tab");
-      await expect
-        .poll(() => composer.inputValue())
-        .toBe("Review this with $autoreview and $technical_documentation ");
-
-      if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, "skill-references-selected.png"),
-          fullPage: true,
+          {
+            acceptsArgs: true,
+            description: "Build and review technical documentation.",
+            name: "technical_documentation",
+            scope: "both",
+            source: "skill",
+            skillModelVisible: true,
+            textAliases: ["/technical_documentation"],
+          },
+          {
+            acceptsArgs: false,
+            description: "Show gateway status.",
+            name: "status",
+            scope: "both",
+            source: "native",
+            textAliases: ["/status"],
+          },
+        ];
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["chat.send"],
+          methodResponses: {
+            "chat.startup": {
+              agentsList: {
+                agents: [{ id: "main", name: "OpenClaw" }],
+                defaultId: "main",
+                mainKey: "main",
+                scope: "agent",
+              },
+              messages: [],
+              metadata: { commands, models: [] },
+              sessionId: "skill-reference-session",
+              thinkingLevel: null,
+            },
+            "commands.list": { commands },
+          },
         });
-      }
 
-      await page.getByRole("button", { name: "Send message" }).click();
-      const request = await gateway.waitForRequest("chat.send");
-      expect((request.params as { message?: unknown }).message).toBe(
-        "Review this with $autoreview and $technical_documentation",
-      );
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.fill("Review this with $auto");
 
-      await composer.fill("Print $HOME");
-      await expect.poll(() => picker.count()).toBe(0);
-      await composer.fill("/");
-      await page.getByRole("listbox", { name: "Slash commands" }).waitFor({ state: "visible" });
-      await expect.poll(() => page.getByRole("option", { name: /\/status/u }).count()).toBe(1);
-    } finally {
-      await context.close();
-    }
+        const picker = page.getByRole("listbox", { name: "Skill references" });
+        await picker.waitFor({ state: "visible" });
+        await expect.poll(() => picker.getByRole("option").count()).toBe(1);
+        await expect
+          .poll(() => picker.getByRole("option").first().textContent())
+          .toContain("$autoreview");
+        await composer.press("Enter");
+        await expect.poll(() => composer.inputValue()).toBe("Review this with $autoreview ");
+
+        await composer.fill(`${await composer.inputValue()}and $technical`);
+        await expect.poll(() => picker.getByRole("option").count()).toBe(1);
+        await composer.press("Tab");
+        await expect
+          .poll(() => composer.inputValue())
+          .toBe("Review this with $autoreview and $technical_documentation ");
+
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, "skill-references-selected.png"),
+            fullPage: true,
+          });
+        }
+
+        await page.getByRole("button", { name: "Send message" }).click();
+        const request = await gateway.waitForRequest("chat.send");
+        expect((request.params as { message?: unknown }).message).toBe(
+          "Review this with $autoreview and $technical_documentation",
+        );
+
+        await composer.fill("Print $HOME");
+        await expect.poll(() => picker.count()).toBe(0);
+        await composer.fill("/");
+        await page.getByRole("listbox", { name: "Slash commands" }).waitFor({ state: "visible" });
+        await expect.poll(() => page.getByRole("option", { name: /\/status/u }).count()).toBe(1);
+      },
+    );
   });
 });

--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -1,24 +1,14 @@
 // Control UI E2E tests cover autonomous tool-turn outcome rendering.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  controlUiSessionUrl,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI autonomous tool-turn outcomes",
+  startServerBeforeBrowser: true,
+});
 
 function failedTool(timestamp: number) {
   return {
@@ -50,19 +40,9 @@ async function expandCompletedWorkGroups(page: import("playwright").Page) {
   }
 }
 
-describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
-  beforeAll(async () => {
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps an earlier autonomous failure visible after a later turn recovers", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const page = await context.newPage();
     const sessionKey = "agent:main:dashboard:tool-turn-outcome";
     await installMockGateway(page, {
@@ -85,7 +65,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
       ],
     });
 
-    await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
     await page.getByText("Recovered on the next autonomous turn.", { exact: true }).waitFor();
     await expandCompletedWorkGroups(page);
 
@@ -105,7 +85,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
   });
 
   it("pairs a canonical parallel batch and renders per-file patch sections", async () => {
-    const context = await browser.newContext({ viewport: { height: 900, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1200 } });
     const page = await context.newPage();
     await installMockGateway(page, {
       historyMessages: [
@@ -155,7 +135,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
       ],
     });
 
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     const activity = page.locator(".chat-group--activity .chat-activity-group__summary");
     await activity.waitFor();
     expect(await activity.textContent()).toContain("Read a file, edited 2 files");
@@ -192,7 +172,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
   });
 
   it("keeps a message-only turn visible with its first message line", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const page = await context.newPage();
     const message = "Hello Molty, first claw-to-claw hello.";
     await installMockGateway(page, {
@@ -225,7 +205,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
       ],
     });
 
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     const row = page.locator(".chat-tool-msg-summary", { hasText: message });
     await row.waitFor();
 
@@ -243,7 +223,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
   });
 
   it("sweeps a text wave over the active tool row and stops it on the result", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       historyMessages: [
@@ -255,7 +235,7 @@ describeControlUiE2e("Control UI autonomous tool-turn outcomes", () => {
       ],
     });
 
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await page.getByText("Ready for the running tool wave proof.").waitFor();
     await page.locator(".agent-chat__input textarea").fill("run a long command");
     await page.getByRole("button", { name: "Send message" }).click();

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -1,22 +1,15 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const available = canRunPlaywrightChromium(executablePath);
-const allowMissing = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const suite = available || !allowMissing ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Claude native session catalog",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 type VisibleVirtualRow = {
   key: string;
@@ -222,7 +215,7 @@ async function expandCodingSection(page: Page) {
 }
 
 async function openClaudeCatalogTerminal(page: Page) {
-  await page.goto(`${server.baseUrl}chat`);
+  await page.goto(`${suite.server.baseUrl}chat`);
   await expandCodingSection(page);
   const row = page.locator('[data-session-key^="catalog:"]').filter({
     hasText: "Native Claude terminal",
@@ -231,29 +224,16 @@ async function openClaudeCatalogTerminal(page: Page) {
   await page.locator('wa-dropdown-item[value="terminal"]').click();
 }
 
-suite("Claude native session catalog", () => {
-  beforeAll(async () => {
-    if (!available) {
-      throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("groups Claude and Codex sessions by Gateway and paired-node host", async () => {
-    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    const page = await suite.browser.newPage({ viewport: { width: 1440, height: 900 } });
     await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
       methodResponses: { "sessions.catalog.list": hostGroupedNativeCatalogs() },
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await expandCodingSection(page);
       for (const catalogId of ["claude", "codex"]) {
         const catalogLabel = catalogId === "claude" ? "Claude Code" : "Codex";
@@ -286,30 +266,28 @@ suite("Claude native session catalog", () => {
   });
 
   it("shows catalog connection progress until the first terminal output", async () => {
-    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["terminal.open"],
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "sessions.catalog.list",
-        "sessions.catalog.read",
-        "terminal.open",
-      ],
-      methodResponses: {
-        "sessions.catalog.list": resumableClaudeCatalog(),
-        "sessions.catalog.read": {
-          hostId: "gateway:local",
-          threadId: "claude-terminal-session",
-          items: [{ type: "userMessage", text: "Continue the native session" }],
+    await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["terminal.open"],
+        featureMethods: [
+          "chat.metadata",
+          "chat.startup",
+          "sessions.catalog.list",
+          "sessions.catalog.read",
+          "terminal.open",
+        ],
+        methodResponses: {
+          "sessions.catalog.list": resumableClaudeCatalog(),
+          "sessions.catalog.read": {
+            hostId: "gateway:local",
+            threadId: "claude-terminal-session",
+            items: [{ type: "userMessage", text: "Continue the native session" }],
+          },
+          "terminal.list": { sessions: [] },
         },
-        "terminal.list": { sessions: [] },
-      },
-      terminalEnabled: true,
-    });
+        terminalEnabled: true,
+      });
 
-    try {
       await openClaudeCatalogTerminal(page);
       const open = await gateway.waitForRequest("terminal.open");
       expect(open.params).toMatchObject({
@@ -345,43 +323,39 @@ suite("Claude native session catalog", () => {
       });
       await expect.poll(() => connecting.count()).toBe(0);
       expect(await page.locator(".tabstrip-tab.is-live").count()).toBe(1);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("closes a catalog terminal that produces no output before the deadline", async () => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "sessions.catalog.list",
-        "sessions.catalog.read",
-        "terminal.open",
-      ],
-      methodResponses: {
-        "sessions.catalog.list": resumableClaudeCatalog(),
-        "sessions.catalog.read": {
-          hostId: "gateway:local",
-          threadId: "claude-terminal-session",
-          items: [],
+    await suite.withPage(undefined, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: [
+          "chat.metadata",
+          "chat.startup",
+          "sessions.catalog.list",
+          "sessions.catalog.read",
+          "terminal.open",
+        ],
+        methodResponses: {
+          "sessions.catalog.list": resumableClaudeCatalog(),
+          "sessions.catalog.read": {
+            hostId: "gateway:local",
+            threadId: "claude-terminal-session",
+            items: [],
+          },
+          "terminal.list": { sessions: [] },
+          "terminal.open": {
+            agentId: "main",
+            confined: false,
+            cwd: "/workspace",
+            sessionId: "claude-terminal-timeout",
+            shell: "/bin/zsh",
+            title: "claude --resume claude-termi…",
+          },
         },
-        "terminal.list": { sessions: [] },
-        "terminal.open": {
-          agentId: "main",
-          confined: false,
-          cwd: "/workspace",
-          sessionId: "claude-terminal-timeout",
-          shell: "/bin/zsh",
-          title: "claude --resume claude-termi…",
-        },
-      },
-      terminalEnabled: true,
-    });
+        terminalEnabled: true,
+      });
 
-    try {
       await page.clock.install();
       await openClaudeCatalogTerminal(page);
       await gateway.waitForRequest("terminal.open");
@@ -392,13 +366,11 @@ suite("Claude native session catalog", () => {
       const close = await gateway.waitForRequest("terminal.close");
       expect(close.params).toEqual({ sessionId: "claude-terminal-timeout" });
       expect(await page.locator(".tabstrip-tab").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("auto-loads older chat without moving the viewport and disables paired-node continuation", async () => {
-    const page = await browser.newPage();
+    const page = await suite.browser.newPage();
     await page.clock.install();
     const catalogResponse = (threadId: string, name: string, nextCursor?: string) => ({
       catalogs: [
@@ -483,7 +455,7 @@ suite("Claude native session catalog", () => {
         },
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await expandCodingSection(page);
     await page.locator('[data-session-catalog-load-more="claude"]').click();
     await page.getByText("Older remote review", { exact: true }).waitFor();
@@ -582,7 +554,7 @@ suite("Claude native session catalog", () => {
   });
 
   it("auto-loads older native history with a spinner and stable viewport", async () => {
-    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+    const page = await suite.browser.newPage({ viewport: { width: 1280, height: 800 } });
     await page.clock.install();
     const historyMessage = (seq: number, prefix: string) => ({
       __openclaw: { seq },
@@ -629,7 +601,7 @@ suite("Claude native session catalog", () => {
       },
     });
 
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await page.getByText(/^recent native message 140\n/).waitFor();
     const thread = page.locator(".chat-thread");
     await expect
@@ -681,7 +653,7 @@ suite("Claude native session catalog", () => {
   });
 
   it("keeps a focused message action mounted while its row scrolls out of view", async () => {
-    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+    const page = await suite.browser.newPage({ viewport: { width: 1280, height: 800 } });
     const messages = Array.from({ length: 200 }, (_, index) => ({
       __openclaw: { seq: index + 1 },
       content: [
@@ -706,7 +678,7 @@ suite("Claude native session catalog", () => {
       },
     });
 
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await page.getByText(/^focus retention message 200\n/).waitFor();
     const thread = page.locator(".chat-thread");
     const action = thread.locator("button.chat-group-delete").last();

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -1,24 +1,17 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
 import type { SessionsCatalogHostEvent } from "../../../packages/gateway-protocol/src/index.ts";
-import {
-  canRunPlaywrightChromium,
-  controlUiSessionPath,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const available = canRunPlaywrightChromium(executablePath);
-const allowMissing = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const suite = available || !allowMissing ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Codex native session catalog",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const catalogGroupingStorageKey = "openclaw:sidebar:sessions:catalog-grouping";
 const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
@@ -49,22 +42,9 @@ async function expandCodingSection(page: Page, required = false) {
   }
 }
 
-suite("Codex native session catalog", () => {
-  beforeAll(async () => {
-    if (!available) {
-      throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("omits empty native session catalogs from the sidebar", async () => {
-    const page = await browser.newPage();
+    const page = await suite.browser.newPage();
     const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
       methodResponses: {
@@ -103,7 +83,7 @@ suite("Codex native session catalog", () => {
       },
     });
 
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await gateway.waitForRequest("sessions.catalog.list");
     expect(await page.locator('[data-session-section="catalog:codex"]').count()).toBe(0);
     expect(await page.locator('[data-session-section="catalog:claude"]').count()).toBe(0);
@@ -111,7 +91,7 @@ suite("Codex native session catalog", () => {
   });
 
   it("separates native catalogs from live Coding rows", async () => {
-    const page = await browser.newPage({
+    const page = await suite.browser.newPage({
       deviceScaleFactor: 2,
       viewport: { height: 900, width: 1280 },
     });
@@ -208,7 +188,7 @@ suite("Codex native session catalog", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
       await expandCodingSection(page, true);
       const sessionGroups = page.locator(".sidebar-recent-sessions");
@@ -254,14 +234,14 @@ suite("Codex native session catalog", () => {
   });
 
   it("shows a completed host while the aggregate catalog request is still pending", async () => {
-    const page = await browser.newPage({ viewport: { height: 900, width: 1280 } });
+    const page = await suite.browser.newPage({ viewport: { height: 900, width: 1280 } });
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.catalog.list"],
       featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const request = await gateway.waitForRequest("sessions.catalog.list");
       const progressId = (request.params as { progressId?: string })?.progressId;
       expect(progressId).toEqual(expect.any(String));
@@ -316,7 +296,7 @@ suite("Codex native session catalog", () => {
   });
 
   it("groups sessions by host and hides empty offline nodes", async () => {
-    const page = await browser.newPage({
+    const page = await suite.browser.newPage({
       deviceScaleFactor: 2,
       viewport: { height: 1100, width: 1440 },
     });
@@ -437,7 +417,7 @@ suite("Codex native session catalog", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.evaluate(() => {
         document.documentElement.setAttribute("data-theme", "openknot");
         document.documentElement.setAttribute("data-theme-mode", "dark");
@@ -650,7 +630,7 @@ suite("Codex native session catalog", () => {
   });
 
   it("explains node-list failures and exposes independent discovery settings", async () => {
-    const page = await browser.newPage({ viewport: { height: 1100, width: 1440 } });
+    const page = await suite.browser.newPage({ viewport: { height: 1100, width: 1440 } });
     await installMockGateway(page, {
       featureMethods: [
         "chat.metadata",
@@ -754,7 +734,7 @@ suite("Codex native session catalog", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await expandCodingSection(page);
       const warning = page.locator(
         '[data-session-section="catalog:codex"] .sidebar-session-group-toggle',
@@ -778,7 +758,7 @@ suite("Codex native session catalog", () => {
         });
       }
 
-      await page.goto(`${server.baseUrl}settings/automation?section=plugins&advanced=1`);
+      await page.goto(`${suite.server.baseUrl}settings/automation?section=plugins&advanced=1`);
       const expandPluginSetting = async (pluginLabel: string) => {
         const pluginGroup = page
           .getByText(pluginLabel, { exact: true })
@@ -831,7 +811,7 @@ suite("Codex native session catalog", () => {
   });
 
   it("shows a catalog Load More rejection without losing the retry cursor", async () => {
-    const page = await browser.newPage();
+    const page = await suite.browser.newPage();
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));
     const gateway = await installMockGateway(page, {
@@ -869,7 +849,7 @@ suite("Codex native session catalog", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await expandCodingSection(page);
       await expect
         .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
@@ -901,7 +881,7 @@ suite("Codex native session catalog", () => {
   });
 
   it("adopts from the native chat composer, navigates, and auto-sends", async () => {
-    const page = await browser.newPage();
+    const page = await suite.browser.newPage();
     const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
       methodResponses: {
@@ -942,7 +922,7 @@ suite("Codex native session catalog", () => {
         "chat.send": { runId: "run-adopted", status: "started" },
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await expandCodingSection(page);
     await page.getByText("Release checklist", { exact: true }).click();
     await expect.poll(() => page.getByText("prepare release", { exact: true }).count()).toBe(1);

--- a/ui/src/e2e/config-controls-visual.e2e.test.ts
+++ b/ui/src/e2e/config-controls-visual.e2e.test.ts
@@ -1,23 +1,18 @@
 // Control UI tests cover shared Settings control styling through the mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Settings controls mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -37,81 +32,65 @@ async function resolvedBackground(page: Page, value: string): Promise<string> {
   }, value);
 }
 
-describeControlUiE2e("Control UI Settings controls mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps checked switches on the scene accent on the security page", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const config = { browser: { enabled: true } };
-    await installMockGateway(page, {
-      methodResponses: {
-        "config.get": {
-          config,
-          hash: "hash-1",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/security`);
-      expect(response?.status()).toBe(200);
-
-      const overview = page.locator(".security-page");
-      const browserSwitchRole = overview.getByRole("switch", {
-        name: "Browser enabled",
-        exact: true,
-      });
-      await browserSwitchRole.waitFor();
-      expect(await browserSwitchRole.getAttribute("aria-checked")).toBe("true");
-      const browserSwitch = overview.locator("wa-switch.settings-toggle").first();
-      expect(
-        await browserSwitch.evaluate((element) => {
-          const control = element.shadowRoot?.querySelector<HTMLElement>('[part="control"]');
-          return control ? getComputedStyle(control).backgroundColor : null;
-        }),
-      ).toBe(await resolvedBackground(page, "var(--accent)"));
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.locator(".content-header").screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "01-settings-view.png"),
+      async ({ page }) => {
+        const config = { browser: { enabled: true } };
+        await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              config,
+              hash: "hash-1",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+          },
         });
-        await overview
-          .locator(".settings-section")
-          .first()
-          .screenshot({
-            animations: "disabled",
-            path: path.join(uiProofArtifactDir, "02-security-controls.png"),
-          });
-      }
 
-      await browserSwitch.click();
-      await expect.poll(() => browserSwitchRole.getAttribute("aria-checked")).toBe("false");
-    } finally {
-      await context.close();
-    }
+        const response = await page.goto(`${suite.server.baseUrl}settings/security`);
+        expect(response?.status()).toBe(200);
+
+        const overview = page.locator(".security-page");
+        const browserSwitchRole = overview.getByRole("switch", {
+          name: "Browser enabled",
+          exact: true,
+        });
+        await browserSwitchRole.waitFor();
+        expect(await browserSwitchRole.getAttribute("aria-checked")).toBe("true");
+        const browserSwitch = overview.locator("wa-switch.settings-toggle").first();
+        expect(
+          await browserSwitch.evaluate((element) => {
+            const control = element.shadowRoot?.querySelector<HTMLElement>('[part="control"]');
+            return control ? getComputedStyle(control).backgroundColor : null;
+          }),
+        ).toBe(await resolvedBackground(page, "var(--accent)"));
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.locator(".content-header").screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "01-settings-view.png"),
+          });
+          await overview
+            .locator(".settings-section")
+            .first()
+            .screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "02-security-controls.png"),
+            });
+        }
+
+        await browserSwitch.click();
+        await expect.poll(() => browserSwitchRole.getAttribute("aria-checked")).toBe("false");
+      },
+    );
   });
 });

--- a/ui/src/e2e/config-form-defaults.e2e.test.ts
+++ b/ui/src/e2e/config-form-defaults.e2e.test.ts
@@ -1,21 +1,17 @@
 // Control UI tests cover schema defaults and restoring inherited config values.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayRequest,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI config form defaults mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
@@ -24,9 +20,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "config-form-defaults",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function requestRaw(request: MockGatewayRequest): Record<string, unknown> {
   const params = request.params;
@@ -42,230 +35,216 @@ function settingsRow(page: Page, title: string): Locator {
   });
 }
 
-describeControlUiE2e("Control UI config form defaults mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("shows defaults and removes restored optional overrides from config.set", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const config = {
-      runtime: {
-        enabled: false,
-        keep: "preserved",
-        mode: "custom",
-        payload: { mode: "custom" },
-        profile: { enabled: false, mode: "custom" },
-        retries: 9,
-        tags: ["custom"],
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
       },
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": {
-          config,
-          hash: "config-form-defaults-e2e",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
-        "config.schema": {
-          generatedAt: "2026-07-31T00:00:00.000Z",
-          schema: {
-            type: "object",
-            properties: {
-              runtime: {
+      async ({ page }) => {
+        const config = {
+          runtime: {
+            enabled: false,
+            keep: "preserved",
+            mode: "custom",
+            payload: { mode: "custom" },
+            profile: { enabled: false, mode: "custom" },
+            retries: 9,
+            tags: ["custom"],
+          },
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              config,
+              hash: "config-form-defaults-e2e",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+            "config.schema": {
+              generatedAt: "2026-07-31T00:00:00.000Z",
+              schema: {
                 type: "object",
-                title: "Runtime defaults",
                 properties: {
-                  enabled: {
-                    type: "boolean",
-                    title: "Enabled",
-                    description: "Controls runtime processing.",
-                    default: true,
-                  },
-                  keep: { type: "string", title: "Keep" },
-                  mode: {
-                    type: "string",
-                    title: "Mode",
-                    default: "balanced",
-                    enum: ["balanced", "fast", "careful", "safe", "strict", "custom"],
-                  },
-                  payload: {
-                    title: "Payload",
-                    anyOf: [{ type: "object" }, { type: "array" }],
-                    default: { mode: "balanced" },
-                  },
-                  profile: {
+                  runtime: {
                     type: "object",
-                    title: "Profile",
-                    default: { enabled: true, mode: "balanced" },
+                    title: "Runtime defaults",
                     properties: {
-                      enabled: { type: "boolean", title: "Profile enabled" },
-                      mode: { type: "string", title: "Profile mode" },
+                      enabled: {
+                        type: "boolean",
+                        title: "Enabled",
+                        description: "Controls runtime processing.",
+                        default: true,
+                      },
+                      keep: { type: "string", title: "Keep" },
+                      mode: {
+                        type: "string",
+                        title: "Mode",
+                        default: "balanced",
+                        enum: ["balanced", "fast", "careful", "safe", "strict", "custom"],
+                      },
+                      payload: {
+                        title: "Payload",
+                        anyOf: [{ type: "object" }, { type: "array" }],
+                        default: { mode: "balanced" },
+                      },
+                      profile: {
+                        type: "object",
+                        title: "Profile",
+                        default: { enabled: true, mode: "balanced" },
+                        properties: {
+                          enabled: { type: "boolean", title: "Profile enabled" },
+                          mode: { type: "string", title: "Profile mode" },
+                        },
+                      },
+                      retries: { type: "integer", title: "Retries", default: 3 },
+                      tags: {
+                        type: "array",
+                        title: "Tags",
+                        items: { type: "string" },
+                        default: ["stable", "default"],
+                      },
                     },
-                  },
-                  retries: { type: "integer", title: "Retries", default: 3 },
-                  tags: {
-                    type: "array",
-                    title: "Tags",
-                    items: { type: "string" },
-                    default: ["stable", "default"],
                   },
                 },
               },
+              uiHints: {
+                "runtime.enabled": { advanced: false },
+                "runtime.keep": { advanced: false },
+                "runtime.mode": { advanced: false },
+                "runtime.payload": { advanced: false },
+                "runtime.profile": { advanced: false },
+                "runtime.retries": { advanced: false },
+                "runtime.tags": { advanced: false },
+              },
+              version: "e2e",
             },
           },
-          uiHints: {
-            "runtime.enabled": { advanced: false },
-            "runtime.keep": { advanced: false },
-            "runtime.mode": { advanced: false },
-            "runtime.payload": { advanced: false },
-            "runtime.profile": { advanced: false },
-            "runtime.retries": { advanced: false },
-            "runtime.tags": { advanced: false },
-          },
-          version: "e2e",
-        },
+        });
+
+        const response = await page.goto(
+          `${suite.server.baseUrl}settings/advanced?section=runtime`,
+        );
+        expect(response?.status()).toBe(200);
+
+        const panel = page.locator("#config-section-panel");
+        const enabledRow = settingsRow(page, "Enabled");
+        const modeRow = settingsRow(page, "Mode");
+        const payloadRow = settingsRow(page, "Payload");
+        const profileBlock = panel.locator("details").filter({
+          has: page.locator(".cfg-object__summary .settings-row__title").getByText("Profile", {
+            exact: true,
+          }),
+        });
+        const retriesRow = settingsRow(page, "Retries");
+        const tagsBlock = panel.locator(".cfg-array").filter({ hasText: "Tags" });
+
+        await expect.poll(() => enabledRow.textContent()).toContain("Default: true");
+        await expect
+          .poll(() => enabledRow.textContent().then((text) => text?.replace(/\s+/gu, " ").trim()))
+          .toContain("Controls runtime processing. Default: true");
+        await expect.poll(() => modeRow.textContent()).toContain("Default: balanced");
+        await expect.poll(() => modeRow.locator("select").inputValue()).not.toBe("__unset__");
+        await expect.poll(() => payloadRow.textContent()).toContain('Default: {"mode":"balanced"}');
+        await expect
+          .poll(() => profileBlock.textContent())
+          .toContain('Default: {"enabled":true,"mode":"balanced"}');
+        await expect.poll(() => retriesRow.getByRole("spinbutton").inputValue()).toBe("9");
+        await expect.poll(() => tagsBlock.textContent()).toContain('Default: ["stable","default"]');
+        await expect
+          .poll(() => panel.getByRole("button", { name: "Reset to default" }).count())
+          .toBe(5);
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await panel.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "01-explicit-overrides.png"),
+          });
+        }
+
+        await gateway.deferNext("config.set");
+        await enabledRow.getByRole("button", { name: "Reset to default" }).click();
+        await modeRow.locator("select").selectOption("__unset__");
+        await payloadRow.getByRole("button", { name: "Reset to default" }).click();
+        await profileBlock.getByRole("button", { name: "Reset to default" }).click();
+        await retriesRow.getByRole("button", { name: "Reset to default" }).click();
+        await tagsBlock.getByRole("button", { name: "Reset to default" }).click();
+
+        // Form mutations schedule config.set automatically; form mode has no manual Save control.
+        const saved = requestRaw(await gateway.waitForRequest("config.set"));
+        expect(saved).toEqual({ runtime: { keep: "preserved" } });
+        await expect
+          .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
+          .toContain("Saving");
+
+        await expect.poll(() => enabledRow.textContent()).toContain("Using default: true");
+        await expect.poll(() => modeRow.locator("select").inputValue()).toBe("__unset__");
+        await expect
+          .poll(() => payloadRow.textContent())
+          .toContain('Using default: {"mode":"balanced"}');
+        await expect
+          .poll(() => profileBlock.textContent())
+          .toContain('Using default: {"enabled":true,"mode":"balanced"}');
+        await expect.poll(() => retriesRow.getByRole("spinbutton").inputValue()).toBe("");
+        await expect
+          .poll(() => retriesRow.getByRole("spinbutton").getAttribute("placeholder"))
+          .toBe("Default: 3");
+        await expect
+          .poll(() => tagsBlock.textContent())
+          .toContain('Using default: ["stable","default"]');
+        await expect
+          .poll(() => panel.getByRole("button", { name: "Reset to default" }).count())
+          .toBe(0);
+
+        const configGetsBeforeReload = (await gateway.getRequests("config.get")).length;
+        await gateway.resolveDeferred("config.set");
+        await expect
+          .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
+          .toContain("Saved");
+        expect((await page.reload())?.status()).toBe(200);
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBe(configGetsBeforeReload + 1);
+
+        const reloadedPanel = page.locator("#config-section-panel");
+        const reloadedEnabledRow = settingsRow(page, "Enabled");
+        const reloadedModeRow = settingsRow(page, "Mode");
+        const reloadedPayloadRow = settingsRow(page, "Payload");
+        const reloadedProfileBlock = reloadedPanel.locator("details").filter({
+          has: page
+            .locator(".cfg-object__summary .settings-row__title")
+            .getByText("Profile", { exact: true }),
+        });
+        const reloadedRetriesRow = settingsRow(page, "Retries");
+        const reloadedTagsBlock = reloadedPanel.locator(".cfg-array").filter({ hasText: "Tags" });
+        await expect.poll(() => reloadedEnabledRow.textContent()).toContain("Using default: true");
+        await expect.poll(() => reloadedModeRow.locator("select").inputValue()).toBe("__unset__");
+        await expect
+          .poll(() => reloadedPayloadRow.textContent())
+          .toContain('Using default: {"mode":"balanced"}');
+        await expect
+          .poll(() => reloadedProfileBlock.textContent())
+          .toContain('Using default: {"enabled":true,"mode":"balanced"}');
+        await expect.poll(() => reloadedRetriesRow.getByRole("spinbutton").inputValue()).toBe("");
+        await expect
+          .poll(() => reloadedTagsBlock.textContent())
+          .toContain('Using default: ["stable","default"]');
+        await expect
+          .poll(() => reloadedPanel.getByRole("button", { name: "Reset to default" }).count())
+          .toBe(0);
+
+        if (captureUiProofEnabled) {
+          await reloadedPanel.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "02-inherited-defaults.png"),
+          });
+        }
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/advanced?section=runtime`);
-      expect(response?.status()).toBe(200);
-
-      const panel = page.locator("#config-section-panel");
-      const enabledRow = settingsRow(page, "Enabled");
-      const modeRow = settingsRow(page, "Mode");
-      const payloadRow = settingsRow(page, "Payload");
-      const profileBlock = panel.locator("details").filter({
-        has: page.locator(".cfg-object__summary .settings-row__title").getByText("Profile", {
-          exact: true,
-        }),
-      });
-      const retriesRow = settingsRow(page, "Retries");
-      const tagsBlock = panel.locator(".cfg-array").filter({ hasText: "Tags" });
-
-      await expect.poll(() => enabledRow.textContent()).toContain("Default: true");
-      await expect
-        .poll(() => enabledRow.textContent().then((text) => text?.replace(/\s+/gu, " ").trim()))
-        .toContain("Controls runtime processing. Default: true");
-      await expect.poll(() => modeRow.textContent()).toContain("Default: balanced");
-      await expect.poll(() => modeRow.locator("select").inputValue()).not.toBe("__unset__");
-      await expect.poll(() => payloadRow.textContent()).toContain('Default: {"mode":"balanced"}');
-      await expect
-        .poll(() => profileBlock.textContent())
-        .toContain('Default: {"enabled":true,"mode":"balanced"}');
-      await expect.poll(() => retriesRow.getByRole("spinbutton").inputValue()).toBe("9");
-      await expect.poll(() => tagsBlock.textContent()).toContain('Default: ["stable","default"]');
-      await expect
-        .poll(() => panel.getByRole("button", { name: "Reset to default" }).count())
-        .toBe(5);
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await panel.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "01-explicit-overrides.png"),
-        });
-      }
-
-      await gateway.deferNext("config.set");
-      await enabledRow.getByRole("button", { name: "Reset to default" }).click();
-      await modeRow.locator("select").selectOption("__unset__");
-      await payloadRow.getByRole("button", { name: "Reset to default" }).click();
-      await profileBlock.getByRole("button", { name: "Reset to default" }).click();
-      await retriesRow.getByRole("button", { name: "Reset to default" }).click();
-      await tagsBlock.getByRole("button", { name: "Reset to default" }).click();
-
-      // Form mutations schedule config.set automatically; form mode has no manual Save control.
-      const saved = requestRaw(await gateway.waitForRequest("config.set"));
-      expect(saved).toEqual({ runtime: { keep: "preserved" } });
-      await expect
-        .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
-        .toContain("Saving");
-
-      await expect.poll(() => enabledRow.textContent()).toContain("Using default: true");
-      await expect.poll(() => modeRow.locator("select").inputValue()).toBe("__unset__");
-      await expect
-        .poll(() => payloadRow.textContent())
-        .toContain('Using default: {"mode":"balanced"}');
-      await expect
-        .poll(() => profileBlock.textContent())
-        .toContain('Using default: {"enabled":true,"mode":"balanced"}');
-      await expect.poll(() => retriesRow.getByRole("spinbutton").inputValue()).toBe("");
-      await expect
-        .poll(() => retriesRow.getByRole("spinbutton").getAttribute("placeholder"))
-        .toBe("Default: 3");
-      await expect
-        .poll(() => tagsBlock.textContent())
-        .toContain('Using default: ["stable","default"]');
-      await expect
-        .poll(() => panel.getByRole("button", { name: "Reset to default" }).count())
-        .toBe(0);
-
-      const configGetsBeforeReload = (await gateway.getRequests("config.get")).length;
-      await gateway.resolveDeferred("config.set");
-      await expect
-        .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
-        .toContain("Saved");
-      expect((await page.reload())?.status()).toBe(200);
-      await expect
-        .poll(async () => (await gateway.getRequests("config.get")).length)
-        .toBe(configGetsBeforeReload + 1);
-
-      const reloadedPanel = page.locator("#config-section-panel");
-      const reloadedEnabledRow = settingsRow(page, "Enabled");
-      const reloadedModeRow = settingsRow(page, "Mode");
-      const reloadedPayloadRow = settingsRow(page, "Payload");
-      const reloadedProfileBlock = reloadedPanel.locator("details").filter({
-        has: page
-          .locator(".cfg-object__summary .settings-row__title")
-          .getByText("Profile", { exact: true }),
-      });
-      const reloadedRetriesRow = settingsRow(page, "Retries");
-      const reloadedTagsBlock = reloadedPanel.locator(".cfg-array").filter({ hasText: "Tags" });
-      await expect.poll(() => reloadedEnabledRow.textContent()).toContain("Using default: true");
-      await expect.poll(() => reloadedModeRow.locator("select").inputValue()).toBe("__unset__");
-      await expect
-        .poll(() => reloadedPayloadRow.textContent())
-        .toContain('Using default: {"mode":"balanced"}');
-      await expect
-        .poll(() => reloadedProfileBlock.textContent())
-        .toContain('Using default: {"enabled":true,"mode":"balanced"}');
-      await expect.poll(() => reloadedRetriesRow.getByRole("spinbutton").inputValue()).toBe("");
-      await expect
-        .poll(() => reloadedTagsBlock.textContent())
-        .toContain('Using default: ["stable","default"]');
-      await expect
-        .poll(() => reloadedPanel.getByRole("button", { name: "Reset to default" }).count())
-        .toBe(0);
-
-      if (captureUiProofEnabled) {
-        await reloadedPanel.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "02-inherited-defaults.png"),
-        });
-      }
-    } finally {
-      await context.close();
-    }
+    );
   });
 });

--- a/ui/src/e2e/config-form-guidance.e2e.test.ts
+++ b/ui/src/e2e/config-form-guidance.e2e.test.ts
@@ -1,20 +1,16 @@
 // Control UI tests cover form support for transform-backed config fields.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI config form guidance mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
@@ -23,9 +19,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "config-form-guidance",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function notificationStatusConfigMocks() {
   const config = { ui: { prefs: { theme: "claw" } } };
@@ -63,265 +56,247 @@ function notificationStatusConfigMocks() {
   };
 }
 
-describeControlUiE2e("Control UI config form guidance mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders every accepted branch of a transform input schema", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const config = { update: { groupPolicy: "allowlist" } };
-    await installMockGateway(page, {
-      methodResponses: {
-        "config.get": {
-          config,
-          hash: "config-form-guidance-e2e",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
-        "config.schema": {
-          generatedAt: "2026-07-14T00:00:00.000Z",
-          schema: {
-            type: "object",
-            properties: {
-              update: {
-                type: "object",
-                title: "Updates",
-                properties: {
-                  groupPolicy: {
-                    title: "Group policy",
-                    anyOf: [
-                      { type: "string", enum: ["open", "allowlist", "disabled"] },
-                      { type: "string", const: "allowall" },
-                    ],
-                  },
-                },
-              },
-            },
-          },
-          uiHints: {},
-          version: "e2e",
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/advanced`);
-      expect(response?.status()).toBe(200);
-
-      await page.getByRole("button", { name: "Core" }).click();
-      await page.getByRole("button", { name: "Updates", exact: true }).click();
-
-      const policyRow = page.locator(".settings-row").filter({ hasText: "Group policy" });
-      await expect.poll(() => policyRow.locator("wa-radio").count()).toBe(4);
-      await expect.poll(() => policyRow.getByText("open", { exact: true }).count()).toBe(1);
-      await expect.poll(() => policyRow.getByText("allowlist", { exact: true }).count()).toBe(1);
-      await expect.poll(() => policyRow.getByText("disabled", { exact: true }).count()).toBe(1);
-      await expect.poll(() => policyRow.getByText("allowall", { exact: true }).count()).toBe(1);
-      await expect
-        .poll(() => page.getByText("Unsupported schema node. Use Raw mode.").count())
-        .toBe(0);
-      await expect
-        .poll(() => page.locator(".config-content-callout .callout.info").count())
-        .toBe(0);
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(uiProofArtifactDir, "01-transform-field-supported.png"),
-        });
-      }
-
-      await page.getByRole("button", { name: "Raw", exact: true }).click();
-      await expect.poll(() => page.locator(".config-raw-field textarea").count()).toBe(1);
-      await expect
-        .poll(() => page.locator(".config-content-callout .callout.info").count())
-        .toBe(0);
-    } finally {
-      await context.close();
-    }
-  });
-
-  it("keeps the one advanced disclosure browser-local", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const config = { ui: { prefs: { theme: "claw" } } };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": {
-          appliedConfigHash: "advanced-disclosure-e2e",
-          config,
-          configRevisionHash: "advanced-disclosure-e2e",
-          hash: "advanced-disclosure-e2e",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
-        "config.schema": {
-          generatedAt: "2026-07-27T00:00:00.000Z",
-          schema: {
-            type: "object",
-            properties: {
-              ui: {
+      async ({ page }) => {
+        const config = { update: { groupPolicy: "allowlist" } };
+        await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              config,
+              hash: "config-form-guidance-e2e",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+            "config.schema": {
+              generatedAt: "2026-07-14T00:00:00.000Z",
+              schema: {
                 type: "object",
-                title: "UI",
                 properties: {
-                  seamColor: { type: "string", title: "Accent Color" },
-                  prefs: {
+                  update: {
                     type: "object",
-                    title: "Prefs",
+                    title: "Updates",
                     properties: {
-                      theme: { type: "string", title: "Theme" },
-                      sidebarEntries: {
-                        type: "array",
-                        title: "Sidebar Entries",
-                        items: { type: "string" },
+                      groupPolicy: {
+                        title: "Group policy",
+                        anyOf: [
+                          { type: "string", enum: ["open", "allowlist", "disabled"] },
+                          { type: "string", const: "allowall" },
+                        ],
                       },
                     },
                   },
                 },
               },
+              uiHints: {},
+              version: "e2e",
             },
           },
-          uiHints: {
-            "ui.prefs.theme": { advanced: false },
-            "ui.prefs.sidebarEntries": { advanced: true },
-            "ui.seamColor": { advanced: true },
-          },
-          version: "e2e",
-        },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/advanced`);
+        expect(response?.status()).toBe(200);
+
+        await page.getByRole("button", { name: "Core" }).click();
+        await page.getByRole("button", { name: "Updates", exact: true }).click();
+
+        const policyRow = page.locator(".settings-row").filter({ hasText: "Group policy" });
+        await expect.poll(() => policyRow.locator("wa-radio").count()).toBe(4);
+        await expect.poll(() => policyRow.getByText("open", { exact: true }).count()).toBe(1);
+        await expect.poll(() => policyRow.getByText("allowlist", { exact: true }).count()).toBe(1);
+        await expect.poll(() => policyRow.getByText("disabled", { exact: true }).count()).toBe(1);
+        await expect.poll(() => policyRow.getByText("allowall", { exact: true }).count()).toBe(1);
+        await expect
+          .poll(() => page.getByText("Unsupported schema node. Use Raw mode.").count())
+          .toBe(0);
+        await expect
+          .poll(() => page.locator(".config-content-callout .callout.info").count())
+          .toBe(0);
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "01-transform-field-supported.png"),
+          });
+        }
+
+        await page.getByRole("button", { name: "Raw", exact: true }).click();
+        await expect.poll(() => page.locator(".config-raw-field textarea").count()).toBe(1);
+        await expect
+          .poll(() => page.locator(".config-content-callout .callout.info").count())
+          .toBe(0);
       },
-    });
+    );
+  });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("radio", { name: "UI", exact: true }).click();
-
-      const disclosure = page.locator(".config-advanced-ghost");
-      await expect.poll(() => disclosure.count()).toBe(1);
-      await expect.poll(() => disclosure.textContent()).toContain("2 advanced settings hidden");
-      await expect.poll(() => page.locator(".config-show-advanced").count()).toBe(1);
-      await expect
-        .poll(() => page.getByText("Show Advanced Settings", { exact: true }).count())
-        .toBe(0);
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(uiProofArtifactDir, "02-advanced-collapsed.png"),
+  it("keeps the one advanced disclosure browser-local", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const config = { ui: { prefs: { theme: "claw" } } };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              appliedConfigHash: "advanced-disclosure-e2e",
+              config,
+              configRevisionHash: "advanced-disclosure-e2e",
+              hash: "advanced-disclosure-e2e",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+            "config.schema": {
+              generatedAt: "2026-07-27T00:00:00.000Z",
+              schema: {
+                type: "object",
+                properties: {
+                  ui: {
+                    type: "object",
+                    title: "UI",
+                    properties: {
+                      seamColor: { type: "string", title: "Accent Color" },
+                      prefs: {
+                        type: "object",
+                        title: "Prefs",
+                        properties: {
+                          theme: { type: "string", title: "Theme" },
+                          sidebarEntries: {
+                            type: "array",
+                            title: "Sidebar Entries",
+                            items: { type: "string" },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              uiHints: {
+                "ui.prefs.theme": { advanced: false },
+                "ui.prefs.sidebarEntries": { advanced: true },
+                "ui.seamColor": { advanced: true },
+              },
+              version: "e2e",
+            },
+          },
         });
-      }
 
-      await disclosure.click();
-      const hideAdvanced = page.locator(".config-advanced-divider__toggle");
-      await expect.poll(() => hideAdvanced.count()).toBe(1);
-      await expect.poll(() => hideAdvanced.textContent()).toContain("Hide Advanced");
-      await expect.poll(() => disclosure.count()).toBe(0);
+        const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("radio", { name: "UI", exact: true }).click();
 
-      if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(uiProofArtifactDir, "03-advanced-expanded.png"),
-        });
-      }
+        const disclosure = page.locator(".config-advanced-ghost");
+        await expect.poll(() => disclosure.count()).toBe(1);
+        await expect.poll(() => disclosure.textContent()).toContain("2 advanced settings hidden");
+        await expect.poll(() => page.locator(".config-show-advanced").count()).toBe(1);
+        await expect
+          .poll(() => page.getByText("Show Advanced Settings", { exact: true }).count())
+          .toBe(0);
 
-      await hideAdvanced.click();
-      await expect.poll(() => disclosure.count()).toBe(1);
-      await page.waitForTimeout(750);
-      expect(await gateway.getRequests("config.patch")).toHaveLength(0);
-      expect(await gateway.getRequests("config.set")).toHaveLength(0);
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "02-advanced-collapsed.png"),
+          });
+        }
 
-      if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(uiProofArtifactDir, "04-advanced-collapsed-final.png"),
-        });
-      }
-    } finally {
-      await context.close();
-    }
+        await disclosure.click();
+        const hideAdvanced = page.locator(".config-advanced-divider__toggle");
+        await expect.poll(() => hideAdvanced.count()).toBe(1);
+        await expect.poll(() => hideAdvanced.textContent()).toContain("Hide Advanced");
+        await expect.poll(() => disclosure.count()).toBe(0);
+
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "03-advanced-expanded.png"),
+          });
+        }
+
+        await hideAdvanced.click();
+        await expect.poll(() => disclosure.count()).toBe(1);
+        await page.waitForTimeout(750);
+        expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+        expect(await gateway.getRequests("config.set")).toHaveLength(0);
+
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "04-advanced-collapsed-final.png"),
+          });
+        }
+      },
+    );
   });
 
   it("keeps a settled autosave quiet on Notifications", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: notificationStatusConfigMocks(),
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("radio", { name: "UI", exact: true }).click();
-
-      const themeInput = page
-        .locator(".settings-row")
-        .filter({ hasText: "Theme" })
-        .locator("input.settings-input");
-      await expect.poll(() => themeInput.count()).toBe(1);
-      await themeInput.fill("knot");
-      await gateway.waitForRequest("config.set");
-      await page.getByRole("button", { name: "Apply changes", exact: true }).click();
-      await gateway.waitForRequest("config.apply");
-
-      await page.getByRole("link", { name: "Notifications", exact: true }).click();
-      await page.getByRole("heading", { name: "Push notifications", exact: true }).waitFor();
-
-      const section = page.locator("#settings-communications-notifications");
-      await expect.poll(() => page.locator(".config-toolbar").count()).toBe(0);
-      await expect.poll(() => page.getByText("Saved", { exact: true }).count()).toBe(0);
-      await expect
-        .poll(() => section.locator(".settings-section__header .settings-status").count())
-        .toBe(1);
-      await expect
-        .poll(() => section.locator(".settings-section__header").textContent())
-        .toContain("Ready");
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(uiProofArtifactDir, "05-notifications-ready-aligned.png"),
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: notificationStatusConfigMocks(),
         });
-      }
-    } finally {
-      await context.close();
-    }
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("radio", { name: "UI", exact: true }).click();
+
+        const themeInput = page
+          .locator(".settings-row")
+          .filter({ hasText: "Theme" })
+          .locator("input.settings-input");
+        await expect.poll(() => themeInput.count()).toBe(1);
+        await themeInput.fill("knot");
+        await gateway.waitForRequest("config.set");
+        await page.getByRole("button", { name: "Apply changes", exact: true }).click();
+        await gateway.waitForRequest("config.apply");
+
+        await page.getByRole("link", { name: "Notifications", exact: true }).click();
+        await page.getByRole("heading", { name: "Push notifications", exact: true }).waitFor();
+
+        const section = page.locator("#settings-communications-notifications");
+        await expect.poll(() => page.locator(".config-toolbar").count()).toBe(0);
+        await expect.poll(() => page.getByText("Saved", { exact: true }).count()).toBe(0);
+        await expect
+          .poll(() => section.locator(".settings-section__header .settings-status").count())
+          .toBe(1);
+        await expect
+          .poll(() => section.locator(".settings-section__header").textContent())
+          .toContain("Ready");
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "05-notifications-ready-aligned.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/config-form-integrity.e2e.test.ts
+++ b/ui/src/e2e/config-form-integrity.e2e.test.ts
@@ -1,20 +1,16 @@
 // Control UI tests cover schema-backed form constraints, draft recovery, and accessible names.
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI config form integrity mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofVariant = process.env.OPENCLAW_UI_PROOF_VARIANT ?? "after";
@@ -25,9 +21,6 @@ const uiProofArtifactDir = path.join(
   "config-form-integrity",
   proofVariant,
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function configFormIntegrityMocks() {
   const config = {
@@ -99,150 +92,144 @@ function configFormIntegrityMocks() {
   };
 }
 
-describeControlUiE2e("Control UI config form integrity mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps invalid drafts visible and exposes schema constraints to the browser", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, { methodResponses: configFormIntegrityMocks() });
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, { methodResponses: configFormIntegrityMocks() });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/advanced?section=laboratory`);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(
+          `${suite.server.baseUrl}settings/advanced?section=laboratory`,
+        );
+        expect(response?.status()).toBe(200);
 
-      const endpoint = page.getByRole("textbox", { name: "Endpoint slug" });
-      const retryBudget = page.getByRole("spinbutton", { name: "Retry budget" });
-      const weights = page.locator(".cfg-array").filter({ hasText: "Weights" });
-      const addWeight = weights.getByRole("button", { name: "Add" });
-      await addWeight.click();
+        const endpoint = page.getByRole("textbox", { name: "Endpoint slug" });
+        const retryBudget = page.getByRole("spinbutton", { name: "Retry budget" });
+        const weights = page.locator(".cfg-array").filter({ hasText: "Weights" });
+        const addWeight = weights.getByRole("button", { name: "Add" });
+        await addWeight.click();
 
-      const metadataEditor = page.locator(".cfg-map textarea");
-      await metadataEditor.fill('{"mode":');
-      await metadataEditor.blur();
+        const metadataEditor = page.locator(".cfg-map textarea");
+        await metadataEditor.fill('{"mode":');
+        await metadataEditor.blur();
 
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.locator("#config-section-panel").screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "01-invalid-json-draft.png"),
-        });
-      }
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.locator("#config-section-panel").screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "01-invalid-json-draft.png"),
+          });
+        }
 
-      await expect.poll(() => endpoint.getAttribute("minlength")).toBeNull();
-      await expect.poll(() => endpoint.getAttribute("maxlength")).toBeNull();
-      await expect.poll(() => endpoint.getAttribute("pattern")).toBeNull();
-      await expect.poll(() => endpoint.getAttribute("aria-describedby")).not.toBeNull();
-      await expect.poll(() => retryBudget.getAttribute("min")).toBe("2");
-      await expect.poll(() => retryBudget.getAttribute("max")).toBe("8");
-      await expect.poll(() => retryBudget.getAttribute("step")).toBe("2");
-      await expect
-        .poll(() => page.locator(".cfg-array input[type='number']").last().inputValue())
-        .toBe("2");
-      await expect.poll(() => metadataEditor.inputValue()).toBe('{"mode":');
-      await expect.poll(() => metadataEditor.getAttribute("aria-invalid")).toBe("true");
-      await expect.poll(() => page.getByRole("alert").textContent()).toContain("valid JSON");
+        await expect.poll(() => endpoint.getAttribute("minlength")).toBeNull();
+        await expect.poll(() => endpoint.getAttribute("maxlength")).toBeNull();
+        await expect.poll(() => endpoint.getAttribute("pattern")).toBeNull();
+        await expect.poll(() => endpoint.getAttribute("aria-describedby")).not.toBeNull();
+        await expect.poll(() => retryBudget.getAttribute("min")).toBe("2");
+        await expect.poll(() => retryBudget.getAttribute("max")).toBe("8");
+        await expect.poll(() => retryBudget.getAttribute("step")).toBe("2");
+        await expect
+          .poll(() => page.locator(".cfg-array input[type='number']").last().inputValue())
+          .toBe("2");
+        await expect.poll(() => metadataEditor.inputValue()).toBe('{"mode":');
+        await expect.poll(() => metadataEditor.getAttribute("aria-invalid")).toBe("true");
+        await expect.poll(() => page.getByRole("alert").textContent()).toContain("valid JSON");
 
-      const codes = page.locator(".cfg-array").filter({ hasText: "Codes" });
-      await codes.getByRole("button", { name: "Add" }).click();
-      const codeDraft = codes.locator(".cfg-collection-draft");
-      await expect.poll(() => codeDraft.isVisible()).toBe(true);
-      const codeValue = codeDraft.getByRole("textbox", { name: "Add: Codes" });
-      await codeValue.fill("abc");
-      await codeDraft.getByRole("button", { name: "Add" }).click();
-      await expect.poll(() => codeValue.getAttribute("aria-invalid")).toBe("true");
-      await expect.poll(() => codes.locator("input[aria-label='Codes']").count()).toBe(0);
+        const codes = page.locator(".cfg-array").filter({ hasText: "Codes" });
+        await codes.getByRole("button", { name: "Add" }).click();
+        const codeDraft = codes.locator(".cfg-collection-draft");
+        await expect.poll(() => codeDraft.isVisible()).toBe(true);
+        const codeValue = codeDraft.getByRole("textbox", { name: "Add: Codes" });
+        await codeValue.fill("abc");
+        await codeDraft.getByRole("button", { name: "Add" }).click();
+        await expect.poll(() => codeValue.getAttribute("aria-invalid")).toBe("true");
+        await expect.poll(() => codes.locator("input[aria-label='Codes']").count()).toBe(0);
 
-      if (captureUiProofEnabled) {
-        await page.locator("#config-section-panel").screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "02-pattern-collection-draft.png"),
-        });
-      }
+        if (captureUiProofEnabled) {
+          await page.locator("#config-section-panel").screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "02-pattern-collection-draft.png"),
+          });
+        }
 
-      await codeValue.fill("123");
-      await codeDraft.getByRole("button", { name: "Add" }).click();
-      await expect
-        .poll(() => codes.locator("input[aria-label='Codes']").last().inputValue())
-        .toBe("123");
-    } finally {
-      await context.close();
-    }
+        await codeValue.fill("123");
+        await codeDraft.getByRole("button", { name: "Add" }).click();
+        await expect
+          .poll(() => codes.locator("input[aria-label='Codes']").last().inputValue())
+          .toBe("123");
+      },
+    );
   });
 
   it("matches rejected Settings-save errors to visible one-based model rows", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const providerId = "z.ai";
-    const config = {
-      models: {
-        providers: {
-          [providerId]: {
-            models: [{ name: "First" }, { name: "Second" }, { name: "Third" }, { name: "Fourth" }],
-          },
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
       },
-    };
-    const issue = {
-      path: `models.providers.${providerId}.models.3.name`,
-      message: "Invalid model name",
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": {
-          appliedConfigHash: "model-row-e2e",
-          config,
-          configRevisionHash: "model-row-e2e",
-          hash: "model-row-e2e",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
-        "config.schema": {
-          generatedAt: "2026-08-01T00:00:00.000Z",
-          schema: {
-            type: "object",
-            properties: {
-              models: {
+      async ({ page }) => {
+        const providerId = "z.ai";
+        const config = {
+          models: {
+            providers: {
+              [providerId]: {
+                models: [
+                  { name: "First" },
+                  { name: "Second" },
+                  { name: "Third" },
+                  { name: "Fourth" },
+                ],
+              },
+            },
+          },
+        };
+        const issue = {
+          path: `models.providers.${providerId}.models.3.name`,
+          message: "Invalid model name",
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              appliedConfigHash: "model-row-e2e",
+              config,
+              configRevisionHash: "model-row-e2e",
+              hash: "model-row-e2e",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+            "config.schema": {
+              generatedAt: "2026-08-01T00:00:00.000Z",
+              schema: {
                 type: "object",
-                title: "Models",
                 properties: {
-                  providers: {
+                  models: {
                     type: "object",
-                    title: "Providers",
-                    additionalProperties: {
-                      type: "object",
-                      properties: {
-                        models: {
-                          type: "array",
-                          title: "Configured models",
-                          items: {
-                            type: "object",
-                            properties: {
-                              name: { type: "string", title: "Model name" },
+                    title: "Models",
+                    properties: {
+                      providers: {
+                        type: "object",
+                        title: "Providers",
+                        additionalProperties: {
+                          type: "object",
+                          properties: {
+                            models: {
+                              type: "array",
+                              title: "Configured models",
+                              items: {
+                                type: "object",
+                                properties: {
+                                  name: { type: "string", title: "Model name" },
+                                },
+                              },
                             },
                           },
                         },
@@ -251,66 +238,62 @@ describeControlUiE2e("Control UI config form integrity mocked Gateway E2E", () =
                   },
                 },
               },
+              uiHints: {},
+              version: "e2e",
             },
           },
-          uiHints: {},
-          version: "e2e",
-        },
-      },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/advanced?section=models`);
-      expect(response?.status()).toBe(200);
-      const panel = page.locator("#config-section-panel");
-      const fourthRow = panel.locator(".settings-row__title").getByText("#4", { exact: true });
-      await expect.poll(() => fourthRow.isVisible()).toBe(true);
-
-      await gateway.deferNext("config.set");
-      await panel.getByRole("textbox", { name: "Model name" }).nth(3).fill("Broken");
-      const request = await gateway.waitForRequest("config.set");
-      const params = request.params as { baseHash?: string; raw?: string };
-      const submitted = JSON.parse(String(params.raw)) as {
-        models: { providers: Record<string, { models: Array<{ name: string }> }> };
-      };
-      expect(submitted.models.providers[providerId]?.models[3]?.name).toBe("Broken");
-      expect(params.baseHash).toBe("model-row-e2e");
-
-      const rejection = {
-        code: "INVALID_REQUEST",
-        message: `invalid config: ${issue.path}: ${issue.message}`,
-        details: { issues: [issue] },
-      };
-      await gateway.rejectDeferred("config.set", rejection);
-
-      const status = page.locator('.settings-save-indicator--danger[role="status"]');
-      await expect.poll(() => status.isVisible()).toBe(true);
-      await expect
-        .poll(() => status.getAttribute("title"))
-        .toBe(
-          `GatewayRequestError: invalid config: models.providers.${providerId}.models.#4.name: Invalid model name`,
-        );
-      expect(await status.getAttribute("aria-label")).toContain(
-        `models.providers.${providerId}.models.#4.name`,
-      );
-      expect(await status.textContent()).toContain("Save failed");
-      expect(issue.path).toBe(`models.providers.${providerId}.models.3.name`);
-      expect(rejection.message).toContain(".3.name");
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(uiProofArtifactDir, "03-model-row-rejection.png"),
         });
-        await writeFile(
-          path.join(uiProofArtifactDir, "03-model-row-rejection-accessibility.yml"),
-          await status.ariaSnapshot(),
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/advanced?section=models`);
+        expect(response?.status()).toBe(200);
+        const panel = page.locator("#config-section-panel");
+        const fourthRow = panel.locator(".settings-row__title").getByText("#4", { exact: true });
+        await expect.poll(() => fourthRow.isVisible()).toBe(true);
+
+        await gateway.deferNext("config.set");
+        await panel.getByRole("textbox", { name: "Model name" }).nth(3).fill("Broken");
+        const request = await gateway.waitForRequest("config.set");
+        const params = request.params as { baseHash?: string; raw?: string };
+        const submitted = JSON.parse(String(params.raw)) as {
+          models: { providers: Record<string, { models: Array<{ name: string }> }> };
+        };
+        expect(submitted.models.providers[providerId]?.models[3]?.name).toBe("Broken");
+        expect(params.baseHash).toBe("model-row-e2e");
+
+        const rejection = {
+          code: "INVALID_REQUEST",
+          message: `invalid config: ${issue.path}: ${issue.message}`,
+          details: { issues: [issue] },
+        };
+        await gateway.rejectDeferred("config.set", rejection);
+
+        const status = page.locator('.settings-save-indicator--danger[role="status"]');
+        await expect.poll(() => status.isVisible()).toBe(true);
+        await expect
+          .poll(() => status.getAttribute("title"))
+          .toBe(
+            `GatewayRequestError: invalid config: models.providers.${providerId}.models.#4.name: Invalid model name`,
+          );
+        expect(await status.getAttribute("aria-label")).toContain(
+          `models.providers.${providerId}.models.#4.name`,
         );
-      }
-    } finally {
-      await context.close();
-    }
+        expect(await status.textContent()).toContain("Save failed");
+        expect(issue.path).toBe(`models.providers.${providerId}.models.3.name`);
+        expect(rejection.message).toContain(".3.name");
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "03-model-row-rejection.png"),
+          });
+          await writeFile(
+            path.join(uiProofArtifactDir, "03-model-row-rejection-accessibility.yml"),
+            await status.ariaSnapshot(),
+          );
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
+++ b/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
@@ -1,22 +1,14 @@
 // Control UI tests cover shared model-behavior persistence through the mocked Gateway.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayRequest,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Models settings behavior persistence mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 function configResponse(
   thinkingDefault: "low" | "high",
@@ -49,89 +41,74 @@ function requestRaw(request: MockGatewayRequest): Record<string, unknown> {
   return JSON.parse(String((params as Record<string, unknown>).raw)) as Record<string, unknown>;
 }
 
-describeControlUiE2e("Control UI Models settings behavior persistence mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("redirects the legacy General model deep link to Models", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page);
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/general#settings-general-model`);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(
+          `${suite.server.baseUrl}settings/general#settings-general-model`,
+        );
+        expect(response?.status()).toBe(200);
 
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-providers");
-      expect(await gateway.getRequests("config.set")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-providers");
+        expect(await gateway.getRequests("config.set")).toHaveLength(0);
+      },
+    );
   });
 
   it("reads and writes only agents.defaults.thinkingDefault", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const initialConfig = configResponse("low", "hash-1");
-    const savedConfig = configResponse("high", "hash-2");
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": initialConfig,
-        "config.set": savedConfig,
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ context, page }) => {
+        const initialConfig = configResponse("low", "hash-1");
+        const savedConfig = configResponse("high", "hash-2");
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": initialConfig,
+            "config.set": savedConfig,
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-providers`);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-providers`);
+        expect(response?.status()).toBe(200);
 
-      const modelCard = page.locator("#settings-model-behavior");
-      const lowButton = modelCard.getByRole("radio", { name: "Low", exact: true });
-      await lowButton.waitFor();
-      expect(await lowButton.getAttribute("aria-checked")).toBe("true");
+        const modelCard = page.locator("#settings-model-behavior");
+        const lowButton = modelCard.getByRole("radio", { name: "Low", exact: true });
+        await lowButton.waitFor();
+        expect(await lowButton.getAttribute("aria-checked")).toBe("true");
 
-      await modelCard.getByRole("radio", { name: "High", exact: true }).click();
+        await modelCard.getByRole("radio", { name: "High", exact: true }).click();
 
-      const raw = requestRaw(await gateway.waitForRequest("config.set"));
-      expect(raw).toEqual({
-        agents: { defaults: { model: "openai/gpt-5.5", thinkingDefault: "high" } },
-      });
-      expect(JSON.stringify(raw)).not.toContain("thinkingLevel");
-      expect(JSON.stringify(raw)).not.toContain("fastMode");
+        const raw = requestRaw(await gateway.waitForRequest("config.set"));
+        expect(raw).toEqual({
+          agents: { defaults: { model: "openai/gpt-5.5", thinkingDefault: "high" } },
+        });
+        expect(JSON.stringify(raw)).not.toContain("thinkingLevel");
+        expect(JSON.stringify(raw)).not.toContain("fastMode");
 
-      const freshPage = await context.newPage();
-      await installMockGateway(freshPage, {
-        methodResponses: { "config.get": savedConfig },
-      });
-      await freshPage.goto(`${server.baseUrl}settings/model-providers`);
-      const highButton = freshPage
-        .locator("#settings-model-behavior")
-        .getByRole("radio", { name: "High", exact: true });
-      await highButton.waitFor();
-      expect(await highButton.getAttribute("aria-checked")).toBe("true");
-    } finally {
-      await context.close();
-    }
+        const freshPage = await context.newPage();
+        await installMockGateway(freshPage, {
+          methodResponses: { "config.get": savedConfig },
+        });
+        await freshPage.goto(`${suite.server.baseUrl}settings/model-providers`);
+        const highButton = freshPage
+          .locator("#settings-model-behavior")
+          .getByRole("radio", { name: "High", exact: true });
+        await highButton.waitFor();
+        expect(await highButton.getAttribute("aria-checked")).toBe("true");
+      },
+    );
   });
 
   it.each([
@@ -141,48 +118,47 @@ describeControlUiE2e("Control UI Models settings behavior persistence mocked Gat
   ])(
     "persists agents.defaults.fastModeDefault from $initialLabel to $nextLabel",
     async ({ initial, initialLabel, next, nextLabel }) => {
-      const context = await browser.newContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
-      const page = await context.newPage();
-      const initialConfig = configResponse("low", "hash-1", initial);
-      const gateway = await installMockGateway(page, {
-        methodResponses: { "config.get": initialConfig },
-      });
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1280 },
+        },
+        async ({ page }) => {
+          const initialConfig = configResponse("low", "hash-1", initial);
+          const gateway = await installMockGateway(page, {
+            methodResponses: { "config.get": initialConfig },
+          });
 
-      try {
-        const response = await page.goto(`${server.baseUrl}settings/model-providers`);
-        expect(response?.status()).toBe(200);
+          const response = await page.goto(`${suite.server.baseUrl}settings/model-providers`);
+          expect(response?.status()).toBe(200);
 
-        const modelCard = page.locator("#settings-model-behavior");
-        const initialButton = modelCard.getByRole("radio", { name: initialLabel, exact: true });
-        await initialButton.waitFor();
-        expect(await initialButton.getAttribute("aria-checked")).toBe("true");
+          const modelCard = page.locator("#settings-model-behavior");
+          const initialButton = modelCard.getByRole("radio", { name: initialLabel, exact: true });
+          await initialButton.waitFor();
+          expect(await initialButton.getAttribute("aria-checked")).toBe("true");
 
-        await modelCard.getByRole("radio", { name: nextLabel, exact: true }).click();
+          await modelCard.getByRole("radio", { name: nextLabel, exact: true }).click();
 
-        const raw = requestRaw(await gateway.waitForRequest("config.set"));
-        expect(raw).toEqual({
-          agents: {
-            defaults: {
-              model: "openai/gpt-5.5",
-              thinkingDefault: "low",
-              fastModeDefault: next,
+          const raw = requestRaw(await gateway.waitForRequest("config.set"));
+          expect(raw).toEqual({
+            agents: {
+              defaults: {
+                model: "openai/gpt-5.5",
+                thinkingDefault: "low",
+                fastModeDefault: next,
+              },
             },
-          },
-        });
-        expect(raw.agents).not.toHaveProperty("defaults.fastMode");
+          });
+          expect(raw.agents).not.toHaveProperty("defaults.fastMode");
 
-        const reloadResponse = await page.reload();
-        expect(reloadResponse?.status()).toBe(200);
-        const persistedButton = modelCard.getByRole("radio", { name: nextLabel, exact: true });
-        await persistedButton.waitFor();
-        expect(await persistedButton.getAttribute("aria-checked")).toBe("true");
-      } finally {
-        await context.close();
-      }
+          const reloadResponse = await page.reload();
+          expect(reloadResponse?.status()).toBe(200);
+          const persistedButton = modelCard.getByRole("radio", { name: nextLabel, exact: true });
+          await persistedButton.waitFor();
+          expect(await persistedButton.getAttribute("aria-checked")).toBe("true");
+        },
+      );
     },
   );
 });

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -1,21 +1,17 @@
 // Control UI browser proof covers the config snapshot and guarded-write lifecycle.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayRequest,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI guarded config writes mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
@@ -24,9 +20,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "config-safe-write",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function configResponse(config: Record<string, unknown>, hash: string, appliedConfigHash = hash) {
   return {
@@ -76,162 +69,151 @@ async function capture(page: Page, name: string): Promise<void> {
   });
 }
 
-describeControlUiE2e("Control UI guarded config writes mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("edits schema and raw config with guarded set, patch, reload, and apply requests", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const initialConfig = {
-      laboratory: { endpoint: "local-api", retryBudget: 2 },
-      tools: { codeMode: { enabled: false } },
-    };
-    const patchedConfig = {
-      laboratory: initialConfig.laboratory,
-      tools: {},
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse(initialConfig, "snapshot-1"),
-        "config.schema": {
-          generatedAt: "2026-08-03T00:00:00.000Z",
-          schema: {
-            type: "object",
-            properties: {
-              laboratory: {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const initialConfig = {
+          laboratory: { endpoint: "local-api", retryBudget: 2 },
+          tools: { codeMode: { enabled: false } },
+        };
+        const patchedConfig = {
+          laboratory: initialConfig.laboratory,
+          tools: {},
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse(initialConfig, "snapshot-1"),
+            "config.schema": {
+              generatedAt: "2026-08-03T00:00:00.000Z",
+              schema: {
                 type: "object",
-                title: "Safe writes",
                 properties: {
-                  endpoint: {
-                    type: "string",
-                    title: "Endpoint",
-                    description: "Endpoint selected by the operator.",
+                  laboratory: {
+                    type: "object",
+                    title: "Safe writes",
+                    properties: {
+                      endpoint: {
+                        type: "string",
+                        title: "Endpoint",
+                        description: "Endpoint selected by the operator.",
+                      },
+                      retryBudget: {
+                        type: "integer",
+                        title: "Retry budget",
+                        minimum: 0,
+                        maximum: 10,
+                      },
+                    },
                   },
-                  retryBudget: {
-                    type: "integer",
-                    title: "Retry budget",
-                    minimum: 0,
-                    maximum: 10,
+                  tools: {
+                    type: "object",
+                    title: "Tools",
+                    additionalProperties: true,
                   },
                 },
               },
-              tools: {
-                type: "object",
-                title: "Tools",
-                additionalProperties: true,
+              uiHints: {
+                "laboratory.endpoint": { advanced: false },
+                "laboratory.retryBudget": { advanced: false },
               },
+              version: "e2e",
             },
           },
-          uiHints: {
-            "laboratory.endpoint": { advanced: false },
-            "laboratory.retryBudget": { advanced: false },
-          },
-          version: "e2e",
-        },
-      },
-    });
+        });
 
-    try {
-      expect((await page.goto(`${server.baseUrl}settings/labs`))?.status()).toBe(200);
-      const codeModeRow = settingsRow(page, "Code Mode");
-      await codeModeRow.getByRole("switch", { name: "Code Mode", exact: true }).waitFor();
-      await expect.poll(() => codeModeRow.textContent()).toContain("Default: Enabled");
+        expect((await page.goto(`${suite.server.baseUrl}settings/labs`))?.status()).toBe(200);
+        const codeModeRow = settingsRow(page, "Code Mode");
+        await codeModeRow.getByRole("switch", { name: "Code Mode", exact: true }).waitFor();
+        await expect.poll(() => codeModeRow.textContent()).toContain("Default: Enabled");
 
-      const configGetsBeforePatch = (await gateway.getRequests("config.get")).length;
-      await gateway.deferNext("config.patch");
-      await codeModeRow.getByRole("button", { name: "Reset to default" }).click();
-      const patchParams = mutationParams(await gateway.waitForRequest("config.patch"));
-      expect(patchParams.baseHash).toBe("snapshot-1");
-      expect(patchParams.sessionKey).toBe("main");
-      expect(JSON.parse(String(patchParams.raw))).toEqual({
-        tools: { codeMode: { enabled: null } },
-      });
+        const configGetsBeforePatch = (await gateway.getRequests("config.get")).length;
+        await gateway.deferNext("config.patch");
+        await codeModeRow.getByRole("button", { name: "Reset to default" }).click();
+        const patchParams = mutationParams(await gateway.waitForRequest("config.patch"));
+        expect(patchParams.baseHash).toBe("snapshot-1");
+        expect(patchParams.sessionKey).toBe("main");
+        expect(JSON.parse(String(patchParams.raw))).toEqual({
+          tools: { codeMode: { enabled: null } },
+        });
 
-      const patchedResponse = configResponse(patchedConfig, "snapshot-2", "snapshot-1");
-      await gateway.setMethodResponse("config.get", patchedResponse);
-      await gateway.resolveDeferred("config.patch", {
-        hash: "snapshot-2",
-        ok: true,
-      });
-      await expect
-        .poll(async () => (await gateway.getRequests("config.get")).length)
-        .toBeGreaterThan(configGetsBeforePatch);
-      await expect.poll(() => codeModeRow.textContent()).toContain("Using default: Enabled");
+        const patchedResponse = configResponse(patchedConfig, "snapshot-2", "snapshot-1");
+        await gateway.setMethodResponse("config.get", patchedResponse);
+        await gateway.resolveDeferred("config.patch", {
+          hash: "snapshot-2",
+          ok: true,
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBeGreaterThan(configGetsBeforePatch);
+        await expect.poll(() => codeModeRow.textContent()).toContain("Using default: Enabled");
 
-      expect(
-        (await page.goto(`${server.baseUrl}settings/advanced?section=laboratory`))?.status(),
-      ).toBe(200);
-      const endpoint = page.getByRole("textbox", { name: "Endpoint", exact: true });
-      await expect.poll(() => endpoint.inputValue()).toBe("local-api");
+        expect(
+          (
+            await page.goto(`${suite.server.baseUrl}settings/advanced?section=laboratory`)
+          )?.status(),
+        ).toBe(200);
+        const endpoint = page.getByRole("textbox", { name: "Endpoint", exact: true });
+        await expect.poll(() => endpoint.inputValue()).toBe("local-api");
 
-      await gateway.deferNext("config.set");
-      await endpoint.fill("form-api");
-      const staleSetParams = mutationParams(await gateway.waitForRequest("config.set"));
-      expect(staleSetParams.baseHash).toBe("snapshot-2");
-      expect(JSON.parse(String(staleSetParams.raw))).toMatchObject({
-        laboratory: { endpoint: "form-api", retryBudget: 2 },
-      });
-      await gateway.rejectDeferred("config.set", {
-        code: "INVALID_REQUEST",
-        message: "config changed since last load; re-run config.get and retry",
-      });
+        await gateway.deferNext("config.set");
+        await endpoint.fill("form-api");
+        const staleSetParams = mutationParams(await gateway.waitForRequest("config.set"));
+        expect(staleSetParams.baseHash).toBe("snapshot-2");
+        expect(JSON.parse(String(staleSetParams.raw))).toMatchObject({
+          laboratory: { endpoint: "form-api", retryBudget: 2 },
+        });
+        await gateway.rejectDeferred("config.set", {
+          code: "INVALID_REQUEST",
+          message: "config changed since last load; re-run config.get and retry",
+        });
 
-      const saveIndicator = page.locator("openclaw-settings-save-indicator");
-      await expect.poll(() => saveIndicator.textContent()).toContain("Settings changed elsewhere");
-      await expect
-        .poll(() => saveIndicator.getByRole("button", { name: "Reload" }).count())
-        .toBe(1);
-      await capture(page, "01-base-hash-conflict.png");
+        const saveIndicator = page.locator("openclaw-settings-save-indicator");
+        await expect
+          .poll(() => saveIndicator.textContent())
+          .toContain("Settings changed elsewhere");
+        await expect
+          .poll(() => saveIndicator.getByRole("button", { name: "Reload" }).count())
+          .toBe(1);
+        await capture(page, "01-base-hash-conflict.png");
 
-      const externalConfig = {
-        laboratory: { endpoint: "external-api", retryBudget: 4 },
-        tools: {},
-      };
-      await gateway.setMethodResponse(
-        "config.get",
-        configResponse(externalConfig, "snapshot-3", "snapshot-1"),
-      );
-      const configGetsBeforeReload = (await gateway.getRequests("config.get")).length;
-      await saveIndicator.getByRole("button", { name: "Reload" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("config.get")).length)
-        .toBeGreaterThan(configGetsBeforeReload);
-      await expect.poll(() => endpoint.inputValue()).toBe("external-api");
+        const externalConfig = {
+          laboratory: { endpoint: "external-api", retryBudget: 4 },
+          tools: {},
+        };
+        await gateway.setMethodResponse(
+          "config.get",
+          configResponse(externalConfig, "snapshot-3", "snapshot-1"),
+        );
+        const configGetsBeforeReload = (await gateway.getRequests("config.get")).length;
+        await saveIndicator.getByRole("button", { name: "Reload" }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBeGreaterThan(configGetsBeforeReload);
+        await expect.poll(() => endpoint.inputValue()).toBe("external-api");
 
-      const setRequestsBeforeRetry = (await gateway.getRequests("config.set")).length;
-      await endpoint.fill("form-api");
-      await expect
-        .poll(async () => (await gateway.getRequests("config.set")).length)
-        .toBe(setRequestsBeforeRetry + 1);
-      const retriedSetParams = mutationParams((await gateway.getRequests("config.set")).at(-1)!);
-      expect(retriedSetParams.baseHash).toBe("snapshot-3");
-      expect(JSON.parse(String(retriedSetParams.raw))).toMatchObject({
-        laboratory: { endpoint: "form-api", retryBudget: 4 },
-      });
-      await expect.poll(() => saveIndicator.textContent()).toContain("Saved");
+        const setRequestsBeforeRetry = (await gateway.getRequests("config.set")).length;
+        await endpoint.fill("form-api");
+        await expect
+          .poll(async () => (await gateway.getRequests("config.set")).length)
+          .toBe(setRequestsBeforeRetry + 1);
+        const retriedSetParams = mutationParams((await gateway.getRequests("config.set")).at(-1)!);
+        expect(retriedSetParams.baseHash).toBe("snapshot-3");
+        expect(JSON.parse(String(retriedSetParams.raw))).toMatchObject({
+          laboratory: { endpoint: "form-api", retryBudget: 4 },
+        });
+        await expect.poll(() => saveIndicator.textContent()).toContain("Saved");
 
-      await page.getByRole("button", { name: "Raw", exact: true }).click();
-      const rawEditor = page.locator(".config-raw-field textarea");
-      await rawEditor.waitFor();
-      const rawDraft = `{
+        await page.getByRole("button", { name: "Raw", exact: true }).click();
+        const rawEditor = page.locator(".config-raw-field textarea");
+        await rawEditor.waitFor();
+        const rawDraft = `{
   laboratory: {
     endpoint: "raw-api",
     retryBudget: 8,
@@ -239,43 +221,42 @@ describeControlUiE2e("Control UI guarded config writes mocked Gateway E2E", () =
   tools: {},
 }
 `;
-      await rawEditor.fill(rawDraft);
-      await capture(page, "02-raw-draft.png");
+        await rawEditor.fill(rawDraft);
+        await capture(page, "02-raw-draft.png");
 
-      const setRequestsBeforeRawSave = (await gateway.getRequests("config.set")).length;
-      await page.getByRole("button", { name: "Save", exact: true }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("config.set")).length)
-        .toBe(setRequestsBeforeRawSave + 1);
-      const rawSetParams = mutationParams((await gateway.getRequests("config.set")).at(-1)!);
-      expect(rawSetParams.baseHash).toBe("mock-config-hash-1");
-      expect(rawSetParams.raw).toBe(rawDraft);
-      await expect
-        .poll(() => page.getByRole("button", { name: "Apply changes", exact: true }).count(), {
-          timeout: 5_000,
-        })
-        .toBe(1);
-      await gateway.deferNext("config.apply");
-      await page.getByRole("button", { name: "Apply changes", exact: true }).click();
-      const applyParams = mutationParams(await gateway.waitForRequest("config.apply"));
-      expect(applyParams.baseHash).toBe("mock-config-hash-2");
-      expect(applyParams.raw).toBe(rawDraft);
-      expect(applyParams.sessionKey).toBe("main");
-      await expect.poll(() => saveIndicator.textContent()).toContain("Applying");
-      await capture(page, "03-applying.png");
+        const setRequestsBeforeRawSave = (await gateway.getRequests("config.set")).length;
+        await page.getByRole("button", { name: "Save", exact: true }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("config.set")).length)
+          .toBe(setRequestsBeforeRawSave + 1);
+        const rawSetParams = mutationParams((await gateway.getRequests("config.set")).at(-1)!);
+        expect(rawSetParams.baseHash).toBe("mock-config-hash-1");
+        expect(rawSetParams.raw).toBe(rawDraft);
+        await expect
+          .poll(() => page.getByRole("button", { name: "Apply changes", exact: true }).count(), {
+            timeout: 5_000,
+          })
+          .toBe(1);
+        await gateway.deferNext("config.apply");
+        await page.getByRole("button", { name: "Apply changes", exact: true }).click();
+        const applyParams = mutationParams(await gateway.waitForRequest("config.apply"));
+        expect(applyParams.baseHash).toBe("mock-config-hash-2");
+        expect(applyParams.raw).toBe(rawDraft);
+        expect(applyParams.sessionKey).toBe("main");
+        await expect.poll(() => saveIndicator.textContent()).toContain("Applying");
+        await capture(page, "03-applying.png");
 
-      const configGetsBeforeApply = (await gateway.getRequests("config.get")).length;
-      await gateway.resolveDeferred("config.apply");
-      await expect
-        .poll(async () => (await gateway.getRequests("config.get")).length)
-        .toBeGreaterThan(configGetsBeforeApply);
-      await expect
-        .poll(() => page.getByRole("button", { name: "Apply changes", exact: true }).count())
-        .toBe(0);
-      await expect.poll(() => rawEditor.inputValue()).toBe(rawDraft);
-      await capture(page, "04-apply-complete.png");
-    } finally {
-      await context.close();
-    }
+        const configGetsBeforeApply = (await gateway.getRequests("config.get")).length;
+        await gateway.resolveDeferred("config.apply");
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBeGreaterThan(configGetsBeforeApply);
+        await expect
+          .poll(() => page.getByRole("button", { name: "Apply changes", exact: true }).count())
+          .toBe(0);
+        await expect.poll(() => rawEditor.inputValue()).toBe(rawDraft);
+        await capture(page, "04-apply-complete.png");
+      },
+    );
   });
 });

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -1,4 +1,4 @@
-import { chromium, type Browser, type BrowserContext } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -8,9 +8,17 @@ import {
 } from "../test-helpers/control-ui-e2e.ts";
 
 type ControlUiE2eSuiteOptions = {
+  browserLaunchOptions?: Omit<NonNullable<Parameters<typeof chromium.launch>[0]>, "executablePath">;
   name: string;
-  unavailableMessage: (executablePath: string) => string;
+  startServer?: () => Promise<ControlUiE2eServer>;
+  startServerBeforeBrowser?: boolean;
   trackBrowserContexts?: boolean;
+  unavailableMessage?: (executablePath: string) => string;
+};
+
+type ControlUiE2ePage = {
+  context: BrowserContext;
+  page: Page;
 };
 
 type ControlUiE2eSuite = {
@@ -19,6 +27,10 @@ type ControlUiE2eSuite = {
   closeBrowserContext: (context: BrowserContext) => Promise<void>;
   define: (defineTests: () => void) => void;
   newBrowserContext: (options: Parameters<Browser["newContext"]>[0]) => Promise<BrowserContext>;
+  withPage: <T>(
+    options: Parameters<Browser["newContext"]>[0],
+    run: (fixture: ControlUiE2ePage) => Promise<T>,
+  ) => Promise<T>;
 };
 
 export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): ControlUiE2eSuite {
@@ -38,6 +50,16 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
   const closeOpenBrowserContexts = async (): Promise<void> => {
     await Promise.all([...openBrowserContexts].map((context) => closeBrowserContext(context)));
   };
+  const newBrowserContext = async (
+    contextOptions: Parameters<Browser["newContext"]>[0],
+  ): Promise<BrowserContext> => {
+    if (!browser) {
+      throw new Error("Control UI E2E browser accessed before suite setup");
+    }
+    const context = await browser.newContext(contextOptions);
+    openBrowserContexts.add(context);
+    return context;
+  };
 
   return {
     get browser() {
@@ -56,15 +78,32 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
     define(defineTests) {
       describeControlUiE2e(options.name, () => {
         beforeAll(async () => {
-          if (!chromiumAvailable) {
+          if (!chromiumAvailable && options.unavailableMessage) {
             throw new Error(options.unavailableMessage(chromiumExecutablePath));
           }
-          browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-          try {
-            server = await startControlUiE2eServer();
-          } catch (error) {
-            await browser.close();
-            throw error;
+          const startServer = options.startServer ?? startControlUiE2eServer;
+          if (options.startServerBeforeBrowser) {
+            server = await startServer();
+            try {
+              browser = await chromium.launch({
+                ...options.browserLaunchOptions,
+                executablePath: chromiumExecutablePath,
+              });
+            } catch (error) {
+              await server.close();
+              throw error;
+            }
+          } else {
+            browser = await chromium.launch({
+              ...options.browserLaunchOptions,
+              executablePath: chromiumExecutablePath,
+            });
+            try {
+              server = await startServer();
+            } catch (error) {
+              await browser.close();
+              throw error;
+            }
           }
         });
 
@@ -81,13 +120,15 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
         defineTests();
       });
     },
-    async newBrowserContext(contextOptions) {
-      if (!browser) {
-        throw new Error("Control UI E2E browser accessed before suite setup");
+    newBrowserContext,
+    async withPage(contextOptions, run) {
+      const context = await newBrowserContext(contextOptions);
+      try {
+        const page = await context.newPage();
+        return await run({ context, page });
+      } finally {
+        await closeBrowserContext(context);
       }
-      const context = await browser.newContext(contextOptions);
-      openBrowserContexts.add(context);
-      return context;
     },
   };
 }

--- a/ui/src/e2e/cron-descriptions.e2e.test.ts
+++ b/ui/src/e2e/cron-descriptions.e2e.test.ts
@@ -53,68 +53,67 @@ suite.define(() => {
       },
     ] as const;
     const undescribedJob = cronJob("without-description", "Plain task");
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": {
-          jobs: [...jobs, undescribedJob],
-          total: jobs.length + 1,
-          offset: 0,
-          limit: 50,
-          hasMore: false,
-          nextOffset: null,
-        },
-        "cron.runs": { entries: [], total: 0, offset: 0, hasMore: false },
-        "cron.status": { enabled: true, jobs: jobs.length + 1, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": {
+              jobs: [...jobs, undescribedJob],
+              total: jobs.length + 1,
+              offset: 0,
+              limit: 50,
+              hasMore: false,
+              nextOffset: null,
+            },
+            "cron.runs": { entries: [], total: 0, offset: 0, hasMore: false },
+            "cron.status": { enabled: true, jobs: jobs.length + 1, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${suite.server.baseUrl}cron`);
-      await page.locator(`[data-test-id="cron-row-${jobs[0].id}"]`).waitFor({ timeout: 10_000 });
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await page.locator(`[data-test-id="cron-row-${jobs[0].id}"]`).waitFor({ timeout: 10_000 });
 
-      for (const job of jobs) {
-        const description = page.locator(`[data-test-id="cron-row-description-${job.id}"]`);
-        expect((await description.textContent())?.trim()).toBe(`· ${job.description.trim()}`);
-        expect(await description.getAttribute("title")).toBe(
-          `Description: ${job.description.trim()}`,
-        );
-      }
-      expect(
-        await page.locator(`[data-test-id="cron-row-description-${undescribedJob.id}"]`).count(),
-      ).toBe(0);
+        for (const job of jobs) {
+          const description = page.locator(`[data-test-id="cron-row-description-${job.id}"]`);
+          expect((await description.textContent())?.trim()).toBe(`· ${job.description.trim()}`);
+          expect(await description.getAttribute("title")).toBe(
+            `Description: ${job.description.trim()}`,
+          );
+        }
+        expect(
+          await page.locator(`[data-test-id="cron-row-description-${undescribedJob.id}"]`).count(),
+        ).toBe(0);
 
-      const describedRow = await page
-        .locator(`[data-test-id="cron-row-${jobs[1].id}"]`)
-        .boundingBox();
-      const undescribedRow = await page
-        .locator(`[data-test-id="cron-row-${undescribedJob.id}"]`)
-        .boundingBox();
-      expect(describedRow?.height).toBe(undescribedRow?.height);
+        const describedRow = await page
+          .locator(`[data-test-id="cron-row-${jobs[1].id}"]`)
+          .boundingBox();
+        const undescribedRow = await page
+          .locator(`[data-test-id="cron-row-${undescribedJob.id}"]`)
+          .boundingBox();
+        expect(describedRow?.height).toBe(undescribedRow?.height);
 
-      for (const job of jobs) {
-        const row = page.locator(`[data-test-id="cron-row-${job.id}"]`);
-        await row.locator(".cron-table__name-text").click();
-        const detailDescription = page.locator('[data-test-id="cron-detail-description"]');
-        await detailDescription.waitFor({ state: "visible" });
-        expect((await detailDescription.textContent())?.replace(/\s+/g, " ").trim()).toBe(
-          `Description: ${job.description.trim()}`,
-        );
+        for (const job of jobs) {
+          const row = page.locator(`[data-test-id="cron-row-${job.id}"]`);
+          await row.locator(".cron-table__name-text").click();
+          const detailDescription = page.locator('[data-test-id="cron-detail-description"]');
+          await detailDescription.waitFor({ state: "visible" });
+          expect((await detailDescription.textContent())?.replace(/\s+/g, " ").trim()).toBe(
+            `Description: ${job.description.trim()}`,
+          );
 
-        await page.locator('[data-test-id="cron-detail-tab-history"]').click();
-        expect((await detailDescription.textContent())?.replace(/\s+/g, " ").trim()).toBe(
-          `Description: ${job.description.trim()}`,
-        );
-        await page.locator('[data-test-id="cron-back"]').click();
-        await row.waitFor({ timeout: 10_000 });
-      }
-    } finally {
-      await suite.closeBrowserContext(context);
-    }
+          await page.locator('[data-test-id="cron-detail-tab-history"]').click();
+          expect((await detailDescription.textContent())?.replace(/\s+/g, " ").trim()).toBe(
+            `Description: ${job.description.trim()}`,
+          );
+          await page.locator('[data-test-id="cron-back"]').click();
+          await row.waitFor({ timeout: 10_000 });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -1,23 +1,19 @@
 // Control UI tests cover cron filters behavior.
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
 import {
-  canRunPlaywrightChromium,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI cron mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 function cronJob(id: string, name: string, schedule: Record<string, unknown>, state = {}) {
   return {
@@ -140,61 +136,45 @@ async function waitForJobTitle(
   }
 }
 
-describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("suggests browser-supported timezones without restricting free-form input", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([]),
-        "cron.runs": cronRunsResponse([]),
-        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([]),
+            "cron.runs": cronRunsResponse([]),
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}cron`);
-      expect(response?.status()).toBe(200);
-      await page.locator('[data-test-id="cron-new-task"]').click();
-      await page.locator('[data-test-id="cron-schedule-kind-cron"]').click();
+        const response = await page.goto(`${suite.server.baseUrl}cron`);
+        expect(response?.status()).toBe(200);
+        await page.locator('[data-test-id="cron-new-task"]').click();
+        await page.locator('[data-test-id="cron-schedule-kind-cron"]').click();
 
-      const timezone = page.locator("#cron-cron-tz");
-      await timezone.waitFor({ state: "visible" });
-      expect(await timezone.getAttribute("list")).toBe("cron-tz-suggestions");
-      const browserTimezone = await page.evaluate(
-        () => Intl.DateTimeFormat().resolvedOptions().timeZone,
-      );
-      const timezoneOptions = await page
-        .locator("#cron-tz-suggestions option")
-        .evaluateAll((options) => options.map((option) => option.getAttribute("value")));
-      expect(timezoneOptions).toContain(browserTimezone);
-      expect(timezoneOptions).toContain("UTC");
-      expect(timezoneOptions.length).toBeGreaterThan(100);
+        const timezone = page.locator("#cron-cron-tz");
+        await timezone.waitFor({ state: "visible" });
+        expect(await timezone.getAttribute("list")).toBe("cron-tz-suggestions");
+        const browserTimezone = await page.evaluate(
+          () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+        );
+        const timezoneOptions = await page
+          .locator("#cron-tz-suggestions option")
+          .evaluateAll((options) => options.map((option) => option.getAttribute("value")));
+        expect(timezoneOptions).toContain(browserTimezone);
+        expect(timezoneOptions).toContain("UTC");
+        expect(timezoneOptions.length).toBeGreaterThan(100);
 
-      await timezone.fill("Etc/GMT+3");
-      expect(await timezone.inputValue()).toBe("Etc/GMT+3");
-    } finally {
-      await context.close();
-    }
+        await timezone.fill("Etc/GMT+3");
+        expect(await timezone.inputValue()).toBe("Etc/GMT+3");
+      },
+    );
   });
 
   it("sends cron job table filters through the Gateway and renders the filtered page", async () => {
@@ -211,91 +191,105 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       {},
     );
 
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    const consoleMessages: string[] = [];
-    page.on("pageerror", (err) => pageErrors.push(String(err)));
-    page.on("console", (msg) => consoleMessages.push(`${msg.type()}: ${msg.text()}`));
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": {
-          cases: [
-            {
-              match: { scheduleKind: "cron", lastRunStatus: "unknown" },
-              response: cronListResponse([cronUnknown]),
-            },
-            {
-              match: {},
-              response: cronListResponse([everyOk, cronUnknown], 2),
-            },
-          ],
-        },
-        "cron.runs": {
-          entries: [],
-          total: 0,
-          offset: 0,
-          limit: 50,
-          hasMore: false,
-          nextOffset: null,
-        },
-        "cron.status": {
-          enabled: true,
-          jobs: 2,
-          nextWakeAtMs: Date.parse("2026-05-29T09:00:00.000Z"),
-          storePath: "/tmp/openclaw-e2e/cron/jobs.json",
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        const consoleMessages: string[] = [];
+        page.on("pageerror", (err) => pageErrors.push(String(err)));
+        page.on("console", (msg) => consoleMessages.push(`${msg.type()}: ${msg.text()}`));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": {
+              cases: [
+                {
+                  match: { scheduleKind: "cron", lastRunStatus: "unknown" },
+                  response: cronListResponse([cronUnknown]),
+                },
+                {
+                  match: {},
+                  response: cronListResponse([everyOk, cronUnknown], 2),
+                },
+              ],
+            },
+            "cron.runs": {
+              entries: [],
+              total: 0,
+              offset: 0,
+              limit: 50,
+              hasMore: false,
+              nextOffset: null,
+            },
+            "cron.status": {
+              enabled: true,
+              jobs: 2,
+              nextWakeAtMs: Date.parse("2026-05-29T09:00:00.000Z"),
+              storePath: "/tmp/openclaw-e2e/cron/jobs.json",
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}cron`);
-      expect(response?.status()).toBe(200);
-      await waitForJobTitle(page, gateway, { consoleMessages, pageErrors }, "Digest every minute");
-      await waitForJobTitle(page, gateway, { consoleMessages, pageErrors }, "Nightly cron pending");
+        const response = await page.goto(`${suite.server.baseUrl}cron`);
+        expect(response?.status()).toBe(200);
+        await waitForJobTitle(
+          page,
+          gateway,
+          { consoleMessages, pageErrors },
+          "Digest every minute",
+        );
+        await waitForJobTitle(
+          page,
+          gateway,
+          { consoleMessages, pageErrors },
+          "Nightly cron pending",
+        );
 
-      const initialRequest = await waitForCronListRequest(
-        gateway,
-        (params) => params.limit === 50 && params.scheduleKind === "all",
-      );
-      expect(requestParams(initialRequest)).toMatchObject({
-        enabled: "all",
-        includeDisabled: true,
-        lastRunStatus: "all",
-        limit: 50,
-        offset: 0,
-        scheduleKind: "all",
-        sortBy: "nextRunAtMs",
-        sortDir: "asc",
-      });
+        const initialRequest = await waitForCronListRequest(
+          gateway,
+          (params) => params.limit === 50 && params.scheduleKind === "all",
+        );
+        expect(requestParams(initialRequest)).toMatchObject({
+          enabled: "all",
+          includeDisabled: true,
+          lastRunStatus: "all",
+          limit: 50,
+          offset: 0,
+          scheduleKind: "all",
+          sortBy: "nextRunAtMs",
+          sortDir: "asc",
+        });
 
-      await page.locator(".cron-filter-popover__trigger").click();
-      await page.locator('[data-test-id="cron-jobs-schedule-filter"]').selectOption("cron");
-      await page.locator('[data-test-id="cron-jobs-last-status-filter"]').selectOption("unknown");
+        await page.locator(".cron-filter-popover__trigger").click();
+        await page.locator('[data-test-id="cron-jobs-schedule-filter"]').selectOption("cron");
+        await page.locator('[data-test-id="cron-jobs-last-status-filter"]').selectOption("unknown");
 
-      const filteredRequest = await waitForCronListRequest(
-        gateway,
-        (params) => params.scheduleKind === "cron" && params.lastRunStatus === "unknown",
-      );
-      expect(requestParams(filteredRequest)).toMatchObject({
-        enabled: "all",
-        includeDisabled: true,
-        lastRunStatus: "unknown",
-        limit: 50,
-        offset: 0,
-        scheduleKind: "cron",
-        sortBy: "nextRunAtMs",
-        sortDir: "asc",
-      });
-      await waitForJobTitle(page, gateway, { consoleMessages, pageErrors }, "Nightly cron pending");
-      await expect.poll(async () => jobTitle(page, "Digest every minute").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        const filteredRequest = await waitForCronListRequest(
+          gateway,
+          (params) => params.scheduleKind === "cron" && params.lastRunStatus === "unknown",
+        );
+        expect(requestParams(filteredRequest)).toMatchObject({
+          enabled: "all",
+          includeDisabled: true,
+          lastRunStatus: "unknown",
+          limit: 50,
+          offset: 0,
+          scheduleKind: "cron",
+          sortBy: "nextRunAtMs",
+          sortDir: "asc",
+        });
+        await waitForJobTitle(
+          page,
+          gateway,
+          { consoleMessages, pageErrors },
+          "Nightly cron pending",
+        );
+        await expect.poll(async () => jobTitle(page, "Digest every minute").count()).toBe(0);
+      },
+    );
   });
 
   it("creates a cron-scheduled task and renders the refreshed row", async () => {
@@ -306,42 +300,41 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "Prepare the weekday report" },
     };
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.add": { id: createdJob.id },
-        "cron.list": cronListResponse([]),
-        "cron.runs": cronRunsResponse([]),
-        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.add": { id: createdJob.id },
+            "cron.list": cronListResponse([]),
+            "cron.runs": cronRunsResponse([]),
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await page.locator('[data-test-id="cron-new-task"]').click();
-      await page.locator("#cron-name").fill(createdJob.name);
-      await page.locator("#cron-payload-text").fill(createdJob.payload.message);
-      await page.locator('[data-test-id="cron-schedule-kind-cron"]').click();
-      await page.locator("#cron-cron-expr").fill(schedule.expr);
-      await page.locator("#cron-cron-tz").fill(schedule.tz);
-      await gateway.setMethodResponse("cron.list", cronListResponse([createdJob]));
-      await page.locator('[data-test-id="cron-submit"]').click();
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await page.locator('[data-test-id="cron-new-task"]').click();
+        await page.locator("#cron-name").fill(createdJob.name);
+        await page.locator("#cron-payload-text").fill(createdJob.payload.message);
+        await page.locator('[data-test-id="cron-schedule-kind-cron"]').click();
+        await page.locator("#cron-cron-expr").fill(schedule.expr);
+        await page.locator("#cron-cron-tz").fill(schedule.tz);
+        await gateway.setMethodResponse("cron.list", cronListResponse([createdJob]));
+        await page.locator('[data-test-id="cron-submit"]').click();
 
-      const addRequest = await gateway.waitForRequest("cron.add");
-      expect(requestParams(addRequest)).toMatchObject({
-        name: createdJob.name,
-        payload: createdJob.payload,
-        schedule,
-      });
-      await jobTitle(page, createdJob.name).waitFor({ state: "visible", timeout: 10_000 });
-    } finally {
-      await context.close();
-    }
+        const addRequest = await gateway.waitForRequest("cron.add");
+        expect(requestParams(addRequest)).toMatchObject({
+          name: createdJob.name,
+          payload: createdJob.payload,
+          schedule,
+        });
+        await jobTitle(page, createdJob.name).waitFor({ state: "visible", timeout: 10_000 });
+      },
+    );
   });
 
   it("keeps read-only operators on Cron browse and history surfaces", async () => {
@@ -354,353 +347,357 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       ),
       description: "Explain the nightly digest without granting write access",
     };
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      operatorScopes: ["operator.read"],
-      methodResponses: {
-        "cron.list": cronListResponse([readOnlyJob]),
-        "cron.runs": cronRunsResponse([
-          {
-            ts: 1,
-            jobId: readOnlyJob.id,
-            jobName: readOnlyJob.name,
-            status: "ok",
-            summary: "Read-only history remains available",
-          },
-        ]),
-        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          operatorScopes: ["operator.read"],
+          methodResponses: {
+            "cron.list": cronListResponse([readOnlyJob]),
+            "cron.runs": cronRunsResponse([
+              {
+                ts: 1,
+                jobId: readOnlyJob.id,
+                jobName: readOnlyJob.name,
+                status: "ok",
+                summary: "Read-only history remains available",
+              },
+            ]),
+            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await jobTitle(page, readOnlyJob.name).waitFor({ timeout: 10_000 });
-      await page.getByRole("note").filter({ hasText: "Browsing only" }).waitFor();
-      expect(
-        await page.locator(`[data-test-id="cron-row-description-${readOnlyJob.id}"]`).textContent(),
-      ).toContain(readOnlyJob.description);
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await jobTitle(page, readOnlyJob.name).waitFor({ timeout: 10_000 });
+        await page.getByRole("note").filter({ hasText: "Browsing only" }).waitFor();
+        expect(
+          await page
+            .locator(`[data-test-id="cron-row-description-${readOnlyJob.id}"]`)
+            .textContent(),
+        ).toContain(readOnlyJob.description);
 
-      await expect.poll(() => page.locator('[data-test-id="cron-new-task"]').count()).toBe(0);
-      await expect
-        .poll(() => page.locator(`[data-test-id="cron-row-run-${readOnlyJob.id}"]`).count())
-        .toBe(0);
-      await expect
-        .poll(() => page.locator(`[data-test-id="cron-row-toggle-${readOnlyJob.id}"]`).count())
-        .toBe(0);
-      await expect.poll(() => page.locator("wa-dropdown.cron-job-menu").count()).toBe(0);
-      await expect.poll(() => page.locator("[data-suggestion]").count()).toBe(0);
-      expect(await page.locator(".cron-filter-popover__trigger").count()).toBe(1);
+        await expect.poll(() => page.locator('[data-test-id="cron-new-task"]').count()).toBe(0);
+        await expect
+          .poll(() => page.locator(`[data-test-id="cron-row-run-${readOnlyJob.id}"]`).count())
+          .toBe(0);
+        await expect
+          .poll(() => page.locator(`[data-test-id="cron-row-toggle-${readOnlyJob.id}"]`).count())
+          .toBe(0);
+        await expect.poll(() => page.locator("wa-dropdown.cron-job-menu").count()).toBe(0);
+        await expect.poll(() => page.locator("[data-suggestion]").count()).toBe(0);
+        expect(await page.locator(".cron-filter-popover__trigger").count()).toBe(1);
 
-      await jobTitle(page, readOnlyJob.name).click();
-      await page.locator("fieldset.cron-editor:disabled").waitFor();
-      expect(
-        await page.locator('[data-test-id="cron-detail-description"]').textContent(),
-      ).toContain(readOnlyJob.description);
-      await expect.poll(() => page.locator('[data-test-id="cron-run-now"]').count()).toBe(0);
-      await expect.poll(() => page.locator('[data-test-id="cron-submit"]').count()).toBe(0);
-      await expect.poll(() => page.locator(".cron-editor-actions").count()).toBe(0);
+        await jobTitle(page, readOnlyJob.name).click();
+        await page.locator("fieldset.cron-editor:disabled").waitFor();
+        expect(
+          await page.locator('[data-test-id="cron-detail-description"]').textContent(),
+        ).toContain(readOnlyJob.description);
+        await expect.poll(() => page.locator('[data-test-id="cron-run-now"]').count()).toBe(0);
+        await expect.poll(() => page.locator('[data-test-id="cron-submit"]').count()).toBe(0);
+        await expect.poll(() => page.locator(".cron-editor-actions").count()).toBe(0);
 
-      await page.locator('[data-test-id="cron-detail-tab-history"]').click();
-      await page.getByText("Read-only history remains available", { exact: true }).waitFor();
-      expect(
-        await page.locator('[data-test-id="cron-detail-description"]').textContent(),
-      ).toContain(readOnlyJob.description);
+        await page.locator('[data-test-id="cron-detail-tab-history"]').click();
+        await page.getByText("Read-only history remains available", { exact: true }).waitFor();
+        expect(
+          await page.locator('[data-test-id="cron-detail-description"]').textContent(),
+        ).toContain(readOnlyJob.description);
 
-      const mutationMethods = new Set(["cron.add", "cron.remove", "cron.run", "cron.update"]);
-      expect(
-        (await gateway.getRequests()).filter((request) => mutationMethods.has(request.method)),
-      ).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+        const mutationMethods = new Set(["cron.add", "cron.remove", "cron.run", "cron.update"]);
+        expect(
+          (await gateway.getRequests()).filter((request) => mutationMethods.has(request.method)),
+        ).toHaveLength(0);
+      },
+    );
   });
 
   it("announces selected history filters and sends their Gateway request values", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([]),
-        "cron.runs": cronRunsResponse([
-          {
-            ts: 1,
-            jobId: "filtered-job",
-            status: "error",
-            deliveryStatus: "delivered",
-            summary: "Delivered failure",
-          },
-        ]),
-        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([]),
+            "cron.runs": cronRunsResponse([
+              {
+                ts: 1,
+                jobId: "filtered-job",
+                status: "error",
+                deliveryStatus: "delivered",
+                summary: "Delivered failure",
+              },
+            ]),
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await page.getByRole("tab", { name: "Run history", exact: true }).click();
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await page.getByRole("tab", { name: "Run history", exact: true }).click();
 
-      const statusFilter = page.locator('[data-filter="status"]');
-      const deliveryFilter = page.locator('[data-filter="delivery"]');
-      const statusTrigger = statusFilter.locator(".cron-filter-dropdown__trigger");
-      const deliveryTrigger = deliveryFilter.locator(".cron-filter-dropdown__trigger");
-      await page.getByRole("button", { name: "Status All statuses", exact: true }).waitFor();
-      await page.getByRole("button", { name: "Delivery All delivery", exact: true }).waitFor();
+        const statusFilter = page.locator('[data-filter="status"]');
+        const deliveryFilter = page.locator('[data-filter="delivery"]');
+        const statusTrigger = statusFilter.locator(".cron-filter-dropdown__trigger");
+        const deliveryTrigger = deliveryFilter.locator(".cron-filter-dropdown__trigger");
+        await page.getByRole("button", { name: "Status All statuses", exact: true }).waitFor();
+        await page.getByRole("button", { name: "Delivery All delivery", exact: true }).waitFor();
 
-      const initialRequestCount = (await gateway.getRequests("cron.runs")).length;
-      await statusTrigger.click();
-      await statusFilter.locator('wa-dropdown-item[value="option:error"]').click();
-      await page.getByRole("button", { name: "Status Error", exact: true }).waitFor();
-      await statusFilter.locator('wa-dropdown-item[value="option:ok"]').click();
-      await page.getByRole("button", { name: "Status OK, Error", exact: true }).waitFor();
-      expect(await statusTrigger.textContent()).toContain("OK, Error");
-      await statusFilter.locator('wa-dropdown-item[value="option:skipped"]').click();
-      await page
-        .getByRole("button", { name: "Status OK +2 (OK, Error, and Skipped)", exact: true })
-        .waitFor();
-      expect(await statusTrigger.textContent()).toContain("OK +2");
-      await expect
-        .poll(async () =>
-          (await gateway.getRequests("cron.runs")).slice(initialRequestCount).some((request) => {
-            const params = requestParams(request);
-            const statuses = params.statuses;
-            return (
-              Array.isArray(statuses) &&
-              ["ok", "error", "skipped"].every((status) => statuses.includes(status))
-            );
-          }),
-        )
-        .toBe(true);
-
-      const statusRequestCount = (await gateway.getRequests("cron.runs")).length;
-      await deliveryTrigger.click();
-      await deliveryFilter.locator('wa-dropdown-item[value="option:delivered"]').click();
-      await page.getByRole("button", { name: "Delivery Delivered", exact: true }).waitFor();
-      await deliveryFilter.locator('wa-dropdown-item[value="option:not-delivered"]').click();
-      await page
-        .getByRole("button", { name: "Delivery Delivered, Not delivered", exact: true })
-        .waitFor();
-      expect(await deliveryTrigger.textContent()).toContain("Delivered, Not delivered");
-      await deliveryFilter.locator('wa-dropdown-item[value="option:unknown"]').click();
-      await page
-        .getByRole("button", {
-          name: "Delivery Delivered +2 (Delivered, Not delivered, and Unknown)",
-          exact: true,
-        })
-        .waitFor();
-      expect(await deliveryTrigger.textContent()).toContain("Delivered +2");
-      await expect
-        .poll(async () =>
-          (await gateway.getRequests("cron.runs")).slice(statusRequestCount).some((request) => {
-            const params = requestParams(request);
-            const statuses = params.statuses;
-            const deliveryStatuses = params.deliveryStatuses;
-            return (
-              Array.isArray(statuses) &&
-              ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
-              Array.isArray(deliveryStatuses) &&
-              ["delivered", "not-delivered", "unknown"].every((status) =>
-                deliveryStatuses.includes(status),
-              )
-            );
-          }),
-        )
-        .toBe(true);
-
-      const deliveryRequestCount = (await gateway.getRequests("cron.runs")).length;
-      await deliveryFilter.locator('wa-dropdown-item[value="command:clear"]').click();
-      await page.getByRole("button", { name: "Delivery All delivery", exact: true }).waitFor();
-      await expect
-        .poll(async () =>
-          (await gateway.getRequests("cron.runs")).slice(deliveryRequestCount).some((request) => {
-            const params = requestParams(request);
-            const statuses = params.statuses;
-            return (
-              Array.isArray(statuses) &&
-              ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
-              !("deliveryStatuses" in params)
-            );
-          }),
-        )
-        .toBe(true);
-
-      const clearedDeliveryRequestCount = (await gateway.getRequests("cron.runs")).length;
-      await statusTrigger.click();
-      await statusFilter.locator('wa-dropdown-item[value="command:clear"]').click();
-      await page.getByRole("button", { name: "Status All statuses", exact: true }).waitFor();
-      await expect
-        .poll(async () =>
-          (await gateway.getRequests("cron.runs"))
-            .slice(clearedDeliveryRequestCount)
-            .some((request) => {
+        const initialRequestCount = (await gateway.getRequests("cron.runs")).length;
+        await statusTrigger.click();
+        await statusFilter.locator('wa-dropdown-item[value="option:error"]').click();
+        await page.getByRole("button", { name: "Status Error", exact: true }).waitFor();
+        await statusFilter.locator('wa-dropdown-item[value="option:ok"]').click();
+        await page.getByRole("button", { name: "Status OK, Error", exact: true }).waitFor();
+        expect(await statusTrigger.textContent()).toContain("OK, Error");
+        await statusFilter.locator('wa-dropdown-item[value="option:skipped"]').click();
+        await page
+          .getByRole("button", { name: "Status OK +2 (OK, Error, and Skipped)", exact: true })
+          .waitFor();
+        expect(await statusTrigger.textContent()).toContain("OK +2");
+        await expect
+          .poll(async () =>
+            (await gateway.getRequests("cron.runs")).slice(initialRequestCount).some((request) => {
               const params = requestParams(request);
-              return !("statuses" in params) && !("deliveryStatuses" in params);
+              const statuses = params.statuses;
+              return (
+                Array.isArray(statuses) &&
+                ["ok", "error", "skipped"].every((status) => statuses.includes(status))
+              );
             }),
-        )
-        .toBe(true);
-    } finally {
-      await context.close();
-    }
+          )
+          .toBe(true);
+
+        const statusRequestCount = (await gateway.getRequests("cron.runs")).length;
+        await deliveryTrigger.click();
+        await deliveryFilter.locator('wa-dropdown-item[value="option:delivered"]').click();
+        await page.getByRole("button", { name: "Delivery Delivered", exact: true }).waitFor();
+        await deliveryFilter.locator('wa-dropdown-item[value="option:not-delivered"]').click();
+        await page
+          .getByRole("button", { name: "Delivery Delivered, Not delivered", exact: true })
+          .waitFor();
+        expect(await deliveryTrigger.textContent()).toContain("Delivered, Not delivered");
+        await deliveryFilter.locator('wa-dropdown-item[value="option:unknown"]').click();
+        await page
+          .getByRole("button", {
+            name: "Delivery Delivered +2 (Delivered, Not delivered, and Unknown)",
+            exact: true,
+          })
+          .waitFor();
+        expect(await deliveryTrigger.textContent()).toContain("Delivered +2");
+        await expect
+          .poll(async () =>
+            (await gateway.getRequests("cron.runs")).slice(statusRequestCount).some((request) => {
+              const params = requestParams(request);
+              const statuses = params.statuses;
+              const deliveryStatuses = params.deliveryStatuses;
+              return (
+                Array.isArray(statuses) &&
+                ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
+                Array.isArray(deliveryStatuses) &&
+                ["delivered", "not-delivered", "unknown"].every((status) =>
+                  deliveryStatuses.includes(status),
+                )
+              );
+            }),
+          )
+          .toBe(true);
+
+        const deliveryRequestCount = (await gateway.getRequests("cron.runs")).length;
+        await deliveryFilter.locator('wa-dropdown-item[value="command:clear"]').click();
+        await page.getByRole("button", { name: "Delivery All delivery", exact: true }).waitFor();
+        await expect
+          .poll(async () =>
+            (await gateway.getRequests("cron.runs")).slice(deliveryRequestCount).some((request) => {
+              const params = requestParams(request);
+              const statuses = params.statuses;
+              return (
+                Array.isArray(statuses) &&
+                ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
+                !("deliveryStatuses" in params)
+              );
+            }),
+          )
+          .toBe(true);
+
+        const clearedDeliveryRequestCount = (await gateway.getRequests("cron.runs")).length;
+        await statusTrigger.click();
+        await statusFilter.locator('wa-dropdown-item[value="command:clear"]').click();
+        await page.getByRole("button", { name: "Status All statuses", exact: true }).waitFor();
+        await expect
+          .poll(async () =>
+            (await gateway.getRequests("cron.runs"))
+              .slice(clearedDeliveryRequestCount)
+              .some((request) => {
+                const params = requestParams(request);
+                return !("statuses" in params) && !("deliveryStatuses" in params);
+              }),
+          )
+          .toBe(true);
+      },
+    );
   });
 
   it("localizes history filters and selects them using only native keyboard controls", async () => {
-    const context = await browser.newContext({
-      locale: "de-DE",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([]),
-        "cron.runs": cronRunsResponse([]),
-        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "de-DE",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([]),
+            "cron.runs": cronRunsResponse([]),
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await expect.poll(() => page.evaluate(() => document.documentElement.lang)).toBe("de");
-      await page.getByRole("tab", { name: "Ausführungsverlauf", exact: true }).click();
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await expect.poll(() => page.evaluate(() => document.documentElement.lang)).toBe("de");
+        await page.getByRole("tab", { name: "Ausführungsverlauf", exact: true }).click();
 
-      const statusFilter = page.locator('[data-filter="status"]');
-      const deliveryFilter = page.locator('[data-filter="delivery"]');
-      const statusTrigger = statusFilter.locator(".cron-filter-dropdown__trigger");
-      const deliveryTrigger = deliveryFilter.locator(".cron-filter-dropdown__trigger");
-      await page.getByRole("button", { name: "Status Alle Status", exact: true }).waitFor();
-      await page
-        .getByRole("button", { name: "Zustellung Alle Zustellungen", exact: true })
-        .waitFor();
+        const statusFilter = page.locator('[data-filter="status"]');
+        const deliveryFilter = page.locator('[data-filter="delivery"]');
+        const statusTrigger = statusFilter.locator(".cron-filter-dropdown__trigger");
+        const deliveryTrigger = deliveryFilter.locator(".cron-filter-dropdown__trigger");
+        await page.getByRole("button", { name: "Status Alle Status", exact: true }).waitFor();
+        await page
+          .getByRole("button", { name: "Zustellung Alle Zustellungen", exact: true })
+          .waitFor();
 
-      await statusTrigger.focus();
-      await page.keyboard.press("Enter");
-      await expect.poll(() => statusFilter.locator("wa-dropdown-item:focus").count()).toBe(1);
-      await page.keyboard.press("ArrowDown");
-      await page.keyboard.press("Enter");
-      await page.getByRole("button", { name: "Status Fehler", exact: true }).waitFor();
-      await page.keyboard.press("Home");
-      await page.keyboard.press("Enter");
-      await page.getByRole("button", { name: "Status OK, Fehler", exact: true }).waitFor();
-      expect(await statusTrigger.textContent()).toContain("OK, Fehler");
-      await page.keyboard.press("ArrowDown");
-      await page.keyboard.press("ArrowDown");
-      await page.keyboard.press("Enter");
-      await page
-        .getByRole("button", { name: "Status OK +2 (OK, Fehler und Übersprungen)", exact: true })
-        .waitFor();
-      expect(await statusTrigger.textContent()).toContain("OK +2");
+        await statusTrigger.focus();
+        await page.keyboard.press("Enter");
+        await expect.poll(() => statusFilter.locator("wa-dropdown-item:focus").count()).toBe(1);
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("Enter");
+        await page.getByRole("button", { name: "Status Fehler", exact: true }).waitFor();
+        await page.keyboard.press("Home");
+        await page.keyboard.press("Enter");
+        await page.getByRole("button", { name: "Status OK, Fehler", exact: true }).waitFor();
+        expect(await statusTrigger.textContent()).toContain("OK, Fehler");
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("Enter");
+        await page
+          .getByRole("button", { name: "Status OK +2 (OK, Fehler und Übersprungen)", exact: true })
+          .waitFor();
+        expect(await statusTrigger.textContent()).toContain("OK +2");
 
-      await dismissDropdownToNextTrigger(page, statusTrigger, deliveryTrigger);
-      await page.keyboard.press("Enter");
-      await expect.poll(() => deliveryFilter.locator("wa-dropdown-item:focus").count()).toBe(1);
-      await page.keyboard.press("Enter");
-      await page.keyboard.press("ArrowDown");
-      await page.keyboard.press("Enter");
-      await page
-        .getByRole("button", { name: "Zustellung Zugestellt, Nicht zugestellt", exact: true })
-        .waitFor();
-      expect(await deliveryTrigger.textContent()).toContain("Zugestellt, Nicht zugestellt");
-      await page.keyboard.press("ArrowDown");
-      await page.keyboard.press("Enter");
-      await page
-        .getByRole("button", {
-          name: "Zustellung Zugestellt +2 (Zugestellt, Nicht zugestellt und Unbekannt)",
-          exact: true,
-        })
-        .waitFor();
-      expect(await deliveryTrigger.textContent()).toContain("Zugestellt +2");
+        await dismissDropdownToNextTrigger(page, statusTrigger, deliveryTrigger);
+        await page.keyboard.press("Enter");
+        await expect.poll(() => deliveryFilter.locator("wa-dropdown-item:focus").count()).toBe(1);
+        await page.keyboard.press("Enter");
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("Enter");
+        await page
+          .getByRole("button", { name: "Zustellung Zugestellt, Nicht zugestellt", exact: true })
+          .waitFor();
+        expect(await deliveryTrigger.textContent()).toContain("Zugestellt, Nicht zugestellt");
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("Enter");
+        await page
+          .getByRole("button", {
+            name: "Zustellung Zugestellt +2 (Zugestellt, Nicht zugestellt und Unbekannt)",
+            exact: true,
+          })
+          .waitFor();
+        expect(await deliveryTrigger.textContent()).toContain("Zugestellt +2");
 
-      await expect
-        .poll(async () =>
-          (await gateway.getRequests("cron.runs")).some((request) => {
-            const params = requestParams(request);
-            const statuses = params.statuses;
-            const deliveryStatuses = params.deliveryStatuses;
-            return (
-              Array.isArray(statuses) &&
-              ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
-              Array.isArray(deliveryStatuses) &&
-              ["delivered", "not-delivered", "unknown"].every((status) =>
-                deliveryStatuses.includes(status),
-              )
-            );
-          }),
-        )
-        .toBe(true);
-    } finally {
-      await context.close();
-    }
+        await expect
+          .poll(async () =>
+            (await gateway.getRequests("cron.runs")).some((request) => {
+              const params = requestParams(request);
+              const statuses = params.statuses;
+              const deliveryStatuses = params.deliveryStatuses;
+              return (
+                Array.isArray(statuses) &&
+                ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
+                Array.isArray(deliveryStatuses) &&
+                ["delivered", "not-delivered", "unknown"].every((status) =>
+                  deliveryStatuses.includes(status),
+                )
+              );
+            }),
+          )
+          .toBe(true);
+      },
+    );
   });
 
   it("keeps the newest visible overview when an older history search resolves last", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([]),
-        "cron.runs": cronRunsResponse([
-          { ts: 1, jobId: "initial-job", status: "ok", summary: "Initial history" },
-        ]),
-        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([]),
+            "cron.runs": cronRunsResponse([
+              { ts: 1, jobId: "initial-job", status: "ok", summary: "Initial history" },
+            ]),
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await page.getByRole("tab", { name: "Run history", exact: true }).click();
-      await expect
-        .poll(() => page.locator(".cron-run-entry", { hasText: "Initial history" }).count())
-        .toBe(1);
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await page.getByRole("tab", { name: "Run history", exact: true }).click();
+        await expect
+          .poll(() => page.locator(".cron-run-entry", { hasText: "Initial history" }).count())
+          .toBe(1);
 
-      await gateway.deferNext("cron.runs");
-      const search = page.locator(".cron-run-filter-search input");
-      await search.fill("stale");
-      await expect
-        .poll(async () =>
-          (await gateway.getRequests("cron.runs")).some(
-            (request) => requestParams(request).query === "stale",
-          ),
-        )
-        .toBe(true);
+        await gateway.deferNext("cron.runs");
+        const search = page.locator(".cron-run-filter-search input");
+        await search.fill("stale");
+        await expect
+          .poll(async () =>
+            (await gateway.getRequests("cron.runs")).some(
+              (request) => requestParams(request).query === "stale",
+            ),
+          )
+          .toBe(true);
 
-      await gateway.setMethodResponse(
-        "cron.runs",
-        cronRunsResponse([
-          { ts: 3, jobId: "fresh-job", status: "ok", summary: "Newest matching history" },
-        ]),
-      );
-      await search.fill("fresh");
-      await expect
-        .poll(() => page.locator(".cron-run-entry", { hasText: "Newest matching history" }).count())
-        .toBe(1);
+        await gateway.setMethodResponse(
+          "cron.runs",
+          cronRunsResponse([
+            { ts: 3, jobId: "fresh-job", status: "ok", summary: "Newest matching history" },
+          ]),
+        );
+        await search.fill("fresh");
+        await expect
+          .poll(() =>
+            page.locator(".cron-run-entry", { hasText: "Newest matching history" }).count(),
+          )
+          .toBe(1);
 
-      await gateway.resolveDeferred(
-        "cron.runs",
-        cronRunsResponse([
-          { ts: 2, jobId: "stale-job", status: "ok", summary: "Stale matching history" },
-        ]),
-      );
+        await gateway.resolveDeferred(
+          "cron.runs",
+          cronRunsResponse([
+            { ts: 2, jobId: "stale-job", status: "ok", summary: "Stale matching history" },
+          ]),
+        );
 
-      await expect
-        .poll(() => page.locator(".cron-run-entry", { hasText: "Newest matching history" }).count())
-        .toBe(1);
-      await expect
-        .poll(() => page.locator(".cron-run-entry", { hasText: "Stale matching history" }).count())
-        .toBe(0);
-    } finally {
-      await context.close();
-    }
+        await expect
+          .poll(() =>
+            page.locator(".cron-run-entry", { hasText: "Newest matching history" }).count(),
+          )
+          .toBe(1);
+        await expect
+          .poll(() =>
+            page.locator(".cron-run-entry", { hasText: "Stale matching history" }).count(),
+          )
+          .toBe(0);
+      },
+    );
   });
 
   it("keeps selected task history when a deferred overview refresh resolves last", async () => {
@@ -708,84 +705,83 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       kind: "every",
       everyMs: 60_000,
     });
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([selectedJob]),
-        "cron.runs": {
-          cases: [
-            {
-              match: { scope: "job", id: selectedJob.id },
-              response: cronRunsResponse([
-                {
-                  ts: 2,
-                  jobId: selectedJob.id,
-                  status: "ok",
-                  summary: "Selected task history",
-                },
-              ]),
-            },
-            {
-              match: { scope: "all" },
-              response: cronRunsResponse([
-                { ts: 1, jobId: "overview-job", status: "ok", summary: "Overview history" },
-              ]),
-            },
-          ],
-        },
-        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([selectedJob]),
+            "cron.runs": {
+              cases: [
+                {
+                  match: { scope: "job", id: selectedJob.id },
+                  response: cronRunsResponse([
+                    {
+                      ts: 2,
+                      jobId: selectedJob.id,
+                      status: "ok",
+                      summary: "Selected task history",
+                    },
+                  ]),
+                },
+                {
+                  match: { scope: "all" },
+                  response: cronRunsResponse([
+                    { ts: 1, jobId: "overview-job", status: "ok", summary: "Overview history" },
+                  ]),
+                },
+              ],
+            },
+            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await jobTitle(page, selectedJob.name).waitFor({ timeout: 10_000 });
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await jobTitle(page, selectedJob.name).waitFor({ timeout: 10_000 });
 
-      const previousHistoryRequestCount = (await gateway.getRequests("cron.runs")).length;
-      await gateway.deferNext("cron.runs");
-      await gateway.emitGatewayEvent("cron", {});
-      await expect
-        .poll(async () => (await gateway.getRequests("cron.runs")).length)
-        .toBeGreaterThan(previousHistoryRequestCount);
+        const previousHistoryRequestCount = (await gateway.getRequests("cron.runs")).length;
+        await gateway.deferNext("cron.runs");
+        await gateway.emitGatewayEvent("cron", {});
+        await expect
+          .poll(async () => (await gateway.getRequests("cron.runs")).length)
+          .toBeGreaterThan(previousHistoryRequestCount);
 
-      await jobTitle(page, selectedJob.name).click();
-      await page.locator('[data-test-id="cron-detail-tab-history"]').click();
-      await expect
-        .poll(() => page.locator(".cron-run-entry", { hasText: "Selected task history" }).count())
-        .toBe(1);
+        await jobTitle(page, selectedJob.name).click();
+        await page.locator('[data-test-id="cron-detail-tab-history"]').click();
+        await expect
+          .poll(() => page.locator(".cron-run-entry", { hasText: "Selected task history" }).count())
+          .toBe(1);
 
-      await gateway.resolveDeferred(
-        "cron.runs",
-        cronRunsResponse([
-          { ts: 3, jobId: "overview-job", status: "ok", summary: "Late overview history" },
-        ]),
-      );
+        await gateway.resolveDeferred(
+          "cron.runs",
+          cronRunsResponse([
+            { ts: 3, jobId: "overview-job", status: "ok", summary: "Late overview history" },
+          ]),
+        );
 
-      await expect
-        .poll(() => page.locator(".cron-run-entry", { hasText: "Selected task history" }).count())
-        .toBe(1);
-      await expect
-        .poll(() => page.locator(".cron-run-entry", { hasText: "Late overview history" }).count())
-        .toBe(0);
+        await expect
+          .poll(() => page.locator(".cron-run-entry", { hasText: "Selected task history" }).count())
+          .toBe(1);
+        await expect
+          .poll(() => page.locator(".cron-run-entry", { hasText: "Late overview history" }).count())
+          .toBe(0);
 
-      const statusTrigger = page.locator('[data-filter="status"] .cron-filter-dropdown__trigger');
-      const deliveryTrigger = page.locator(
-        '[data-filter="delivery"] .cron-filter-dropdown__trigger',
-      );
-      await statusTrigger.focus();
-      await page.keyboard.press("Enter");
-      await expect
-        .poll(() => page.locator('[data-filter="status"] wa-dropdown-item:focus').count())
-        .toBe(1);
-      await dismissDropdownToNextTrigger(page, statusTrigger, deliveryTrigger);
-    } finally {
-      await context.close();
-    }
+        const statusTrigger = page.locator('[data-filter="status"] .cron-filter-dropdown__trigger');
+        const deliveryTrigger = page.locator(
+          '[data-filter="delivery"] .cron-filter-dropdown__trigger',
+        );
+        await statusTrigger.focus();
+        await page.keyboard.press("Enter");
+        await expect
+          .poll(() => page.locator('[data-filter="status"] wa-dropdown-item:focus').count())
+          .toBe(1);
+        await dismissDropdownToNextTrigger(page, statusTrigger, deliveryTrigger);
+      },
+    );
   });
 
   it("saves and displays agent-turn model overrides", async () => {
@@ -796,60 +792,59 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "Use the configured model", model: configuredModel },
     };
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.add": { id: "quick-created-model-job" },
-        "cron.list": cronListResponse([existingJob]),
-        "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
-        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.add": { id: "quick-created-model-job" },
+            "cron.list": cronListResponse([existingJob]),
+            "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
 
-      // Selecting the task opens the detail view with its stored model override.
-      await jobTitle(page, existingJob.name).click();
-      await expect
-        .poll(async () => page.locator("#cron-payload-model").inputValue())
-        .toBe(configuredModel);
+        // Selecting the task opens the detail view with its stored model override.
+        await jobTitle(page, existingJob.name).click();
+        await expect
+          .poll(async () => page.locator("#cron-payload-model").inputValue())
+          .toBe(configuredModel);
 
-      // The create button lives on the list view; navigate back first.
-      await page.locator('[data-test-id="cron-back"]').click();
-      await page.locator('[data-test-id="cron-new-task"]').click();
-      await page.locator("#cron-payload-text").fill("Run with a selected model");
-      await page.locator("#cron-name").fill("Model override task");
+        // The create button lives on the list view; navigate back first.
+        await page.locator('[data-test-id="cron-back"]').click();
+        await page.locator('[data-test-id="cron-new-task"]').click();
+        await page.locator("#cron-payload-text").fill("Run with a selected model");
+        await page.locator("#cron-name").fill("Model override task");
 
-      const modelInput = page.locator("#cron-payload-model");
-      await modelInput.fill("openai/gpt-5.5");
-      expect(await modelInput.getAttribute("list")).toBe("cron-model-suggestions");
-      expect(
-        await page
-          .locator("#cron-model-suggestions option")
-          .evaluateAll((options) => options.map((option) => option.getAttribute("value"))),
-      ).toContain(configuredModel);
+        const modelInput = page.locator("#cron-payload-model");
+        await modelInput.fill("openai/gpt-5.5");
+        expect(await modelInput.getAttribute("list")).toBe("cron-model-suggestions");
+        expect(
+          await page
+            .locator("#cron-model-suggestions option")
+            .evaluateAll((options) => options.map((option) => option.getAttribute("value"))),
+        ).toContain(configuredModel);
 
-      await page.locator('[data-test-id="cron-submit"]').click();
-      const addRequest = await gateway.waitForRequest("cron.add");
-      expect(requestParams(addRequest)).toMatchObject({
-        name: "Model override task",
-        payload: {
-          kind: "agentTurn",
-          message: "Run with a selected model",
-          model: "openai/gpt-5.5",
-        },
-      });
-      expect(requireRecord(requestParams(addRequest).delivery).accountId).toBeUndefined();
-    } finally {
-      await context.close();
-    }
+        await page.locator('[data-test-id="cron-submit"]').click();
+        const addRequest = await gateway.waitForRequest("cron.add");
+        expect(requestParams(addRequest)).toMatchObject({
+          name: "Model override task",
+          payload: {
+            kind: "agentTurn",
+            message: "Run with a selected model",
+            model: "openai/gpt-5.5",
+          },
+        });
+        expect(requireRecord(requestParams(addRequest).delivery).accountId).toBeUndefined();
+      },
+    );
   });
 
   it("creates and edits agent-turn jobs with an explicit zero timeout", async () => {
@@ -866,64 +861,63 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
         timeoutSeconds: 0,
       },
     };
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.add": { id: "created-no-timeout" },
-        "cron.update": { id: existingJob.id },
-        "cron.list": cronListResponse([existingJob]),
-        "cron.runs": cronRunsResponse([]),
-        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.add": { id: "created-no-timeout" },
+            "cron.update": { id: existingJob.id },
+            "cron.list": cronListResponse([existingJob]),
+            "cron.runs": cronRunsResponse([]),
+            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
 
-      await page.locator('[data-test-id="cron-new-task"]').click();
-      await page.locator("#cron-name").fill("Created no-timeout task");
-      await page.locator("#cron-payload-text").fill("Continue until the new task finishes");
-      await page.locator("details.cron-advanced > summary").click();
-      await page.locator("#cron-timeout-seconds").fill("0");
-      await page.locator('[data-test-id="cron-submit"]').click();
+        await page.locator('[data-test-id="cron-new-task"]').click();
+        await page.locator("#cron-name").fill("Created no-timeout task");
+        await page.locator("#cron-payload-text").fill("Continue until the new task finishes");
+        await page.locator("details.cron-advanced > summary").click();
+        await page.locator("#cron-timeout-seconds").fill("0");
+        await page.locator('[data-test-id="cron-submit"]').click();
 
-      const addRequest = await gateway.waitForRequest("cron.add");
-      expect(requestParams(addRequest)).toMatchObject({
-        name: "Created no-timeout task",
-        payload: {
-          kind: "agentTurn",
-          message: "Continue until the new task finishes",
-          timeoutSeconds: 0,
-        },
-      });
-
-      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
-      await jobTitle(page, existingJob.name).click();
-      await page.locator("details.cron-advanced > summary").click();
-      expect(await page.locator("#cron-timeout-seconds").inputValue()).toBe("0");
-      await page.locator("#cron-payload-text").fill("Continue until the edited task finishes");
-      await page.locator('[data-test-id="cron-submit"]').click();
-
-      const updateRequest = await gateway.waitForRequest("cron.update");
-      expect(requestParams(updateRequest)).toMatchObject({
-        id: existingJob.id,
-        patch: {
+        const addRequest = await gateway.waitForRequest("cron.add");
+        expect(requestParams(addRequest)).toMatchObject({
+          name: "Created no-timeout task",
           payload: {
             kind: "agentTurn",
-            message: "Continue until the edited task finishes",
+            message: "Continue until the new task finishes",
             timeoutSeconds: 0,
           },
-        },
-      });
-    } finally {
-      await context.close();
-    }
+        });
+
+        await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+        await jobTitle(page, existingJob.name).click();
+        await page.locator("details.cron-advanced > summary").click();
+        expect(await page.locator("#cron-timeout-seconds").inputValue()).toBe("0");
+        await page.locator("#cron-payload-text").fill("Continue until the edited task finishes");
+        await page.locator('[data-test-id="cron-submit"]').click();
+
+        const updateRequest = await gateway.waitForRequest("cron.update");
+        expect(requestParams(updateRequest)).toMatchObject({
+          id: existingJob.id,
+          patch: {
+            payload: {
+              kind: "agentTurn",
+              message: "Continue until the edited task finishes",
+              timeoutSeconds: 0,
+            },
+          },
+        });
+      },
+    );
   });
 
   it("defaults recurring jobs converted to one-time cleanup", async () => {
@@ -931,54 +925,53 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       ...cronJob("recurring-to-once", "Recurring retention", { kind: "every", everyMs: 60_000 }),
       deleteAfterRun: false,
     };
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([existingJob]),
-        "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
-        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
-        "cron.update": { id: existingJob.id },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([existingJob]),
+            "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+            "cron.update": { id: existingJob.id },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
-      await jobTitle(page, existingJob.name).click();
-      await page.locator("details.cron-advanced > summary").click();
-      expect(
-        await page
-          .locator("wa-switch.settings-toggle")
-          .filter({ hasText: "Delete after run" })
-          .count(),
-      ).toBe(0);
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+        await jobTitle(page, existingJob.name).click();
+        await page.locator("details.cron-advanced > summary").click();
+        expect(
+          await page
+            .locator("wa-switch.settings-toggle")
+            .filter({ hasText: "Delete after run" })
+            .count(),
+        ).toBe(0);
 
-      await page.locator('[data-test-id="cron-schedule-kind-at"]').click();
-      await page.locator("#cron-schedule-at").fill("2026-07-19T09:00");
-      const expectedAt = await page.evaluate(() => new Date("2026-07-19T09:00").toISOString());
-      const deleteToggle = page.locator("wa-switch.settings-toggle").filter({
-        hasText: "Delete after run",
-      });
-      await expect
-        .poll(() => deleteToggle.evaluate((element) => Reflect.get(element, "checked")))
-        .toBe(true);
+        await page.locator('[data-test-id="cron-schedule-kind-at"]').click();
+        await page.locator("#cron-schedule-at").fill("2026-07-19T09:00");
+        const expectedAt = await page.evaluate(() => new Date("2026-07-19T09:00").toISOString());
+        const deleteToggle = page.locator("wa-switch.settings-toggle").filter({
+          hasText: "Delete after run",
+        });
+        await expect
+          .poll(() => deleteToggle.evaluate((element) => Reflect.get(element, "checked")))
+          .toBe(true);
 
-      await page.locator('[data-test-id="cron-submit"]').click();
-      const request = await gateway.waitForRequest("cron.update");
-      const params = requestParams(request);
-      expect(params.id).toBe(existingJob.id);
-      expect(requireRecord(params.patch)).toMatchObject({
-        deleteAfterRun: true,
-        schedule: { kind: "at", at: expectedAt },
-      });
-    } finally {
-      await context.close();
-    }
+        await page.locator('[data-test-id="cron-submit"]').click();
+        const request = await gateway.waitForRequest("cron.update");
+        const params = requestParams(request);
+        expect(params.id).toBe(existingJob.id);
+        expect(requireRecord(params.patch)).toMatchObject({
+          deleteAfterRun: true,
+          schedule: { kind: "at", at: expectedAt },
+        });
+      },
+    );
   });
 
   it("shows why a requested run was not started", async () => {
@@ -988,87 +981,85 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       { kind: "every", everyMs: 60_000 },
       { runningAtMs: Date.parse("2026-05-29T08:10:00.000Z") },
     );
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(String(error)));
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([existingJob]),
-        "cron.run": { ok: true, ran: false, reason: "already-running" },
-        "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
-        "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([existingJob]),
+            "cron.run": { ok: true, ran: false, reason: "already-running" },
+            "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
-      await jobTitle(page, existingJob.name).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("cron.runs")).length)
-        .toBeGreaterThan(0);
-      const historyRequestsBeforeRun = (await gateway.getRequests("cron.runs")).length;
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+        await jobTitle(page, existingJob.name).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("cron.runs")).length)
+          .toBeGreaterThan(0);
+        const historyRequestsBeforeRun = (await gateway.getRequests("cron.runs")).length;
 
-      await page.locator('[data-test-id="cron-run-now"]').click();
-      await gateway.waitForRequest("cron.run");
+        await page.locator('[data-test-id="cron-run-now"]').click();
+        await gateway.waitForRequest("cron.run");
 
-      await expect
-        .poll(() => page.locator(".cron-error-banner").textContent())
-        .toContain("This automation is already running.");
-      expect(await gateway.getRequests("cron.runs")).toHaveLength(historyRequestsBeforeRun);
-      expect(pageErrors).toEqual([]);
-    } finally {
-      await context.close();
-    }
+        await expect
+          .poll(() => page.locator(".cron-error-banner").textContent())
+          .toContain("This automation is already running.");
+        expect(await gateway.getRequests("cron.runs")).toHaveLength(historyRequestsBeforeRun);
+        expect(pageErrors).toEqual([]);
+      },
+    );
   });
 
   it("supports skip navigation and keyboard tab activation", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": cronListResponse([]),
-        "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
-        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": cronListResponse([]),
+            "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}cron`);
-      await page.locator('[data-test-id="cron-list-tab-tasks"]').waitFor();
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await page.locator('[data-test-id="cron-list-tab-tasks"]').waitFor();
 
-      await page.keyboard.press("Tab");
-      await expect
-        .poll(() => page.evaluate(() => document.activeElement?.textContent?.trim()))
-        .toBe("Skip to main content");
-      await page.keyboard.press("Enter");
-      await expect
-        .poll(() => page.evaluate(() => document.activeElement?.id))
-        .toBe("control-ui-main");
+        await page.keyboard.press("Tab");
+        await expect
+          .poll(() => page.evaluate(() => document.activeElement?.textContent?.trim()))
+          .toBe("Skip to main content");
+        await page.keyboard.press("Enter");
+        await expect
+          .poll(() => page.evaluate(() => document.activeElement?.id))
+          .toBe("control-ui-main");
 
-      const tasksTab = page.getByRole("tab", { name: "Automations", exact: true });
-      const activityTab = page.getByRole("tab", { name: "Run history", exact: true });
-      await tasksTab.focus();
-      await page.keyboard.press("ArrowRight");
-      await expect
-        .poll(() => activityTab.evaluate((element) => element === document.activeElement))
-        .toBe(true);
-      await page.keyboard.press("Enter");
-      await expect.poll(() => activityTab.getAttribute("aria-selected")).toBe("true");
-      await expect
-        .poll(() => page.getByRole("tabpanel", { name: "Run history" }).isVisible())
-        .toBe(true);
-    } finally {
-      await context.close();
-    }
+        const tasksTab = page.getByRole("tab", { name: "Automations", exact: true });
+        const activityTab = page.getByRole("tab", { name: "Run history", exact: true });
+        await tasksTab.focus();
+        await page.keyboard.press("ArrowRight");
+        await expect
+          .poll(() => activityTab.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+        await page.keyboard.press("Enter");
+        await expect.poll(() => activityTab.getAttribute("aria-selected")).toBe("true");
+        await expect
+          .poll(() => page.getByRole("tabpanel", { name: "Run history" }).isVisible())
+          .toBe(true);
+      },
+    );
   });
 });

--- a/ui/src/e2e/curated-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/curated-settings-defaults.e2e.test.ts
@@ -1,21 +1,17 @@
 // Control UI tests cover inherited defaults across curated settings pages.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayRequest,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI curated settings defaults mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
@@ -24,9 +20,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "curated-settings-defaults",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function configResponse(config: Record<string, unknown>, hash: string) {
   return {
@@ -75,227 +68,215 @@ async function expectInherited(row: Locator, value: string) {
   await expect.poll(() => row.getByRole("button", { name: "Reset to default" }).count()).toBe(0);
 }
 
-describeControlUiE2e("Control UI curated settings defaults mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("restores Labs, Security, and Models overrides to inherited defaults across reloads", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const initialConfig = {
-      agents: {
-        defaults: {
-          fastModeDefault: true,
-          model: "openai/gpt-5.5",
-          thinkingDefault: "high",
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
       },
-      browser: { enabled: false },
-      tools: {
-        codeMode: { enabled: false },
-        profile: "minimal",
-      },
-    };
-    const afterLabsReset = {
-      agents: initialConfig.agents,
-      browser: initialConfig.browser,
-      tools: { profile: "minimal" },
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse(initialConfig, "curated-defaults-1"),
-      },
-    });
-
-    try {
-      expect((await page.goto(`${server.baseUrl}settings/labs`))?.status()).toBe(200);
-      const codeModeRow = settingsRow(page, "Code Mode");
-      const codeModeSwitch = codeModeRow.getByRole("switch", { name: "Code Mode", exact: true });
-      await codeModeSwitch.waitFor();
-      expect(await codeModeSwitch.getAttribute("aria-checked")).toBe("false");
-      await expect.poll(() => codeModeRow.textContent()).toContain("Default: Enabled");
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await codeModeRow.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "01-labs-explicit-override.png"),
+      async ({ page }) => {
+        const initialConfig = {
+          agents: {
+            defaults: {
+              fastModeDefault: true,
+              model: "openai/gpt-5.5",
+              thinkingDefault: "high",
+            },
+          },
+          browser: { enabled: false },
+          tools: {
+            codeMode: { enabled: false },
+            profile: "minimal",
+          },
+        };
+        const afterLabsReset = {
+          agents: initialConfig.agents,
+          browser: initialConfig.browser,
+          tools: { profile: "minimal" },
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse(initialConfig, "curated-defaults-1"),
+          },
         });
-      }
 
-      const configGetsBeforeLabsReset = (await gateway.getRequests("config.get")).length;
-      await gateway.deferNext("config.patch");
-      await codeModeRow.getByRole("button", { name: "Reset to default" }).click();
-      const labsPatch = requestRaw(await gateway.waitForRequest("config.patch"));
-      expect(labsPatch).toEqual({ tools: { codeMode: { enabled: null } } });
+        expect((await page.goto(`${suite.server.baseUrl}settings/labs`))?.status()).toBe(200);
+        const codeModeRow = settingsRow(page, "Code Mode");
+        const codeModeSwitch = codeModeRow.getByRole("switch", { name: "Code Mode", exact: true });
+        await codeModeSwitch.waitFor();
+        expect(await codeModeSwitch.getAttribute("aria-checked")).toBe("false");
+        await expect.poll(() => codeModeRow.textContent()).toContain("Default: Enabled");
 
-      const afterLabsResponse = configResponse(afterLabsReset, "curated-defaults-2");
-      await gateway.setMethodResponse("config.get", afterLabsResponse);
-      await gateway.resolveDeferred("config.patch", afterLabsResponse);
-      await expect
-        .poll(async () => (await gateway.getRequests("config.get")).length)
-        .toBe(configGetsBeforeLabsReset + 1);
-      await expectInherited(codeModeRow, "Enabled");
-      expect(await codeModeSwitch.getAttribute("aria-checked")).toBe("true");
-
-      if (captureUiProofEnabled) {
-        await codeModeRow.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "02-labs-inherited-default.png"),
-        });
-      }
-
-      expect((await page.goto(`${server.baseUrl}settings/security`))?.status()).toBe(200);
-      const browserRow = settingsRow(page, "Browser enabled");
-      const profileRow = settingsRow(page, "Tool profile");
-      await browserRow.getByRole("switch", { name: "Browser enabled", exact: true }).waitFor();
-      await expect.poll(() => browserRow.textContent()).toContain("Default: Enabled");
-      await expect.poll(() => profileRow.textContent()).toContain("Default: Full");
-
-      if (captureUiProofEnabled) {
-        await page
-          .locator(".security-page .settings-section")
-          .first()
-          .screenshot({
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await codeModeRow.screenshot({
             animations: "disabled",
-            path: path.join(uiProofArtifactDir, "03-security-explicit-overrides.png"),
+            path: path.join(uiProofArtifactDir, "01-labs-explicit-override.png"),
           });
-      }
+        }
 
-      const securitySavesBefore = (await gateway.getRequests("config.set")).length;
-      await browserRow.getByRole("button", { name: "Reset to default" }).click();
-      await profileRow.getByRole("button", { name: "Reset to default" }).click();
-      await expectInherited(browserRow, "Enabled");
-      await expectInherited(profileRow, "Full");
-      await expect
-        .poll(async () => {
-          const requests = await gateway.getRequests("config.set");
-          const latest = requests.at(-1);
-          if (requests.length <= securitySavesBefore || !latest) {
-            return false;
-          }
-          const raw = requestRaw(latest);
-          return !hasOwnPath(raw, ["browser", "enabled"]) && !hasOwnPath(raw, ["tools", "profile"]);
-        })
-        .toBe(true);
-      await expect
-        .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
-        .toContain("Saved");
+        const configGetsBeforeLabsReset = (await gateway.getRequests("config.get")).length;
+        await gateway.deferNext("config.patch");
+        await codeModeRow.getByRole("button", { name: "Reset to default" }).click();
+        const labsPatch = requestRaw(await gateway.waitForRequest("config.patch"));
+        expect(labsPatch).toEqual({ tools: { codeMode: { enabled: null } } });
 
-      if (captureUiProofEnabled) {
-        await page
-          .locator(".security-page .settings-section")
-          .first()
-          .screenshot({
+        const afterLabsResponse = configResponse(afterLabsReset, "curated-defaults-2");
+        await gateway.setMethodResponse("config.get", afterLabsResponse);
+        await gateway.resolveDeferred("config.patch", afterLabsResponse);
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBe(configGetsBeforeLabsReset + 1);
+        await expectInherited(codeModeRow, "Enabled");
+        expect(await codeModeSwitch.getAttribute("aria-checked")).toBe("true");
+
+        if (captureUiProofEnabled) {
+          await codeModeRow.screenshot({
             animations: "disabled",
-            path: path.join(uiProofArtifactDir, "04-security-inherited-defaults.png"),
+            path: path.join(uiProofArtifactDir, "02-labs-inherited-default.png"),
           });
-      }
+        }
 
-      expect((await page.reload())?.status()).toBe(200);
-      await expectInherited(settingsRow(page, "Browser enabled"), "Enabled");
-      await expectInherited(settingsRow(page, "Tool profile"), "Full");
+        expect((await page.goto(`${suite.server.baseUrl}settings/security`))?.status()).toBe(200);
+        const browserRow = settingsRow(page, "Browser enabled");
+        const profileRow = settingsRow(page, "Tool profile");
+        await browserRow.getByRole("switch", { name: "Browser enabled", exact: true }).waitFor();
+        await expect.poll(() => browserRow.textContent()).toContain("Default: Enabled");
+        await expect.poll(() => profileRow.textContent()).toContain("Default: Full");
 
-      expect((await page.goto(`${server.baseUrl}settings/model-providers`))?.status()).toBe(200);
-      const thinkingRow = settingsRow(page, "Thinking");
-      const fastModeRow = settingsRow(page, "Fast mode");
-      await thinkingRow.getByRole("radio", { name: "High", exact: true }).waitFor();
-      expect(
-        await thinkingRow
-          .getByRole("radio", { name: "High", exact: true })
-          .getAttribute("aria-checked"),
-      ).toBe("true");
-      await expect.poll(() => thinkingRow.textContent()).toContain("Default: Model policy");
-      await expect.poll(() => fastModeRow.textContent()).toContain("Default: Model policy");
+        if (captureUiProofEnabled) {
+          await page
+            .locator(".security-page .settings-section")
+            .first()
+            .screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "03-security-explicit-overrides.png"),
+            });
+        }
 
-      if (captureUiProofEnabled) {
-        await page.locator("#settings-model-behavior").screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "05-models-explicit-overrides.png"),
-        });
-      }
+        const securitySavesBefore = (await gateway.getRequests("config.set")).length;
+        await browserRow.getByRole("button", { name: "Reset to default" }).click();
+        await profileRow.getByRole("button", { name: "Reset to default" }).click();
+        await expectInherited(browserRow, "Enabled");
+        await expectInherited(profileRow, "Full");
+        await expect
+          .poll(async () => {
+            const requests = await gateway.getRequests("config.set");
+            const latest = requests.at(-1);
+            if (requests.length <= securitySavesBefore || !latest) {
+              return false;
+            }
+            const raw = requestRaw(latest);
+            return (
+              !hasOwnPath(raw, ["browser", "enabled"]) && !hasOwnPath(raw, ["tools", "profile"])
+            );
+          })
+          .toBe(true);
+        await expect
+          .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
+          .toContain("Saved");
 
-      const modelSavesBefore = (await gateway.getRequests("config.set")).length;
-      await thinkingRow.getByRole("button", { name: "Reset to default" }).click();
-      await fastModeRow.getByRole("button", { name: "Reset to default" }).click();
-      await expectInherited(thinkingRow, "Model policy");
-      await expectInherited(fastModeRow, "Model policy");
-      await expect
-        .poll(async () => {
-          const requests = await gateway.getRequests("config.set");
-          const latest = requests.at(-1);
-          if (requests.length <= modelSavesBefore || !latest) {
-            return false;
-          }
-          const raw = requestRaw(latest);
-          return (
-            !hasOwnPath(raw, ["agents", "defaults", "thinkingDefault"]) &&
-            !hasOwnPath(raw, ["agents", "defaults", "fastModeDefault"])
-          );
-        })
-        .toBe(true);
-      await expect
-        .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
-        .toContain("Saved");
+        if (captureUiProofEnabled) {
+          await page
+            .locator(".security-page .settings-section")
+            .first()
+            .screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "04-security-inherited-defaults.png"),
+            });
+        }
 
-      if (captureUiProofEnabled) {
-        await page.locator("#settings-model-behavior").screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "06-models-inherited-defaults.png"),
-        });
-      }
+        expect((await page.reload())?.status()).toBe(200);
+        await expectInherited(settingsRow(page, "Browser enabled"), "Enabled");
+        await expectInherited(settingsRow(page, "Tool profile"), "Full");
 
-      expect((await page.reload())?.status()).toBe(200);
-      const reloadedThinkingRow = settingsRow(page, "Thinking");
-      const reloadedFastModeRow = settingsRow(page, "Fast mode");
-      await expectInherited(reloadedThinkingRow, "Model policy");
-      await expectInherited(reloadedFastModeRow, "Model policy");
-      expect(
-        await reloadedThinkingRow
-          .getByRole("radio", { name: "Default", exact: true })
-          .getAttribute("aria-checked"),
-      ).toBe("true");
-      expect(
-        await reloadedFastModeRow
-          .getByRole("radio", { name: "Default", exact: true })
-          .getAttribute("aria-checked"),
-      ).toBe("true");
+        expect((await page.goto(`${suite.server.baseUrl}settings/model-providers`))?.status()).toBe(
+          200,
+        );
+        const thinkingRow = settingsRow(page, "Thinking");
+        const fastModeRow = settingsRow(page, "Fast mode");
+        await thinkingRow.getByRole("radio", { name: "High", exact: true }).waitFor();
+        expect(
+          await thinkingRow
+            .getByRole("radio", { name: "High", exact: true })
+            .getAttribute("aria-checked"),
+        ).toBe("true");
+        await expect.poll(() => thinkingRow.textContent()).toContain("Default: Model policy");
+        await expect.poll(() => fastModeRow.textContent()).toContain("Default: Model policy");
 
-      expect((await page.goto(`${server.baseUrl}settings/labs`))?.status()).toBe(200);
-      const reloadedCodeModeRow = settingsRow(page, "Code Mode");
-      await expectInherited(reloadedCodeModeRow, "Enabled");
-      expect(
-        await reloadedCodeModeRow
-          .getByRole("switch", { name: "Code Mode", exact: true })
-          .getAttribute("aria-checked"),
-      ).toBe("true");
+        if (captureUiProofEnabled) {
+          await page.locator("#settings-model-behavior").screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "05-models-explicit-overrides.png"),
+          });
+        }
 
-      if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(uiProofArtifactDir, "07-reload-inherited-defaults.png"),
-        });
-      }
-    } finally {
-      await context.close();
-    }
+        const modelSavesBefore = (await gateway.getRequests("config.set")).length;
+        await thinkingRow.getByRole("button", { name: "Reset to default" }).click();
+        await fastModeRow.getByRole("button", { name: "Reset to default" }).click();
+        await expectInherited(thinkingRow, "Model policy");
+        await expectInherited(fastModeRow, "Model policy");
+        await expect
+          .poll(async () => {
+            const requests = await gateway.getRequests("config.set");
+            const latest = requests.at(-1);
+            if (requests.length <= modelSavesBefore || !latest) {
+              return false;
+            }
+            const raw = requestRaw(latest);
+            return (
+              !hasOwnPath(raw, ["agents", "defaults", "thinkingDefault"]) &&
+              !hasOwnPath(raw, ["agents", "defaults", "fastModeDefault"])
+            );
+          })
+          .toBe(true);
+        await expect
+          .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
+          .toContain("Saved");
+
+        if (captureUiProofEnabled) {
+          await page.locator("#settings-model-behavior").screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "06-models-inherited-defaults.png"),
+          });
+        }
+
+        expect((await page.reload())?.status()).toBe(200);
+        const reloadedThinkingRow = settingsRow(page, "Thinking");
+        const reloadedFastModeRow = settingsRow(page, "Fast mode");
+        await expectInherited(reloadedThinkingRow, "Model policy");
+        await expectInherited(reloadedFastModeRow, "Model policy");
+        expect(
+          await reloadedThinkingRow
+            .getByRole("radio", { name: "Default", exact: true })
+            .getAttribute("aria-checked"),
+        ).toBe("true");
+        expect(
+          await reloadedFastModeRow
+            .getByRole("radio", { name: "Default", exact: true })
+            .getAttribute("aria-checked"),
+        ).toBe("true");
+
+        expect((await page.goto(`${suite.server.baseUrl}settings/labs`))?.status()).toBe(200);
+        const reloadedCodeModeRow = settingsRow(page, "Code Mode");
+        await expectInherited(reloadedCodeModeRow, "Enabled");
+        expect(
+          await reloadedCodeModeRow
+            .getByRole("switch", { name: "Code Mode", exact: true })
+            .getAttribute("aria-checked"),
+        ).toBe("true");
+
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "07-reload-inherited-defaults.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -1,20 +1,17 @@
 // Control UI tests cover event-reactive custodian presence against a mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI custodian event nudge mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -22,9 +19,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "custodian-event-nudge",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 async function settleUi(page: Page): Promise<void> {
   await page.evaluate(
@@ -35,427 +29,410 @@ async function settleUi(page: Page): Promise<void> {
   );
 }
 
-describeControlUiE2e("Control UI custodian event nudge mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("shows one consequential nudge and sends its canonical message", async () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-      ...(captureUiProofEnabled
-        ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } } }
-        : {}),
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-      methodResponses: {
-        "openclaw.chat": {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(captureUiProofEnabled
+          ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+          methodResponses: {
+            "openclaw.chat": {
+              sessionId: "e2e-custodian",
+              reply: "I'm watching the system.",
+              action: "none",
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}custodian`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
+        await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(1);
+
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "01-before-event.png"),
+          });
+        }
+
+        await gateway.emitGatewayEvent("config.changed", {
+          hash: "config-hash",
+          path: "/tmp/openclaw.json",
+          ts: Date.now(),
+        });
+        await settleUi(page);
+        expect(await page.locator(".custodian__nudge").count()).toBe(0);
+
+        await gateway.emitGatewayEvent("health", {
+          channelLabels: { telegram: "Telegram" },
+          channels: {
+            telegram: { configured: true, connected: false, running: true },
+          },
+        });
+
+        const nudge = page.getByRole("button", {
+          name: "Telegram just disconnected — ask me what happened",
+        });
+        await nudge.waitFor();
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "02-disconnected-nudge.png"),
+          });
+        }
+
+        await gateway.deferNext("openclaw.chat");
+        await nudge.click();
+        await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
+        const requests = await gateway.getRequests("openclaw.chat");
+        expect(requests[1]?.params).toMatchObject({
+          message: "what happened with telegram?",
+          sessionId: "e2e-custodian",
+        });
+        await page
+          .locator(".chat-group.user", { hasText: "what happened with telegram?" })
+          .waitFor();
+        await gateway.resolveDeferred("openclaw.chat", {
           sessionId: "e2e-custodian",
           reply: "I'm watching the system.",
           action: "none",
-        },
+        });
+        await expect.poll(() => page.locator(".chat-group.assistant").count()).toBe(2);
+        expect(await nudge.count()).toBe(0);
+
+        await gateway.emitGatewayEvent("health", {
+          configReload: { hotReloadStatus: "disabled" },
+        });
+        await settleUi(page);
+        expect(await page.locator(".custodian__nudge").count()).toBe(0);
+
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "03-message-sent.png"),
+          });
+        }
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}custodian`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
-      await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(1);
-
-      if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "01-before-event.png"),
-        });
-      }
-
-      await gateway.emitGatewayEvent("config.changed", {
-        hash: "config-hash",
-        path: "/tmp/openclaw.json",
-        ts: Date.now(),
-      });
-      await settleUi(page);
-      expect(await page.locator(".custodian__nudge").count()).toBe(0);
-
-      await gateway.emitGatewayEvent("health", {
-        channelLabels: { telegram: "Telegram" },
-        channels: {
-          telegram: { configured: true, connected: false, running: true },
-        },
-      });
-
-      const nudge = page.getByRole("button", {
-        name: "Telegram just disconnected — ask me what happened",
-      });
-      await nudge.waitFor();
-      if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "02-disconnected-nudge.png"),
-        });
-      }
-
-      await gateway.deferNext("openclaw.chat");
-      await nudge.click();
-      await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
-      const requests = await gateway.getRequests("openclaw.chat");
-      expect(requests[1]?.params).toMatchObject({
-        message: "what happened with telegram?",
-        sessionId: "e2e-custodian",
-      });
-      await page.locator(".chat-group.user", { hasText: "what happened with telegram?" }).waitFor();
-      await gateway.resolveDeferred("openclaw.chat", {
-        sessionId: "e2e-custodian",
-        reply: "I'm watching the system.",
-        action: "none",
-      });
-      await expect.poll(() => page.locator(".chat-group.assistant").count()).toBe(2);
-      expect(await nudge.count()).toBe(0);
-
-      await gateway.emitGatewayEvent("health", {
-        configReload: { hotReloadStatus: "disabled" },
-      });
-      await settleUi(page);
-      expect(await page.locator(".custodian__nudge").count()).toBe(0);
-
-      if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "03-message-sent.png"),
-        });
-      }
-    } finally {
-      await context.close();
-    }
+    );
   });
 
   it("keeps a blocking startup error next to the composer", async () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1200, width: 1600 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["openclaw.chat"],
-      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}custodian`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("openclaw.chat");
-      await gateway.rejectDeferred("openclaw.chat", {
-        code: "UNAVAILABLE",
-        message:
-          "OpenClaw requires working inference: No agent model is configured. Run `openclaw onboard` first.",
-        retryable: true,
-      });
-
-      const alert = page.getByRole("alert");
-      await alert.waitFor();
-      const composer = page.locator(".agent-chat__composer-shell");
-      const [alertBox, composerBox] = await Promise.all([
-        alert.boundingBox(),
-        composer.boundingBox(),
-      ]);
-      expect(alertBox).not.toBeNull();
-      expect(composerBox).not.toBeNull();
-
-      if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "04-inference-error.png"),
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1200, width: 1600 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["openclaw.chat"],
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
         });
-      }
 
-      const verticalGap = composerBox!.y - (alertBox!.y + alertBox!.height);
-      expect(verticalGap).toBeLessThanOrEqual(32);
-    } finally {
-      await context.close();
-    }
+        const response = await page.goto(`${suite.server.baseUrl}custodian`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("openclaw.chat");
+        await gateway.rejectDeferred("openclaw.chat", {
+          code: "UNAVAILABLE",
+          message:
+            "OpenClaw requires working inference: No agent model is configured. Run `openclaw onboard` first.",
+          retryable: true,
+        });
+
+        const alert = page.getByRole("alert");
+        await alert.waitFor();
+        const composer = page.locator(".agent-chat__composer-shell");
+        const [alertBox, composerBox] = await Promise.all([
+          alert.boundingBox(),
+          composer.boundingBox(),
+        ]);
+        expect(alertBox).not.toBeNull();
+        expect(composerBox).not.toBeNull();
+
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "04-inference-error.png"),
+          });
+        }
+
+        const verticalGap = composerBox!.y - (alertBox!.y + alertBox!.height);
+        expect(verticalGap).toBeLessThanOrEqual(32);
+      },
+    );
   });
 
   it("keeps event nudges out of sensitive wizard input", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-      methodResponses: {
-        "openclaw.chat": {
-          sessionId: "e2e-sensitive-custodian",
-          reply: "Paste your API key.",
-          action: "none",
-          sensitive: true,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+          methodResponses: {
+            "openclaw.chat": {
+              sessionId: "e2e-sensitive-custodian",
+              reply: "Paste your API key.",
+              action: "none",
+              sensitive: true,
+            },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}custodian`);
-      await page.getByPlaceholder("Enter sensitive value").waitFor();
-      await gateway.emitGatewayEvent("health", {
-        channelLabels: { discord: "Discord" },
-        channels: { discord: { configured: true, connected: false, running: true } },
-      });
+        await page.goto(`${suite.server.baseUrl}custodian`);
+        await page.getByPlaceholder("Enter sensitive value").waitFor();
+        await gateway.emitGatewayEvent("health", {
+          channelLabels: { discord: "Discord" },
+          channels: { discord: { configured: true, connected: false, running: true } },
+        });
 
-      const nudge = page.getByRole("button", {
-        name: "Discord just disconnected — ask me what happened",
-      });
-      await nudge.waitFor();
-      await expect.poll(() => nudge.isDisabled()).toBe(true);
-      await nudge.evaluate((element) => (element as HTMLButtonElement).click());
-      await settleUi(page);
+        const nudge = page.getByRole("button", {
+          name: "Discord just disconnected — ask me what happened",
+        });
+        await nudge.waitFor();
+        await expect.poll(() => nudge.isDisabled()).toBe(true);
+        await nudge.evaluate((element) => (element as HTMLButtonElement).click());
+        await settleUi(page);
 
-      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
-      expect(await page.getByText("what happened with discord?").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
+        expect(await page.getByText("what happened with discord?").count()).toBe(0);
+      },
+    );
   });
 
   it("keeps nudges out of a closed question and sends a parseable skip answer", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-      methodResponses: {
-        "openclaw.chat": {
-          sessionId: "e2e-wizard-custodian",
-          reply: "Choose one.",
-          action: "none",
-          question: {
-            id: "access",
-            header: "Access",
-            question: "How should OpenClaw work?",
-            options: [{ label: "Full access" }, { label: "Ask first" }],
-            isOther: false,
-          },
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+          methodResponses: {
+            "openclaw.chat": {
+              sessionId: "e2e-wizard-custodian",
+              reply: "Choose one.",
+              action: "none",
+              question: {
+                id: "access",
+                header: "Access",
+                question: "How should OpenClaw work?",
+                options: [{ label: "Full access" }, { label: "Ask first" }],
+                isOther: false,
+              },
+            },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}custodian`);
-      const skip = page.getByRole("button", { name: "Skip for now" });
-      await skip.waitFor();
-      await gateway.emitGatewayEvent("health", {
-        channelLabels: { discord: "Discord" },
-        channels: { discord: { configured: true, connected: false, running: true } },
-      });
-      const nudge = page.getByRole("button", {
-        name: "Discord just disconnected — ask me what happened",
-      });
-      await nudge.waitFor();
-      await expect.poll(() => nudge.isDisabled()).toBe(true);
-      await nudge.evaluate((element) => (element as HTMLButtonElement).click());
-      await settleUi(page);
-      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
+        await page.goto(`${suite.server.baseUrl}custodian`);
+        const skip = page.getByRole("button", { name: "Skip for now" });
+        await skip.waitFor();
+        await gateway.emitGatewayEvent("health", {
+          channelLabels: { discord: "Discord" },
+          channels: { discord: { configured: true, connected: false, running: true } },
+        });
+        const nudge = page.getByRole("button", {
+          name: "Discord just disconnected — ask me what happened",
+        });
+        await nudge.waitFor();
+        await expect.poll(() => nudge.isDisabled()).toBe(true);
+        await nudge.evaluate((element) => (element as HTMLButtonElement).click());
+        await settleUi(page);
+        expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
 
-      await gateway.setMethodResponse("openclaw.chat", {
-        sessionId: "e2e-wizard-custodian",
-        reply: "Moving on.",
-        action: "none",
-      });
-      await skip.click();
+        await gateway.setMethodResponse("openclaw.chat", {
+          sessionId: "e2e-wizard-custodian",
+          reply: "Moving on.",
+          action: "none",
+        });
+        await skip.click();
 
-      await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
-      const requests = await gateway.getRequests("openclaw.chat");
-      expect(requests[1]?.params).toMatchObject({
-        message: "cancel",
-        sessionId: "e2e-wizard-custodian",
-      });
-      await page.locator(".chat-group.user", { hasText: "Skip for now" }).waitFor();
-      await page.getByText("Moving on.").waitFor();
-      expect(await page.locator("openclaw-option-card").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
+        const requests = await gateway.getRequests("openclaw.chat");
+        expect(requests[1]?.params).toMatchObject({
+          message: "cancel",
+          sessionId: "e2e-wizard-custodian",
+        });
+        await page.locator(".chat-group.user", { hasText: "Skip for now" }).waitFor();
+        await page.getByText("Moving on.").waitFor();
+        expect(await page.locator("openclaw-option-card").count()).toBe(0);
+      },
+    );
   });
 
   it("renders rich wizard controls and sends typed answers", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-      methodResponses: {
-        "openclaw.chat": {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+          methodResponses: {
+            "openclaw.chat": {
+              sessionId: "e2e-rich-wizard",
+              reply: "Choose a channel.",
+              action: "none",
+              wizardInputPending: true,
+              step: {
+                id: "channel",
+                type: "select",
+                message: "Which channel?",
+                options: ["Discord", "Slack", "Telegram", "WhatsApp", "Twitch"].map((label) => ({
+                  label,
+                  value: label.toLowerCase(),
+                })),
+              },
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}custodian`);
+        await page.getByLabel("Twitch").waitFor();
+        expect(await page.locator("openclaw-option-card").count()).toBe(0);
+        expect(await page.locator(".agent-chat__composer-shell").count()).toBe(0);
+
+        await gateway.setMethodResponse("openclaw.chat", {
           sessionId: "e2e-rich-wizard",
-          reply: "Choose a channel.",
+          reply: "Choose features.",
           action: "none",
           wizardInputPending: true,
           step: {
-            id: "channel",
-            type: "select",
-            message: "Which channel?",
-            options: ["Discord", "Slack", "Telegram", "WhatsApp", "Twitch"].map((label) => ({
-              label,
-              value: label.toLowerCase(),
-            })),
+            id: "features",
+            type: "multiselect",
+            message: "Which features?",
+            options: [
+              { label: "Chat", value: "chat" },
+              { label: "Moderation", value: "moderation" },
+              { label: "Announcements", value: "announcements" },
+            ],
           },
-        },
-      },
-    });
+        });
+        await page.getByLabel("Twitch").check();
+        await page.getByRole("button", { name: "Continue" }).click();
+        await page.getByLabel("Announcements").waitFor();
 
-    try {
-      await page.goto(`${server.baseUrl}custodian`);
-      await page.getByLabel("Twitch").waitFor();
-      expect(await page.locator("openclaw-option-card").count()).toBe(0);
-      expect(await page.locator(".agent-chat__composer-shell").count()).toBe(0);
-
-      await gateway.setMethodResponse("openclaw.chat", {
-        sessionId: "e2e-rich-wizard",
-        reply: "Choose features.",
-        action: "none",
-        wizardInputPending: true,
-        step: {
-          id: "features",
-          type: "multiselect",
-          message: "Which features?",
-          options: [
-            { label: "Chat", value: "chat" },
-            { label: "Moderation", value: "moderation" },
-            { label: "Announcements", value: "announcements" },
-          ],
-        },
-      });
-      await page.getByLabel("Twitch").check();
-      await page.getByRole("button", { name: "Continue" }).click();
-      await page.getByLabel("Announcements").waitFor();
-
-      await gateway.setMethodResponse("openclaw.chat", {
-        sessionId: "e2e-rich-wizard",
-        reply: "Enter the secret.",
-        action: "none",
-        sensitive: true,
-        wizardInputPending: true,
-        step: {
-          id: "secret",
-          type: "text",
-          message: "Twitch client secret",
+        await gateway.setMethodResponse("openclaw.chat", {
+          sessionId: "e2e-rich-wizard",
+          reply: "Enter the secret.",
+          action: "none",
           sensitive: true,
-        },
-      });
-      await page.getByLabel("Chat").check();
-      await page.getByLabel("Announcements").check();
-      await page.getByRole("button", { name: "Continue" }).click();
-      const secretInput = page.getByRole("textbox", {
-        name: "Twitch client secret",
-      });
-      await secretInput.waitFor();
-      expect(await secretInput.getAttribute("type")).toBe("password");
-      await page.getByRole("button", { name: "Reveal value" }).click();
-      expect(await secretInput.getAttribute("type")).toBe("text");
-      await page.getByRole("button", { name: "Hide value" }).click();
-      expect(await secretInput.getAttribute("type")).toBe("password");
+          wizardInputPending: true,
+          step: {
+            id: "secret",
+            type: "text",
+            message: "Twitch client secret",
+            sensitive: true,
+          },
+        });
+        await page.getByLabel("Chat").check();
+        await page.getByLabel("Announcements").check();
+        await page.getByRole("button", { name: "Continue" }).click();
+        const secretInput = page.getByRole("textbox", {
+          name: "Twitch client secret",
+        });
+        await secretInput.waitFor();
+        expect(await secretInput.getAttribute("type")).toBe("password");
+        await page.getByRole("button", { name: "Reveal value" }).click();
+        expect(await secretInput.getAttribute("type")).toBe("text");
+        await page.getByRole("button", { name: "Hide value" }).click();
+        expect(await secretInput.getAttribute("type")).toBe("password");
 
-      await gateway.setMethodResponse("openclaw.chat", {
-        sessionId: "e2e-rich-wizard",
-        reply: "Setup complete.",
-        action: "none",
-      });
-      await secretInput.fill("fake-client-secret");
-      await page.getByRole("button", { name: "Submit" }).click();
-      await page.getByText("Setup complete.").waitFor();
+        await gateway.setMethodResponse("openclaw.chat", {
+          sessionId: "e2e-rich-wizard",
+          reply: "Setup complete.",
+          action: "none",
+        });
+        await secretInput.fill("fake-client-secret");
+        await page.getByRole("button", { name: "Submit" }).click();
+        await page.getByText("Setup complete.").waitFor();
 
-      const requests = await gateway.getRequests("openclaw.chat");
-      expect(requests.map((request) => request.params)).toEqual([
-        expect.objectContaining({ sessionId: expect.any(String) }),
-        expect.objectContaining({
-          wizardAnswer: { stepId: "channel", value: "twitch" },
-        }),
-        expect.objectContaining({
-          wizardAnswer: { stepId: "features", value: ["chat", "announcements"] },
-        }),
-        expect.objectContaining({
-          wizardAnswer: { stepId: "secret", value: "fake-client-secret" },
-        }),
-      ]);
-      expect(
-        requests
-          .slice(1)
-          .every(
-            (request) =>
-              typeof request.params === "object" &&
-              request.params !== null &&
-              !Object.hasOwn(request.params, "message"),
-          ),
-      ).toBe(true);
-      expect(await page.getByText("Sensitive reply sent").count()).toBe(1);
-      expect(await page.getByText("fake-client-secret").count()).toBe(0);
-      expect(await page.locator(".agent-chat__composer-shell").count()).toBe(1);
-    } finally {
-      await context.close();
-    }
+        const requests = await gateway.getRequests("openclaw.chat");
+        expect(requests.map((request) => request.params)).toEqual([
+          expect.objectContaining({ sessionId: expect.any(String) }),
+          expect.objectContaining({
+            wizardAnswer: { stepId: "channel", value: "twitch" },
+          }),
+          expect.objectContaining({
+            wizardAnswer: { stepId: "features", value: ["chat", "announcements"] },
+          }),
+          expect.objectContaining({
+            wizardAnswer: { stepId: "secret", value: "fake-client-secret" },
+          }),
+        ]);
+        expect(
+          requests
+            .slice(1)
+            .every(
+              (request) =>
+                typeof request.params === "object" &&
+                request.params !== null &&
+                !Object.hasOwn(request.params, "message"),
+            ),
+        ).toBe(true);
+        expect(await page.getByText("Sensitive reply sent").count()).toBe(1);
+        expect(await page.getByText("fake-client-secret").count()).toBe(0);
+        expect(await page.locator(".agent-chat__composer-shell").count()).toBe(1);
+      },
+    );
   });
 
   it("stays silent during onboarding", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-      methodResponses: {
-        "openclaw.chat": {
-          sessionId: "e2e-onboarding-custodian",
-          reply: "Let's finish setup.",
-          action: "none",
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+          methodResponses: {
+            "openclaw.chat": {
+              sessionId: "e2e-onboarding-custodian",
+              reply: "Let's finish setup.",
+              action: "none",
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}custodian?onboarding=1`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
-      await gateway.emitGatewayEvent("health", {
-        channelLabels: { telegram: "Telegram" },
-        channels: {
-          telegram: { configured: true, connected: false, running: true },
-        },
-      });
-      await settleUi(page);
-      expect(await page.locator(".custodian__nudge").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        const response = await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
+        await gateway.emitGatewayEvent("health", {
+          channelLabels: { telegram: "Telegram" },
+          channels: {
+            telegram: { configured: true, connected: false, running: true },
+          },
+        });
+        await settleUi(page);
+        expect(await page.locator(".custodian__nudge").count()).toBe(0);
+      },
+    );
   });
 });

--- a/ui/src/e2e/debug-diagnostics.e2e.test.ts
+++ b/ui/src/e2e/debug-diagnostics.e2e.test.ts
@@ -1,112 +1,94 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Debug diagnostics mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-debug-diagnostics");
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI Debug diagnostics mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders status, health, heartbeat, and model snapshots from the Gateway", async () => {
     if (captureUiProof) {
       await mkdir(path.join(proofDir, "video"), { recursive: true });
     }
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1280 },
-      ...(captureUiProof
-        ? {
-            recordVideo: { dir: path.join(proofDir, "video"), size: { height: 1000, width: 1280 } },
-          }
-        : {}),
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        status: {
-          runtime: "diagnostics-e2e",
-          securityAudit: { summary: { critical: 0, warn: 1, info: 2 } },
-        },
-        health: { ok: true, gateway: "healthy" },
-        "models.list": {
-          models: [
-            {
-              available: true,
-              id: "gpt-5.6-luna",
-              name: "GPT-5.6 Luna",
-              provider: "openai",
-            },
-          ],
-        },
-        "last-heartbeat": { ageMs: 1250, source: "gateway-heartbeat" },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1280 },
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: path.join(proofDir, "video"),
+                size: { height: 1000, width: 1280 },
+              },
+            }
+          : {}),
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}debug`);
-      expect(response?.status()).toBe(200);
-      await page.locator(".page-title", { hasText: "Debug" }).waitFor();
-      const snapshots = page.locator(".settings-section", {
-        has: page.getByRole("heading", { name: "Snapshots" }),
-      });
-      await snapshots.waitFor();
-      await expect.poll(() => snapshots.textContent()).toContain("1 warning");
-      await expect.poll(() => snapshots.textContent()).toContain("diagnostics-e2e");
-      await expect.poll(() => snapshots.textContent()).toContain("healthy");
-      await expect.poll(() => snapshots.textContent()).toContain("gateway-heartbeat");
-      const models = page.locator(".settings-section", {
-        has: page.getByRole("heading", { name: "Models" }),
-      });
-      await expect.poll(() => models.textContent()).toContain("gpt-5.6-luna");
-
-      for (const method of ["status", "health", "models.list", "last-heartbeat"]) {
-        const requests = await gateway.getRequests(method);
-        expect(requests.length).toBeGreaterThanOrEqual(1);
-        expect(requests[0]?.params).toEqual({});
-      }
-
-      if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(proofDir, "diagnostic-snapshots.png"),
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            status: {
+              runtime: "diagnostics-e2e",
+              securityAudit: { summary: { critical: 0, warn: 1, info: 2 } },
+            },
+            health: { ok: true, gateway: "healthy" },
+            "models.list": {
+              models: [
+                {
+                  available: true,
+                  id: "gpt-5.6-luna",
+                  name: "GPT-5.6 Luna",
+                  provider: "openai",
+                },
+              ],
+            },
+            "last-heartbeat": { ageMs: 1250, source: "gateway-heartbeat" },
+          },
         });
-        await models.scrollIntoViewIfNeeded();
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(proofDir, "models-snapshot.png"),
+
+        const response = await page.goto(`${suite.server.baseUrl}debug`);
+        expect(response?.status()).toBe(200);
+        await page.locator(".page-title", { hasText: "Debug" }).waitFor();
+        const snapshots = page.locator(".settings-section", {
+          has: page.getByRole("heading", { name: "Snapshots" }),
         });
-      }
-    } finally {
-      await context.close();
-    }
+        await snapshots.waitFor();
+        await expect.poll(() => snapshots.textContent()).toContain("1 warning");
+        await expect.poll(() => snapshots.textContent()).toContain("diagnostics-e2e");
+        await expect.poll(() => snapshots.textContent()).toContain("healthy");
+        await expect.poll(() => snapshots.textContent()).toContain("gateway-heartbeat");
+        const models = page.locator(".settings-section", {
+          has: page.getByRole("heading", { name: "Models" }),
+        });
+        await expect.poll(() => models.textContent()).toContain("gpt-5.6-luna");
+
+        for (const method of ["status", "health", "models.list", "last-heartbeat"]) {
+          const requests = await gateway.getRequests(method);
+          expect(requests.length).toBeGreaterThanOrEqual(1);
+          expect(requests[0]?.params).toEqual({});
+        }
+
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDir, "diagnostic-snapshots.png"),
+          });
+          await models.scrollIntoViewIfNeeded();
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "models-snapshot.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/dynamic-route-loader-count.e2e.test.ts
+++ b/ui/src/e2e/dynamic-route-loader-count.e2e.test.ts
@@ -1,22 +1,13 @@
 // Control UI E2E tests prove dynamic startup routes do not reload their Gateway data.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  waitForControlUiRoute,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI dynamic route startup loaders",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 async function activeRouteFetchCount(page: import("playwright").Page): Promise<number | null> {
   return page.evaluate(() => {
@@ -31,44 +22,22 @@ async function activeRouteFetchCount(page: import("playwright").Page): Promise<n
   });
 }
 
-describeControlUiE2e("Control UI dynamic route startup loaders", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("loads the Plugins Discover deep link once and preserves it through reconnect", async () => {
-    const context = await browser.newContext({ viewport: { height: 900, width: 1440 } });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["plugins.list"],
-      methodResponses: {
-        "plugins.list": {
-          diagnostics: [],
-          mutationAllowed: true,
-          plugins: [],
+    await suite.withPage({ viewport: { height: 900, width: 1440 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["plugins.list"],
+        methodResponses: {
+          "plugins.list": {
+            diagnostics: [],
+            mutationAllowed: true,
+            plugins: [],
+          },
         },
-      },
-    });
-    const pathname = "/settings/plugins/discover";
+      });
+      const pathname = "/settings/plugins/discover";
 
-    try {
-      const response = await page.goto(`${server.baseUrl}${pathname.slice(1)}`);
+      const response = await page.goto(`${suite.server.baseUrl}${pathname.slice(1)}`);
       expect(response?.status()).toBe(200);
       await waitForControlUiRoute(page, { pathname, routeId: "plugins" });
       expect(await activeRouteFetchCount(page)).toBe(1);
@@ -78,8 +47,6 @@ describeControlUiE2e("Control UI dynamic route startup loaders", () => {
       await expect.poll(() => gateway.getSocketCount(), { timeout: 10_000 }).toBe(socketCount + 1);
       await waitForControlUiRoute(page, { pathname, routeId: "plugins" });
       expect(await activeRouteFetchCount(page)).toBe(1);
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -1,39 +1,18 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const available = canRunPlaywrightChromium(executablePath);
-const allowMissing = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const suite = available || !allowMissing ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "OpenCode and Pi external session catalogs",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-suite("OpenCode and Pi external session catalogs", () => {
-  beforeAll(async () => {
-    if (!available) {
-      throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("shows both paired-node catalogs and opens their view-only transcripts", async () => {
-    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    const page = await suite.browser.newPage({ viewport: { width: 1440, height: 900 } });
     const gateway = await installMockGateway(page, {
       featureMethods: [
         "chat.metadata",
@@ -115,7 +94,7 @@ suite("OpenCode and Pi external session catalogs", () => {
       },
     });
 
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     await expect
       .poll(() =>
         page
@@ -129,7 +108,7 @@ suite("OpenCode and Pi external session catalogs", () => {
       )
       .toBe(1);
     const piIconResponse = await page.request.get(
-      new URL("provider-icons/ProviderIcon-pi.svg", server.baseUrl).toString(),
+      new URL("provider-icons/ProviderIcon-pi.svg", suite.server.baseUrl).toString(),
     );
     expect(piIconResponse.ok()).toBe(true);
 

--- a/ui/src/e2e/file-drop-guard.e2e.test.ts
+++ b/ui/src/e2e/file-drop-guard.e2e.test.ts
@@ -1,153 +1,126 @@
 // Control UI tests cover browser-level file-drop routing against a mocked Gateway.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI file-drop guard",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed at ${executablePath}`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI file-drop guard", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not installed at ${chromiumExecutablePath}`);
-    }
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("rejects a stray file drop while preserving attachment inputs", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page);
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
-      const composer = page.locator(".agent-chat__composer-combobox textarea");
-      await composer.waitFor({ state: "visible", timeout: 10_000 });
-      await composer.fill("draft survives stray drop");
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor({ state: "visible", timeout: 10_000 });
+        await composer.fill("draft survives stray drop");
 
-      const stray = await page.locator("openclaw-app-shell").evaluate((element) => {
-        const transfer = new DataTransfer();
-        transfer.items.add(new File(["stray"], "stray-proof.txt", { type: "text/plain" }));
-        const beforeUrl = location.href;
-        const beforeDraft = document.querySelector<HTMLTextAreaElement>(
-          ".agent-chat__composer-combobox textarea",
-        )?.value;
-        const dragOver = new DragEvent("dragover", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer: transfer,
+        const stray = await page.locator("openclaw-app-shell").evaluate((element) => {
+          const transfer = new DataTransfer();
+          transfer.items.add(new File(["stray"], "stray-proof.txt", { type: "text/plain" }));
+          const beforeUrl = location.href;
+          const beforeDraft = document.querySelector<HTMLTextAreaElement>(
+            ".agent-chat__composer-combobox textarea",
+          )?.value;
+          const dragOver = new DragEvent("dragover", {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: transfer,
+          });
+          const drop = new DragEvent("drop", {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: transfer,
+          });
+          element.dispatchEvent(dragOver);
+          element.dispatchEvent(drop);
+          return {
+            draftUnchanged:
+              document.querySelector<HTMLTextAreaElement>(".agent-chat__composer-combobox textarea")
+                ?.value === beforeDraft,
+            dragOverPrevented: dragOver.defaultPrevented,
+            dropEffect: transfer.dropEffect,
+            dropPrevented: drop.defaultPrevented,
+            urlUnchanged: location.href === beforeUrl,
+          };
         });
-        const drop = new DragEvent("drop", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer: transfer,
+
+        expect(stray).toEqual({
+          draftUnchanged: true,
+          dragOverPrevented: true,
+          dropEffect: "none",
+          dropPrevented: true,
+          urlUnchanged: true,
         });
-        element.dispatchEvent(dragOver);
-        element.dispatchEvent(drop);
-        return {
-          draftUnchanged:
-            document.querySelector<HTMLTextAreaElement>(".agent-chat__composer-combobox textarea")
-              ?.value === beforeDraft,
-          dragOverPrevented: dragOver.defaultPrevented,
-          dropEffect: transfer.dropEffect,
-          dropPrevented: drop.defaultPrevented,
-          urlUnchanged: location.href === beforeUrl,
-        };
-      });
 
-      expect(stray).toEqual({
-        draftUnchanged: true,
-        dragOverPrevented: true,
-        dropEffect: "none",
-        dropPrevented: true,
-        urlUnchanged: true,
-      });
+        const accepted = await page.locator("section.card.chat").evaluate((element) => {
+          const transfer = new DataTransfer();
+          transfer.items.add(
+            new File(["accepted drop"], "accepted-drop.txt", { type: "text/plain" }),
+          );
+          const dragOver = new DragEvent("dragover", {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: transfer,
+          });
+          const drop = new DragEvent("drop", {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: transfer,
+          });
+          element.dispatchEvent(dragOver);
+          element.dispatchEvent(drop);
+          return {
+            dragOverPrevented: dragOver.defaultPrevented,
+            dropPrevented: drop.defaultPrevented,
+          };
+        });
 
-      const accepted = await page.locator("section.card.chat").evaluate((element) => {
-        const transfer = new DataTransfer();
-        transfer.items.add(
-          new File(["accepted drop"], "accepted-drop.txt", { type: "text/plain" }),
+        expect(accepted).toEqual({
+          dragOverPrevented: true,
+          dropPrevented: true,
+        });
+        await page
+          .locator(".chat-attachment-file__name", { hasText: "accepted-drop.txt" })
+          .first()
+          .waitFor({ timeout: 10_000 });
+        await expect
+          .poll(() =>
+            page.locator(".chat-attachment-file__name", { hasText: "stray-proof.txt" }).count(),
+          )
+          .toBe(0);
+
+        const nativeInput = page.locator(".agent-chat__file-input");
+        expect(await nativeInput.isEnabled()).toBe(true);
+        await nativeInput.setInputFiles({
+          name: "native-input.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from("native input"),
+        });
+        await page
+          .locator(".chat-attachment-file__name", { hasText: "native-input.txt" })
+          .first()
+          .waitFor({ timeout: 10_000 });
+
+        console.info(
+          `[file-drop-proof] ${JSON.stringify({
+            accepted,
+            nativeInputAccepted: true,
+            path: new URL(page.url()).pathname,
+            stray,
+          })}`,
         );
-        const dragOver = new DragEvent("dragover", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer: transfer,
-        });
-        const drop = new DragEvent("drop", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer: transfer,
-        });
-        element.dispatchEvent(dragOver);
-        element.dispatchEvent(drop);
-        return {
-          dragOverPrevented: dragOver.defaultPrevented,
-          dropPrevented: drop.defaultPrevented,
-        };
-      });
-
-      expect(accepted).toEqual({
-        dragOverPrevented: true,
-        dropPrevented: true,
-      });
-      await page
-        .locator(".chat-attachment-file__name", { hasText: "accepted-drop.txt" })
-        .first()
-        .waitFor({ timeout: 10_000 });
-      await expect
-        .poll(() =>
-          page.locator(".chat-attachment-file__name", { hasText: "stray-proof.txt" }).count(),
-        )
-        .toBe(0);
-
-      const nativeInput = page.locator(".agent-chat__file-input");
-      expect(await nativeInput.isEnabled()).toBe(true);
-      await nativeInput.setInputFiles({
-        name: "native-input.txt",
-        mimeType: "text/plain",
-        buffer: Buffer.from("native input"),
-      });
-      await page
-        .locator(".chat-attachment-file__name", { hasText: "native-input.txt" })
-        .first()
-        .waitFor({ timeout: 10_000 });
-
-      console.info(
-        `[file-drop-proof] ${JSON.stringify({
-          accepted,
-          nativeInputAccepted: true,
-          path: new URL(page.url()).pathname,
-          stray,
-        })}`,
-      );
-    } finally {
-      await context.close();
-    }
+      },
+    );
   });
 });

--- a/ui/src/e2e/lobster-pet.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet.e2e.test.ts
@@ -1,18 +1,14 @@
 // Control UI E2E tests cover real-browser lobster pet timing and pointer cancellation.
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { BrowserContext, Page } from "playwright";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI lobster pet",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium cannot start at ${executablePath}`,
+});
 
 type BrowserLobsterPet = HTMLElement & {
   mode: "idle" | "busy" | "offline";
@@ -21,11 +17,8 @@ type BrowserLobsterPet = HTMLElement & {
   updateComplete: Promise<unknown>;
 };
 
-let browser: Browser;
 let context: BrowserContext;
 let page: Page;
-let server: ControlUiE2eServer;
-
 async function mountPet(params: {
   mode: BrowserLobsterPet["mode"];
   outcome: BrowserLobsterPet["runOutcome"];
@@ -47,21 +40,13 @@ async function settlePet() {
   );
 }
 
-describeControlUiE2e("Control UI lobster pet", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium cannot start at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
+suite.define(() => {
   beforeEach(async () => {
-    context = await browser.newContext({ hasTouch: true });
+    context = await suite.browser.newContext({ hasTouch: true });
     page = await context.newPage();
     await page.clock.install({ time: new Date("2026-07-09T12:00:00") });
     await installMockGateway(page);
-    await page.goto(server.baseUrl);
+    await page.goto(suite.server.baseUrl);
     await page.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
     const loadedAt = await page.evaluate(() => Date.now());
     await page.clock.pauseAt(loadedAt + 1_000);
@@ -69,11 +54,6 @@ describeControlUiE2e("Control UI lobster pet", () => {
 
   afterEach(async () => {
     await context.close();
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
   });
 
   it("keeps a vigil-only failure present through droop and sweep before leaving", async () => {

--- a/ui/src/e2e/locale-offline-retry.e2e.test.ts
+++ b/ui/src/e2e/locale-offline-retry.e2e.test.ts
@@ -1,27 +1,26 @@
 // Control UI tests prove locale chunk recovery through a real browser reconnect.
-import { chromium, type Browser, type BrowserContext, type Page, type Route } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext, Page, Route } from "playwright";
+import { expect, it } from "vitest";
 import { SUPPORTED_LOCALES } from "../i18n/lib/registry.ts";
 import {
-  canRunPlaywrightChromium,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
-  type ControlUiE2eServer,
   type MockGatewayControls,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI offline locale retry",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const frenchLocaleModule = /\/src\/i18n\/locales\/fr\.ts(?:\?.*)?$/;
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
 async function createContext(): Promise<BrowserContext> {
-  return browser.newContext({
+  return suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1280 },
@@ -55,22 +54,7 @@ async function reconnect(page: Page, gateway: MockGatewayControls): Promise<void
   await expect.poll(() => gatewayPhase(page)).toBe("connected");
 }
 
-describeControlUiE2e("Control UI offline locale retry", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer(undefined, { source: true });
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("lazy-loads each registered locale only after the operator selects it", async () => {
     const context = await createContext();
     const page = await context.newPage();
@@ -84,7 +68,7 @@ describeControlUiE2e("Control UI offline locale retry", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}settings/appearance`);
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
       const picker = page.locator("#settings-language wa-select");
       await picker.waitFor();
       expect(requests.size).toBe(0);
@@ -116,7 +100,7 @@ describeControlUiE2e("Control UI offline locale retry", () => {
     let navigationCount = 0;
 
     try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
       expect(response?.status()).toBe(200);
       page.on("framenavigated", (frame) => {
         if (frame === page.mainFrame()) {

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -1,25 +1,19 @@
 // Control UI tests cover the responsive disconnected login gate.
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI responsive login gate E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 async function renderLoginGate(page: Page): Promise<void> {
-  const response = await page.goto(server.baseUrl);
+  const response = await page.goto(suite.server.baseUrl);
   expect(response?.status()).toBe(200);
 
   await mountLoginGate(page);
@@ -64,30 +58,15 @@ async function closeContext(context: BrowserContext): Promise<void> {
   await context.close().catch(() => {});
 }
 
-describeControlUiE2e("Control UI responsive login gate E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("shows a protocol mismatch without reconnecting", async () => {
-    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
     await page.clock.install();
     const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
 
     try {
-      await page.goto(server.baseUrl);
+      await page.goto(suite.server.baseUrl);
       await gateway.waitForRequest("connect");
       await gateway.rejectDeferred("connect", {
         code: "INVALID_REQUEST",
@@ -108,7 +87,7 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
   });
 
   it("keeps mobile controls compact, touchable, and keyboard-friendly", async () => {
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       hasTouch: true,
       isMobile: true,
       viewport: { height: 500, width: 375 },
@@ -183,7 +162,7 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
   });
 
   it("keeps failure recovery visible while generic help stays collapsed", async () => {
-    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
 
     try {
@@ -204,7 +183,7 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
   });
 
   it("applies standalone safe-area insets exactly once", async () => {
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       hasTouch: true,
       isMobile: true,
       viewport: { height: 500, width: 375 },

--- a/ui/src/e2e/logs-autofollow.e2e.test.ts
+++ b/ui/src/e2e/logs-autofollow.e2e.test.ts
@@ -1,24 +1,18 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI logs auto-follow mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-live-log-tail");
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const logLines = Array.from({ length: 200 }, (_value, index) =>
   JSON.stringify({
@@ -35,124 +29,113 @@ const appendedLogLine = JSON.stringify({
   _meta: { logLevelName: "warn" },
 });
 
-describeControlUiE2e("Control UI logs auto-follow mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("returns to the newest line when auto-follow is re-enabled", async () => {
     if (captureUiProof) {
       await mkdir(path.join(proofDir, "video"), { recursive: true });
     }
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 800, width: 1_200 },
-      ...(captureUiProof
-        ? {
-            recordVideo: { dir: path.join(proofDir, "video"), size: { height: 800, width: 1_200 } },
-          }
-        : {}),
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(String(error)));
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "logs.tail": {
-          sequence: [
-            {
-              cursor: logLines.length,
-              file: "/tmp/openclaw.log",
-              lines: logLines,
-              reset: true,
-            },
-            {
-              cursor: logLines.length + 1,
-              file: "/tmp/openclaw.log",
-              lines: [appendedLogLine],
-              reset: false,
-            },
-            {
-              cursor: logLines.length + 1,
-              file: "/tmp/openclaw.log",
-              lines: [],
-              reset: false,
-            },
-          ],
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 800, width: 1_200 },
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: path.join(proofDir, "video"),
+                size: { height: 800, width: 1_200 },
+              },
+            }
+          : {}),
       },
-    });
-
-    try {
-      await page.goto(`${server.baseUrl}logs`);
-      await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
-      expect((await gateway.getRequests("logs.tail"))[0]?.params).toEqual({
-        limit: 500,
-        maxBytes: 250_000,
-      });
-      await expect
-        .poll(async () => (await gateway.getRequests("logs.tail")).length, { timeout: 5000 })
-        .toBeGreaterThanOrEqual(2);
-      expect((await gateway.getRequests("logs.tail"))[1]?.params).toEqual({
-        cursor: logLines.length,
-        limit: 500,
-        maxBytes: 250_000,
-      });
-      await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length + 1);
-      await page.locator(".log-row", { hasText: "log line 201" }).waitFor();
-
-      const stream = page.locator(".log-stream");
-      const autoFollow = page.locator("wa-switch.settings-toggle").filter({
-        hasText: "Auto-follow",
-      });
-      await expect
-        .poll(() => stream.evaluate((element) => element.scrollHeight - element.clientHeight))
-        .toBeGreaterThan(0);
-      await expect
-        .poll(() => autoFollow.evaluate((element) => Reflect.get(element, "checked")))
-        .toBe(true);
-      await autoFollow.click();
-      await expect
-        .poll(() => autoFollow.evaluate((element) => Reflect.get(element, "checked")))
-        .toBe(false);
-      await stream.evaluate((element) => {
-        element.scrollTop = 0;
-        element.dispatchEvent(new Event("scroll"));
-      });
-      await expect.poll(() => stream.evaluate((element) => element.scrollTop)).toBe(0);
-
-      await autoFollow.click();
-      await expect
-        .poll(() => autoFollow.evaluate((element) => Reflect.get(element, "checked")))
-        .toBe(true);
-
-      await expect
-        .poll(() =>
-          stream.evaluate(
-            (element) => element.scrollHeight - element.scrollTop - element.clientHeight,
-          ),
-        )
-        .toBeLessThan(2);
-      if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(proofDir, "incremental-tail-and-autofollow.png"),
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "logs.tail": {
+              sequence: [
+                {
+                  cursor: logLines.length,
+                  file: "/tmp/openclaw.log",
+                  lines: logLines,
+                  reset: true,
+                },
+                {
+                  cursor: logLines.length + 1,
+                  file: "/tmp/openclaw.log",
+                  lines: [appendedLogLine],
+                  reset: false,
+                },
+                {
+                  cursor: logLines.length + 1,
+                  file: "/tmp/openclaw.log",
+                  lines: [],
+                  reset: false,
+                },
+              ],
+            },
+          },
         });
-      }
-      expect(pageErrors).toEqual([]);
-    } finally {
-      await context.close();
-    }
+
+        await page.goto(`${suite.server.baseUrl}logs`);
+        await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
+        expect((await gateway.getRequests("logs.tail"))[0]?.params).toEqual({
+          limit: 500,
+          maxBytes: 250_000,
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("logs.tail")).length, { timeout: 5000 })
+          .toBeGreaterThanOrEqual(2);
+        expect((await gateway.getRequests("logs.tail"))[1]?.params).toEqual({
+          cursor: logLines.length,
+          limit: 500,
+          maxBytes: 250_000,
+        });
+        await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length + 1);
+        await page.locator(".log-row", { hasText: "log line 201" }).waitFor();
+
+        const stream = page.locator(".log-stream");
+        const autoFollow = page.locator("wa-switch.settings-toggle").filter({
+          hasText: "Auto-follow",
+        });
+        await expect
+          .poll(() => stream.evaluate((element) => element.scrollHeight - element.clientHeight))
+          .toBeGreaterThan(0);
+        await expect
+          .poll(() => autoFollow.evaluate((element) => Reflect.get(element, "checked")))
+          .toBe(true);
+        await autoFollow.click();
+        await expect
+          .poll(() => autoFollow.evaluate((element) => Reflect.get(element, "checked")))
+          .toBe(false);
+        await stream.evaluate((element) => {
+          element.scrollTop = 0;
+          element.dispatchEvent(new Event("scroll"));
+        });
+        await expect.poll(() => stream.evaluate((element) => element.scrollTop)).toBe(0);
+
+        await autoFollow.click();
+        await expect
+          .poll(() => autoFollow.evaluate((element) => Reflect.get(element, "checked")))
+          .toBe(true);
+
+        await expect
+          .poll(() =>
+            stream.evaluate(
+              (element) => element.scrollHeight - element.scrollTop - element.clientHeight,
+            ),
+          )
+          .toBeLessThan(2);
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDir, "incremental-tail-and-autofollow.png"),
+          });
+        }
+        expect(pageErrors).toEqual([]);
+      },
+    );
   });
 });

--- a/ui/src/e2e/logs-layout.e2e.test.ts
+++ b/ui/src/e2e/logs-layout.e2e.test.ts
@@ -1,27 +1,21 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import {
-  canRunPlaywrightChromium,
   controlUiBundledSettingsStorageKey,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI logs native app layout E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 const proofLabel = process.env.OPENCLAW_UI_E2E_PROOF_LABEL?.trim() || "logs-layout";
 const viewport = { height: 584, width: 863 };
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const logLines = Array.from({ length: 40 }, (_value, index) =>
   JSON.stringify({
@@ -32,111 +26,97 @@ const logLines = Array.from({ length: 40 }, (_value, index) =>
   }),
 );
 
-describeControlUiE2e("Control UI logs native app layout E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps wrapped filters inside their rows in the macOS dashboard viewport", async () => {
     if (artifactDir) {
       await mkdir(path.join(artifactDir, proofLabel, "video"), { recursive: true });
     }
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport,
-      ...(artifactDir
-        ? { recordVideo: { dir: path.join(artifactDir, proofLabel, "video"), size: viewport } }
-        : {}),
-    });
-    const page = await context.newPage();
-    await page.addInitScript((settingsKey) => {
-      localStorage.setItem(settingsKey, JSON.stringify({ textScale: 125, themeMode: "dark" }));
-      const nativeWindow = window as Window & {
-        __OPENCLAW_NATIVE_WEB_CHROME__?: boolean;
-        __OPENCLAW_NATIVE_HISTORY__?: { canGoBack: boolean; canGoForward: boolean };
-      };
-      nativeWindow["__OPENCLAW_NATIVE_WEB_CHROME__"] = true;
-      nativeWindow["__OPENCLAW_NATIVE_HISTORY__"] = {
-        canGoBack: false,
-        canGoForward: false,
-      };
-      const stamp = () =>
-        document.documentElement.classList.add(
-          "openclaw-native-macos",
-          "openclaw-native-web-chrome",
-        );
-      if (document.documentElement) {
-        stamp();
-      } else {
-        document.addEventListener("DOMContentLoaded", stamp);
-      }
-    }, controlUiBundledSettingsStorageKey(server.baseUrl));
-    await installMockGateway(page, {
-      methodResponses: {
-        "logs.tail": {
-          cursor: logLines.length,
-          file: "/tmp/openclaw/openclaw-2026-07-21.log",
-          lines: logLines,
-          reset: true,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport,
+        ...(artifactDir
+          ? { recordVideo: { dir: path.join(artifactDir, proofLabel, "video"), size: viewport } }
+          : {}),
       },
-    });
-
-    try {
-      await page.goto(`${server.baseUrl}settings/general`);
-      await page.locator('.settings-sidebar__item[href="/logs"]').click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/logs");
-      await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
-      if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, proofLabel, "logs-layout.png"),
-          fullPage: true,
+      async ({ page }) => {
+        await page.addInitScript((settingsKey) => {
+          localStorage.setItem(settingsKey, JSON.stringify({ textScale: 125, themeMode: "dark" }));
+          const nativeWindow = window as Window & {
+            __OPENCLAW_NATIVE_WEB_CHROME__?: boolean;
+            __OPENCLAW_NATIVE_HISTORY__?: { canGoBack: boolean; canGoForward: boolean };
+          };
+          nativeWindow["__OPENCLAW_NATIVE_WEB_CHROME__"] = true;
+          nativeWindow["__OPENCLAW_NATIVE_HISTORY__"] = {
+            canGoBack: false,
+            canGoForward: false,
+          };
+          const stamp = () =>
+            document.documentElement.classList.add(
+              "openclaw-native-macos",
+              "openclaw-native-web-chrome",
+            );
+          if (document.documentElement) {
+            stamp();
+          } else {
+            document.addEventListener("DOMContentLoaded", stamp);
+          }
+        }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
+        await installMockGateway(page, {
+          methodResponses: {
+            "logs.tail": {
+              cursor: logLines.length,
+              file: "/tmp/openclaw/openclaw-2026-07-21.log",
+              lines: logLines,
+              reset: true,
+            },
+          },
         });
-      }
 
-      const metrics = await page.locator(".logs-card").evaluate((card) => {
-        const rows = [...card.querySelectorAll<HTMLElement>(":scope > .settings-row")];
-        const stream = card.querySelector<HTMLElement>(":scope > .log-stream");
-        return {
-          cardDisplay: getComputedStyle(card).display,
-          rows: rows.map((row) => {
-            const bounds = row.getBoundingClientRect();
-            return {
-              bottom: bounds.bottom,
-              clientHeight: row.clientHeight,
-              scrollHeight: row.scrollHeight,
-              top: bounds.top,
-            };
-          }),
-          streamFlexGrow: stream ? getComputedStyle(stream).flexGrow : "",
-          streamTop: stream?.getBoundingClientRect().top ?? Number.NaN,
-        };
-      });
+        await page.goto(`${suite.server.baseUrl}settings/general`);
+        await page.locator('.settings-sidebar__item[href="/logs"]').click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/logs");
+        await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, proofLabel, "logs-layout.png"),
+            fullPage: true,
+          });
+        }
 
-      expect(metrics.cardDisplay).toBe("flex");
-      expect(metrics.streamFlexGrow).toBe("1");
-      expect(metrics.rows).toHaveLength(2);
-      const [firstRow, secondRow] = metrics.rows;
-      if (!firstRow || !secondRow) {
-        throw new Error(`Expected two log control rows, received ${metrics.rows.length}.`);
-      }
-      for (const row of metrics.rows) {
-        expect(row.scrollHeight).toBeLessThanOrEqual(row.clientHeight + 1);
-      }
-      expect(firstRow.bottom).toBeLessThanOrEqual(secondRow.top + 1);
-      expect(secondRow.bottom).toBeLessThanOrEqual(metrics.streamTop + 1);
-    } finally {
-      await context.close();
-    }
+        const metrics = await page.locator(".logs-card").evaluate((card) => {
+          const rows = [...card.querySelectorAll<HTMLElement>(":scope > .settings-row")];
+          const stream = card.querySelector<HTMLElement>(":scope > .log-stream");
+          return {
+            cardDisplay: getComputedStyle(card).display,
+            rows: rows.map((row) => {
+              const bounds = row.getBoundingClientRect();
+              return {
+                bottom: bounds.bottom,
+                clientHeight: row.clientHeight,
+                scrollHeight: row.scrollHeight,
+                top: bounds.top,
+              };
+            }),
+            streamFlexGrow: stream ? getComputedStyle(stream).flexGrow : "",
+            streamTop: stream?.getBoundingClientRect().top ?? Number.NaN,
+          };
+        });
+
+        expect(metrics.cardDisplay).toBe("flex");
+        expect(metrics.streamFlexGrow).toBe("1");
+        expect(metrics.rows).toHaveLength(2);
+        const [firstRow, secondRow] = metrics.rows;
+        if (!firstRow || !secondRow) {
+          throw new Error(`Expected two log control rows, received ${metrics.rows.length}.`);
+        }
+        for (const row of metrics.rows) {
+          expect(row.scrollHeight).toBeLessThanOrEqual(row.clientHeight + 1);
+        }
+        expect(firstRow.bottom).toBeLessThanOrEqual(secondRow.top + 1);
+        expect(secondRow.bottom).toBeLessThanOrEqual(metrics.streamTop + 1);
+      },
+    );
   });
 });

--- a/ui/src/e2e/memory-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-defaults.e2e.test.ts
@@ -1,21 +1,18 @@
 // Control UI tests cover Memory default provenance and persisted restore actions.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayRequest,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Memory defaults mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -23,9 +20,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "memory-settings-defaults",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const memoryPlugins = [
   {
@@ -78,121 +72,105 @@ async function captureProof(page: Page, name: string, locator?: Locator) {
   });
 }
 
-describeControlUiE2e("Control UI Memory defaults mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("persists engine, backend, and dreaming resets and reloads inherited defaults", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const config = {
-      agents: { defaults: { userTimezone: "Asia/Singapore" } },
-      memory: { backend: "qmd" },
-      plugins: {
-        slots: { memory: "memory-core" },
-        entries: {
-          "memory-core": {
-            config: {
-              dreaming: {
-                frequency: "0 6 * * *",
-                verboseLogging: true,
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const config = {
+          agents: { defaults: { userTimezone: "Asia/Singapore" } },
+          memory: { backend: "qmd" },
+          plugins: {
+            slots: { memory: "memory-core" },
+            entries: {
+              "memory-core": {
+                config: {
+                  dreaming: {
+                    frequency: "0 6 * * *",
+                    verboseLogging: true,
+                  },
+                },
               },
             },
           },
-        },
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              config,
+              hash: "memory-defaults-e2e",
+              appliedConfigHash: "memory-defaults-e2e",
+              issues: [],
+              raw: JSON.stringify(config),
+              valid: true,
+            },
+            "plugins.list": {
+              plugins: memoryPlugins,
+              diagnostics: [],
+              mutationAllowed: true,
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/memory/settings`);
+        expect(response?.status()).toBe(200);
+
+        const engineRow = settingsRow(page, "Memory engine");
+        const backendRow = settingsRow(page, "Retrieval backend");
+        const frequencyRow = settingsRow(page, "Dreaming frequency");
+        await expect.poll(() => engineRow.textContent()).toContain("Default: OpenClaw Memory");
+        await expect.poll(() => backendRow.textContent()).toContain("Default: Built-in");
+        await expect.poll(() => frequencyRow.textContent()).toContain("Default: 0 3 * * *");
+        await expect.poll(() => frequencyRow.getByRole("textbox").inputValue()).toBe("0 6 * * *");
+
+        await captureProof(page, "01-explicit-engine-backend.png");
+        await captureProof(page, "02-explicit-dreaming.png", scheduleSection(page));
+
+        await engineRow.getByRole("button", { name: "Reset to default" }).click();
+        await backendRow.getByRole("button", { name: "Reset to default" }).click();
+        await frequencyRow.getByRole("button", { name: "Reset to default" }).click();
+
+        const saved = requestRaw(await gateway.waitForRequest("config.set"));
+        expect(saved).not.toHaveProperty("plugins.slots.memory");
+        expect(saved).not.toHaveProperty("memory.backend");
+        expect(saved).not.toHaveProperty("plugins.entries.memory-core.config.dreaming.frequency");
+        expect(saved).toHaveProperty(
+          "plugins.entries.memory-core.config.dreaming.verboseLogging",
+          true,
+        );
+        await expect
+          .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
+          .toContain("Saved");
+
+        await page.reload();
+        const reloadedEngineRow = settingsRow(page, "Memory engine");
+        const reloadedBackendRow = settingsRow(page, "Retrieval backend");
+        const reloadedFrequencyRow = settingsRow(page, "Dreaming frequency");
+        await expect
+          .poll(() => reloadedEngineRow.textContent())
+          .toContain("Using default: OpenClaw Memory");
+        await expect
+          .poll(() => reloadedBackendRow.textContent())
+          .toContain("Using default: Built-in");
+        await expect
+          .poll(() => reloadedFrequencyRow.textContent())
+          .toContain("Using default: 0 3 * * *");
+        await expect.poll(() => reloadedFrequencyRow.getByRole("textbox").inputValue()).toBe("");
+        await expect
+          .poll(() => reloadedFrequencyRow.getByRole("textbox").getAttribute("placeholder"))
+          .toBe("0 3 * * *");
+        await expect
+          .poll(() => page.getByRole("button", { name: "Reset to default" }).count())
+          .toBe(1);
+
+        await captureProof(page, "03-inherited-engine-backend.png");
+        await captureProof(page, "04-inherited-dreaming.png", scheduleSection(page));
       },
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": {
-          config,
-          hash: "memory-defaults-e2e",
-          appliedConfigHash: "memory-defaults-e2e",
-          issues: [],
-          raw: JSON.stringify(config),
-          valid: true,
-        },
-        "plugins.list": {
-          plugins: memoryPlugins,
-          diagnostics: [],
-          mutationAllowed: true,
-        },
-      },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/memory/settings`);
-      expect(response?.status()).toBe(200);
-
-      const engineRow = settingsRow(page, "Memory engine");
-      const backendRow = settingsRow(page, "Retrieval backend");
-      const frequencyRow = settingsRow(page, "Dreaming frequency");
-      await expect.poll(() => engineRow.textContent()).toContain("Default: OpenClaw Memory");
-      await expect.poll(() => backendRow.textContent()).toContain("Default: Built-in");
-      await expect.poll(() => frequencyRow.textContent()).toContain("Default: 0 3 * * *");
-      await expect.poll(() => frequencyRow.getByRole("textbox").inputValue()).toBe("0 6 * * *");
-
-      await captureProof(page, "01-explicit-engine-backend.png");
-      await captureProof(page, "02-explicit-dreaming.png", scheduleSection(page));
-
-      await engineRow.getByRole("button", { name: "Reset to default" }).click();
-      await backendRow.getByRole("button", { name: "Reset to default" }).click();
-      await frequencyRow.getByRole("button", { name: "Reset to default" }).click();
-
-      const saved = requestRaw(await gateway.waitForRequest("config.set"));
-      expect(saved).not.toHaveProperty("plugins.slots.memory");
-      expect(saved).not.toHaveProperty("memory.backend");
-      expect(saved).not.toHaveProperty("plugins.entries.memory-core.config.dreaming.frequency");
-      expect(saved).toHaveProperty(
-        "plugins.entries.memory-core.config.dreaming.verboseLogging",
-        true,
-      );
-      await expect
-        .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
-        .toContain("Saved");
-
-      await page.reload();
-      const reloadedEngineRow = settingsRow(page, "Memory engine");
-      const reloadedBackendRow = settingsRow(page, "Retrieval backend");
-      const reloadedFrequencyRow = settingsRow(page, "Dreaming frequency");
-      await expect
-        .poll(() => reloadedEngineRow.textContent())
-        .toContain("Using default: OpenClaw Memory");
-      await expect
-        .poll(() => reloadedBackendRow.textContent())
-        .toContain("Using default: Built-in");
-      await expect
-        .poll(() => reloadedFrequencyRow.textContent())
-        .toContain("Using default: 0 3 * * *");
-      await expect.poll(() => reloadedFrequencyRow.getByRole("textbox").inputValue()).toBe("");
-      await expect
-        .poll(() => reloadedFrequencyRow.getByRole("textbox").getAttribute("placeholder"))
-        .toBe("0 3 * * *");
-      await expect
-        .poll(() => page.getByRole("button", { name: "Reset to default" }).count())
-        .toBe(1);
-
-      await captureProof(page, "03-inherited-engine-backend.png");
-      await captureProof(page, "04-inherited-dreaming.png", scheduleSection(page));
-    } finally {
-      await context.close();
-    }
+    );
   });
 });

--- a/ui/src/e2e/memory-settings-engine.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-engine.e2e.test.ts
@@ -1,20 +1,17 @@
 // Control UI tests cover memory engine ordering and serialized config writes.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI memory engine settings mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -22,9 +19,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "memory-settings-engine",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function configResponse(engineId: string, hash: string) {
   const config = { plugins: { slots: { memory: engineId } } };
@@ -58,242 +52,226 @@ const memoryPlugins = [
   },
 ];
 
-describeControlUiE2e("Control UI memory engine settings mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps the default engine first and drains Off before selecting it", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const initialConfig = configResponse("memory-lancedb", "memory-hash-1");
-    const selectedConfig = configResponse("memory-core", "memory-hash-2");
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": initialConfig,
-        "plugins.list": { plugins: memoryPlugins, diagnostics: [], mutationAllowed: true },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const initialConfig = configResponse("memory-lancedb", "memory-hash-1");
+        const selectedConfig = configResponse("memory-core", "memory-hash-2");
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": initialConfig,
+            "plugins.list": { plugins: memoryPlugins, diagnostics: [], mutationAllowed: true },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/memory/settings`);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(`${suite.server.baseUrl}settings/memory/settings`);
+        expect(response?.status()).toBe(200);
 
-      const engineGroup = page.locator("wa-radio-group.settings-segmented").first();
-      await engineGroup.waitFor();
-      await expect
-        .poll(async () =>
-          (await engineGroup.locator("wa-radio").allTextContents()).map((label) => label.trim()),
-        )
-        .toEqual(["OpenClaw Memory", "Memory LanceDB", "Off"]);
+        const engineGroup = page.locator("wa-radio-group.settings-segmented").first();
+        await engineGroup.waitFor();
+        await expect
+          .poll(async () =>
+            (await engineGroup.locator("wa-radio").allTextContents()).map((label) => label.trim()),
+          )
+          .toEqual(["OpenClaw Memory", "Memory LanceDB", "Off"]);
 
-      await gateway.deferNext("config.set");
-      await gateway.deferNext("plugins.setEnabled");
-      await engineGroup.getByRole("radio", { name: "Off", exact: true }).click();
-      // Click again immediately, before the 800 ms autosave debounce. The
-      // write barrier must flush Off first instead of letting the plugin RPC
-      // race a still-scheduled config.set.
-      await engineGroup.getByRole("radio", { name: "OpenClaw Memory", exact: true }).click();
-      expect(await gateway.getRequests("plugins.setEnabled")).toHaveLength(0);
+        await gateway.deferNext("config.set");
+        await gateway.deferNext("plugins.setEnabled");
+        await engineGroup.getByRole("radio", { name: "Off", exact: true }).click();
+        // Click again immediately, before the 800 ms autosave debounce. The
+        // write barrier must flush Off first instead of letting the plugin RPC
+        // race a still-scheduled config.set.
+        await engineGroup.getByRole("radio", { name: "OpenClaw Memory", exact: true }).click();
+        expect(await gateway.getRequests("plugins.setEnabled")).toHaveLength(0);
 
-      const pendingOffSave = await gateway.waitForRequest("config.set");
-      expect(pendingOffSave.params).toMatchObject({ baseHash: "memory-hash-1" });
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page
-          .locator(".settings-page > .settings-section")
-          .first()
-          .screenshot({
-            animations: "disabled",
-            path: path.join(uiProofArtifactDir, "00-off-write-draining.png"),
-          });
-      }
-      await gateway.resolveDeferred("config.set", { ok: true, hash: "mock-config-hash-1" });
-      const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
-      expect(enableRequest.params).toEqual({ pluginId: "memory-core", enabled: true });
+        const pendingOffSave = await gateway.waitForRequest("config.set");
+        expect(pendingOffSave.params).toMatchObject({ baseHash: "memory-hash-1" });
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page
+            .locator(".settings-page > .settings-section")
+            .first()
+            .screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "00-off-write-draining.png"),
+            });
+        }
+        await gateway.resolveDeferred("config.set", { ok: true, hash: "mock-config-hash-1" });
+        const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
+        expect(enableRequest.params).toEqual({ pluginId: "memory-core", enabled: true });
 
-      await gateway.setMethodResponse("config.get", selectedConfig);
-      await gateway.resolveDeferred("plugins.setEnabled", {
-        ok: true,
-        plugin: memoryPlugins[1],
-        restartRequired: false,
-      });
+        await gateway.setMethodResponse("config.get", selectedConfig);
+        await gateway.resolveDeferred("plugins.setEnabled", {
+          ok: true,
+          plugin: memoryPlugins[1],
+          restartRequired: false,
+        });
 
-      const selected = engineGroup.getByRole("radio", {
-        name: "OpenClaw Memory",
-        exact: true,
-      });
-      await expect.poll(() => selected.getAttribute("aria-checked")).toBe("true");
-      await expect.poll(() => page.getByText("Could not change the memory engine").count()).toBe(0);
+        const selected = engineGroup.getByRole("radio", {
+          name: "OpenClaw Memory",
+          exact: true,
+        });
+        await expect.poll(() => selected.getAttribute("aria-checked")).toBe("true");
+        await expect
+          .poll(() => page.getByText("Could not change the memory engine").count())
+          .toBe(0);
 
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page
-          .locator(".settings-page > .settings-section")
-          .first()
-          .screenshot({
-            animations: "disabled",
-            path: path.join(uiProofArtifactDir, "01-openclaw-memory-selected.png"),
-          });
-      }
-    } finally {
-      await context.close();
-    }
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page
+            .locator(".settings-page > .settings-section")
+            .first()
+            .screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "01-openclaw-memory-selected.png"),
+            });
+        }
+      },
+    );
   });
 
   it("keeps a committed add-on enabled and makes a failed config refresh visible", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(String(error)));
-    const activeMemory = {
-      id: "active-memory",
-      name: "Active memory",
-      installed: true,
-      enabled: false,
-      state: "disabled",
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse("memory-lancedb", "memory-refresh-hash-1"),
-        "plugins.list": {
-          plugins: [...memoryPlugins, activeMemory],
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const activeMemory = {
+          id: "active-memory",
+          name: "Active memory",
+          installed: true,
+          enabled: false,
+          state: "disabled",
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse("memory-lancedb", "memory-refresh-hash-1"),
+            "plugins.list": {
+              plugins: [...memoryPlugins, activeMemory],
+              diagnostics: [],
+              mutationAllowed: true,
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}settings/memory/settings`);
+        const toggle = page.getByRole("switch", { name: "Enable or disable Active memory" });
+        await toggle.waitFor();
+        const initialConfigReads = (await gateway.getRequests("config.get")).length;
+        const initialCatalogReads = (await gateway.getRequests("plugins.list")).length;
+        await gateway.deferNext("plugins.setEnabled");
+        await gateway.deferNext("config.get");
+        await page
+          .locator("wa-switch.settings-toggle")
+          .filter({ hasText: "Enable or disable Active memory" })
+          .click();
+
+        const mutation = await gateway.waitForRequest("plugins.setEnabled");
+        expect(mutation.params).toEqual({ pluginId: "active-memory", enabled: true });
+        const committed = { ...activeMemory, enabled: true, state: "enabled" };
+        await gateway.setMethodResponse("plugins.list", {
+          plugins: [...memoryPlugins, committed],
           diagnostics: [],
           mutationAllowed: true,
-        },
-      },
-    });
-
-    try {
-      await page.goto(`${server.baseUrl}settings/memory/settings`);
-      const toggle = page.getByRole("switch", { name: "Enable or disable Active memory" });
-      await toggle.waitFor();
-      const initialConfigReads = (await gateway.getRequests("config.get")).length;
-      const initialCatalogReads = (await gateway.getRequests("plugins.list")).length;
-      await gateway.deferNext("plugins.setEnabled");
-      await gateway.deferNext("config.get");
-      await page
-        .locator("wa-switch.settings-toggle")
-        .filter({ hasText: "Enable or disable Active memory" })
-        .click();
-
-      const mutation = await gateway.waitForRequest("plugins.setEnabled");
-      expect(mutation.params).toEqual({ pluginId: "active-memory", enabled: true });
-      const committed = { ...activeMemory, enabled: true, state: "enabled" };
-      await gateway.setMethodResponse("plugins.list", {
-        plugins: [...memoryPlugins, committed],
-        diagnostics: [],
-        mutationAllowed: true,
-      });
-      await gateway.resolveDeferred("plugins.setEnabled", {
-        ok: true,
-        plugin: committed,
-        restartRequired: false,
-      });
-      await expect
-        .poll(async () => (await gateway.getRequests("config.get")).length)
-        .toBeGreaterThan(initialConfigReads);
-      await gateway.rejectDeferred("config.get", {
-        code: "UNAVAILABLE",
-        message: "authoritative snapshot unavailable",
-      });
-
-      await expect
-        .poll(async () => (await gateway.getRequests("plugins.list")).length)
-        .toBeGreaterThan(initialCatalogReads);
-      await expect.poll(() => toggle.getAttribute("aria-checked")).toBe("true");
-      await page.getByText("Needs attention", { exact: true }).first().waitFor();
-      await page
-        .getByText(
-          "Could not refresh Control UI configuration: GatewayRequestError: authoritative snapshot unavailable",
-        )
-        .waitFor();
-      expect(await page.getByText("Could not update Active memory").count()).toBe(0);
-      expect(pageErrors).toEqual([]);
-
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page.locator("openclaw-memory-settings").screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "03-addon-committed-refresh-warning.png"),
         });
-      }
-    } finally {
-      await context.close();
-    }
+        await gateway.resolveDeferred("plugins.setEnabled", {
+          ok: true,
+          plugin: committed,
+          restartRequired: false,
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBeGreaterThan(initialConfigReads);
+        await gateway.rejectDeferred("config.get", {
+          code: "UNAVAILABLE",
+          message: "authoritative snapshot unavailable",
+        });
+
+        await expect
+          .poll(async () => (await gateway.getRequests("plugins.list")).length)
+          .toBeGreaterThan(initialCatalogReads);
+        await expect.poll(() => toggle.getAttribute("aria-checked")).toBe("true");
+        await page.getByText("Needs attention", { exact: true }).first().waitFor();
+        await page
+          .getByText(
+            "Could not refresh Control UI configuration: GatewayRequestError: authoritative snapshot unavailable",
+          )
+          .waitFor();
+        expect(await page.getByText("Could not update Active memory").count()).toBe(0);
+        expect(pageErrors).toEqual([]);
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.locator("openclaw-memory-settings").screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "03-addon-committed-refresh-warning.png"),
+          });
+        }
+      },
+    );
   });
 
   it("keeps a missing default engine labelled, first, and selected as unavailable", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "config.get": configResponse("memory-core", "memory-hash-missing-default"),
-        "plugins.list": {
-          plugins: memoryPlugins.filter((plugin) => plugin.id !== "memory-core"),
-          diagnostics: [],
-          mutationAllowed: true,
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse("memory-core", "memory-hash-missing-default"),
+            "plugins.list": {
+              plugins: memoryPlugins.filter((plugin) => plugin.id !== "memory-core"),
+              diagnostics: [],
+              mutationAllowed: true,
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/memory/settings`);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(`${suite.server.baseUrl}settings/memory/settings`);
+        expect(response?.status()).toBe(200);
 
-      const engineGroup = page.locator("wa-radio-group.settings-segmented").first();
-      await engineGroup.waitFor();
-      await expect
-        .poll(async () =>
-          (await engineGroup.locator("wa-radio").allTextContents()).map((label) => label.trim()),
-        )
-        .toEqual(["OpenClaw Memory (Unavailable)", "Memory LanceDB", "Off"]);
-      await expect
-        .poll(() =>
-          engineGroup
-            .getByRole("radio", { name: "OpenClaw Memory (Unavailable)", exact: true })
-            .getAttribute("aria-checked"),
-        )
-        .toBe("true");
+        const engineGroup = page.locator("wa-radio-group.settings-segmented").first();
+        await engineGroup.waitFor();
+        await expect
+          .poll(async () =>
+            (await engineGroup.locator("wa-radio").allTextContents()).map((label) => label.trim()),
+          )
+          .toEqual(["OpenClaw Memory (Unavailable)", "Memory LanceDB", "Off"]);
+        await expect
+          .poll(() =>
+            engineGroup
+              .getByRole("radio", { name: "OpenClaw Memory (Unavailable)", exact: true })
+              .getAttribute("aria-checked"),
+          )
+          .toBe("true");
 
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await page
-          .locator(".settings-page > .settings-section")
-          .first()
-          .screenshot({
-            animations: "disabled",
-            path: path.join(uiProofArtifactDir, "02-configured-engine-unavailable.png"),
-          });
-      }
-    } finally {
-      await context.close();
-    }
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page
+            .locator(".settings-page > .settings-section")
+            .first()
+            .screenshot({
+              animations: "disabled",
+              path: path.join(uiProofArtifactDir, "02-configured-engine-unavailable.png"),
+            });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/mobile-pairing.e2e.test.ts
+++ b/ui/src/e2e/mobile-pairing.e2e.test.ts
@@ -1,42 +1,21 @@
 // Control UI tests cover mobile pairing setup through the mocked Gateway.
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
 import qrcode from "qrcode";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI mobile pairing mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/mobile-pairing");
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI mobile pairing mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("defaults to full before issuance, supports limited fallback, and resets when reopened", async () => {
     const setupCode = Buffer.from(
       JSON.stringify({
@@ -47,165 +26,175 @@ describeControlUiE2e("Control UI mobile pairing mocked Gateway E2E", () => {
     ).toString("base64url");
     const qrDataUrl = await qrcode.toDataURL(setupCode, { margin: 2, width: 360 });
     mkdirSync(artifactDir, { recursive: true });
-    const context = await browser.newContext({
-      locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(String(error)));
-    const gateway = await installMockGateway(page, {
-      presenceUsers: [{ self: true, id: "operator", name: "Operator" }],
-      methodResponses: {
-        "device.pair.list": {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const gateway = await installMockGateway(page, {
+          presenceUsers: [{ self: true, id: "operator", name: "Operator" }],
+          methodResponses: {
+            "device.pair.list": {
+              paired: [],
+              pending: [{ deviceId: "mobile-1", requestId: "request-1" }],
+            },
+            "device.pair.setupCode": {
+              auth: "token",
+              gatewayUrl: "wss://gateway.example.test",
+              qrDataUrl,
+              setupCode,
+              urlSource: "test",
+            },
+            "node.list": { nodes: [] },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}chat`);
+        expect(response?.status()).toBe(200);
+
+        // Pairing lives with the account-level controls in the footer identity menu.
+        const sidebar = page.locator("openclaw-app-sidebar");
+        await sidebar.getByRole("button", { name: /^Identity and app menu for / }).click();
+        const sidebarPairingButton = sidebar
+          .locator("wa-dropdown.sidebar-identity-menu")
+          .locator(".sidebar-pair-mobile");
+        await sidebarPairingButton.waitFor();
+        await expect.poll(async () => sidebarPairingButton.isEnabled()).toBe(true);
+        await gateway.deferNext("device.pair.list");
+        await sidebarPairingButton.click();
+
+        const dialog = page.getByRole("dialog", { name: "OpenClaw mobile" });
+        const qr = page.getByAltText("OpenClaw mobile pairing QR code");
+        await dialog.waitFor();
+        expect(await dialog.isVisible()).toBe(true);
+        expect(await qr.count()).toBe(0);
+        expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
+        expect(await page.getByRole("button", { name: "Create setup code" }).isVisible()).toBe(
+          true,
+        );
+        await gateway.resolveDeferred("device.pair.list", {
           paired: [],
           pending: [{ deviceId: "mobile-1", requestId: "request-1" }],
-        },
-        "device.pair.setupCode": {
-          auth: "token",
-          gatewayUrl: "wss://gateway.example.test",
-          qrDataUrl,
-          setupCode,
-          urlSource: "test",
-        },
-        "node.list": { nodes: [] },
-      },
-    });
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}chat`);
-      expect(response?.status()).toBe(200);
+        // modal-dialog renders its content in light DOM outside the native dialog element.
+        const accessRadios = page.locator('input[name="device-pair-access"]');
+        await expect.poll(async () => accessRadios.count()).toBe(2);
+        const fullAccess = accessRadios.nth(0);
+        const limitedAccess = accessRadios.nth(1);
+        expect(await fullAccess.isChecked()).toBe(true);
+        await page.screenshot({ path: path.join(artifactDir, "01-full-access-default.png") });
 
-      // Pairing lives with the account-level controls in the footer identity menu.
-      const sidebar = page.locator("openclaw-app-sidebar");
-      await sidebar.getByRole("button", { name: /^Identity and app menu for / }).click();
-      const sidebarPairingButton = sidebar
-        .locator("wa-dropdown.sidebar-identity-menu")
-        .locator(".sidebar-pair-mobile");
-      await sidebarPairingButton.waitFor();
-      await expect.poll(async () => sidebarPairingButton.isEnabled()).toBe(true);
-      await gateway.deferNext("device.pair.list");
-      await sidebarPairingButton.click();
+        await limitedAccess.check();
+        expect(await limitedAccess.isChecked()).toBe(true);
+        await fullAccess.check();
+        expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
 
-      const dialog = page.getByRole("dialog", { name: "OpenClaw mobile" });
-      const qr = page.getByAltText("OpenClaw mobile pairing QR code");
-      await dialog.waitFor();
-      expect(await dialog.isVisible()).toBe(true);
-      expect(await qr.count()).toBe(0);
-      expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
-      expect(await page.getByRole("button", { name: "Create setup code" }).isVisible()).toBe(true);
-      await gateway.resolveDeferred("device.pair.list", {
-        paired: [],
-        pending: [{ deviceId: "mobile-1", requestId: "request-1" }],
-      });
-
-      // modal-dialog renders its content in light DOM outside the native dialog element.
-      const accessRadios = page.locator('input[name="device-pair-access"]');
-      await expect.poll(async () => accessRadios.count()).toBe(2);
-      const fullAccess = accessRadios.nth(0);
-      const limitedAccess = accessRadios.nth(1);
-      expect(await fullAccess.isChecked()).toBe(true);
-      await page.screenshot({ path: path.join(artifactDir, "01-full-access-default.png") });
-
-      await limitedAccess.check();
-      expect(await limitedAccess.isChecked()).toBe(true);
-      await fullAccess.check();
-      expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
-
-      await page.getByRole("button", { name: "Create setup code" }).click();
-      const firstRequest = await gateway.waitForRequest("device.pair.setupCode");
-      expect(firstRequest.params).toEqual({});
-      await qr.waitFor();
-      expect(await qr.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
-      expect(await page.getByText("wss://gateway.example.test", { exact: true }).isVisible()).toBe(
-        true,
-      );
-      expect(await page.getByText("Device requests waiting for review: 1").isVisible()).toBe(true);
-      expect(await fullAccess.isDisabled()).toBe(true);
-      expect(await limitedAccess.isDisabled()).toBe(true);
-      await page.screenshot({ path: path.join(artifactDir, "02-full-access-code.png") });
-
-      const accessSequenceBeforeClose = (await gateway.getRequests("device.pair.setupCode")).map(
-        (request) =>
-          request.params &&
-          typeof request.params === "object" &&
-          "bootstrapProfile" in request.params &&
-          request.params.bootstrapProfile === "limited"
-            ? "limited"
-            : "full",
-      );
-      expect(accessSequenceBeforeClose).toEqual(["full"]);
-      await expect.poll(async () => (await gateway.getRequests("device.pair.list")).length).toBe(1);
-
-      await gateway.emitGatewayEvent("device.pair.requested", { requestId: "request-2" });
-      await expect.poll(async () => (await gateway.getRequests("device.pair.list")).length).toBe(2);
-
-      await page.locator(".device-pair-setup__close").click();
-      await dialog.waitFor({ state: "hidden" });
-
-      const settingsResponse = await page.goto(`${server.baseUrl}settings/security`);
-      expect(settingsResponse?.status()).toBe(200);
-      const quickSettingsPairingButton = page
-        .locator(".security-page")
-        .getByRole("button", { name: "Pair mobile device" });
-      await quickSettingsPairingButton.waitFor();
-      const setupRequestsBeforeQuickSettings = (await gateway.getRequests("device.pair.setupCode"))
-        .length;
-      await quickSettingsPairingButton.click();
-      await dialog.waitFor();
-      expect((await gateway.getRequests("device.pair.setupCode")).length).toBe(
-        setupRequestsBeforeQuickSettings,
-      );
-      expect(await page.locator('input[name="device-pair-access"]').nth(0).isChecked()).toBe(true);
-      const reopenedLimitedAccess = page.locator('input[name="device-pair-access"]').nth(1);
-      await reopenedLimitedAccess.check();
-      await page.getByRole("button", { name: "Create setup code" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("device.pair.setupCode")).length)
-        .toBe(setupRequestsBeforeQuickSettings + 1);
-      await qr.waitFor();
-      const reopenedAccessSequence = (await gateway.getRequests("device.pair.setupCode"))
-        .slice(setupRequestsBeforeQuickSettings)
-        .map((request) =>
-          request.params &&
-          typeof request.params === "object" &&
-          "bootstrapProfile" in request.params &&
-          request.params.bootstrapProfile === "limited"
-            ? "limited"
-            : "full",
+        await page.getByRole("button", { name: "Create setup code" }).click();
+        const firstRequest = await gateway.waitForRequest("device.pair.setupCode");
+        expect(firstRequest.params).toEqual({});
+        await qr.waitFor();
+        expect(await qr.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
+        expect(
+          await page.getByText("wss://gateway.example.test", { exact: true }).isVisible(),
+        ).toBe(true);
+        expect(await page.getByText("Device requests waiting for review: 1").isVisible()).toBe(
+          true,
         );
-      expect(reopenedAccessSequence).toEqual(["limited"]);
-      const accessSequence = [...accessSequenceBeforeClose, ...reopenedAccessSequence];
-      expect(accessSequence).toEqual(["full", "limited"]);
-      await page.screenshot({ path: path.join(artifactDir, "03-limited-access-code.png") });
-      writeFileSync(
-        path.join(artifactDir, "behavior-summary.json"),
-        `${JSON.stringify(
-          {
-            accessSequence,
-            reopenedDefault: "full",
-            setupRequestsIssued: accessSequence.length,
-          },
-          null,
-          2,
-        )}\n`,
-      );
+        expect(await fullAccess.isDisabled()).toBe(true);
+        expect(await limitedAccess.isDisabled()).toBe(true);
+        await page.screenshot({ path: path.join(artifactDir, "02-full-access-code.png") });
 
-      await page.getByRole("button", { name: "New code" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("device.pair.setupCode")).length)
-        .toBe(setupRequestsBeforeQuickSettings + 2);
-      expect((await gateway.getRequests("device.pair.setupCode")).at(-1)?.params).toEqual({
-        bootstrapProfile: "limited",
-      });
+        const accessSequenceBeforeClose = (await gateway.getRequests("device.pair.setupCode")).map(
+          (request) =>
+            request.params &&
+            typeof request.params === "object" &&
+            "bootstrapProfile" in request.params &&
+            request.params.bootstrapProfile === "limited"
+              ? "limited"
+              : "full",
+        );
+        expect(accessSequenceBeforeClose).toEqual(["full"]);
+        await expect
+          .poll(async () => (await gateway.getRequests("device.pair.list")).length)
+          .toBe(1);
 
-      await page.getByRole("button", { name: "Manage devices" }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/devices");
-      expect(pageErrors).toEqual([]);
-    } finally {
-      await context.close();
-    }
+        await gateway.emitGatewayEvent("device.pair.requested", { requestId: "request-2" });
+        await expect
+          .poll(async () => (await gateway.getRequests("device.pair.list")).length)
+          .toBe(2);
+
+        await page.locator(".device-pair-setup__close").click();
+        await dialog.waitFor({ state: "hidden" });
+
+        const settingsResponse = await page.goto(`${suite.server.baseUrl}settings/security`);
+        expect(settingsResponse?.status()).toBe(200);
+        const quickSettingsPairingButton = page
+          .locator(".security-page")
+          .getByRole("button", { name: "Pair mobile device" });
+        await quickSettingsPairingButton.waitFor();
+        const setupRequestsBeforeQuickSettings = (
+          await gateway.getRequests("device.pair.setupCode")
+        ).length;
+        await quickSettingsPairingButton.click();
+        await dialog.waitFor();
+        expect((await gateway.getRequests("device.pair.setupCode")).length).toBe(
+          setupRequestsBeforeQuickSettings,
+        );
+        expect(await page.locator('input[name="device-pair-access"]').nth(0).isChecked()).toBe(
+          true,
+        );
+        const reopenedLimitedAccess = page.locator('input[name="device-pair-access"]').nth(1);
+        await reopenedLimitedAccess.check();
+        await page.getByRole("button", { name: "Create setup code" }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("device.pair.setupCode")).length)
+          .toBe(setupRequestsBeforeQuickSettings + 1);
+        await qr.waitFor();
+        const reopenedAccessSequence = (await gateway.getRequests("device.pair.setupCode"))
+          .slice(setupRequestsBeforeQuickSettings)
+          .map((request) =>
+            request.params &&
+            typeof request.params === "object" &&
+            "bootstrapProfile" in request.params &&
+            request.params.bootstrapProfile === "limited"
+              ? "limited"
+              : "full",
+          );
+        expect(reopenedAccessSequence).toEqual(["limited"]);
+        const accessSequence = [...accessSequenceBeforeClose, ...reopenedAccessSequence];
+        expect(accessSequence).toEqual(["full", "limited"]);
+        await page.screenshot({ path: path.join(artifactDir, "03-limited-access-code.png") });
+        writeFileSync(
+          path.join(artifactDir, "behavior-summary.json"),
+          `${JSON.stringify(
+            {
+              accessSequence,
+              reopenedDefault: "full",
+              setupRequestsIssued: accessSequence.length,
+            },
+            null,
+            2,
+          )}\n`,
+        );
+
+        await page.getByRole("button", { name: "New code" }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("device.pair.setupCode")).length)
+          .toBe(setupRequestsBeforeQuickSettings + 2);
+        expect((await gateway.getRequests("device.pair.setupCode")).at(-1)?.params).toEqual({
+          bootstrapProfile: "limited",
+        });
+
+        await page.getByRole("button", { name: "Manage devices" }).click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/devices");
+        expect(pageErrors).toEqual([]);
+      },
+    );
   });
 });

--- a/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
+++ b/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
@@ -1,20 +1,16 @@
 // Control UI tests cover llama.cpp setup against a mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI llama.cpp setup mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 const prepareOptions = [
   {
@@ -42,204 +38,187 @@ const prepareOptions = [
   },
 ];
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI llama.cpp setup mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("downloads, verifies, and keeps llama.cpp visible in settings", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const initialDetection = {
-      candidates: [],
-      manualProviders: [],
-      prepareOptions,
-      workspace: "/tmp/openclaw-e2e",
-      setupComplete: false,
-    };
-    const modelRef = "llama-cpp/gemma-4-e4b-it-q4_k_m";
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.activate",
-        "openclaw.setup.prepare.start",
-        "wizard.next",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": initialDetection,
-        "openclaw.setup.prepare.start": {
-          sessionId: "llama-cpp-prepare-session",
-          done: false,
-          status: "running",
-        },
-        "openclaw.setup.activate": {
-          ok: true,
-          modelRef,
-          latencyMs: 731,
-          lines: ["Model ready"],
-        },
-        "wizard.next": {
-          sequence: [
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "llama-cpp-consent",
-                type: "confirm",
-                message:
-                  "OpenClaw will download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) and run it directly inside this Gateway. Continue?",
-                initialValue: false,
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "llama-cpp-download-20",
-                type: "progress",
-                message: "Downloading Gemma 4 E4B… 20% (1.0/5.0 GB, 38 MB/s)",
-                executor: "gateway",
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "llama-cpp-download-100",
-                type: "progress",
-                message: "Gemma 4 E4B model downloaded",
-                executor: "gateway",
-              },
-            },
-            { done: true, status: "done" },
-          ],
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      const llamaCppRow = page.locator('[data-prepare-choice="llama-cpp"]');
-      await llamaCppRow.getByRole("button", { name: "Set up model" }).waitFor();
-      await expect
-        .poll(() => llamaCppRow.locator('[data-provider-icon="llamacpp"]').count())
-        .toBe(1);
-      await expect.poll(() => llamaCppRow.textContent()).not.toContain("Gemma");
-      await expect.poll(() => llamaCppRow.textContent()).not.toContain("GB");
-      await expect.poll(() => llamaCppRow.textContent()).not.toContain("RAM");
-
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "llama-cpp-offer-desktop.png"),
-        });
-      }
-
-      await llamaCppRow.getByRole("button", { name: "Set up model" }).click();
-      const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
-      expect(start.params).toMatchObject({ authChoice: "llama-cpp" });
-      await page.getByRole("heading", { name: "Set up a local model" }).waitFor();
-      await page.getByText("OpenClaw will download Gemma 4 E4B IT Q4_K_M").waitFor();
-
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "llama-cpp-confirm-desktop.png"),
-        });
-      }
-
-      await gateway.setMethodResponse("openclaw.setup.detect", {
-        ...initialDetection,
-        candidates: [
-          {
-            kind: "provider-auto:llama-cpp",
-            brandId: "llama-cpp",
-            label: "llama.cpp",
-            detail: "Gemma 4 E4B downloaded",
-            modelRef,
-            recommended: true,
-            credentials: true,
+      async ({ page }) => {
+        const initialDetection = {
+          candidates: [],
+          manualProviders: [],
+          prepareOptions,
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        };
+        const modelRef = "llama-cpp/gemma-4-e4b-it-q4_k_m";
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+            "openclaw.setup.prepare.start",
+            "wizard.next",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": initialDetection,
+            "openclaw.setup.prepare.start": {
+              sessionId: "llama-cpp-prepare-session",
+              done: false,
+              status: "running",
+            },
+            "openclaw.setup.activate": {
+              ok: true,
+              modelRef,
+              latencyMs: 731,
+              lines: ["Model ready"],
+            },
+            "wizard.next": {
+              sequence: [
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "llama-cpp-consent",
+                    type: "confirm",
+                    message:
+                      "OpenClaw will download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) and run it directly inside this Gateway. Continue?",
+                    initialValue: false,
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "llama-cpp-download-20",
+                    type: "progress",
+                    message: "Downloading Gemma 4 E4B… 20% (1.0/5.0 GB, 38 MB/s)",
+                    executor: "gateway",
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "llama-cpp-download-100",
+                    type: "progress",
+                    message: "Gemma 4 E4B model downloaded",
+                    executor: "gateway",
+                  },
+                },
+                { done: true, status: "done" },
+              ],
+            },
           },
-        ],
-      });
-      await page.getByRole("button", { name: "Continue" }).click();
-      await page.getByRole("heading", { name: "Connection verified" }).waitFor();
-      await expect
-        .poll(() => page.locator(".model-setup-success").textContent())
-        .toContain(modelRef);
-      await expect
-        .poll(() => page.locator(".model-setup-success").textContent())
-        .toContain("Verified in 731 ms");
-      await expect
-        .poll(() => page.locator('.model-setup-success [data-provider-icon="llamacpp"]').count())
-        .toBe(1);
-
-      const activate = await gateway.waitForRequest("openclaw.setup.activate");
-      expect(activate.params).toEqual({
-        kind: "provider-auto:llama-cpp",
-        modelRef,
-      });
-
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "llama-cpp-ready-desktop.png"),
         });
-        await page.setViewportSize({ height: 844, width: 390 });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "llama-cpp-ready-mobile.png"),
-        });
-      }
 
-      await gateway.setMethodResponse("openclaw.setup.detect", {
-        ...initialDetection,
-        candidates: [],
-        configuredModel: modelRef,
-        setupComplete: true,
-      });
-      await page.setViewportSize({ height: 900, width: 1280 });
-      await page.getByRole("button", { name: "Stay in settings" }).click();
-      const currentConnection = page.locator(".model-setup__current");
-      await currentConnection.getByText("llama.cpp", { exact: true }).waitFor();
-      await currentConnection.getByText("gemma-4-e4b-it-q4_k_m", { exact: true }).waitFor();
-      await expect
-        .poll(() => currentConnection.locator('[data-provider-icon="llamacpp"]').count())
-        .toBe(1);
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "llama-cpp-main-desktop.png"),
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
+        const llamaCppRow = page.locator('[data-prepare-choice="llama-cpp"]');
+        await llamaCppRow.getByRole("button", { name: "Set up model" }).waitFor();
+        await expect
+          .poll(() => llamaCppRow.locator('[data-provider-icon="llamacpp"]').count())
+          .toBe(1);
+        await expect.poll(() => llamaCppRow.textContent()).not.toContain("Gemma");
+        await expect.poll(() => llamaCppRow.textContent()).not.toContain("GB");
+        await expect.poll(() => llamaCppRow.textContent()).not.toContain("RAM");
+
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "llama-cpp-offer-desktop.png"),
+          });
+        }
+
+        await llamaCppRow.getByRole("button", { name: "Set up model" }).click();
+        const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
+        expect(start.params).toMatchObject({ authChoice: "llama-cpp" });
+        await page.getByRole("heading", { name: "Set up a local model" }).waitFor();
+        await page.getByText("OpenClaw will download Gemma 4 E4B IT Q4_K_M").waitFor();
+
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "llama-cpp-confirm-desktop.png"),
+          });
+        }
+
+        await gateway.setMethodResponse("openclaw.setup.detect", {
+          ...initialDetection,
+          candidates: [
+            {
+              kind: "provider-auto:llama-cpp",
+              brandId: "llama-cpp",
+              label: "llama.cpp",
+              detail: "Gemma 4 E4B downloaded",
+              modelRef,
+              recommended: true,
+              credentials: true,
+            },
+          ],
         });
-      }
-    } finally {
-      await context.close();
-    }
+        await page.getByRole("button", { name: "Continue" }).click();
+        await page.getByRole("heading", { name: "Connection verified" }).waitFor();
+        await expect
+          .poll(() => page.locator(".model-setup-success").textContent())
+          .toContain(modelRef);
+        await expect
+          .poll(() => page.locator(".model-setup-success").textContent())
+          .toContain("Verified in 731 ms");
+        await expect
+          .poll(() => page.locator('.model-setup-success [data-provider-icon="llamacpp"]').count())
+          .toBe(1);
+
+        const activate = await gateway.waitForRequest("openclaw.setup.activate");
+        expect(activate.params).toEqual({
+          kind: "provider-auto:llama-cpp",
+          modelRef,
+        });
+
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "llama-cpp-ready-desktop.png"),
+          });
+          await page.setViewportSize({ height: 844, width: 390 });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "llama-cpp-ready-mobile.png"),
+          });
+        }
+
+        await gateway.setMethodResponse("openclaw.setup.detect", {
+          ...initialDetection,
+          candidates: [],
+          configuredModel: modelRef,
+          setupComplete: true,
+        });
+        await page.setViewportSize({ height: 900, width: 1280 });
+        await page.getByRole("button", { name: "Stay in settings" }).click();
+        const currentConnection = page.locator(".model-setup__current");
+        await currentConnection.getByText("llama.cpp", { exact: true }).waitFor();
+        await currentConnection.getByText("gemma-4-e4b-it-q4_k_m", { exact: true }).waitFor();
+        await expect
+          .poll(() => currentConnection.locator('[data-provider-icon="llamacpp"]').count())
+          .toBe(1);
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "llama-cpp-main-desktop.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
+++ b/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
@@ -1,20 +1,16 @@
 // Control UI tests cover LM Studio setup against a mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI LM Studio setup mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 const prepareOptions = [
   {
@@ -28,221 +24,206 @@ const prepareOptions = [
   },
 ];
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI LM Studio setup mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("connects, retries, verifies, and keeps LM Studio visible in settings", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const initialDetection = {
-      candidates: [],
-      manualProviders: [],
-      prepareOptions,
-      workspace: "/tmp/openclaw-e2e",
-      setupComplete: false,
-    };
-    const modelRef = "lmstudio/qwen3-8b-instruct";
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.activate",
-        "openclaw.setup.prepare.start",
-        "wizard.next",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": initialDetection,
-        "openclaw.setup.prepare.start": {
-          sessionId: "lmstudio-prepare-session",
-          done: false,
-          status: "running",
-        },
-        "openclaw.setup.activate": {
-          ok: true,
-          modelRef,
-          latencyMs: 416,
-          lines: ["Model ready"],
-        },
-        "wizard.next": {
-          sequence: [
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "lmstudio-base-url",
-                type: "text",
-                message: "LM Studio base URL",
-                initialValue: "http://localhost:1234/v1",
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "lmstudio-api-key",
-                type: "text",
-                message: "LM Studio API key",
-                placeholder: "Leave blank if auth is disabled",
-                sensitive: true,
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "lmstudio-retry",
-                type: "note",
-                title: "LM Studio",
-                message: [
-                  "LM Studio could not be reached at http://localhost:1234/v1.",
-                  "Start LM Studio (or run lms server start), then continue to retry.",
-                ].join("\n"),
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "lmstudio-retry-confirm",
-                type: "confirm",
-                message: "Retry this LM Studio connection now?",
-                initialValue: true,
-              },
-            },
-            { done: true, status: "done" },
-          ],
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      const lmStudioRow = page.locator('[data-prepare-choice="lmstudio"]');
-      await lmStudioRow.getByRole("button", { name: "Connect server" }).waitFor();
-      await expect
-        .poll(() => lmStudioRow.locator('[data-provider-icon="lmstudio"]').count())
-        .toBe(1);
-
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "lmstudio-offer-desktop.png"),
-        });
-      }
-
-      await lmStudioRow.getByRole("button", { name: "Connect server" }).click();
-      const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
-      expect(start.params).toMatchObject({ authChoice: "lmstudio" });
-      await expect
-        .poll(() => page.getByLabel("LM Studio base URL").inputValue())
-        .toBe("http://localhost:1234/v1");
-      await page.getByRole("button", { name: "Submit" }).click();
-      await page.getByLabel("LM Studio API key").fill("");
-      await page.getByRole("button", { name: "Submit" }).click();
-      await page.getByText("LM Studio could not be reached at http://localhost:1234/v1.").waitFor();
-
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "lmstudio-recovery-desktop.png"),
-        });
-      }
-
-      await page.getByRole("button", { name: "Continue" }).click();
-      await page.getByText("Retry this LM Studio connection now?").waitFor();
-      await gateway.setMethodResponse("openclaw.setup.detect", {
-        ...initialDetection,
-        candidates: [
-          {
-            kind: "provider-auto:lmstudio",
-            brandId: "lmstudio",
-            label: "LM Studio",
-            detail: "qwen3-8b-instruct at http://localhost:1234/v1",
-            modelRef,
-            recommended: false,
-            credentials: true,
+      async ({ page }) => {
+        const initialDetection = {
+          candidates: [],
+          manualProviders: [],
+          prepareOptions,
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        };
+        const modelRef = "lmstudio/qwen3-8b-instruct";
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+            "openclaw.setup.prepare.start",
+            "wizard.next",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": initialDetection,
+            "openclaw.setup.prepare.start": {
+              sessionId: "lmstudio-prepare-session",
+              done: false,
+              status: "running",
+            },
+            "openclaw.setup.activate": {
+              ok: true,
+              modelRef,
+              latencyMs: 416,
+              lines: ["Model ready"],
+            },
+            "wizard.next": {
+              sequence: [
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "lmstudio-base-url",
+                    type: "text",
+                    message: "LM Studio base URL",
+                    initialValue: "http://localhost:1234/v1",
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "lmstudio-api-key",
+                    type: "text",
+                    message: "LM Studio API key",
+                    placeholder: "Leave blank if auth is disabled",
+                    sensitive: true,
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "lmstudio-retry",
+                    type: "note",
+                    title: "LM Studio",
+                    message: [
+                      "LM Studio could not be reached at http://localhost:1234/v1.",
+                      "Start LM Studio (or run lms server start), then continue to retry.",
+                    ].join("\n"),
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "lmstudio-retry-confirm",
+                    type: "confirm",
+                    message: "Retry this LM Studio connection now?",
+                    initialValue: true,
+                  },
+                },
+                { done: true, status: "done" },
+              ],
+            },
           },
-        ],
-      });
-      await page.getByRole("button", { name: "Continue" }).click();
-      await page.getByRole("heading", { name: "Connection verified" }).waitFor();
-      await expect
-        .poll(() => page.locator(".model-setup-success").textContent())
-        .toContain(modelRef);
-      await expect
-        .poll(() => page.locator(".model-setup-success").textContent())
-        .toContain("Verified in 416 ms");
-      await expect
-        .poll(() => page.locator('.model-setup-success [data-provider-icon="lmstudio"]').count())
-        .toBe(1);
-
-      const activate = await gateway.waitForRequest("openclaw.setup.activate");
-      expect(activate.params).toEqual({
-        kind: "provider-auto:lmstudio",
-        modelRef,
-      });
-
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "lmstudio-ready-desktop.png"),
         });
-        await page.setViewportSize({ height: 844, width: 390 });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "lmstudio-ready-mobile.png"),
-        });
-      }
 
-      await gateway.setMethodResponse("openclaw.setup.detect", {
-        ...initialDetection,
-        candidates: [],
-        configuredModel: modelRef,
-        setupComplete: true,
-      });
-      await page.setViewportSize({ height: 900, width: 1280 });
-      await page.getByRole("button", { name: "Stay in settings" }).click();
-      const currentConnection = page.locator(".model-setup__current");
-      await currentConnection.getByText("LM Studio", { exact: true }).waitFor();
-      await currentConnection.getByText("qwen3-8b-instruct", { exact: true }).waitFor();
-      await expect
-        .poll(() => currentConnection.locator('[data-provider-icon="lmstudio"]').count())
-        .toBe(1);
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "lmstudio-main-desktop.png"),
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
+        const lmStudioRow = page.locator('[data-prepare-choice="lmstudio"]');
+        await lmStudioRow.getByRole("button", { name: "Connect server" }).waitFor();
+        await expect
+          .poll(() => lmStudioRow.locator('[data-provider-icon="lmstudio"]').count())
+          .toBe(1);
+
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "lmstudio-offer-desktop.png"),
+          });
+        }
+
+        await lmStudioRow.getByRole("button", { name: "Connect server" }).click();
+        const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
+        expect(start.params).toMatchObject({ authChoice: "lmstudio" });
+        await expect
+          .poll(() => page.getByLabel("LM Studio base URL").inputValue())
+          .toBe("http://localhost:1234/v1");
+        await page.getByRole("button", { name: "Submit" }).click();
+        await page.getByLabel("LM Studio API key").fill("");
+        await page.getByRole("button", { name: "Submit" }).click();
+        await page
+          .getByText("LM Studio could not be reached at http://localhost:1234/v1.")
+          .waitFor();
+
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "lmstudio-recovery-desktop.png"),
+          });
+        }
+
+        await page.getByRole("button", { name: "Continue" }).click();
+        await page.getByText("Retry this LM Studio connection now?").waitFor();
+        await gateway.setMethodResponse("openclaw.setup.detect", {
+          ...initialDetection,
+          candidates: [
+            {
+              kind: "provider-auto:lmstudio",
+              brandId: "lmstudio",
+              label: "LM Studio",
+              detail: "qwen3-8b-instruct at http://localhost:1234/v1",
+              modelRef,
+              recommended: false,
+              credentials: true,
+            },
+          ],
         });
-      }
-    } finally {
-      await context.close();
-    }
+        await page.getByRole("button", { name: "Continue" }).click();
+        await page.getByRole("heading", { name: "Connection verified" }).waitFor();
+        await expect
+          .poll(() => page.locator(".model-setup-success").textContent())
+          .toContain(modelRef);
+        await expect
+          .poll(() => page.locator(".model-setup-success").textContent())
+          .toContain("Verified in 416 ms");
+        await expect
+          .poll(() => page.locator('.model-setup-success [data-provider-icon="lmstudio"]').count())
+          .toBe(1);
+
+        const activate = await gateway.waitForRequest("openclaw.setup.activate");
+        expect(activate.params).toEqual({
+          kind: "provider-auto:lmstudio",
+          modelRef,
+        });
+
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "lmstudio-ready-desktop.png"),
+          });
+          await page.setViewportSize({ height: 844, width: 390 });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "lmstudio-ready-mobile.png"),
+          });
+        }
+
+        await gateway.setMethodResponse("openclaw.setup.detect", {
+          ...initialDetection,
+          candidates: [],
+          configuredModel: modelRef,
+          setupComplete: true,
+        });
+        await page.setViewportSize({ height: 900, width: 1280 });
+        await page.getByRole("button", { name: "Stay in settings" }).click();
+        const currentConnection = page.locator(".model-setup__current");
+        await currentConnection.getByText("LM Studio", { exact: true }).waitFor();
+        await currentConnection.getByText("qwen3-8b-instruct", { exact: true }).waitFor();
+        await expect
+          .poll(() => currentConnection.locator('[data-provider-icon="lmstudio"]').count())
+          .toBe(1);
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "lmstudio-main-desktop.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/model-setup-reconnect.e2e.test.ts
+++ b/ui/src/e2e/model-setup-reconnect.e2e.test.ts
@@ -1,20 +1,16 @@
 // Browser proof that model setup reloads after a same-client Gateway reconnect.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI model setup same-client reconnect",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const artifactDir = path.join(
   process.cwd(),
@@ -33,71 +29,54 @@ function detection(modelRef: string) {
   };
 }
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI model setup same-client reconnect", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("re-detects once and replaces stale visible model state after reconnect", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(String(error)));
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["openclaw.setup.detect"],
-      methodResponses: { "openclaw.setup.detect": detection("provider/original-model") },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      await page.getByText("original-model", { exact: true }).waitFor();
-      const initialDetections = (await gateway.getRequests("openclaw.setup.detect")).length;
-      const initialConnections = (await gateway.getRequests("connect")).length;
-      await gateway.setMethodResponse(
-        "openclaw.setup.detect",
-        detection("provider/reconnected-model"),
-      );
-      await gateway.deferNext("connect");
-      await gateway.closeLatest(1012, "model setup reconnect proof");
-      await expect
-        .poll(async () => page.getByText("original-model", { exact: true }).count())
-        .toBe(0);
-      await expect
-        .poll(async () => (await gateway.getRequests("connect")).length)
-        .toBeGreaterThan(initialConnections);
-      await gateway.resolveDeferred("connect");
-      await expect
-        .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
-        .toBe(initialDetections + 1);
-      await page.getByText("reconnected-model", { exact: true }).waitFor();
-      expect(pageErrors).toEqual([]);
-
-      if (captureUiProofEnabled) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.locator("openclaw-model-setup-page").screenshot({
-          animations: "disabled",
-          path: path.join(artifactDir, "00-reconnected-model-visible.png"),
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["openclaw.setup.detect"],
+          methodResponses: { "openclaw.setup.detect": detection("provider/original-model") },
         });
-      }
-    } finally {
-      await context.close();
-    }
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
+        await page.getByText("original-model", { exact: true }).waitFor();
+        const initialDetections = (await gateway.getRequests("openclaw.setup.detect")).length;
+        const initialConnections = (await gateway.getRequests("connect")).length;
+        await gateway.setMethodResponse(
+          "openclaw.setup.detect",
+          detection("provider/reconnected-model"),
+        );
+        await gateway.deferNext("connect");
+        await gateway.closeLatest(1012, "model setup reconnect proof");
+        await expect
+          .poll(async () => page.getByText("original-model", { exact: true }).count())
+          .toBe(0);
+        await expect
+          .poll(async () => (await gateway.getRequests("connect")).length)
+          .toBeGreaterThan(initialConnections);
+        await gateway.resolveDeferred("connect");
+        await expect
+          .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
+          .toBe(initialDetections + 1);
+        await page.getByText("reconnected-model", { exact: true }).waitFor();
+        expect(pageErrors).toEqual([]);
+
+        if (captureUiProofEnabled) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.locator("openclaw-model-setup-page").screenshot({
+            animations: "disabled",
+            path: path.join(artifactDir, "00-reconnected-model-visible.png"),
+          });
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/model-setup-recovery.e2e.test.ts
+++ b/ui/src/e2e/model-setup-recovery.e2e.test.ts
@@ -1,140 +1,119 @@
 // Control UI tests cover local-provider recovery against a mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI local-provider recovery mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI local-provider recovery mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("shows a failed LM Studio connection with its detected endpoint", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const modelRef = "lmstudio/qwen3-8b-instruct";
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.verify",
-        "openclaw.setup.prepare.start",
-        "wizard.next",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": {
-          candidates: [
-            {
-              kind: "provider-auto:lmstudio",
-              brandId: "lmstudio",
-              label: "LM Studio",
-              detail: "qwen3-8b-instruct at http://localhost:1234/v1",
-              modelRef,
-              recommended: false,
-              credentials: true,
-            },
-          ],
-          manualProviders: [],
-          prepareOptions: [
-            {
-              id: "lmstudio",
-              brandId: "lmstudio",
-              label: "LM Studio",
-              hint: "Connect to a running LM Studio server and use an already loaded model",
-              actionLabel: "Connect server",
-            },
-          ],
-          workspace: "/tmp/openclaw-e2e",
-          configuredModel: modelRef,
-          setupComplete: true,
-        },
-        "openclaw.setup.verify": {
-          ok: false,
-          status: "unavailable",
-          error: "connect ECONNREFUSED 127.0.0.1:1234",
-        },
-        "openclaw.setup.prepare.start": {
-          sessionId: "lmstudio-recovery-session",
-          done: false,
-          status: "running",
-        },
-        "wizard.next": {
-          done: false,
-          status: "running",
-          step: {
-            id: "lmstudio-base-url",
-            type: "text",
-            message: "LM Studio base URL",
-            initialValue: "http://localhost:1234/v1",
-          },
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      const selectedModel = page.locator(".model-setup__current");
-      await selectedModel.getByText("LM Studio", { exact: true }).waitFor();
-      await selectedModel.getByRole("button", { name: "Check model" }).click();
-      await selectedModel.getByText("qwen3-8b-instruct at http://localhost:1234/v1").waitFor();
-      await selectedModel.getByText("LM Studio isn’t responding.").waitFor();
-      await selectedModel.getByRole("button", { name: "Try again" }).waitFor();
-      await expect.poll(() => selectedModel.getByText("Change connection").count()).toBe(0);
-      await expect
-        .poll(() => page.locator('[data-candidate-kind="provider-auto:lmstudio"]').count())
-        .toBe(0);
-
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "local-provider-failure-desktop.png"),
+      async ({ page }) => {
+        const modelRef = "lmstudio/qwen3-8b-instruct";
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.verify",
+            "openclaw.setup.prepare.start",
+            "wizard.next",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": {
+              candidates: [
+                {
+                  kind: "provider-auto:lmstudio",
+                  brandId: "lmstudio",
+                  label: "LM Studio",
+                  detail: "qwen3-8b-instruct at http://localhost:1234/v1",
+                  modelRef,
+                  recommended: false,
+                  credentials: true,
+                },
+              ],
+              manualProviders: [],
+              prepareOptions: [
+                {
+                  id: "lmstudio",
+                  brandId: "lmstudio",
+                  label: "LM Studio",
+                  hint: "Connect to a running LM Studio server and use an already loaded model",
+                  actionLabel: "Connect server",
+                },
+              ],
+              workspace: "/tmp/openclaw-e2e",
+              configuredModel: modelRef,
+              setupComplete: true,
+            },
+            "openclaw.setup.verify": {
+              ok: false,
+              status: "unavailable",
+              error: "connect ECONNREFUSED 127.0.0.1:1234",
+            },
+            "openclaw.setup.prepare.start": {
+              sessionId: "lmstudio-recovery-session",
+              done: false,
+              status: "running",
+            },
+            "wizard.next": {
+              done: false,
+              status: "running",
+              step: {
+                id: "lmstudio-base-url",
+                type: "text",
+                message: "LM Studio base URL",
+                initialValue: "http://localhost:1234/v1",
+              },
+            },
+          },
         });
-        await page.setViewportSize({ height: 844, width: 390 });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "local-provider-failure-mobile.png"),
-        });
-      }
 
-      const verify = await gateway.waitForRequest("openclaw.setup.verify");
-      expect(verify.params).toEqual({});
-    } finally {
-      await context.close();
-    }
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
+        const selectedModel = page.locator(".model-setup__current");
+        await selectedModel.getByText("LM Studio", { exact: true }).waitFor();
+        await selectedModel.getByRole("button", { name: "Check model" }).click();
+        await selectedModel.getByText("qwen3-8b-instruct at http://localhost:1234/v1").waitFor();
+        await selectedModel.getByText("LM Studio isn’t responding.").waitFor();
+        await selectedModel.getByRole("button", { name: "Try again" }).waitFor();
+        await expect.poll(() => selectedModel.getByText("Change connection").count()).toBe(0);
+        await expect
+          .poll(() => page.locator('[data-candidate-kind="provider-auto:lmstudio"]').count())
+          .toBe(0);
+
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "local-provider-failure-desktop.png"),
+          });
+          await page.setViewportSize({ height: 844, width: 390 });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "local-provider-failure-mobile.png"),
+          });
+        }
+
+        const verify = await gateway.waitForRequest("openclaw.setup.verify");
+        expect(verify.params).toEqual({});
+      },
+    );
   });
 });

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -1,20 +1,16 @@
 // Control UI tests cover guided model setup against a mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Model Setup mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 const localPrepareOptions = [
   {
@@ -42,842 +38,826 @@ const localPrepareOptions = [
   },
 ];
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("hands first-run model setup to the custodian in onboarding chrome", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.activate",
-        "openclaw.chat",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": {
-          candidates: [
-            {
-              kind: "codex-cli",
-              brandId: "openai",
-              label: "Codex CLI",
-              detail: "Signed in locally",
-              modelRef: "openai/gpt-5",
-              recommended: true,
-              credentials: true,
-            },
-          ],
-          manualProviders: [{ id: "openai", label: "OpenAI" }],
-          workspace: "/tmp/openclaw-e2e",
-          setupComplete: false,
-        },
-        "openclaw.setup.activate": {
-          ok: true,
-          modelRef: "openai/gpt-5",
-          latencyMs: 73,
-          lines: ["Model ready"],
-        },
-        "openclaw.chat": {
-          sessionId: "e2e-custodian",
-          reply: "## Hi, I'm OpenClaw",
-          action: "none",
-          question: {
-            id: "onboarding-next-step",
-            header: "Next step",
-            question: "What would you like to do first?",
-            options: [
-              { label: "Talk to my agent", reply: "talk to agent", recommended: true },
-              { label: "Connect WhatsApp", reply: "connect whatsapp" },
-            ],
-            isOther: true,
-            skipAction: "exit",
-          },
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+            "openclaw.chat",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": {
+              candidates: [
+                {
+                  kind: "codex-cli",
+                  brandId: "openai",
+                  label: "Codex CLI",
+                  detail: "Signed in locally",
+                  modelRef: "openai/gpt-5",
+                  recommended: true,
+                  credentials: true,
+                },
+              ],
+              manualProviders: [{ id: "openai", label: "OpenAI" }],
+              workspace: "/tmp/openclaw-e2e",
+              setupComplete: false,
+            },
+            "openclaw.setup.activate": {
+              ok: true,
+              modelRef: "openai/gpt-5",
+              latencyMs: 73,
+              lines: ["Model ready"],
+            },
+            "openclaw.chat": {
+              sessionId: "e2e-custodian",
+              reply: "## Hi, I'm OpenClaw",
+              action: "none",
+              question: {
+                id: "onboarding-next-step",
+                header: "Next step",
+                question: "What would you like to do first?",
+                options: [
+                  { label: "Talk to my agent", reply: "talk to agent", recommended: true },
+                  { label: "Connect WhatsApp", reply: "connect whatsapp" },
+                ],
+                isOther: true,
+                skipAction: "exit",
+              },
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup?firstRun=1`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
-      const candidate = page.locator('[data-candidate-kind="codex-cli"]');
-      await expect.poll(() => candidate.locator('[data-provider-icon="codex"]').count()).toBe(1);
-      await candidate.getByRole("button", { name: "Test & use" }).click();
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup?firstRun=1`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
+        const candidate = page.locator('[data-candidate-kind="codex-cli"]');
+        await expect.poll(() => candidate.locator('[data-provider-icon="codex"]').count()).toBe(1);
+        await candidate.getByRole("button", { name: "Test & use" }).click();
 
-      const detect = await gateway.waitForRequest("openclaw.setup.detect");
-      expect(detect.params).toEqual({});
-      const activate = await gateway.waitForRequest("openclaw.setup.activate");
-      expect(activate.params).toEqual({ kind: "codex-cli", modelRef: "openai/gpt-5" });
+        const detect = await gateway.waitForRequest("openclaw.setup.detect");
+        expect(detect.params).toEqual({});
+        const activate = await gateway.waitForRequest("openclaw.setup.activate");
+        expect(activate.params).toEqual({ kind: "codex-cli", modelRef: "openai/gpt-5" });
 
-      await page.getByRole("heading", { name: "Connection verified" }).waitFor();
-      await expect
-        .poll(async () => page.locator(".model-setup-success").textContent())
-        .toContain("openai/gpt-5");
-      await expect
-        .poll(async () => page.locator(".model-setup-success").textContent())
-        .toContain("Verified in 73 ms");
-      await page.getByRole("button", { name: "Continue setup" }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/custodian");
-      expect(new URL(page.url()).searchParams.get("onboarding")).toBe("1");
-      await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
-      await expect
-        .poll(() => page.locator(".shell").getAttribute("class"))
-        .toContain("shell--onboarding");
-      expect(await page.locator(".shell-nav").isVisible()).toBe(false);
+        await page.getByRole("heading", { name: "Connection verified" }).waitFor();
+        await expect
+          .poll(async () => page.locator(".model-setup-success").textContent())
+          .toContain("openai/gpt-5");
+        await expect
+          .poll(async () => page.locator(".model-setup-success").textContent())
+          .toContain("Verified in 73 ms");
+        await page.getByRole("button", { name: "Continue setup" }).click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/custodian");
+        expect(new URL(page.url()).searchParams.get("onboarding")).toBe("1");
+        await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();
+        await expect
+          .poll(() => page.locator(".shell").getAttribute("class"))
+          .toContain("shell--onboarding");
+        expect(await page.locator(".shell-nav").isVisible()).toBe(false);
 
-      const chatRequest = await gateway.waitForRequest("openclaw.chat");
-      expect(chatRequest.params).toMatchObject({
-        sessionId: expect.stringMatching(/^control-ui-onboarding-/u),
-        welcomeVariant: "onboarding",
-      });
-      await page.getByRole("button", { name: "Skip for now" }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/chat");
-      await expect
-        .poll(() => page.locator(".shell").getAttribute("class"))
-        .not.toContain("shell--onboarding");
-      const userTurns = (await gateway.getRequests("openclaw.chat")).filter((request) => {
-        const params = request.params;
-        return typeof params === "object" && params !== null && "message" in params;
-      });
-      expect(userTurns).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+        const chatRequest = await gateway.waitForRequest("openclaw.chat");
+        expect(chatRequest.params).toMatchObject({
+          sessionId: expect.stringMatching(/^control-ui-onboarding-/u),
+          welcomeVariant: "onboarding",
+        });
+        await page.getByRole("button", { name: "Skip for now" }).click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/chat");
+        await expect
+          .poll(() => page.locator(".shell").getAttribute("class"))
+          .not.toContain("shell--onboarding");
+        const userTurns = (await gateway.getRequests("openclaw.chat")).filter((request) => {
+          const params = request.params;
+          return typeof params === "object" && params !== null && "message" in params;
+        });
+        expect(userTurns).toHaveLength(0);
+      },
+    );
   });
 
   it("completes device-code sign-in and re-detects the configured model", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const initialDetection = {
-      candidates: [],
-      manualProviders: [],
-      authOptions: [
-        {
-          id: "provider-device-code",
-          label: "Provider account",
-          kind: "device-code",
-          featured: true,
-        },
-      ],
-      workspace: "/tmp/openclaw-e2e",
-      setupComplete: false,
-    };
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.auth.start",
-        "wizard.next",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": initialDetection,
-        "openclaw.setup.auth.start": {
-          sessionId: "device-code-session",
-          done: false,
-          status: "running",
-        },
-        "wizard.next": {
-          sequence: [
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const initialDetection = {
+          candidates: [],
+          manualProviders: [],
+          authOptions: [
             {
+              id: "provider-device-code",
+              label: "Provider account",
+              kind: "device-code",
+              featured: true,
+            },
+          ],
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        };
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.auth.start",
+            "wizard.next",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": initialDetection,
+            "openclaw.setup.auth.start": {
+              sessionId: "device-code-session",
               done: false,
               status: "running",
-              step: {
-                id: "device-code",
-                type: "note",
-                title: "Authorize device",
-                externalUrl: "https://example.com/device",
-                deviceCode: { code: "ABCD-1234", expiresInMinutes: 14 },
-              },
             },
-            { done: true, status: "done" },
-          ],
-        },
+            "wizard.next": {
+              sequence: [
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "device-code",
+                    type: "note",
+                    title: "Authorize device",
+                    externalUrl: "https://example.com/device",
+                    deviceCode: { code: "ABCD-1234", expiresInMinutes: 14 },
+                  },
+                },
+                { done: true, status: "done" },
+              ],
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("button", { name: "Pair" }).click();
+
+        const start = await gateway.waitForRequest("openclaw.setup.auth.start");
+        expect(start.params).toMatchObject({ authChoice: "provider-device-code" });
+        await page.getByText("ABCD-1234").waitFor();
+        await page.getByText("Expires in 14 minutes").waitFor();
+        const signInLink = page.getByRole("link", { name: "Open sign-in page" });
+        await expect.poll(() => signInLink.getAttribute("href")).toBe("https://example.com/device");
+
+        await gateway.setMethodResponse("openclaw.setup.detect", {
+          ...initialDetection,
+          authOptions: [],
+          configuredModel: "provider/verified-model",
+          setupComplete: true,
+        });
+        const detectCountBeforeCompletion = (await gateway.getRequests("openclaw.setup.detect"))
+          .length;
+        await page.getByRole("button", { name: "Continue" }).click();
+        await expect.poll(async () => (await gateway.getRequests("wizard.next")).length).toBe(2);
+        const wizardRequests = await gateway.getRequests("wizard.next");
+        expect(wizardRequests[0]?.params).toMatchObject({ sessionId: expect.any(String) });
+        expect(wizardRequests[1]?.params).toMatchObject({
+          sessionId: expect.any(String),
+          answer: { stepId: "device-code" },
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
+          .toBe(detectCountBeforeCompletion + 1);
+        await page.getByRole("heading", { name: "Connection verified" }).waitFor();
+        await expect
+          .poll(async () => page.locator(".model-setup-success").textContent())
+          .toContain("provider/verified-model");
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("button", { name: "Pair" }).click();
-
-      const start = await gateway.waitForRequest("openclaw.setup.auth.start");
-      expect(start.params).toMatchObject({ authChoice: "provider-device-code" });
-      await page.getByText("ABCD-1234").waitFor();
-      await page.getByText("Expires in 14 minutes").waitFor();
-      const signInLink = page.getByRole("link", { name: "Open sign-in page" });
-      await expect.poll(() => signInLink.getAttribute("href")).toBe("https://example.com/device");
-
-      await gateway.setMethodResponse("openclaw.setup.detect", {
-        ...initialDetection,
-        authOptions: [],
-        configuredModel: "provider/verified-model",
-        setupComplete: true,
-      });
-      const detectCountBeforeCompletion = (await gateway.getRequests("openclaw.setup.detect"))
-        .length;
-      await page.getByRole("button", { name: "Continue" }).click();
-      await expect.poll(async () => (await gateway.getRequests("wizard.next")).length).toBe(2);
-      const wizardRequests = await gateway.getRequests("wizard.next");
-      expect(wizardRequests[0]?.params).toMatchObject({ sessionId: expect.any(String) });
-      expect(wizardRequests[1]?.params).toMatchObject({
-        sessionId: expect.any(String),
-        answer: { stepId: "device-code" },
-      });
-      await expect
-        .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
-        .toBe(detectCountBeforeCompletion + 1);
-      await page.getByRole("heading", { name: "Connection verified" }).waitFor();
-      await expect
-        .poll(async () => page.locator(".model-setup-success").textContent())
-        .toContain("provider/verified-model");
-    } finally {
-      await context.close();
-    }
+    );
   });
 
   it("recovers Ollama setup in place after the local server starts", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const initialDetection = {
-      candidates: [],
-      manualProviders: [],
-      prepareOptions: localPrepareOptions,
-      recommendedInstalls: [
-        {
-          id: "ollama",
-          brandId: "ollama",
-          label: "Ollama",
-          hint: "Run open models locally",
-          website: "https://ollama.com/download",
-        },
-      ],
-      workspace: "/tmp/openclaw-e2e",
-      setupComplete: false,
-    };
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.activate",
-        "openclaw.setup.prepare.start",
-        "wizard.next",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": initialDetection,
-        "openclaw.setup.prepare.start": {
-          sessionId: "ollama-prepare-session",
-          done: false,
-          status: "running",
-        },
-        "openclaw.setup.activate": {
-          ok: true,
-          modelRef: "ollama/qwen3:0.6b",
-          latencyMs: 284,
-          lines: ["Model ready"],
-        },
-        "wizard.next": {
-          sequence: [
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const initialDetection = {
+          candidates: [],
+          manualProviders: [],
+          prepareOptions: localPrepareOptions,
+          recommendedInstalls: [
             {
-              done: false,
-              status: "running",
-              step: {
-                id: "ollama-mode",
-                type: "select",
-                message: "Ollama mode",
-                options: [
-                  {
-                    value: "cloud-local",
-                    label: "Cloud + Local",
-                    hint: "Route cloud and local models through your Ollama host",
-                  },
-                  { value: "cloud-only", label: "Cloud only", hint: "Hosted Ollama models" },
-                  { value: "local-only", label: "Local only", hint: "Local models only" },
-                ],
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "ollama-base-url",
-                type: "text",
-                message: "Ollama base URL",
-                initialValue: "http://127.0.0.1:11434",
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "ollama-retry",
-                type: "note",
-                title: "Ollama",
-                message: [
-                  "Ollama could not be reached at http://127.0.0.1:11434.",
-                  "Start or restart the Ollama server for this address.",
-                  "If Ollama is not installed on that machine, download it at https://ollama.com/download",
-                  "",
-                  "Continue when it is running. OpenClaw will retry this address.",
-                ].join("\n"),
-              },
-            },
-            {
-              done: false,
-              status: "running",
-              step: {
-                id: "ollama-retry-confirm",
-                type: "confirm",
-                message: "Retry this Ollama address now?",
-                initialValue: true,
-              },
-            },
-            {
-              done: true,
-              status: "done",
-              preparedModelRef: "ollama/qwen3:0.6b",
+              id: "ollama",
+              brandId: "ollama",
+              label: "Ollama",
+              hint: "Run open models locally",
+              website: "https://ollama.com/download",
             },
           ],
-        },
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        };
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+            "openclaw.setup.prepare.start",
+            "wizard.next",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": initialDetection,
+            "openclaw.setup.prepare.start": {
+              sessionId: "ollama-prepare-session",
+              done: false,
+              status: "running",
+            },
+            "openclaw.setup.activate": {
+              ok: true,
+              modelRef: "ollama/qwen3:0.6b",
+              latencyMs: 284,
+              lines: ["Model ready"],
+            },
+            "wizard.next": {
+              sequence: [
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "ollama-mode",
+                    type: "select",
+                    message: "Ollama mode",
+                    options: [
+                      {
+                        value: "cloud-local",
+                        label: "Cloud + Local",
+                        hint: "Route cloud and local models through your Ollama host",
+                      },
+                      { value: "cloud-only", label: "Cloud only", hint: "Hosted Ollama models" },
+                      { value: "local-only", label: "Local only", hint: "Local models only" },
+                    ],
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "ollama-base-url",
+                    type: "text",
+                    message: "Ollama base URL",
+                    initialValue: "http://127.0.0.1:11434",
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "ollama-retry",
+                    type: "note",
+                    title: "Ollama",
+                    message: [
+                      "Ollama could not be reached at http://127.0.0.1:11434.",
+                      "Start or restart the Ollama server for this address.",
+                      "If Ollama is not installed on that machine, download it at https://ollama.com/download",
+                      "",
+                      "Continue when it is running. OpenClaw will retry this address.",
+                    ].join("\n"),
+                  },
+                },
+                {
+                  done: false,
+                  status: "running",
+                  step: {
+                    id: "ollama-retry-confirm",
+                    type: "confirm",
+                    message: "Retry this Ollama address now?",
+                    initialValue: true,
+                  },
+                },
+                {
+                  done: true,
+                  status: "done",
+                  preparedModelRef: "ollama/qwen3:0.6b",
+                },
+              ],
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
+        const localProviderIcons = page.locator(
+          [
+            '[data-prepare-choice="ollama"] [data-provider-icon="ollama"]',
+            '[data-prepare-choice="llama-cpp"] [data-provider-icon="llamacpp"]',
+            '[data-prepare-choice="lmstudio"] [data-provider-icon="lmstudio"]',
+          ].join(","),
+        );
+        await expect.poll(() => localProviderIcons.count()).toBe(3);
+        const localProviderIconColors = await localProviderIcons.evaluateAll((icons) =>
+          icons.map((icon) => getComputedStyle(icon).color),
+        );
+        expect(localProviderIconColors).toHaveLength(3);
+        expect(new Set(localProviderIconColors).size).toBe(1);
+        await page
+          .locator('[data-prepare-choice="ollama"]')
+          .getByRole("button", { name: "Choose connection" })
+          .click();
+
+        const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
+        expect(start.params).toMatchObject({ authChoice: "ollama" });
+
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "ollama-mode-select-desktop.png"),
+          });
+        }
+
+        await page.getByRole("radio", { name: /Local only/u }).check();
+        await page.getByRole("button", { name: "Continue" }).click();
+        const baseUrl = page.getByLabel("Ollama base URL");
+        await expect.poll(() => baseUrl.inputValue()).toBe("http://127.0.0.1:11434");
+
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "ollama-host-desktop.png"),
+          });
+        }
+
+        await page.getByRole("button", { name: "Submit" }).click();
+        await page.getByText("Ollama could not be reached at http://127.0.0.1:11434.").waitFor();
+        await page
+          .getByText("Continue when it is running. OpenClaw will retry this address.")
+          .waitFor();
+
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "ollama-recovery-desktop.png"),
+          });
+        }
+
+        await page.getByRole("button", { name: "Continue" }).click();
+        await page.getByText("Retry this Ollama address now?").waitFor();
+
+        await page.getByRole("button", { name: "Continue" }).click();
+        await page.getByRole("heading", { name: "Connection verified" }).waitFor();
+        await expect
+          .poll(() => page.locator(".model-setup-success").textContent())
+          .toContain("ollama/qwen3:0.6b");
+        await expect
+          .poll(() => page.locator(".model-setup-success").textContent())
+          .toContain("Verified in 284 ms");
+        await expect
+          .poll(() => page.locator('.model-setup-success [data-provider-icon="ollama"]').count())
+          .toBe(1);
+
+        const activate = await gateway.waitForRequest("openclaw.setup.activate");
+        expect(activate.params).toEqual({
+          kind: "provider-auto:ollama",
+          modelRef: "ollama/qwen3:0.6b",
+        });
+
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "ollama-ready-desktop.png"),
+          });
+        }
+
+        await gateway.setMethodResponse("openclaw.setup.detect", {
+          ...initialDetection,
+          candidates: [],
+          configuredModel: "ollama/qwen3:0.6b",
+          recommendedInstalls: [],
+          setupComplete: true,
+        });
+        await page.getByRole("button", { name: "Stay in settings" }).click();
+        const currentConnection = page.locator(".model-setup__current");
+        await currentConnection.getByText("Ollama", { exact: true }).waitFor();
+        await currentConnection.getByText("qwen3:0.6b", { exact: true }).waitFor();
+        await expect
+          .poll(() => currentConnection.locator('[data-provider-icon="ollama"]').count())
+          .toBe(1);
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "ollama-main-desktop.png"),
+          });
+        }
+
+        const wizardRequests = await gateway.getRequests("wizard.next");
+        expect(wizardRequests).toHaveLength(5);
+        expect(wizardRequests[2]?.params).toMatchObject({
+          answer: {
+            stepId: "ollama-base-url",
+            value: "http://127.0.0.1:11434",
+          },
+        });
+        expect(wizardRequests[3]?.params).toMatchObject({
+          answer: { stepId: "ollama-retry" },
+        });
+        expect(wizardRequests[4]?.params).toMatchObject({
+          answer: { stepId: "ollama-retry-confirm", value: true },
+        });
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      const localProviderIcons = page.locator(
-        [
-          '[data-prepare-choice="ollama"] [data-provider-icon="ollama"]',
-          '[data-prepare-choice="llama-cpp"] [data-provider-icon="llamacpp"]',
-          '[data-prepare-choice="lmstudio"] [data-provider-icon="lmstudio"]',
-        ].join(","),
-      );
-      await expect.poll(() => localProviderIcons.count()).toBe(3);
-      const localProviderIconColors = await localProviderIcons.evaluateAll((icons) =>
-        icons.map((icon) => getComputedStyle(icon).color),
-      );
-      expect(localProviderIconColors).toHaveLength(3);
-      expect(new Set(localProviderIconColors).size).toBe(1);
-      await page
-        .locator('[data-prepare-choice="ollama"]')
-        .getByRole("button", { name: "Choose connection" })
-        .click();
-
-      const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
-      expect(start.params).toMatchObject({ authChoice: "ollama" });
-
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "ollama-mode-select-desktop.png"),
-        });
-      }
-
-      await page.getByRole("radio", { name: /Local only/u }).check();
-      await page.getByRole("button", { name: "Continue" }).click();
-      const baseUrl = page.getByLabel("Ollama base URL");
-      await expect.poll(() => baseUrl.inputValue()).toBe("http://127.0.0.1:11434");
-
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "ollama-host-desktop.png"),
-        });
-      }
-
-      await page.getByRole("button", { name: "Submit" }).click();
-      await page.getByText("Ollama could not be reached at http://127.0.0.1:11434.").waitFor();
-      await page
-        .getByText("Continue when it is running. OpenClaw will retry this address.")
-        .waitFor();
-
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "ollama-recovery-desktop.png"),
-        });
-      }
-
-      await page.getByRole("button", { name: "Continue" }).click();
-      await page.getByText("Retry this Ollama address now?").waitFor();
-
-      await page.getByRole("button", { name: "Continue" }).click();
-      await page.getByRole("heading", { name: "Connection verified" }).waitFor();
-      await expect
-        .poll(() => page.locator(".model-setup-success").textContent())
-        .toContain("ollama/qwen3:0.6b");
-      await expect
-        .poll(() => page.locator(".model-setup-success").textContent())
-        .toContain("Verified in 284 ms");
-      await expect
-        .poll(() => page.locator('.model-setup-success [data-provider-icon="ollama"]').count())
-        .toBe(1);
-
-      const activate = await gateway.waitForRequest("openclaw.setup.activate");
-      expect(activate.params).toEqual({
-        kind: "provider-auto:ollama",
-        modelRef: "ollama/qwen3:0.6b",
-      });
-
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "ollama-ready-desktop.png"),
-        });
-      }
-
-      await gateway.setMethodResponse("openclaw.setup.detect", {
-        ...initialDetection,
-        candidates: [],
-        configuredModel: "ollama/qwen3:0.6b",
-        recommendedInstalls: [],
-        setupComplete: true,
-      });
-      await page.getByRole("button", { name: "Stay in settings" }).click();
-      const currentConnection = page.locator(".model-setup__current");
-      await currentConnection.getByText("Ollama", { exact: true }).waitFor();
-      await currentConnection.getByText("qwen3:0.6b", { exact: true }).waitFor();
-      await expect
-        .poll(() => currentConnection.locator('[data-provider-icon="ollama"]').count())
-        .toBe(1);
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "ollama-main-desktop.png"),
-        });
-      }
-
-      const wizardRequests = await gateway.getRequests("wizard.next");
-      expect(wizardRequests).toHaveLength(5);
-      expect(wizardRequests[2]?.params).toMatchObject({
-        answer: {
-          stepId: "ollama-base-url",
-          value: "http://127.0.0.1:11434",
-        },
-      });
-      expect(wizardRequests[3]?.params).toMatchObject({
-        answer: { stepId: "ollama-retry" },
-      });
-      expect(wizardRequests[4]?.params).toMatchObject({
-        answer: { stepId: "ollama-retry-confirm", value: true },
-      });
-    } finally {
-      await context.close();
-    }
+    );
   });
 
   it("offers supported Google setup in an accessible provider picker", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1000, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.activate",
-        "openclaw.setup.prepare.start",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": {
-          candidates: [],
-          unavailableCandidates: [],
-          manualProviders: [
-            {
-              id: "qwen-cn",
-              brandId: "qwen",
-              groupLabel: "Qwen Cloud",
-              label: "Coding Plan API Key for China (subscription)",
-              hint: "Endpoint: coding.dashscope.aliyuncs.com",
-            },
-            {
-              id: "qwen-global",
-              brandId: "qwen",
-              groupLabel: "Qwen Cloud",
-              label: "Coding Plan API Key for Global/Intl (subscription)",
-              hint: "Endpoint: coding-intl.dashscope.aliyuncs.com",
-            },
-            {
-              id: "zai-cn",
-              brandId: "zai",
-              groupLabel: "Z.AI",
-              label: "Coding-Plan-CN",
-            },
-            {
-              id: "gemini-api-key",
-              brandId: "google",
-              groupLabel: "Google",
-              label: "Google AI Studio API key",
-              hint: "Supported API-key access from aistudio.google.com/apikey",
-            },
-          ],
-          authOptions: [],
-          workspace: "/tmp/openclaw-e2e",
-          setupComplete: false,
-        },
-        "openclaw.setup.activate": {
-          ok: true,
-          modelRef: "qwen/qwen3-coder-plus",
-          latencyMs: 412,
-          lines: ["Model ready"],
-        },
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.activate",
+            "openclaw.setup.prepare.start",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": {
+              candidates: [],
+              unavailableCandidates: [],
+              manualProviders: [
+                {
+                  id: "qwen-cn",
+                  brandId: "qwen",
+                  groupLabel: "Qwen Cloud",
+                  label: "Coding Plan API Key for China (subscription)",
+                  hint: "Endpoint: coding.dashscope.aliyuncs.com",
+                },
+                {
+                  id: "qwen-global",
+                  brandId: "qwen",
+                  groupLabel: "Qwen Cloud",
+                  label: "Coding Plan API Key for Global/Intl (subscription)",
+                  hint: "Endpoint: coding-intl.dashscope.aliyuncs.com",
+                },
+                {
+                  id: "zai-cn",
+                  brandId: "zai",
+                  groupLabel: "Z.AI",
+                  label: "Coding-Plan-CN",
+                },
+                {
+                  id: "gemini-api-key",
+                  brandId: "google",
+                  groupLabel: "Google",
+                  label: "Google AI Studio API key",
+                  hint: "Supported API-key access from aistudio.google.com/apikey",
+                },
+              ],
+              authOptions: [],
+              workspace: "/tmp/openclaw-e2e",
+              setupComplete: false,
+            },
+            "openclaw.setup.activate": {
+              ok: true,
+              modelRef: "qwen/qwen3-coder-plus",
+              latencyMs: 412,
+              lines: ["Model ready"],
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
-      await expect.poll(() => page.getByText("Gemini CLI OAuth").count()).toBe(0);
-      await expect.poll(() => page.getByText("Found, but needs attention").count()).toBe(0);
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
+        await expect.poll(() => page.getByText("Gemini CLI OAuth").count()).toBe(0);
+        await expect.poll(() => page.getByText("Found, but needs attention").count()).toBe(0);
 
-      const providerPicker = page.locator(".model-setup-provider-select");
-      const providerTrigger = providerPicker.locator(".model-setup-provider-select__trigger");
-      const manualProviderIsActive = (providerId: string) =>
-        page
-          .locator(`[data-manual-provider="${providerId}"]`)
-          .evaluate((element) => Reflect.get(element, "active") === true);
-      const manualProviderMenuReady = () =>
-        page
+        const providerPicker = page.locator(".model-setup-provider-select");
+        const providerTrigger = providerPicker.locator(".model-setup-provider-select__trigger");
+        const manualProviderIsActive = (providerId: string) =>
+          page
+            .locator(`[data-manual-provider="${providerId}"]`)
+            .evaluate((element) => Reflect.get(element, "active") === true);
+        const manualProviderMenuReady = () =>
+          page
+            .locator("[data-manual-provider]")
+            .evaluateAll((options) =>
+              options.some((option) => Reflect.get(option, "active") === true),
+            );
+        const waitForProviderHide = () =>
+          providerPicker.evaluate(
+            (element) =>
+              new Promise<void>((resolve) => {
+                element.addEventListener("wa-after-hide", () => resolve(), { once: true });
+              }),
+          );
+        const providerIds = await page
           .locator("[data-manual-provider]")
           .evaluateAll((options) =>
-            options.some((option) => Reflect.get(option, "active") === true),
+            options
+              .map((option) =>
+                option instanceof HTMLElement ? option.dataset.manualProvider : null,
+              )
+              .filter((value): value is string => Boolean(value)),
           );
-      const waitForProviderHide = () =>
-        providerPicker.evaluate(
-          (element) =>
-            new Promise<void>((resolve) => {
-              element.addEventListener("wa-after-hide", () => resolve(), { once: true });
-            }),
-        );
-      const providerIds = await page
-        .locator("[data-manual-provider]")
-        .evaluateAll((options) =>
-          options
-            .map((option) => (option instanceof HTMLElement ? option.dataset.manualProvider : null))
-            .filter((value): value is string => Boolean(value)),
-        );
-      const firstProviderId = providerIds[0]!;
-      const lastProviderId = providerIds.at(-1)!;
-      await providerTrigger.click();
-      await expect
-        .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
-        .toBe(true);
-      await expect
-        .poll(() => page.locator('[data-manual-provider="qwen-cn"]').getAttribute("aria-label"))
-        .toContain("Qwen Cloud");
-      await expect
-        .poll(() => page.locator('[data-manual-provider="zai-cn"]').getAttribute("aria-label"))
-        .toContain("Z.AI");
-      await expect
-        .poll(() =>
-          page.locator('[data-manual-provider="qwen-cn"] [data-provider-icon="alibaba"]').count(),
-        )
-        .toBe(1);
-
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "provider-picker-desktop.png"),
-        });
-        await page.setViewportSize({ height: 844, width: 390 });
-        await providerPicker.scrollIntoViewIfNeeded();
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(artifactDir, "provider-picker-mobile.png"),
-        });
-        await page.setViewportSize({ height: 1000, width: 1440 });
-      }
-      const providerHidden = waitForProviderHide();
-      await page.keyboard.press("Escape");
-      await providerHidden;
-      await expect
-        .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
-        .toBe(false);
-
-      const accessValue = page.locator('.model-setup__manual input[type="password"]');
-      await expect
-        .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
-        .toBe(true);
-      await page.keyboard.press("Enter");
-      await expect
-        .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
-        .toBe(true);
-      await expect.poll(manualProviderMenuReady).toBe(true);
-      await page.keyboard.press("Home");
-      await expect.poll(() => manualProviderIsActive(firstProviderId)).toBe(true);
-      await page.keyboard.press("End");
-      await expect.poll(() => manualProviderIsActive(lastProviderId)).toBe(true);
-      await page.keyboard.press("Home");
-      await expect.poll(() => manualProviderIsActive(firstProviderId)).toBe(true);
-      await page.keyboard.press("z");
-      await expect.poll(() => manualProviderIsActive("zai-cn")).toBe(true);
-      const zaiProviderHidden = waitForProviderHide();
-      await page.keyboard.press("Enter");
-      await zaiProviderHidden;
-      await expect.poll(() => providerTrigger.textContent()).toContain("Z.AI");
-      await expect
-        .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
-        .toBe(true);
-
-      await accessValue.fill("same-provider-secret");
-      await providerTrigger.click();
-      await expect.poll(manualProviderMenuReady).toBe(true);
-      const sameProviderHidden = waitForProviderHide();
-      await page.locator('[data-manual-provider="zai-cn"]').click();
-      await sameProviderHidden;
-      await expect.poll(() => accessValue.inputValue()).toBe("same-provider-secret");
-      await expect
-        .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
-        .toBe(true);
-
-      await providerTrigger.click();
-      await expect.poll(manualProviderMenuReady).toBe(true);
-      const providerHiddenBackward = waitForProviderHide();
-      await page.keyboard.press("Shift+Tab");
-      await providerHiddenBackward;
-      await expect
-        .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
-        .toBe(true);
-
-      await providerTrigger.click();
-      await expect.poll(manualProviderMenuReady).toBe(true);
-      await page.keyboard.press("Tab");
-      await expect
-        .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
-        .toBe(false);
-      await expect
-        .poll(() => accessValue.evaluate((element) => element === document.activeElement))
-        .toBe(true);
-
-      await accessValue.fill("sk-old-provider-secret");
-      await providerTrigger.click();
-      await expect.poll(manualProviderMenuReady).toBe(true);
-      const googleProviderHidden = waitForProviderHide();
-      await page.locator('[data-manual-provider="gemini-api-key"]').click();
-      await googleProviderHidden;
-      await expect.poll(() => providerTrigger.textContent()).toContain("Google");
-      await expect.poll(() => providerTrigger.textContent()).toContain("AI Studio API key");
-      await expect.poll(() => accessValue.inputValue()).toBe("");
-      await expect
-        .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
-        .toBe(true);
-
-      await providerTrigger.click();
-      const qwenProviderHidden = waitForProviderHide();
-      await page.locator('[data-manual-provider="qwen-cn"]').click();
-      await qwenProviderHidden;
-      await expect
-        .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
-        .toBe(false);
-      await expect.poll(() => providerTrigger.textContent()).toContain("Qwen Cloud");
-      await accessValue.fill("qwen-test-secret");
-      await expect.poll(() => accessValue.inputValue()).toBe("qwen-test-secret");
-      await page.evaluate(
-        () =>
-          new Promise<void>((resolve) => {
-            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-          }),
-      );
-      await page.getByRole("button", { name: "Connect & verify" }).click();
-      const activate = await gateway.waitForRequest("openclaw.setup.activate");
-      expect(activate.params).toEqual({
-        kind: "api-key",
-        authChoice: "qwen-cn",
-        apiKey: "qwen-test-secret",
-      });
-      await page.getByRole("heading", { name: "Connection verified" }).waitFor();
-      await page.getByText("qwen/qwen3-coder-plus", { exact: true }).waitFor();
-
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "success-desktop.png"),
-        });
-        await page.setViewportSize({ height: 844, width: 390 });
+        const firstProviderId = providerIds[0]!;
+        const lastProviderId = providerIds.at(-1)!;
+        await providerTrigger.click();
+        await expect
+          .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
+          .toBe(true);
+        await expect
+          .poll(() => page.locator('[data-manual-provider="qwen-cn"]').getAttribute("aria-label"))
+          .toContain("Qwen Cloud");
+        await expect
+          .poll(() => page.locator('[data-manual-provider="zai-cn"]').getAttribute("aria-label"))
+          .toContain("Z.AI");
         await expect
           .poll(() =>
-            page.locator("openclaw-modal-dialog.nav-drawer").evaluate((element) => {
-              const dialog = element.shadowRoot
-                ?.querySelector("wa-dialog")
-                ?.shadowRoot?.querySelector("dialog");
-              return dialog?.open ?? false;
-            }),
+            page.locator('[data-manual-provider="qwen-cn"] [data-provider-icon="alibaba"]').count(),
           )
-          .toBe(false);
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "success-mobile.png"),
-        });
-        await page.setViewportSize({ height: 1000, width: 1440 });
-      }
-      await expect
-        .poll(() => page.locator(".model-setup-success").textContent())
-        .toContain("Verified in 412 ms");
+          .toBe(1);
 
-      const detectCountBeforeDismiss = (await gateway.getRequests("openclaw.setup.detect")).length;
-      await page.getByRole("button", { name: "Stay in settings" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
-        .toBe(detectCountBeforeDismiss + 1);
-      await providerTrigger.click();
-      await expect.poll(manualProviderMenuReady).toBe(true);
-      const googleProviderHiddenAfterDismiss = waitForProviderHide();
-      await page.locator('[data-manual-provider="gemini-api-key"]').click();
-      await googleProviderHiddenAfterDismiss;
-      await expect.poll(() => providerTrigger.textContent()).toContain("Google");
-      await expect.poll(() => page.getByText("Gemini CLI OAuth").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "provider-picker-desktop.png"),
+          });
+          await page.setViewportSize({ height: 844, width: 390 });
+          await providerPicker.scrollIntoViewIfNeeded();
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(artifactDir, "provider-picker-mobile.png"),
+          });
+          await page.setViewportSize({ height: 1000, width: 1440 });
+        }
+        const providerHidden = waitForProviderHide();
+        await page.keyboard.press("Escape");
+        await providerHidden;
+        await expect
+          .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
+          .toBe(false);
+
+        const accessValue = page.locator('.model-setup__manual input[type="password"]');
+        await expect
+          .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+        await page.keyboard.press("Enter");
+        await expect
+          .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
+          .toBe(true);
+        await expect.poll(manualProviderMenuReady).toBe(true);
+        await page.keyboard.press("Home");
+        await expect.poll(() => manualProviderIsActive(firstProviderId)).toBe(true);
+        await page.keyboard.press("End");
+        await expect.poll(() => manualProviderIsActive(lastProviderId)).toBe(true);
+        await page.keyboard.press("Home");
+        await expect.poll(() => manualProviderIsActive(firstProviderId)).toBe(true);
+        await page.keyboard.press("z");
+        await expect.poll(() => manualProviderIsActive("zai-cn")).toBe(true);
+        const zaiProviderHidden = waitForProviderHide();
+        await page.keyboard.press("Enter");
+        await zaiProviderHidden;
+        await expect.poll(() => providerTrigger.textContent()).toContain("Z.AI");
+        await expect
+          .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+
+        await accessValue.fill("same-provider-secret");
+        await providerTrigger.click();
+        await expect.poll(manualProviderMenuReady).toBe(true);
+        const sameProviderHidden = waitForProviderHide();
+        await page.locator('[data-manual-provider="zai-cn"]').click();
+        await sameProviderHidden;
+        await expect.poll(() => accessValue.inputValue()).toBe("same-provider-secret");
+        await expect
+          .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+
+        await providerTrigger.click();
+        await expect.poll(manualProviderMenuReady).toBe(true);
+        const providerHiddenBackward = waitForProviderHide();
+        await page.keyboard.press("Shift+Tab");
+        await providerHiddenBackward;
+        await expect
+          .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+
+        await providerTrigger.click();
+        await expect.poll(manualProviderMenuReady).toBe(true);
+        await page.keyboard.press("Tab");
+        await expect
+          .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
+          .toBe(false);
+        await expect
+          .poll(() => accessValue.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+
+        await accessValue.fill("sk-old-provider-secret");
+        await providerTrigger.click();
+        await expect.poll(manualProviderMenuReady).toBe(true);
+        const googleProviderHidden = waitForProviderHide();
+        await page.locator('[data-manual-provider="gemini-api-key"]').click();
+        await googleProviderHidden;
+        await expect.poll(() => providerTrigger.textContent()).toContain("Google");
+        await expect.poll(() => providerTrigger.textContent()).toContain("AI Studio API key");
+        await expect.poll(() => accessValue.inputValue()).toBe("");
+        await expect
+          .poll(() => providerTrigger.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+
+        await providerTrigger.click();
+        const qwenProviderHidden = waitForProviderHide();
+        await page.locator('[data-manual-provider="qwen-cn"]').click();
+        await qwenProviderHidden;
+        await expect
+          .poll(() => providerPicker.evaluate((element) => element.hasAttribute("open")))
+          .toBe(false);
+        await expect.poll(() => providerTrigger.textContent()).toContain("Qwen Cloud");
+        await accessValue.fill("qwen-test-secret");
+        await expect.poll(() => accessValue.inputValue()).toBe("qwen-test-secret");
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            }),
+        );
+        await page.getByRole("button", { name: "Connect & verify" }).click();
+        const activate = await gateway.waitForRequest("openclaw.setup.activate");
+        expect(activate.params).toEqual({
+          kind: "api-key",
+          authChoice: "qwen-cn",
+          apiKey: "qwen-test-secret",
+        });
+        await page.getByRole("heading", { name: "Connection verified" }).waitFor();
+        await page.getByText("qwen/qwen3-coder-plus", { exact: true }).waitFor();
+
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "success-desktop.png"),
+          });
+          await page.setViewportSize({ height: 844, width: 390 });
+          await expect
+            .poll(() =>
+              page.locator("openclaw-modal-dialog.nav-drawer").evaluate((element) => {
+                const dialog = element.shadowRoot
+                  ?.querySelector("wa-dialog")
+                  ?.shadowRoot?.querySelector("dialog");
+                return dialog?.open ?? false;
+              }),
+            )
+            .toBe(false);
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "success-mobile.png"),
+          });
+          await page.setViewportSize({ height: 1000, width: 1440 });
+        }
+        await expect
+          .poll(() => page.locator(".model-setup-success").textContent())
+          .toContain("Verified in 412 ms");
+
+        const detectCountBeforeDismiss = (await gateway.getRequests("openclaw.setup.detect"))
+          .length;
+        await page.getByRole("button", { name: "Stay in settings" }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
+          .toBe(detectCountBeforeDismiss + 1);
+        await providerTrigger.click();
+        await expect.poll(manualProviderMenuReady).toBe(true);
+        const googleProviderHiddenAfterDismiss = waitForProviderHide();
+        await page.locator('[data-manual-provider="gemini-api-key"]').click();
+        await googleProviderHiddenAfterDismiss;
+        await expect.poll(() => providerTrigger.textContent()).toContain("Google");
+        await expect.poll(() => page.getByText("Gemini CLI OAuth").count()).toBe(0);
+      },
+    );
   });
 
   it("verifies the current model connection", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      ...(artifactDir
-        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
-        : {}),
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: [
-        "chat.metadata",
-        "chat.startup",
-        "openclaw.setup.detect",
-        "openclaw.setup.verify",
-      ],
-      methodResponses: {
-        "openclaw.setup.detect": {
-          candidates: [
-            {
-              kind: "existing-model",
-              brandId: "openai",
-              label: "Current model",
-              detail: "openai/gpt-5 — already configured",
-              modelRef: "openai/gpt-5",
-              recommended: false,
-              credentials: true,
-            },
-            {
-              kind: "claude-cli",
-              brandId: "claude",
-              label: "Claude Code",
-              detail: "logged in",
-              modelRef: "claude-cli/claude-opus-5",
-              recommended: false,
-              credentials: true,
-            },
-          ],
-          manualProviders: [],
-          workspace: "/tmp/openclaw-e2e",
-          configuredModel: "openai/gpt-5",
-          setupComplete: true,
-        },
-        "openclaw.setup.verify": {
-          ok: true,
-          modelRef: "openai/gpt-5",
-          latencyMs: 1234,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+          : {}),
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.verify",
+          ],
+          methodResponses: {
+            "openclaw.setup.detect": {
+              candidates: [
+                {
+                  kind: "existing-model",
+                  brandId: "openai",
+                  label: "Current model",
+                  detail: "openai/gpt-5 — already configured",
+                  modelRef: "openai/gpt-5",
+                  recommended: false,
+                  credentials: true,
+                },
+                {
+                  kind: "claude-cli",
+                  brandId: "claude",
+                  label: "Claude Code",
+                  detail: "logged in",
+                  modelRef: "claude-cli/claude-opus-5",
+                  recommended: false,
+                  credentials: true,
+                },
+              ],
+              manualProviders: [],
+              workspace: "/tmp/openclaw-e2e",
+              configuredModel: "openai/gpt-5",
+              setupComplete: true,
+            },
+            "openclaw.setup.verify": {
+              ok: true,
+              modelRef: "openai/gpt-5",
+              latencyMs: 1234,
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
-      expect(response?.status()).toBe(200);
-      await expect
-        .poll(() => page.locator('[data-candidate-kind="existing-model"]').count())
-        .toBe(0);
-      await expect.poll(() => page.locator('[data-candidate-kind="claude-cli"]').count()).toBe(1);
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "configured-route-dedup-desktop.png"),
-        });
-        await page.setViewportSize({ height: 844, width: 390 });
+        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        expect(response?.status()).toBe(200);
         await expect
-          .poll(() =>
-            page.locator("openclaw-modal-dialog.nav-drawer").evaluate((element) => {
-              const dialog = element.shadowRoot
-                ?.querySelector("wa-dialog")
-                ?.shadowRoot?.querySelector("dialog");
-              return dialog?.open ?? false;
-            }),
-          )
-          .toBe(false);
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "configured-route-dedup-mobile.png"),
-        });
-        await page.setViewportSize({ height: 900, width: 1280 });
-      }
-      await page.getByRole("button", { name: "Check model" }).click();
-      const verify = await gateway.waitForRequest("openclaw.setup.verify");
-      expect(verify.params).toEqual({});
-      await page.getByText("Ready · 1234 ms").waitFor();
-      const detectCountBeforeRefresh = (await gateway.getRequests("openclaw.setup.detect")).length;
-      const verifyCountBeforeRefresh = (await gateway.getRequests("openclaw.setup.verify")).length;
-      await page.getByRole("button", { name: "Check again" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("openclaw.setup.verify")).length)
-        .toBe(verifyCountBeforeRefresh + 1);
-      expect((await gateway.getRequests("openclaw.setup.detect")).length).toBe(
-        detectCountBeforeRefresh,
-      );
-      await page.getByRole("button", { name: "Check again" }).waitFor();
-      await page.getByText("Ready · 1234 ms").waitFor();
-    } finally {
-      await context.close();
-    }
+          .poll(() => page.locator('[data-candidate-kind="existing-model"]').count())
+          .toBe(0);
+        await expect.poll(() => page.locator('[data-candidate-kind="claude-cli"]').count()).toBe(1);
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "configured-route-dedup-desktop.png"),
+          });
+          await page.setViewportSize({ height: 844, width: 390 });
+          await expect
+            .poll(() =>
+              page.locator("openclaw-modal-dialog.nav-drawer").evaluate((element) => {
+                const dialog = element.shadowRoot
+                  ?.querySelector("wa-dialog")
+                  ?.shadowRoot?.querySelector("dialog");
+                return dialog?.open ?? false;
+              }),
+            )
+            .toBe(false);
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "configured-route-dedup-mobile.png"),
+          });
+          await page.setViewportSize({ height: 900, width: 1280 });
+        }
+        await page.getByRole("button", { name: "Check model" }).click();
+        const verify = await gateway.waitForRequest("openclaw.setup.verify");
+        expect(verify.params).toEqual({});
+        await page.getByText("Ready · 1234 ms").waitFor();
+        const detectCountBeforeRefresh = (await gateway.getRequests("openclaw.setup.detect"))
+          .length;
+        const verifyCountBeforeRefresh = (await gateway.getRequests("openclaw.setup.verify"))
+          .length;
+        await page.getByRole("button", { name: "Check again" }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("openclaw.setup.verify")).length)
+          .toBe(verifyCountBeforeRefresh + 1);
+        expect((await gateway.getRequests("openclaw.setup.detect")).length).toBe(
+          detectCountBeforeRefresh,
+        );
+        await page.getByRole("button", { name: "Check again" }).waitFor();
+        await page.getByText("Ready · 1234 ms").waitFor();
+      },
+    );
   });
 });

--- a/ui/src/e2e/mount-recovery.e2e.test.ts
+++ b/ui/src/e2e/mount-recovery.e2e.test.ts
@@ -1,89 +1,70 @@
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI mount recovery E2E",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI mount recovery E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer(undefined, { source: true });
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("reloads a fresh document after the initial app module is unavailable", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/mount-recovery");
-    const context = await browser.newContext({
-      locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
-      serviceWorkers: "block",
-      viewport: { height: 720, width: 1280 },
-    });
-    const page = await context.newPage();
-    const baseUrl = new URL(server.baseUrl);
-    let documentRequests = 0;
-    let failedModuleRequests = 0;
-    await page.route(`${baseUrl.origin}/**`, async (route) => {
-      const request = route.request();
-      const url = new URL(request.url());
-      if (request.resourceType() === "document") {
-        documentRequests += 1;
-        const response = await route.fetch();
-        const documentHtml = await response.text();
-        // Accelerate only the broken document. The recovered Vite module needs the
-        // real mount deadline so a loaded CI runner cannot race its own recovery.
-        const body =
-          documentRequests === 1
-            ? documentHtml.replace(
-                'data-openclaw-mount-timeout-ms="12000"',
-                'data-openclaw-mount-timeout-ms="250"',
-              )
-            : documentHtml;
-        await route.fulfill({ response, body });
-        return;
-      }
-      if (url.pathname === "/src/main.ts" && failedModuleRequests === 0) {
-        failedModuleRequests += 1;
-        await route.fulfill({ body: "gateway restarting", status: 503 });
-        return;
-      }
-      await route.continue();
-    });
-    await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+        serviceWorkers: "block",
+        viewport: { height: 720, width: 1280 },
+      },
+      async ({ page }) => {
+        const baseUrl = new URL(suite.server.baseUrl);
+        let documentRequests = 0;
+        let failedModuleRequests = 0;
+        await page.route(`${baseUrl.origin}/**`, async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          if (request.resourceType() === "document") {
+            documentRequests += 1;
+            const response = await route.fetch();
+            const documentHtml = await response.text();
+            // Accelerate only the broken document. The recovered Vite module needs the
+            // real mount deadline so a loaded CI runner cannot race its own recovery.
+            const body =
+              documentRequests === 1
+                ? documentHtml.replace(
+                    'data-openclaw-mount-timeout-ms="12000"',
+                    'data-openclaw-mount-timeout-ms="250"',
+                  )
+                : documentHtml;
+            await route.fulfill({ response, body });
+            return;
+          }
+          if (url.pathname === "/src/main.ts" && failedModuleRequests === 0) {
+            failedModuleRequests += 1;
+            await route.fulfill({ body: "gateway restarting", status: 503 });
+            return;
+          }
+          await route.continue();
+        });
+        await installMockGateway(page);
 
-    try {
-      expect(
-        (await page.goto(`${server.baseUrl}chat`, { waitUntil: "domcontentloaded" }))?.status(),
-      ).toBe(200);
-      await page.locator("openclaw-app-shell").waitFor();
-      await page.locator(".agent-chat__welcome").waitFor();
+        expect(
+          (
+            await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" })
+          )?.status(),
+        ).toBe(200);
+        await page.locator("openclaw-app-shell").waitFor();
+        await page.locator(".agent-chat__welcome").waitFor();
 
-      expect(documentRequests).toBe(2);
-      expect(failedModuleRequests).toBe(1);
-      await expect.poll(() => page.url()).not.toContain("openclaw_mount_recovery");
-      await page.screenshot({ path: path.join(artifactDir, "recovered-control-ui.png") });
-    } finally {
-      await context.close();
-    }
+        expect(documentRequests).toBe(2);
+        expect(failedModuleRequests).toBe(1);
+        await expect.poll(() => page.url()).not.toContain("openclaw_mount_recovery");
+        await page.screenshot({ path: path.join(artifactDir, "recovered-control-ui.png") });
+      },
+    );
   });
 });

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -1,41 +1,24 @@
 // Shipped apps stamp `openclaw-native-nav`; current apps advertise web chrome
 // at document start and stamp `openclaw-native-web-chrome` at document end.
 // Plain browsers keep their normal in-page controls.
-import { chromium, type Browser, type BrowserContext } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext } from "playwright";
+import { afterEach, expect, it } from "vitest";
 import {
-  canRunPlaywrightChromium,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
   type ControlUiMockGatewayScenario,
 } from "../test-helpers/control-ui-e2e.ts";
 import { chatSessionListResponse } from "./chat-flow.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI native-nav sidebar toggle E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
 let context: BrowserContext | undefined;
 
-describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await context?.close();
     context = undefined;
@@ -47,7 +30,7 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
     webChrome?: boolean;
     width?: number;
   }) {
-    context = await browser.newContext({
+    context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: options.width ?? 1280 },
@@ -110,7 +93,7 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.create"],
       ...options.scenario,
     });
-    const response = await page.goto(server.baseUrl);
+    const response = await page.goto(suite.server.baseUrl);
     expect(response?.status()).toBe(200);
     // The brand row only becomes visible on desktop widths; drawer widths keep
     // the sidebar hidden, so wait for DOM attachment instead of visibility.
@@ -257,7 +240,7 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
 
   it("keeps only history controls in the Settings titlebar", async () => {
     const page = await openPage({ webChrome: true });
-    const response = await page.goto(`${server.baseUrl}settings/general`);
+    const response = await page.goto(`${suite.server.baseUrl}settings/general`);
     expect(response?.status()).toBe(200);
 
     const toolbar = page.locator(".macos-titlebar-controls");
@@ -278,7 +261,7 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
 
   it("keeps the document root scroll-locked in the Settings takeover", async () => {
     const page = await openPage({ webChrome: true });
-    const response = await page.goto(`${server.baseUrl}settings/general`);
+    const response = await page.goto(`${suite.server.baseUrl}settings/general`);
     expect(response?.status()).toBe(200);
     await page.locator(".settings-sidebar").waitFor({ state: "visible" });
 

--- a/ui/src/e2e/native-session-sidebar.e2e.test.ts
+++ b/ui/src/e2e/native-session-sidebar.e2e.test.ts
@@ -1,19 +1,15 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const available = canRunPlaywrightChromium(executablePath);
-const allowMissing = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const suite = available || !allowMissing ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "native session sidebar",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
 const uiProofArtifactDir = path.join(
@@ -23,25 +19,9 @@ const uiProofArtifactDir = path.join(
   "native-session-discovery",
 );
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-suite("native session sidebar", () => {
-  beforeAll(async () => {
-    if (!available) {
-      throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("hides empty native hosts and the empty Coding section", async () => {
-    const page = await browser.newPage({
+    const page = await suite.browser.newPage({
       deviceScaleFactor: 2,
       viewport: { height: 1100, width: 1440 },
     });
@@ -110,7 +90,7 @@ suite("native session sidebar", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.evaluate(() => {
         document.documentElement.setAttribute("data-theme", "openknot");
         document.documentElement.setAttribute("data-theme-mode", "dark");

--- a/ui/src/e2e/operator-admin.e2e.test.ts
+++ b/ui/src/e2e/operator-admin.e2e.test.ts
@@ -1,28 +1,24 @@
 // Control UI E2E coverage for operator-facing Skills, Nodes, and exec approvals administration.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
 import {
-  canRunPlaywrightChromium,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI operator administration",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "operator-admin");
 const viewport = { height: 960, width: 1440 };
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const agentRoster = [
   { id: "main", identity: { name: "Main" }, name: "Main" },
@@ -123,7 +119,7 @@ async function createContext(): Promise<BrowserContext> {
   if (captureUiProof) {
     await mkdir(proofDir, { recursive: true });
   }
-  return browser.newContext({
+  return suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport,
@@ -151,20 +147,7 @@ async function screenshot(page: Page, name: string) {
   });
 }
 
-describeControlUiE2e("Control UI operator administration", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("administers agent-scoped Skills and inspects the connected Nodes inventory", async () => {
     const context = await createContext();
     const page = await context.newPage();
@@ -218,7 +201,7 @@ describeControlUiE2e("Control UI operator administration", () => {
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}skills`);
+      const response = await page.goto(`${suite.server.baseUrl}skills`);
       expect(response?.status()).toBe(200);
       await gateway.waitForRequest("skills.status");
 
@@ -250,7 +233,7 @@ describeControlUiE2e("Control UI operator administration", () => {
       await expect.poll(() => dialog.getByText("Installed Deploy Helper").isVisible()).toBe(true);
       await screenshot(page, "01-reviewer-skill-installed.png");
 
-      await page.goto(`${server.baseUrl}nodes`);
+      await page.goto(`${suite.server.baseUrl}nodes`);
       await Promise.all([
         gateway.waitForRequest("node.list"),
         gateway.waitForRequest("device.pair.list"),
@@ -376,7 +359,7 @@ describeControlUiE2e("Control UI operator administration", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}agents`);
+      await page.goto(`${suite.server.baseUrl}agents`);
       await gateway.waitForRequest("agents.list");
       await selectAgentOnAgentsPage(page, "Reviewer");
       const setDefault = page.locator(".agents-toolbar-actions button").nth(1);
@@ -385,7 +368,7 @@ describeControlUiE2e("Control UI operator administration", () => {
       expect(await gateway.getRequests("config.set")).toHaveLength(0);
       await screenshot(page, "05-read-only-agents.png");
 
-      await page.goto(`${server.baseUrl}settings/agents/main/files`);
+      await page.goto(`${suite.server.baseUrl}settings/agents/main/files`);
       await gateway.waitForRequest("agents.files.list");
       await page.locator("openclaw-agents-page").evaluate((element) => {
         const agentsPage = element as HTMLElement & {
@@ -422,7 +405,7 @@ describeControlUiE2e("Control UI operator administration", () => {
       await fileSave.click({ force: true });
       expect(await gateway.getRequests("agents.files.set")).toHaveLength(0);
 
-      await page.goto(`${server.baseUrl}settings/agents/main/skills`);
+      await page.goto(`${suite.server.baseUrl}settings/agents/main/skills`);
       await waitForRequest(gateway, "skills.status", (params) => params.agentId === "main");
       const agentSkillsActions = page.locator(".settings-section", { hasText: "Skills" });
       const disableAll = agentSkillsActions.getByRole("button", { name: "Disable All" });
@@ -430,7 +413,7 @@ describeControlUiE2e("Control UI operator administration", () => {
       await disableAll.click({ force: true });
       expect(await gateway.getRequests("config.set")).toHaveLength(0);
 
-      await page.goto(`${server.baseUrl}skills`);
+      await page.goto(`${suite.server.baseUrl}skills`);
       await gateway.waitForRequest("skills.status");
       const globalSkillToggle = page.locator("wa-switch.settings-toggle").first();
       await expect.poll(() => globalSkillToggle.getAttribute("disabled")).not.toBeNull();
@@ -444,7 +427,7 @@ describeControlUiE2e("Control UI operator administration", () => {
       expect(await gateway.getRequests("skills.install")).toHaveLength(0);
       await screenshot(page, "06-read-only-skills.png");
 
-      await page.goto(`${server.baseUrl}skills/workshop`);
+      await page.goto(`${suite.server.baseUrl}skills/workshop`);
       await gateway.waitForRequest("skills.proposals.list");
       await page.locator("#skill-workshop-mode-tab-board").click();
       const actionButtons = page.locator(".sw-action-bar button");
@@ -499,7 +482,7 @@ describeControlUiE2e("Control UI operator administration", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}agents`);
+      await page.goto(`${suite.server.baseUrl}agents`);
       await gateway.waitForRequest("agents.list");
       await selectAgentOnAgentsPage(page, "Reviewer");
       const setDefault = page.locator(".agents-toolbar-actions button").nth(1);
@@ -507,7 +490,7 @@ describeControlUiE2e("Control UI operator administration", () => {
       await setDefault.click();
       await gateway.waitForRequest("config.set");
 
-      await page.goto(`${server.baseUrl}skills`);
+      await page.goto(`${suite.server.baseUrl}skills`);
       await gateway.waitForRequest("skills.status");
       await page.getByRole("button", { name: "Open Deploy Helper details" }).click();
       const install = page
@@ -573,7 +556,7 @@ describeControlUiE2e("Control UI operator administration", () => {
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}nodes`);
+      const response = await page.goto(`${suite.server.baseUrl}nodes`);
       expect(response?.status()).toBe(200);
       await gateway.waitForRequest("exec.approvals.get");
 

--- a/ui/src/e2e/plan-replay-reconnect.e2e.test.ts
+++ b/ui/src/e2e/plan-replay-reconnect.e2e.test.ts
@@ -1,21 +1,14 @@
 // Control UI tests cover plan-snapshot replay on connect/reconnect.
-import { chromium, expect, type Browser, type BrowserContext, type Page } from "playwright/test";
-import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, type BrowserContext, type Page } from "playwright/test";
+import { afterEach, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI plan snapshot replay",
+  startServerBeforeBrowser: true,
+});
 
-let server: ControlUiE2eServer;
-let browser: Browser;
 const openBrowserContexts = new Set<BrowserContext>();
 
 const REPLAY_RUN_ID = "run-plan-replay";
@@ -37,7 +30,7 @@ const replayScenario = {
 };
 
 async function newPage(): Promise<{ context: BrowserContext; page: Page }> {
-  const context = await browser.newContext({
+  const context = await suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1280 },
@@ -51,28 +44,18 @@ async function closeBrowserContext(context: BrowserContext): Promise<void> {
   await context.close();
 }
 
-describeControlUiE2e("Control UI plan snapshot replay", () => {
-  beforeAll(async () => {
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
+suite.define(() => {
   afterEach(async () => {
     for (const context of openBrowserContexts) {
       await closeBrowserContext(context);
     }
   });
 
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
   it("seeds the plan checklist from a replayed in-flight snapshot on load", async () => {
     const { context, page } = await newPage();
     await installMockGateway(page, replayScenario);
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
 
       // The checklist must render from the replayed snapshot alone, before any
       // live plan event arrives — this is the reconnect gap the replay closes.
@@ -89,7 +72,7 @@ describeControlUiE2e("Control UI plan snapshot replay", () => {
     const { context, page } = await newPage();
     const gateway = await installMockGateway(page, replayScenario);
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.locator(".plan-checklist").first().waitFor({ state: "visible", timeout: 10_000 });
       // Bar + in-thread card render for an active run; the live event must
       // replace both in place, not mount additional checklists.
@@ -126,7 +109,7 @@ describeControlUiE2e("Control UI plan snapshot replay", () => {
     const { context, page } = await newPage();
     await installMockGateway(page, replayScenario);
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await page.locator(".plan-checklist").first().waitFor({ state: "visible", timeout: 10_000 });
 
       // Mock routes are page-scoped, so reinstall before reload to keep serving

--- a/ui/src/e2e/plugins-config-mutation.e2e.test.ts
+++ b/ui/src/e2e/plugins-config-mutation.e2e.test.ts
@@ -1,21 +1,17 @@
 // Control UI tests cover plugin mutations serialized behind pending config drafts.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  waitForControlUiRoute,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI plugin config mutation mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -23,9 +19,6 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "plugins-config-mutation",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function configResponse(fallback: string | undefined, workboardEnabled: boolean, hash: string) {
   const config = {
@@ -73,112 +66,96 @@ const workboardEnabled = {
   state: "enabled",
 };
 
-describeControlUiE2e("Control UI plugin config mutation mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("drains a pending draft before enabling a plugin and refreshes the result", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "agents.list": {
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
-          agents: [{ id: "main", identity: { name: "Main" }, name: "Main" }],
-        },
-        "config.get": configResponse(undefined, false, "config-hash-1"),
-        "plugins.list": {
-          plugins: [workboardDisabled],
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+              agents: [{ id: "main", identity: { name: "Main" }, name: "Main" }],
+            },
+            "config.get": configResponse(undefined, false, "config-hash-1"),
+            "plugins.list": {
+              plugins: [workboardDisabled],
+              diagnostics: [],
+              mutationAllowed: true,
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/overview`);
+        expect(response?.status()).toBe(200);
+
+        const fallbackInput = page.locator(".agent-chip-input input");
+        await fallbackInput.waitFor();
+        await gateway.deferNext("config.set");
+        await fallbackInput.fill("anthropic/claude-sonnet-4-6");
+        await fallbackInput.press("Enter");
+        await page.evaluate(() => {
+          history.pushState(null, "", "/settings/plugins");
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        });
+        await waitForControlUiRoute(page, {
+          pathname: "/settings/plugins",
+          routeId: "plugins",
+        });
+
+        const workboardRow = page.locator('[data-plugin-id="workboard"]');
+        await workboardRow.waitFor();
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await workboardRow.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "00-before-enable.png"),
+          });
+        }
+
+        await gateway.deferNext("plugins.setEnabled");
+        await workboardRow.getByRole("button", { name: "Enable", exact: true }).click();
+        expect(await gateway.getRequests("plugins.setEnabled")).toHaveLength(0);
+
+        const pendingDraft = await gateway.waitForRequest("config.set");
+        expect(pendingDraft.params).toMatchObject({ baseHash: "config-hash-1" });
+        await gateway.resolveDeferred("config.set", { ok: true, hash: "config-hash-2" });
+
+        const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
+        expect(enableRequest.params).toEqual({ pluginId: "workboard", enabled: true });
+        await gateway.setMethodResponse(
+          "config.get",
+          configResponse("anthropic/claude-sonnet-4-6", true, "config-hash-3"),
+        );
+        await gateway.setMethodResponse("plugins.list", {
+          plugins: [workboardEnabled],
           diagnostics: [],
           mutationAllowed: true,
-        },
+        });
+        await gateway.resolveDeferred("plugins.setEnabled", {
+          ok: true,
+          plugin: workboardEnabled,
+          restartRequired: true,
+        });
+
+        await workboardRow.getByRole("button", { name: "Disable", exact: true }).waitFor();
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBeGreaterThanOrEqual(2);
+        if (captureUiProofEnabled) {
+          await workboardRow.screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "01-after-enable.png"),
+          });
+        }
       },
-    });
-
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/agents/main/overview`);
-      expect(response?.status()).toBe(200);
-
-      const fallbackInput = page.locator(".agent-chip-input input");
-      await fallbackInput.waitFor();
-      await gateway.deferNext("config.set");
-      await fallbackInput.fill("anthropic/claude-sonnet-4-6");
-      await fallbackInput.press("Enter");
-      await page.evaluate(() => {
-        history.pushState(null, "", "/settings/plugins");
-        window.dispatchEvent(new PopStateEvent("popstate"));
-      });
-      await waitForControlUiRoute(page, {
-        pathname: "/settings/plugins",
-        routeId: "plugins",
-      });
-
-      const workboardRow = page.locator('[data-plugin-id="workboard"]');
-      await workboardRow.waitFor();
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-        await workboardRow.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "00-before-enable.png"),
-        });
-      }
-
-      await gateway.deferNext("plugins.setEnabled");
-      await workboardRow.getByRole("button", { name: "Enable", exact: true }).click();
-      expect(await gateway.getRequests("plugins.setEnabled")).toHaveLength(0);
-
-      const pendingDraft = await gateway.waitForRequest("config.set");
-      expect(pendingDraft.params).toMatchObject({ baseHash: "config-hash-1" });
-      await gateway.resolveDeferred("config.set", { ok: true, hash: "config-hash-2" });
-
-      const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
-      expect(enableRequest.params).toEqual({ pluginId: "workboard", enabled: true });
-      await gateway.setMethodResponse(
-        "config.get",
-        configResponse("anthropic/claude-sonnet-4-6", true, "config-hash-3"),
-      );
-      await gateway.setMethodResponse("plugins.list", {
-        plugins: [workboardEnabled],
-        diagnostics: [],
-        mutationAllowed: true,
-      });
-      await gateway.resolveDeferred("plugins.setEnabled", {
-        ok: true,
-        plugin: workboardEnabled,
-        restartRequired: true,
-      });
-
-      await workboardRow.getByRole("button", { name: "Disable", exact: true }).waitFor();
-      await expect
-        .poll(async () => (await gateway.getRequests("config.get")).length)
-        .toBeGreaterThanOrEqual(2);
-      if (captureUiProofEnabled) {
-        await workboardRow.screenshot({
-          animations: "disabled",
-          path: path.join(uiProofArtifactDir, "01-after-enable.png"),
-        });
-      }
-    } finally {
-      await context.close();
-    }
+    );
   });
 });

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -1,24 +1,22 @@
 // Control UI tests cover the settings profile page against a mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
 import {
   buildControlUiCspHeader,
   computeInlineScriptHashes,
 } from "../../../src/gateway/control-ui-csp.ts";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI profile page mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "profile-identity");
 const basePath = "/wilfred";
@@ -34,9 +32,6 @@ async function screenshot(page: Page, name: string) {
     path: path.join(proofDir, name),
   });
 }
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const testProfile = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -58,22 +53,7 @@ const testPresenceUsers = [
   },
 ];
 
-describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   async function openProfilePage(page: Page) {
     const gateway = await installMockGateway(page, {
       basePath,
@@ -82,15 +62,13 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
         "users.self": { profile: testProfile },
       },
     });
-    const response = await page.goto(new URL(profilePath, server.baseUrl).href);
+    const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
     expect(response?.status()).toBe(200);
     return gateway;
   }
 
   it("renders hero, identity, and a Usage statistics link without loading usage", async () => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    try {
+    await suite.withPage(undefined, async ({ page }) => {
       const gateway = await openProfilePage(page);
 
       await page.locator(".profile-hero__name").waitFor({ timeout: 10_000 });
@@ -108,249 +86,247 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
       expect(await page.locator(".profile-stats, .profile-heatmap, .profile-tools").count()).toBe(
         0,
       );
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("shares one authenticated avatar between the sidebar and profile preview", async () => {
     if (captureUiProof) {
       await mkdir(proofDir, { recursive: true });
     }
-    const context = await browser.newContext({
-      ...(captureUiProof
-        ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 800 } } }
-        : {}),
-      viewport: { width: 1280, height: 800 },
-    });
-    const page = await context.newPage();
-    await page.route(new URL(profilePath, server.baseUrl).href, async (route) => {
-      const response = await route.fetch();
-      const body = await response.text();
-      await route.fulfill({
-        body,
-        headers: {
-          ...response.headers(),
-          "content-security-policy": buildControlUiCspHeader({
-            inlineScriptHashes: computeInlineScriptHashes(body),
-          }),
-        },
-        response,
-      });
-    });
-    const gatewayUrl = server.baseUrl.replace(/^http/u, "ws").replace(/\/$/u, "");
-    await page.addInitScript((sameOriginGatewayUrl) => {
-      (
-        window as Window & {
-          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
-        }
-      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
-        gatewayUrl: sameOriginGatewayUrl,
-        token: "test",
-      };
-    }, gatewayUrl);
-    const avatarRequests: Array<{ authorization?: string; url: string }> = [];
-    let releaseRevisedAvatar: (() => void) | undefined;
-    const revisedAvatarReady = new Promise<void>((resolve) => {
-      releaseRevisedAvatar = resolve;
-    });
-    // Profile images require the same bearer auth as gateway RPCs. One cached
-    // blob keeps the sidebar and preview inside the Control UI's image CSP.
-    await page.route(`**/api/users/${testProfile.id}/avatar*`, async (route) => {
-      const revision = new URL(route.request().url()).searchParams.get("v");
-      avatarRequests.push({
-        authorization: route.request().headers().authorization,
-        url: route.request().url(),
-      });
-      if (revision === "3") {
-        // Hold the real response so Chromium can prove pending fallback and
-        // stable image-node identity before the replacement finishes loading.
-        await revisedAvatarReady;
-      }
-      if (revision === "4") {
-        await route.fulfill({
-          body: JSON.stringify({ ok: false, error: { type: "not_found" } }),
-          contentType: "application/json",
-          status: 404,
-        });
-        return;
-      }
-      await route.fulfill({
-        body: Buffer.from(
-          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/a6kAAAAASUVORK5CYII=",
-          "base64",
-        ),
-        contentType: "image/png",
-        status: 200,
-      });
-    });
-    const gateway = await installMockGateway(page, {
-      basePath,
-      presenceUsers: testPresenceUsers,
-      methodResponses: {
-        "users.self": { profile: testProfile },
+    await suite.withPage(
+      {
+        ...(captureUiProof
+          ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 800 } } }
+          : {}),
+        viewport: { width: 1280, height: 800 },
       },
-    });
-
-    try {
-      const response = await page.goto(new URL(profilePath, server.baseUrl).href);
-      expect(response?.status()).toBe(200);
-      expect(response?.headers()["content-security-policy"]).toContain(
-        "img-src 'self' data: blob:",
-      );
-
-      const profileAvatar = page.locator("#settings-profile-identity openclaw-viewer-avatar img");
-      await profileAvatar.waitFor({ timeout: 10_000 });
-      const imageUrl = await profileAvatar.getAttribute("src");
-      expect(imageUrl).toMatch(/^blob:/u);
-      await expect
-        .poll(() => profileAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
-        .toBe(1);
-      expect(
-        await profileAvatar.evaluate((image) =>
-          image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
-        ),
-      ).toBe(false);
-      if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(proofDir, "03-authenticated-profile-avatar.png"),
-        });
-      }
-
-      await page.getByRole("button", { name: "Back to app" }).click();
-      const sidebarAvatar = page.locator(".sidebar-identity-card openclaw-viewer-avatar img");
-      await sidebarAvatar.waitFor({ timeout: 10_000 });
-      await expect.poll(() => avatarRequests.length).toBe(1);
-      expect(avatarRequests[0]).toEqual({
-        authorization: "Bearer e2e-device-token",
-        url: new URL(`${basePath}/api/users/${testProfile.id}/avatar?v=2`, server.baseUrl).href,
-      });
-      expect(await sidebarAvatar.getAttribute("src")).toBe(imageUrl);
-      expect(
-        await sidebarAvatar.evaluate((image) =>
-          image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
-        ),
-      ).toBe(false);
-      if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(proofDir, "03-authenticated-user-avatar-cache.png"),
-        });
-      }
-
-      const originalSidebarImage = await sidebarAvatar.elementHandle();
-      expect(originalSidebarImage).not.toBeNull();
-      const connect = await gateway.waitForRequest("connect");
-      const selfInstanceId = (connect.params as { client?: { instanceId?: string } } | undefined)
-        ?.client?.instanceId;
-      expect(selfInstanceId).toBeTruthy();
-      const publishAvatarRevision = async (revision: number) => {
-        await gateway.emitGatewayEvent("presence", {
-          presence: [
-            {
-              instanceId: selfInstanceId,
-              mode: "webchat",
-              reason: "connect",
-              user: {
-                id: testProfile.id,
-                name: testProfile.displayName,
-                email: testProfile.emails[0],
-                avatarUrl: `/api/users/${testProfile.id}/avatar?v=${revision}`,
-              },
-              watchedSessions: [],
+      async ({ page }) => {
+        await page.route(new URL(profilePath, suite.server.baseUrl).href, async (route) => {
+          const response = await route.fetch();
+          const body = await response.text();
+          await route.fulfill({
+            body,
+            headers: {
+              ...response.headers(),
+              "content-security-policy": buildControlUiCspHeader({
+                inlineScriptHashes: computeInlineScriptHashes(body),
+              }),
             },
-          ],
+            response,
+          });
         });
-      };
-
-      await publishAvatarRevision(3);
-      await expect.poll(() => avatarRequests.length).toBe(2);
-      expect(
-        await originalSidebarImage?.evaluate((image) =>
-          image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
-        ),
-      ).toBe(true);
-      expect(await originalSidebarImage?.evaluate((image) => image.isConnected)).toBe(true);
-
-      releaseRevisedAvatar?.();
-      await expect
-        .poll(() => sidebarAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
-        .toBe(1);
-      const revisedImageUrl = await sidebarAvatar.getAttribute("src");
-      expect(revisedImageUrl).toMatch(/^blob:/u);
-      expect(revisedImageUrl).not.toBe(imageUrl);
-      expect(await originalSidebarImage?.evaluate((image) => image.getAttribute("src"))).toBe(
-        revisedImageUrl,
-      );
-      expect(
-        await sidebarAvatar.evaluate((image) =>
-          image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
-        ),
-      ).toBe(false);
-      expect(avatarRequests[1]).toEqual({
-        authorization: "Bearer e2e-device-token",
-        url: new URL(`${basePath}/api/users/${testProfile.id}/avatar?v=3`, server.baseUrl).href,
-      });
-      if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(proofDir, "04-authenticated-user-avatar-revision.png"),
+        const gatewayUrl = suite.server.baseUrl.replace(/^http/u, "ws").replace(/\/$/u, "");
+        await page.addInitScript((sameOriginGatewayUrl) => {
+          (
+            window as Window & {
+              ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+            }
+          )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+            gatewayUrl: sameOriginGatewayUrl,
+            token: "test",
+          };
+        }, gatewayUrl);
+        const avatarRequests: Array<{ authorization?: string; url: string }> = [];
+        let releaseRevisedAvatar: (() => void) | undefined;
+        const revisedAvatarReady = new Promise<void>((resolve) => {
+          releaseRevisedAvatar = resolve;
         });
-      }
+        // Profile images require the same bearer auth as gateway RPCs. One cached
+        // blob keeps the sidebar and preview inside the Control UI's image CSP.
+        await page.route(`**/api/users/${testProfile.id}/avatar*`, async (route) => {
+          const revision = new URL(route.request().url()).searchParams.get("v");
+          avatarRequests.push({
+            authorization: route.request().headers().authorization,
+            url: route.request().url(),
+          });
+          if (revision === "3") {
+            // Hold the real response so Chromium can prove pending fallback and
+            // stable image-node identity before the replacement finishes loading.
+            await revisedAvatarReady;
+          }
+          if (revision === "4") {
+            await route.fulfill({
+              body: JSON.stringify({ ok: false, error: { type: "not_found" } }),
+              contentType: "application/json",
+              status: 404,
+            });
+            return;
+          }
+          await route.fulfill({
+            body: Buffer.from(
+              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/a6kAAAAASUVORK5CYII=",
+              "base64",
+            ),
+            contentType: "image/png",
+            status: 200,
+          });
+        });
+        const gateway = await installMockGateway(page, {
+          basePath,
+          presenceUsers: testPresenceUsers,
+          methodResponses: {
+            "users.self": { profile: testProfile },
+          },
+        });
 
-      const missingAvatarResponse = page.waitForResponse(
-        (candidateResponse) =>
-          candidateResponse.url().includes(`/api/users/${testProfile.id}/avatar?v=4`) &&
-          candidateResponse.status() === 404,
-      );
-      await publishAvatarRevision(4);
-      await missingAvatarResponse;
-      await expect.poll(() => avatarRequests.length).toBe(3);
-      await expect.poll(() => sidebarAvatar.getAttribute("src")).toBeNull();
-      await expect
-        .poll(() =>
-          sidebarAvatar.evaluate((image) =>
+        const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
+        expect(response?.status()).toBe(200);
+        expect(response?.headers()["content-security-policy"]).toContain(
+          "img-src 'self' data: blob:",
+        );
+
+        const profileAvatar = page.locator("#settings-profile-identity openclaw-viewer-avatar img");
+        await profileAvatar.waitFor({ timeout: 10_000 });
+        const imageUrl = await profileAvatar.getAttribute("src");
+        expect(imageUrl).toMatch(/^blob:/u);
+        await expect
+          .poll(() => profileAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
+          .toBe(1);
+        expect(
+          await profileAvatar.evaluate((image) =>
             image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
           ),
-        )
-        .toBe(true);
-      await expect
-        .poll(async () =>
-          (
-            await page.locator(".sidebar-identity-card .viewer-avatar__fallback").textContent()
-          )?.trim(),
-        )
-        .toBe("TP");
-      expect(await originalSidebarImage?.evaluate((image) => image.isConnected)).toBe(true);
-      expect(avatarRequests[2]).toEqual({
-        authorization: "Bearer e2e-device-token",
-        url: new URL(`${basePath}/api/users/${testProfile.id}/avatar?v=4`, server.baseUrl).href,
-      });
-      if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          path: path.join(proofDir, "05-authenticated-user-avatar-missing.png"),
+        ).toBe(false);
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "03-authenticated-profile-avatar.png"),
+          });
+        }
+
+        await page.getByRole("button", { name: "Back to app" }).click();
+        const sidebarAvatar = page.locator(".sidebar-identity-card openclaw-viewer-avatar img");
+        await sidebarAvatar.waitFor({ timeout: 10_000 });
+        await expect.poll(() => avatarRequests.length).toBe(1);
+        expect(avatarRequests[0]).toEqual({
+          authorization: "Bearer e2e-device-token",
+          url: new URL(`${basePath}/api/users/${testProfile.id}/avatar?v=2`, suite.server.baseUrl)
+            .href,
         });
-      }
-    } finally {
-      await context.close();
-    }
+        expect(await sidebarAvatar.getAttribute("src")).toBe(imageUrl);
+        expect(
+          await sidebarAvatar.evaluate((image) =>
+            image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+          ),
+        ).toBe(false);
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "03-authenticated-user-avatar-cache.png"),
+          });
+        }
+
+        const originalSidebarImage = await sidebarAvatar.elementHandle();
+        expect(originalSidebarImage).not.toBeNull();
+        const connect = await gateway.waitForRequest("connect");
+        const selfInstanceId = (connect.params as { client?: { instanceId?: string } } | undefined)
+          ?.client?.instanceId;
+        expect(selfInstanceId).toBeTruthy();
+        const publishAvatarRevision = async (revision: number) => {
+          await gateway.emitGatewayEvent("presence", {
+            presence: [
+              {
+                instanceId: selfInstanceId,
+                mode: "webchat",
+                reason: "connect",
+                user: {
+                  id: testProfile.id,
+                  name: testProfile.displayName,
+                  email: testProfile.emails[0],
+                  avatarUrl: `/api/users/${testProfile.id}/avatar?v=${revision}`,
+                },
+                watchedSessions: [],
+              },
+            ],
+          });
+        };
+
+        await publishAvatarRevision(3);
+        await expect.poll(() => avatarRequests.length).toBe(2);
+        expect(
+          await originalSidebarImage?.evaluate((image) =>
+            image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+          ),
+        ).toBe(true);
+        expect(await originalSidebarImage?.evaluate((image) => image.isConnected)).toBe(true);
+
+        releaseRevisedAvatar?.();
+        await expect
+          .poll(() => sidebarAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
+          .toBe(1);
+        const revisedImageUrl = await sidebarAvatar.getAttribute("src");
+        expect(revisedImageUrl).toMatch(/^blob:/u);
+        expect(revisedImageUrl).not.toBe(imageUrl);
+        expect(await originalSidebarImage?.evaluate((image) => image.getAttribute("src"))).toBe(
+          revisedImageUrl,
+        );
+        expect(
+          await sidebarAvatar.evaluate((image) =>
+            image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+          ),
+        ).toBe(false);
+        expect(avatarRequests[1]).toEqual({
+          authorization: "Bearer e2e-device-token",
+          url: new URL(`${basePath}/api/users/${testProfile.id}/avatar?v=3`, suite.server.baseUrl)
+            .href,
+        });
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "04-authenticated-user-avatar-revision.png"),
+          });
+        }
+
+        const missingAvatarResponse = page.waitForResponse(
+          (candidateResponse) =>
+            candidateResponse.url().includes(`/api/users/${testProfile.id}/avatar?v=4`) &&
+            candidateResponse.status() === 404,
+        );
+        await publishAvatarRevision(4);
+        await missingAvatarResponse;
+        await expect.poll(() => avatarRequests.length).toBe(3);
+        await expect.poll(() => sidebarAvatar.getAttribute("src")).toBeNull();
+        await expect
+          .poll(() =>
+            sidebarAvatar.evaluate((image) =>
+              image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+            ),
+          )
+          .toBe(true);
+        await expect
+          .poll(async () =>
+            (
+              await page.locator(".sidebar-identity-card .viewer-avatar__fallback").textContent()
+            )?.trim(),
+          )
+          .toBe("TP");
+        expect(await originalSidebarImage?.evaluate((image) => image.isConnected)).toBe(true);
+        expect(avatarRequests[2]).toEqual({
+          authorization: "Bearer e2e-device-token",
+          url: new URL(`${basePath}/api/users/${testProfile.id}/avatar?v=4`, suite.server.baseUrl)
+            .href,
+        });
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "05-authenticated-user-avatar-missing.png"),
+          });
+        }
+      },
+    );
   });
 
   it("retries the missing identity bootstrap and opens the profile editor", async () => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      basePath,
-      presenceUsers: testPresenceUsers,
-      methodResponses: {
-        "users.self": { sequence: [{}, { profile: testProfile }] },
-      },
-    });
+    await suite.withPage(undefined, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        basePath,
+        presenceUsers: testPresenceUsers,
+        methodResponses: {
+          "users.self": { sequence: [{}, { profile: testProfile }] },
+        },
+      });
 
-    try {
-      const response = await page.goto(new URL(profilePath, server.baseUrl).href);
+      const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
       expect(response?.status()).toBe(200);
 
       const emptyState = page.locator(".profile-identity-empty");
@@ -366,25 +342,21 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
         testProfile.displayName,
       );
       await screenshot(page, "02-identity-editor.png");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("keeps identity refresh single-flight and retries after a failed request", async () => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      basePath,
-      deferredMethods: ["users.self"],
-      presenceUsers: testPresenceUsers,
-      methodResponses: {
-        "users.self": { profile: testProfile },
-      },
-    });
+    await suite.withPage(undefined, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        basePath,
+        deferredMethods: ["users.self"],
+        presenceUsers: testPresenceUsers,
+        methodResponses: {
+          "users.self": { profile: testProfile },
+        },
+      });
 
-    try {
-      const response = await page.goto(new URL(profilePath, server.baseUrl).href);
+      const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
       expect(response?.status()).toBe(200);
 
       const refresh = page.locator(".profile-refresh");
@@ -422,8 +394,6 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
       await expect(displayName.inputValue()).resolves.toBe(testProfile.displayName);
       await expect.poll(() => refresh.isEnabled()).toBe(true);
       expect(await refresh.ariaSnapshot()).toContain('button "Refresh"');
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -2,32 +2,29 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { QuestionResolveResult } from "@openclaw/gateway-protocol";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext, Page } from "playwright";
+import { afterEach, expect, it } from "vitest";
 import type { SessionsListResult } from "../api/types.ts";
 import {
-  canRunPlaywrightChromium,
   controlUiSessionUrl,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
   type MockGatewayControls,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Gateway question flow",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "question-flow");
 const mainSessionKey = "agent:main:main";
 const questionSessionKey = "agent:main:question-proof";
 
-let browser: Browser;
 let context: BrowserContext | undefined;
-let server: ControlUiE2eServer;
-
 function questionRecord(
   id: string,
   questions: Array<{
@@ -80,7 +77,7 @@ function historyMessages() {
 }
 
 async function openQuestionPage() {
-  context = await browser.newContext({
+  context = await suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1440 },
@@ -125,7 +122,7 @@ async function openQuestionPage() {
     // lives in its own existing thread so the real sidebar can render its row.
     sessionKey: mainSessionKey,
   });
-  await page.goto(controlUiSessionUrl(server.baseUrl, questionSessionKey));
+  await page.goto(controlUiSessionUrl(suite.server.baseUrl, questionSessionKey));
   // Chat and sidebar each own a projection; both must bind to the advertised
   // real client before a lost-broadcast test can prove cross-surface delivery.
   await expect
@@ -159,23 +156,10 @@ async function emitRequested(
   await gateway.emitGatewayEvent("question.requested", record);
 }
 
-describeControlUiE2e("Control UI Gateway question flow", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await context?.close().catch(() => {});
     context = undefined;
-  });
-
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
   });
 
   it("restores the composer and its draft from an authoritative answer without a resolution event", async () => {

--- a/ui/src/e2e/route-css.e2e.test.ts
+++ b/ui/src/e2e/route-css.e2e.test.ts
@@ -1,158 +1,137 @@
 // Control UI tests prove route-scoped CSS on fresh direct navigation.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI route CSS mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI route CSS mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("loads shared Markdown and session-link styles on direct Cron, Skills, and Chat routes", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "cron.list": {
-          jobs: [],
-          total: 0,
-          offset: 0,
-          limit: 50,
-          hasMore: false,
-          nextOffset: null,
-        },
-        "cron.runs": {
-          entries: [],
-          total: 0,
-          offset: 0,
-          limit: 50,
-          hasMore: false,
-          nextOffset: null,
-        },
-        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [],
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": {
+              jobs: [],
+              total: 0,
+              offset: 0,
+              limit: 50,
+              hasMore: false,
+              nextOffset: null,
+            },
+            "cron.runs": {
+              entries: [],
+              total: 0,
+              offset: 0,
+              limit: 50,
+              hasMore: false,
+              nextOffset: null,
+            },
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+            "skills.status": {
+              workspaceDir: "/tmp/openclaw-e2e/workspace",
+              managedSkillsDir: "/tmp/openclaw-e2e/skills",
+              skills: [],
+            },
+          },
+        });
 
-    try {
-      const cronResponse = await page.goto(`${server.baseUrl}cron`);
-      expect(cronResponse?.status()).toBe(200);
-      await page.locator(".cron-page").waitFor();
+        const cronResponse = await page.goto(`${suite.server.baseUrl}cron`);
+        expect(cronResponse?.status()).toBe(200);
+        await page.locator(".cron-page").waitFor();
 
-      const cronStyles = await page.evaluate(() => {
-        const probe = document.createElement("div");
-        probe.innerHTML = `
+        const cronStyles = await page.evaluate(() => {
+          const probe = document.createElement("div");
+          probe.innerHTML = `
           <div class="chat-text"><ul><li>First</li><li>Second</li></ul><pre><code>code</code></pre></div>
           <a class="session-link">session</a>
         `;
-        document.body.append(probe);
-        const list = probe.querySelector("ul");
-        const secondListItem = probe.querySelector("li + li");
-        const pre = probe.querySelector("pre");
-        const link = probe.querySelector(".session-link");
-        if (
-          !(list instanceof HTMLElement) ||
-          !(secondListItem instanceof HTMLElement) ||
-          !(pre instanceof HTMLElement) ||
-          !link
-        ) {
-          throw new Error("Cron style probe did not render");
-        }
-        const listItemStyle = getComputedStyle(secondListItem);
-        const result = {
-          listPadding: Number.parseFloat(getComputedStyle(list).paddingLeft),
-          listItemGap: Number.parseFloat(listItemStyle.marginTop),
-          listItemFontSize: Number.parseFloat(listItemStyle.fontSize),
-          preBorderStyle: getComputedStyle(pre).borderTopStyle,
-          preOverflow: getComputedStyle(pre).overflowX,
-          sessionFontWeight: getComputedStyle(link).fontWeight,
-          sessionTextDecoration: getComputedStyle(link).textDecorationLine,
-        };
-        probe.remove();
-        return result;
-      });
-      expect(cronStyles.listPadding).toBeGreaterThan(0);
-      expect(cronStyles.listItemGap / cronStyles.listItemFontSize).toBeCloseTo(0.4, 2);
-      expect(cronStyles.preBorderStyle).toBe("solid");
-      expect(cronStyles.preOverflow).toBe("auto");
-      expect(cronStyles.sessionFontWeight).toBe("500");
-      expect(cronStyles.sessionTextDecoration).toBe("none");
+          document.body.append(probe);
+          const list = probe.querySelector("ul");
+          const secondListItem = probe.querySelector("li + li");
+          const pre = probe.querySelector("pre");
+          const link = probe.querySelector(".session-link");
+          if (
+            !(list instanceof HTMLElement) ||
+            !(secondListItem instanceof HTMLElement) ||
+            !(pre instanceof HTMLElement) ||
+            !link
+          ) {
+            throw new Error("Cron style probe did not render");
+          }
+          const listItemStyle = getComputedStyle(secondListItem);
+          const result = {
+            listPadding: Number.parseFloat(getComputedStyle(list).paddingLeft),
+            listItemGap: Number.parseFloat(listItemStyle.marginTop),
+            listItemFontSize: Number.parseFloat(listItemStyle.fontSize),
+            preBorderStyle: getComputedStyle(pre).borderTopStyle,
+            preOverflow: getComputedStyle(pre).overflowX,
+            sessionFontWeight: getComputedStyle(link).fontWeight,
+            sessionTextDecoration: getComputedStyle(link).textDecorationLine,
+          };
+          probe.remove();
+          return result;
+        });
+        expect(cronStyles.listPadding).toBeGreaterThan(0);
+        expect(cronStyles.listItemGap / cronStyles.listItemFontSize).toBeCloseTo(0.4, 2);
+        expect(cronStyles.preBorderStyle).toBe("solid");
+        expect(cronStyles.preOverflow).toBe("auto");
+        expect(cronStyles.sessionFontWeight).toBe("500");
+        expect(cronStyles.sessionTextDecoration).toBe("none");
 
-      const skillsResponse = await page.goto(`${server.baseUrl}skills`);
-      expect(skillsResponse?.status()).toBe(200);
-      await page.locator(".settings-section__heading", { hasText: "ClawHub" }).waitFor();
+        const skillsResponse = await page.goto(`${suite.server.baseUrl}skills`);
+        expect(skillsResponse?.status()).toBe(200);
+        await page.locator(".settings-section__heading", { hasText: "ClawHub" }).waitFor();
 
-      const skillsStyles = await page.evaluate(() => {
-        const probe = document.createElement("article");
-        probe.className = "sidebar-markdown";
-        probe.innerHTML = `
+        const skillsStyles = await page.evaluate(() => {
+          const probe = document.createElement("article");
+          probe.className = "sidebar-markdown";
+          probe.innerHTML = `
           <h2>Heading</h2>
           <ul><li class="task-list-item">Task</li></ul>
           <pre><code>code</code></pre>
           <table><tbody><tr><td>Cell</td></tr></tbody></table>
         `;
-        document.body.append(probe);
-        const heading = probe.querySelector("h2");
-        const task = probe.querySelector(".task-list-item");
-        const pre = probe.querySelector("pre");
-        const table = probe.querySelector("table");
-        if (!heading || !task || !pre || !table) {
-          throw new Error("Skills style probe did not render");
-        }
-        const result = {
-          headingBorderStyle: getComputedStyle(heading).borderBottomStyle,
-          preOverflow: getComputedStyle(pre).overflowX,
-          tableDisplay: getComputedStyle(table).display,
-          taskListStyle: getComputedStyle(task).listStyleType,
-        };
-        probe.remove();
-        return result;
-      });
-      expect(skillsStyles.headingBorderStyle).toBe("solid");
-      expect(skillsStyles.preOverflow).toBe("auto");
-      expect(skillsStyles.tableDisplay).toBe("block");
-      expect(skillsStyles.taskListStyle).toBe("none");
+          document.body.append(probe);
+          const heading = probe.querySelector("h2");
+          const task = probe.querySelector(".task-list-item");
+          const pre = probe.querySelector("pre");
+          const table = probe.querySelector("table");
+          if (!heading || !task || !pre || !table) {
+            throw new Error("Skills style probe did not render");
+          }
+          const result = {
+            headingBorderStyle: getComputedStyle(heading).borderBottomStyle,
+            preOverflow: getComputedStyle(pre).overflowX,
+            tableDisplay: getComputedStyle(table).display,
+            taskListStyle: getComputedStyle(task).listStyleType,
+          };
+          probe.remove();
+          return result;
+        });
+        expect(skillsStyles.headingBorderStyle).toBe("solid");
+        expect(skillsStyles.preOverflow).toBe("auto");
+        expect(skillsStyles.tableDisplay).toBe("block");
+        expect(skillsStyles.taskListStyle).toBe("none");
 
-      const chatResponse = await page.goto(`${server.baseUrl}chat?session=main`);
-      expect(chatResponse?.status()).toBe(200);
-      await page.locator("openclaw-chat-page").waitFor();
+        const chatResponse = await page.goto(`${suite.server.baseUrl}chat?session=main`);
+        expect(chatResponse?.status()).toBe(200);
+        await page.locator("openclaw-chat-page").waitFor();
 
-      const chatMarkdownStyles = await page.evaluate(() => {
-        const probe = document.createElement("div");
-        probe.className = "chat-text";
-        probe.style.width = "900px";
-        probe.innerHTML = `
+        const chatMarkdownStyles = await page.evaluate(() => {
+          const probe = document.createElement("div");
+          probe.className = "chat-text";
+          probe.style.width = "900px";
+          probe.innerHTML = `
           <table>
             <thead><tr><th>Dimension</th><th>Sentiment signal</th></tr></thead>
             <tbody><tr><td>Demographics</td><td>Experience-dependent sentiment.</td></tr></tbody>
@@ -160,40 +139,39 @@ describeControlUiE2e("Control UI route CSS mocked Gateway E2E", () => {
           <ol><li>One central pattern</li><li>Another central pattern</li></ol>
           <p><strong>Overall characterization:</strong> Pragmatic adoption under suspicion.</p>
         `;
-        document.body.append(probe);
-        const dimension = probe.querySelector("th:first-child");
-        const demographics = probe.querySelector("td:first-child");
-        const list = probe.querySelector("ol");
-        const summary = probe.querySelector("ol + p");
-        if (!dimension || !demographics || !list || !summary) {
-          throw new Error("Chat Markdown style probe did not render");
-        }
-        const lineCount = (element: Element) => {
-          const range = document.createRange();
-          range.selectNodeContents(element);
-          return new Set(Array.from(range.getClientRects(), (rect) => Math.round(rect.top))).size;
-        };
-        const result = {
-          demographicsLineCount: lineCount(demographics),
-          dimensionLineCount: lineCount(dimension),
-          firstColumnWidth: dimension.getBoundingClientRect().width,
-          postListGap: summary.getBoundingClientRect().top - list.getBoundingClientRect().bottom,
-          postListMargin: Number.parseFloat(getComputedStyle(summary).marginTop),
-          summaryFontSize: Number.parseFloat(getComputedStyle(summary).fontSize),
-        };
-        probe.remove();
-        return result;
-      });
-      expect(chatMarkdownStyles.dimensionLineCount).toBe(1);
-      expect(chatMarkdownStyles.demographicsLineCount).toBe(1);
-      expect(chatMarkdownStyles.firstColumnWidth).toBeGreaterThanOrEqual(128);
-      expect(chatMarkdownStyles.postListGap).toBeGreaterThan(0);
-      expect(chatMarkdownStyles.postListMargin / chatMarkdownStyles.summaryFontSize).toBeCloseTo(
-        0.75,
-        2,
-      );
-    } finally {
-      await context.close();
-    }
+          document.body.append(probe);
+          const dimension = probe.querySelector("th:first-child");
+          const demographics = probe.querySelector("td:first-child");
+          const list = probe.querySelector("ol");
+          const summary = probe.querySelector("ol + p");
+          if (!dimension || !demographics || !list || !summary) {
+            throw new Error("Chat Markdown style probe did not render");
+          }
+          const lineCount = (element: Element) => {
+            const range = document.createRange();
+            range.selectNodeContents(element);
+            return new Set(Array.from(range.getClientRects(), (rect) => Math.round(rect.top))).size;
+          };
+          const result = {
+            demographicsLineCount: lineCount(demographics),
+            dimensionLineCount: lineCount(dimension),
+            firstColumnWidth: dimension.getBoundingClientRect().width,
+            postListGap: summary.getBoundingClientRect().top - list.getBoundingClientRect().bottom,
+            postListMargin: Number.parseFloat(getComputedStyle(summary).marginTop),
+            summaryFontSize: Number.parseFloat(getComputedStyle(summary).fontSize),
+          };
+          probe.remove();
+          return result;
+        });
+        expect(chatMarkdownStyles.dimensionLineCount).toBe(1);
+        expect(chatMarkdownStyles.demographicsLineCount).toBe(1);
+        expect(chatMarkdownStyles.firstColumnWidth).toBeGreaterThanOrEqual(128);
+        expect(chatMarkdownStyles.postListGap).toBeGreaterThan(0);
+        expect(chatMarkdownStyles.postListMargin / chatMarkdownStyles.summaryFontSize).toBeCloseTo(
+          0.75,
+          2,
+        );
+      },
+    );
   });
 });

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -1,25 +1,23 @@
 // Control UI E2E covers the real session-dashboard provider and transcript bridge.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
 import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { SANDBOX_HOST_PATH } from "../../../src/agents/sandbox-host.js";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
 import {
-  canRunPlaywrightChromium,
   controlUiBundledSettingsStorageKey,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI session dashboard stitch",
+  startServerBeforeBrowser: true,
+});
+
 const cardboardProofDir = path.resolve(
   process.cwd(),
   ".artifacts/control-ui-e2e/workboard-cardboard",
@@ -28,9 +26,6 @@ const pluginWidgetsProofDir = path.resolve(
   process.cwd(),
   ".artifacts/control-ui-e2e/workboard-plugin-widgets",
 );
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const sessionKey = "agent:main:dashboard";
 const boardSnapshot = {
@@ -140,7 +135,7 @@ const pluginWidgetBoardSnapshot = {
 };
 
 async function showDashboard(page: Page): Promise<void> {
-  const settingsKey = controlUiBundledSettingsStorageKey(server.baseUrl);
+  const settingsKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
   await page.addInitScript(
     ({ key, storageKey }) => {
       const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
@@ -177,17 +172,7 @@ function workboardConfigSnapshot(enabled = true) {
   };
 }
 
-describeControlUiE2e("Control UI session dashboard stitch", () => {
-  beforeAll(async () => {
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps widget documents in standards mode and cancels self-navigation", async () => {
     const sandboxHost = createSandboxHostHttpServer();
     await new Promise<void>((resolve, reject) => {
@@ -201,7 +186,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     if (!sandboxAddress || typeof sandboxAddress === "string") {
       throw new Error("sandbox host did not bind a TCP address");
     }
-    const context = await browser.newContext();
+    const context = await suite.browser.newContext();
     try {
       const page = await context.newPage();
       const escapeRequests: string[] = [];
@@ -210,7 +195,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
           escapeRequests.push(request.url());
         }
       });
-      await page.goto(server.baseUrl);
+      await page.goto(suite.server.baseUrl);
       await page.evaluate((sandboxUrl) => {
         Reflect.set(globalThis, "widgetProbes", []);
         addEventListener("message", (event) => {
@@ -276,7 +261,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
   });
 
   it("pins Canvas HTML, follows board commands, and persists dock resizing", async () => {
-    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
     const resizableBoardSnapshot = {
       ...boardSnapshot,
@@ -327,7 +312,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     });
     await showDashboard(page);
 
-    await page.goto(`${server.baseUrl}dashboard`);
+    await page.goto(`${suite.server.baseUrl}dashboard`);
     await expect
       .poll(async () => (await gateway.getRequests("board.get")).length, { timeout: 30_000 })
       .toBeGreaterThan(0);
@@ -384,7 +369,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
   });
 
   it("pins an inline MCP App using only its session-bound view identity", async () => {
-    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       sessionKey,
@@ -433,7 +418,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     });
     await showDashboard(page);
 
-    await page.goto(`${server.baseUrl}dashboard`);
+    await page.goto(`${suite.server.baseUrl}dashboard`);
     await page.locator(".board-session-surface").waitFor();
     const preview = page.locator('.chat-tool-card__preview[data-kind="canvas"]');
     await preview.hover();
@@ -457,7 +442,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     if (recordProof) {
       await mkdir(pluginWidgetsProofDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       viewport: { height: 900, width: 1280 },
       ...(recordProof
         ? { recordVideo: { dir: pluginWidgetsProofDir, size: { height: 900, width: 1280 } } }
@@ -511,7 +496,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     await showDashboard(page);
 
     try {
-      await page.goto(`${server.baseUrl}dashboard`);
+      await page.goto(`${suite.server.baseUrl}dashboard`);
       const cardWidget = page.locator('[data-test-id="workboard-card-widget"]');
       const miniWidget = page.locator('[data-test-id="workboard-mini-widget"]');
       await cardWidget.waitFor();
@@ -574,66 +559,64 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
   });
 
   it("keeps a read-only Workboard dashboard card visible without allowing status changes", async () => {
-    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
-    const page = await context.newPage();
-    const widgetKinds = [
-      { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },
-      { pluginId: "workboard", kind: "workboard:mini", label: "Workboard summary" },
-    ];
-    const methods = [
-      "board.get",
-      "chat.metadata",
-      "chat.startup",
-      "workboard.cards.list",
-      "workboard.cards.move",
-    ];
-    const card = {
-      id: "card-widget-ready",
-      title: "Read-only dashboard card",
-      status: "ready",
-      priority: "high",
-      labels: ["dashboard"],
-      position: 1,
-      createdAt: 1,
-      updatedAt: 2,
-      agentId: "main",
-      metadata: { automation: { boardId: "platform" } },
-    };
-    const gateway = await installMockGateway(page, {
-      controlUiWidgetKinds: widgetKinds,
-      featureMethods: methods,
-      methodResponses: {
-        connect: {
-          type: "hello-ok",
-          protocol: PROTOCOL_VERSION,
-          server: { connId: "read-only-dashboard-widget", version: "e2e" },
-          auth: {
-            deviceToken: "e2e-read-only-dashboard-device-token",
-            role: "operator",
-            scopes: ["operator.read"],
-          },
-          features: { capabilities: [], events: [], methods },
-          controlUiWidgetKinds: widgetKinds,
-          snapshot: {
-            sessionDefaults: {
-              defaultAgentId: "main",
-              mainKey: "main",
-              mainSessionKey: "main",
-              scope: "agent",
+    await suite.withPage({ viewport: { height: 900, width: 1280 } }, async ({ page }) => {
+      const widgetKinds = [
+        { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },
+        { pluginId: "workboard", kind: "workboard:mini", label: "Workboard summary" },
+      ];
+      const methods = [
+        "board.get",
+        "chat.metadata",
+        "chat.startup",
+        "workboard.cards.list",
+        "workboard.cards.move",
+      ];
+      const card = {
+        id: "card-widget-ready",
+        title: "Read-only dashboard card",
+        status: "ready",
+        priority: "high",
+        labels: ["dashboard"],
+        position: 1,
+        createdAt: 1,
+        updatedAt: 2,
+        agentId: "main",
+        metadata: { automation: { boardId: "platform" } },
+      };
+      const gateway = await installMockGateway(page, {
+        controlUiWidgetKinds: widgetKinds,
+        featureMethods: methods,
+        methodResponses: {
+          connect: {
+            type: "hello-ok",
+            protocol: PROTOCOL_VERSION,
+            server: { connId: "read-only-dashboard-widget", version: "e2e" },
+            auth: {
+              deviceToken: "e2e-read-only-dashboard-device-token",
+              role: "operator",
+              scopes: ["operator.read"],
+            },
+            features: { capabilities: [], events: [], methods },
+            controlUiWidgetKinds: widgetKinds,
+            snapshot: {
+              sessionDefaults: {
+                defaultAgentId: "main",
+                mainKey: "main",
+                mainSessionKey: "main",
+                scope: "agent",
+              },
             },
           },
+          "board.get": pluginWidgetBoardSnapshot,
+          "workboard.cards.list": {
+            cards: [card],
+            statuses: ["ready", "running", "done"],
+          },
         },
-        "board.get": pluginWidgetBoardSnapshot,
-        "workboard.cards.list": {
-          cards: [card],
-          statuses: ["ready", "running", "done"],
-        },
-      },
-    });
-    await showDashboard(page);
+      });
+      await showDashboard(page);
 
-    try {
-      await page.goto(`${server.baseUrl}dashboard`);
+      await page.goto(`${suite.server.baseUrl}dashboard`);
       const cardWidget = page.locator('[data-test-id="workboard-card-widget"]');
       await cardWidget.waitFor();
       await expect.poll(() => cardWidget.textContent()).toContain(card.title);
@@ -644,9 +627,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
         select.dispatchEvent(new Event("change", { bubbles: true }));
       });
       expect(await gateway.getRequests("workboard.cards.move")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("links a dispatched Workboard card and its live session dashboard in both directions", async () => {
@@ -654,7 +635,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     if (recordProof) {
       await mkdir(cardboardProofDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       viewport: { height: 900, width: 1280 },
       ...(recordProof
         ? { recordVideo: { dir: cardboardProofDir, size: { height: 900, width: 1280 } } }
@@ -695,7 +676,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     await showDashboard(page);
 
     try {
-      await page.goto(`${server.baseUrl}dashboard`);
+      await page.goto(`${suite.server.baseUrl}dashboard`);
       const chip = page.locator(".board-session-surface__workboard-chip");
       await chip.waitFor();
       await expect.poll(() => chip.textContent()).toContain("Ship dashboard stitch");
@@ -791,43 +772,41 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
     ];
 
     for (const testCase of cases) {
-      const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
-      const page = await context.newPage();
-      const gateway = await installMockGateway(page, {
-        sessionKey,
-        featureMethods: [
-          "board.get",
-          "chat.metadata",
-          "chat.startup",
-          "config.get",
-          "workboard.cards.list",
-        ],
-        methodResponses: {
-          "board.get": testCase.board,
-          "config.get": testCase.config,
-          "workboard.cards.list": {
-            cards: [
-              {
-                id: `card-${testCase.name.replaceAll(" ", "-")}`,
-                title: testCase.name,
-                status: "running",
-                priority: "normal",
-                labels: [],
-                position: 1,
-                createdAt: 1,
-                updatedAt: 2,
-                sessionKey,
-                metadata: { automation: { boardId: "platform" } },
-              },
-            ],
-            statuses: ["running"],
+      await suite.withPage({ viewport: { height: 900, width: 1280 } }, async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          sessionKey,
+          featureMethods: [
+            "board.get",
+            "chat.metadata",
+            "chat.startup",
+            "config.get",
+            "workboard.cards.list",
+          ],
+          methodResponses: {
+            "board.get": testCase.board,
+            "config.get": testCase.config,
+            "workboard.cards.list": {
+              cards: [
+                {
+                  id: `card-${testCase.name.replaceAll(" ", "-")}`,
+                  title: testCase.name,
+                  status: "running",
+                  priority: "normal",
+                  labels: [],
+                  position: 1,
+                  createdAt: 1,
+                  updatedAt: 2,
+                  sessionKey,
+                  metadata: { automation: { boardId: "platform" } },
+                },
+              ],
+              statuses: ["running"],
+            },
           },
-        },
-      });
-      await showDashboard(page);
+        });
+        await showDashboard(page);
 
-      try {
-        await page.goto(`${server.baseUrl}dashboard`);
+        await page.goto(`${suite.server.baseUrl}dashboard`);
         await expect
           .poll(async () => (await gateway.getRequests("board.get")).length)
           .toBeGreaterThan(0);
@@ -835,9 +814,7 @@ describeControlUiE2e("Control UI session dashboard stitch", () => {
           .poll(() => page.locator(".board-session-surface__workboard-chip").count())
           .toBe(0);
         expect(await gateway.getRequests("workboard.cards.list")).toHaveLength(0);
-      } finally {
-        await context.close();
-      }
+      });
     }
   });
 });

--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -1,35 +1,16 @@
 // Control UI E2E tests cover session-list event scope through the Gateway WebSocket.
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { afterEach, expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI session-list event scope",
+});
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
-let browser: Browser;
 let page: Page | undefined;
-let server: ControlUiE2eServer | undefined;
-
-describeControlUiE2e("Control UI session-list event scope", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await page
       ?.context()
@@ -38,15 +19,10 @@ describeControlUiE2e("Control UI session-list event scope", () => {
     page = undefined;
   });
 
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
   it("refetches instead of showing a row excluded by configured-agent filtering", async () => {
     const visibleLabel = "Visible configured session";
     const hiddenLabel = "Hidden unconfigured session";
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, {
@@ -69,7 +45,7 @@ describeControlUiE2e("Control UI session-list event scope", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}sessions`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}sessions`);
     const visibleRow = currentPage.getByText(visibleLabel, { exact: true }).first();
     await visibleRow.waitFor({ timeout: 10_000 });
     // Arm the deferred response before sampling requests; startup may still finish in between.
@@ -131,7 +107,7 @@ describeControlUiE2e("Control UI session-list event scope", () => {
       ],
       ts: 1,
     };
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, {
@@ -155,7 +131,7 @@ describeControlUiE2e("Control UI session-list event scope", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     const sidebarRow = currentPage.locator(
       `.sidebar-recent-session[data-session-key="${sessionKey}"]`,
     );
@@ -168,7 +144,7 @@ describeControlUiE2e("Control UI session-list event scope", () => {
     expect(sidebarParams).toMatchObject({ limit: 50 });
     expect(sidebarParams).not.toHaveProperty("activeMinutes");
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}sessions`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}sessions`);
     const sessionsPage = currentPage.locator("openclaw-sessions-page");
     await sessionsPage.getByText(sessionLabel, { exact: true }).waitFor({ timeout: 10_000 });
     const initialPageRequests = await gateway.getRequests("sessions.list");
@@ -211,7 +187,7 @@ describeControlUiE2e("Control UI session-list event scope", () => {
   });
 
   it("omits noncanonical numeric filters from sessions.list requests", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, {
@@ -227,7 +203,7 @@ describeControlUiE2e("Control UI session-list event scope", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}sessions`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}sessions`);
     await gateway.waitForRequest("sessions.list");
     const activeMinutes = currentPage.getByLabel("Updated within");
     const limit = currentPage.getByLabel("Limit");

--- a/ui/src/e2e/session-manager-history.e2e.test.ts
+++ b/ui/src/e2e/session-manager-history.e2e.test.ts
@@ -39,111 +39,110 @@ suite.define(() => {
     const timestamp = Date.parse("2026-08-03T09:00:00.000Z");
     const main = sessionRow("agent:main:main", "Main", timestamp);
     const research = sessionRow("agent:main:research", "Research notes", timestamp - 60_000);
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1_280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "sessions.search"],
-      historyMessages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "The deployment history is ready to review." }],
-          timestamp,
-        },
-      ],
-      methodResponses: {
-        "sessions.list": sessionsListResponse([main, research]),
-        "sessions.patch": {},
-        "sessions.search": {
-          results: [
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "sessions.search"],
+          historyMessages: [
             {
-              messageId: "message-research",
               role: "assistant",
-              score: 2.5,
-              sessionId: "research",
-              sessionKey: research.key,
-              snippet: "The deployment history is ready to review.",
+              content: [{ type: "text", text: "The deployment history is ready to review." }],
               timestamp,
             },
           ],
-        },
+          methodResponses: {
+            "sessions.list": sessionsListResponse([main, research]),
+            "sessions.patch": {},
+            "sessions.search": {
+              results: [
+                {
+                  messageId: "message-research",
+                  role: "assistant",
+                  score: 2.5,
+                  sessionId: "research",
+                  sessionKey: research.key,
+                  snippet: "The deployment history is ready to review.",
+                  timestamp,
+                },
+              ],
+            },
+          },
+          sessionKey: main.key,
+        });
+
+        await page.goto(`${suite.server.baseUrl}sessions`);
+        const mainRow = page
+          .locator(".session-data-row")
+          .filter({ has: page.locator(`.session-label-chip[title="${main.label}"]`) });
+        const researchRow = page
+          .locator(".session-data-row")
+          .filter({ has: page.locator(`.session-label-chip[title="${research.label}"]`) });
+        await mainRow.waitFor({ state: "visible", timeout: 10_000 });
+        await researchRow.waitFor({ state: "visible", timeout: 10_000 });
+
+        const rosterFilter = page.locator('.sessions-toolbar__search input[type="text"]');
+        await rosterFilter.fill("Research");
+        await expect.poll(() => mainRow.count()).toBe(0);
+        await researchRow.waitFor({ state: "visible" });
+        await captureUiProof(page, "01-session-filter.png");
+        await rosterFilter.fill("");
+        await mainRow.waitFor({ state: "visible" });
+
+        const transcriptSearch = page.getByRole("search", { name: "Search transcripts" });
+        const transcriptInput = transcriptSearch.getByRole("searchbox", {
+          name: "Search thread transcripts",
+        });
+        await transcriptInput.fill("deployment history");
+        await transcriptInput.press("Enter");
+        const result = page.locator(".sessions-transcript-search__result");
+        await result.waitFor({ state: "visible", timeout: 10_000 });
+        expect((await gateway.getRequests("sessions.search"))[0]?.params).toEqual({
+          agentId: "main",
+          limit: 25,
+          query: "deployment history",
+          sessionKeys: [main.key, research.key],
+        });
+        await result.click();
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe(controlUiSessionPath(research.key));
+        await page
+          .locator(".chat-group.assistant")
+          .getByText("The deployment history is ready to review.", { exact: true })
+          .waitFor({ state: "visible", timeout: 10_000 });
+        await captureUiProof(page, "02-session-history.png");
+
+        await page.goto(`${suite.server.baseUrl}sessions`);
+        const actionRow = page
+          .locator(".session-data-row")
+          .filter({ has: page.locator(`.session-label-chip[title="${research.label}"]`) });
+        await actionRow.waitFor({ state: "visible", timeout: 10_000 });
+        await actionRow.getByRole("button", { name: "Open thread menu" }).click();
+        await activateMenuItem(
+          page.locator("openclaw-session-menu").getByRole("menuitem", {
+            name: "Archive thread",
+          }),
+        );
+        const patch = await waitForPatch(
+          gateway,
+          (params) => params.key === research.key && params.archived === true,
+        );
+        expect(requireRecord(patch.params)).toMatchObject({
+          archived: true,
+          key: research.key,
+        });
+        const toast = page
+          .locator("openclaw-toast-host .app-toast")
+          .filter({ hasText: "Thread archived" });
+        await toast.waitFor({ state: "visible", timeout: 10_000 });
+        await toast.getByRole("button", { name: "Undo" }).waitFor({ state: "visible" });
+        await captureUiProof(page, "03-session-archive-feedback.png");
       },
-      sessionKey: main.key,
-    });
-
-    try {
-      await page.goto(`${suite.server.baseUrl}sessions`);
-      const mainRow = page
-        .locator(".session-data-row")
-        .filter({ has: page.locator(`.session-label-chip[title="${main.label}"]`) });
-      const researchRow = page
-        .locator(".session-data-row")
-        .filter({ has: page.locator(`.session-label-chip[title="${research.label}"]`) });
-      await mainRow.waitFor({ state: "visible", timeout: 10_000 });
-      await researchRow.waitFor({ state: "visible", timeout: 10_000 });
-
-      const rosterFilter = page.locator('.sessions-toolbar__search input[type="text"]');
-      await rosterFilter.fill("Research");
-      await expect.poll(() => mainRow.count()).toBe(0);
-      await researchRow.waitFor({ state: "visible" });
-      await captureUiProof(page, "01-session-filter.png");
-      await rosterFilter.fill("");
-      await mainRow.waitFor({ state: "visible" });
-
-      const transcriptSearch = page.getByRole("search", { name: "Search transcripts" });
-      const transcriptInput = transcriptSearch.getByRole("searchbox", {
-        name: "Search thread transcripts",
-      });
-      await transcriptInput.fill("deployment history");
-      await transcriptInput.press("Enter");
-      const result = page.locator(".sessions-transcript-search__result");
-      await result.waitFor({ state: "visible", timeout: 10_000 });
-      expect((await gateway.getRequests("sessions.search"))[0]?.params).toEqual({
-        agentId: "main",
-        limit: 25,
-        query: "deployment history",
-        sessionKeys: [main.key, research.key],
-      });
-      await result.click();
-      await expect
-        .poll(() => new URL(page.url()).pathname)
-        .toBe(controlUiSessionPath(research.key));
-      await page
-        .locator(".chat-group.assistant")
-        .getByText("The deployment history is ready to review.", { exact: true })
-        .waitFor({ state: "visible", timeout: 10_000 });
-      await captureUiProof(page, "02-session-history.png");
-
-      await page.goto(`${suite.server.baseUrl}sessions`);
-      const actionRow = page
-        .locator(".session-data-row")
-        .filter({ has: page.locator(`.session-label-chip[title="${research.label}"]`) });
-      await actionRow.waitFor({ state: "visible", timeout: 10_000 });
-      await actionRow.getByRole("button", { name: "Open thread menu" }).click();
-      await activateMenuItem(
-        page.locator("openclaw-session-menu").getByRole("menuitem", {
-          name: "Archive thread",
-        }),
-      );
-      const patch = await waitForPatch(
-        gateway,
-        (params) => params.key === research.key && params.archived === true,
-      );
-      expect(requireRecord(patch.params)).toMatchObject({
-        archived: true,
-        key: research.key,
-      });
-      const toast = page
-        .locator("openclaw-toast-host .app-toast")
-        .filter({ hasText: "Thread archived" });
-      await toast.waitFor({ state: "visible", timeout: 10_000 });
-      await toast.getByRole("button", { name: "Undo" }).waitFor({ state: "visible" });
-      await captureUiProof(page, "03-session-archive-feedback.png");
-    } finally {
-      await suite.closeBrowserContext(context);
-    }
+    );
   });
 });

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -1,28 +1,20 @@
 // Control UI E2E tests cover session ownership dormancy and creator filtering.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
+import type { Page } from "playwright";
 import { expect as expectBrowser } from "playwright/test";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { afterEach, expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI session ownership",
+});
+
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "drafts-ux");
 
-let browser: Browser;
 let page: Page | undefined;
-let server: ControlUiE2eServer | undefined;
-
 function sessionsList(creators: [string, string]) {
   const creatorFacet = [
     { id: creators[0], label: "Ada" },
@@ -101,17 +93,7 @@ async function replaceGatewayClient(targetPage: Page) {
   });
 }
 
-describeControlUiE2e("Control UI session ownership", () => {
-  beforeAll(async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
+suite.define(() => {
   afterEach(async () => {
     await page
       ?.context()
@@ -120,13 +102,8 @@ describeControlUiE2e("Control UI session ownership", () => {
     page = undefined;
   });
 
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
   it("shows permanent owner chips and filters existing custom groups", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, {
@@ -135,7 +112,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       methodResponses: { "sessions.list": sessionsList(["profile-ada", "profile-bob"]) },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("Ada research", { exact: true }).first().waitFor();
     await currentPage.getByText("Bob operations", { exact: true }).first().waitFor();
     await currentPage.locator('[data-session-key="agent:main:ada"] a').click();
@@ -171,7 +148,7 @@ describeControlUiE2e("Control UI session ownership", () => {
   });
 
   it("renders zero ownership chrome for a single creator", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     await installMockGateway(currentPage, {
@@ -180,7 +157,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       methodResponses: { "sessions.list": sessionsList(["profile-ada", "profile-ada"]) },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("Ada research", { exact: true }).first().waitFor();
     await currentPage.getByText("Bob operations", { exact: true }).first().waitFor();
     await currentPage.locator('[data-session-key="agent:main:ada"] a').click();
@@ -194,7 +171,7 @@ describeControlUiE2e("Control UI session ownership", () => {
   });
 
   it("keeps grouped single-creator thread actions accessible to keyboard users", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     await installMockGateway(currentPage, {
@@ -204,7 +181,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       methodResponses: { "sessions.list": sessionsList(["profile-ada", "profile-ada"]) },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("Ada research", { exact: true }).first().waitFor();
     await currentPage.getByText("Bob operations", { exact: true }).first().waitFor();
 
@@ -234,7 +211,7 @@ describeControlUiE2e("Control UI session ownership", () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
         ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 800, width: 1200 } } }
@@ -248,7 +225,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       methodResponses: { "sessions.list": draftSessionsList() },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     const ownDraft = currentPage.locator('[data-session-key="agent:main:ada"]');
     const otherDraft = currentPage.locator('[data-session-key="agent:main:bob"]');
     await ownDraft.waitFor();
@@ -271,7 +248,7 @@ describeControlUiE2e("Control UI session ownership", () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
         ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 800, width: 1200 } } }
@@ -289,7 +266,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}new`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}new`);
     // Playwright check()/isChecked() support role="switch" buttons via aria-checked.
     const draftToggle = currentPage.getByRole("switch", { name: "Draft", exact: true });
     await draftToggle.waitFor();
@@ -311,7 +288,7 @@ describeControlUiE2e("Control UI session ownership", () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
         ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 800, width: 1200 } } }
@@ -354,7 +331,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("Ready.", { exact: true }).waitFor();
     await currentPage.getByLabel("Thread sharing").click();
     const publish = currentPage.getByText("Publish draft", { exact: true });
@@ -371,7 +348,7 @@ describeControlUiE2e("Control UI session ownership", () => {
   });
 
   it("keeps rejected visibility-only sharing changes visible after the menu closes", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const sessions = draftSessionsList();
@@ -390,7 +367,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       methodResponses: { "sessions.list": sessions },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("Ready.", { exact: true }).waitFor();
     await currentPage.getByRole("button", { name: "Thread sharing" }).click();
     const dropdown = currentPage.locator(".chat-pane__sharing-menu");
@@ -414,7 +391,7 @@ describeControlUiE2e("Control UI session ownership", () => {
   });
 
   it("lets a read-scoped owner inspect sharing but blocks mutations", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const sessions = draftSessionsList();
@@ -447,7 +424,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}chat`);
     await currentPage.getByText("Ready.", { exact: true }).waitFor();
     await currentPage.getByLabel("Thread sharing").click();
     await gateway.waitForRequest("session.members.list");
@@ -474,7 +451,7 @@ describeControlUiE2e("Control UI session ownership", () => {
   });
 
   it("clears a selected draft mode when sharing policy becomes unavailable", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, {
@@ -483,7 +460,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       methodResponses: { "sessions.list": sessionsList(["profile-ada", "profile-bob"]) },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}new`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}new`);
     const draftToggle = currentPage.getByRole("switch", { name: "Draft", exact: true });
     await draftToggle.check();
     await gateway.setSessionSharingPolicy({
@@ -503,7 +480,7 @@ describeControlUiE2e("Control UI session ownership", () => {
   });
 
   it("keeps create-as-draft dormant for one creator", async () => {
-    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
     await installMockGateway(currentPage, {
@@ -512,7 +489,7 @@ describeControlUiE2e("Control UI session ownership", () => {
       methodResponses: { "sessions.list": sessionsList(["profile-ada", "profile-ada"]) },
     });
 
-    await currentPage.goto(`${server?.baseUrl ?? ""}new`);
+    await currentPage.goto(`${suite.server?.baseUrl ?? ""}new`);
     await currentPage.locator(".new-session-page__message").waitFor();
     expect(await currentPage.getByRole("switch", { name: "Draft", exact: true }).count()).toBe(0);
   });

--- a/ui/src/e2e/session-suggestions.e2e.test.ts
+++ b/ui/src/e2e/session-suggestions.e2e.test.ts
@@ -1,25 +1,17 @@
 // Control UI E2E tests cover suggestion queue and solo-dormancy behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, expect, type Browser, type Page } from "playwright/test";
-import { afterAll, beforeAll, describe, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  controlUiSessionUrl,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, type Page } from "playwright/test";
+import { it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI session suggestions",
+  startServerBeforeBrowser: true,
+});
+
 const sessionKey = "agent:main:main";
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 function artifactDir(): string | undefined {
   return process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() || undefined;
@@ -30,7 +22,7 @@ async function contextAndPage() {
   if (output) {
     await fs.mkdir(output, { recursive: true });
   }
-  const context = await browser.newContext({
+  const context = await suite.browser.newContext({
     viewport: { height: 760, width: 1180 },
     ...(output ? { recordVideo: { dir: output, size: { height: 760, width: 1180 } } } : {}),
   });
@@ -74,17 +66,7 @@ const featureMethods = [
   "session.typing",
 ];
 
-describeControlUiE2e("Control UI session suggestions", () => {
-  beforeAll(async () => {
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("submits a viewer draft as a suggestion and shows its pending state", async () => {
     const { context, page } = await contextAndPage();
     const suggestion = {
@@ -115,7 +97,7 @@ describeControlUiE2e("Control UI session suggestions", () => {
       },
     });
 
-    await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
     const composer = page.locator(".agent-chat__composer-combobox textarea");
     await gateway.waitForRequest("session.suggestions.list");
     await expect(composer).toBeEnabled();
@@ -164,7 +146,7 @@ describeControlUiE2e("Control UI session suggestions", () => {
       },
     });
 
-    await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
     const row = page.locator(".session-suggestion");
     await expect(row).toBeVisible();
     await expect(row.locator("button")).toHaveCount(4);
@@ -206,7 +188,7 @@ describeControlUiE2e("Control UI session suggestions", () => {
       methodResponses: { "sessions.list": sessionRow("viewer") },
     });
 
-    await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
     await expect(page.locator(".agent-chat__composer-combobox textarea")).toBeDisabled();
     await expect(page.getByRole("button", { name: "Suggest message" })).toHaveCount(0);
     await expect(page.locator(".agent-chat__typing-indicator")).toHaveCount(0);
@@ -225,7 +207,7 @@ describeControlUiE2e("Control UI session suggestions", () => {
       methodResponses: { "sessions.list": sessionRow("viewer") },
     });
 
-    await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
     await expect(page.locator(".agent-chat__composer-combobox textarea")).toBeDisabled();
     await expect(page.getByRole("button", { name: "Suggest message" })).toHaveCount(0);
     await context.close();

--- a/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
+++ b/ui/src/e2e/settings-prefs-reconnect.e2e.test.ts
@@ -1,23 +1,19 @@
 // Control UI tests cover server preference replay and reconciliation through real reconnects.
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
 import {
-  canRunPlaywrightChromium,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI server prefs reconnect sync",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 function configResponse(prefs: Record<string, unknown>, hash: string) {
   const config = { ui: { prefs } };
@@ -49,7 +45,7 @@ function patchPrefs(request: MockGatewayRequest): Record<string, unknown> {
 }
 
 async function createContext(): Promise<BrowserContext> {
-  return browser.newContext({
+  return suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1440 },
@@ -138,22 +134,7 @@ function themeModeOption(page: Page, mode: "system" | "light" | "dark") {
   return page.locator(`wa-radio.settings-segmented__btn[value="${mode}"]`);
 }
 
-describeControlUiE2e("Control UI server prefs reconnect sync", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("replays an offline theme edit after a same-client reconnect", async () => {
     const context = await createContext();
     const page = await context.newPage();
@@ -164,7 +145,7 @@ describeControlUiE2e("Control UI server prefs reconnect sync", () => {
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
       expect(response?.status()).toBe(200);
       await themeCard(page, "claw").waitFor();
       await gateway.waitForRequest("config.get");
@@ -199,7 +180,7 @@ describeControlUiE2e("Control UI server prefs reconnect sync", () => {
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}settings/appearance`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
       expect(response?.status()).toBe(200);
       await themeCard(page, "claw").waitFor();
       await gateway.waitForRequest("config.get");
@@ -244,8 +225,8 @@ describeControlUiE2e("Control UI server prefs reconnect sync", () => {
     });
     try {
       await Promise.all([
-        pageA.goto(`${server.baseUrl}settings/appearance`),
-        pageB.goto(`${server.baseUrl}settings/appearance`),
+        pageA.goto(`${suite.server.baseUrl}settings/appearance`),
+        pageB.goto(`${suite.server.baseUrl}settings/appearance`),
       ]);
       await Promise.all([themeCard(pageA, "claw").waitFor(), themeCard(pageB, "claw").waitFor()]);
       await Promise.all([
@@ -294,8 +275,8 @@ describeControlUiE2e("Control UI server prefs reconnect sync", () => {
 
     try {
       await Promise.all([
-        pageA.goto(`${server.baseUrl}settings/appearance`),
-        pageB.goto(`${server.baseUrl}settings/appearance`),
+        pageA.goto(`${suite.server.baseUrl}settings/appearance`),
+        pageB.goto(`${suite.server.baseUrl}settings/appearance`),
       ]);
       await Promise.all([themeCard(pageA, "claw").waitFor(), themeCard(pageB, "claw").waitFor()]);
       await Promise.all([gatewayA.deferNext("config.patch"), gatewayB.deferNext("config.patch")]);
@@ -352,7 +333,7 @@ describeControlUiE2e("Control UI server prefs reconnect sync", () => {
     });
 
     try {
-      await page.goto(`${server.baseUrl}settings/appearance`);
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
       await themeCard(page, "claw").waitFor();
       await gateway.waitForRequest("config.get");
       const initialConfigGets = (await gateway.getRequests("config.get")).length;

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -1,27 +1,24 @@
 // Control UI tests cover customizable sidebar navigation and persistence.
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
 import {
-  canRunPlaywrightChromium,
   controlUiSessionPath,
   controlUiSessionUrl,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
   waitForControlUiRoute,
   waitForControlUiSettingsTakeover,
-  type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI sidebar customization mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
-let browser: Browser;
-let server: ControlUiE2eServer;
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const uiProofArtifactDir = path.join(
   process.cwd(),
@@ -97,39 +94,24 @@ async function holdUiProof(page: Page, durationMs = 600) {
 }
 
 async function openSidebarTestPage() {
-  const context = await browser.newContext({
+  const context = await suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1440 },
   });
   const page = await context.newPage();
   await installMockGateway(page);
-  await page.goto(`${server.baseUrl}chat`);
+  await page.goto(`${suite.server.baseUrl}chat`);
   await page.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
   return { context, page };
 }
 
-describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("pins routes, restores defaults, and persists navigation state across reloads", async () => {
     if (captureUiProofEnabled) {
       await mkdir(uiProofArtifactDir, { recursive: true });
     }
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       locale: "en-US",
       recordVideo: captureUiProofEnabled
         ? { dir: path.join(uiProofArtifactDir, "video"), size: { height: 900, width: 1300 } }
@@ -180,7 +162,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
     });
 
     try {
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
 
       const sidebar = page.locator("openclaw-app-sidebar");
       const pinnedItems = sidebar.locator(
@@ -434,7 +416,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect
         .poll(() => page.getByRole("button", { name: "Exit setup" }).isVisible())
         .toBe(false);
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       await captureUiProof(page, "01-default-pinned.png");
 
       const moreButton = sidebar.locator(".sidebar-nav__head-action");
@@ -608,111 +590,110 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
   });
 
   it("shows the Workboard route when the plugin is enabled in config", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "config.get": {
-          config: { plugins: { entries: { workboard: { enabled: true } } } },
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              config: { plugins: { entries: { workboard: { enabled: true } } } },
+            },
+          },
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
-      const sidebar = page.locator("openclaw-app-sidebar");
-      await sidebar.locator(".sidebar-nav__head-action").click();
-      await expect
-        .poll(() =>
-          trimmedTextContents(
-            sidebar.locator("wa-dropdown.sidebar-more-menu").getByRole("menuitem"),
-          ),
-        )
-        .toContain("Workboard");
-    } finally {
-      await context.close();
-    }
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const sidebar = page.locator("openclaw-app-sidebar");
+        await sidebar.locator(".sidebar-nav__head-action").click();
+        await expect
+          .poll(() =>
+            trimmedTextContents(
+              sidebar.locator("wa-dropdown.sidebar-more-menu").getByRole("menuitem"),
+            ),
+          )
+          .toContain("Workboard");
+      },
+    );
   });
 
   it("opens the start screen from the sidebar action without carrying the active session", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page);
 
-    try {
-      await page.goto(controlUiSessionUrl(server.baseUrl, "agent:main:work"));
-      await page.locator("openclaw-app-sidebar .sidebar-brand__new-thread").click();
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:work"));
+        await page.locator("openclaw-app-sidebar .sidebar-brand__new-thread").click();
 
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
-      await expect.poll(() => new URL(page.url()).searchParams.get("agent")).toBe("main");
-      await expect.poll(() => new URL(page.url()).searchParams.has("session")).toBe(false);
-      await expect.poll(() => page.locator(".new-session-page").isVisible()).toBe(true);
-      await captureUiProof(page, "07-sidebar-start-screen.png");
-    } finally {
-      await context.close();
-    }
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
+        await expect.poll(() => new URL(page.url()).searchParams.get("agent")).toBe("main");
+        await expect.poll(() => new URL(page.url()).searchParams.has("session")).toBe(false);
+        await expect.poll(() => page.locator(".new-session-page").isVisible()).toBe(true);
+        await captureUiProof(page, "07-sidebar-start-screen.png");
+      },
+    );
   });
 
   it("passes failed run outcomes through the desktop and drawer sidebar", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "sessions.list": {
-          count: 1,
-          defaults: {
-            contextTokens: null,
-            model: "gpt-5.5",
-            modelProvider: "openai",
-          },
-          path: "",
-          sessions: [
-            {
-              endedAt: 100,
-              key: "main",
-              kind: "direct",
-              status: "failed",
-              updatedAt: 100,
-            },
-          ],
-          ts: 100,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "sessions.list": {
+              count: 1,
+              defaults: {
+                contextTokens: null,
+                model: "gpt-5.5",
+                modelProvider: "openai",
+              },
+              path: "",
+              sessions: [
+                {
+                  endedAt: 100,
+                  key: "main",
+                  kind: "direct",
+                  status: "failed",
+                  updatedAt: 100,
+                },
+              ],
+              ts: 100,
+            },
+          },
+        });
 
-    const outcome = (locator: Locator) =>
-      locator.evaluate((element) => (element as HTMLElement & { runOutcome: string }).runOutcome);
+        const outcome = (locator: Locator) =>
+          locator.evaluate(
+            (element) => (element as HTMLElement & { runOutcome: string }).runOutcome,
+          );
 
-    try {
-      await page.goto(`${server.baseUrl}chat`);
-      const sidebar = page.locator("openclaw-app-sidebar");
-      const pet = sidebar.locator(".sidebar-shell openclaw-lobster-pet");
-      await expect.poll(() => pet.count()).toBe(1);
-      await expect.poll(() => outcome(pet)).toBe("error");
-      await expect.poll(() => page.locator(".topbar").isVisible()).toBe(false);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const pet = sidebar.locator(".sidebar-shell openclaw-lobster-pet");
+        await expect.poll(() => pet.count()).toBe(1);
+        await expect.poll(() => outcome(pet)).toBe("error");
+        await expect.poll(() => page.locator(".topbar").isVisible()).toBe(false);
 
-      await page.setViewportSize({ height: 900, width: 900 });
-      const drawerButton = visibleDrawerButton(page);
-      await expect.poll(() => drawerButton.isVisible()).toBe(true);
-      await drawerButton.click();
-      await expect.poll(() => sidebar.isVisible()).toBe(true);
-      await expect.poll(() => pet.count()).toBe(1);
-      await expect.poll(() => outcome(pet)).toBe("error");
-    } finally {
-      await context.close();
-    }
+        await page.setViewportSize({ height: 900, width: 900 });
+        const drawerButton = visibleDrawerButton(page);
+        await expect.poll(() => drawerButton.isVisible()).toBe(true);
+        await drawerButton.click();
+        await expect.poll(() => sidebar.isVisible()).toBe(true);
+        await expect.poll(() => pet.count()).toBe(1);
+        await expect.poll(() => outcome(pet)).toBe("error");
+      },
+    );
   });
 
   it("keeps the lobster on the footer ledge across desktop and drawer layouts", async () => {

--- a/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
+++ b/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
@@ -3,108 +3,85 @@
 // renders it in the danger color; release gateways omit it entirely.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI sidebar dev branch badge E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 const DEV_BRANCH = "feat/dev-branch-badge";
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI sidebar dev branch badge E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders the dev checkout branch in the footer in the danger color", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, { devGitBranch: DEV_BRANCH });
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, { devGitBranch: DEV_BRANCH });
 
-    try {
-      const response = await page.goto(server.baseUrl);
-      expect(response?.status()).toBe(200);
+        const response = await page.goto(suite.server.baseUrl);
+        expect(response?.status()).toBe(200);
 
-      const badge = page.locator(".sidebar-footer-branch");
-      await badge.waitFor();
-      await expect
-        .poll(() => badge.locator(".sidebar-footer-branch__name").textContent())
-        .toBe(DEV_BRANCH);
-      // The branch name surfaces via the shared tooltip's accessible
-      // description instead of a native title attribute.
-      await expect
-        .poll(() =>
-          badge.evaluate((element) => {
-            const id = element.getAttribute("aria-describedby");
-            return id ? (document.getElementById(id)?.textContent ?? null) : null;
-          }),
-        )
-        .toBe(DEV_BRANCH);
+        const badge = page.locator(".sidebar-footer-branch");
+        await badge.waitFor();
+        await expect
+          .poll(() => badge.locator(".sidebar-footer-branch__name").textContent())
+          .toBe(DEV_BRANCH);
+        // The branch name surfaces via the shared tooltip's accessible
+        // description instead of a native title attribute.
+        await expect
+          .poll(() =>
+            badge.evaluate((element) => {
+              const id = element.getAttribute("aria-describedby");
+              return id ? (document.getElementById(id)?.textContent ?? null) : null;
+            }),
+          )
+          .toBe(DEV_BRANCH);
 
-      const colors = await badge.evaluate((element) => {
-        // Compare resolved colors: getComputedStyle().color returns rgb() while
-        // the raw --danger token may be hex/oklch, so resolve it via a probe.
-        const probe = document.createElement("span");
-        probe.style.color = "var(--danger)";
-        element.append(probe);
-        const danger = getComputedStyle(probe).color;
-        probe.remove();
-        return { badge: getComputedStyle(element).color, danger };
-      });
-      expect(colors.danger).not.toBe("");
-      expect(colors.badge).toBe(colors.danger);
+        const colors = await badge.evaluate((element) => {
+          // Compare resolved colors: getComputedStyle().color returns rgb() while
+          // the raw --danger token may be hex/oklch, so resolve it via a probe.
+          const probe = document.createElement("span");
+          probe.style.color = "var(--danger)";
+          element.append(probe);
+          const danger = getComputedStyle(probe).color;
+          probe.remove();
+          return { badge: getComputedStyle(element).color, danger };
+        });
+        expect(colors.danger).not.toBe("");
+        expect(colors.badge).toBe(colors.danger);
 
-      const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "dev-branch");
-      await mkdir(artifactDir, { recursive: true });
-      await page
-        .locator(".sidebar-shell__footer")
-        .screenshot({ path: path.join(artifactDir, "footer-dev-branch.png") });
-    } finally {
-      await context.close();
-    }
+        const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "dev-branch");
+        await mkdir(artifactDir, { recursive: true });
+        await page
+          .locator(".sidebar-shell__footer")
+          .screenshot({ path: path.join(artifactDir, "footer-dev-branch.png") });
+      },
+    );
   });
 
   it("omits the badge when the gateway reports no dev branch", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page);
 
-    try {
-      const response = await page.goto(server.baseUrl);
-      expect(response?.status()).toBe(200);
-      await page.locator(".sidebar-agent-card").waitFor();
-      expect(await page.locator(".sidebar-footer-branch").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        const response = await page.goto(suite.server.baseUrl);
+        expect(response?.status()).toBe(200);
+        await page.locator(".sidebar-agent-card").waitFor();
+        expect(await page.locator(".sidebar-footer-branch").count()).toBe(0);
+      },
+    );
   });
 });

--- a/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
+++ b/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
@@ -1,21 +1,13 @@
 // Control UI coverage proves alternative skill binaries remain diagnosable and installable.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI alternative skill binary requirements",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 function codingAgentSkill(missingAnyBins: string[]) {
   return {
@@ -61,88 +53,75 @@ function codingAgentSkill(missingAnyBins: string[]) {
   };
 }
 
-describeControlUiE2e("Control UI alternative skill binary requirements", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("explains alternative missing binaries and installs one through the Gateway", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "skills.install"],
-      methodResponses: {
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [codingAgentSkill(["claude", "codex", "opencode"])],
-        },
-        "skills.install": { message: "Installed Codex CLI" },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "skills.install"],
+          methodResponses: {
+            "skills.status": {
+              workspaceDir: "/tmp/openclaw-e2e/workspace",
+              managedSkillsDir: "/tmp/openclaw-e2e/skills",
+              skills: [codingAgentSkill(["claude", "codex", "opencode"])],
+            },
+            "skills.install": { message: "Installed Codex CLI" },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}skills`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("button", { name: "Open Coding Agent details" }).click();
+        const response = await page.goto(`${suite.server.baseUrl}skills`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("button", { name: "Open Coding Agent details" }).click();
 
-      const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
-      await expect.poll(async () => await dialog.count()).toBe(1);
-      expect(await dialog.textContent()).toContain("bin:any of (claude, codex, opencode)");
-      await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).click();
+        const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
+        await expect.poll(async () => await dialog.count()).toBe(1);
+        expect(await dialog.textContent()).toContain("bin:any of (claude, codex, opencode)");
+        await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).click();
 
-      const request = await gateway.waitForRequest("skills.install");
-      expect(request.params).toMatchObject({
-        name: "Coding Agent",
-        installId: "node-codex",
-        dangerouslyForceUnsafeInstall: false,
-      });
-    } finally {
-      await context.close();
-    }
+        const request = await gateway.waitForRequest("skills.install");
+        expect(request.params).toMatchObject({
+          name: "Coding Agent",
+          installId: "node-codex",
+          dangerouslyForceUnsafeInstall: false,
+        });
+      },
+    );
   });
 
   it("does not show missing alternatives or an installer for an eligible skill", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      methodResponses: {
-        "skills.status": {
-          workspaceDir: "/tmp/openclaw-e2e/workspace",
-          managedSkillsDir: "/tmp/openclaw-e2e/skills",
-          skills: [codingAgentSkill([])],
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "skills.status": {
+              workspaceDir: "/tmp/openclaw-e2e/workspace",
+              managedSkillsDir: "/tmp/openclaw-e2e/skills",
+              skills: [codingAgentSkill([])],
+            },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}skills`);
-      expect(response?.status()).toBe(200);
-      await page.getByRole("button", { name: "Open Coding Agent details" }).click();
+        const response = await page.goto(`${suite.server.baseUrl}skills`);
+        expect(response?.status()).toBe(200);
+        await page.getByRole("button", { name: "Open Coding Agent details" }).click();
 
-      const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
-      await expect.poll(async () => await dialog.count()).toBe(1);
-      expect(await dialog.getByText("bin:any of", { exact: false }).count()).toBe(0);
-      expect(await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
+        await expect.poll(async () => await dialog.count()).toBe(1);
+        expect(await dialog.getByText("bin:any of", { exact: false }).count()).toBe(0);
+        expect(await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).count()).toBe(
+          0,
+        );
+      },
+    );
   });
 });

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -1,73 +1,50 @@
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "embedded terminal document",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const deadSessionScreenshotPath = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_SCREENSHOT?.trim();
 const deadSessionVideoDir = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_VIDEO_DIR?.trim();
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("embedded terminal document", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders only the terminal with a tab-attached close control while native auth connects", async () => {
-    const context = await browser.newContext({ serviceWorkers: "block" });
-    const page = await context.newPage();
-    await page.addInitScript(() => {
-      (
-        window as Window & {
-          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: {
-            gatewayUrl: string;
-            token: string;
-          };
-        }
-      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
-        gatewayUrl: "ws://gateway.example.test",
-        token: "native-terminal-token",
-      };
-    });
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["connect"],
-      featureMethods: ["terminal.open"],
-      methodResponses: {
-        "terminal.list": { sessions: [] },
-        "terminal.open": {
-          agentId: "main",
-          confined: false,
-          cwd: "/workspace",
-          sessionId: "terminal-e2e",
-          shell: "/bin/bash",
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      await page.addInitScript(() => {
+        (
+          window as Window & {
+            ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: {
+              gatewayUrl: string;
+              token: string;
+            };
+          }
+        )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+          gatewayUrl: "ws://gateway.example.test",
+          token: "native-terminal-token",
+        };
+      });
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["connect"],
+        featureMethods: ["terminal.open"],
+        methodResponses: {
+          "terminal.list": { sessions: [] },
+          "terminal.open": {
+            agentId: "main",
+            confined: false,
+            cwd: "/workspace",
+            sessionId: "terminal-e2e",
+            shell: "/bin/bash",
+          },
         },
-      },
-      terminalEnabled: true,
-    });
+        terminalEnabled: true,
+      });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}?view=terminal`);
+      const response = await page.goto(`${suite.server.baseUrl}?view=terminal`);
       expect(response?.status()).toBe(200);
       const connect = await gateway.waitForRequest("connect");
 
@@ -128,73 +105,72 @@ describeControlUiE2e("embedded terminal document", () => {
       await closeControl.click();
       const terminalClose = await gateway.waitForRequest("terminal.close");
       expect(terminalClose.params).toEqual({ sessionId: "terminal-e2e" });
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   it("restores a persisted session with no gateway PTY as exited", async () => {
-    const context = await browser.newContext({
-      serviceWorkers: "block",
-      viewport: { width: 1280, height: 800 },
-      ...(deadSessionVideoDir
-        ? { recordVideo: { dir: deadSessionVideoDir, size: { width: 1280, height: 800 } } }
-        : {}),
-    });
-    const page = await context.newPage();
-    await page.addInitScript(() => {
-      (
-        window as Window & {
-          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: {
-            gatewayUrl: string;
-            token: string;
-          };
-        }
-      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
-        gatewayUrl: "ws://gateway.example.test",
-        token: "test",
-      };
-      window.sessionStorage.setItem(
-        "openclaw.terminal.sessions.v1",
-        JSON.stringify(["terminal-dead-after-restart"]),
-      );
-    });
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["connect"],
-      featureMethods: ["terminal.open"],
-      methodResponses: {
-        "terminal.list": { sessions: [] },
-        "terminal.open": {
-          agentId: "main",
-          confined: false,
-          cwd: "/workspace",
-          sessionId: "replacement-terminal",
-          shell: "/bin/bash",
-        },
+    await suite.withPage(
+      {
+        serviceWorkers: "block",
+        viewport: { width: 1280, height: 800 },
+        ...(deadSessionVideoDir
+          ? { recordVideo: { dir: deadSessionVideoDir, size: { width: 1280, height: 800 } } }
+          : {}),
       },
-      terminalEnabled: true,
-    });
+      async ({ page }) => {
+        await page.addInitScript(() => {
+          (
+            window as Window & {
+              ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: {
+                gatewayUrl: string;
+                token: string;
+              };
+            }
+          )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+            gatewayUrl: "ws://gateway.example.test",
+            token: "test",
+          };
+          window.sessionStorage.setItem(
+            "openclaw.terminal.sessions.v1",
+            JSON.stringify(["terminal-dead-after-restart"]),
+          );
+        });
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["connect"],
+          featureMethods: ["terminal.open"],
+          methodResponses: {
+            "terminal.list": { sessions: [] },
+            "terminal.open": {
+              agentId: "main",
+              confined: false,
+              cwd: "/workspace",
+              sessionId: "replacement-terminal",
+              shell: "/bin/bash",
+            },
+          },
+          terminalEnabled: true,
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}?view=terminal`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("connect");
-      await gateway.resolveDeferred("connect");
-      await gateway.waitForRequest("terminal.list");
-      await page.waitForTimeout(250);
+        const response = await page.goto(`${suite.server.baseUrl}?view=terminal`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("connect");
+        await gateway.resolveDeferred("connect");
+        await gateway.waitForRequest("terminal.list");
+        await page.waitForTimeout(250);
 
-      if (deadSessionScreenshotPath) {
-        await page.screenshot({ path: deadSessionScreenshotPath, fullPage: true });
-      }
-      const status = page.locator("openclaw-terminal-panel .tabstrip-tab__status");
-      await expect.poll(async () => await status.textContent(), { timeout: 5_000 }).toBe("exited");
-      expect(await gateway.getRequests("terminal.attach")).toHaveLength(0);
-      expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
-      expect(
-        await page.evaluate(() => window.sessionStorage.getItem("openclaw.terminal.sessions.v1")),
-      ).toBe("[]");
-    } finally {
-      await context.close();
-    }
+        if (deadSessionScreenshotPath) {
+          await page.screenshot({ path: deadSessionScreenshotPath, fullPage: true });
+        }
+        const status = page.locator("openclaw-terminal-panel .tabstrip-tab__status");
+        await expect
+          .poll(async () => await status.textContent(), { timeout: 5_000 })
+          .toBe("exited");
+        expect(await gateway.getRequests("terminal.attach")).toHaveLength(0);
+        expect(await gateway.getRequests("terminal.open")).toHaveLength(0);
+        expect(
+          await page.evaluate(() => window.sessionStorage.getItem("openclaw.terminal.sessions.v1")),
+        ).toBe("[]");
+      },
+    );
   });
 });

--- a/ui/src/e2e/terminal-repaint.e2e.test.ts
+++ b/ui/src/e2e/terminal-repaint.e2e.test.ts
@@ -1,125 +1,104 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Locator } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Locator } from "playwright";
+import { expect, it } from "vitest";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiTerminalReady,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI terminal repaint",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
+});
+
 const screenshotPath = process.env.OPENCLAW_TERMINAL_REPAINT_SCREENSHOT?.trim();
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 async function terminalCanvasDigest(canvas: Locator): Promise<string> {
   const png = await canvas.screenshot({ animations: "disabled", caret: "hide" });
   return createHash("sha256").update(png).digest("hex");
 }
 
-describeControlUiE2e("Control UI terminal repaint", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps one interactive terminal sized and clean across repeated hide and show cycles", async () => {
-    const context = await browser.newContext({
-      serviceWorkers: "block",
-      viewport: { width: 1180, height: 520 },
-    });
-    const page = await context.newPage();
-    await page.addInitScript(() => {
-      (
-        window as Window & {
-          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
-        }
-      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
-        gatewayUrl: "ws://gateway.example.test",
-        token: "test",
-      };
-    });
-    const gateway = await installMockGateway(page, {
-      featureMethods: ["terminal.open"],
-      methodResponses: {
-        "terminal.list": { sessions: [] },
-        "terminal.open": {
-          agentId: "main",
-          confined: false,
-          cwd: "/workspace",
-          sessionId: "terminal-repaint-e2e",
-          shell: "/bin/zsh",
-        },
+    await suite.withPage(
+      {
+        serviceWorkers: "block",
+        viewport: { width: 1180, height: 520 },
       },
-      terminalEnabled: true,
-    });
+      async ({ page }) => {
+        await page.addInitScript(() => {
+          (
+            window as Window & {
+              ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+            }
+          )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+            gatewayUrl: "ws://gateway.example.test",
+            token: "test",
+          };
+        });
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["terminal.open"],
+          methodResponses: {
+            "terminal.list": { sessions: [] },
+            "terminal.open": {
+              agentId: "main",
+              confined: false,
+              cwd: "/workspace",
+              sessionId: "terminal-repaint-e2e",
+              shell: "/bin/zsh",
+            },
+          },
+          terminalEnabled: true,
+        });
 
-    try {
-      await page.goto(server.baseUrl);
-      await waitForControlUiGatewayReady(page);
-      await waitForControlUiTerminalReady(page);
-      await page.keyboard.press("Control+Backquote");
-      const openRequest = await gateway.waitForRequest("terminal.open");
-      const openParams = openRequest.params as { cols?: unknown };
-
-      const hideTerminal = page.getByRole("button", { name: "Hide terminal" });
-      const terminalCanvas = page.locator(".tp-host canvas");
-      await terminalCanvas.waitFor({ state: "visible" });
-      const blankCanvasDigest = await terminalCanvasDigest(terminalCanvas);
-      await gateway.emitGatewayEvent("terminal.data", {
-        sessionId: "terminal-repaint-e2e",
-        seq: 0,
-        data: "\u001b[?25lterminal repaint sentinel\r\n$ ",
-      });
-      await expect.poll(() => terminalCanvasDigest(terminalCanvas)).not.toBe(blankCanvasDigest);
-      const renderedCanvasDigest = await terminalCanvasDigest(terminalCanvas);
-
-      if (screenshotPath) {
-        await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
-        await page.screenshot({ path: screenshotPath });
-      }
-
-      expect(openParams.cols).toBeTypeOf("number");
-      expect(openParams.cols).toBeGreaterThanOrEqual(125);
-
-      for (let cycle = 0; cycle < 3; cycle += 1) {
-        await hideTerminal.click();
-        await expect.poll(() => terminalCanvas.count()).toBe(0);
+        await page.goto(suite.server.baseUrl);
+        await waitForControlUiGatewayReady(page);
+        await waitForControlUiTerminalReady(page);
         await page.keyboard.press("Control+Backquote");
-        await terminalCanvas.waitFor({ state: "visible" });
-        await expect.poll(() => terminalCanvasDigest(terminalCanvas)).toBe(renderedCanvasDigest);
-      }
+        const openRequest = await gateway.waitForRequest("terminal.open");
+        const openParams = openRequest.params as { cols?: unknown };
 
-      await terminalCanvas.click();
-      await page.keyboard.type("echo repaint");
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.input")).length)
-        .toBeGreaterThan(0);
-      expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
-    } finally {
-      await context.close();
-    }
+        const hideTerminal = page.getByRole("button", { name: "Hide terminal" });
+        const terminalCanvas = page.locator(".tp-host canvas");
+        await terminalCanvas.waitFor({ state: "visible" });
+        const blankCanvasDigest = await terminalCanvasDigest(terminalCanvas);
+        await gateway.emitGatewayEvent("terminal.data", {
+          sessionId: "terminal-repaint-e2e",
+          seq: 0,
+          data: "\u001b[?25lterminal repaint sentinel\r\n$ ",
+        });
+        await expect.poll(() => terminalCanvasDigest(terminalCanvas)).not.toBe(blankCanvasDigest);
+        const renderedCanvasDigest = await terminalCanvasDigest(terminalCanvas);
+
+        if (screenshotPath) {
+          await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
+          await page.screenshot({ path: screenshotPath });
+        }
+
+        expect(openParams.cols).toBeTypeOf("number");
+        expect(openParams.cols).toBeGreaterThanOrEqual(125);
+
+        for (let cycle = 0; cycle < 3; cycle += 1) {
+          await hideTerminal.click();
+          await expect.poll(() => terminalCanvas.count()).toBe(0);
+          await page.keyboard.press("Control+Backquote");
+          await terminalCanvas.waitFor({ state: "visible" });
+          await expect.poll(() => terminalCanvasDigest(terminalCanvas)).toBe(renderedCanvasDigest);
+        }
+
+        await terminalCanvas.click();
+        await page.keyboard.type("echo repaint");
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.input")).length)
+          .toBeGreaterThan(0);
+        expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
+      },
+    );
   });
 });

--- a/ui/src/e2e/terminal-runtime.e2e.test.ts
+++ b/ui/src/e2e/terminal-runtime.e2e.test.ts
@@ -1,16 +1,14 @@
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI terminal runtime isolation",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 type BrowserTerminalController = {
   terminal: {
@@ -29,32 +27,13 @@ type BrowserTerminalFactory = (options: {
   size: { columns: number; rows: number };
 }) => Promise<BrowserTerminalController>;
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI terminal runtime isolation", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer(undefined, { source: true });
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("does not reuse freed terminal cells in the next tab", async () => {
-    const context = await browser.newContext({ serviceWorkers: "block" });
-    const page = await context.newPage();
-    const moduleUrl = new URL("src/components/terminal/terminal-runtime.ts", server.baseUrl).href;
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const moduleUrl = new URL("src/components/terminal/terminal-runtime.ts", suite.server.baseUrl)
+        .href;
 
-    try {
-      await page.goto(server.baseUrl);
+      await page.goto(suite.server.baseUrl);
       // addScriptTag resolves before the module body runs, so the global is not
       // observable yet; wait for the assignment instead of racing page.evaluate.
       await page.addScriptTag({
@@ -120,8 +99,6 @@ describeControlUiE2e("Control UI terminal runtime isolation", () => {
       expect(result.initialSecondLine).not.toContain(sentinel);
       expect(result.initialSecondLine.trim()).toBe("");
       expect(result.finalSecondLine).toContain("FRESH");
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/e2e/terminal-upload.e2e.test.ts
+++ b/ui/src/e2e/terminal-upload.e2e.test.ts
@@ -1,231 +1,209 @@
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI terminal file upload",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
+});
+
 const expectUploadSurface = process.env.OPENCLAW_TERMINAL_UPLOAD_EXPECT_PRESENT !== "0";
 const screenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_SCREENSHOT?.trim();
 const progressScreenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_PROGRESS_SCREENSHOT?.trim();
 const errorScreenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_ERROR_SCREENSHOT?.trim();
 const videoDir = process.env.OPENCLAW_TERMINAL_UPLOAD_VIDEO_DIR?.trim();
 
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI terminal file upload", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("uploads picked and dropped files, then pastes staged paths without Enter", async () => {
-    const context = await browser.newContext({
-      serviceWorkers: "block",
-      viewport: { width: 1280, height: 800 },
-      ...(videoDir ? { recordVideo: { dir: videoDir, size: { width: 1280, height: 800 } } } : {}),
-    });
-    const page = await context.newPage();
-    await page.addInitScript(() => {
-      (
-        window as Window & {
-          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
-        }
-      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
-        gatewayUrl: "ws://gateway.example.test",
-        token: "test",
-      };
-    });
-    const stagedPath = "/tmp/openclaw-terminal-upload/sample file.pdf";
-    const stagedNotesPath = "/tmp/openclaw-terminal-upload/notes.txt";
-    const stagedDropPath = "/tmp/openclaw-terminal-upload/dropped.png";
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["connect"],
-      featureMethods: ["terminal.open", "terminal.upload"],
-      methodResponses: {
-        "terminal.list": { sessions: [] },
-        "terminal.open": {
-          agentId: "main",
-          confined: false,
-          cwd: "/workspace",
-          sessionId: "terminal-upload-e2e",
-          shell: "/bin/bash",
-        },
-        "terminal.upload": { path: stagedPath, size: 4 },
+    await suite.withPage(
+      {
+        serviceWorkers: "block",
+        viewport: { width: 1280, height: 800 },
+        ...(videoDir ? { recordVideo: { dir: videoDir, size: { width: 1280, height: 800 } } } : {}),
       },
-      terminalEnabled: true,
-    });
+      async ({ page }) => {
+        await page.addInitScript(() => {
+          (
+            window as Window & {
+              ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+            }
+          )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+            gatewayUrl: "ws://gateway.example.test",
+            token: "test",
+          };
+        });
+        const stagedPath = "/tmp/openclaw-terminal-upload/sample file.pdf";
+        const stagedNotesPath = "/tmp/openclaw-terminal-upload/notes.txt";
+        const stagedDropPath = "/tmp/openclaw-terminal-upload/dropped.png";
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["connect"],
+          featureMethods: ["terminal.open", "terminal.upload"],
+          methodResponses: {
+            "terminal.list": { sessions: [] },
+            "terminal.open": {
+              agentId: "main",
+              confined: false,
+              cwd: "/workspace",
+              sessionId: "terminal-upload-e2e",
+              shell: "/bin/bash",
+            },
+            "terminal.upload": { path: stagedPath, size: 4 },
+          },
+          terminalEnabled: true,
+        });
 
-    try {
-      await page.goto(`${server.baseUrl}?view=terminal`);
-      await gateway.waitForRequest("connect");
-      await gateway.resolveDeferred("connect");
-      await gateway.waitForRequest("terminal.open");
+        await page.goto(`${suite.server.baseUrl}?view=terminal`);
+        await gateway.waitForRequest("connect");
+        await gateway.resolveDeferred("connect");
+        await gateway.waitForRequest("terminal.open");
 
-      const addFiles = page.locator("button.tp-upload");
-      if (!expectUploadSurface) {
-        expect(await addFiles.count()).toBe(0);
+        const addFiles = page.locator("button.tp-upload");
+        if (!expectUploadSurface) {
+          expect(await addFiles.count()).toBe(0);
+          if (screenshotPath) {
+            await page.screenshot({ path: screenshotPath });
+          }
+          return;
+        }
+
+        await addFiles.waitFor({ state: "visible" });
+        expect(await addFiles.isEnabled()).toBe(true);
         if (screenshotPath) {
           await page.screenshot({ path: screenshotPath });
         }
-        return;
-      }
 
-      await addFiles.waitFor({ state: "visible" });
-      expect(await addFiles.isEnabled()).toBe(true);
-      if (screenshotPath) {
-        await page.screenshot({ path: screenshotPath });
-      }
+        await gateway.deferNext("terminal.upload");
+        await page.locator("input.tp-file-input").setInputFiles([
+          { name: "sample file.pdf", mimeType: "application/pdf", buffer: Buffer.from("%PDF") },
+          { name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("note") },
+        ]);
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
+            timeout: 10_000,
+          })
+          .toBe(1);
+        await page.getByText("Uploading 1 of 2").waitFor();
+        const progress = page.locator(".tp-upload-progress");
+        await expect.poll(async () => await progress.getAttribute("aria-valuenow")).toBe("0");
+        await expect.poll(async () => await progress.getAttribute("aria-valuemax")).toBe("2");
+        if (progressScreenshotPath) {
+          await page.screenshot({ path: progressScreenshotPath });
+        }
 
-      await gateway.deferNext("terminal.upload");
-      await page.locator("input.tp-file-input").setInputFiles([
-        { name: "sample file.pdf", mimeType: "application/pdf", buffer: Buffer.from("%PDF") },
-        { name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("note") },
-      ]);
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
-          timeout: 10_000,
-        })
-        .toBe(1);
-      await page.getByText("Uploading 1 of 2").waitFor();
-      const progress = page.locator(".tp-upload-progress");
-      await expect.poll(async () => await progress.getAttribute("aria-valuenow")).toBe("0");
-      await expect.poll(async () => await progress.getAttribute("aria-valuemax")).toBe("2");
-      if (progressScreenshotPath) {
-        await page.screenshot({ path: progressScreenshotPath });
-      }
+        await gateway.deferNext("terminal.upload");
+        await gateway.resolveDeferred("terminal.upload", { path: stagedPath, size: 4 });
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
+            timeout: 10_000,
+          })
+          .toBe(2);
+        await page.getByText("Uploading 2 of 2").waitFor();
+        await expect.poll(async () => await progress.getAttribute("aria-valuenow")).toBe("1");
+        await gateway.rejectDeferred("terminal.upload", {
+          code: "UNAVAILABLE",
+          message: "paired node went offline",
+        });
+        await page.getByText("Upload failed").waitFor();
+        await page.getByText("paired node went offline").waitFor();
+        expect(await page.getByRole("button", { name: "Retry" }).isVisible()).toBe(true);
+        expect((await gateway.getRequests("terminal.input")).length).toBe(0);
+        if (errorScreenshotPath) {
+          await page.screenshot({ path: errorScreenshotPath });
+        }
 
-      await gateway.deferNext("terminal.upload");
-      await gateway.resolveDeferred("terminal.upload", { path: stagedPath, size: 4 });
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
-          timeout: 10_000,
-        })
-        .toBe(2);
-      await page.getByText("Uploading 2 of 2").waitFor();
-      await expect.poll(async () => await progress.getAttribute("aria-valuenow")).toBe("1");
-      await gateway.rejectDeferred("terminal.upload", {
-        code: "UNAVAILABLE",
-        message: "paired node went offline",
-      });
-      await page.getByText("Upload failed").waitFor();
-      await page.getByText("paired node went offline").waitFor();
-      expect(await page.getByRole("button", { name: "Retry" }).isVisible()).toBe(true);
-      expect((await gateway.getRequests("terminal.input")).length).toBe(0);
-      if (errorScreenshotPath) {
-        await page.screenshot({ path: errorScreenshotPath });
-      }
+        await gateway.setMethodResponse("terminal.upload", { path: stagedNotesPath, size: 4 });
+        await page.getByRole("button", { name: "Retry" }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
+            timeout: 10_000,
+          })
+          .toBe(3);
+        const pickedUploads = await gateway.getRequests("terminal.upload");
+        expect(pickedUploads.slice(0, 3).map((request) => request.params)).toEqual([
+          {
+            sessionId: "terminal-upload-e2e",
+            name: "sample file.pdf",
+            contentBase64: "JVBERg==",
+          },
+          {
+            sessionId: "terminal-upload-e2e",
+            name: "notes.txt",
+            contentBase64: "bm90ZQ==",
+          },
+          {
+            sessionId: "terminal-upload-e2e",
+            name: "notes.txt",
+            contentBase64: "bm90ZQ==",
+          },
+        ]);
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.input")).length, {
+            timeout: 10_000,
+          })
+          .toBe(1);
+        const pickedInput = (await gateway.getRequests("terminal.input"))[0]?.params as {
+          data?: string;
+        };
+        expect(pickedInput.data).toContain("'/tmp/openclaw-terminal-upload/sample file.pdf'");
+        expect(pickedInput.data).toContain("/tmp/openclaw-terminal-upload/notes.txt");
+        expect(pickedInput.data).not.toMatch(/[\r\n]/);
 
-      await gateway.setMethodResponse("terminal.upload", { path: stagedNotesPath, size: 4 });
-      await page.getByRole("button", { name: "Retry" }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
-          timeout: 10_000,
-        })
-        .toBe(3);
-      const pickedUploads = await gateway.getRequests("terminal.upload");
-      expect(pickedUploads.slice(0, 3).map((request) => request.params)).toEqual([
-        {
+        await gateway.setMethodResponse("terminal.upload", { path: stagedDropPath, size: 3 });
+        await page.locator("wa-tab-panel.tp-viewport").evaluate((target) => {
+          const transfer = new DataTransfer();
+          transfer.items.add(new File([new Uint8Array([1, 2, 3])], "dropped.png"));
+          target.dispatchEvent(
+            new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }),
+          );
+          target.dispatchEvent(
+            new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
+          );
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
+            timeout: 10_000,
+          })
+          .toBe(4);
+        const droppedUpload = (await gateway.getRequests("terminal.upload")).at(-1);
+        expect(droppedUpload?.params).toEqual({
           sessionId: "terminal-upload-e2e",
-          name: "sample file.pdf",
-          contentBase64: "JVBERg==",
-        },
-        {
-          sessionId: "terminal-upload-e2e",
-          name: "notes.txt",
-          contentBase64: "bm90ZQ==",
-        },
-        {
-          sessionId: "terminal-upload-e2e",
-          name: "notes.txt",
-          contentBase64: "bm90ZQ==",
-        },
-      ]);
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.input")).length, {
-          timeout: 10_000,
-        })
-        .toBe(1);
-      const pickedInput = (await gateway.getRequests("terminal.input"))[0]?.params as {
-        data?: string;
-      };
-      expect(pickedInput.data).toContain("'/tmp/openclaw-terminal-upload/sample file.pdf'");
-      expect(pickedInput.data).toContain("/tmp/openclaw-terminal-upload/notes.txt");
-      expect(pickedInput.data).not.toMatch(/[\r\n]/);
+          name: "dropped.png",
+          contentBase64: "AQID",
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.input")).length, {
+            timeout: 10_000,
+          })
+          .toBe(2);
+        const droppedInput = (await gateway.getRequests("terminal.input")).at(-1)?.params as {
+          data?: string;
+        };
+        expect(droppedInput.data).toContain("/tmp/openclaw-terminal-upload/dropped.png");
+        expect(droppedInput.data).not.toMatch(/[\r\n]/);
 
-      await gateway.setMethodResponse("terminal.upload", { path: stagedDropPath, size: 3 });
-      await page.locator("wa-tab-panel.tp-viewport").evaluate((target) => {
-        const transfer = new DataTransfer();
-        transfer.items.add(new File([new Uint8Array([1, 2, 3])], "dropped.png"));
-        target.dispatchEvent(
-          new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }),
-        );
-        target.dispatchEvent(
-          new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }),
-        );
-      });
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
-          timeout: 10_000,
-        })
-        .toBe(4);
-      const droppedUpload = (await gateway.getRequests("terminal.upload")).at(-1);
-      expect(droppedUpload?.params).toEqual({
-        sessionId: "terminal-upload-e2e",
-        name: "dropped.png",
-        contentBase64: "AQID",
-      });
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.input")).length, {
-          timeout: 10_000,
-        })
-        .toBe(2);
-      const droppedInput = (await gateway.getRequests("terminal.input")).at(-1)?.params as {
-        data?: string;
-      };
-      expect(droppedInput.data).toContain("/tmp/openclaw-terminal-upload/dropped.png");
-      expect(droppedInput.data).not.toMatch(/[\r\n]/);
-
-      await gateway.deferNext("terminal.upload");
-      await page.locator("input.tp-file-input").setInputFiles({
-        name: "cancelled.zip",
-        mimeType: "application/zip",
-        buffer: Buffer.from("zip"),
-      });
-      await expect
-        .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
-          timeout: 10_000,
-        })
-        .toBe(5);
-      await page.getByText("Uploading 1 of 1").waitFor();
-      await page.getByRole("button", { name: "Cancel" }).click();
-      await expect.poll(async () => await page.locator(".tp-upload-card").count()).toBe(0);
-      await gateway.resolveDeferred("terminal.upload", {
-        path: "/tmp/openclaw-terminal-upload/cancelled.zip",
-        size: 3,
-      });
-      await page.waitForTimeout(100);
-      expect((await gateway.getRequests("terminal.input")).length).toBe(2);
-    } finally {
-      await context.close();
-    }
+        await gateway.deferNext("terminal.upload");
+        await page.locator("input.tp-file-input").setInputFiles({
+          name: "cancelled.zip",
+          mimeType: "application/zip",
+          buffer: Buffer.from("zip"),
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("terminal.upload")).length, {
+            timeout: 10_000,
+          })
+          .toBe(5);
+        await page.getByText("Uploading 1 of 1").waitFor();
+        await page.getByRole("button", { name: "Cancel" }).click();
+        await expect.poll(async () => await page.locator(".tp-upload-card").count()).toBe(0);
+        await gateway.resolveDeferred("terminal.upload", {
+          path: "/tmp/openclaw-terminal-upload/cancelled.zip",
+          size: 3,
+        });
+        await page.waitForTimeout(100);
+        expect((await gateway.getRequests("terminal.input")).length).toBe(2);
+      },
+    );
   });
 });

--- a/ui/src/e2e/theme-muted-contrast.e2e.test.ts
+++ b/ui/src/e2e/theme-muted-contrast.e2e.test.ts
@@ -309,95 +309,94 @@ suite.define(() => {
   );
 
   it("keeps the actual Skill Workshop Today view within a 390px mobile viewport", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 844, width: 390 },
-    });
-    const page = await context.newPage();
-    const updatedAt = "2026-07-29T10:00:00.000Z";
-    const proposal = {
-      createdAt: updatedAt,
-      description: "Clean inbox triage",
-      id: "proposal-1",
-      kind: "create",
-      scanState: "clean",
-      skillKey: "inbox-cleaner",
-      skillName: "Inbox Cleaner",
-      status: "pending",
-      title: "Inbox Cleaner",
-      updatedAt,
-    };
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "config.get": themeConfigResponse("claw", "light"),
-        "skills.proposals.inspect": {
-          content: "Review unread mail and archive low-priority threads.",
-          record: {
-            createdAt: updatedAt,
-            description: proposal.description,
-            id: proposal.id,
-            kind: proposal.kind,
-            proposedVersion: "v1",
-            status: proposal.status,
-            target: { skillKey: proposal.skillKey, skillName: proposal.skillName },
-            title: proposal.title,
-            updatedAt,
-          },
-          supportFiles: [],
-        },
-        "skills.proposals.list": {
-          proposals: [proposal],
-          schema: "openclaw.skill-workshop.proposals-manifest.v1",
-          updatedAt,
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 844, width: 390 },
       },
-    });
-
-    try {
-      const response = await page.goto(`${suite.server.baseUrl}skills/workshop`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("skills.proposals.list");
-
-      const todayTab = page.locator("#skill-workshop-mode-tab-today");
-      await todayTab.waitFor({ state: "visible" });
-      await todayTab.click();
-
-      const today = page.locator(".sw-today");
-      await today.waitFor({ state: "visible" });
-      const rendered = await today.evaluate((element) => {
-        const styles = getComputedStyle(element);
-        return {
-          bodyWidth: document.body.scrollWidth,
-          boxSizing: styles.boxSizing,
-          clientWidth: element.clientWidth,
-          parentWidth: element.parentElement?.clientWidth ?? 0,
-          scrollWidth: element.scrollWidth,
-          viewportWidth: window.innerWidth,
-          width: element.getBoundingClientRect().width,
+      async ({ page }) => {
+        const updatedAt = "2026-07-29T10:00:00.000Z";
+        const proposal = {
+          createdAt: updatedAt,
+          description: "Clean inbox triage",
+          id: "proposal-1",
+          kind: "create",
+          scanState: "clean",
+          skillKey: "inbox-cleaner",
+          skillName: "Inbox Cleaner",
+          status: "pending",
+          title: "Inbox Cleaner",
+          updatedAt,
         };
-      });
-
-      expect(rendered.viewportWidth).toBe(390);
-      expect(rendered.boxSizing).toBe("border-box");
-      expect(rendered.width).toBeLessThanOrEqual(rendered.parentWidth);
-      expect(rendered.scrollWidth).toBeLessThanOrEqual(rendered.clientWidth);
-      expect(rendered.bodyWidth).toBeLessThanOrEqual(rendered.viewportWidth);
-
-      if (captureUiProof) {
-        await mkdir(proofDirectory, { recursive: true });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(proofDirectory, "skill-workshop-today-mobile.png"),
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": themeConfigResponse("claw", "light"),
+            "skills.proposals.inspect": {
+              content: "Review unread mail and archive low-priority threads.",
+              record: {
+                createdAt: updatedAt,
+                description: proposal.description,
+                id: proposal.id,
+                kind: proposal.kind,
+                proposedVersion: "v1",
+                status: proposal.status,
+                target: { skillKey: proposal.skillKey, skillName: proposal.skillName },
+                title: proposal.title,
+                updatedAt,
+              },
+              supportFiles: [],
+            },
+            "skills.proposals.list": {
+              proposals: [proposal],
+              schema: "openclaw.skill-workshop.proposals-manifest.v1",
+              updatedAt,
+            },
+          },
         });
-        await writeFile(
-          path.join(proofDirectory, "skill-workshop-today-mobile.json"),
-          `${JSON.stringify(rendered, null, 2)}\n`,
-        );
-      }
-    } finally {
-      await suite.closeBrowserContext(context);
-    }
+
+        const response = await page.goto(`${suite.server.baseUrl}skills/workshop`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("skills.proposals.list");
+
+        const todayTab = page.locator("#skill-workshop-mode-tab-today");
+        await todayTab.waitFor({ state: "visible" });
+        await todayTab.click();
+
+        const today = page.locator(".sw-today");
+        await today.waitFor({ state: "visible" });
+        const rendered = await today.evaluate((element) => {
+          const styles = getComputedStyle(element);
+          return {
+            bodyWidth: document.body.scrollWidth,
+            boxSizing: styles.boxSizing,
+            clientWidth: element.clientWidth,
+            parentWidth: element.parentElement?.clientWidth ?? 0,
+            scrollWidth: element.scrollWidth,
+            viewportWidth: window.innerWidth,
+            width: element.getBoundingClientRect().width,
+          };
+        });
+
+        expect(rendered.viewportWidth).toBe(390);
+        expect(rendered.boxSizing).toBe("border-box");
+        expect(rendered.width).toBeLessThanOrEqual(rendered.parentWidth);
+        expect(rendered.scrollWidth).toBeLessThanOrEqual(rendered.clientWidth);
+        expect(rendered.bodyWidth).toBeLessThanOrEqual(rendered.viewportWidth);
+
+        if (captureUiProof) {
+          await mkdir(proofDirectory, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDirectory, "skill-workshop-today-mobile.png"),
+          });
+          await writeFile(
+            path.join(proofDirectory, "skill-workshop-today-mobile.json"),
+            `${JSON.stringify(rendered, null, 2)}\n`,
+          );
+        }
+      },
+    );
   });
 });

--- a/ui/src/e2e/update-coalesced.e2e.test.ts
+++ b/ui/src/e2e/update-coalesced.e2e.test.ts
@@ -1,13 +1,13 @@
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI coalesced update E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 
 const NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT = "openclaw:native-update-availability-changed";
 const MANAGED_UPDATE_HANDOFF_RESPONSE = {
@@ -16,157 +16,133 @@ const MANAGED_UPDATE_HANDOFF_RESPONSE = {
   result: { reason: "managed-service-handoff-started", status: "skipped" },
 } as const;
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
-
-describeControlUiE2e("Control UI coalesced update E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("identifies a beta release in the visible Gateway update card", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-beta-channel");
-    const context = await browser.newContext({
-      locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
-      serviceWorkers: "block",
-      viewport: { height: 720, width: 1280 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page);
+    await suite.withPage(
+      {
+        locale: "en-US",
+        recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+        serviceWorkers: "block",
+        viewport: { height: 720, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page);
 
-    try {
-      expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
-      await gateway.waitForRequest("chat.startup");
-      await gateway.emitGatewayEvent("update.available", {
-        updateAvailable: {
-          channel: "beta",
-          currentVersion: "2026.7.1-2",
-          latestVersion: "2026.7.2-beta.5",
-        },
-      });
+        expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
+        await gateway.waitForRequest("chat.startup");
+        await gateway.emitGatewayEvent("update.available", {
+          updateAvailable: {
+            channel: "beta",
+            currentVersion: "2026.7.1-2",
+            latestVersion: "2026.7.2-beta.5",
+          },
+        });
 
-      await page
-        .getByRole("button", {
-          name: /Update Gateway · v2026\.7\.2-beta\.5 \(beta\)/u,
-        })
-        .waitFor({ timeout: 10_000 });
-      await page.screenshot({ path: path.join(artifactDir, "beta-update-card.png") });
-      expect(await gateway.getRequests("update.run")).toHaveLength(0);
-    } finally {
-      await context.close();
-    }
+        await page
+          .getByRole("button", {
+            name: /Update Gateway · v2026\.7\.2-beta\.5 \(beta\)/u,
+          })
+          .waitFor({ timeout: 10_000 });
+        await page.screenshot({ path: path.join(artifactDir, "beta-update-card.png") });
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+      },
+    );
   });
 
   it("shows package update failure status after the Update click", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-package-status");
-    const context = await browser.newContext({
-      locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
-      serviceWorkers: "block",
-      viewport: { height: 720, width: 1280 },
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(String(error)));
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "update.run": {
-          ok: false,
-          result: { reason: "global-install-failed", status: "error" },
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+        serviceWorkers: "block",
+        viewport: { height: 720, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "update.run": {
+              ok: false,
+              result: { reason: "global-install-failed", status: "error" },
+            },
+          },
+        });
 
-    try {
-      expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
-      await gateway.waitForRequest("chat.startup");
-      await gateway.emitGatewayEvent("update.available", {
-        updateAvailable: {
-          channel: "stable",
-          currentVersion: "1.0.0",
-          latestVersion: "2.0.0",
-        },
-      });
+        expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
+        await gateway.waitForRequest("chat.startup");
+        await gateway.emitGatewayEvent("update.available", {
+          updateAvailable: {
+            channel: "stable",
+            currentVersion: "1.0.0",
+            latestVersion: "2.0.0",
+          },
+        });
 
-      await page.getByRole("button", { name: /Update Gateway/ }).click();
-      await page
-        .getByText(
-          "Update error: global-install-failed. The global package install did not verify on disk. Retry or reinstall from the CLI.",
-          { exact: true },
-        )
-        .waitFor();
+        await page.getByRole("button", { name: /Update Gateway/ }).click();
+        await page
+          .getByText(
+            "Update error: global-install-failed. The global package install did not verify on disk. Retry or reinstall from the CLI.",
+            { exact: true },
+          )
+          .waitFor();
 
-      expect(await gateway.getRequests("update.run")).toHaveLength(1);
-      expect(await page.getByRole("button", { name: /Update Gateway/ }).isEnabled()).toBe(true);
-      expect(pageErrors).toEqual([]);
-      await page.screenshot({ path: path.join(artifactDir, "package-update-failure.png") });
-    } finally {
-      await context.close();
-    }
+        expect(await gateway.getRequests("update.run")).toHaveLength(1);
+        expect(await page.getByRole("button", { name: /Update Gateway/ }).isEnabled()).toBe(true);
+        expect(pageErrors).toEqual([]);
+        await page.screenshot({ path: path.join(artifactDir, "package-update-failure.png") });
+      },
+    );
   });
 
   it("shows coalesced restart feedback after the Update click", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-coalesced");
-    const context = await browser.newContext({
-      locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
-      serviceWorkers: "block",
-      viewport: { height: 720, width: 1280 },
-    });
-    const page = await context.newPage();
-    const pageErrors: string[] = [];
-    page.on("pageerror", (error) => pageErrors.push(String(error)));
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "update.run": {
-          ok: true,
-          restart: { coalesced: true },
-          result: { after: { version: "2.0.0" }, status: "ok" },
-        },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+        serviceWorkers: "block",
+        viewport: { height: 720, width: 1280 },
       },
-    });
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "update.run": {
+              ok: true,
+              restart: { coalesced: true },
+              result: { after: { version: "2.0.0" }, status: "ok" },
+            },
+          },
+        });
 
-    try {
-      expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
-      await gateway.waitForRequest("chat.startup");
-      await gateway.emitGatewayEvent("update.available", {
-        updateAvailable: {
-          channel: "stable",
-          currentVersion: "1.0.0",
-          latestVersion: "2.0.0",
-        },
-      });
+        expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
+        await gateway.waitForRequest("chat.startup");
+        await gateway.emitGatewayEvent("update.available", {
+          updateAvailable: {
+            channel: "stable",
+            currentVersion: "1.0.0",
+            latestVersion: "2.0.0",
+          },
+        });
 
-      await page.getByRole("button", { name: /Update Gateway/ }).click();
-      await page
-        .getByText(
-          "Update installed. A gateway restart is already in progress; status will refresh after it reconnects.",
-          { exact: true },
-        )
-        .waitFor();
+        await page.getByRole("button", { name: /Update Gateway/ }).click();
+        await page
+          .getByText(
+            "Update installed. A gateway restart is already in progress; status will refresh after it reconnects.",
+            { exact: true },
+          )
+          .waitFor();
 
-      expect(await gateway.getRequests("update.run")).toHaveLength(1);
-      expect(await page.getByRole("button", { name: /Update Gateway/ }).isEnabled()).toBe(true);
-      expect(pageErrors).toEqual([]);
-      await page.screenshot({ path: path.join(artifactDir, "coalesced-restart-banner.png") });
-    } finally {
-      await context.close();
-    }
+        expect(await gateway.getRequests("update.run")).toHaveLength(1);
+        expect(await page.getByRole("button", { name: /Update Gateway/ }).isEnabled()).toBe(true);
+        expect(pageErrors).toEqual([]);
+        await page.screenshot({ path: path.join(artifactDir, "coalesced-restart-banner.png") });
+      },
+    );
   });
 
   it.each([
@@ -190,77 +166,76 @@ describeControlUiE2e("Control UI coalesced update E2E", () => {
       const artifactDir = path.resolve(
         `.artifacts/control-ui-e2e/update-managed-handoff-${artifactName}`,
       );
-      const context = await browser.newContext({
-        locale: "en-US",
-        recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
-        serviceWorkers: "block",
-        viewport: { height: 720, width: 1280 },
-      });
-      const page = await context.newPage();
-      const pageErrors: string[] = [];
-      page.on("pageerror", (error) => pageErrors.push(String(error)));
-      const gateway = await installMockGateway(page, {
-        deferredMethods: ["update.run"],
-        methodResponses: {
-          "update.run": MANAGED_UPDATE_HANDOFF_RESPONSE,
-          "update.status": {
-            sequence: [
-              {
-                sentinel: {
-                  kind: "update",
-                  status: "skipped",
-                  stats: { reason: "managed-service-handoff-started" },
-                },
-              },
-              {
-                sentinel: {
-                  kind: "update",
-                  status: "ok",
-                  stats: { after: { version: "1.0.0" } },
-                },
-              },
-            ],
-          },
+      await suite.withPage(
+        {
+          locale: "en-US",
+          recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+          serviceWorkers: "block",
+          viewport: { height: 720, width: 1280 },
         },
-      });
+        async ({ page }) => {
+          const pageErrors: string[] = [];
+          page.on("pageerror", (error) => pageErrors.push(String(error)));
+          const gateway = await installMockGateway(page, {
+            deferredMethods: ["update.run"],
+            methodResponses: {
+              "update.run": MANAGED_UPDATE_HANDOFF_RESPONSE,
+              "update.status": {
+                sequence: [
+                  {
+                    sentinel: {
+                      kind: "update",
+                      status: "skipped",
+                      stats: { reason: "managed-service-handoff-started" },
+                    },
+                  },
+                  {
+                    sentinel: {
+                      kind: "update",
+                      status: "ok",
+                      stats: { after: { version: "1.0.0" } },
+                    },
+                  },
+                ],
+              },
+            },
+          });
 
-      try {
-        expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
-        await gateway.waitForRequest("chat.startup");
-        await gateway.emitGatewayEvent("update.available", {
-          updateAvailable: {
-            channel: "stable",
-            currentVersion: "1.0.0",
-            latestVersion: "2.0.0",
-          },
-        });
+          expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
+          await gateway.waitForRequest("chat.startup");
+          await gateway.emitGatewayEvent("update.available", {
+            updateAvailable: {
+              channel: "stable",
+              currentVersion: "1.0.0",
+              latestVersion: "2.0.0",
+            },
+          });
 
-        await page.getByRole("button", { name: /Update Gateway/ }).click();
-        await gateway.waitForRequest("update.run");
-        if (responseFirst) {
-          await gateway.resolveDeferred("update.run", MANAGED_UPDATE_HANDOFF_RESPONSE);
-          await expect
-            .poll(() => page.getByRole("button", { name: /Update Gateway/ }).isEnabled())
-            .toBe(true);
-        }
-        await gateway.closeLatest(1012, "managed update handoff");
+          await page.getByRole("button", { name: /Update Gateway/ }).click();
+          await gateway.waitForRequest("update.run");
+          if (responseFirst) {
+            await gateway.resolveDeferred("update.run", MANAGED_UPDATE_HANDOFF_RESPONSE);
+            await expect
+              .poll(() => page.getByRole("button", { name: /Update Gateway/ }).isEnabled())
+              .toBe(true);
+          }
+          await gateway.closeLatest(1012, "managed update handoff");
 
-        await page.getByText(expectedText, { exact: false }).waitFor({ timeout: 15_000 });
-        expect(await gateway.getRequests("update.run")).toHaveLength(1);
-        expect(await gateway.getRequests("update.status")).toHaveLength(expectedStatusRequests);
-        expect(pageErrors).toEqual([]);
-        await page.screenshot({
-          path: path.join(artifactDir, `managed-handoff-${artifactName}.png`),
-        });
-      } finally {
-        await context.close();
-      }
+          await page.getByText(expectedText, { exact: false }).waitFor({ timeout: 15_000 });
+          expect(await gateway.getRequests("update.run")).toHaveLength(1);
+          expect(await gateway.getRequests("update.status")).toHaveLength(expectedStatusRequests);
+          expect(pageErrors).toEqual([]);
+          await page.screenshot({
+            path: path.join(artifactDir, `managed-handoff-${artifactName}.png`),
+          });
+        },
+      );
     },
   );
 
   it("shows and routes the update target from live Mac app ownership", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-ownership");
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 720, width: 1280 },
@@ -295,7 +270,7 @@ describeControlUiE2e("Control UI coalesced update E2E", () => {
     });
 
     try {
-      expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
+      expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
       await gateway.waitForRequest("chat.startup");
       await gateway.emitGatewayEvent("update.available", {
         updateAvailable: {

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -1,22 +1,15 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI usage cost analysis mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
 
 const totals = {
   input: 1_200_000,
@@ -63,141 +56,162 @@ const daily = [
   dailyEntry(0, 11, 1_100_000),
 ];
 
-describeControlUiE2e("Control UI usage cost analysis mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps pending sessions visible when their UTC activity day is selected", async () => {
     const selectedDay = "2026-05-14";
     const updatedAt = Date.parse("2026-05-14T00:30:00.000Z");
     const pendingSessionKey = "agent:main:pending-cache";
     const cachedSessionKey = "agent:main:cached-usage";
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      timezoneId: "America/Los_Angeles",
-      viewport: { height: 1_000, width: 1_440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "sessions.usage": {
-          updatedAt,
-          startDate: selectedDay,
-          endDate: selectedDay,
-          sessions: [
-            {
-              key: cachedSessionKey,
-              label: "Cached session",
-              agentId: "main",
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        timezoneId: "America/Los_Angeles",
+        viewport: { height: 1_000, width: 1_440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.usage": {
               updatedAt,
-              usage: {
-                ...totals,
-                activityDates: [selectedDay],
-                dailyBreakdown: [
-                  { date: selectedDay, cost: totals.totalCost, tokens: totals.totalTokens },
+              startDate: selectedDay,
+              endDate: selectedDay,
+              sessions: [
+                {
+                  key: cachedSessionKey,
+                  label: "Cached session",
+                  agentId: "main",
+                  updatedAt,
+                  usage: {
+                    ...totals,
+                    activityDates: [selectedDay],
+                    dailyBreakdown: [
+                      { date: selectedDay, cost: totals.totalCost, tokens: totals.totalTokens },
+                    ],
+                  },
+                },
+                {
+                  key: pendingSessionKey,
+                  label: "Pending session",
+                  agentId: "main",
+                  updatedAt,
+                  usage: null,
+                },
+              ],
+              totals,
+              aggregates: {
+                messages: {
+                  total: 0,
+                  user: 0,
+                  assistant: 0,
+                  toolCalls: 0,
+                  toolResults: 0,
+                  errors: 0,
+                },
+                tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+                byModel: [],
+                byProvider: [],
+                byAgent: [{ agentId: "main", totals }],
+                byChannel: [],
+                daily: [
+                  {
+                    date: selectedDay,
+                    tokens: totals.totalTokens,
+                    cost: totals.totalCost,
+                    messages: 0,
+                    toolCalls: 0,
+                    errors: 0,
+                  },
                 ],
               },
+              cacheStatus: { status: "refreshing", cachedFiles: 1, pendingFiles: 1, staleFiles: 0 },
             },
-            {
-              key: pendingSessionKey,
-              label: "Pending session",
-              agentId: "main",
+            "usage.cost": {
               updatedAt,
-              usage: null,
+              days: 1,
+              daily: [{ ...totals, date: selectedDay }],
+              totals,
             },
-          ],
-          totals,
-          aggregates: {
-            messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
-            tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
-            byModel: [],
-            byProvider: [],
-            byAgent: [{ agentId: "main", totals }],
-            byChannel: [],
-            daily: [
-              {
-                date: selectedDay,
-                tokens: totals.totalTokens,
-                cost: totals.totalCost,
-                messages: 0,
-                toolCalls: 0,
-                errors: 0,
-              },
-            ],
+            "usage.status": { updatedAt, providers: [] },
           },
-          cacheStatus: { status: "refreshing", cachedFiles: 1, pendingFiles: 1, staleFiles: 0 },
-        },
-        "usage.cost": {
-          updatedAt,
-          days: 1,
-          daily: [{ ...totals, date: selectedDay }],
-          totals,
-        },
-        "usage.status": { updatedAt, providers: [] },
+        });
+
+        await page.goto(`${suite.server.baseUrl}usage`);
+        const pendingRow = page.locator(".session-bar-row").filter({ hasText: "Pending session" });
+        const cachedRow = page.locator(".session-bar-row").filter({ hasText: "Cached session" });
+        await expect.poll(() => pendingRow.count(), { timeout: 10_000 }).toBe(1);
+
+        await page.locator(".usage-select").selectOption("utc");
+        await expect
+          .poll(async () => (await gateway.getRequests("sessions.usage")).at(-1)?.params)
+          .toMatchObject({ mode: "utc" });
+        await expect.poll(() => cachedRow.count(), { timeout: 10_000 }).toBe(1);
+        await page.locator(".daily-bar-wrapper").click();
+
+        await expect.poll(() => cachedRow.count()).toBe(1);
+        await expect.poll(() => pendingRow.count()).toBe(1);
       },
-    });
-
-    try {
-      await page.goto(`${server.baseUrl}usage`);
-      const pendingRow = page.locator(".session-bar-row").filter({ hasText: "Pending session" });
-      const cachedRow = page.locator(".session-bar-row").filter({ hasText: "Cached session" });
-      await expect.poll(() => pendingRow.count(), { timeout: 10_000 }).toBe(1);
-
-      await page.locator(".usage-select").selectOption("utc");
-      await expect
-        .poll(async () => (await gateway.getRequests("sessions.usage")).at(-1)?.params)
-        .toMatchObject({ mode: "utc" });
-      await expect.poll(() => cachedRow.count(), { timeout: 10_000 }).toBe(1);
-      await page.locator(".daily-bar-wrapper").click();
-
-      await expect.poll(() => cachedRow.count()).toBe(1);
-      await expect.poll(() => pendingRow.count()).toBe(1);
-    } finally {
-      await context.close();
-    }
+    );
   });
 
   it("renders cost analysis from Gateway usage data", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1_000, width: 1_440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "sessions.usage": {
-          updatedAt: Date.now(),
-          startDate: dayOffset(-89),
-          endDate: dayOffset(0),
-          sessions: [
-            {
-              key: "agent:main:cost-analysis",
-              label: "Cost analysis",
-              agentId: "main",
-              modelProvider: "openai",
-              model: "gpt-5.5",
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1_000, width: 1_440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.usage": {
               updatedAt: Date.now(),
-              usage: {
-                ...totals,
-                activityDates: daily.map((entry) => entry.date),
-                dailyBreakdown: daily.map((entry) => ({
-                  date: entry.date,
-                  cost: entry.totalCost,
-                  tokens: entry.totalTokens,
-                })),
-                messageCounts: {
+              startDate: dayOffset(-89),
+              endDate: dayOffset(0),
+              sessions: [
+                {
+                  key: "agent:main:cost-analysis",
+                  label: "Cost analysis",
+                  agentId: "main",
+                  modelProvider: "openai",
+                  model: "gpt-5.5",
+                  updatedAt: Date.now(),
+                  usage: {
+                    ...totals,
+                    activityDates: daily.map((entry) => entry.date),
+                    dailyBreakdown: daily.map((entry) => ({
+                      date: entry.date,
+                      cost: entry.totalCost,
+                      tokens: entry.totalTokens,
+                    })),
+                    messageCounts: {
+                      total: 40,
+                      user: 20,
+                      assistant: 20,
+                      toolCalls: 12,
+                      toolResults: 12,
+                      errors: 0,
+                    },
+                    modelUsage: [
+                      {
+                        provider: "openai",
+                        model: "gpt-5.5",
+                        count: 30,
+                        totals: { ...totals, totalCost: 22 },
+                      },
+                      {
+                        provider: "anthropic",
+                        model: "claude-opus-4-6",
+                        count: 10,
+                        totals: { ...totals, totalCost: 10 },
+                      },
+                    ],
+                  },
+                },
+              ],
+              totals,
+              aggregates: {
+                messages: {
                   total: 40,
                   user: 20,
                   assistant: 20,
@@ -205,7 +219,8 @@ describeControlUiE2e("Control UI usage cost analysis mocked Gateway E2E", () => 
                   toolResults: 12,
                   errors: 0,
                 },
-                modelUsage: [
+                tools: { totalCalls: 12, uniqueTools: 2, tools: [{ name: "exec", count: 8 }] },
+                byModel: [
                   {
                     provider: "openai",
                     model: "gpt-5.5",
@@ -219,270 +234,246 @@ describeControlUiE2e("Control UI usage cost analysis mocked Gateway E2E", () => 
                     totals: { ...totals, totalCost: 10 },
                   },
                 ],
+                byProvider: [
+                  { provider: "openai", count: 30, totals: { ...totals, totalCost: 22 } },
+                  { provider: "anthropic", count: 10, totals: { ...totals, totalCost: 10 } },
+                ],
+                byAgent: [{ agentId: "main", totals }],
+                byChannel: [],
+                daily: daily.map((entry) => ({
+                  date: entry.date,
+                  tokens: entry.totalTokens,
+                  cost: entry.totalCost,
+                  messages: 10,
+                  toolCalls: 3,
+                  errors: 0,
+                })),
               },
             },
-          ],
-          totals,
-          aggregates: {
-            messages: {
-              total: 40,
-              user: 20,
-              assistant: 20,
-              toolCalls: 12,
-              toolResults: 12,
-              errors: 0,
+            "usage.cost": {
+              updatedAt: Date.now(),
+              days: 90,
+              daily,
+              totals,
             },
-            tools: { totalCalls: 12, uniqueTools: 2, tools: [{ name: "exec", count: 8 }] },
-            byModel: [
-              {
-                provider: "openai",
-                model: "gpt-5.5",
-                count: 30,
-                totals: { ...totals, totalCost: 22 },
-              },
-              {
-                provider: "anthropic",
-                model: "claude-opus-4-6",
-                count: 10,
-                totals: { ...totals, totalCost: 10 },
-              },
-            ],
-            byProvider: [
-              { provider: "openai", count: 30, totals: { ...totals, totalCost: 22 } },
-              { provider: "anthropic", count: 10, totals: { ...totals, totalCost: 10 } },
-            ],
-            byAgent: [{ agentId: "main", totals }],
-            byChannel: [],
-            daily: daily.map((entry) => ({
-              date: entry.date,
-              tokens: entry.totalTokens,
-              cost: entry.totalCost,
-              messages: 10,
-              toolCalls: 3,
-              errors: 0,
-            })),
-          },
-        },
-        "usage.cost": {
-          updatedAt: Date.now(),
-          days: 90,
-          daily,
-          totals,
-        },
-        "usage.status": {
-          updatedAt: Date.now(),
-          providers: [
-            {
-              provider: "openai",
-              displayName: "OpenAI",
-              plan: "Admin API",
-              windows: [],
-              billing: [{ type: "spend", label: "30-day API spend", amount: 98.75, unit: "USD" }],
-              costHistory: {
-                unit: "USD",
-                periodDays: 30,
-                daily: [
-                  {
-                    date: dayOffset(-6),
-                    amount: 38.5,
-                    requests: 12_300,
-                    inputTokens: 4_200_000,
-                    cacheReadTokens: 2_100_000,
-                    cacheWriteTokens: 0,
-                    outputTokens: 850_000,
-                    totalTokens: 5_050_000,
-                  },
-                  {
-                    date: dayOffset(0),
-                    amount: 60.25,
-                    requests: 18_450,
-                    inputTokens: 6_100_000,
-                    cacheReadTokens: 3_400_000,
-                    cacheWriteTokens: 0,
-                    outputTokens: 1_200_000,
-                    totalTokens: 7_300_000,
-                  },
-                ],
-                models: [
-                  {
-                    name: "gpt-5.5",
-                    requests: 30_750,
-                    inputTokens: 10_300_000,
-                    cacheReadTokens: 5_500_000,
-                    cacheWriteTokens: 0,
-                    outputTokens: 2_050_000,
-                    totalTokens: 12_350_000,
-                  },
-                ],
-                categories: [{ name: "Responses", amount: 98.75 }],
-              },
-            },
-            {
-              provider: "anthropic",
-              displayName: "Anthropic",
-              plan: "Admin API",
-              windows: [],
-              billing: [{ type: "spend", label: "30-day API spend", amount: 42.4, unit: "USD" }],
-              costHistory: {
-                unit: "USD",
-                periodDays: 30,
-                daily: [
-                  {
-                    date: dayOffset(-6),
-                    amount: 17.15,
-                    inputTokens: 1_800_000,
-                    cacheReadTokens: 900_000,
-                    cacheWriteTokens: 200_000,
-                    outputTokens: 350_000,
-                    totalTokens: 3_250_000,
-                  },
-                  {
-                    date: dayOffset(0),
-                    amount: 25.25,
-                    inputTokens: 2_600_000,
-                    cacheReadTokens: 1_400_000,
-                    cacheWriteTokens: 300_000,
-                    outputTokens: 500_000,
-                    totalTokens: 4_800_000,
-                  },
-                ],
-                models: [
-                  {
-                    name: "claude-opus-4-8",
-                    inputTokens: 4_400_000,
-                    cacheReadTokens: 2_300_000,
-                    cacheWriteTokens: 500_000,
-                    outputTokens: 850_000,
-                    totalTokens: 8_050_000,
-                  },
-                ],
-                categories: [{ name: "Claude API", amount: 42.4 }],
-              },
-            },
-            {
-              provider: "openrouter",
-              displayName: "OpenRouter",
-              plan: "Production",
-              windows: [{ label: "API key budget", usedPercent: 25 }],
-              billing: [
+            "usage.status": {
+              updatedAt: Date.now(),
+              providers: [
                 {
-                  type: "balance",
-                  label: "Account balance",
-                  amount: 64.5,
-                  unit: "USD",
+                  provider: "openai",
+                  displayName: "OpenAI",
+                  plan: "Admin API",
+                  windows: [],
+                  billing: [
+                    { type: "spend", label: "30-day API spend", amount: 98.75, unit: "USD" },
+                  ],
+                  costHistory: {
+                    unit: "USD",
+                    periodDays: 30,
+                    daily: [
+                      {
+                        date: dayOffset(-6),
+                        amount: 38.5,
+                        requests: 12_300,
+                        inputTokens: 4_200_000,
+                        cacheReadTokens: 2_100_000,
+                        cacheWriteTokens: 0,
+                        outputTokens: 850_000,
+                        totalTokens: 5_050_000,
+                      },
+                      {
+                        date: dayOffset(0),
+                        amount: 60.25,
+                        requests: 18_450,
+                        inputTokens: 6_100_000,
+                        cacheReadTokens: 3_400_000,
+                        cacheWriteTokens: 0,
+                        outputTokens: 1_200_000,
+                        totalTokens: 7_300_000,
+                      },
+                    ],
+                    models: [
+                      {
+                        name: "gpt-5.5",
+                        requests: 30_750,
+                        inputTokens: 10_300_000,
+                        cacheReadTokens: 5_500_000,
+                        cacheWriteTokens: 0,
+                        outputTokens: 2_050_000,
+                        totalTokens: 12_350_000,
+                      },
+                    ],
+                    categories: [{ name: "Responses", amount: 98.75 }],
+                  },
                 },
                 {
-                  type: "budget",
-                  label: "API key budget",
-                  used: 5,
-                  limit: 20,
-                  unit: "USD",
+                  provider: "anthropic",
+                  displayName: "Anthropic",
+                  plan: "Admin API",
+                  windows: [],
+                  billing: [
+                    { type: "spend", label: "30-day API spend", amount: 42.4, unit: "USD" },
+                  ],
+                  costHistory: {
+                    unit: "USD",
+                    periodDays: 30,
+                    daily: [
+                      {
+                        date: dayOffset(-6),
+                        amount: 17.15,
+                        inputTokens: 1_800_000,
+                        cacheReadTokens: 900_000,
+                        cacheWriteTokens: 200_000,
+                        outputTokens: 350_000,
+                        totalTokens: 3_250_000,
+                      },
+                      {
+                        date: dayOffset(0),
+                        amount: 25.25,
+                        inputTokens: 2_600_000,
+                        cacheReadTokens: 1_400_000,
+                        cacheWriteTokens: 300_000,
+                        outputTokens: 500_000,
+                        totalTokens: 4_800_000,
+                      },
+                    ],
+                    models: [
+                      {
+                        name: "claude-opus-4-8",
+                        inputTokens: 4_400_000,
+                        cacheReadTokens: 2_300_000,
+                        cacheWriteTokens: 500_000,
+                        outputTokens: 850_000,
+                        totalTokens: 8_050_000,
+                      },
+                    ],
+                    categories: [{ name: "Claude API", amount: 42.4 }],
+                  },
+                },
+                {
+                  provider: "openrouter",
+                  displayName: "OpenRouter",
+                  plan: "Production",
+                  windows: [{ label: "API key budget", usedPercent: 25 }],
+                  billing: [
+                    {
+                      type: "balance",
+                      label: "Account balance",
+                      amount: 64.5,
+                      unit: "USD",
+                    },
+                    {
+                      type: "budget",
+                      label: "API key budget",
+                      used: 5,
+                      limit: 20,
+                      unit: "USD",
+                    },
+                  ],
+                  summary: "$1.25 today · $5.00 this month",
                 },
               ],
-              summary: "$1.25 today · $5.00 this month",
             },
-          ],
-        },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}usage`);
+        await page.locator(".daily-chart-compact").waitFor({ state: "visible", timeout: 10_000 });
+        const agentScope = page.locator(".agent-scope-control openclaw-agent-select");
+        await agentScope.locator(".agent-select__trigger").click();
+        await agentScope
+          .locator("wa-dropdown-item[data-agent-option]")
+          .filter({ hasText: "All agents" })
+          .click();
+        await expect
+          .poll(async () => (await gateway.getRequests("usage.cost")).at(-1)?.params)
+          .toMatchObject({ agentScope: "all" });
+        const costRequestsBeforeRangeChange = (await gateway.getRequests("usage.cost")).length;
+        await page.getByRole("button", { name: "90d", exact: true }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("usage.cost")).length)
+          .toBeGreaterThan(costRequestsBeforeRangeChange);
+        await page.getByRole("button", { name: "Cost", exact: true }).click();
+
+        const windowCards = page.locator(".cost-window-card");
+        await expect.poll(() => windowCards.count()).toBe(4);
+        await expect
+          .poll(async () => ({
+            labels: await windowCards.locator(".cost-window-card__label").allTextContents(),
+            values: (await windowCards.locator(".cost-window-card__value").allTextContents()).map(
+              (value) => value.trim(),
+            ),
+          }))
+          .toEqual({
+            labels: ["Selected Range", "Today", "Last 7 days", "Last 30 days"],
+            values: ["$32.00", "$11.00", "$20.00", "$27.00"],
+          });
+        await expect
+          .poll(() => page.locator(".daily-chart-scale span").allTextContents())
+          .toEqual(["$11.00", "$5.50", "$0.00"]);
+        await expect
+          .poll(() =>
+            page.locator(".usage-insight-card", { hasText: "Top Providers" }).textContent(),
+          )
+          .toContain("openai");
+        const messagesHint = page.locator("#usage-summary-hint-messages");
+        const messagesTooltipHost = messagesHint.locator("xpath=..");
+        const messagesTooltip = messagesTooltipHost.locator("wa-tooltip");
+        await messagesHint.hover();
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
+        await page.mouse.move(1, 1);
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
+
+        await messagesHint.focus();
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
+        await page.getByRole("button", { name: "Cost", exact: true }).focus();
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
+
+        await messagesHint.click();
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
+        await expect
+          .poll(() => messagesTooltipHost.locator('[slot="content"]').textContent())
+          .toContain("Total user and assistant messages in range.");
+        await page.getByRole("button", { name: "Cost", exact: true }).click();
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
+        await messagesHint.focus();
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
+        await messagesHint.press("Escape");
+        await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
+        const providerCards = page.locator(".provider-usage-card");
+        await expect.poll(() => providerCards.count()).toBe(3);
+        await expect
+          .poll(async () => (await gateway.getRequests("usage.status")).length)
+          .toBeGreaterThan(0);
+        await expect
+          .poll(() => providerCards.filter({ hasText: "OpenRouter" }).textContent())
+          .toContain("$64.50");
+        await expect
+          .poll(() => providerCards.filter({ hasText: "OpenAI" }).textContent())
+          .toContain("$98.75");
+        await expect
+          .poll(() => providerCards.filter({ hasText: "Anthropic" }).textContent())
+          .toContain("claude-opus-4-8");
+
+        await page.locator(".usage-query-input").fill("missing-session");
+        await page.locator(".usage-query-input").press("Enter");
+        const topProviders = page.locator(".usage-insight-card", { hasText: "Top Providers" });
+        await expect.poll(() => topProviders.textContent()).toContain("No provider data");
+        await expect.poll(() => topProviders.textContent()).not.toContain("openai");
+
+        if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+          const artifactDir = path.join(
+            process.cwd(),
+            ".artifacts",
+            "control-ui-e2e",
+            "provider-plans",
+          );
+          await mkdir(artifactDir, { recursive: true });
+          await page.locator(".usage-page").screenshot({
+            path: path.join(artifactDir, "after.png"),
+          });
+        }
       },
-    });
-
-    try {
-      await page.goto(`${server.baseUrl}usage`);
-      await page.locator(".daily-chart-compact").waitFor({ state: "visible", timeout: 10_000 });
-      const agentScope = page.locator(".agent-scope-control openclaw-agent-select");
-      await agentScope.locator(".agent-select__trigger").click();
-      await agentScope
-        .locator("wa-dropdown-item[data-agent-option]")
-        .filter({ hasText: "All agents" })
-        .click();
-      await expect
-        .poll(async () => (await gateway.getRequests("usage.cost")).at(-1)?.params)
-        .toMatchObject({ agentScope: "all" });
-      const costRequestsBeforeRangeChange = (await gateway.getRequests("usage.cost")).length;
-      await page.getByRole("button", { name: "90d", exact: true }).click();
-      await expect
-        .poll(async () => (await gateway.getRequests("usage.cost")).length)
-        .toBeGreaterThan(costRequestsBeforeRangeChange);
-      await page.getByRole("button", { name: "Cost", exact: true }).click();
-
-      const windowCards = page.locator(".cost-window-card");
-      await expect.poll(() => windowCards.count()).toBe(4);
-      await expect
-        .poll(async () => ({
-          labels: await windowCards.locator(".cost-window-card__label").allTextContents(),
-          values: (await windowCards.locator(".cost-window-card__value").allTextContents()).map(
-            (value) => value.trim(),
-          ),
-        }))
-        .toEqual({
-          labels: ["Selected Range", "Today", "Last 7 days", "Last 30 days"],
-          values: ["$32.00", "$11.00", "$20.00", "$27.00"],
-        });
-      await expect
-        .poll(() => page.locator(".daily-chart-scale span").allTextContents())
-        .toEqual(["$11.00", "$5.50", "$0.00"]);
-      await expect
-        .poll(() => page.locator(".usage-insight-card", { hasText: "Top Providers" }).textContent())
-        .toContain("openai");
-      const messagesHint = page.locator("#usage-summary-hint-messages");
-      const messagesTooltipHost = messagesHint.locator("xpath=..");
-      const messagesTooltip = messagesTooltipHost.locator("wa-tooltip");
-      await messagesHint.hover();
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
-      await page.mouse.move(1, 1);
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
-
-      await messagesHint.focus();
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
-      await page.getByRole("button", { name: "Cost", exact: true }).focus();
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
-
-      await messagesHint.click();
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
-      await expect
-        .poll(() => messagesTooltipHost.locator('[slot="content"]').textContent())
-        .toContain("Total user and assistant messages in range.");
-      await page.getByRole("button", { name: "Cost", exact: true }).click();
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
-      await messagesHint.focus();
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBe("");
-      await messagesHint.press("Escape");
-      await expect.poll(() => messagesTooltip.getAttribute("open")).toBeNull();
-      const providerCards = page.locator(".provider-usage-card");
-      await expect.poll(() => providerCards.count()).toBe(3);
-      await expect
-        .poll(async () => (await gateway.getRequests("usage.status")).length)
-        .toBeGreaterThan(0);
-      await expect
-        .poll(() => providerCards.filter({ hasText: "OpenRouter" }).textContent())
-        .toContain("$64.50");
-      await expect
-        .poll(() => providerCards.filter({ hasText: "OpenAI" }).textContent())
-        .toContain("$98.75");
-      await expect
-        .poll(() => providerCards.filter({ hasText: "Anthropic" }).textContent())
-        .toContain("claude-opus-4-8");
-
-      await page.locator(".usage-query-input").fill("missing-session");
-      await page.locator(".usage-query-input").press("Enter");
-      const topProviders = page.locator(".usage-insight-card", { hasText: "Top Providers" });
-      await expect.poll(() => topProviders.textContent()).toContain("No provider data");
-      await expect.poll(() => topProviders.textContent()).not.toContain("openai");
-
-      if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
-        const artifactDir = path.join(
-          process.cwd(),
-          ".artifacts",
-          "control-ui-e2e",
-          "provider-plans",
-        );
-        await mkdir(artifactDir, { recursive: true });
-        await page.locator(".usage-page").screenshot({
-          path: path.join(artifactDir, "after.png"),
-        });
-      }
-    } finally {
-      await context.close();
-    }
+    );
   });
 });

--- a/ui/src/e2e/usage-reconnect.e2e.test.ts
+++ b/ui/src/e2e/usage-reconnect.e2e.test.ts
@@ -1,28 +1,22 @@
 // Control UI tests cover proxy-style same-client reconnects through the real browser lifecycle.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-  type MockGatewayControls,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI usage proxy reconnect lifecycle",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
 
 // Mirrors the module-private default usage TTL asserted by this flow.
 const USAGE_PAYLOAD_TTL_MS = 5 * 60_000;
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const totals = {
   input: 100,
@@ -113,7 +107,7 @@ async function createContext(): Promise<BrowserContext> {
   if (proofDir) {
     await mkdir(proofDir, { recursive: true });
   }
-  return browser.newContext({
+  return suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 900, width: 1440 },
@@ -155,20 +149,7 @@ async function usageBadges(page: Page): Promise<string[]> {
   );
 }
 
-describeControlUiE2e("Control UI usage proxy reconnect lifecycle", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("avoids a reload storm but retries Usage work interrupted by a proxy drop", async () => {
     const context = await createContext();
     const page = await context.newPage();
@@ -181,7 +162,7 @@ describeControlUiE2e("Control UI usage proxy reconnect lifecycle", () => {
     });
 
     try {
-      const response = await page.goto(`${server.baseUrl}chat`);
+      const response = await page.goto(`${suite.server.baseUrl}chat`);
       expect(response?.status()).toBe(200);
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.locator(".sidebar-identity-card").click();

--- a/ui/src/e2e/usage-session-unicode.e2e.test.ts
+++ b/ui/src/e2e/usage-session-unicode.e2e.test.ts
@@ -1,23 +1,18 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI usage session filter Unicode",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
 const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-
-let browser: Browser;
-let server: ControlUiE2eServer;
 
 const usageTotals = {
   input: 100,
@@ -109,20 +104,7 @@ async function captureProof(page: Page, name: string): Promise<void> {
   await page.locator(".usage-page").screenshot({ path: path.join(proofDir, name) });
 }
 
-describeControlUiE2e("Control UI usage session filter Unicode", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it.each([
     {
       name: "surrogate pair at the truncation boundary",
@@ -143,58 +125,59 @@ describeControlUiE2e("Control UI usage session filter Unicode", () => {
       screenshot: "usage-session-ascii.png",
     },
   ])("preserves $name after a selected Gateway session disappears", async (scenario) => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "sessions.usage": usageResponse(scenario.key),
-        "usage.cost": costResponse(),
-        "usage.status": { updatedAt: Date.now(), providers: [] },
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
       },
-    });
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.usage": usageResponse(scenario.key),
+            "usage.cost": costResponse(),
+            "usage.status": { updatedAt: Date.now(), providers: [] },
+          },
+        });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}usage`);
-      expect(response?.status()).toBe(200);
-      await expect
-        .poll(() => gateway.getRequests("sessions.usage"), { timeout: 10_000 })
-        .not.toHaveLength(0);
+        const response = await page.goto(`${suite.server.baseUrl}usage`);
+        expect(response?.status()).toBe(200);
+        await expect
+          .poll(() => gateway.getRequests("sessions.usage"), { timeout: 10_000 })
+          .not.toHaveLength(0);
 
-      const row = page.locator(".session-bar-row").filter({ hasText: scenario.key });
-      await expect.poll(() => row.count(), { timeout: 10_000 }).toBe(1);
-      const select = row.getByRole("button", { name: scenario.key, exact: true });
-      expect(await select.getAttribute("aria-pressed")).toBe("false");
-      await select.focus();
-      await page.keyboard.press("Shift+Enter");
-      await expect.poll(() => select.getAttribute("aria-pressed")).toBe("true");
+        const row = page.locator(".session-bar-row").filter({ hasText: scenario.key });
+        await expect.poll(() => row.count(), { timeout: 10_000 }).toBe(1);
+        const select = row.getByRole("button", { name: scenario.key, exact: true });
+        expect(await select.getAttribute("aria-pressed")).toBe("false");
+        await select.focus();
+        await page.keyboard.press("Shift+Enter");
+        await expect.poll(() => select.getAttribute("aria-pressed")).toBe("true");
 
-      const chip = page.locator(".filter-chip").filter({ has: page.locator(".filter-chip-label") });
-      const label = chip.locator(".filter-chip-label");
-      await expect.poll(() => label.textContent(), { timeout: 10_000 }).toContain(scenario.key);
-      await expect.poll(() => chip.getAttribute("title")).toBe(scenario.key);
+        const chip = page
+          .locator(".filter-chip")
+          .filter({ has: page.locator(".filter-chip-label") });
+        const label = chip.locator(".filter-chip-label");
+        await expect.poll(() => label.textContent(), { timeout: 10_000 }).toContain(scenario.key);
+        await expect.poll(() => chip.getAttribute("title")).toBe(scenario.key);
 
-      const previousRequests = (await gateway.getRequests("sessions.usage")).length;
-      await gateway.setMethodResponse("sessions.usage", usageResponse());
-      await page
-        .locator("openclaw-usage-page")
-        .getByRole("button", { name: "Refresh", exact: true })
-        .click();
-      await expect
-        .poll(() => gateway.getRequests("sessions.usage"), { timeout: 10_000 })
-        .toHaveLength(previousRequests + 1);
+        const previousRequests = (await gateway.getRequests("sessions.usage")).length;
+        await gateway.setMethodResponse("sessions.usage", usageResponse());
+        await page
+          .locator("openclaw-usage-page")
+          .getByRole("button", { name: "Refresh", exact: true })
+          .click();
+        await expect
+          .poll(() => gateway.getRequests("sessions.usage"), { timeout: 10_000 })
+          .toHaveLength(previousRequests + 1);
 
-      await captureProof(page, scenario.screenshot);
-      await expect.poll(() => chip.getAttribute("title")).toBe(scenario.key);
-      await expect.poll(() => label.textContent()).toBe(`Session: ${scenario.truncated}`);
-      const renderedLabel = (await label.textContent()) ?? "";
-      expect((renderedLabel as string & { isWellFormed(): boolean }).isWellFormed()).toBe(true);
-      expect(renderedLabel).not.toContain("�");
-    } finally {
-      await context.close();
-    }
+        await captureProof(page, scenario.screenshot);
+        await expect.poll(() => chip.getAttribute("title")).toBe(scenario.key);
+        await expect.poll(() => label.textContent()).toBe(`Session: ${scenario.truncated}`);
+        const renderedLabel = (await label.textContent()) ?? "";
+        expect((renderedLabel as string & { isWellFormed(): boolean }).isWellFormed()).toBe(true);
+        expect(renderedLabel).not.toContain("�");
+      },
+    );
   });
 });

--- a/ui/src/e2e/worktrees.e2e.test.ts
+++ b/ui/src/e2e/worktrees.e2e.test.ts
@@ -1,21 +1,14 @@
 // Control UI tests cover Worktrees mutation failures through the rendered settings page.
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-
-let browser: Browser;
-let server: ControlUiE2eServer;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Worktrees mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
 
 const restorableWorktree = {
   baseRef: "main",
@@ -32,34 +25,17 @@ const restorableWorktree = {
   snapshotRef: "refs/openclaw/worktree-snapshots/test",
 };
 
-describeControlUiE2e("Control UI Worktrees mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("keeps a restore failure visible after the automatic list refresh succeeds", async () => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["worktrees.restore"],
-      methodResponses: {
-        "worktrees.list": { worktrees: [restorableWorktree] },
-      },
-    });
+    await suite.withPage(undefined, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["worktrees.restore"],
+        methodResponses: {
+          "worktrees.list": { worktrees: [restorableWorktree] },
+        },
+      });
 
-    try {
-      const response = await page.goto(`${server.baseUrl}settings/worktrees`);
+      const response = await page.goto(`${suite.server.baseUrl}settings/worktrees`);
       expect(response?.status()).toBe(200);
       await page.getByRole("button", { name: "Restore" }).click();
       await gateway.waitForRequest("worktrees.restore");
@@ -74,8 +50,6 @@ describeControlUiE2e("Control UI Worktrees mocked Gateway E2E", () => {
         "source repository is unavailable",
       );
       await expect(page.getByRole("button", { name: "Restore" }).count()).resolves.toBe(1);
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -1,19 +1,16 @@
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { installMockGateway } from "../../test-helpers/control-ui-e2e.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat background-tasks rail mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-background-tasks");
 const baseTime = Date.now();
 const chatSessionKey = "agent:main:main";
@@ -80,238 +77,222 @@ const runningExec = {
   progressSummary: "Command running",
 };
 
-let server: ControlUiE2eServer;
-let browser: Browser;
-
-describeControlUiE2e("Control UI chat background-tasks rail mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("opens the rail, applies pushed completion, and sends cancel", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     await mkdir(artifactDir, { recursive: true });
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { width: 1440, height: 900 },
-    });
-    const page = await context.newPage();
-    try {
-      const gateway = await installMockGateway(page, {
-        historyMessages: [
-          {
-            content: [{ type: "text", text: "Background tasks rail proof." }],
-            role: "assistant",
-            timestamp: Date.now(),
-          },
-        ],
-        methodResponses: {
-          "chat.history": {
-            cases: [
-              {
-                match: { sessionKey: runningSubagent.childSessionKey },
-                response: {
-                  messages: [
-                    {
-                      content: [{ type: "text", text: "Subagent transcript proof." }],
-                      role: "assistant",
-                      timestamp: Date.now(),
-                    },
-                  ],
-                  sessionId: "subagent-transcript",
-                  thinkingLevel: null,
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1440, height: 900 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          historyMessages: [
+            {
+              content: [{ type: "text", text: "Background tasks rail proof." }],
+              role: "assistant",
+              timestamp: Date.now(),
+            },
+          ],
+          methodResponses: {
+            "chat.history": {
+              cases: [
+                {
+                  match: { sessionKey: runningSubagent.childSessionKey },
+                  response: {
+                    messages: [
+                      {
+                        content: [{ type: "text", text: "Subagent transcript proof." }],
+                        role: "assistant",
+                        timestamp: Date.now(),
+                      },
+                    ],
+                    sessionId: "subagent-transcript",
+                    thinkingLevel: null,
+                  },
                 },
+              ],
+            },
+            "tasks.list": { tasks: [runningSubagent, queuedCron, finishedCli] },
+            "tasks.get": {
+              task: {
+                ...runningSubagent,
+                prompt: "Trace model routing across provider and session boundaries.",
               },
-            ],
-          },
-          "tasks.list": { tasks: [runningSubagent, queuedCron, finishedCli] },
-          "tasks.get": {
-            task: {
-              ...runningSubagent,
-              prompt: "Trace model routing across provider and session boundaries.",
+            },
+            "tasks.cancel": {
+              found: true,
+              cancelled: true,
+              task: { ...queuedCron, status: "cancelled", updatedAt: baseTime + 2_000 },
             },
           },
-          "tasks.cancel": {
-            found: true,
-            cancelled: true,
-            task: { ...queuedCron, status: "cancelled", updatedAt: baseTime + 2_000 },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}chat`);
+        expect(response?.status()).toBe(200);
+        await page.getByText("Background tasks rail proof.").waitFor({ timeout: 10_000 });
+
+        // The snapshot loads eagerly, so the collapsed toggle badge already
+        // detects the two active tasks before the rail is ever opened.
+        const badge = page.locator(".chat-tasks-toggle__badge");
+        await badge.waitFor({ state: "visible" });
+        expect(await badge.textContent()).toBe("2");
+
+        await page.getByRole("button", { name: "Show background tasks" }).click();
+        const rail = page.locator(".chat-tasks-rail");
+        await rail.locator('[data-task-id="task-subagent"]').waitFor({ state: "visible" });
+        await rail.locator('[data-task-id="task-cron"]').waitFor({ state: "visible" });
+        // Finished history starts collapsed: only the section header with the
+        // count renders until it is expanded.
+        const finishedToggle = rail.getByRole("button", { name: "Finished (1)" });
+        await finishedToggle.waitFor({ state: "visible" });
+        expect(await rail.locator('[data-task-id="task-cli"]').count()).toBe(0);
+        await finishedToggle.click();
+        await rail.locator('[data-task-id="task-cli"]').waitFor({ state: "visible" });
+        const railText = await rail.textContent();
+        expect(railText).toContain("Reading provider catalogs");
+        expect(railText).toContain("12 tool uses");
+        expect(railText).toContain("read");
+
+        const listRequests = await gateway.getRequests("tasks.list");
+        expect(listRequests.length).toBeGreaterThanOrEqual(2);
+        for (const request of listRequests) {
+          expect(request.params).toMatchObject({ sessionKey: "main" });
+          expect(request.params).not.toHaveProperty("agentId");
+        }
+        await page.screenshot({ path: path.join(artifactDir, "01-rail-open.png"), fullPage: true });
+
+        const chatUrl = page.url();
+        await rail
+          .locator('[data-task-id="task-subagent"]')
+          .getByRole("button", { name: "Show details for Map model routing code" })
+          .click();
+        await rail
+          .getByText("Trace model routing across provider and session boundaries.")
+          .waitFor();
+        expect(await rail.textContent()).toContain("Reading provider catalogs");
+        expect(await rail.getByRole("button", { name: "Back to background tasks" }).count()).toBe(
+          1,
+        );
+        expect(await rail.getByRole("button", { name: "View transcript" }).count()).toBe(0);
+        expect(page.url()).toBe(chatUrl);
+        await page.getByText("Background tasks rail proof.").waitFor({ state: "visible" });
+        const detailRequest = await gateway.waitForRequest("tasks.get");
+        expect(detailRequest.params).toEqual({ taskId: "task-subagent" });
+        await page.screenshot({
+          path: path.join(artifactDir, "02-task-detail.png"),
+          fullPage: true,
+        });
+
+        await gateway.emitGatewayEvent("task", {
+          action: "upserted",
+          task: {
+            ...runningSubagent,
+            status: "completed",
+            updatedAt: baseTime + 1_000,
+            terminalSummary: "Routing map complete",
           },
-        },
-      });
+        });
+        await rail.getByText("Routing map complete").waitFor({ state: "visible" });
+        await page.screenshot({
+          path: path.join(artifactDir, "03-pushed-completion.png"),
+          fullPage: true,
+        });
 
-      const response = await page.goto(`${server.baseUrl}chat`);
-      expect(response?.status()).toBe(200);
-      await page.getByText("Background tasks rail proof.").waitFor({ timeout: 10_000 });
+        await rail.getByRole("button", { name: "Back to background tasks" }).click();
+        await rail
+          .locator('[data-tasks-section="finished"] [data-task-id="task-subagent"]')
+          .waitFor({ state: "visible" });
+        await rail
+          .locator('[data-tasks-section="running"] [data-task-id="task-subagent"]')
+          .waitFor({ state: "detached" });
 
-      // The snapshot loads eagerly, so the collapsed toggle badge already
-      // detects the two active tasks before the rail is ever opened.
-      const badge = page.locator(".chat-tasks-toggle__badge");
-      await badge.waitFor({ state: "visible" });
-      expect(await badge.textContent()).toBe("2");
-
-      await page.getByRole("button", { name: "Show background tasks" }).click();
-      const rail = page.locator(".chat-tasks-rail");
-      await rail.locator('[data-task-id="task-subagent"]').waitFor({ state: "visible" });
-      await rail.locator('[data-task-id="task-cron"]').waitFor({ state: "visible" });
-      // Finished history starts collapsed: only the section header with the
-      // count renders until it is expanded.
-      const finishedToggle = rail.getByRole("button", { name: "Finished (1)" });
-      await finishedToggle.waitFor({ state: "visible" });
-      expect(await rail.locator('[data-task-id="task-cli"]').count()).toBe(0);
-      await finishedToggle.click();
-      await rail.locator('[data-task-id="task-cli"]').waitFor({ state: "visible" });
-      const railText = await rail.textContent();
-      expect(railText).toContain("Reading provider catalogs");
-      expect(railText).toContain("12 tool uses");
-      expect(railText).toContain("read");
-
-      const listRequests = await gateway.getRequests("tasks.list");
-      expect(listRequests.length).toBeGreaterThanOrEqual(2);
-      for (const request of listRequests) {
-        expect(request.params).toMatchObject({ sessionKey: "main" });
-        expect(request.params).not.toHaveProperty("agentId");
-      }
-      await page.screenshot({ path: path.join(artifactDir, "01-rail-open.png"), fullPage: true });
-
-      const chatUrl = page.url();
-      await rail
-        .locator('[data-task-id="task-subagent"]')
-        .getByRole("button", { name: "Show details for Map model routing code" })
-        .click();
-      await rail.getByText("Trace model routing across provider and session boundaries.").waitFor();
-      expect(await rail.textContent()).toContain("Reading provider catalogs");
-      expect(await rail.getByRole("button", { name: "Back to background tasks" }).count()).toBe(1);
-      expect(await rail.getByRole("button", { name: "View transcript" }).count()).toBe(0);
-      expect(page.url()).toBe(chatUrl);
-      await page.getByText("Background tasks rail proof.").waitFor({ state: "visible" });
-      const detailRequest = await gateway.waitForRequest("tasks.get");
-      expect(detailRequest.params).toEqual({ taskId: "task-subagent" });
-      await page.screenshot({
-        path: path.join(artifactDir, "02-task-detail.png"),
-        fullPage: true,
-      });
-
-      await gateway.emitGatewayEvent("task", {
-        action: "upserted",
-        task: {
-          ...runningSubagent,
-          status: "completed",
-          updatedAt: baseTime + 1_000,
-          terminalSummary: "Routing map complete",
-        },
-      });
-      await rail.getByText("Routing map complete").waitFor({ state: "visible" });
-      await page.screenshot({
-        path: path.join(artifactDir, "03-pushed-completion.png"),
-        fullPage: true,
-      });
-
-      await rail.getByRole("button", { name: "Back to background tasks" }).click();
-      await rail
-        .locator('[data-tasks-section="finished"] [data-task-id="task-subagent"]')
-        .waitFor({ state: "visible" });
-      await rail
-        .locator('[data-tasks-section="running"] [data-task-id="task-subagent"]')
-        .waitFor({ state: "detached" });
-
-      await rail
-        .locator('[data-task-id="task-cron"]')
-        .getByRole("button", { name: "Stop Nightly cleanup" })
-        .click();
-      const cancelRequest = await gateway.waitForRequest("tasks.cancel");
-      expect(cancelRequest.params).toEqual({ taskId: "task-cron" });
-      expect(page.url()).toBe(chatUrl);
-      expect(
-        (await gateway.getRequests("chat.history")).some(
-          (request) =>
-            (request.params as { sessionKey?: string }).sessionKey ===
-            runningSubagent.childSessionKey,
-        ),
-      ).toBe(false);
-      await page.screenshot({
-        path: path.join(artifactDir, "04-back-to-list.png"),
-        fullPage: true,
-      });
-    } finally {
-      await context.close();
-    }
+        await rail
+          .locator('[data-task-id="task-cron"]')
+          .getByRole("button", { name: "Stop Nightly cleanup" })
+          .click();
+        const cancelRequest = await gateway.waitForRequest("tasks.cancel");
+        expect(cancelRequest.params).toEqual({ taskId: "task-cron" });
+        expect(page.url()).toBe(chatUrl);
+        expect(
+          (await gateway.getRequests("chat.history")).some(
+            (request) =>
+              (request.params as { sessionKey?: string }).sessionKey ===
+              runningSubagent.childSessionKey,
+          ),
+        ).toBe(false);
+        await page.screenshot({
+          path: path.join(artifactDir, "04-back-to-list.png"),
+          fullPage: true,
+        });
+      },
+    );
   });
 
   it("shows one detached exec after the agent turn ends", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { width: 1440, height: 900 },
-    });
-    const page = await context.newPage();
-    try {
-      await installMockGateway(page, {
-        historyMessages: [
-          {
-            content: [{ type: "text", text: "I started the CLI command in the background." }],
-            role: "assistant",
-            timestamp: Date.now(),
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1440, height: 900 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          historyMessages: [
+            {
+              content: [{ type: "text", text: "I started the CLI command in the background." }],
+              role: "assistant",
+              timestamp: Date.now(),
+            },
+          ],
+          methodResponses: {
+            "tasks.list": { tasks: [runningExec] },
           },
-        ],
-        methodResponses: {
-          "tasks.list": { tasks: [runningExec] },
-        },
-      });
+        });
 
-      const response = await page.goto(`${server.baseUrl}chat`);
-      expect(response?.status()).toBe(200);
-      await page
-        .getByText("I started the CLI command in the background.")
-        .waitFor({ timeout: 10_000 });
-      expect(await page.locator(".chat-tasks-toggle__badge").textContent()).toBe("1");
-      expect(await page.locator(".chat-tasks-status__link").textContent()).toContain(
-        "1 running task",
-      );
-      const statusLink = page.locator(".chat-tasks-status__link");
-      await statusLink.hover();
-      const previewBody = page.locator(
-        "openclaw-tooltip.chat-tasks-status__preview wa-tooltip[open] .body",
-      );
-      await previewBody.waitFor({ state: "visible" });
-      const linkBox = await statusLink.boundingBox();
-      const previewBox = await previewBody.boundingBox();
-      expect(linkBox).not.toBeNull();
-      expect(previewBox).not.toBeNull();
-      if (!linkBox || !previewBox) {
-        throw new Error("expected running-task link and preview geometry");
-      }
-      const linkCenter = linkBox.x + linkBox.width / 2;
-      const previewCenter = previewBox.x + previewBox.width / 2;
-      expect(Math.abs(previewCenter - linkCenter)).toBeLessThanOrEqual(2);
-      expect(previewBox.y + previewBox.height).toBeLessThanOrEqual(linkBox.y);
-      await page.screenshot({
-        path: path.join(artifactDir, "05-running-task-popover-centered.png"),
-        fullPage: true,
-      });
+        const response = await page.goto(`${suite.server.baseUrl}chat`);
+        expect(response?.status()).toBe(200);
+        await page
+          .getByText("I started the CLI command in the background.")
+          .waitFor({ timeout: 10_000 });
+        expect(await page.locator(".chat-tasks-toggle__badge").textContent()).toBe("1");
+        expect(await page.locator(".chat-tasks-status__link").textContent()).toContain(
+          "1 running task",
+        );
+        const statusLink = page.locator(".chat-tasks-status__link");
+        await statusLink.hover();
+        const previewBody = page.locator(
+          "openclaw-tooltip.chat-tasks-status__preview wa-tooltip[open] .body",
+        );
+        await previewBody.waitFor({ state: "visible" });
+        const linkBox = await statusLink.boundingBox();
+        const previewBox = await previewBody.boundingBox();
+        expect(linkBox).not.toBeNull();
+        expect(previewBox).not.toBeNull();
+        if (!linkBox || !previewBox) {
+          throw new Error("expected running-task link and preview geometry");
+        }
+        const linkCenter = linkBox.x + linkBox.width / 2;
+        const previewCenter = previewBox.x + previewBox.width / 2;
+        expect(Math.abs(previewCenter - linkCenter)).toBeLessThanOrEqual(2);
+        expect(previewBox.y + previewBox.height).toBeLessThanOrEqual(linkBox.y);
+        await page.screenshot({
+          path: path.join(artifactDir, "05-running-task-popover-centered.png"),
+          fullPage: true,
+        });
 
-      await page.getByRole("button", { name: "Show background tasks" }).click();
-      const row = page.locator('[data-task-id="task-exec"]');
-      await row.waitFor({ state: "visible" });
-      expect(await row.textContent()).toContain("CLI command");
-      expect(await row.textContent()).toContain("Command running");
-      await page.screenshot({
-        path: path.join(artifactDir, "06-one-background-exec.png"),
-        fullPage: true,
-      });
-    } finally {
-      await context.close();
-    }
+        await page.getByRole("button", { name: "Show background tasks" }).click();
+        const row = page.locator('[data-task-id="task-exec"]');
+        await row.waitFor({ state: "visible" });
+        expect(await row.textContent()).toContain("CLI command");
+        expect(await row.textContent()).toContain("Command running");
+        await page.screenshot({
+          path: path.join(artifactDir, "06-one-background-exec.png"),
+          fullPage: true,
+        });
+      },
+    );
   });
 });

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -1,21 +1,20 @@
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
 import {
-  canRunPlaywrightChromium,
   controlUiSessionPath,
   controlUiSessionUrl,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
 } from "../../test-helpers/control-ui-e2e.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI critical observer notice mocked Gateway E2E",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const artifactDir = path.resolve(
   process.cwd(),
   ".artifacts/control-ui-e2e/critical-observer-notice",
@@ -23,9 +22,6 @@ const artifactDir = path.resolve(
 const selectedSessionKey = "agent:main:main";
 const backgroundSessionKey = "agent:main:other";
 const baseTime = Date.parse("2026-07-25T18:00:00.000Z");
-
-let server: ControlUiE2eServer;
-let browser: Browser;
 
 function sessionsListResponse() {
   return {
@@ -157,155 +153,137 @@ async function emitObserverAndReadToast(
   );
 }
 
-describeControlUiE2e("Control UI critical observer notice mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close().catch(() => {});
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
+suite.define(() => {
   it("announces critical background sessions, navigates, and dedupes after dismissal", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     await mkdir(artifactDir, { recursive: true });
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    page.setDefaultTimeout(10_000);
-    try {
-      const gateway = await installMockGateway(page, {
-        historyMessages: [
-          {
-            content: [{ type: "text", text: "Selected session A is ready." }],
-            role: "assistant",
-            timestamp: baseTime,
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        page.setDefaultTimeout(10_000);
+
+        const gateway = await installMockGateway(page, {
+          historyMessages: [
+            {
+              content: [{ type: "text", text: "Selected session A is ready." }],
+              role: "assistant",
+              timestamp: baseTime,
+            },
+          ],
+          methodResponses: {
+            "sessions.list": sessionsListResponse(),
           },
-        ],
-        methodResponses: {
-          "sessions.list": sessionsListResponse(),
-        },
-        sessionKey: selectedSessionKey,
-      });
-
-      const response = await page.goto(controlUiSessionUrl(server.baseUrl, selectedSessionKey));
-      expect(response?.status()).toBe(200);
-      await page.getByText("Selected session A is ready.").waitFor({ state: "visible" });
-      expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(selectedSessionKey));
-
-      const toast = page.locator(".app-toast");
-      await gateway.emitGatewayEvent(
-        "session.observer",
-        observerDigest({
-          sessionKey: backgroundSessionKey,
-          health: "on-track",
-          headline: "Background session is healthy",
-          revision: 1,
-        }),
-      );
-      await waitForToastUpdate(page);
-      expect(await toast.count()).toBe(0);
-
-      await gateway.emitGatewayEvent(
-        "session.observer",
-        observerDigest({
           sessionKey: selectedSessionKey,
-          health: "stuck",
-          headline: "Selected session needs attention",
-          revision: 1,
-        }),
-      );
-      await waitForToastUpdate(page);
-      expect(await toast.count()).toBe(0);
+        });
 
-      const firstHeadline = "Background verification is stuck";
-      const firstToast = await emitObserverAndReadToast(
-        page,
-        observerDigest({
-          sessionKey: backgroundSessionKey,
-          health: "stuck",
-          headline: firstHeadline,
-          revision: 2,
-        }),
-        "open",
-      );
-      expect(firstToast.visible).toBe(true);
-      expect(firstToast.actionable).toBe(true);
-      expect(firstToast.message).toContain(firstHeadline);
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "01-critical-background-session.png"),
-      });
+        const response = await page.goto(
+          controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey),
+        );
+        expect(response?.status()).toBe(200);
+        await page.getByText("Selected session A is ready.").waitFor({ state: "visible" });
+        expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(selectedSessionKey));
 
-      await expect
-        .poll(() => new URL(page.url()).pathname)
-        .toBe(controlUiSessionPath(backgroundSessionKey));
-      expect(await toast.count()).toBe(0);
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "02-after-open-thread-navigation.png"),
-      });
+        const toast = page.locator(".app-toast");
+        await gateway.emitGatewayEvent(
+          "session.observer",
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "on-track",
+            headline: "Background session is healthy",
+            revision: 1,
+          }),
+        );
+        await waitForToastUpdate(page);
+        expect(await toast.count()).toBe(0);
 
-      await page.locator("a.nav-item--home").click();
-      await expect
-        .poll(() => new URL(page.url()).pathname)
-        .toBe(controlUiSessionPath(selectedSessionKey));
+        await gateway.emitGatewayEvent(
+          "session.observer",
+          observerDigest({
+            sessionKey: selectedSessionKey,
+            health: "stuck",
+            headline: "Selected session needs attention",
+            revision: 1,
+          }),
+        );
+        await waitForToastUpdate(page);
+        expect(await toast.count()).toBe(0);
 
-      await gateway.emitGatewayEvent(
-        "session.observer",
-        observerDigest({
-          sessionKey: backgroundSessionKey,
-          health: "on-track",
-          headline: "Background verification recovered",
-          revision: 3,
-        }),
-      );
-      await waitForToastUpdate(page);
-      expect(await toast.count()).toBe(0);
+        const firstHeadline = "Background verification is stuck";
+        const firstToast = await emitObserverAndReadToast(
+          page,
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline: firstHeadline,
+            revision: 2,
+          }),
+          "open",
+        );
+        expect(firstToast.visible).toBe(true);
+        expect(firstToast.actionable).toBe(true);
+        expect(firstToast.message).toContain(firstHeadline);
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "01-critical-background-session.png"),
+        });
 
-      const dismissToast = await emitObserverAndReadToast(
-        page,
-        observerDigest({
-          sessionKey: backgroundSessionKey,
-          health: "stuck",
-          headline: "Background verification is stuck again",
-          revision: 4,
-        }),
-        "dismiss",
-      );
-      expect(dismissToast.visible).toBe(true);
-      expect(dismissToast.actionable).toBe(true);
-      expect(await toast.count()).toBe(0);
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe(controlUiSessionPath(backgroundSessionKey));
+        expect(await toast.count()).toBe(0);
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "02-after-open-thread-navigation.png"),
+        });
 
-      await gateway.emitGatewayEvent(
-        "session.observer",
-        observerDigest({
-          sessionKey: backgroundSessionKey,
-          health: "stuck",
-          headline: "Repeated stuck update remains deduped",
-          revision: 5,
-        }),
-      );
-      await waitForToastUpdate(page);
-      expect(await toast.count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+        await page.locator("a.nav-item--home").click();
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe(controlUiSessionPath(selectedSessionKey));
+
+        await gateway.emitGatewayEvent(
+          "session.observer",
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "on-track",
+            headline: "Background verification recovered",
+            revision: 3,
+          }),
+        );
+        await waitForToastUpdate(page);
+        expect(await toast.count()).toBe(0);
+
+        const dismissToast = await emitObserverAndReadToast(
+          page,
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline: "Background verification is stuck again",
+            revision: 4,
+          }),
+          "dismiss",
+        );
+        expect(dismissToast.visible).toBe(true);
+        expect(dismissToast.actionable).toBe(true);
+        expect(await toast.count()).toBe(0);
+
+        await gateway.emitGatewayEvent(
+          "session.observer",
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline: "Repeated stuck update remains deduped",
+            revision: 5,
+          }),
+        );
+        await waitForToastUpdate(page);
+        expect(await toast.count()).toBe(0);
+      },
+    );
   });
 
   it.each([
@@ -350,91 +328,93 @@ describeControlUiE2e("Control UI critical observer notice mocked Gateway E2E", (
       mainKey: "primary",
       scope: "global",
     };
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    page.setDefaultTimeout(10_000);
-    try {
-      const gateway = await installMockGateway(page, {
-        assistantAgentId: "work",
-        defaultAgentId: "work",
-        historyMessages,
-        methodResponses: {
-          "agents.list": agentsList,
-          "chat.startup": {
-            agentsList,
-            messages: historyMessages,
-            metadata: {
-              models: [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        page.setDefaultTimeout(10_000);
+
+        const gateway = await installMockGateway(page, {
+          assistantAgentId: "work",
+          defaultAgentId: "work",
+          historyMessages,
+          methodResponses: {
+            "agents.list": agentsList,
+            "chat.startup": {
+              agentsList,
+              messages: historyMessages,
+              metadata: {
+                models: [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+              },
+              sessionId: "configured-global-observer-session",
+              thinkingLevel: null,
             },
-            sessionId: "configured-global-observer-session",
-            thinkingLevel: null,
-          },
-          "sessions.list": {
-            count: 3,
-            defaults: {
-              contextTokens: null,
-              model: "gpt-5.5",
-              modelProvider: "openai",
+            "sessions.list": {
+              count: 3,
+              defaults: {
+                contextTokens: null,
+                model: "gpt-5.5",
+                modelProvider: "openai",
+              },
+              path: "",
+              sessions: [
+                {
+                  key: "global",
+                  kind: "global",
+                  label: "Configured global foreground",
+                  updatedAt: baseTime,
+                },
+                {
+                  key: "agent:work:investigation",
+                  kind: "direct",
+                  label: "Selected-agent background investigation",
+                  updatedAt: baseTime - 1_000,
+                },
+                {
+                  key: "agent:other:primary",
+                  kind: "direct",
+                  label: "Other-agent configured main",
+                  updatedAt: baseTime - 2_000,
+                },
+              ],
+              ts: baseTime,
             },
-            path: "",
-            sessions: [
-              {
-                key: "global",
-                kind: "global",
-                label: "Configured global foreground",
-                updatedAt: baseTime,
-              },
-              {
-                key: "agent:work:investigation",
-                kind: "direct",
-                label: "Selected-agent background investigation",
-                updatedAt: baseTime - 1_000,
-              },
-              {
-                key: "agent:other:primary",
-                kind: "direct",
-                label: "Other-agent configured main",
-                updatedAt: baseTime - 2_000,
-              },
-            ],
-            ts: baseTime,
           },
-        },
-        sessionKey: "global",
-      });
+          sessionKey: "global",
+        });
 
-      const globalRouteKey = "agent:work:global";
-      const response = await page.goto(controlUiSessionUrl(server.baseUrl, globalRouteKey));
-      expect(response?.status()).toBe(200);
-      await page.getByText("Configured global foreground is ready.").waitFor({ state: "visible" });
-      expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(globalRouteKey));
-      expect(await gateway.getRequests("connect")).toHaveLength(1);
+        const globalRouteKey = "agent:work:global";
+        const response = await page.goto(controlUiSessionUrl(suite.server.baseUrl, globalRouteKey));
+        expect(response?.status()).toBe(200);
+        await page
+          .getByText("Configured global foreground is ready.")
+          .waitFor({ state: "visible" });
+        expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(globalRouteKey));
+        expect(await gateway.getRequests("connect")).toHaveLength(1);
 
-      const headline = `Configured-global observer notice for ${testCase.sessionKey}`;
-      const digest = observerDigest({
-        agentId: testCase.agentId,
-        sessionKey: testCase.sessionKey,
-        health: "stuck",
-        headline,
-        revision: 1,
-      });
+        const headline = `Configured-global observer notice for ${testCase.sessionKey}`;
+        const digest = observerDigest({
+          agentId: testCase.agentId,
+          sessionKey: testCase.sessionKey,
+          health: "stuck",
+          headline,
+          revision: 1,
+        });
 
-      const toast = page.locator(".app-toast");
-      if (testCase.visible) {
-        const toastState = await emitObserverAndReadToast(page, digest);
-        expect(toastState.visible).toBe(true);
-        expect(toastState.message).toContain(headline);
-      } else {
-        await gateway.emitGatewayEvent("session.observer", digest);
-        await waitForToastUpdate(page);
-        expect(await toast.count()).toBe(0);
-      }
-    } finally {
-      await context.close();
-    }
+        const toast = page.locator(".app-toast");
+        if (testCase.visible) {
+          const toastState = await emitObserverAndReadToast(page, digest);
+          expect(toastState.visible).toBe(true);
+          expect(toastState.message).toContain(headline);
+        } else {
+          await gateway.emitGatewayEvent("session.observer", digest);
+          await waitForToastUpdate(page);
+          expect(await toast.count()).toBe(0);
+        }
+      },
+    );
   });
 });

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -1,19 +1,16 @@
 import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
-} from "../../test-helpers/control-ui-e2e.ts";
+import { expect, it } from "vitest";
+import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { installMockGateway } from "../../test-helpers/control-ui-e2e.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Tasks mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/tasks");
 const baseTime = Date.parse("2026-07-05T18:00:00.000Z");
 
@@ -68,31 +65,13 @@ const failedTask = {
   error: "Worker exited",
 };
 
-let server: ControlUiE2eServer;
-let browser: Browser;
-
-describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    server = await startControlUiE2eServer();
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  });
-
-  afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
-
+suite.define(() => {
   it("renders task sections, applies pushed completion, and sends cancel", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     await mkdir(artifactDir, { recursive: true });
     const rawVideoDir = path.join(artifactDir, "raw-video");
     await mkdir(rawVideoDir, { recursive: true });
-    const context = await browser.newContext({
+    const context = await suite.browser.newContext({
       locale: "en-US",
       recordVideo: { dir: rawVideoDir, size: { width: 1440, height: 900 } },
       serviceWorkers: "block",
@@ -114,7 +93,7 @@ describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
         },
       });
 
-      const response = await page.goto(`${server.baseUrl}tasks`);
+      const response = await page.goto(`${suite.server.baseUrl}tasks`);
       expect(response?.status()).toBe(200);
       const active = page.locator('[data-task-section="active"]');
       const recent = page.locator('[data-task-section="recent"]');

--- a/ui/src/pages/workboard/workboard-routing.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-routing.e2e.test.ts
@@ -1,20 +1,16 @@
 import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  canRunPlaywrightChromium,
-  installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  waitForControlUiRoute,
-  type ControlUiE2eServer,
-} from "../../test-helpers/control-ui-e2e.ts";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
+import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { installMockGateway, waitForControlUiRoute } from "../../test-helpers/control-ui-e2e.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Workboard routing",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed at ${executablePath}.`,
+});
+
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-routing");
 const boards = [
   { id: "default", total: 0, active: 0, archived: 0, byStatus: {} },
@@ -29,9 +25,6 @@ const boards = [
     byStatus: {},
   },
 ];
-
-let server: ControlUiE2eServer;
-let browser: Browser;
 
 function configSnapshot(enabled: boolean) {
   const config = { plugins: { entries: { workboard: { enabled } } } };
@@ -64,7 +57,7 @@ async function newRecordedPage(label: string): Promise<{
   const rawVideoDir = path.join(artifactDir, `${label}-raw`);
   await rm(rawVideoDir, { force: true, recursive: true });
   await mkdir(rawVideoDir, { recursive: true });
-  const context = await browser.newContext({
+  const context = await suite.browser.newContext({
     locale: "en-US",
     recordVideo: { dir: rawVideoDir, size: { width: 1600, height: 1000 } },
     serviceWorkers: "block",
@@ -87,20 +80,7 @@ async function closeRecordedPage(
   await rm(recorded.rawVideoDir, { force: true, recursive: true });
 }
 
-describeControlUiE2e("Control UI Workboard routing", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is not installed at ${chromiumExecutablePath}.`);
-    }
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    server = await startControlUiE2eServer();
-  });
-
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
+suite.define(() => {
   it("routes, pins, persists, and normalizes Workboard boards", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     const recorded = await newRecordedPage("routing");
@@ -116,7 +96,7 @@ describeControlUiE2e("Control UI Workboard routing", () => {
         },
       });
 
-      const response = await page.goto(`${server.baseUrl}workboard/ops?agent=main`);
+      const response = await page.goto(`${suite.server.baseUrl}workboard/ops?agent=main`);
       expect(response?.status()).toBe(200);
       await page.locator(".workboard-page-title", { hasText: "Operations" }).waitFor();
       const headerGlyph = page.locator(".workboard-board-glyph--header");
@@ -147,7 +127,7 @@ describeControlUiE2e("Control UI Workboard routing", () => {
         path: path.join(artifactDir, "02-pinned-board.png"),
       });
 
-      await page.goto(`${server.baseUrl}workboard?board=ops&agent=main`);
+      await page.goto(`${suite.server.baseUrl}workboard?board=ops&agent=main`);
       await waitForControlUiRoute(page, {
         pathname: "/workboard/ops",
         routeId: "workboard",
@@ -164,7 +144,7 @@ describeControlUiE2e("Control UI Workboard routing", () => {
         path: path.join(artifactDir, "03-legacy-normalized-and-persisted.png"),
       });
 
-      await page.goto(`${server.baseUrl}workboard/deleted?agent=main`);
+      await page.goto(`${suite.server.baseUrl}workboard/deleted?agent=main`);
       await waitForControlUiRoute(page, {
         pathname: "/workboard",
         routeId: "workboard",
@@ -178,112 +158,111 @@ describeControlUiE2e("Control UI Workboard routing", () => {
   });
 
   it("creates cards for the selected named agent without hiding them", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { width: 1600, height: 1000 },
-    });
-    const page = await context.newPage();
-    const createdCard = {
-      id: "writer-card",
-      title: "Keep the writer task visible",
-      status: "todo",
-      priority: "normal",
-      labels: [],
-      agentId: "writer",
-      position: 1000,
-      createdAt: 1,
-      updatedAt: 1,
-    };
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1600, height: 1000 },
+      },
+      async ({ page }) => {
+        const createdCard = {
+          id: "writer-card",
+          title: "Keep the writer task visible",
+          status: "todo",
+          priority: "normal",
+          labels: [],
+          agentId: "writer",
+          position: 1000,
+          createdAt: 1,
+          updatedAt: 1,
+        };
 
-    try {
-      const gateway = await installMockGateway(page, {
-        methodResponses: {
-          "agents.list": {
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
-            agents: [
-              { id: "main", name: "Main" },
-              { id: "writer", name: "Writer" },
-            ],
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+              agents: [
+                { id: "main", name: "Main" },
+                { id: "writer", name: "Writer" },
+              ],
+            },
+            "config.get": configSnapshot(true),
+            "sessions.list": sessionsListResponse(),
+            "tasks.list": { nextCursor: null, tasks: [] },
+            "workboard.boards.list": { boards },
+            "workboard.cards.list": { boards, cards: [], statuses: ["todo", "done"] },
           },
-          "config.get": configSnapshot(true),
-          "sessions.list": sessionsListResponse(),
-          "tasks.list": { nextCursor: null, tasks: [] },
-          "workboard.boards.list": { boards },
-          "workboard.cards.list": { boards, cards: [], statuses: ["todo", "done"] },
-        },
-      });
-      await page.goto(`${server.baseUrl}workboard`);
-      await gateway.waitForRequest("agents.list");
+        });
+        await page.goto(`${suite.server.baseUrl}workboard`);
+        await gateway.waitForRequest("agents.list");
 
-      const agentScope = page.locator(".agent-scope-control openclaw-agent-select");
-      await agentScope.locator(".agent-select__trigger").click();
-      await expect
-        .poll(() =>
-          agentScope
-            .locator("wa-dropdown-item[data-agent-option]")
-            .filter({ hasText: "Main" })
-            .evaluate((option) => option === document.activeElement),
-        )
-        .toBe(true);
-      await agentScope
-        .locator("wa-dropdown-item[data-agent-option]")
-        .filter({ hasText: "Writer" })
-        .click();
-      await expect
-        .poll(() =>
-          agentScope.evaluate((select) => (select as HTMLElement & { value: string }).value),
-        )
-        .toBe("writer");
-      await expect
-        .poll(
-          () =>
-            agentScope.locator("wa-dropdown").evaluate((dropdown) => {
-              const popup = dropdown.shadowRoot?.querySelector("wa-popup");
-              return {
-                open: (dropdown as HTMLElement & { open: boolean }).open,
-                popupActive: Boolean((popup as (HTMLElement & { active: boolean }) | null)?.active),
-              };
-            }),
-          { timeout: 5_000 },
-        )
-        .toEqual({ open: false, popupActive: false });
+        const agentScope = page.locator(".agent-scope-control openclaw-agent-select");
+        await agentScope.locator(".agent-select__trigger").click();
+        await expect
+          .poll(() =>
+            agentScope
+              .locator("wa-dropdown-item[data-agent-option]")
+              .filter({ hasText: "Main" })
+              .evaluate((option) => option === document.activeElement),
+          )
+          .toBe(true);
+        await agentScope
+          .locator("wa-dropdown-item[data-agent-option]")
+          .filter({ hasText: "Writer" })
+          .click();
+        await expect
+          .poll(() =>
+            agentScope.evaluate((select) => (select as HTMLElement & { value: string }).value),
+          )
+          .toBe("writer");
+        await expect
+          .poll(
+            () =>
+              agentScope.locator("wa-dropdown").evaluate((dropdown) => {
+                const popup = dropdown.shadowRoot?.querySelector("wa-popup");
+                return {
+                  open: (dropdown as HTMLElement & { open: boolean }).open,
+                  popupActive: Boolean(
+                    (popup as (HTMLElement & { active: boolean }) | null)?.active,
+                  ),
+                };
+              }),
+            { timeout: 5_000 },
+          )
+          .toEqual({ open: false, popupActive: false });
 
-      await gateway.deferNext("workboard.cards.create");
-      await page.getByRole("button", { name: /New card/u }).click();
+        await gateway.deferNext("workboard.cards.create");
+        await page.getByRole("button", { name: /New card/u }).click();
 
-      const createForm = page.locator('openclaw-modal-dialog[label="New card"]');
-      await expect
-        .poll(() =>
-          createForm
-            .locator(".workboard-agent-select")
-            .evaluate((select) => (select as HTMLElement & { value: string }).value),
-        )
-        .toBe("writer");
-      await createForm.getByLabel("Title").fill(createdCard.title);
-      await createForm.getByRole("button", { name: /^Create$/u }).click();
+        const createForm = page.locator('openclaw-modal-dialog[label="New card"]');
+        await expect
+          .poll(() =>
+            createForm
+              .locator(".workboard-agent-select")
+              .evaluate((select) => (select as HTMLElement & { value: string }).value),
+          )
+          .toBe("writer");
+        await createForm.getByLabel("Title").fill(createdCard.title);
+        await createForm.getByRole("button", { name: /^Create$/u }).click();
 
-      const createRequest = await gateway.waitForRequest("workboard.cards.create");
-      expect(createRequest.params).toMatchObject({
-        agentId: "writer",
-        title: createdCard.title,
-      });
-      await gateway.resolveDeferred("workboard.cards.create", { card: createdCard });
+        const createRequest = await gateway.waitForRequest("workboard.cards.create");
+        expect(createRequest.params).toMatchObject({
+          agentId: "writer",
+          title: createdCard.title,
+        });
+        await gateway.resolveDeferred("workboard.cards.create", { card: createdCard });
 
-      await page.locator(".workboard-card", { hasText: createdCard.title }).waitFor({
-        state: "visible",
-      });
-    } finally {
-      await context.close();
-    }
+        await page.locator(".workboard-card", { hasText: createdCard.title }).waitFor({
+          state: "visible",
+        });
+      },
+    );
   });
 
   it("hides Workboard navigation while the plugin is inactive", async () => {
-    const context = await browser.newContext({ serviceWorkers: "block" });
-    const page = await context.newPage();
-    try {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       await installMockGateway(page, {
         methodResponses: {
           "config.get": configSnapshot(false),
@@ -291,7 +270,7 @@ describeControlUiE2e("Control UI Workboard routing", () => {
           "workboard.boards.list": { boards },
         },
       });
-      await page.goto(`${server.baseUrl}chat`);
+      await page.goto(`${suite.server.baseUrl}chat`);
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.locator(".sidebar-nav__head-action").click();
       const moreMenu = sidebar.locator("wa-dropdown.sidebar-more-menu");
@@ -303,8 +282,6 @@ describeControlUiE2e("Control UI Workboard routing", () => {
       );
       expect(await customize.getByText("WorkBoard", { exact: true }).count()).toBe(0);
       expect(await customize.locator('[value^="workboard:"]').count()).toBe(0);
-    } finally {
-      await context.close();
-    }
+    });
   });
 });

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -1,30 +1,29 @@
 // Control UI tests cover workboard behavior.
 import { copyFile, mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext, Locator, Page } from "playwright";
+import { expect, it } from "vitest";
 import { PROTOCOL_VERSION } from "../../../../packages/gateway-protocol/src/version.js";
 import { WORKBOARD_CHANGED_EVENT } from "../../../../packages/workboard-contract/src/index.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
 import type {
   WorkboardBoardSummary,
   WorkboardCard,
   WorkboardStatus,
 } from "../../lib/workboard/index.ts";
 import {
-  canRunPlaywrightChromium,
   installMockGateway,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../../test-helpers/control-ui-e2e.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "Control UI Workboard mocked Gateway E2E",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard");
 const viewport = { height: 1000, width: 2400 };
 const baseTime = Date.parse("2026-06-01T18:00:00.000Z");
@@ -41,9 +40,6 @@ const WORKBOARD_STATUSES: readonly WorkboardStatus[] = [
   "blocked",
   "done",
 ];
-
-let server: ControlUiE2eServer;
-let browser: Browser;
 
 type RecordedPage = {
   context: BrowserContext;
@@ -300,7 +296,7 @@ async function newRecordedPage(label: string): Promise<RecordedPage> {
   let context: BrowserContext | undefined;
   let page: Page | undefined;
   try {
-    context = await browser.newContext({
+    context = await suite.browser.newContext({
       locale: "en-US",
       recordVideo: {
         dir: rawVideoDir,
@@ -350,27 +346,7 @@ async function closeRecordedPage(
   }
 }
 
-describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(
-        `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
-      );
-    }
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close().catch(() => {});
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await browser?.close().catch(() => {});
-    await server?.close();
-  });
-
+suite.define(() => {
   it("persists Workboard create, edit, running move, lifecycle sync, reload, and read-only state", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     const artifacts: ProofArtifacts = { screenshots: [], videos: [] };
@@ -426,7 +402,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
           "workboard.cards.list": cardsListResponse([]),
         },
       });
-      const response = await writable.page.goto(`${server.baseUrl}workboard`);
+      const response = await writable.page.goto(`${suite.server.baseUrl}workboard`);
       expect(response?.status()).toBe(200);
       await statusColumn(writable.page, "Todo").waitFor({ state: "visible" });
       await captureScreenshot(writable.page, artifacts, "01-empty-board");
@@ -703,7 +679,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
           "workboard.cards.list": cardsListResponse([runningCard]),
         },
       });
-      const response = await readOnly.page.goto(`${server.baseUrl}workboard`);
+      const response = await readOnly.page.goto(`${suite.server.baseUrl}workboard`);
       expect(response?.status()).toBe(200);
       await cardInColumn(readOnly.page, "Running", editedCard.title).waitFor({
         state: "visible",
@@ -770,7 +746,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       });
       // Constrain the height so the Todo column must overflow its visible area.
       await recorded.page.setViewportSize({ height: 720, width: 1400 });
-      const response = await recorded.page.goto(`${server.baseUrl}workboard`);
+      const response = await recorded.page.goto(`${suite.server.baseUrl}workboard`);
       expect(response?.status()).toBe(200);
       const column = statusColumn(recorded.page, "Todo");
       await column.waitFor({ state: "visible" });
@@ -835,7 +811,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
         },
       });
 
-      const response = await recorded.page.goto(`${server.baseUrl}workboard?board=ops`);
+      const response = await recorded.page.goto(`${suite.server.baseUrl}workboard?board=ops`);
       expect(response?.status()).toBe(200);
       await cardInColumn(recorded.page, "Todo", opsCard.title).waitFor({ state: "visible" });
       await expect.poll(() => new URL(recorded.page.url()).pathname).toBe("/workboard/ops");


### PR DESCRIPTION
## What Problem This Solves

Control UI browser E2E files duplicated Chromium resolution, missing-browser gating, browser/server startup and teardown, and per-test context/page cleanup. This made lifecycle fixes repetitive and allowed suites to drift subtly.

## Why This Change Was Made

This adopts `createControlUiE2eSuite` in 87 previously hand-rolled suites and adds a small `withPage` fixture used by 136 test paths. The shared helper now supports only the variants the migrated files require: server-before-browser ordering, custom server factories, and browser launch options. Existing describe/it names, Chromium skip semantics, timeouts, context options, Gateway scenarios, and assertions are preserved.

Thirty-two files keep their explicit lifecycle because they use materially different ownership: standalone or production servers, one browser per test/context, real transport or multi-context cleanup, or always-skip Chromium gates.

## User Impact

No product behavior changes. The Control UI E2E lane has one canonical bootstrap and page cleanup path for the clean majority of suites, reducing duplicated test infrastructure while retaining specialized harnesses.

## Evidence

- `env PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/tmp/openclaw-missing-chromium OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/about.e2e.test.ts` — passed with 1 file and 1 test skipped, proving the missing-Chromium gate.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/about.e2e.test.ts ui/src/e2e/activity-summaries.e2e.test.ts ui/src/e2e/agent-page-scope.e2e.test.ts ui/src/e2e/avatar-initial-emoji.e2e.test.ts ui/src/e2e/build-info-unicode.e2e.test.ts ui/src/e2e/file-drop-guard.e2e.test.ts ui/src/e2e/mount-recovery.e2e.test.ts ui/src/e2e/worktrees.e2e.test.ts ui/src/pages/chat/background-tasks.e2e.test.ts ui/src/pages/tasks/tasks.e2e.test.ts ui/src/e2e/cron-descriptions.e2e.test.ts ui/src/e2e/session-manager-history.e2e.test.ts ui/src/e2e/chat-active-turn-recovery.e2e.test.ts` — 13 files passed, 19 tests passed.
- `node scripts/run-oxlint.mjs $(git diff --name-only -- ui/src)` — passed.
- `env CI=1 node scripts/check-changed.mjs` — passed locally, including core-test typecheck, format, lint, dead-export, i18n, and repository guards. The normal remote route was attempted first but failed before execution because Blacksmith was unhealthy, Daytona timed out, and Azure required admin-token auth.
- Structural comparison against `origin/main` verified all 91 touched test files retain identical test names, assertions, context options, and timeouts.
- Autoreview: three fresh pre-commit reviews, all clean; the full migration was reviewed in three complete chunks.
- `git diff origin/main...HEAD --numstat`: production 0 additions / 0 deletions; tests and test support 10,178 additions / 12,049 deletions, net -1,871 LOC across 91 files.
