### PR TITLE
fix(status): harden vector probe failure handling and drop empty catch

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
@@ -6,7 +6,7 @@ import {
   resolveInboundDebounceMs,
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramHandlerMessageRuntime } from "./bot-handlers.message.runtime.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
@@ -215,7 +215,7 @@ export function createTelegramInboundDebounceRuntime(
             threadParams,
           )
           .catch((sendError: unknown) => {
-            logVerbose(`telegram: error fallback send failed: ${String(sendError)}`);
+            runtime.error?.(danger(`telegram: error fallback send failed: ${String(sendError)}`));
           });
       }
     },

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -1,6 +1,5 @@
 // Telegram tests cover bot message plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
@@ -877,7 +876,7 @@ describe("telegram bot message processor", () => {
     expect(runtimeError).toHaveBeenCalledWith(
       "telegram message processing failed: Error: dispatch exploded",
     );
-    expect(logVerbose).toHaveBeenCalledWith(
+    expect(runtimeError).toHaveBeenCalledWith(
       "telegram: error fallback send failed: Error: blocked by user",
     );
   });

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover bot message plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
@@ -855,7 +856,7 @@ describe("telegram bot message processor", () => {
     );
   });
 
-  it("swallows fallback delivery failures after dispatch throws", async () => {
+  it("logs the send failure when error fallback delivery also fails", async () => {
     const sendMessage = vi.fn().mockRejectedValue(new Error("blocked by user"));
     const { processMessage, runtimeError, dispatchError } = createDispatchFailureHarness(
       {
@@ -875,6 +876,9 @@ describe("telegram bot message processor", () => {
     );
     expect(runtimeError).toHaveBeenCalledWith(
       "telegram message processing failed: Error: dispatch exploded",
+    );
+    expect(logVerbose).toHaveBeenCalledWith(
+      "telegram: error fallback send failed: Error: blocked by user",
     );
   });
 });

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -323,7 +323,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               buildTelegramThreadParams(context.threadSpec),
             );
           } catch (sendError: unknown) {
-            logVerbose(`telegram: error fallback send failed: ${String(sendError)}`);
+            runtime.error?.(danger(`telegram: error fallback send failed: ${String(sendError)}`));
           }
         }
         const result: TelegramMessageProcessingResult = {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -322,7 +322,9 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               "Something went wrong while processing your request. Please try again.",
               buildTelegramThreadParams(context.threadSpec),
             );
-          } catch {}
+          } catch (sendError: unknown) {
+            logVerbose(`telegram: error fallback send failed: ${String(sendError)}`);
+          }
         }
         const result: TelegramMessageProcessingResult = {
           kind: "failed-retryable",

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -1,10 +1,12 @@
 // Status command section tests cover footer, health, and report section rendering.
 import { describe, expect, it } from "vitest";
+import { resolveMemoryVectorState } from "../memory-host-sdk/status.js";
 import type { HealthSummary } from "./health.js";
 import {
   buildStatusFooterLines,
   buildStatusHealthRows,
   buildStatusHeartbeatValue,
+  buildStatusMemoryValue,
   buildStatusModelSelectionLines,
   buildStatusPairingRecoveryLines,
   buildStatusPluginCompatibilityLines,
@@ -365,5 +367,70 @@ describe("status.command-sections", () => {
       { key: "Status", header: "Status", minWidth: 8 },
       { key: "Detail", header: "Detail", flex: true, minWidth: 28 },
     ]);
+  });
+
+  it("renders builtin vector store and semantic health independently", () => {
+    const value = buildStatusMemoryValue({
+      memory: {
+        backend: "builtin",
+        provider: "local",
+        files: 1,
+        chunks: 2,
+        vector: {
+          enabled: true,
+          storeAvailable: true,
+          semanticAvailable: false,
+          available: false,
+        },
+      },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      ok: (v) => `ok(${v})`,
+      warn: (v) => `warn(${v})`,
+      muted: (v) => `muted(${v})`,
+      resolveMemoryVectorState,
+      resolveMemoryFtsState: () => ({ state: "ready", tone: "ok" }),
+      resolveMemoryCacheSummary: () => ({ text: "cache warm", tone: "muted" }),
+    });
+    expect(value).toContain("warn(vector store ready · semantic unavailable)");
+  });
+
+  it("keeps builtin vector store-only rendering when semantic health is unknown", () => {
+    const value = buildStatusMemoryValue({
+      memory: {
+        backend: "builtin",
+        provider: "local",
+        files: 1,
+        chunks: 2,
+        vector: { enabled: true, storeAvailable: true },
+      },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      ok: (v) => `ok(${v})`,
+      warn: (v) => `warn(${v})`,
+      muted: (v) => `muted(${v})`,
+      resolveMemoryVectorState,
+      resolveMemoryFtsState: () => ({ state: "ready", tone: "ok" }),
+      resolveMemoryCacheSummary: () => ({ text: "cache warm", tone: "muted" }),
+    });
+    expect(value).toContain("ok(vector store ready)");
+  });
+
+  it("keeps builtin vector rendering on aggregate availability when store health is unknown", () => {
+    const value = buildStatusMemoryValue({
+      memory: {
+        backend: "builtin",
+        provider: "local",
+        files: 1,
+        chunks: 2,
+        vector: { enabled: true, available: false, semanticAvailable: false },
+      },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      ok: (v) => `ok(${v})`,
+      warn: (v) => `warn(${v})`,
+      muted: (v) => `muted(${v})`,
+      resolveMemoryVectorState,
+      resolveMemoryFtsState: () => ({ state: "ready", tone: "ok" }),
+      resolveMemoryCacheSummary: () => ({ text: "cache warm", tone: "muted" }),
+    });
+    expect(value).toContain("warn(vector unavailable)");
   });
 });

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -372,6 +372,7 @@ describe("status.command-sections", () => {
   it("renders builtin vector store and semantic health independently", () => {
     const value = buildStatusMemoryValue({
       memory: {
+        agentId: "main",
         backend: "builtin",
         provider: "local",
         files: 1,
@@ -397,6 +398,7 @@ describe("status.command-sections", () => {
   it("keeps builtin vector store-only rendering when semantic health is unknown", () => {
     const value = buildStatusMemoryValue({
       memory: {
+        agentId: "main",
         backend: "builtin",
         provider: "local",
         files: 1,
@@ -417,6 +419,7 @@ describe("status.command-sections", () => {
   it("keeps builtin vector rendering on aggregate availability when store health is unknown", () => {
     const value = buildStatusMemoryValue({
       memory: {
+        agentId: "main",
         backend: "builtin",
         provider: "local",
         files: 1,

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -434,6 +434,6 @@ describe("status.command-sections", () => {
       resolveMemoryFtsState: () => ({ state: "ready", tone: "ok" }),
       resolveMemoryCacheSummary: () => ({ text: "cache warm", tone: "muted" }),
     });
-    expect(value).toContain("warn(vector unavailable)");
+    expect(value).toContain("warn(vector store unavailable)");
   });
 });

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -181,15 +181,37 @@ export function buildStatusMemoryValue(
   const colorByTone = (tone: Tone, text: string) =>
     tone === "ok" ? params.ok(text) : tone === "warn" ? params.warn(text) : params.muted(text);
   if (params.memory.vector) {
-    const vector =
-      params.memory.backend === "builtin" && params.memory.vector.storeAvailable !== undefined
-        ? // Built-in memory reports store availability under a backend-specific field.
-          { ...params.memory.vector, available: params.memory.vector.storeAvailable }
-        : params.memory.vector;
-    const state = params.resolveMemoryVectorState(vector);
+    const vector = params.memory.vector;
     const prefix = params.memory.backend === "builtin" ? "vector store" : "vector";
-    const label = state.state === "disabled" ? `${prefix} off` : `${prefix} ${state.state}`;
-    parts.push(colorByTone(state.tone, label));
+    const isBuiltinWithIndependentVectorHealth =
+      params.memory.backend === "builtin" &&
+      vector.storeAvailable !== undefined &&
+      vector.semanticAvailable !== undefined;
+    let label: string;
+    let tone: Tone;
+    if (isBuiltinWithIndependentVectorHealth) {
+      // Builtin can report store health and semantic probing independently;
+      // show both facts so a healthy store does not mask a failed semantic probe.
+      const storeState = vector.storeAvailable === true ? "ready" : "unavailable";
+      const semanticState = vector.semanticAvailable === true ? "ready" : "unavailable";
+      label = `${prefix} ${storeState} · semantic ${semanticState}`;
+      tone =
+        vector.storeAvailable === true && vector.semanticAvailable === true
+          ? "ok"
+          : vector.storeAvailable === false || vector.semanticAvailable === false
+            ? "warn"
+            : "muted";
+    } else {
+      const vectorForState =
+        params.memory.backend === "builtin" && vector.storeAvailable !== undefined
+          ? // Built-in memory reports store availability under a backend-specific field.
+            { ...vector, available: vector.storeAvailable }
+          : vector;
+      const state = params.resolveMemoryVectorState(vectorForState);
+      label = state.state === "disabled" ? `${prefix} off` : `${prefix} ${state.state}`;
+      tone = state.tone;
+    }
+    parts.push(colorByTone(tone, label));
   }
   if (params.memory.fts) {
     const state = params.resolveMemoryFtsState(params.memory.fts);

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -699,6 +699,51 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
     expect(result?.vector?.available).toBe(undefined);
   });
 
+  it("hardens vector.storeAvailable when builtin fallback probe throws without optional store probe", async () => {
+    const manager = {
+      // No probeVectorStoreAvailability — builtin without the optional store probe
+      probeVectorAvailability: vi.fn(async () => {
+        throw new Error("embedding provider unavailable");
+      }),
+      status: vi.fn(() => ({
+        backend: "builtin" as const,
+        provider: "local",
+        files: 10,
+        chunks: 20,
+        vector: {
+          enabled: true,
+          storeAvailable: true,
+          semanticAvailable: true,
+          available: true,
+        },
+        fts: { enabled: true, available: true },
+      })),
+      close: vi.fn(async () => {}),
+    };
+    const resolveMemoryConfig = vi.fn(() => ({
+      store: {
+        databasePath: `/tmp/openclaw-status-builtin-fb-throw-${process.pid}.sqlite`,
+      },
+    }));
+    const getMemorySearchManager = vi.fn(async () => ({ manager }));
+
+    const result = await resolveSharedMemoryStatusSnapshot({
+      cfg: { memory: { search: { provider: "local" } } },
+      agentStatus: { defaultId: "main" },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      resolveMemoryConfig,
+      getMemorySearchManager,
+      requireDefaultDatabasePath: () =>
+        `/tmp/openclaw-status-builtin-fb-throw-default-${process.pid}.sqlite`,
+    });
+
+    expect(manager.probeVectorAvailability).toHaveBeenCalled();
+    expect(manager.close).toHaveBeenCalled();
+    expect(result?.vector?.storeAvailable).toBe(false);
+    expect(result?.vector?.semanticAvailable).toBe(false);
+    expect(result?.vector?.available).toBe(false);
+  });
+
   it("hardens vector.semanticAvailable when builtin semantic probe throws", async () => {
     const manager = {
       probeVectorAvailability: vi.fn(async () => {

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -659,6 +659,77 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
     });
   });
 
+  it("hardens vector.storeAvailable when builtin store probe throws", async () => {
+    const manager = {
+      probeVectorStoreAvailability: vi.fn(async () => {
+        throw new Error("SQLITE_IOERR: disk full");
+      }),
+      probeVectorAvailability: vi.fn(async () => true),
+      status: vi.fn(() => ({
+        backend: "builtin" as const,
+        provider: "local",
+        files: 10,
+        chunks: 20,
+        vector: { enabled: true, storeAvailable: undefined, semanticAvailable: undefined },
+        fts: { enabled: true, available: true },
+      })),
+      close: vi.fn(async () => {}),
+    };
+    const resolveMemoryConfig = vi.fn(() => ({
+      store: { databasePath: `/tmp/openclaw-status-store-throw-${process.pid}.sqlite` },
+    }));
+    const getMemorySearchManager = vi.fn(async () => ({ manager }));
+
+    const result = await resolveSharedMemoryStatusSnapshot({
+      cfg: { memory: { search: { provider: "local" } } },
+      agentStatus: { defaultId: "main" },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      resolveMemoryConfig,
+      getMemorySearchManager,
+      requireDefaultDatabasePath: () =>
+        `/tmp/openclaw-status-store-throw-default-${process.pid}.sqlite`,
+    });
+
+    expect(manager.probeVectorStoreAvailability).toHaveBeenCalled();
+    expect(manager.probeVectorAvailability).not.toHaveBeenCalled();
+    expect(manager.close).toHaveBeenCalled();
+    expect(result?.vector?.storeAvailable).toBe(false);
+    // Semantic availability is not affected by the store probe alone.
+    expect(result?.vector?.semanticAvailable).toBe(undefined);
+    expect(result?.vector?.available).toBe(undefined);
+  });
+
+  it("hardens vector.semanticAvailable when builtin semantic probe throws", async () => {
+    const manager = {
+      probeVectorAvailability: vi.fn(async () => {
+        throw new Error("embedding provider unavailable");
+      }),
+      status: vi.fn(() => ({
+        backend: "builtin" as const,
+        provider: "local",
+        files: 5,
+        chunks: 5,
+        vector: { enabled: true, available: true, semanticAvailable: true },
+      })),
+      close: vi.fn(async () => {}),
+    };
+    const getMemorySearchManager = vi.fn(async () => ({ manager }));
+
+    const result = await resolveSharedMemoryStatusSnapshot({
+      cfg: { memory: { search: { provider: "local" } } },
+      agentStatus: { defaultId: "main" },
+      memoryPlugin: { enabled: true, slot: "memory-core" },
+      resolveMemoryConfig: vi.fn(() => null),
+      getMemorySearchManager,
+      requireDefaultDatabasePath: vi.fn(),
+    });
+
+    expect(manager.probeVectorAvailability).toHaveBeenCalled();
+    expect(manager.close).toHaveBeenCalled();
+    expect(result?.vector?.semanticAvailable).toBe(false);
+    expect(result?.vector?.available).toBe(false);
+  });
+
   it("keeps default memory-core on the cold-start store shortcut", async () => {
     const resolveMemoryConfig = vi.fn(() => null);
     const getMemorySearchManager = vi.fn(async () => ({ manager: null }));

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -759,15 +759,19 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
       })),
       close: vi.fn(async () => {}),
     };
+    const resolveMemoryConfig = vi.fn(() => ({
+      store: { databasePath: `/tmp/openclaw-status-semantic-throw-${process.pid}.sqlite` },
+    }));
     const getMemorySearchManager = vi.fn(async () => ({ manager }));
 
     const result = await resolveSharedMemoryStatusSnapshot({
       cfg: { memory: { search: { provider: "local" } } },
       agentStatus: { defaultId: "main" },
       memoryPlugin: { enabled: true, slot: "memory-core" },
-      resolveMemoryConfig: vi.fn(() => null),
+      resolveMemoryConfig,
       getMemorySearchManager,
-      requireDefaultDatabasePath: vi.fn(),
+      requireDefaultDatabasePath: () =>
+        `/tmp/openclaw-status-semantic-throw-default-${process.pid}.sqlite`,
     });
 
     expect(manager.probeVectorAvailability).toHaveBeenCalled();

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -699,7 +699,7 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
     expect(result?.vector?.available).toBe(undefined);
   });
 
-  it("hardens vector.storeAvailable when builtin fallback probe throws without optional store probe", async () => {
+  it("hardens vector.semanticAvailable when builtin fallback probe throws without optional store probe", async () => {
     const manager = {
       // No probeVectorStoreAvailability — builtin without the optional store probe
       probeVectorAvailability: vi.fn(async () => {
@@ -739,7 +739,8 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
 
     expect(manager.probeVectorAvailability).toHaveBeenCalled();
     expect(manager.close).toHaveBeenCalled();
-    expect(result?.vector?.storeAvailable).toBe(false);
+    // The fallback probe is semantic, so store availability must stay intact.
+    expect(result?.vector?.storeAvailable).toBe(true);
     expect(result?.vector?.semanticAvailable).toBe(false);
     expect(result?.vector?.available).toBe(false);
   });

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -441,16 +441,30 @@ async function resolveMemoryManagerStatusSnapshot(
     return null;
   }
   try {
+    const currentStatus = manager.status();
+    const isStoreProbe =
+      currentStatus.backend === "builtin" && manager.probeVectorStoreAvailability;
+    // Store the probe result so the status can reflect a real failure
+    // Even when internal state was not updated.
+    let probeAvailable: boolean | undefined;
     try {
-      const currentStatus = manager.status();
-      if (currentStatus.backend === "builtin" && manager.probeVectorStoreAvailability) {
-        // Built-in vector store has a store-level probe that avoids conflating index absence with plugin failure.
-        await manager.probeVectorStoreAvailability();
-      } else {
-        await manager.probeVectorAvailability();
-      }
-    } catch {}
+      probeAvailable = isStoreProbe
+        ? await manager.probeVectorStoreAvailability()
+        : await manager.probeVectorAvailability();
+    } catch {
+      probeAvailable = false;
+    }
     const status = manager.status();
+    // Harden vector fields when the probe is authoritative and negative,
+    // So the operator sees the degraded state.
+    if (probeAvailable === false && status.vector) {
+      status.vector = {
+        ...status.vector,
+        storeAvailable: isStoreProbe ? false : status.vector.storeAvailable,
+        semanticAvailable: isStoreProbe ? status.vector.semanticAvailable : false,
+        available: isStoreProbe ? status.vector.available : false,
+      };
+    }
     return { agentId, ...status };
   } finally {
     // Status probes must not leak plugin resources such as SQLite handles.

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -458,9 +458,10 @@ async function resolveMemoryManagerStatusSnapshot(
     // Harden vector fields when the probe is authoritative and negative,
     // So the operator sees the degraded state.
     if (probeAvailable === false && status.vector) {
+      const isBuiltin = currentStatus.backend === "builtin";
       status.vector = {
         ...status.vector,
-        storeAvailable: isStoreProbe ? false : status.vector.storeAvailable,
+        storeAvailable: isBuiltin ? false : status.vector.storeAvailable,
         semanticAvailable: isStoreProbe ? status.vector.semanticAvailable : false,
         available: isStoreProbe ? status.vector.available : false,
       };

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -442,14 +442,19 @@ async function resolveMemoryManagerStatusSnapshot(
   }
   try {
     const currentStatus = manager.status();
-    const isStoreProbe =
-      currentStatus.backend === "builtin" && manager.probeVectorStoreAvailability;
+    // Capture the optional store probe bound to manager so TS can narrow
+    // the call and `this` context is preserved.
+    const storeProbeFn =
+      currentStatus.backend === "builtin"
+        ? manager.probeVectorStoreAvailability?.bind(manager)
+        : undefined;
+    const isStoreProbe = storeProbeFn != null;
     // Store the probe result so the status can reflect a real failure
     // Even when internal state was not updated.
     let probeAvailable: boolean | undefined;
     try {
-      probeAvailable = isStoreProbe
-        ? await manager.probeVectorStoreAvailability()
+      probeAvailable = storeProbeFn
+        ? await storeProbeFn()
         : await manager.probeVectorAvailability();
     } catch {
       probeAvailable = false;
@@ -457,7 +462,7 @@ async function resolveMemoryManagerStatusSnapshot(
     const status = manager.status();
     // Harden vector fields when the probe is authoritative and negative,
     // So the operator sees the degraded state.
-    if (probeAvailable === false && status.vector) {
+    if (!probeAvailable && status.vector) {
       const isBuiltin = currentStatus.backend === "builtin";
       status.vector = {
         ...status.vector,

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -450,10 +450,10 @@ async function resolveMemoryManagerStatusSnapshot(
         : undefined;
     const isStoreProbe = storeProbeFn != null;
     // Store the probe result so the status can reflect a real failure
-    // Even when internal state was not updated.
+    // even when internal state was not updated.
     let probeAvailable: boolean | undefined;
     try {
-      probeAvailable = storeProbeFn
+      probeAvailable = isStoreProbe
         ? await storeProbeFn()
         : await manager.probeVectorAvailability();
     } catch {
@@ -461,12 +461,14 @@ async function resolveMemoryManagerStatusSnapshot(
     }
     const status = manager.status();
     // Harden vector fields when the probe is authoritative and negative,
-    // So the operator sees the degraded state.
+    // so the operator sees the degraded state. A failed store probe only
+    // clears store availability; a failed semantic/fallback probe clears
+    // semantic availability and the aggregate available flag, leaving any
+    // distinct store health intact.
     if (!probeAvailable && status.vector) {
-      const isBuiltin = currentStatus.backend === "builtin";
       status.vector = {
         ...status.vector,
-        storeAvailable: isBuiltin ? false : status.vector.storeAvailable,
+        storeAvailable: isStoreProbe ? false : status.vector.storeAvailable,
         semanticAvailable: isStoreProbe ? status.vector.semanticAvailable : false,
         available: isStoreProbe ? status.vector.available : false,
       };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw status` would silently report vector storage as healthy
when a probe failure (disk full, SQLite corruption, manager closed, etc.) caused the
probe exception to be swallowed by an empty `catch {}` block, leaving the operator
with no visible indication of the degraded state.

This is a "silent failure > crash" class bug (highest severity per Product Doctrine).

**ClawSweeper review follow-up:** The previous revision conflated the optional
builtin store probe with the semantic fallback probe. When a builtin manager lacked
`probeVectorStoreAvailability` and the fallback semantic probe failed, the code
cleared `storeAvailable`, falsely reporting a healthy builtin vector store as
unavailable. The corrected change distinguishes probe kinds and only clears the
fields each probe is authoritative for.

A second ClawSweeper P1 follow-up fixed the text renderer in
`src/commands/status.command-sections.ts`: the builtin formatter previously
overwrote the aggregate `available` flag with `storeAvailable`, so the new
`storeAvailable: true, semanticAvailable: false, available: false` tuple still
rendered as "vector store ready". The renderer now shows both facts independently
when store and semantic health are known.

## Why This Change Was Made

The `resolveMemoryManagerStatusSnapshot()` helper in the shared status scan code
wrapped vector probe calls in `try { ... } catch {}` — an empty catch that discarded
the probe's boolean return value and swallowed any exceptions. When the probe threw
before updating internal state (e.g. `withManagerOperation` throwing on a closed
manager), the subsequent `manager.status()` call returned pre-probe state, hiding
the failure entirely.

The fix stores the probe's authoritative boolean result and, when negative, hardens
only the vector fields the failed probe is authoritative for:

- **Dedicated store probe fails** (`probeVectorStoreAvailability` present on builtin
  backend): clear `storeAvailable` only. Semantic availability and the aggregate
  `available` flag remain as reported by the manager.
- **Semantic/fallback probe fails** (`probeVectorAvailability` used for builtin
  without store probe or for non-builtin backends): clear `semanticAvailable` and
  `available` only. `storeAvailable` is not touched because the probe never
  inspected the store.

The text status renderer was also updated so that a builtin backend with both
`storeAvailable` and `semanticAvailable` no longer substitutes store health for the
aggregate availability. Instead it renders both facts, e.g.
`vector store ready · semantic unavailable`, ensuring a healthy store cannot mask a
failed semantic probe.

## User Impact

Operators running `openclaw status` now see accurate vector health:

- A failed store probe reports `vector.storeAvailable: false` while leaving semantic
  state unchanged.
- A failed semantic probe reports `vector.semanticAvailable: false` and
  `vector.available: false` without falsely marking the vector store as down.
- For builtin memory when both store and semantic health are known, the text status
  row renders both facts independently (e.g. `vector store ready · semantic unavailable`)
  instead of showing only the store state.

Previously the command could either hide failures entirely (empty catch) or, in the
revised patch, misclassify a semantic failure as a store outage or mask it behind a
healthy store status.

## Evidence

### Before fix

```typescript
// src/commands/status.scan.shared.ts:444-452 (before)
try {
  const currentStatus = manager.status();
  if (currentStatus.backend === "builtin" && manager.probeVectorStoreAvailability) {
    await manager.probeVectorStoreAvailability();   // return value discarded
  } else {
    await manager.probeVectorAvailability();         // return value discarded
  }
} catch {}                                           // empty catch swallows ALL errors
const status = manager.status();                     // may return pre-probe state
```

If the probe threw before updating `this.vector.available`, the status report showed
the old values — the operator saw no sign of trouble.

### After fix

The probe kind is tracked explicitly (`isStoreProbe`), and the hardened fields depend
on which probe failed:

```typescript
status.vector = {
  ...status.vector,
  storeAvailable: isStoreProbe ? false : status.vector.storeAvailable,
  semanticAvailable: isStoreProbe ? status.vector.semanticAvailable : false,
  available: isStoreProbe ? status.vector.available : false,
};
```

The text renderer distinguishes builtin store and semantic health:

```typescript
// src/commands/status.command-sections.ts
if (isBuiltinWithIndependentVectorHealth) {
  const storeState = vector.storeAvailable === true ? "ready" : "unavailable";
  const semanticState = vector.semanticAvailable === true ? "ready" : "unavailable";
  label = `${prefix} ${storeState} · semantic ${semanticState}`;
  // ... tone warns if either fact is false
}
```

Focused regression tests cover each probe-kind failure path and the renderer:

- Store probe throws → `vector.storeAvailable` is hardened to `false`, semantic
  availability is preserved.
- Builtin fallback (semantic) probe throws without optional store probe →
  `vector.semanticAvailable` and `vector.available` are hardened to `false`,
  `vector.storeAvailable` stays `true`.
- Semantic probe throws on non-builtin backend → `vector.semanticAvailable` and
  `vector.available` are hardened to `false`.
- Builtin renderer with healthy store and failed semantic probe → text status shows
  `vector store ready · semantic unavailable` with a warn tone.

```
$ node scripts/run-vitest.mjs src/commands/status.scan.shared.test.ts src/commands/status.command-sections.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts

 RUN  v4.1.10 /home/0668000452/codes/OPENSOURCES/openclaw

 ✓ |unit-fast| src/commands/status.command-sections.test.ts (12 tests) 14ms

 Test Files  1 passed (1)
      Tests  12 passed (12)

[test] starting test/vitest/vitest.commands.config.ts

 RUN  v4.1.10 /home/0668000452/codes/OPENSOURCES/openclaw

 ✓ |commands| src/commands/status.scan.shared.test.ts (27 tests) 3024ms

 Test Files  1 passed (1)
      Tests  27 passed (27)

[test] passed 2 Vitest shards in 29.48s
```

Additional checks:

```
$ git diff --check
# no whitespace errors

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
    src/commands/status.command-sections.ts src/commands/status.command-sections.test.ts \
    src/commands/status.scan.shared.ts src/commands/status.scan.shared.test.ts
Found 0 warnings and 0 errors.

$ pnpm exec oxfmt --check \
    src/commands/status.command-sections.ts src/commands/status.command-sections.test.ts \
    src/commands/status.scan.shared.ts src/commands/status.scan.shared.test.ts
All matched files use the correct format.
```

### CI proof: vector probe silent failure fix

Proved the fix at exact heads by running the same standalone real-behavior
harness against `openclaw/openclaw` `main` (BEFORE) and the rebased PR head
(AFTER). The harness creates a real `MemoryIndexManager`, warms the store probe
so the manager records healthy store state, drops the optional store probe,
forces the semantic probe to throw, and then calls the production
`resolveSharedMemoryStatusSnapshot` and `buildStatusMemoryValue` paths. Vitest
runs the harness without mocks on the probe/status path itself.

This revision was rebased onto the latest `openclaw/openclaw` `main`; during
rebase `MemoryProviderStatus.backend` narrowed to the literal `"builtin"`, so
the rebased tests no longer use the removed `"qmd"` fixture backend and the
non-builtin renderer test was adjusted to exercise the builtin aggregate-health
fallback path.

- Before (main): `4d606ecb`
- After (PR head): `7bf93a8f`
- Proof branch: `xialonglee/openclaw@fix/gap-vector-probe-silent-fail-proof`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/31555593405
- Artifact download URL: https://github.com/xialonglee/openclaw/actions/runs/31555593405/artifacts/9126046468

**Before fix** — semantic probe failure swallowed; renderer masks semantic unavailability:

```
[proof] scene=real-semantic-probe-throw storeAvailable=true semanticAvailable=undefined available=undefined
[proof] scene=renderer-independent-health value=1 files · 2 chunks · plugin memory-core · ok(vector store ready)
```

**After fix** — semantic probe failure hardens only authoritative fields; renderer shows both facts:

```
[proof] scene=real-semantic-probe-throw storeAvailable=true semanticAvailable=false available=false
[proof] scene=renderer-independent-health value=1 files · 2 chunks · plugin memory-core · warn(vector store ready · semantic unavailable)
```

The focused regression unit tests from the PR description remain in the Evidence
section above as supplementary coverage.


### ClawSweeper P1 follow-up: guard the initial status read

The previous PR revision moved the first `manager.status()` call outside the
probe-failure catch. Because `MemoryIndexManager.status()` performs
SQLite-backed reads, a transient read error could abort `openclaw status --all`
instead of being tolerated like on current `main`. The branch has been rebased
onto current `openclaw/openclaw` `main` and the initial read is now guarded:

```typescript
// src/commands/status.scan.shared.ts
let storeProbeFn: (() => Promise<boolean>) | undefined;
try {
  const currentStatus = manager.status();
  storeProbeFn =
    currentStatus.backend === "builtin"
      ? manager.probeVectorStoreAvailability?.bind(manager)
      : undefined;
} catch {
  // First status read can fail transiently (SQLite I/O); fall through
  // to the semantic probe. The second status() below still returns
  // whatever state it can.
}
```

A focused regression test verifies the guarded path: the first `status()` call
throws, the second succeeds, the scan returns a snapshot instead of escaping,
and the fallback semantic probe is used.

```
$ node scripts/run-vitest.mjs src/commands/status.scan.shared.test.ts --reporter=verbose -t "survives when the first manager.status() throws then succeeds"
✓ |commands| src/commands/status.scan.shared.test.ts > resolveSharedMemoryStatusSnapshot > survives when the first manager.status() throws then succeeds 45ms
Test Files  1 passed (1)
Tests  1 passed | 27 skipped (28)
```

### Store-probe failure boundary proof

The dedicated store-probe throw path is exercised through the production
`resolveSharedMemoryStatusSnapshot` seam with a manager object whose
`probeVectorStoreAvailability` throws:

```
$ node scripts/run-vitest.mjs src/commands/status.scan.shared.test.ts --reporter=verbose -t "hardens vector.storeAvailable when builtin store probe throws"
✓ |commands| src/commands/status.scan.shared.test.ts > resolveSharedMemoryStatusSnapshot > hardens vector.storeAvailable when builtin store probe throws 60ms
Test Files  1 passed (1)
Tests  1 passed | 27 skipped (28)
```

### Telegram fallback-send failure proof

The Telegram fallback path is exercised through the production message processor,
asserting that a second send failure is routed through `runtime.error`:

```
$ node scripts/run-vitest.mjs extensions/telegram/src/bot-message.test.ts --reporter=verbose -t "logs the send failure when error fallback delivery also fails"
✓ |extension-telegram| ../../extensions/telegram/src/bot-message.test.ts > telegram bot message processor > logs the send failure when error fallback delivery also fails 31ms
Test Files  1 passed (1)
Tests  1 passed | 24 skipped (25)
```

### Full focused suites (after rebase)

```
$ node scripts/run-vitest.mjs src/commands/status.scan.shared.test.ts src/commands/status.command-sections.test.ts
✓ |unit-fast| src/commands/status.command-sections.test.ts (12 tests)
✓ |commands| src/commands/status.scan.shared.test.ts (28 tests)
[test] passed 2 Vitest shards in 31.94s

$ pnpm test extensions/telegram/src/bot-message.test.ts
✓ |extension-telegram| extensions/telegram/src/bot-message.test.ts (25 tests)
[test] passed 1 Vitest shard in 27.19s

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <changed-files>
Found 0 warnings and 0 errors.

$ pnpm exec oxfmt --check <changed-files>
All matched files use the correct format.
```

