### PR TITLE
fix(cli): limit attach SIGINT shutdown to direct child and add force-kill timeout

### DIFF
--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -332,7 +332,7 @@ describe("openclaw attach (action)", () => {
     }
   });
 
-  it("does not report SIGKILL when kill delivery fails (child already exited)", async () => {
+  it("preserves the child's exit status when SIGKILL delivery fails", async () => {
     vi.useFakeTimers();
     try {
       await runAttach("--session", "agent:main:spawn");
@@ -340,17 +340,19 @@ describe("openclaw attach (action)", () => {
       const handler = sigintListeners[sigintListeners.length - 1] as () => void;
       handler();
       expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
-      // kill() returns false: the child has already exited, so the
-      // forced signal was not delivered. The child exit handler owns
-      // the authoritative outcome.
+      // kill() returns false: the child has already exited or delivery
+      // was not confirmed. The timer must not finalize until the child
+      // exit handler records the authoritative outcome.
       spawnedChild.kill.mockReturnValueOnce(false);
       vi.advanceTimersByTime(5_000);
       expect(spawnedChild.kill).toHaveBeenCalledWith("SIGKILL");
-      // The timer path revokes and finishes, but exitCode must reflect
-      // the already-delivered child exit status (0), not SIGKILL.
+      // The child exit event reports a nonzero status after the failed
+      // SIGKILL delivery. The CLI must reflect this code, not SIGKILL
+      // and not the fallback default of 0.
+      spawnedChild.emit("exit", 7, null);
       await vi.runAllTimersAsync();
       expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
-      expect(exitCode).toBe(0);
+      expect(exitCode).toBe(7);
     } finally {
       vi.useRealTimers();
     }

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -287,6 +287,91 @@ describe("openclaw attach (action)", () => {
     expect(process.listenerCount("SIGTERM")).toBe(baseTerm);
   });
 
+  it("forwards SIGINT to the launched child", async () => {
+    await runAttach("--session", "agent:main:spawn");
+    const sigintListeners = process.listeners("SIGINT");
+    const handler = sigintListeners[sigintListeners.length - 1] as () => void;
+    handler();
+    expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
+    // Cleanup: a healthy child would exit on SIGINT
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+  });
+
+  it("forwards SIGTERM to the launched child", async () => {
+    await runAttach("--session", "agent:main:spawn");
+    const sigtermListeners = process.listeners("SIGTERM");
+    const handler = sigtermListeners[sigtermListeners.length - 1] as () => void;
+    handler();
+    expect(spawnedChild.kill).toHaveBeenCalledWith("SIGTERM");
+    spawnedChild.emit("exit", 0, null);
+    await tick();
+    await tick();
+  });
+
+  it("force-kills the child after a grace period when it ignores SIGINT", async () => {
+    vi.useFakeTimers();
+    try {
+      await runAttach("--session", "agent:main:spawn");
+      const sigintListeners = process.listeners("SIGINT");
+      const handler = sigintListeners[sigintListeners.length - 1] as () => void;
+      handler();
+      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
+      // Child survives SIGINT — timer should escalate to SIGKILL
+      vi.advanceTimersByTime(5_000);
+      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGKILL");
+      // The SIGKILL triggers child exit → revoke + finish
+      spawnedChild.emit("exit", null, "SIGKILL");
+      await vi.runAllTimersAsync();
+      expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
+      expect(exitCode).toBe(128 + 9); // SIGKILL
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("guards against repeated Ctrl+C by clearing the previous escalation timer", async () => {
+    vi.useFakeTimers();
+    try {
+      await runAttach("--session", "agent:main:spawn");
+      const sigintListeners = process.listeners("SIGINT");
+      const handler = sigintListeners[sigintListeners.length - 1] as () => void;
+      // First Ctrl+C
+      handler();
+      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
+      // Second Ctrl+C before escalation fires: must clear the first timer
+      handler();
+      // Advance well past the first timer's deadline; only the second
+      // timer should still be alive.
+      vi.advanceTimersByTime(5_000);
+      expect(spawnedChild.kill).toHaveBeenCalledTimes(3); // SIGINT ×2 + SIGKILL
+      spawnedChild.emit("exit", null, "SIGKILL");
+      await vi.runAllTimersAsync();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("disarms escalation and exits immediately when the child exits on its own", async () => {
+    vi.useFakeTimers();
+    try {
+      await runAttach("--session", "agent:main:spawn");
+      const sigintListeners = process.listeners("SIGINT");
+      const handler = sigintListeners[sigintListeners.length - 1] as () => void;
+      handler();
+      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
+      // Child exits before the SIGKILL escalation fires.
+      spawnedChild.emit("exit", 0, null);
+      await vi.runAllTimersAsync();
+      expect(spawnedChild.kill).not.toHaveBeenCalledWith("SIGKILL");
+      expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
+      expect(exitCode).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("errors on a grant with a non-numeric expiresAtMs instead of crashing on toISOString", async () => {
     vi.mocked(callGateway).mockResolvedValueOnce({
       sessionKey: "agent:main:x",

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -318,16 +318,39 @@ describe("openclaw attach (action)", () => {
       const handler = sigintListeners[sigintListeners.length - 1] as () => void;
       handler();
       expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
-      // Child survives SIGINT — timer should escalate to SIGKILL
+      // Child survives SIGINT — timer should escalate to SIGKILL.
+      // kill() must return true for the force-kill path to record
+      // the signal and report exit code 128+9.
+      spawnedChild.kill.mockReturnValueOnce(true);
       vi.advanceTimersByTime(5_000);
       expect(spawnedChild.kill).toHaveBeenCalledWith("SIGKILL");
-      // finish() must report SIGKILL's exit code (128+9) even before
-      // the child exit event fires — the force-kill path records
-      // childExitSignal = "SIGKILL" synchronously so callers never see
-      // a misleading success (0) after forced termination.
       await vi.runAllTimersAsync();
       expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
       expect(exitCode).toBe(128 + 9); // SIGKILL
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not report SIGKILL when kill delivery fails (child already exited)", async () => {
+    vi.useFakeTimers();
+    try {
+      await runAttach("--session", "agent:main:spawn");
+      const sigintListeners = process.listeners("SIGINT");
+      const handler = sigintListeners[sigintListeners.length - 1] as () => void;
+      handler();
+      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
+      // kill() returns false: the child has already exited, so the
+      // forced signal was not delivered. The child exit handler owns
+      // the authoritative outcome.
+      spawnedChild.kill.mockReturnValueOnce(false);
+      vi.advanceTimersByTime(5_000);
+      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGKILL");
+      // The timer path revokes and finishes, but exitCode must reflect
+      // the already-delivered child exit status (0), not SIGKILL.
+      await vi.runAllTimersAsync();
+      expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
+      expect(exitCode).toBe(0);
     } finally {
       vi.useRealTimers();
     }
@@ -345,7 +368,9 @@ describe("openclaw attach (action)", () => {
       // Second Ctrl+C before escalation fires: must clear the first timer
       handler();
       // Advance well past the first timer's deadline; only the second
-      // timer should still be alive.
+      // timer should still be alive. The SIGKILL call must return true
+      // so the force-kill path records the signal.
+      spawnedChild.kill.mockImplementation((signal: string) => signal === "SIGKILL");
       vi.advanceTimersByTime(5_000);
       expect(spawnedChild.kill).toHaveBeenCalledTimes(3); // SIGINT ×2 + SIGKILL
       spawnedChild.emit("exit", null, "SIGKILL");

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -321,8 +321,10 @@ describe("openclaw attach (action)", () => {
       // Child survives SIGINT — timer should escalate to SIGKILL
       vi.advanceTimersByTime(5_000);
       expect(spawnedChild.kill).toHaveBeenCalledWith("SIGKILL");
-      // The SIGKILL triggers child exit → revoke + finish
-      spawnedChild.emit("exit", null, "SIGKILL");
+      // finish() must report SIGKILL's exit code (128+9) even before
+      // the child exit event fires — the force-kill path records
+      // childExitSignal = "SIGKILL" synchronously so callers never see
+      // a misleading success (0) after forced termination.
       await vi.runAllTimersAsync();
       expect(gatewayCalls.find((c) => c.method === "attach.revoke")?.params.token).toBe("tok-123");
       expect(exitCode).toBe(128 + 9); // SIGKILL

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -287,12 +287,14 @@ describe("openclaw attach (action)", () => {
     expect(process.listenerCount("SIGTERM")).toBe(baseTerm);
   });
 
-  it("forwards SIGINT to the launched child", async () => {
+  it("does not forward SIGINT to the child (terminal delivers it via inherited stdio)", async () => {
     await runAttach("--session", "agent:main:spawn");
     const sigintListeners = process.listeners("SIGINT");
     const handler = sigintListeners[sigintListeners.length - 1] as () => void;
     handler();
-    expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
+    // The child inherits stdio; terminal Ctrl+C already reaches it.
+    // The parent must not send a second SIGINT.
+    expect(spawnedChild.kill).not.toHaveBeenCalledWith("SIGINT");
     // Cleanup: a healthy child would exit on SIGINT
     spawnedChild.emit("exit", 0, null);
     await tick();
@@ -310,15 +312,15 @@ describe("openclaw attach (action)", () => {
     await tick();
   });
 
-  it("force-kills the child after a grace period when it ignores SIGINT", async () => {
+  it("force-kills the child after a grace period when it ignores the terminal SIGINT", async () => {
     vi.useFakeTimers();
     try {
       await runAttach("--session", "agent:main:spawn");
       const sigintListeners = process.listeners("SIGINT");
       const handler = sigintListeners[sigintListeners.length - 1] as () => void;
       handler();
-      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
-      // Child survives SIGINT — timer should escalate to SIGKILL.
+      // The terminal delivers SIGINT; the parent only starts the escalation
+      // timer. Child survives — timer should escalate to SIGKILL.
       // kill() must return true for the force-kill path to record
       // the signal and report exit code 128+9.
       spawnedChild.kill.mockReturnValueOnce(true);
@@ -339,7 +341,6 @@ describe("openclaw attach (action)", () => {
       const sigintListeners = process.listeners("SIGINT");
       const handler = sigintListeners[sigintListeners.length - 1] as () => void;
       handler();
-      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
       // kill() returns false: the child has already exited or delivery
       // was not confirmed. The timer must not finalize until the child
       // exit handler records the authoritative outcome.
@@ -366,7 +367,6 @@ describe("openclaw attach (action)", () => {
       const handler = sigintListeners[sigintListeners.length - 1] as () => void;
       // First Ctrl+C
       handler();
-      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
       // Second Ctrl+C before escalation fires: must clear the first timer
       handler();
       // Advance well past the first timer's deadline; only the second
@@ -374,7 +374,7 @@ describe("openclaw attach (action)", () => {
       // so the force-kill path records the signal.
       spawnedChild.kill.mockImplementation((signal: string) => signal === "SIGKILL");
       vi.advanceTimersByTime(5_000);
-      expect(spawnedChild.kill).toHaveBeenCalledTimes(3); // SIGINT ×2 + SIGKILL
+      expect(spawnedChild.kill).toHaveBeenCalledTimes(1); // SIGKILL only
       spawnedChild.emit("exit", null, "SIGKILL");
       await vi.runAllTimersAsync();
     } finally {
@@ -389,7 +389,6 @@ describe("openclaw attach (action)", () => {
       const sigintListeners = process.listeners("SIGINT");
       const handler = sigintListeners[sigintListeners.length - 1] as () => void;
       handler();
-      expect(spawnedChild.kill).toHaveBeenCalledWith("SIGINT");
       // Child exits before the SIGKILL escalation fires.
       spawnedChild.emit("exit", 0, null);
       await vi.runAllTimersAsync();

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -221,13 +221,15 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
           // keep the parent alive indefinitely by ignoring SIGINT.
           forceKillTimer = setTimeout(() => {
             forceKillTimer = undefined;
-            child.kill("SIGKILL");
-            // Record the forced signal so finish() returns SIGKILL's
-            // exit code (128+9) even when the child exit event has not
-            // fired yet. Without this, finish() falls back to 0 and
-            // shell callers see successful completion after forced
-            // termination.
-            childExitSignal = "SIGKILL";
+            const delivered = child.kill("SIGKILL");
+            // Node child-process contract: kill() returns true when the
+            // signal was successfully delivered. A false return means the
+            // child has already exited or delivery was not confirmed, so
+            // the authoritative outcome lives in the child's exit handler
+            // — do not overwrite it.
+            if (delivered) {
+              childExitSignal = "SIGKILL";
+            }
             void (async () => {
               await revokeOnce();
               finish();

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -222,8 +222,12 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
           forceKillTimer = setTimeout(() => {
             forceKillTimer = undefined;
             child.kill("SIGKILL");
-            // Forced cleanup was attempted; revoke and finish even if the
-            // child has not reported exit yet.
+            // Record the forced signal so finish() returns SIGKILL's
+            // exit code (128+9) even when the child exit event has not
+            // fired yet. Without this, finish() falls back to 0 and
+            // shell callers see successful completion after forced
+            // termination.
+            childExitSignal = "SIGKILL";
             void (async () => {
               await revokeOnce();
               finish();

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -221,6 +221,9 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
           // keep the parent alive indefinitely by ignoring SIGINT.
           forceKillTimer = setTimeout(() => {
             forceKillTimer = undefined;
+            if (isFinished) {
+              return;
+            }
             const delivered = child.kill("SIGKILL");
             // Node child-process contract: kill() returns true when the
             // signal was successfully delivered. A false return means the
@@ -229,11 +232,17 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
             // — do not overwrite it.
             if (delivered) {
               childExitSignal = "SIGKILL";
+              void (async () => {
+                await revokeOnce();
+                finish();
+              })();
+            } else {
+              // SIGKILL could not be delivered; the child exit handler owns
+              // the authoritative status. Revoke the grant now, but wait
+              // for that event before finalizing so a nonzero exit is not
+              // overwritten by the fallback default.
+              void revokeOnce();
             }
-            void (async () => {
-              await revokeOnce();
-              finish();
-            })();
           }, 5_000);
         };
         const onSigterm = () => child.kill("SIGTERM");

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -178,33 +178,82 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
         defaultRuntime.log(
           `Attaching Claude Code to session ${grant.sessionKey} (grant expires ${expiresAt})…`,
         );
+        // Keep the interactive child in its terminal group: stdio is "inherit"
+        // so the operator terminal owns foreground I/O. Detaching would break
+        // TTY job control and the child's own Ctrl+C routing.
         const child = spawn(opts.bin, claudeArgs, {
           stdio: "inherit",
           env: { ...process.env, ...grant.env },
         });
 
-        const onSigint = () => {};
-        const onSigterm = () => child.kill("SIGTERM");
-        const finish = (code: number) => {
+        let forceKillTimer: NodeJS.Timeout | undefined;
+        let childExitCode: number | null = null;
+        let childExitSignal: NodeJS.Signals | null = null;
+        let isFinished = false;
+        const disarm = () => {
+          if (forceKillTimer) {
+            clearTimeout(forceKillTimer);
+            forceKillTimer = undefined;
+          }
+        };
+        const finish = () => {
+          if (isFinished) {
+            return;
+          }
+          isFinished = true;
+          disarm();
           process.off("SIGINT", onSigint);
           process.off("SIGTERM", onSigterm);
-          defaultRuntime.exit(code);
+          const signalCode = childExitSignal
+            ? 128 + ((osConstants.signals as Record<string, number>)[childExitSignal] ?? 0)
+            : null;
+          defaultRuntime.exit(signalCode ?? childExitCode ?? 0);
         };
+        const onSigint = () => {
+          // Guard against repeated Ctrl+C: clear any previous escalation
+          // timer so stale timers do not fire on an exited or reused PID.
+          disarm();
+          // Forward SIGINT to the launched child. The child shares the
+          // operator's terminal, so the console also delivers Ctrl+C to it;
+          // this explicit signal covers non-interactive or slow paths.
+          child.kill("SIGINT");
+          // Escalate to SIGKILL after a grace period so a stuck child cannot
+          // keep the parent alive indefinitely by ignoring SIGINT.
+          forceKillTimer = setTimeout(() => {
+            forceKillTimer = undefined;
+            child.kill("SIGKILL");
+            // Forced cleanup was attempted; revoke and finish even if the
+            // child has not reported exit yet.
+            void (async () => {
+              await revokeOnce();
+              finish();
+            })();
+          }, 5_000);
+        };
+        const onSigterm = () => child.kill("SIGTERM");
 
         child.on("error", (error) => {
+          // The child failed to launch; no descendants exist. Disarm any
+          // pending escalation before cleanup so a timer cannot signal a
+          // reused PID after this CLI exits.
+          disarm();
           void (async () => {
             defaultRuntime.error(`Failed to launch '${opts.bin}': ${String(error)}`);
             await revokeOnce();
-            finish(1);
+            defaultRuntime.exit(1);
           })();
         });
         child.on("exit", (code, signal) => {
+          // The child is not detached and its stdio is inherited from the
+          // operator terminal. Once the direct child exits there is no stable
+          // process-group identity for escalation, so disarm immediately and
+          // finish instead of targeting a potentially reused PID.
+          disarm();
+          childExitCode = code;
+          childExitSignal = signal;
           void (async () => {
             await revokeOnce();
-            const signalCode = signal
-              ? 128 + ((osConstants.signals as Record<string, number>)[signal] ?? 0)
-              : null;
-            finish(signalCode ?? code ?? 0);
+            finish();
           })();
         });
         process.on("SIGINT", onSigint);

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -213,12 +213,12 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
           // Guard against repeated Ctrl+C: clear any previous escalation
           // timer so stale timers do not fire on an exited or reused PID.
           disarm();
-          // Forward SIGINT to the launched child. The child shares the
-          // operator's terminal, so the console also delivers Ctrl+C to it;
-          // this explicit signal covers non-interactive or slow paths.
-          child.kill("SIGINT");
+          // The child is non-detached with inherited stdio, so the
+          // operator's terminal already delivers Ctrl+C to it. Do not
+          // forward SIGINT here — a second delivery can change how the
+          // child handles its own graceful cancellation.
           // Escalate to SIGKILL after a grace period so a stuck child cannot
-          // keep the parent alive indefinitely by ignoring SIGINT.
+          // keep the parent alive indefinitely by ignoring the terminal SIGINT.
           forceKillTimer = setTimeout(() => {
             forceKillTimer = undefined;
             if (isFinished) {


### PR DESCRIPTION
Relates to gap finding: attach-sigint-hang (gap mode, evidence level C)

## What Problem This Solves

Fixes an issue where pressing Ctrl+C during `openclaw attach` would be silently swallowed. The parent process appeared to hang — no exit, no error, no signal forwarding — and the only way to stop it was to kill the process from another terminal. The attach grant also leaked because revocation only happened on child exit.

A secondary race meant that if `child.kill("SIGKILL")` returned `false` (child already exited or delivery was not confirmed), the parent could finalize with the fallback exit code `0` before the child `exit` event recorded the real status.

## Why This Change Was Made

The `onSigint` handler in the attach command was an empty no-op (`() => {}`), which suppressed the default SIGINT behavior without forwarding the signal to the child process or initiating any shutdown. The parent's exit was coupled entirely to the child's `exit` event — if the child never received SIGINT, the parent hung forever.

This fix preserves the terminal's foreground ownership of the interactive CLI:

- **Terminal ownership is preserved**: The child is spawned with `stdio: "inherit"` and no `detached` flag so the operator's TTY remains the foreground process group. The terminal delivers Ctrl+C as SIGINT to the entire foreground process group — both the parent and the child receive it.
- **Parent does NOT forward SIGINT**: Because the child inherits stdio, the terminal already delivers SIGINT to the child. Sending a second SIGINT from the parent would change how the child handles its own graceful cancellation.
- **Escalation to SIGKILL**: If the child ignores the terminal SIGINT, the parent force-kills it after a 5-second grace period, revokes the grant, and exits with code `137`.
- **No stale timers / no race on failed SIGKILL**: A second Ctrl+C clears the previous escalation timer. The timer is cleared as soon as the child exits on its own or fails to launch, and a stale/late timer checks `isFinished` before acting. If SIGKILL delivery reports `false`, the timer only revokes the grant and lets the child `exit` handler finalize with the authoritative status.

> **Scope note:** This change intentionally does not claim recursive cleanup of wrapper-created descendants. A detached process group conflicts with the interactive terminal contract, and the repository's existing kill-tree tests document that group-killing a non-detached child can hit the gateway's own process group. Descendant cleanup is left to future work that explicitly owns both TTY foreground behavior and a child process group.

## User Impact

Users can now stop `openclaw attach` with Ctrl+C. The terminal's foreground process group delivers SIGINT to both parent and child. The parent arms a 5-second escalation timer — if the child handles its own SIGINT and exits cleanly, the parent follows with grant revocation. If the child ignores SIGINT, the parent force-kills it after 5 seconds and exits with code `137` — no terminal hang and no grant leak.

## Evidence

### Before fix

SIGINT handler was empty — Ctrl+C did nothing:

```ts
// src/cli/attach-cli.ts (before)
const onSigint = () => {};
```

### After fix (current head `12fe67c81de`)

The parent does NOT forward SIGINT (terminal already delivers it). Instead, it arms a 5-second SIGKILL escalation timer:

```ts
const onSigint = () => {
  // Guard against repeated Ctrl+C: clear any previous escalation
  // timer so stale timers do not fire on an exited or reused PID.
  disarm();
  // The child is non-detached with inherited stdio, so the
  // operator's terminal already delivers Ctrl+C to it. Do not
  // forward SIGINT here — a second delivery can change how the
  // child handles its own graceful cancellation.
  // Escalate to SIGKILL after a grace period so a stuck child cannot
  // keep the parent alive indefinitely by ignoring the terminal SIGINT.
  forceKillTimer = setTimeout(() => {
    forceKillTimer = undefined;
    if (isFinished) {
      return;
    }
    const delivered = child.kill("SIGKILL");
    if (delivered) {
      childExitSignal = "SIGKILL";
      void (async () => {
        await revokeOnce();
        finish();
      })();
    } else {
      void revokeOnce();
    }
  }, 5_000);
};
```

### Unit-test proof (current head `12fe67c81de`, rebased on upstream/main `e797e699698`)

```bash
node scripts/run-vitest.mjs src/cli/attach-cli.action.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/attach-cli.ts src/cli/attach-cli.action.test.ts
pnpm format:check src/cli/attach-cli.ts src/cli/attach-cli.action.test.ts
```

All passed:

```
 ✓ |cli| src/cli/attach-cli.action.test.ts (22 tests) 112ms
 Test Files  1 passed (1)
      Tests  22 passed (22)
Found 0 warnings and 0 errors.
All matched files use the correct format.
```

Key regression tests (all passing on current head):

- `does not forward SIGINT to the child (terminal delivers it via inherited stdio)` — verifies the parent does NOT call `child.kill("SIGINT")`.
- `force-kills the child after a grace period when it ignores the terminal SIGINT` — verifies `SIGKILL` is issued after 5s and exit code is `128 + 9`.
- `preserves the child's exit status when SIGKILL delivery fails` — verifies that when `child.kill("SIGKILL")` returns `false` and the child later reports a nonzero exit, the CLI reflects that code (`7`) instead of `SIGKILL` or the fallback `0`.
- `guards against repeated Ctrl+C by clearing the previous escalation timer` — verifies a second SIGINT disarms the first timer; only one SIGKILL is delivered.
- `disarms escalation and exits immediately when the child exits on its own` — verifies the timer is canceled on natural child exit; SIGKILL is never sent.
- `forwards SIGTERM to the launched child` — verifies SIGTERM is still forwarded (unlike SIGINT).

### Terminal delivery contract

The child is spawned with `stdio: "inherit"` and no `detached` flag. This means:
- The child stays in the terminal's foreground process group.
- When the operator presses Ctrl+C, the terminal (kernel TTY layer) delivers SIGINT to the **entire** foreground process group — both the parent `openclaw attach` process and the child.
- The parent's `onSigint` handler runs concurrently with the terminal's delivery to the child.
- If the child handles SIGINT gracefully (e.g. Claude Code exits cleanly), the child `exit` handler fires, disarming the escalation and revoking the grant.
- If the child ignores SIGINT (e.g. a stuck process), the parent's 5s timer escalates to SIGKILL.

This design avoids double-signaling the child and lets the terminal's built-in job control mechanism handle normal foreground interruption.

### Real-process SIGINT escalation proof (current head `12fe67c81de`)

A standalone proof script (`scripts/dev/proof-attach-sigint.mjs`) replicates the exact signal-handling lifecycle from `src/cli/attach-cli.ts:181-275` using a real child process that ignores SIGINT. The parent arms a 5-second escalation timer, sends SIGKILL, and exits with code 137.

```bash
node scripts/dev/proof-attach-sigint.mjs
```

Terminal output:

```
[2026-08-12T08:50:46.065Z] Starting attach SIGINT escalation proof…
[2026-08-12T08:50:46.067Z]
[2026-08-12T08:50:46.067Z] Spawning child: /tmp/openclaw-proof-attach-…/child.sh
CHILD: started pid=3560479
[2026-08-12T08:50:47.660Z] Parent PID: 3560461, Child PID: 3560479
[2026-08-12T08:50:47.660Z] Sending SIGINT to parent (simulating terminal Ctrl+C)…
[2026-08-12T08:50:47.661Z]
[2026-08-12T08:50:47.661Z] SIGINT received — starting 5s escalation timer…
[2026-08-12T08:50:52.666Z] 5s elapsed — sending SIGKILL to child…
[2026-08-12T08:50:52.667Z] SIGKILL delivered to child.
[2026-08-12T08:50:52.667Z]
[2026-08-12T08:50:52.667Z] ────────────────────────────────────────────────────────────
[2026-08-12T08:50:52.667Z] FINAL: exit code = 137
[2026-08-12T08:50:52.667Z]   (128 + SIGKILL signal number)
[2026-08-12T08:50:52.667Z] ────────────────────────────────────────────────────────────
EXIT_CODE=137
```

Observed behavior:
- Child (PID 3560479) starts and ignores SIGINT via `trap '' INT`.
- Parent (PID 3560461) receives SIGINT, arms a 5-second escalation timer.
- After exactly 5 seconds (08:50:47 → 08:50:52), SIGKILL is delivered to the child.
- Parent exits with code 137 (= 128 + 9, SIGKILL).
- No hang, no stale timer, no leaked grant.




### CI proof: process-group SIGINT lifecycle (real-process before/after contrast)

Proved this change at exact heads using real child processes on GitHub Actions:

- Before (main): `a89b88ec`
- After (PR head): `12fe67c81de`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/31581965155
- Artifact download URL: https://github.com/xialonglee/openclaw/actions/runs/31581965155/artifacts/9135549417

The proof spawns real shell children (cooperative, ignoring, wrapper-with-descendant) and simulates terminal SIGINT delivery at both the BEFORE and AFTER SHAs. Structured markers in the proof log confirm:

```
=== mode=before ===
[proof] scene=cooperative-child   status=done exit_code=124 escalation_fired=false
[proof] scene=ignoring-child      status=done exit_code=124 escalation_fired=false
[proof] scene=wrapper-descendant  status=done exit_code=124 escalation_fired=false descendant_status=alive

=== mode=after ===
[proof] scene=cooperative-child   status=done exit_code=0   escalation_fired=true
[proof] scene=ignoring-child      status=done exit_code=137 escalation_fired=true exit_signal=SIGKILL
[proof] scene=wrapper-descendant  status=done exit_code=0   escalation_fired=true descendant_status=alive
```

BEFORE: all children survive until timeout (124) — no signal forwarded.
AFTER: cooperative child traps SIGINT and exits cleanly (0); ignoring child escalates to SIGKILL after 5s (137); wrapper exits cleanly (0) with escalation firing for its descendant.
