### PR TITLE
fix(compaction): recover reset Codex sessions

### DIFF
--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -25,6 +25,7 @@ import {
 } from "../agent-settings.js";
 import { resolveCliBackendConfig as resolveCliBackendConfigImpl } from "../cli-backends.js";
 import {
+  AUTOMATIC_COMPACTION_OWNED_REASON,
   isBenignCompactionSkipReason,
   isBenignCompactionSkipResult,
 } from "../embedded-agent-runner/compact-reasons.js";
@@ -49,8 +50,6 @@ import {
   clearCliSessionInStore as clearCliSessionInStoreImpl,
   recordCliCompactionInStore as recordCliCompactionInStoreImpl,
 } from "./session-store.js";
-
-const CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON = "codex app-server owns automatic compaction";
 
 type SessionManagerLike = ReturnType<typeof SessionManager.open>;
 type SettingsManagerLike = {
@@ -219,9 +218,7 @@ function isIntentionalNativeAutoCompactionSkip(
   result: EmbeddedAgentCompactResult | undefined,
 ): boolean {
   return (
-    result?.ok === true &&
-    !result.compacted &&
-    result.reason === CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON
+    result?.ok === true && !result.compacted && result.reason === AUTOMATIC_COMPACTION_OWNED_REASON
   );
 }
 
@@ -545,7 +542,7 @@ async function compactNativeHarnessCliTranscript(params: {
       // turns); falling back to context-engine compaction here fought that
       // ownership and failed OAuth-only sessions with "No API key found".
       log.info(
-        `CLI native harness compaction skipped for ${params.provider}/${params.model}: ${CODEX_APP_SERVER_OWNS_AUTO_COMPACTION_REASON}`,
+        `CLI native harness compaction skipped for ${params.provider}/${params.model}: ${AUTOMATIC_COMPACTION_OWNED_REASON}`,
       );
       return { compacted: false };
     }

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -1,8 +1,10 @@
 // Classification coverage for compaction failure and skip reason telemetry.
 import { describe, expect, it } from "vitest";
 import {
+  AUTOMATIC_COMPACTION_OWNED_REASON,
   classifyCompactionReason,
   formatUnknownCompactionReasonDetail,
+  isAutomaticCompactionOwnershipResult,
   isBenignCompactionSkipResult,
   isBenignCompactionSkipReason,
   resolveCompactionFailureReason,
@@ -47,6 +49,12 @@ describe("classifyCompactionReason", () => {
     expect(classifyCompactionReason("already compacted")).toBe("already_compacted");
   });
 
+  it("classifies native automatic-compaction ownership", () => {
+    expect(classifyCompactionReason(AUTOMATIC_COMPACTION_OWNED_REASON)).toBe(
+      "automatic_compaction_owned",
+    );
+  });
+
   it("classifies deferred background maintenance as a skip-like reason", () => {
     expect(classifyCompactionReason("deferred to background context-engine maintenance")).toBe(
       "deferred_background",
@@ -88,6 +96,25 @@ describe("isBenignCompactionSkipReason", () => {
       expect(isBenignCompactionSkipResult({ ok: true, compacted: false, reason })).toBe(false);
     },
   );
+});
+
+describe("isAutomaticCompactionOwnershipResult", () => {
+  it("requires the successful native ownership handoff result", () => {
+    expect(
+      isAutomaticCompactionOwnershipResult({
+        ok: true,
+        compacted: false,
+        reason: AUTOMATIC_COMPACTION_OWNED_REASON,
+      }),
+    ).toBe(true);
+    expect(
+      isAutomaticCompactionOwnershipResult({
+        ok: false,
+        compacted: false,
+        reason: AUTOMATIC_COMPACTION_OWNED_REASON,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("formatUnknownCompactionReasonDetail", () => {

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -6,6 +6,8 @@ import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 
 const MAX_COMPACTION_REASON_DETAIL_CHARS = 100;
 
+export const AUTOMATIC_COMPACTION_OWNED_REASON = "codex app-server owns automatic compaction";
+
 export const DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON =
   "deferred to background context-engine maintenance";
 
@@ -41,6 +43,9 @@ export function classifyCompactionReason(reason?: string): string {
   }
   if (text.includes("already compacted") || text.includes("already_compacted")) {
     return "already_compacted";
+  }
+  if (text === AUTOMATIC_COMPACTION_OWNED_REASON) {
+    return "automatic_compaction_owned";
   }
   if (text.includes("deferred to background")) {
     return "deferred_background";
@@ -94,6 +99,17 @@ export function isBenignCompactionSkipResult(result: {
   return (
     isBenignCompactionSkipReason(result.reason) ||
     (result.ok && classifyCompactionReason(result.reason) === "no_compactable_entries")
+  );
+}
+
+/** Return whether a native runtime handed automatic compaction back to its owner. */
+export function isAutomaticCompactionOwnershipResult(
+  result: { ok: boolean; compacted: boolean; reason?: string } | undefined,
+): boolean {
+  return (
+    result?.ok === true &&
+    !result.compacted &&
+    classifyCompactionReason(result.reason) === "automatic_compaction_owned"
   );
 }
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3709,6 +3709,52 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
+  it("routes required model-locked Codex byte preflight through semantic and native compaction", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "openclaw" });
+    maybeCompactAgentHarnessSessionMock
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: false,
+        reason: "codex app-server owns automatic compaction",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        result: {
+          summary: "",
+          firstKeptEntryId: "",
+          tokensBefore: 333,
+        },
+      });
+
+    const result = await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "gpt-5.5",
+        agentHarnessId: "codex",
+        modelSelectionLocked: true,
+        currentTokenCount: 333,
+        trigger: "budget",
+        forcePreflight: true,
+        preflightRequired: true,
+        preflightCompactionTrigger: "transcript_bytes",
+      }),
+    );
+
+    expect(result).toMatchObject({ ok: true, compacted: true });
+    expect(contextEngineCompactMock).toHaveBeenCalledTimes(1);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenCalledTimes(2);
+    expect(maybeCompactAgentHarnessSessionMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.5",
+        agentHarnessId: "codex",
+      }),
+      { nativeCompactionRequest: "after_context_engine" },
+    );
+  });
+
   it.each([
     ["missing_thread_binding", "no codex app-server thread binding"],
     ["stale_thread_binding", "thread not found"],

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -35,7 +35,10 @@ import {
 import { resolveAgentRunSessionTarget } from "../run-session-target.js";
 import { materializePreparedRuntimeModel } from "../runtime-plan/materialize-model.js";
 import { SessionManager } from "../sessions/index.js";
-import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";
+import {
+  DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON,
+  isAutomaticCompactionOwnershipResult,
+} from "./compact-reasons.js";
 import type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
 import { compactionCheckpointStore, persistCompactionCheckpoint } from "./compaction-checkpoint.js";
 import { asCompactionHookRunner, runPostCompactionSideEffects } from "./compaction-hooks.js";
@@ -69,8 +72,12 @@ import type { EmbeddedAgentCompactResult } from "./types.js";
 
 function shouldFallbackAfterHarnessCompaction(
   result: EmbeddedAgentCompactResult | undefined,
+  allowAutomaticOwnershipHandoff: boolean,
 ): boolean {
-  return isRecoverableNativeHarnessBindingFailure(result);
+  return (
+    isRecoverableNativeHarnessBindingFailure(result) ||
+    (allowAutomaticOwnershipHandoff && isAutomaticCompactionOwnershipResult(result))
+  );
 }
 
 function lockedCompactionRuntimeFailure(runtime?: string): EmbeddedAgentCompactResult {
@@ -558,15 +565,23 @@ async function compactResolvedContextEngine(
           contextEngineRuntimeContext,
         })
       : undefined;
-  if (lockedNativeHarness) {
+  const allowAutomaticOwnershipHandoff =
+    params.preflightRequired === true && params.preflightCompactionTrigger === "transcript_bytes";
+  const shouldFallbackFromHarness = shouldFallbackAfterHarnessCompaction(
+    harnessResult,
+    allowAutomaticOwnershipHandoff,
+  );
+  const allowLockedHarnessFallback =
+    allowAutomaticOwnershipHandoff && isAutomaticCompactionOwnershipResult(harnessResult);
+  if (lockedNativeHarness && !allowLockedHarnessFallback) {
     return harnessResult ?? lockedCompactionRuntimeFailure(selectedHarnessRuntime);
   }
   if (harnessResult) {
-    if (!shouldFallbackAfterHarnessCompaction(harnessResult)) {
+    if (!shouldFallbackFromHarness) {
       return harnessResult;
     }
     log.warn(
-      `native harness compaction could not use its session binding; falling back to context engine: ${harnessResult.reason ?? "unknown"}`,
+      `native harness compaction could not complete; falling back to context engine: ${harnessResult.reason ?? "unknown"}`,
     );
   }
   if (

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2851,6 +2851,83 @@ describe("runMemoryFlushIfNeeded", () => {
     });
   });
 
+  it("dispatches past preflight after reset of an oversized physical Codex transcript", async () => {
+    const storePath = path.join(rootDir, "sqlite-codex-reset-byte-guard.json");
+    const sessionKey = "agent:main:discord:direct:test-user";
+    const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionId: "session", updatedAt: 10 });
+    await replaceSqliteTranscriptEvents(scope, [
+      {
+        id: "oversized-history",
+        parentId: null,
+        message: { role: "user", content: "x".repeat(4_300_000) },
+        type: "message",
+      },
+      {
+        id: "kept-user",
+        parentId: "oversized-history",
+        message: { role: "user", content: "kept question" },
+        type: "message",
+      },
+      {
+        id: "kept-assistant",
+        parentId: "kept-user",
+        message: { role: "assistant", content: "kept answer" },
+        type: "message",
+      },
+      {
+        type: "reset",
+        id: "reset-boundary",
+        parentId: "kept-assistant",
+        timestamp: "2026-08-06T14:20:01.969Z",
+        reason: "new",
+        firstKeptEntryId: "kept-user",
+      },
+    ]);
+    expect(readTranscriptStatsSync(scope).sizeBytes).toBeGreaterThan(4 * 1024 * 1024);
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 0,
+      totalTokensFresh: true,
+      compactionCount: 0,
+      agentRuntimeOverride: "codex",
+      agentHarnessId: "codex",
+      modelSelectionLocked: true,
+    };
+    const replyOperation = createReplyOperation();
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { maxActiveTranscriptBytes: "4mb" },
+          },
+        },
+      },
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey,
+      }),
+      defaultModel: "gpt-5.5",
+      agentCfgContextTokens: 1_000_000,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(replyOperation.setPhase).not.toHaveBeenCalled();
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
+
   it("leaves an under-limit SQLite Codex session to native token compaction", async () => {
     const storePath = path.join(rootDir, "sqlite-codex-under-byte-guard.json");
     const sessionKey = "agent:main:main";

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -40,7 +40,7 @@ import {
 } from "../../config/sessions.js";
 import {
   readRecentSessionTranscriptActiveEvents,
-  readSessionTranscriptActiveStats,
+  readSessionTranscriptContextByteSize,
   updateSessionEntry,
 } from "../../config/sessions/session-accessor.js";
 import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
@@ -465,7 +465,7 @@ function readSqliteSessionLogSnapshot(
   const snapshot: SessionLogSnapshot = {};
   try {
     if (options.includeByteSize) {
-      snapshot.byteSize = readSessionTranscriptActiveStats(scope).sizeBytes;
+      snapshot.byteSize = readSessionTranscriptContextByteSize(scope);
     }
     if (options.includeUsage || options.includeTurnTaint) {
       const events = readRecentSessionTranscriptActiveEvents(scope, SQLITE_USAGE_TAIL_MAX_EVENTS);

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -14,6 +14,7 @@ import {
   readSessionTranscriptActiveLeafEvents,
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedMessageTailPage,
+  readSessionTranscriptContextByteSize,
   readSessionTranscriptMessageAnchorPage,
   readSessionTranscriptMessageEventById,
   readSessionTranscriptMessageEventCount,
@@ -224,6 +225,59 @@ describe("SQLite active transcript event projection", () => {
     expect(page.scannedMessages).toBe(2);
     expect(page.serializedBytes).toBeLessThanOrEqual(512);
     expect(page.events.map(({ event }) => (event as { id?: unknown }).id)).toEqual(["small"]);
+  });
+
+  it("sizes only the reset-bounded replay window while retaining oversized history", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "oversized-history",
+          parentId: null,
+          message: { role: "user", content: "x".repeat(4_300_000) },
+        },
+        {
+          eventId: "kept-user",
+          parentId: "oversized-history",
+          message: { role: "user", content: "kept question" },
+        },
+        {
+          eventId: "kept-assistant",
+          parentId: "kept-user",
+          message: { role: "assistant", content: "kept answer" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "kept-assistant",
+      timestamp: "2026-08-06T14:20:01.969Z",
+      reason: "new",
+      firstKeptEntryId: "kept-user",
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "post-reset",
+          parentId: "reset-boundary",
+          message: { role: "user", content: "ordinary next turn" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+
+    expect(readSessionTranscriptActiveStats(scope).sizeBytes).toBeGreaterThan(4 * 1024 * 1024);
+    expect(readSessionTranscriptContextByteSize(scope)).toBeLessThan(4 * 1024);
+    expect(readSessionTranscriptMessageEventCount(scope)).toBe(3);
+    expect(readSessionTranscriptMessageEventById(scope, "oversized-history")).toBeUndefined();
+
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+    expect(
+      database.db
+        .prepare("SELECT COUNT(*) AS count FROM transcript_events WHERE session_id = ?")
+        .get(scope.sessionId),
+    ).toEqual({ count: 6 });
   });
 
   it("fails fast and schedules maintenance when out-of-band state is dirty", async () => {

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -10,6 +10,10 @@ import {
   openOpenClawAgentDatabase,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import {
+  readActiveTranscriptReplayByteSize,
+  readActiveTranscriptStats,
+} from "./session-accessor.sqlite-active-stats.js";
 import type {
   SessionTranscriptVisibleMessageDeltaLimits,
   SessionTranscriptVisibleMessageDeltaResult,
@@ -18,6 +22,7 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import {
   readVisibleMessageRange,
+  resolveActiveSessionReplayWindow,
   resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
@@ -270,30 +275,19 @@ export function readSessionTranscriptActiveStats(scope: SessionTranscriptReadSco
   eventCount: number;
   sizeBytes: number;
 } {
-  return withCurrentProjectionSnapshot(scope, (projection) => {
-    const db = getActiveTranscriptKysely(projection.database);
-    const row = executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events as active")
-        .innerJoin("transcript_events as event", (join) =>
-          join
-            .onRef("event.session_id", "=", "active.session_id")
-            .onRef("event.seq", "=", "active.event_seq"),
-        )
-        .select((eb) => [
-          eb.fn.count<number>("active.event_seq").as("event_count"),
-          /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
-          sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
-            + COUNT(*)`.as("size_bytes"),
-        ])
-        .where("active.session_id", "=", projection.resolved.sessionId),
-    );
-    return {
-      eventCount: row?.event_count ?? 0,
-      sizeBytes: row?.size_bytes ?? 0,
-    };
-  });
+  return withCurrentProjectionSnapshot(scope, (projection) =>
+    readActiveTranscriptStats(projection.database, projection.resolved.sessionId),
+  );
+}
+
+export function readSessionTranscriptContextByteSize(scope: SessionTranscriptReadScope): number {
+  return withCurrentProjectionSnapshot(scope, (projection) =>
+    readActiveTranscriptReplayByteSize(
+      projection.database,
+      projection.resolved.sessionId,
+      resolveActiveSessionReplayWindow(projection),
+    ),
+  );
 }
 
 /** Reads one append-stable forward page from the materialized active-message projection. */

--- a/src/config/sessions/session-accessor.sqlite-active-stats.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-stats.ts
@@ -1,0 +1,82 @@
+import { sql } from "kysely";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import type { ActiveSessionReplayWindow } from "./session-accessor.sqlite-reset-window.js";
+
+type ActiveStatsDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "session_transcript_active_events" | "transcript_events"
+>;
+
+function getActiveStatsKysely(database: OpenClawAgentDatabase) {
+  return getNodeSqliteKysely<ActiveStatsDatabase>(database.db);
+}
+
+/** Reads full active-path event count and JSONL byte size for diagnostics. */
+export function readActiveTranscriptStats(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): { eventCount: number; sizeBytes: number } {
+  const db = getActiveStatsKysely(database);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_transcript_active_events as active")
+      .innerJoin("transcript_events as event", (join) =>
+        join
+          .onRef("event.session_id", "=", "active.session_id")
+          .onRef("event.seq", "=", "active.event_seq"),
+      )
+      .select((eb) => [
+        eb.fn.count<number>("active.event_seq").as("event_count"),
+        /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
+        sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
+          + COUNT(*)`.as("size_bytes"),
+      ])
+      .where("active.session_id", "=", sessionId),
+  );
+  return {
+    eventCount: row?.event_count ?? 0,
+    sizeBytes: row?.size_bytes ?? 0,
+  };
+}
+
+/** Reads the JSONL byte size of only the model-visible replay window. */
+export function readActiveTranscriptReplayByteSize(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  window: ActiveSessionReplayWindow | null,
+): number {
+  const db = getActiveStatsKysely(database);
+  let query = db
+    .selectFrom("session_transcript_active_events as active")
+    .innerJoin("transcript_events as event", (join) =>
+      join
+        .onRef("event.session_id", "=", "active.session_id")
+        .onRef("event.seq", "=", "active.event_seq"),
+    )
+    .select(
+      /* kysely-allow-raw: JSONL size includes one terminating newline per replayed event. */
+      sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
+        + COUNT(*)`.as("size_bytes"),
+    )
+    .where("active.session_id", "=", sessionId);
+  if (window?.boundaryType === "reset") {
+    // Reset replay keeps only retained user/assistant rows, then every post-boundary event.
+    query = query.where(
+      /* kysely-allow-raw: Reset replay combines active positions with a message-role predicate. */
+      sql<boolean>`(
+        active.active_position >= ${window.postBoundaryPosition}
+        OR (
+          active.active_position >= ${window.retainedStartPosition}
+          AND active.active_position < ${window.boundaryPosition}
+          AND json_extract(event.event_json, '$.message.role') IN ('user', 'assistant')
+        )
+      )`,
+    );
+  } else if (window) {
+    query = query.where("active.active_position", ">=", window.retainedStartPosition);
+  }
+  return executeSqliteQueryTakeFirstSync(database.db, query)?.size_bytes ?? 0;
+}

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -37,20 +37,26 @@ type ResetWindowMessageEvent = {
 };
 
 type ResetMessageWindow = {
-  generation: string | undefined;
-  indexedSeq: number;
   keptMessagePositions: number[];
   postBoundaryMessagePosition: number;
 };
 
-type ResetMessageWindowCacheEntry = {
-  generation: string | undefined;
-  indexedSeq: number;
-  window: ResetMessageWindow | null;
+export type ActiveSessionReplayWindow = {
+  boundaryPosition: number;
+  boundaryType: "compaction" | "reset";
+  postBoundaryPosition: number;
+  retainedStartPosition: number;
 };
 
-const resetMessageWindowCache = new Map<string, ResetMessageWindowCacheEntry>();
-const MAX_RESET_MESSAGE_WINDOW_CACHE = 64;
+type ActiveSessionWindow = {
+  generation: string | undefined;
+  indexedSeq: number;
+  replayWindow: ActiveSessionReplayWindow | null;
+  resetWindow: ResetMessageWindow | null;
+};
+
+const activeSessionWindowCache = new Map<string, ActiveSessionWindow>();
+const MAX_ACTIVE_SESSION_WINDOW_CACHE = 64;
 
 function getResetWindowKysely(database: OpenClawAgentDatabase) {
   return getNodeSqliteKysely<ResetWindowDatabase>(database.db);
@@ -105,7 +111,7 @@ function parseTranscriptEventType(eventJson: string): string | undefined {
   }
 }
 
-function resetMessageWindowCacheKey(projection: ResetWindowProjection): string {
+function activeSessionWindowCacheKey(projection: ResetWindowProjection): string {
   return `${projection.database.path}\0${projection.resolved.sessionId}`;
 }
 
@@ -119,16 +125,16 @@ function readTranscriptGeneration(projection: ResetWindowProjection): string | u
   )?.generation;
 }
 
-function cacheResetMessageWindow(key: string, entry: ResetMessageWindowCacheEntry): void {
-  resetMessageWindowCache.delete(key);
-  resetMessageWindowCache.set(key, entry);
-  pruneMapToMaxSize(resetMessageWindowCache, MAX_RESET_MESSAGE_WINDOW_CACHE);
+function cacheActiveSessionWindow(key: string, entry: ActiveSessionWindow): void {
+  activeSessionWindowCache.delete(key);
+  activeSessionWindowCache.set(key, entry);
+  pruneMapToMaxSize(activeSessionWindowCache, MAX_ACTIVE_SESSION_WINDOW_CACHE);
 }
 
-function findLatestResetMessageWindow(
+function findLatestActiveSessionWindow(
   projection: ResetWindowProjection,
   generation: string | undefined,
-): ResetMessageWindow | null {
+): ActiveSessionWindow {
   const db = getResetWindowKysely(projection.database);
   const nonMessageRows = executeSqliteQuerySync(
     projection.database.db,
@@ -148,25 +154,28 @@ function findLatestResetMessageWindow(
     const type = parseTranscriptEventType(row.event_json);
     return type === "reset" || type === "compaction";
   });
-  if (!latestBoundaryRow || parseTranscriptEventType(latestBoundaryRow.event_json) !== "reset") {
-    return null;
+  if (!latestBoundaryRow) {
+    return {
+      generation,
+      indexedSeq: projection.state.indexedSeq,
+      replayWindow: null,
+      resetWindow: null,
+    };
   }
-  const resetRow = latestBoundaryRow;
-  const reset = JSON.parse(resetRow.event_json) as { firstKeptEntryId?: unknown };
-  const postBoundaryMessagePosition =
-    executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events")
-        .select("message_position")
-        .where("session_id", "=", projection.resolved.sessionId)
-        .where("active_position", ">", resetRow.active_position)
-        .where("message_position", "is not", null)
-        .orderBy("active_position", "asc")
-        .limit(1),
-    )?.message_position ?? projection.state.activeMessageCount;
-  let keptMessagePositions: number[] = [];
-  if (typeof reset.firstKeptEntryId === "string") {
+  const boundary = JSON.parse(latestBoundaryRow.event_json) as {
+    firstKeptEntryId?: unknown;
+    type?: unknown;
+  };
+  if (boundary.type !== "reset" && boundary.type !== "compaction") {
+    return {
+      generation,
+      indexedSeq: projection.state.indexedSeq,
+      replayWindow: null,
+      resetWindow: null,
+    };
+  }
+  let retainedStartPosition = latestBoundaryRow.active_position;
+  if (typeof boundary.firstKeptEntryId === "string") {
     const firstKept = executeSqliteQueryTakeFirstSync(
       projection.database.db,
       db
@@ -178,68 +187,102 @@ function findLatestResetMessageWindow(
         )
         .select("active.active_position")
         .where("identity.session_id", "=", projection.resolved.sessionId)
-        .where("identity.event_id", "=", reset.firstKeptEntryId),
+        .where("identity.event_id", "=", boundary.firstKeptEntryId),
     );
-    if (firstKept && firstKept.active_position < resetRow.active_position) {
-      keptMessagePositions = executeSqliteQuerySync(
-        projection.database.db,
-        db
-          .selectFrom("session_transcript_active_events as active")
-          .innerJoin("transcript_events as event", (join) =>
-            join
-              .onRef("event.session_id", "=", "active.session_id")
-              .onRef("event.seq", "=", "active.event_seq"),
-          )
-          .select(["active.message_position", "event.event_json"])
-          .where("active.session_id", "=", projection.resolved.sessionId)
-          .where("active.active_position", ">=", firstKept.active_position)
-          .where("active.active_position", "<", resetRow.active_position)
-          .where("active.message_position", "is not", null)
-          .orderBy("active.active_position", "asc"),
-      ).rows.flatMap((row) => {
-        if (row.message_position === null) {
-          return [];
-        }
-        try {
-          const role = (JSON.parse(row.event_json) as { message?: { role?: unknown } }).message
-            ?.role;
-          return role === "user" || role === "assistant" ? [row.message_position] : [];
-        } catch {
-          return [];
-        }
-      });
+    if (firstKept && firstKept.active_position < latestBoundaryRow.active_position) {
+      retainedStartPosition = firstKept.active_position;
     }
+  }
+  const replayWindow: ActiveSessionReplayWindow = {
+    boundaryPosition: latestBoundaryRow.active_position,
+    boundaryType: boundary.type,
+    postBoundaryPosition: latestBoundaryRow.active_position + 1,
+    retainedStartPosition,
+  };
+  if (boundary.type !== "reset") {
+    return {
+      generation,
+      indexedSeq: projection.state.indexedSeq,
+      replayWindow,
+      resetWindow: null,
+    };
+  }
+  const postBoundaryMessagePosition =
+    executeSqliteQueryTakeFirstSync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_active_events")
+        .select("message_position")
+        .where("session_id", "=", projection.resolved.sessionId)
+        .where("active_position", ">", replayWindow.boundaryPosition)
+        .where("message_position", "is not", null)
+        .orderBy("active_position", "asc")
+        .limit(1),
+    )?.message_position ?? projection.state.activeMessageCount;
+  let keptMessagePositions: number[] = [];
+  if (replayWindow.retainedStartPosition < replayWindow.boundaryPosition) {
+    keptMessagePositions = executeSqliteQuerySync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_active_events as active")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
+        )
+        .select(["active.message_position", "event.event_json"])
+        .where("active.session_id", "=", projection.resolved.sessionId)
+        .where("active.active_position", ">=", replayWindow.retainedStartPosition)
+        .where("active.active_position", "<", replayWindow.boundaryPosition)
+        .where("active.message_position", "is not", null)
+        .orderBy("active.active_position", "asc"),
+    ).rows.flatMap((row) => {
+      if (row.message_position === null) {
+        return [];
+      }
+      try {
+        const role = (JSON.parse(row.event_json) as { message?: { role?: unknown } }).message?.role;
+        return role === "user" || role === "assistant" ? [row.message_position] : [];
+      } catch {
+        return [];
+      }
+    });
   }
   return {
     generation,
     indexedSeq: projection.state.indexedSeq,
-    keptMessagePositions,
-    postBoundaryMessagePosition,
+    replayWindow,
+    resetWindow: {
+      keptMessagePositions,
+      postBoundaryMessagePosition,
+    },
   };
 }
 
-function resolveResetMessageWindow(projection: ResetWindowProjection): ResetMessageWindow | null {
-  const key = resetMessageWindowCacheKey(projection);
-  const cached = resetMessageWindowCache.get(key);
+function resolveActiveSessionWindow(projection: ResetWindowProjection): ActiveSessionWindow {
+  const key = activeSessionWindowCacheKey(projection);
+  const cached = activeSessionWindowCache.get(key);
   const generation = readTranscriptGeneration(projection);
   if (cached) {
     if (cached.generation === generation && cached.indexedSeq === projection.state.indexedSeq) {
-      return cached.window;
+      return cached;
     }
   }
-  const window = findLatestResetMessageWindow(projection, generation);
-  cacheResetMessageWindow(key, {
-    generation,
-    indexedSeq: projection.state.indexedSeq,
-    window,
-  });
+  const window = findLatestActiveSessionWindow(projection, generation);
+  cacheActiveSessionWindow(key, window);
   return window;
+}
+
+export function resolveActiveSessionReplayWindow(
+  projection: ResetWindowProjection,
+): ActiveSessionReplayWindow | null {
+  return resolveActiveSessionWindow(projection).replayWindow;
 }
 
 export function resolveVisibleMessagePositions(
   projection: ResetWindowProjection,
 ): VisibleMessagePositions {
-  const window = resolveResetMessageWindow(projection);
+  const window = resolveActiveSessionWindow(projection).resetWindow;
   if (!window) {
     return { kept: [], postStart: 0, total: projection.state.activeMessageCount };
   }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -223,6 +223,7 @@ export {
   readRecentSessionTranscriptActiveEvents,
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedMessageTailPage,
+  readSessionTranscriptContextByteSize,
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptActiveLeafEvents,
   readSessionTranscriptMessageAnchorPage,


### PR DESCRIPTION
Related: #115904, #115912.

## What Problem This Solves

Fixes an issue where users of long-lived SQLite-backed Codex sessions could receive a fatal preflight compaction error on the first ordinary message after `/new`. The reset created a small logical context but retained the physical transcript for history, so the byte guard could measure megabytes of pre-reset history and invoke a native compaction path that intentionally hands automatic compaction back to Codex.

## Why This Change Was Made

The SQLite byte guard now measures the replay window defined by the latest reset or compaction boundary while preserving every durable transcript event. When a model-locked Codex runtime returns its automatic-compaction ownership result for a genuinely oversized current replay window, required byte preflight falls through to semantic compaction and then the guarded `thread/compact/start` native handoff.

This is a focused current-`main` integration of the replay-window accounting shape in #115912 with the locked-Codex preflight path that the earlier candidate does not cover.

## User Impact

After `/new`, the next ordinary message can reach model dispatch even when the retained physical transcript exceeds `maxActiveTranscriptBytes`. Genuinely oversized current Codex windows still take the bounded semantic-plus-native compaction path instead of treating expected ownership as a fatal error. No transcript rows are deleted or rewritten by this fix.

## Evidence

Validated at exact head `805c66e8732b24b5eae4e68eef63cb83e020478c`:

- `corepack pnpm exec vitest run src/config/sessions/session-accessor.sqlite-active-events.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/agents/embedded-agent-runner/compact-reasons.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts` — 344 passed.
- Regression builds a 4.3 MB retained transcript, appends an in-place reset, proves replay-window bytes are below 4 KiB, preserves all six durable events, and proves Codex preflight does not run.
- Model-locked Codex regression proves the ownership result continues through context-engine compaction and the guarded `after_context_engine` native handoff.
- `corepack pnpm exec oxlint --type-aware --deny-warnings <12 changed files>` — passed.
- `corepack pnpm exec oxfmt --check <12 changed files>` — passed.
- `node scripts/check-kysely-guardrails.mjs` — passed.
- `corepack pnpm build` — passed.
- `git diff --check` — passed before commit.

AI-assisted: Forge implemented and validated this change from a deterministic production RCA. Independent live Discord verification remains intentionally separate.
