### PR TITLE
test(models): isolate scoped catalog fixture

### DIFF
--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -152,21 +152,14 @@ vi.mock("../agents/prepared-model-catalog.js", () => ({
   },
 }));
 
-vi.mock("./models/list.scoped-catalog.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./models/list.scoped-catalog.js")>();
-  return {
-    ...actual,
-    loadScopedListModelCatalogSnapshot: async (
-      params: Parameters<typeof actual.loadScopedListModelCatalogSnapshot>[0],
-    ) => {
-      if (!params.providerIds.includes("zai")) {
-        return await actual.loadScopedListModelCatalogSnapshot(params);
-      }
-      const entries = await loadModelCatalog();
-      return { entries, routeVariants: entries, staticEntries: [] };
-    },
-  };
-});
+vi.mock("./models/list.scoped-catalog.js", () => ({
+  // The scoped-catalog owner covers live discovery; this command fixture supplies
+  // deterministic rows without materializing provider runtime in the shared E2E worker.
+  loadScopedListModelCatalogSnapshot: async () => {
+    const entries = await loadModelCatalog();
+    return { entries, routeVariants: entries, staticEntries: [] };
+  },
+}));
 
 vi.mock("../agents/prepared-model-registry.js", () => ({
   loadPreparedAgentModelRegistry: async (config: object, options?: { agentDir?: string }) => ({
@@ -633,6 +626,7 @@ describe("models list/status", () => {
 
   it("models list all includes catalog rows with unknown auth availability", async () => {
     setDefaultZaiRegistry({ available: false });
+    loadModelCatalog.mockResolvedValueOnce([{ ...MOONSHOT_MODEL, id: "kimi-k3", name: "Kimi K3" }]);
     const runtime = makeRuntime();
 
     await withEnvAsync(
@@ -641,7 +635,7 @@ describe("models list/status", () => {
     );
 
     const payload = parseJsonLog(runtime);
-    expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(loadModelCatalog).toHaveBeenCalledOnce();
     expect(payload.models.length).toBeGreaterThan(0);
     const model = payload.models.find(
       (candidate: { key: string }) => candidate.key === "moonshot/kimi-k3",


### PR DESCRIPTION
Closes #119980

AI-assisted: yes

## What Problem This Solves

Prevents an order-dependent repository E2E timeout when the models-list suite runs before trigger handling. The Moonshot models-list case took roughly 65–81 seconds and left the next trigger file rebuilding unrelated provider/catalog state; `/status` then took about 117 seconds or hit the 120-second test timeout, and the full file could remain silent long enough for the five-minute aggregate watchdog to terminate Vitest.

## Root Cause

`models.list.e2e.test.ts` already mocked prepared registry, catalog, provider, auth, and discovery owners, but its scoped-catalog mock intercepted only Z.AI. Non-Z.AI cases escaped into the real read-only live provider-discovery graph. That was outside this command fixture's ownership and polluted the shared non-isolated E2E worker.

Dedicated scoped-catalog and prepared-runtime tests already own Moonshot live discovery, partial static catalog augmentation, and read-only provider coverage.

## Why This Change Was Made

The command fixture now supplies deterministic scoped-catalog rows for every provider and explicitly seeds the Moonshot row asserted by the unknown-auth test. This keeps models-list row selection/rendering coverage intact while leaving live discovery with its architectural owner.

Production LOC: +0/-0. Tests: +10/-16.

## Evidence

Before on current main `08a3f5f949466d3cdf08fd1a23b3cb5cef9cbfb0`:

- Full E2E order reached models-list then trigger handling and exited 143 after five silent minutes: https://github.com/openclaw/openclaw/actions/runs/31107575698
- Focused trigger handling passed 21/21 in 82.48 seconds: https://github.com/openclaw/openclaw/actions/runs/31108626974
- Forced Moonshot-then-status order made `/status` take about 117 seconds and reproduced the 120-second timeout: https://github.com/openclaw/openclaw/actions/runs/31110050225 and https://github.com/openclaw/openclaw/actions/runs/31110761281

After:

- Exact forced models-list-then-trigger order passed 42/42 in 100.25 seconds; the Moonshot case completed in 173ms and the trigger file started immediately.
- Blacksmith Testbox `tbx_01kzbt8dgfwgm00f5c7sjwyznw`, run https://github.com/openclaw/openclaw/actions/runs/31114907262: models-list 21/21, scoped-catalog 11/11, and complete `pnpm check:changed` with zero warnings/errors.
- AutoReview: clean, no accepted/actionable findings, correctness 0.99.

## User Impact

Maintainers get deterministic full E2E runs without false five-minute stalls after models-list coverage. Product runtime behavior is unchanged.

## Docs and Changelog

Not applicable; this is test fixture ownership only.
