### PR TITLE
feat(release): define gateway node compatibility evidence

### DIFF
--- a/packages/gateway-client/README.md
+++ b/packages/gateway-client/README.md
@@ -9,6 +9,9 @@ The current wire protocol is version 4. General clients must negotiate v4 with
 `minProtocol: 4` and `maxProtocol: 4`. See the
 [Gateway protocol specification](https://docs.openclaw.ai/gateway/protocol) for
 the complete handshake, authentication, role, scope, and method contracts.
+Exact node identities (`role: "node"` plus `mode: "node"`) and probe clients
+default to `[3, 4]`; explicit `minProtocol` and `maxProtocol` values override
+these derived defaults.
 
 ## Versioning
 

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -17,7 +17,12 @@ import type {
   HelloOk,
 } from "@openclaw/gateway-protocol/frame-guards";
 import { resolveGatewayStartupRetryAfterMs } from "@openclaw/gateway-protocol/startup-unavailable";
-import { MIN_CLIENT_PROTOCOL_VERSION, PROTOCOL_VERSION } from "@openclaw/gateway-protocol/version";
+import {
+  MIN_CLIENT_PROTOCOL_VERSION,
+  MIN_NODE_PROTOCOL_VERSION,
+  MIN_PROBE_PROTOCOL_VERSION,
+  PROTOCOL_VERSION,
+} from "@openclaw/gateway-protocol/version";
 import { isLoopbackIpAddress, type ParsedIpAddress } from "@openclaw/net-policy/ip";
 import { isWssUrl } from "@openclaw/net-policy/url-protocol";
 import { WebSocket, type ClientOptions, type CertMeta } from "ws";
@@ -771,10 +776,20 @@ export class GatewayClient {
       defaultScopes: ["operator.admin"],
     });
     const platform = this.opts.platform ?? process.platform;
+    const clientMode = this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND;
+    // Match server admission: only probes and exact node role+mode identities
+    // may advertise specialized floors; every other client stays current-only.
+    const minProtocol =
+      this.opts.minProtocol ??
+      (clientMode === GATEWAY_CLIENT_MODES.PROBE
+        ? MIN_PROBE_PROTOCOL_VERSION
+        : role === "node" && clientMode === GATEWAY_CLIENT_MODES.NODE
+          ? MIN_NODE_PROTOCOL_VERSION
+          : MIN_CLIENT_PROTOCOL_VERSION);
 
     return {
       params: {
-        minProtocol: this.opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
+        minProtocol,
         maxProtocol: this.opts.maxProtocol ?? PROTOCOL_VERSION,
         client: {
           id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
@@ -782,7 +797,7 @@ export class GatewayClient {
           version: this.opts.clientVersion ?? DEFAULT_CLIENT_VERSION,
           platform,
           deviceFamily: this.opts.deviceFamily,
-          mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
+          mode: clientMode,
           instanceId: this.opts.instanceId,
         },
         caps: Array.isArray(this.opts.caps) ? this.opts.caps : [],
@@ -802,6 +817,7 @@ export class GatewayClient {
           signatureToken,
           signedAtMs,
           platform,
+          clientMode,
         }),
       },
       authApprovalRuntimeToken,
@@ -819,17 +835,18 @@ export class GatewayClient {
     signatureToken: string | undefined;
     signedAtMs: number;
     platform: string;
+    clientMode: GatewayClientMode;
   }): ConnectParams["device"] {
     if (!this.opts.deviceIdentity) {
       return undefined;
     }
-    const { nonce, role, scopes, signatureToken, signedAtMs, platform } = params;
+    const { nonce, role, scopes, signatureToken, signedAtMs, platform, clientMode } = params;
     // The signed payload mirrors server verification exactly; keep metadata
     // normalized here so different hosts sign the same logical device facts.
     const payload = buildDeviceAuthPayloadV3({
       deviceId: this.opts.deviceIdentity.deviceId,
       clientId: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-      clientMode: this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
+      clientMode,
       role,
       scopes,
       signedAtMs,

--- a/packages/gateway-protocol/CHANGELOG.md
+++ b/packages/gateway-protocol/CHANGELOG.md
@@ -23,7 +23,7 @@ Wire contract:
   client identity, `caps`, `commands`, `permissions`, `role`/`scopes`, optional signed
   `device` identity, and an `auth` bag: token / bootstrapToken / deviceToken / password /
   approvalRuntimeToken / agentRuntimeIdentityToken).
-- Server replies `hello-ok` with the negotiated `protocol`, server identity, the live
+- Server replies `hello-ok` with its current `protocol`, server identity, the live
   `features` map (`methods`, `events`, `capabilities`), initial `snapshot`, minted `auth`
   device tokens, and connection `policy` (maxPayload / maxBufferedBytes / tickIntervalMs).
 - Server events: `tick` heartbeat and `shutdown` notice; event frames may carry `seq`

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -72,7 +72,7 @@ export const ConnectParamsSchema = closedObject({
   userAgent: Type.Optional(Type.String()),
 });
 
-/** Successful gateway hello response with negotiated protocol and initial state. */
+/** Successful gateway hello response with the server protocol and initial state. */
 export const HelloOkSchema = closedObject({
   type: Type.Literal("hello-ok"),
   protocol: Type.Integer({ minimum: 1 }),

--- a/qa/scenarios/runtime/gateway-node-control-plane.yaml
+++ b/qa/scenarios/runtime/gateway-node-control-plane.yaml
@@ -12,12 +12,15 @@ scenario:
       - gateway.node-actions
       - gateway.node-events
       - gateway.remote-device-capabilities
+      - gateway.version-negotiation
   objective: Verify a real authenticated Gateway pairs and operates a remote device through the node WebSocket control plane.
   successCriteria:
     - A real child Gateway accepts an authenticated operator and pairs an isolated iOS node identity over WebSocket.
     - Approved reconnect declarations appear in node.list and node.describe with the effective capabilities, commands, permissions, name, platform, and connected state.
     - Exact camera.list and location.get requests and results cross the same node.invoke and node.invoke.result socket boundary.
     - A node.presence.alive event is persisted and becomes visible through both node.list and node.describe.
+    - A synthetic overlap fixture records the default node-role and node-mode v3-through-v4 envelope and rejects the current-only operator envelope; shipped-v3 peer behavior is outside this scenario.
+    - One paired current GatewayClient remains usable across v3-only and v4 envelopes, with plugin features hidden and restored according to the advertised envelope.
   docsRefs:
     - docs/gateway/protocol.md
     - docs/nodes/index.md
@@ -29,4 +32,4 @@ scenario:
   execution:
     kind: vitest
     path: test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
-    summary: Start a real child Gateway, pair an iOS node WebSocket, inspect inventory and declarations, invoke camera and location commands, and persist node presence.
+    summary: Capture the default node v3-through-v4 connect envelope with a synthetic overlap fixture, pair a current iOS client to a real child Gateway, verify v3-only filtering and reconnect behavior, invoke built-in and plugin commands, and persist node presence.

--- a/scripts/gateway-node-compat-evidence.d.mts
+++ b/scripts/gateway-node-compat-evidence.d.mts
@@ -1,0 +1,202 @@
+export const GATEWAY_NODE_COMPAT_SCHEMA: "openclaw.gateway-node-compat/v1";
+
+export type GatewayNodeKind = "android" | "ios" | "linux" | "macos" | "windows";
+
+export type GatewayNodeArchitecture = "arm64" | "x64";
+
+export type GatewayNodeCompatOutcome = "passed" | "protocol-mismatch";
+
+export type GatewayNodeCompatArtifactRole = "baseline" | "candidate";
+
+export type GatewayNodeCompatDirection =
+  | "baseline-gateway-baseline-node"
+  | "baseline-gateway-candidate-node"
+  | "baseline-gateway-disjoint-node"
+  | "candidate-gateway-baseline-node"
+  | "candidate-gateway-candidate-node"
+  | "candidate-gateway-disjoint-node";
+
+export type GatewayNodeCompatCaseContract = Readonly<{
+  direction: GatewayNodeCompatDirection;
+  outcome: GatewayNodeCompatOutcome;
+  gatewayArtifactRole: GatewayNodeCompatArtifactRole;
+  nodeArtifactRole: GatewayNodeCompatArtifactRole;
+}>;
+
+export const GATEWAY_NODE_COMPAT_CASE_CONTRACTS: readonly GatewayNodeCompatCaseContract[];
+
+export type GatewayNodeCompatArtifactIdentities = {
+  candidatePackageSha256: string;
+  baselinePackageSha256: string;
+};
+
+export type GatewayNodeCompatActionsArtifact = {
+  id: number;
+  name: string;
+  digest: `sha256:${string}`;
+  sizeBytes: number;
+  runId: string;
+  runAttempt: number;
+};
+
+export type GatewayNodeCompatPackagedArtifact = {
+  version: string;
+  sourceSha: string;
+  name: string;
+  sha256: string;
+  actionsArtifact: GatewayNodeCompatActionsArtifact;
+};
+
+export type GatewayNodeCompatInstalledRuntime = {
+  version: string;
+  sourceSha: string;
+  packageSha256: string;
+  identitySha256: string;
+};
+
+export type GatewayNodeCompatRuntimeBinding = {
+  packagedArtifact: GatewayNodeCompatPackagedArtifact;
+  installedRuntime: GatewayNodeCompatInstalledRuntime;
+};
+
+type GatewayNodeCompatNodeBase = GatewayNodeCompatRuntimeBinding & {
+  architecture: GatewayNodeArchitecture;
+};
+
+export type GatewayNodeCompatMobileNode =
+  | (GatewayNodeCompatNodeBase & {
+      kind: "android";
+      protocolClientId: "openclaw-android";
+    })
+  | (GatewayNodeCompatNodeBase & {
+      kind: "ios";
+      protocolClientId: "openclaw-ios";
+    });
+
+export type GatewayNodeCompatDesktopNode =
+  | (GatewayNodeCompatNodeBase & {
+      kind: "linux";
+      protocolClientId: "node-host";
+    })
+  | (GatewayNodeCompatNodeBase & {
+      kind: "macos";
+      protocolClientId: "openclaw-macos";
+    })
+  | (GatewayNodeCompatNodeBase & {
+      kind: "windows";
+      protocolClientId: "node-host";
+    });
+
+export type GatewayNodeCompatNode = GatewayNodeCompatMobileNode | GatewayNodeCompatDesktopNode;
+
+export type GatewayNodeCompatProtocol = {
+  gatewayProtocolVersion: number;
+  gatewayAcceptedNodeMin: number;
+  protocolClientAdvertisedMin: number;
+  protocolClientAdvertisedMax: number;
+  helloProtocol: number | null;
+};
+
+export type GatewayNodeCompatSystemWhichOperation = {
+  method: "node.invoke";
+  command: "system.which";
+  params: {
+    bins: string[];
+  };
+  ok: true;
+  result: {
+    bins: Record<string, string>;
+  };
+};
+
+export type GatewayNodeCompatDeviceInfoOperation = {
+  method: "node.invoke";
+  command: "device.info";
+  params: Record<string, never>;
+  ok: true;
+  result: {
+    systemName: string;
+    systemVersion: string;
+  };
+};
+
+export type GatewayNodeCompatOperation =
+  | GatewayNodeCompatSystemWhichOperation
+  | GatewayNodeCompatDeviceInfoOperation;
+
+export type GatewayNodeCompatProducer = {
+  repository: string;
+  workflowPath: string;
+  workflowSha: string;
+  runId: string;
+  runAttempt: number;
+  job: string;
+};
+
+type GatewayNodeCompatBase<TNode extends GatewayNodeCompatNode = GatewayNodeCompatNode> = {
+  schema: typeof GATEWAY_NODE_COMPAT_SCHEMA;
+  caseId: string;
+  direction: GatewayNodeCompatDirection;
+  connection: {
+    transport: "gateway-websocket";
+    role: "node";
+    mode: "node";
+  };
+  gateway: GatewayNodeCompatRuntimeBinding;
+  node: TNode;
+  protocol: GatewayNodeCompatProtocol;
+  producer: GatewayNodeCompatProducer;
+};
+
+type GatewayNodeCompatPassedFields = {
+  protocol: GatewayNodeCompatProtocol & { helloProtocol: number };
+  result: {
+    outcome: "passed";
+    startedAt: string;
+    completedAt: string;
+  };
+};
+
+export type GatewayNodeCompatPassedEvidence =
+  | (GatewayNodeCompatBase<GatewayNodeCompatMobileNode> &
+      GatewayNodeCompatPassedFields & {
+        operation: GatewayNodeCompatDeviceInfoOperation;
+      })
+  | (GatewayNodeCompatBase<GatewayNodeCompatDesktopNode> &
+      GatewayNodeCompatPassedFields & {
+        operation: GatewayNodeCompatSystemWhichOperation;
+      });
+
+export type GatewayNodeCompatMismatchEvidence = GatewayNodeCompatBase & {
+  protocol: GatewayNodeCompatProtocol & {
+    helloProtocol: null;
+  };
+  operation: null;
+  result: {
+    outcome: "protocol-mismatch";
+    failureCode: "PROTOCOL_MISMATCH";
+    failurePhase: "connect";
+    startedAt: string;
+    completedAt: string;
+  };
+};
+
+export type GatewayNodeCompatEvidence =
+  | GatewayNodeCompatPassedEvidence
+  | GatewayNodeCompatMismatchEvidence;
+
+export function buildGatewayNodeCompatCaseId(params: {
+  architecture: GatewayNodeArchitecture;
+  direction: GatewayNodeCompatDirection;
+  kind: GatewayNodeKind;
+}): string;
+
+export function validateGatewayNodeCompatEvidence(
+  value: unknown,
+  artifactIdentities: GatewayNodeCompatArtifactIdentities,
+): GatewayNodeCompatEvidence;
+
+export function canonicalizeGatewayNodeCompatEvidence(
+  value: unknown,
+  artifactIdentities: GatewayNodeCompatArtifactIdentities,
+): string;

--- a/scripts/gateway-node-compat-evidence.d.mts
+++ b/scripts/gateway-node-compat-evidence.d.mts
@@ -16,6 +16,16 @@ export type GatewayNodeCompatDirection =
   | "candidate-gateway-candidate-node"
   | "candidate-gateway-disjoint-node";
 
+export type GatewayNodeCompatPassedDirection = Exclude<
+  GatewayNodeCompatDirection,
+  "baseline-gateway-disjoint-node" | "candidate-gateway-disjoint-node"
+>;
+
+export type GatewayNodeCompatMismatchDirection = Extract<
+  GatewayNodeCompatDirection,
+  "baseline-gateway-disjoint-node" | "candidate-gateway-disjoint-node"
+>;
+
 export type GatewayNodeCompatCaseContract = Readonly<{
   direction: GatewayNodeCompatDirection;
   outcome: GatewayNodeCompatOutcome;
@@ -25,9 +35,14 @@ export type GatewayNodeCompatCaseContract = Readonly<{
 
 export const GATEWAY_NODE_COMPAT_CASE_CONTRACTS: readonly GatewayNodeCompatCaseContract[];
 
-export type GatewayNodeCompatArtifactIdentities = {
+export type GatewayNodeCompatArtifactIdentityPair = {
   candidatePackageSha256: string;
   baselinePackageSha256: string;
+};
+
+export type GatewayNodeCompatArtifactIdentities = {
+  gateway: GatewayNodeCompatArtifactIdentityPair;
+  node: GatewayNodeCompatArtifactIdentityPair;
 };
 
 export type GatewayNodeCompatActionsArtifact = {
@@ -133,10 +148,13 @@ export type GatewayNodeCompatProducer = {
   job: string;
 };
 
-type GatewayNodeCompatBase<TNode extends GatewayNodeCompatNode = GatewayNodeCompatNode> = {
+type GatewayNodeCompatBase<
+  TNode extends GatewayNodeCompatNode = GatewayNodeCompatNode,
+  TDirection extends GatewayNodeCompatDirection = GatewayNodeCompatDirection,
+> = {
   schema: typeof GATEWAY_NODE_COMPAT_SCHEMA;
   caseId: string;
-  direction: GatewayNodeCompatDirection;
+  direction: TDirection;
   connection: {
     transport: "gateway-websocket";
     role: "node";
@@ -158,16 +176,19 @@ type GatewayNodeCompatPassedFields = {
 };
 
 export type GatewayNodeCompatPassedEvidence =
-  | (GatewayNodeCompatBase<GatewayNodeCompatMobileNode> &
+  | (GatewayNodeCompatBase<GatewayNodeCompatMobileNode, GatewayNodeCompatPassedDirection> &
       GatewayNodeCompatPassedFields & {
         operation: GatewayNodeCompatDeviceInfoOperation;
       })
-  | (GatewayNodeCompatBase<GatewayNodeCompatDesktopNode> &
+  | (GatewayNodeCompatBase<GatewayNodeCompatDesktopNode, GatewayNodeCompatPassedDirection> &
       GatewayNodeCompatPassedFields & {
         operation: GatewayNodeCompatSystemWhichOperation;
       });
 
-export type GatewayNodeCompatMismatchEvidence = GatewayNodeCompatBase & {
+export type GatewayNodeCompatMismatchEvidence = GatewayNodeCompatBase<
+  GatewayNodeCompatNode,
+  GatewayNodeCompatMismatchDirection
+> & {
   protocol: GatewayNodeCompatProtocol & {
     helloProtocol: null;
   };

--- a/scripts/gateway-node-compat-evidence.mjs
+++ b/scripts/gateway-node-compat-evidence.mjs
@@ -17,15 +17,19 @@ import path from "node:path";
 import process from "node:process";
 import { TextDecoder, types as utilTypes } from "node:util";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
+import { writeFailedTrailer } from "./lib/failed-trailer.mjs";
 
 export const GATEWAY_NODE_COMPAT_SCHEMA = "openclaw.gateway-node-compat/v1";
 
+const CLI_TOOL = "gateway-node-compat-evidence";
 const MAX_INPUT_BYTES = 64 * 1024;
 const SOURCE_SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const ACTIONS_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
 const POSITIVE_DECIMAL_PATTERN = /^[1-9][0-9]*$/u;
 const PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_.-]+$/u;
+const WORKFLOW_PATH_PATTERN = /^\.github\/workflows\/[A-Za-z0-9][A-Za-z0-9_.-]*\.ya?ml$/u;
+const BIDI_CONTROL_PATTERN = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
 
 const NODE_KINDS = new Set(["android", "ios", "linux", "macos", "windows"]);
 const MOBILE_NODE_KINDS = new Set(["android", "ios"]);
@@ -61,8 +65,38 @@ const DEVICE_INFO_SYSTEM_NAMES = new Map([
 function hasControlCharacter(value) {
   return Array.from(value).some((character) => {
     const codePoint = character.codePointAt(0) ?? 0;
-    return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+    return (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029 ||
+      BIDI_CONTROL_PATTERN.test(character)
+    );
   });
+}
+
+function sanitizeDiagnosticText(value, maxLength) {
+  let formatted = "";
+  for (const character of String(value)) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const replacement =
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029 ||
+      BIDI_CONTROL_PATTERN.test(character)
+        ? " "
+        : character;
+    if (formatted.length + replacement.length > maxLength) {
+      break;
+    }
+    formatted += replacement;
+  }
+  return formatted;
+}
+
+function appendDiagnosticPath(label, key) {
+  return sanitizeDiagnosticText(`${label}.${String(key)}`, 512);
 }
 
 function requireObject(value, label) {
@@ -96,7 +130,7 @@ function assertExactKeys(value, label, requiredKeys) {
   }
   for (const key of Reflect.ownKeys(value)) {
     if (typeof key !== "string" || !allowedKeys.has(key)) {
-      throw new Error(`${label}.${String(key)} is not allowed`);
+      throw new Error(`${label}.${sanitizeDiagnosticText(key, 128)} is not allowed`);
     }
   }
 }
@@ -170,20 +204,8 @@ function requireRepository(value) {
 
 function requireWorkflowPath(value) {
   const workflowPath = requireString(value, "producer.workflowPath", 255);
-  if (workflowPath.includes("\\")) {
+  if (!WORKFLOW_PATH_PATTERN.test(workflowPath)) {
     throw new Error("producer.workflowPath is invalid");
-  }
-  const segments = workflowPath.split("/");
-  if (
-    segments.length < 3 ||
-    segments[0] !== ".github" ||
-    segments[1] !== "workflows" ||
-    !/\.ya?ml$/u.test(segments.at(-1) ?? "")
-  ) {
-    throw new Error("producer.workflowPath is invalid");
-  }
-  for (let index = 2; index < segments.length; index += 1) {
-    requirePathSegment(segments[index], `producer.workflowPath segment ${index - 1}`, 128);
   }
   return workflowPath;
 }
@@ -251,24 +273,25 @@ function assertJsonDataTree(value, label, seen = new WeakSet()) {
     if (arrayLength !== undefined && key === "length") {
       continue;
     }
+    const entryLabel = appendDiagnosticPath(label, key);
     if (typeof key !== "string") {
-      throw new Error(`${label}.${String(key)} must be a JSON data property`);
+      throw new Error(`${entryLabel} must be a JSON data property`);
     }
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (!descriptor?.enumerable) {
-      throw new Error(`${label}.${key} must be enumerable`);
+      throw new Error(`${entryLabel} must be enumerable`);
     }
     if (!("value" in descriptor)) {
-      throw new Error(`${label}.${key} must be a JSON data property`);
+      throw new Error(`${entryLabel} must be a JSON data property`);
     }
     if (arrayKeys) {
       const index = Number(key);
       if (!Number.isInteger(index) || index < 0 || index >= arrayLength || String(index) !== key) {
-        throw new Error(`${label}.${key} is not a valid array entry`);
+        throw new Error(`${entryLabel} is not a valid array entry`);
       }
       arrayKeys.add(index);
     }
-    assertJsonDataTree(descriptor.value, `${label}.${key}`, seen);
+    assertJsonDataTree(descriptor.value, entryLabel, seen);
   }
   if (arrayKeys && arrayKeys.size !== arrayLength) {
     throw new Error(`${label} must not contain sparse entries`);
@@ -336,28 +359,34 @@ function validateRuntimeBinding(value, label) {
   }
 }
 
-function validateArtifactIdentities(value) {
-  const identities = requireObject(value, "artifact identities");
-  assertExactKeys(identities, "artifact identities", [
-    "candidatePackageSha256",
-    "baselinePackageSha256",
-  ]);
+function validateArtifactIdentityPair(value, label) {
+  const identities = requireObject(value, label);
+  assertExactKeys(identities, label, ["candidatePackageSha256", "baselinePackageSha256"]);
   const candidatePackageSha256 = requirePattern(
     identities.candidatePackageSha256,
-    "artifact identities.candidatePackageSha256",
+    `${label}.candidatePackageSha256`,
     SHA256_PATTERN,
     64,
   );
   const baselinePackageSha256 = requirePattern(
     identities.baselinePackageSha256,
-    "artifact identities.baselinePackageSha256",
+    `${label}.baselinePackageSha256`,
     SHA256_PATTERN,
     64,
   );
   if (candidatePackageSha256 === baselinePackageSha256) {
-    throw new Error("candidate and baseline package identities must differ");
+    throw new Error(`${label} candidate and baseline package identities must differ`);
   }
   return { baselinePackageSha256, candidatePackageSha256 };
+}
+
+function validateArtifactIdentities(value) {
+  const identities = requireObject(value, "artifact identities");
+  assertExactKeys(identities, "artifact identities", ["gateway", "node"]);
+  return {
+    gateway: validateArtifactIdentityPair(identities.gateway, "artifact identities.gateway"),
+    node: validateArtifactIdentityPair(identities.node, "artifact identities.node"),
+  };
 }
 
 function validateRuntimeArtifactRole(value, label, role, artifactIdentities) {
@@ -484,11 +513,11 @@ function validateSystemWhichResult(value, requestedBins) {
     throw new Error("operation.result.bins must contain 1 to 32 resolved binaries");
   }
   for (const [bin, resolvedPath] of entries) {
-    requirePathSegment(bin, `operation.result.bins.${bin}`, 128);
-    if (!requestedBins.has(bin)) {
-      throw new Error(`operation.result.bins.${bin} was not requested`);
+    const normalizedBin = requirePathSegment(bin, "operation.result.bins key", 128);
+    if (!requestedBins.has(normalizedBin)) {
+      throw new Error(`operation.result.bins.${normalizedBin} was not requested`);
     }
-    requireString(resolvedPath, `operation.result.bins.${bin}`, 4096);
+    requireString(resolvedPath, `operation.result.bins.${normalizedBin}`, 4096);
   }
 }
 
@@ -606,9 +635,14 @@ function validateCaseArtifactRoles(evidence, contract, artifactIdentities) {
     evidence.gateway,
     "gateway",
     contract.gatewayArtifactRole,
-    artifactIdentities,
+    artifactIdentities.gateway,
   );
-  validateRuntimeArtifactRole(evidence.node, "node", contract.nodeArtifactRole, artifactIdentities);
+  validateRuntimeArtifactRole(
+    evidence.node,
+    "node",
+    contract.nodeArtifactRole,
+    artifactIdentities.node,
+  );
 }
 
 function validateOutcomeCoupling(evidence, protocol, outcome, nodeKind) {
@@ -761,7 +795,11 @@ function readEvidenceFile(filePath) {
     if (!Buffer.from(decoded, "utf8").equals(input)) {
       throw new Error("gateway-node compatibility evidence must be canonical UTF-8");
     }
-    return JSON.parse(decoded);
+    try {
+      return JSON.parse(decoded);
+    } catch {
+      throw new Error("gateway-node compatibility evidence must be valid JSON");
+    }
   } finally {
     closeSync(descriptor);
   }
@@ -809,26 +847,58 @@ function parseCanonicalizeArgs(args) {
 }
 
 function parseArtifactIdentityArgs(args) {
-  let candidatePackageSha256;
-  let baselinePackageSha256;
+  let gatewayCandidatePackageSha256;
+  let gatewayBaselinePackageSha256;
+  let nodeCandidatePackageSha256;
+  let nodeBaselinePackageSha256;
   const remaining = [];
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
-    if (argument === "--candidate-package-sha256" && candidatePackageSha256 === undefined) {
-      candidatePackageSha256 = args[++index];
-    } else if (argument === "--baseline-package-sha256" && baselinePackageSha256 === undefined) {
-      baselinePackageSha256 = args[++index];
+    if (
+      argument === "--gateway-candidate-package-sha256" &&
+      gatewayCandidatePackageSha256 === undefined
+    ) {
+      gatewayCandidatePackageSha256 = args[++index];
+    } else if (
+      argument === "--gateway-baseline-package-sha256" &&
+      gatewayBaselinePackageSha256 === undefined
+    ) {
+      gatewayBaselinePackageSha256 = args[++index];
+    } else if (
+      argument === "--node-candidate-package-sha256" &&
+      nodeCandidatePackageSha256 === undefined
+    ) {
+      nodeCandidatePackageSha256 = args[++index];
+    } else if (
+      argument === "--node-baseline-package-sha256" &&
+      nodeBaselinePackageSha256 === undefined
+    ) {
+      nodeBaselinePackageSha256 = args[++index];
     } else {
       remaining.push(argument);
     }
   }
-  if (!candidatePackageSha256 || !baselinePackageSha256) {
+  if (
+    !gatewayCandidatePackageSha256 ||
+    !gatewayBaselinePackageSha256 ||
+    !nodeCandidatePackageSha256 ||
+    !nodeBaselinePackageSha256
+  ) {
     throw new Error(
-      "candidate and baseline package SHA-256 identities are required for evidence validation",
+      "Gateway and node candidate and baseline package SHA-256 identities are required for evidence validation",
     );
   }
   return {
-    artifactIdentities: { baselinePackageSha256, candidatePackageSha256 },
+    artifactIdentities: {
+      gateway: {
+        baselinePackageSha256: gatewayBaselinePackageSha256,
+        candidatePackageSha256: gatewayCandidatePackageSha256,
+      },
+      node: {
+        baselinePackageSha256: nodeBaselinePackageSha256,
+        candidatePackageSha256: nodeCandidatePackageSha256,
+      },
+    },
     remaining,
   };
 }
@@ -849,34 +919,20 @@ async function main(args) {
     return;
   }
   throw new Error(
-    "usage: gateway-node-compat-evidence.mjs validate <file> | canonicalize --input <file> --output <file> --candidate-package-sha256 <sha256> --baseline-package-sha256 <sha256>",
+    "usage: gateway-node-compat-evidence.mjs validate <file> --gateway-candidate-package-sha256 <sha256> --gateway-baseline-package-sha256 <sha256> --node-candidate-package-sha256 <sha256> --node-baseline-package-sha256 <sha256> | canonicalize --input <file> --output <file> --gateway-candidate-package-sha256 <sha256> --gateway-baseline-package-sha256 <sha256> --node-candidate-package-sha256 <sha256> --node-baseline-package-sha256 <sha256>",
   );
 }
 
 function formatCliError(error) {
   const message = error instanceof Error ? error.message : String(error);
-  let formatted = "";
-  // Validation errors can echo hostile JSON keys, so strip terminal controls before stderr.
-  for (const character of message) {
-    const codePoint = character.codePointAt(0) ?? 0;
-    const replacement =
-      codePoint <= 0x1f ||
-      (codePoint >= 0x7f && codePoint <= 0x9f) ||
-      codePoint === 0x2028 ||
-      codePoint === 0x2029
-        ? " "
-        : character;
-    if (formatted.length + replacement.length > 512) {
-      break;
-    }
-    formatted += replacement;
-  }
-  return formatted;
+  // Validation errors can echo hostile JSON keys, so strip terminal and bidi controls.
+  return sanitizeDiagnosticText(message, 512);
 }
 
 if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   await main(process.argv.slice(2)).catch((/** @type {unknown} */ error) => {
     console.error(formatCliError(error));
     process.exitCode = 1;
+    writeFailedTrailer(CLI_TOOL, process.exitCode);
   });
 }

--- a/scripts/gateway-node-compat-evidence.mjs
+++ b/scripts/gateway-node-compat-evidence.mjs
@@ -1,0 +1,882 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { TextDecoder, types as utilTypes } from "node:util";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
+
+export const GATEWAY_NODE_COMPAT_SCHEMA = "openclaw.gateway-node-compat/v1";
+
+const MAX_INPUT_BYTES = 64 * 1024;
+const SOURCE_SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const ACTIONS_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
+const POSITIVE_DECIMAL_PATTERN = /^[1-9][0-9]*$/u;
+const PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_.-]+$/u;
+
+const NODE_KINDS = new Set(["android", "ios", "linux", "macos", "windows"]);
+const MOBILE_NODE_KINDS = new Set(["android", "ios"]);
+const ARCHITECTURES = new Set(["arm64", "x64"]);
+export const GATEWAY_NODE_COMPAT_CASE_CONTRACTS = Object.freeze(
+  [
+    ["baseline-gateway-baseline-node", "passed", "baseline", "baseline"],
+    ["baseline-gateway-candidate-node", "passed", "baseline", "candidate"],
+    ["baseline-gateway-disjoint-node", "protocol-mismatch", "baseline", "candidate"],
+    ["candidate-gateway-baseline-node", "passed", "candidate", "baseline"],
+    ["candidate-gateway-candidate-node", "passed", "candidate", "candidate"],
+    ["candidate-gateway-disjoint-node", "protocol-mismatch", "candidate", "candidate"],
+  ].map(([direction, outcome, gatewayArtifactRole, nodeArtifactRole]) =>
+    Object.freeze({ direction, outcome, gatewayArtifactRole, nodeArtifactRole }),
+  ),
+);
+const CASE_CONTRACTS_BY_DIRECTION = new Map(
+  GATEWAY_NODE_COMPAT_CASE_CONTRACTS.map((contract) => [contract.direction, contract]),
+);
+const OUTCOMES = new Set(GATEWAY_NODE_COMPAT_CASE_CONTRACTS.map((contract) => contract.outcome));
+const NODE_CLIENT_IDS = new Map([
+  ["android", "openclaw-android"],
+  ["ios", "openclaw-ios"],
+  ["linux", "node-host"],
+  ["macos", "openclaw-macos"],
+  ["windows", "node-host"],
+]);
+const DEVICE_INFO_SYSTEM_NAMES = new Map([
+  ["android", new Set(["Android"])],
+  ["ios", new Set(["iOS", "iPadOS"])],
+]);
+
+function hasControlCharacter(value) {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+  });
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function assertExactKeys(value, label, requiredKeys) {
+  const allowedKeys = new Set(requiredKeys);
+  for (const key of requiredKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) {
+      throw new Error(`${label}.${key} is required`);
+    }
+    if (!descriptor.enumerable) {
+      throw new Error(`${label}.${key} must be enumerable`);
+    }
+    if (!("value" in descriptor)) {
+      throw new Error(`${label}.${key} must be a JSON data property`);
+    }
+    if (
+      descriptor.value === undefined ||
+      typeof descriptor.value === "function" ||
+      typeof descriptor.value === "symbol" ||
+      typeof descriptor.value === "bigint"
+    ) {
+      throw new Error(`${label}.${key} must be JSON representable`);
+    }
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string" || !allowedKeys.has(key)) {
+      throw new Error(`${label}.${String(key)} is not allowed`);
+    }
+  }
+}
+
+function requireString(value, label, maxLength) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    value.trim() !== value ||
+    hasControlCharacter(value)
+  ) {
+    throw new Error(`${label} must be a bounded non-control string`);
+  }
+  return value;
+}
+
+function requireEnum(value, label, allowedValues) {
+  const normalized = requireString(value, label, 128);
+  if (!allowedValues.has(normalized)) {
+    throw new Error(`${label} is unsupported`);
+  }
+  return normalized;
+}
+
+function requirePattern(value, label, pattern, maxLength) {
+  const normalized = requireString(value, label, maxLength);
+  if (!pattern.test(normalized)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return normalized;
+}
+
+function requireArtifactName(value, label) {
+  const artifactName = requireString(value, label, 255);
+  if (
+    artifactName === "." ||
+    artifactName === ".." ||
+    artifactName.includes("/") ||
+    artifactName.includes("\\")
+  ) {
+    throw new Error(`${label} must be a basename`);
+  }
+  return artifactName;
+}
+
+function requirePathSegment(value, label, maxLength = 100) {
+  const segment = requireString(value, label, maxLength);
+  if (
+    segment === "." ||
+    segment === ".." ||
+    segment.includes("/") ||
+    segment.includes("\\") ||
+    !PATH_SEGMENT_PATTERN.test(segment)
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return segment;
+}
+
+function requireRepository(value) {
+  const repository = requireString(value, "producer.repository", 201);
+  const segments = repository.split("/");
+  if (segments.length !== 2) {
+    throw new Error("producer.repository is invalid");
+  }
+  requirePathSegment(segments[0], "producer.repository owner");
+  requirePathSegment(segments[1], "producer.repository name");
+  return repository;
+}
+
+function requireWorkflowPath(value) {
+  const workflowPath = requireString(value, "producer.workflowPath", 255);
+  if (workflowPath.includes("\\")) {
+    throw new Error("producer.workflowPath is invalid");
+  }
+  const segments = workflowPath.split("/");
+  if (
+    segments.length < 3 ||
+    segments[0] !== ".github" ||
+    segments[1] !== "workflows" ||
+    !/\.ya?ml$/u.test(segments.at(-1) ?? "")
+  ) {
+    throw new Error("producer.workflowPath is invalid");
+  }
+  for (let index = 2; index < segments.length; index += 1) {
+    requirePathSegment(segments[index], `producer.workflowPath segment ${index - 1}`, 128);
+  }
+  return workflowPath;
+}
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function requireCanonicalTimestamp(value, label) {
+  const timestamp = requireString(value, label, 32);
+  const parsed = new Date(timestamp);
+  if (!Number.isFinite(parsed.valueOf()) || parsed.toISOString() !== timestamp) {
+    throw new Error(`${label} must be a canonical ISO timestamp`);
+  }
+  return parsed.valueOf();
+}
+
+function assertSerializedSize(serialized) {
+  if (Buffer.byteLength(serialized, "utf8") > MAX_INPUT_BYTES) {
+    throw new Error(`gateway-node compatibility evidence exceeds ${MAX_INPUT_BYTES} bytes`);
+  }
+}
+
+function assertJsonDataTree(value, label, seen = new WeakSet()) {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    throw new Error(`${label} must be JSON representable`);
+  }
+  if (utilTypes.isProxy(value)) {
+    throw new Error(`${label} must use a plain JSON data container`);
+  }
+  if (seen.has(value)) {
+    throw new Error("gateway-node compatibility evidence must be JSON serializable");
+  }
+  seen.add(value);
+
+  const isArray = Array.isArray(value);
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== null && prototype !== (isArray ? Array.prototype : Object.prototype)) {
+    throw new Error(`${label} must use a plain JSON data container`);
+  }
+  for (
+    let currentPrototype = prototype;
+    currentPrototype;
+    currentPrototype = Object.getPrototypeOf(currentPrototype)
+  ) {
+    if (Object.getOwnPropertyDescriptor(currentPrototype, "toJSON")) {
+      throw new Error(`${label} must not inherit a JSON serialization hook`);
+    }
+  }
+
+  const arrayLength = isArray ? value.length : undefined;
+  const arrayKeys = arrayLength === undefined ? undefined : new Set();
+  for (const key of Reflect.ownKeys(value)) {
+    if (arrayLength !== undefined && key === "length") {
+      continue;
+    }
+    if (typeof key !== "string") {
+      throw new Error(`${label}.${String(key)} must be a JSON data property`);
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable) {
+      throw new Error(`${label}.${key} must be enumerable`);
+    }
+    if (!("value" in descriptor)) {
+      throw new Error(`${label}.${key} must be a JSON data property`);
+    }
+    if (arrayKeys) {
+      const index = Number(key);
+      if (!Number.isInteger(index) || index < 0 || index >= arrayLength || String(index) !== key) {
+        throw new Error(`${label}.${key} is not a valid array entry`);
+      }
+      arrayKeys.add(index);
+    }
+    assertJsonDataTree(descriptor.value, `${label}.${key}`, seen);
+  }
+  if (arrayKeys && arrayKeys.size !== arrayLength) {
+    throw new Error(`${label} must not contain sparse entries`);
+  }
+  seen.delete(value);
+}
+
+function assertInputSize(value) {
+  assertJsonDataTree(value, "gateway-node compatibility evidence");
+  let serialized;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new Error("gateway-node compatibility evidence must be JSON serializable");
+  }
+  if (serialized === undefined) {
+    throw new Error("gateway-node compatibility evidence must be JSON serializable");
+  }
+  assertSerializedSize(serialized);
+}
+
+function validateActionsArtifact(value, label) {
+  const artifact = requireObject(value, label);
+  assertExactKeys(artifact, label, ["id", "name", "digest", "sizeBytes", "runId", "runAttempt"]);
+  requirePositiveInteger(artifact.id, `${label}.id`);
+  requireArtifactName(artifact.name, `${label}.name`);
+  requirePattern(artifact.digest, `${label}.digest`, ACTIONS_DIGEST_PATTERN, 71);
+  requirePositiveInteger(artifact.sizeBytes, `${label}.sizeBytes`);
+  requirePattern(artifact.runId, `${label}.runId`, POSITIVE_DECIMAL_PATTERN, 32);
+  requirePositiveInteger(artifact.runAttempt, `${label}.runAttempt`);
+}
+
+function validatePackagedArtifact(value, label) {
+  const artifact = requireObject(value, label);
+  assertExactKeys(artifact, label, ["version", "sourceSha", "name", "sha256", "actionsArtifact"]);
+  requireString(artifact.version, `${label}.version`, 128);
+  requirePattern(artifact.sourceSha, `${label}.sourceSha`, SOURCE_SHA_PATTERN, 40);
+  requireArtifactName(artifact.name, `${label}.name`);
+  requirePattern(artifact.sha256, `${label}.sha256`, SHA256_PATTERN, 64);
+  validateActionsArtifact(artifact.actionsArtifact, `${label}.actionsArtifact`);
+}
+
+function validateInstalledRuntime(value, label) {
+  const runtime = requireObject(value, label);
+  assertExactKeys(runtime, label, ["version", "sourceSha", "packageSha256", "identitySha256"]);
+  requireString(runtime.version, `${label}.version`, 128);
+  requirePattern(runtime.sourceSha, `${label}.sourceSha`, SOURCE_SHA_PATTERN, 40);
+  requirePattern(runtime.packageSha256, `${label}.packageSha256`, SHA256_PATTERN, 64);
+  requirePattern(runtime.identitySha256, `${label}.identitySha256`, SHA256_PATTERN, 64);
+}
+
+function validateRuntimeBinding(value, label) {
+  const subject = requireObject(value, label);
+  assertExactKeys(subject, label, ["packagedArtifact", "installedRuntime"]);
+  validatePackagedArtifact(subject.packagedArtifact, `${label}.packagedArtifact`);
+  validateInstalledRuntime(subject.installedRuntime, `${label}.installedRuntime`);
+  if (subject.installedRuntime.version !== subject.packagedArtifact.version) {
+    throw new Error(`${label}.installedRuntime.version must match packaged artifact version`);
+  }
+  if (subject.installedRuntime.sourceSha !== subject.packagedArtifact.sourceSha) {
+    throw new Error(`${label}.installedRuntime.sourceSha must match packaged artifact sourceSha`);
+  }
+  if (subject.installedRuntime.packageSha256 !== subject.packagedArtifact.sha256) {
+    throw new Error(`${label}.installedRuntime.packageSha256 must match packaged artifact sha256`);
+  }
+}
+
+function validateArtifactIdentities(value) {
+  const identities = requireObject(value, "artifact identities");
+  assertExactKeys(identities, "artifact identities", [
+    "candidatePackageSha256",
+    "baselinePackageSha256",
+  ]);
+  const candidatePackageSha256 = requirePattern(
+    identities.candidatePackageSha256,
+    "artifact identities.candidatePackageSha256",
+    SHA256_PATTERN,
+    64,
+  );
+  const baselinePackageSha256 = requirePattern(
+    identities.baselinePackageSha256,
+    "artifact identities.baselinePackageSha256",
+    SHA256_PATTERN,
+    64,
+  );
+  if (candidatePackageSha256 === baselinePackageSha256) {
+    throw new Error("candidate and baseline package identities must differ");
+  }
+  return { baselinePackageSha256, candidatePackageSha256 };
+}
+
+function validateRuntimeArtifactRole(value, label, role, artifactIdentities) {
+  const expectedSha256 =
+    role === "candidate"
+      ? artifactIdentities.candidatePackageSha256
+      : artifactIdentities.baselinePackageSha256;
+  if (value.packagedArtifact.sha256 !== expectedSha256) {
+    throw new Error(`${label} artifact identity must match the ${role} package`);
+  }
+}
+
+function validateNode(value) {
+  const node = requireObject(value, "node");
+  assertExactKeys(node, "node", [
+    "kind",
+    "architecture",
+    "protocolClientId",
+    "packagedArtifact",
+    "installedRuntime",
+  ]);
+  const kind = requireEnum(node.kind, "node.kind", NODE_KINDS);
+  const architecture = requireEnum(node.architecture, "node.architecture", ARCHITECTURES);
+  const expectedClientId = NODE_CLIENT_IDS.get(kind);
+  if (node.protocolClientId !== expectedClientId) {
+    throw new Error(`${kind} nodes require protocol client ${expectedClientId}`);
+  }
+  validateRuntimeBinding(
+    {
+      packagedArtifact: node.packagedArtifact,
+      installedRuntime: node.installedRuntime,
+    },
+    "node",
+  );
+  return { architecture, kind };
+}
+
+function validateConnection(value) {
+  const connection = requireObject(value, "connection");
+  assertExactKeys(connection, "connection", ["transport", "role", "mode"]);
+  if (connection.transport !== "gateway-websocket") {
+    throw new Error("connection.transport must be gateway-websocket");
+  }
+  if (connection.role !== "node") {
+    throw new Error("connection.role must be node");
+  }
+  if (connection.mode !== "node") {
+    throw new Error("connection.mode must be node");
+  }
+}
+
+function validateProtocol(value) {
+  const protocol = requireObject(value, "protocol");
+  assertExactKeys(protocol, "protocol", [
+    "gatewayProtocolVersion",
+    "gatewayAcceptedNodeMin",
+    "protocolClientAdvertisedMin",
+    "protocolClientAdvertisedMax",
+    "helloProtocol",
+  ]);
+  const gatewayProtocolVersion = requirePositiveInteger(
+    protocol.gatewayProtocolVersion,
+    "protocol.gatewayProtocolVersion",
+  );
+  const gatewayAcceptedNodeMin = requirePositiveInteger(
+    protocol.gatewayAcceptedNodeMin,
+    "protocol.gatewayAcceptedNodeMin",
+  );
+  const protocolClientAdvertisedMin = requirePositiveInteger(
+    protocol.protocolClientAdvertisedMin,
+    "protocol.protocolClientAdvertisedMin",
+  );
+  const protocolClientAdvertisedMax = requirePositiveInteger(
+    protocol.protocolClientAdvertisedMax,
+    "protocol.protocolClientAdvertisedMax",
+  );
+  if (
+    gatewayAcceptedNodeMin !== gatewayProtocolVersion &&
+    gatewayAcceptedNodeMin !== gatewayProtocolVersion - 1
+  ) {
+    throw new Error(
+      "protocol.gatewayAcceptedNodeMin must equal protocol.gatewayProtocolVersion or its N-1 floor",
+    );
+  }
+  if (protocolClientAdvertisedMin > protocolClientAdvertisedMax) {
+    throw new Error(
+      "protocol.protocolClientAdvertisedMin must not exceed protocol.protocolClientAdvertisedMax",
+    );
+  }
+  if (protocol.helloProtocol !== null) {
+    requirePositiveInteger(protocol.helloProtocol, "protocol.helloProtocol");
+  }
+  return {
+    gatewayAcceptedNodeMin,
+    gatewayProtocolVersion,
+    protocolClientAdvertisedMax,
+    protocolClientAdvertisedMin,
+  };
+}
+
+function validateSystemWhichParams(value) {
+  const params = requireObject(value, "operation.params");
+  assertExactKeys(params, "operation.params", ["bins"]);
+  if (!Array.isArray(params.bins) || params.bins.length === 0 || params.bins.length > 32) {
+    throw new Error("operation.params.bins must contain 1 to 32 requested binaries");
+  }
+  const bins = new Set();
+  for (const [index, bin] of params.bins.entries()) {
+    const normalized = requirePathSegment(bin, `operation.params.bins.${index}`, 128);
+    if (bins.has(normalized)) {
+      throw new Error("operation.params.bins must not contain duplicates");
+    }
+    bins.add(normalized);
+  }
+  return bins;
+}
+
+function validateSystemWhichResult(value, requestedBins) {
+  const result = requireObject(value, "operation.result");
+  assertExactKeys(result, "operation.result", ["bins"]);
+  const bins = requireObject(result.bins, "operation.result.bins");
+  const entries = Object.entries(bins);
+  if (entries.length === 0 || entries.length > 32) {
+    throw new Error("operation.result.bins must contain 1 to 32 resolved binaries");
+  }
+  for (const [bin, resolvedPath] of entries) {
+    requirePathSegment(bin, `operation.result.bins.${bin}`, 128);
+    if (!requestedBins.has(bin)) {
+      throw new Error(`operation.result.bins.${bin} was not requested`);
+    }
+    requireString(resolvedPath, `operation.result.bins.${bin}`, 4096);
+  }
+}
+
+function validateDeviceInfoParams(value) {
+  const params = requireObject(value, "operation.params");
+  assertExactKeys(params, "operation.params", []);
+}
+
+function validateDeviceInfoResult(value, nodeKind) {
+  const result = requireObject(value, "operation.result");
+  assertExactKeys(result, "operation.result", ["systemName", "systemVersion"]);
+  const systemName = requireString(result.systemName, "operation.result.systemName", 128);
+  const expectedSystemNames = DEVICE_INFO_SYSTEM_NAMES.get(nodeKind);
+  if (!expectedSystemNames?.has(systemName)) {
+    throw new Error(
+      `${nodeKind} nodes require operation.result.systemName ${Array.from(expectedSystemNames ?? []).join(" or ")}`,
+    );
+  }
+  requireString(result.systemVersion, "operation.result.systemVersion", 128);
+}
+
+function validateOperation(value, nodeKind) {
+  const operation = requireObject(value, "operation");
+  assertExactKeys(operation, "operation", ["method", "command", "params", "ok", "result"]);
+  if (operation.method !== "node.invoke") {
+    throw new Error("operation.method must be node.invoke");
+  }
+  if (operation.ok !== true) {
+    throw new Error("operation.ok must be true");
+  }
+
+  if (MOBILE_NODE_KINDS.has(nodeKind)) {
+    if (operation.command !== "device.info") {
+      throw new Error(`${nodeKind} nodes require operation.command device.info`);
+    }
+    validateDeviceInfoParams(operation.params);
+    validateDeviceInfoResult(operation.result, nodeKind);
+    return;
+  }
+
+  if (operation.command !== "system.which") {
+    throw new Error(`${nodeKind} nodes require operation.command system.which`);
+  }
+  const requestedBins = validateSystemWhichParams(operation.params);
+  validateSystemWhichResult(operation.result, requestedBins);
+}
+
+function validateResult(value) {
+  const result = requireObject(value, "result");
+  const outcome = requireEnum(result.outcome, "result.outcome", OUTCOMES);
+  if (outcome === "passed") {
+    assertExactKeys(result, "result", ["outcome", "startedAt", "completedAt"]);
+  } else {
+    assertExactKeys(result, "result", [
+      "outcome",
+      "failureCode",
+      "failurePhase",
+      "startedAt",
+      "completedAt",
+    ]);
+  }
+  const startedAt = requireCanonicalTimestamp(result.startedAt, "result.startedAt");
+  const completedAt = requireCanonicalTimestamp(result.completedAt, "result.completedAt");
+  if (completedAt < startedAt) {
+    throw new Error("result.completedAt must not precede result.startedAt");
+  }
+  return outcome;
+}
+
+function validateProducer(value) {
+  const producer = requireObject(value, "producer");
+  assertExactKeys(producer, "producer", [
+    "repository",
+    "workflowPath",
+    "workflowSha",
+    "runId",
+    "runAttempt",
+    "job",
+  ]);
+  requireRepository(producer.repository);
+  requireWorkflowPath(producer.workflowPath);
+  requirePattern(producer.workflowSha, "producer.workflowSha", SOURCE_SHA_PATTERN, 40);
+  requirePattern(producer.runId, "producer.runId", POSITIVE_DECIMAL_PATTERN, 32);
+  requirePositiveInteger(producer.runAttempt, "producer.runAttempt");
+  requireString(producer.job, "producer.job", 128);
+}
+
+export function buildGatewayNodeCompatCaseId({ architecture, direction, kind }) {
+  return `${kind}-${architecture}-${direction}`;
+}
+
+function validateCaseContract(evidence, node, outcome) {
+  const caseId = requireString(evidence.caseId, "caseId", 128);
+  const direction = requireString(evidence.direction, "direction", 128);
+  const contract = CASE_CONTRACTS_BY_DIRECTION.get(direction);
+  if (!contract) {
+    throw new Error("direction is unsupported");
+  }
+  const expectedCaseId = buildGatewayNodeCompatCaseId({
+    architecture: node.architecture,
+    direction: contract.direction,
+    kind: node.kind,
+  });
+  if (caseId !== expectedCaseId) {
+    throw new Error(`caseId must be ${expectedCaseId} for direction ${contract.direction}`);
+  }
+  if (outcome !== contract.outcome) {
+    throw new Error(`${contract.direction} requires result.outcome ${contract.outcome}`);
+  }
+  return contract;
+}
+
+function validateCaseArtifactRoles(evidence, contract, artifactIdentities) {
+  validateRuntimeArtifactRole(
+    evidence.gateway,
+    "gateway",
+    contract.gatewayArtifactRole,
+    artifactIdentities,
+  );
+  validateRuntimeArtifactRole(evidence.node, "node", contract.nodeArtifactRole, artifactIdentities);
+}
+
+function validateOutcomeCoupling(evidence, protocol, outcome, nodeKind) {
+  // Gateway admission accepts the current protocol or the explicit N-1 node
+  // floor. These are two supported versions, not a continuous numeric range.
+  const advertisesAcceptedProtocol =
+    (protocol.protocolClientAdvertisedMin <= protocol.gatewayProtocolVersion &&
+      protocol.protocolClientAdvertisedMax >= protocol.gatewayProtocolVersion) ||
+    (protocol.protocolClientAdvertisedMin <= protocol.gatewayAcceptedNodeMin &&
+      protocol.protocolClientAdvertisedMax >= protocol.gatewayAcceptedNodeMin);
+
+  if (outcome === "passed") {
+    if (!advertisesAcceptedProtocol) {
+      throw new Error(
+        "passed evidence requires the advertised protocol range to include an accepted Gateway protocol",
+      );
+    }
+    if (evidence.protocol.helloProtocol !== protocol.gatewayProtocolVersion) {
+      throw new Error("passed evidence requires helloProtocol to equal gatewayProtocolVersion");
+    }
+    validateOperation(evidence.operation, nodeKind);
+    return;
+  }
+
+  if (evidence.protocol.helloProtocol !== null) {
+    throw new Error("protocol-mismatch evidence requires helloProtocol to be null");
+  }
+  if (evidence.operation !== null) {
+    throw new Error("protocol-mismatch evidence requires operation to be null");
+  }
+  if (evidence.result.failureCode !== "PROTOCOL_MISMATCH") {
+    throw new Error("protocol-mismatch evidence requires failureCode PROTOCOL_MISMATCH");
+  }
+  if (evidence.result.failurePhase !== "connect") {
+    throw new Error("protocol-mismatch evidence requires failurePhase connect");
+  }
+  if (advertisesAcceptedProtocol) {
+    throw new Error(
+      "protocol-mismatch evidence requires the advertised protocol range to exclude accepted Gateway protocols",
+    );
+  }
+}
+
+/**
+ * Validates one immutable, observed Gateway WebSocket node compatibility result.
+ *
+ * Artifact/run provenance is recorded here and independently verified by the
+ * release aggregator. Outcome authority comes from the observed invoke or
+ * structured connect rejection, never inferred protocol-range overlap.
+ */
+export function validateGatewayNodeCompatEvidence(value, artifactIdentities) {
+  assertInputSize(value);
+  const trustedArtifactIdentities = validateArtifactIdentities(artifactIdentities);
+  const evidence = requireObject(value, "gateway-node compatibility evidence");
+  assertExactKeys(evidence, "gateway-node compatibility evidence", [
+    "schema",
+    "caseId",
+    "direction",
+    "connection",
+    "gateway",
+    "node",
+    "protocol",
+    "operation",
+    "result",
+    "producer",
+  ]);
+  if (evidence.schema !== GATEWAY_NODE_COMPAT_SCHEMA) {
+    throw new Error("gateway-node compatibility evidence schema is unsupported");
+  }
+  validateConnection(evidence.connection);
+  validateRuntimeBinding(evidence.gateway, "gateway");
+  const node = validateNode(evidence.node);
+  const protocol = validateProtocol(evidence.protocol);
+  const outcome = validateResult(evidence.result);
+  validateProducer(evidence.producer);
+  const contract = validateCaseContract(evidence, node, outcome);
+  validateCaseArtifactRoles(evidence, contract, trustedArtifactIdentities);
+  validateOutcomeCoupling(evidence, protocol, outcome, node.kind);
+  assertSerializedSize(serializeCanonicalEvidence(evidence));
+  return evidence;
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, entry]) => [key, sortJson(entry)]),
+    );
+  }
+  return value;
+}
+
+function serializeCanonicalEvidence(value) {
+  return `${JSON.stringify(sortJson(value), null, 2)}\n`;
+}
+
+export function canonicalizeGatewayNodeCompatEvidence(value, artifactIdentities) {
+  const evidence = validateGatewayNodeCompatEvidence(value, artifactIdentities);
+  const serialized = serializeCanonicalEvidence(evidence);
+  validateGatewayNodeCompatEvidence(JSON.parse(serialized), artifactIdentities);
+  return serialized;
+}
+
+function readEvidenceFile(filePath) {
+  const pathStat = lstatSync(filePath);
+  if (!pathStat.isFile() || pathStat.isSymbolicLink()) {
+    throw new Error("gateway-node compatibility evidence input must be a regular file");
+  }
+  if (pathStat.size > MAX_INPUT_BYTES) {
+    throw new Error(`gateway-node compatibility evidence exceeds ${MAX_INPUT_BYTES} bytes`);
+  }
+
+  // Nonblocking, no-follow open closes the race where the checked path is
+  // replaced with a FIFO or symlink before the descriptor is acquired.
+  const descriptor = openSync(
+    filePath,
+    constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_NONBLOCK ?? 0),
+  );
+  try {
+    const stat = fstatSync(descriptor);
+    if (!stat.isFile()) {
+      throw new Error("gateway-node compatibility evidence input must be a regular file");
+    }
+    if (stat.size > MAX_INPUT_BYTES) {
+      throw new Error(`gateway-node compatibility evidence exceeds ${MAX_INPUT_BYTES} bytes`);
+    }
+    const buffer = Buffer.alloc(MAX_INPUT_BYTES + 1);
+    let totalBytes = 0;
+    while (totalBytes < buffer.length) {
+      const bytesRead = readSync(descriptor, buffer, totalBytes, buffer.length - totalBytes, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      totalBytes += bytesRead;
+    }
+    if (totalBytes > MAX_INPUT_BYTES) {
+      throw new Error(`gateway-node compatibility evidence exceeds ${MAX_INPUT_BYTES} bytes`);
+    }
+    const input = buffer.subarray(0, totalBytes);
+    let decoded;
+    try {
+      decoded = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(input);
+    } catch {
+      throw new Error("gateway-node compatibility evidence must be valid UTF-8");
+    }
+    if (!Buffer.from(decoded, "utf8").equals(input)) {
+      throw new Error("gateway-node compatibility evidence must be canonical UTF-8");
+    }
+    return JSON.parse(decoded);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function writeEvidenceFileAtomically(filePath, content) {
+  const directory = path.dirname(path.resolve(filePath));
+  const tempPath = path.join(
+    directory,
+    `.${path.basename(filePath)}.tmp-${process.pid}-${randomUUID()}`,
+  );
+  let descriptor;
+  try {
+    descriptor = openSync(tempPath, "wx", 0o600);
+    writeFileSync(descriptor, content, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(tempPath, filePath);
+  } finally {
+    if (descriptor !== undefined) {
+      closeSync(descriptor);
+    }
+    rmSync(tempPath, { force: true });
+  }
+}
+
+function parseCanonicalizeArgs(args) {
+  let input;
+  let output;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--input" && input === undefined) {
+      input = args[++index];
+    } else if (argument === "--output" && output === undefined) {
+      output = args[++index];
+    } else {
+      throw new Error(`unknown or incomplete argument: ${argument}`);
+    }
+  }
+  if (!input || !output) {
+    throw new Error("canonicalize requires --input <file> --output <file>");
+  }
+  return { input, output };
+}
+
+function parseArtifactIdentityArgs(args) {
+  let candidatePackageSha256;
+  let baselinePackageSha256;
+  const remaining = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--candidate-package-sha256" && candidatePackageSha256 === undefined) {
+      candidatePackageSha256 = args[++index];
+    } else if (argument === "--baseline-package-sha256" && baselinePackageSha256 === undefined) {
+      baselinePackageSha256 = args[++index];
+    } else {
+      remaining.push(argument);
+    }
+  }
+  if (!candidatePackageSha256 || !baselinePackageSha256) {
+    throw new Error(
+      "candidate and baseline package SHA-256 identities are required for evidence validation",
+    );
+  }
+  return {
+    artifactIdentities: { baselinePackageSha256, candidatePackageSha256 },
+    remaining,
+  };
+}
+
+async function main(args) {
+  const [command, ...commandArgs] = args;
+  const { artifactIdentities, remaining } = parseArtifactIdentityArgs(commandArgs);
+  if (command === "validate" && remaining.length === 1) {
+    validateGatewayNodeCompatEvidence(readEvidenceFile(remaining[0]), artifactIdentities);
+    console.log("valid");
+    return;
+  }
+  if (command === "canonicalize") {
+    const { input, output } = parseCanonicalizeArgs(remaining);
+    const evidence = readEvidenceFile(input);
+    const canonical = canonicalizeGatewayNodeCompatEvidence(evidence, artifactIdentities);
+    writeEvidenceFileAtomically(output, canonical);
+    return;
+  }
+  throw new Error(
+    "usage: gateway-node-compat-evidence.mjs validate <file> | canonicalize --input <file> --output <file> --candidate-package-sha256 <sha256> --baseline-package-sha256 <sha256>",
+  );
+}
+
+function formatCliError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  let formatted = "";
+  // Validation errors can echo hostile JSON keys, so strip terminal controls before stderr.
+  for (const character of message) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const replacement =
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+        ? " "
+        : character;
+    if (formatted.length + replacement.length > 512) {
+      break;
+    }
+    formatted += replacement;
+  }
+  return formatted;
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  await main(process.argv.slice(2)).catch((/** @type {unknown} */ error) => {
+    console.error(formatCliError(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -4,12 +4,16 @@ import { generateKeyPairSync } from "node:crypto";
 // proxy bypass setup, command dispatch, reconnect, and error handling.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_CLIENT_MODES } from "../../packages/gateway-protocol/src/client-info.js";
 import {
   MIN_CLIENT_PROTOCOL_VERSION,
+  MIN_NODE_PROTOCOL_VERSION,
+  MIN_PROBE_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
 } from "../../packages/gateway-protocol/src/index.js";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
+import type { GatewayClientOptions } from "./client.js";
 
 function waitForFast<T>(
   callback: () => T | Promise<T>,
@@ -1156,6 +1160,9 @@ describe("GatewayClient connect auth payload", () => {
       minProtocol?: number;
       maxProtocol?: number;
       scopes?: string[];
+      client?: {
+        mode?: string;
+      };
       auth?: {
         token?: string;
         bootstrapToken?: string;
@@ -1190,16 +1197,99 @@ describe("GatewayClient connect auth payload", () => {
     return parseConnectRequest(ws);
   }
 
-  it("advertises the default protocol compatibility range", () => {
-    const client = new GatewayClient({
-      url: "ws://127.0.0.1:18789",
-      deviceIdentity: null,
+  type ProtocolCompatibilityOptions = Pick<
+    GatewayClientOptions,
+    "role" | "mode" | "minProtocol" | "maxProtocol"
+  >;
+
+  const protocolCompatibilityCases = [
+    {
+      name: "general clients",
+      options: {},
+      expectedMinProtocol: MIN_CLIENT_PROTOCOL_VERSION,
+      expectedMaxProtocol: PROTOCOL_VERSION,
+    },
+    {
+      name: "exact node clients",
+      options: { role: "node", mode: GATEWAY_CLIENT_MODES.NODE },
+      expectedMinProtocol: MIN_NODE_PROTOCOL_VERSION,
+      expectedMaxProtocol: PROTOCOL_VERSION,
+    },
+    {
+      name: "node role without node mode",
+      options: { role: "node" },
+      expectedMinProtocol: MIN_CLIENT_PROTOCOL_VERSION,
+      expectedMaxProtocol: PROTOCOL_VERSION,
+    },
+    {
+      name: "node mode without node role",
+      options: { mode: GATEWAY_CLIENT_MODES.NODE },
+      expectedMinProtocol: MIN_CLIENT_PROTOCOL_VERSION,
+      expectedMaxProtocol: PROTOCOL_VERSION,
+    },
+    {
+      name: "probe clients",
+      options: { mode: GATEWAY_CLIENT_MODES.PROBE },
+      expectedMinProtocol: MIN_PROBE_PROTOCOL_VERSION,
+      expectedMaxProtocol: PROTOCOL_VERSION,
+    },
+    {
+      name: "explicit node minimum overrides",
+      options: {
+        role: "node",
+        mode: GATEWAY_CLIENT_MODES.NODE,
+        minProtocol: PROTOCOL_VERSION,
+      },
+      expectedMinProtocol: PROTOCOL_VERSION,
+      expectedMaxProtocol: PROTOCOL_VERSION,
+    },
+    {
+      name: "explicit node maximum overrides",
+      options: {
+        role: "node",
+        mode: GATEWAY_CLIENT_MODES.NODE,
+        maxProtocol: MIN_NODE_PROTOCOL_VERSION,
+      },
+      expectedMinProtocol: MIN_NODE_PROTOCOL_VERSION,
+      expectedMaxProtocol: MIN_NODE_PROTOCOL_VERSION,
+    },
+  ] satisfies Array<{
+    name: string;
+    options: ProtocolCompatibilityOptions;
+    expectedMinProtocol: number;
+    expectedMaxProtocol: number;
+  }>;
+
+  it.each(protocolCompatibilityCases)(
+    "advertises the protocol compatibility range for $name",
+    ({ options, expectedMinProtocol, expectedMaxProtocol }) => {
+      const client = new GatewayClient({
+        url: "ws://127.0.0.1:18789",
+        deviceIdentity: null,
+        ...options,
+      });
+
+      const { connect } = startClientAndConnect({ client });
+
+      expect(connect.params?.minProtocol).toBe(expectedMinProtocol);
+      expect(connect.params?.maxProtocol).toBe(expectedMaxProtocol);
+      client.stop();
+    },
+  );
+
+  it("signs device proof with the emitted node client mode", () => {
+    const signDevicePayload = vi.fn((_privateKeyPem: string, _payload: string) => "signature");
+    const client = createClientWithIdentity("device-node-mode", vi.fn(), {
+      role: "node",
+      mode: GATEWAY_CLIENT_MODES.NODE,
+      hostDeps: { signDevicePayload },
     });
 
     const { connect } = startClientAndConnect({ client });
+    const signedPayload = signDevicePayload.mock.calls[0]?.[1];
 
-    expect(connect.params?.minProtocol).toBe(MIN_CLIENT_PROTOCOL_VERSION);
-    expect(connect.params?.maxProtocol).toBe(PROTOCOL_VERSION);
+    expect(connect.params?.client?.mode).toBe(GATEWAY_CLIENT_MODES.NODE);
+    expect(signedPayload?.split("|")[3]).toBe(connect.params?.client?.mode);
     client.stop();
   });
 

--- a/src/gateway/server.node-version-mismatch.test.ts
+++ b/src/gateway/server.node-version-mismatch.test.ts
@@ -2,6 +2,7 @@
 // gateway accepts matching node hosts and rejects incompatible local runtimes.
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
+import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
 import { approveNodePairing, listNodePairing, requestNodePairing } from "../infra/node-pairing.js";
 import { configureNodeHost } from "../node-host/config.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -38,6 +39,7 @@ describe("node host version mismatch guard", () => {
 
   test("local node with matching released version connects successfully", async () => {
     // Use the actual gateway version so versions match
+    let helloProtocol: number | undefined;
     const client = await connectGatewayClient({
       url: `ws://127.0.0.1:${port}`,
       token: "secret",
@@ -49,8 +51,12 @@ describe("node host version mismatch guard", () => {
       mode: GATEWAY_CLIENT_MODES.NODE,
       scopes: [],
       commands: [],
+      onHelloOk: (hello) => {
+        helloProtocol = hello.protocol;
+      },
     });
     expect(client).toBeDefined();
+    expect(helloProtocol).toBe(PROTOCOL_VERSION);
     await client.stopAndWait({ timeoutMs: 2_000 });
   });
 

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -87,6 +87,7 @@ export async function sendGatewayHello(
   const controlUiWidgetKinds = listControlUiPluginWidgetKinds(helloOkAuthScopes);
   const helloOk = {
     type: "hello-ok",
+    // Admission already verified range overlap; this field reports the server's current protocol.
     protocol: PROTOCOL_VERSION,
     server: {
       version: resolveRuntimeServiceVersion(process.env),

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -1,10 +1,14 @@
 /** Tests node-host runner command parsing, timeout, and plugin dispatch behavior. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
-import type { GatewayClientOptions } from "../gateway/client.js";
+import { GatewayClientRequestError, type GatewayClientOptions } from "../gateway/client.js";
 import type { configureNodeHost } from "./config.js";
 import { startNodeHostMcpManager, type NodeHostMcpManager } from "./mcp.js";
 import { runNodeHost } from "./runner.js";
+
+const NODE_PLUGIN_TOOLS_UPDATE_METHOD = "node.pluginTools.update";
+const NODE_PROTOCOL_FEATURES_UPDATE_METHOD = "node.protocolFeatures.update";
+const NODE_SKILLS_UPDATE_METHOD = "node.skills.update";
 
 const mocks = vi.hoisted(() => ({
   capturedGatewayClientOptions: [] as GatewayClientOptions[],
@@ -66,6 +70,14 @@ vi.mock("../gateway/client-start-readiness.js", () => ({
 }));
 
 vi.mock("../gateway/client.js", () => ({
+  GatewayClientRequestError: class MockGatewayClientRequestError extends Error {
+    readonly gatewayCode: string;
+
+    constructor(params: { code: string; message: string }) {
+      super(params.message);
+      this.gatewayCode = params.code;
+    }
+  },
   GatewayClient: function GatewayClient(opts: GatewayClientOptions) {
     const client = {
       request: vi.fn(async () => ({})),
@@ -172,6 +184,45 @@ vi.mock("./runtime.js", async (importOriginal) => {
 function lastCapturedOptions(): GatewayClientOptions | undefined {
   const list = mocks.capturedGatewayClientOptions;
   return list[list.length - 1];
+}
+
+async function withReadyNodeHost(
+  runTest: (params: {
+    client: (typeof mocks.capturedGatewayClients)[number];
+    options: GatewayClientOptions | undefined;
+  }) => Promise<void>,
+): Promise<void> {
+  mocks.startGatewayClientWhenEventLoopReady.mockResolvedValueOnce({
+    ready: true,
+    aborted: false,
+    elapsedMs: 0,
+  });
+  const processOnceSpy = vi.spyOn(process, "once");
+  const previousExitCode = process.exitCode;
+  let running: Promise<void> | undefined;
+  try {
+    running = runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 });
+    await vi.waitFor(() => expect(mocks.availabilityChanged).toBeDefined());
+    const client = mocks.capturedGatewayClients[0];
+    if (!client) {
+      throw new Error("expected captured Gateway client");
+    }
+    await runTest({ client, options: lastCapturedOptions() });
+  } finally {
+    const onSigterm = processOnceSpy.mock.calls.find(([event]) => event === "SIGTERM")?.[1];
+    try {
+      onSigterm?.("SIGTERM");
+      await running;
+    } finally {
+      for (const [event, listener] of processOnceSpy.mock.calls) {
+        if ((event === "SIGINT" || event === "SIGTERM") && typeof listener === "function") {
+          process.off(event, listener);
+        }
+      }
+      process.exitCode = previousExitCode;
+      processOnceSpy.mockRestore();
+    }
+  }
 }
 
 describe("runNodeHost", () => {
@@ -494,7 +545,10 @@ describe("runNodeHost", () => {
 
     options?.onHelloOk?.({
       protocol: 1,
-      features: { methods: [], events: [] },
+      features: {
+        methods: [NODE_PROTOCOL_FEATURES_UPDATE_METHOD, NODE_PLUGIN_TOOLS_UPDATE_METHOD],
+        events: [],
+      },
     } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
 
     expect(client?.request).toHaveBeenCalledWith("node.pluginTools.update", {
@@ -507,6 +561,193 @@ describe("runNodeHost", () => {
           parameters: { type: "object", properties: {} },
         },
       ],
+    });
+  });
+
+  it("learns unsupported optional publications once per connection without a request flood", async () => {
+    mocks.nodeSkillDescriptors = [
+      {
+        name: "release-helper",
+        description: "Prepare a release",
+        content: "---\nname: release-helper\ndescription: Prepare a release\n---\n",
+      },
+    ];
+    await withReadyNodeHost(async ({ client, options }) => {
+      client.request.mockImplementation(async (method: string) => {
+        if (method === NODE_PLUGIN_TOOLS_UPDATE_METHOD || method === NODE_SKILLS_UPDATE_METHOD) {
+          throw new GatewayClientRequestError({
+            code: "INVALID_REQUEST",
+            message: `unknown method: ${method}`,
+          });
+        }
+        return {};
+      });
+      options?.onHelloOk?.({
+        protocol: 3,
+        features: { methods: ["health", "node.invoke.result", "node.event"], events: [] },
+      } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
+
+      for (let index = 0; index < 10; index += 1) {
+        mocks.availabilityChanged?.();
+      }
+
+      await vi.waitFor(() => {
+        expect(
+          client.request.mock.calls.filter(
+            ([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+          ),
+        ).toHaveLength(1);
+        expect(
+          client.request.mock.calls.filter(([method]) => method === NODE_SKILLS_UPDATE_METHOD),
+        ).toHaveLength(1);
+      });
+    });
+  });
+
+  it("treats exact v3 authorization failures as unsupported optional publications", async () => {
+    mocks.nodeSkillDescriptors = [
+      {
+        name: "release-helper",
+        description: "Prepare a release",
+        content: "---\nname: release-helper\ndescription: Prepare a release\n---\n",
+      },
+    ];
+    await withReadyNodeHost(async ({ client, options }) => {
+      client.request.mockImplementation(async (method: string) => {
+        if (method === NODE_PLUGIN_TOOLS_UPDATE_METHOD || method === NODE_SKILLS_UPDATE_METHOD) {
+          throw new GatewayClientRequestError({
+            code: "INVALID_REQUEST",
+            message: "unauthorized role: node",
+          });
+        }
+        return {};
+      });
+      options?.onHelloOk?.({
+        protocol: 3,
+        features: { methods: [], events: [] },
+      } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
+      await vi.waitFor(() => {
+        expect(
+          client.request.mock.calls.filter(
+            ([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+          ),
+        ).toHaveLength(1);
+      });
+
+      mocks.availabilityChanged?.();
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(
+        client.request.mock.calls.filter(([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD),
+      ).toHaveLength(1);
+      expect(
+        client.request.mock.calls.filter(([method]) => method === NODE_SKILLS_UPDATE_METHOD),
+      ).toHaveLength(1);
+
+      client.request.mockResolvedValue({});
+      options?.onClose?.(1000, "legacy gateway closed");
+      options?.onHelloOk?.({
+        protocol: 4,
+        features: { methods: [], events: [] },
+      } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
+
+      await vi.waitFor(() => {
+        expect(
+          client.request.mock.calls.filter(
+            ([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+          ),
+        ).toHaveLength(2);
+        expect(
+          client.request.mock.calls.filter(([method]) => method === NODE_SKILLS_UPDATE_METHOD),
+        ).toHaveLength(2);
+      });
+    });
+  });
+
+  it.each([
+    { protocol: 4, message: "unauthorized role: node", label: "exact v4 authorization" },
+    { protocol: 3, message: "unauthorized role: node ", label: "near-match v3 authorization" },
+  ])("fails closed without flooding on $label failures", async ({ protocol, message }) => {
+    await withReadyNodeHost(async ({ client, options }) => {
+      client.request.mockImplementation(async (method: string) => {
+        if (method === NODE_PLUGIN_TOOLS_UPDATE_METHOD) {
+          throw new GatewayClientRequestError({
+            code: "INVALID_REQUEST",
+            message,
+          });
+        }
+        return {};
+      });
+      options?.onHelloOk?.({
+        protocol,
+        features: { methods: [], events: [] },
+      } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
+      await vi.waitFor(() => {
+        expect(
+          client.request.mock.calls.filter(
+            ([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+          ),
+        ).toHaveLength(1);
+      });
+
+      for (let index = 0; index < 10; index += 1) {
+        mocks.availabilityChanged?.();
+      }
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(
+        client.request.mock.calls.filter(([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD),
+      ).toHaveLength(1);
+
+      mocks.nodePluginTools = [];
+      mocks.availabilityChanged?.();
+      await vi.waitFor(() => {
+        expect(
+          client.request.mock.calls.filter(
+            ([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+          ),
+        ).toHaveLength(2);
+      });
+      mocks.availabilityChanged?.();
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(
+        client.request.mock.calls.filter(([method]) => method === NODE_PLUGIN_TOOLS_UPDATE_METHOD),
+      ).toHaveLength(2);
+    });
+  });
+
+  it("publishes the latest inventory queued during a failed optional publication", async () => {
+    let rejectFirstPluginPublication: ((error: Error) => void) | undefined;
+    await withReadyNodeHost(async ({ client, options }) => {
+      client.request.mockImplementation((method: string) => {
+        if (method === NODE_PLUGIN_TOOLS_UPDATE_METHOD && !rejectFirstPluginPublication) {
+          return new Promise((_resolve, reject) => {
+            rejectFirstPluginPublication = reject;
+          });
+        }
+        return Promise.resolve({});
+      });
+      options?.onHelloOk?.({
+        protocol: 3,
+        features: { methods: [], events: [] },
+      } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
+      await vi.waitFor(() => expect(rejectFirstPluginPublication).toBeDefined());
+
+      mocks.nodePluginTools = [];
+      mocks.availabilityChanged?.();
+      rejectFirstPluginPublication?.(new Error("temporary publish failure"));
+
+      await vi.waitFor(() => {
+        expect(client.request).toHaveBeenCalledWith(NODE_PLUGIN_TOOLS_UPDATE_METHOD, {
+          tools: [],
+        });
+      });
     });
   });
 
@@ -524,7 +765,7 @@ describe("runNodeHost", () => {
       const client = mocks.capturedGatewayClients[0];
       lastCapturedOptions()?.onHelloOk?.({
         protocol: 1,
-        features: { methods: [], events: [] },
+        features: { methods: [NODE_PLUGIN_TOOLS_UPDATE_METHOD], events: [] },
       } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
       expect(client?.request).toHaveBeenCalledWith("node.pluginTools.update", {
         tools: [expect.objectContaining({ name: "remote_echo" })],
@@ -533,7 +774,9 @@ describe("runNodeHost", () => {
       mocks.nodePluginTools = [];
       mocks.availabilityChanged?.();
 
-      expect(client?.request).toHaveBeenLastCalledWith("node.pluginTools.update", { tools: [] });
+      await vi.waitFor(() => {
+        expect(client?.request).toHaveBeenLastCalledWith("node.pluginTools.update", { tools: [] });
+      });
       const onSigterm = processOnceSpy.mock.calls.find(([event]) => event === "SIGTERM")?.[1];
       onSigterm?.("SIGTERM");
       await running;
@@ -568,7 +811,7 @@ describe("runNodeHost", () => {
     );
     options?.onHelloOk?.({
       protocol: 1,
-      features: { methods: [], events: [] },
+      features: { methods: [NODE_SKILLS_UPDATE_METHOD], events: [] },
     } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
     expect(mocks.capturedGatewayClients[0]?.request).toHaveBeenCalledWith("node.skills.update", {
       skills: mocks.nodeSkillDescriptors,
@@ -586,7 +829,7 @@ describe("runNodeHost", () => {
     );
     lastCapturedOptions()?.onHelloOk?.({
       protocol: 1,
-      features: { methods: [], events: [] },
+      features: { methods: [NODE_SKILLS_UPDATE_METHOD], events: [] },
     } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
 
     expect(mocks.capturedGatewayClients[0]?.request).not.toHaveBeenCalledWith(
@@ -616,7 +859,7 @@ describe("runNodeHost", () => {
     expect(options?.commands).toContain("mcp.tools.call.v1");
     options?.onHelloOk?.({
       protocol: 1,
-      features: { methods: [], events: [] },
+      features: { methods: [NODE_PLUGIN_TOOLS_UPDATE_METHOD], events: [] },
     } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
     expect(mocks.capturedGatewayClients[0]?.request).toHaveBeenCalledWith(
       "node.pluginTools.update",
@@ -641,7 +884,7 @@ describe("runNodeHost", () => {
     await vi.waitFor(() => expect(lastCapturedOptions()).toBeDefined());
     lastCapturedOptions()?.onHelloOk?.({
       protocol: 1,
-      features: { methods: [], events: [] },
+      features: { methods: [NODE_PLUGIN_TOOLS_UPDATE_METHOD], events: [] },
     } as unknown as Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0]);
     expect(mocks.capturedGatewayClients[0]?.request).toHaveBeenCalledWith(
       "node.pluginTools.update",
@@ -663,10 +906,12 @@ describe("runNodeHost", () => {
       close: mocks.closeMcpManager,
     });
     await expect(running).rejects.toThrow("event loop readiness timeout");
-    expect(mocks.capturedGatewayClients[0]?.request).toHaveBeenLastCalledWith(
-      "node.pluginTools.update",
-      { tools: expect.arrayContaining([expect.objectContaining({ pluginId: "node-mcp" })]) },
-    );
+    await vi.waitFor(() => {
+      expect(mocks.capturedGatewayClients[0]?.request).toHaveBeenLastCalledWith(
+        "node.pluginTools.update",
+        { tools: expect.arrayContaining([expect.objectContaining({ pluginId: "node-mcp" })]) },
+      );
+    });
   });
 
   it.each([

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -1,4 +1,5 @@
 /** CLI runner for node-host stdin/stdout command dispatch. */
+import { isDeepStrictEqual } from "node:util";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -108,43 +109,56 @@ function handleNodeHostReconnectPaused(
   exit(1);
 }
 
-function isUnsupportedNodePluginToolsUpdateError(error: unknown): boolean {
+const NODE_PLUGIN_TOOLS_UPDATE_METHOD = "node.pluginTools.update";
+const NODE_PROTOCOL_FEATURES_UPDATE_METHOD = "node.protocolFeatures.update";
+const NODE_SKILLS_UPDATE_METHOD = "node.skills.update";
+
+function isExactUnknownMethodError(error: unknown, method: string): boolean {
   return (
     error instanceof GatewayClientRequestError &&
     error.gatewayCode === "INVALID_REQUEST" &&
-    error.message.includes("unknown method: node.pluginTools.update")
+    error.message === `unknown method: ${method}`
   );
 }
 
-function isUnsupportedNodeSkillsUpdateError(error: unknown): boolean {
+function isExactLegacyNodeAuthorizationError(error: unknown, gatewayProtocol: number): boolean {
   return (
+    gatewayProtocol === 3 &&
     error instanceof GatewayClientRequestError &&
     error.gatewayCode === "INVALID_REQUEST" &&
-    error.message.includes("unknown method: node.skills.update")
+    error.message === "unauthorized role: node"
   );
 }
 
-async function publishNodePluginTools(client: GatewayClient, tools: unknown[]): Promise<void> {
-  try {
-    await client.request("node.pluginTools.update", { tools });
-  } catch (error) {
-    if (isUnsupportedNodePluginToolsUpdateError(error)) {
-      return;
-    }
-    writeStderrLine(`node host plugin tool publish failed: ${String(error)}`);
+function classifyNodeMethodFailure(
+  error: unknown,
+  method: string,
+  gatewayProtocol: number,
+): "legacy-unsupported" | "rejected" | "transient" {
+  if (
+    isExactUnknownMethodError(error, method) ||
+    isExactLegacyNodeAuthorizationError(error, gatewayProtocol)
+  ) {
+    return "legacy-unsupported";
   }
+  if (error instanceof GatewayClientRequestError && error.gatewayCode === "INVALID_REQUEST") {
+    return "rejected";
+  }
+  return "transient";
 }
 
-async function publishNodeSkills(client: GatewayClient, skills: unknown[]): Promise<void> {
-  try {
-    await client.request("node.skills.update", { skills });
-  } catch (error) {
-    if (isUnsupportedNodeSkillsUpdateError(error)) {
-      return;
-    }
-    writeStderrLine(`node host skill publish failed: ${String(error)}`);
-  }
-}
+type NodeOptionalPublicationMethod =
+  | typeof NODE_PLUGIN_TOOLS_UPDATE_METHOD
+  | typeof NODE_SKILLS_UPDATE_METHOD;
+
+type NodeOptionalPublicationState = {
+  status: "unknown" | "supported" | "unsupported";
+  hasPending: boolean;
+  pendingParams?: unknown;
+  hasRejectedParams: boolean;
+  rejectedParams?: unknown;
+  inFlight?: Promise<void>;
+};
 
 async function resolveNodeHostGatewayCredentials(params: {
   config: OpenClawConfig;
@@ -224,15 +238,105 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const url = `${scheme}://${urlHost}:${port}${contextPath}`;
   let inventory: NodeHostInventory = preparedRuntime.initialInventory;
   let gatewayHelloReceived = false;
+  let gatewayConnectionGeneration = 0;
+  let connectedGatewayProtocol = 0;
+  let optionalPublicationStates = new Map<
+    NodeOptionalPublicationMethod,
+    NodeOptionalPublicationState
+  >();
+
+  const queueOptionalPublication = (
+    method: NodeOptionalPublicationMethod,
+    params: unknown,
+    label: string,
+  ): void => {
+    if (!gatewayHelloReceived) {
+      return;
+    }
+    const connectionGeneration = gatewayConnectionGeneration;
+    const gatewayProtocol = connectedGatewayProtocol;
+    let state = optionalPublicationStates.get(method);
+    if (!state) {
+      state = { status: "unknown", hasPending: false, hasRejectedParams: false };
+      optionalPublicationStates.set(method, state);
+    }
+    if (
+      state.status === "unsupported" ||
+      (state.hasRejectedParams && isDeepStrictEqual(state.rejectedParams, params))
+    ) {
+      return;
+    }
+    state.hasRejectedParams = false;
+    state.rejectedParams = undefined;
+    state.pendingParams = params;
+    state.hasPending = true;
+    if (state.inFlight) {
+      return;
+    }
+    const publish = async () => {
+      while (state.hasPending && state.status !== "unsupported") {
+        if (connectionGeneration !== gatewayConnectionGeneration) {
+          return;
+        }
+        const nextParams = state.pendingParams;
+        state.pendingParams = undefined;
+        state.hasPending = false;
+        try {
+          await client.request(method, nextParams);
+          state.status = "supported";
+          state.hasRejectedParams = false;
+          state.rejectedParams = undefined;
+        } catch (error) {
+          const failure = classifyNodeMethodFailure(error, method, gatewayProtocol);
+          if (failure === "legacy-unsupported") {
+            state.status = "unsupported";
+            state.pendingParams = undefined;
+            state.hasPending = false;
+          } else {
+            writeStderrLine(`node host ${label} publish failed: ${String(error)}`);
+            if (failure === "rejected") {
+              state.hasRejectedParams = true;
+              state.rejectedParams = nextParams;
+              if (state.hasPending && isDeepStrictEqual(state.pendingParams, nextParams)) {
+                state.pendingParams = undefined;
+                state.hasPending = false;
+              }
+            }
+          }
+        }
+      }
+    };
+    const inFlight = publish().finally(() => {
+      if (state.inFlight === inFlight) {
+        state.inFlight = undefined;
+        if (
+          state.hasPending &&
+          state.status !== "unsupported" &&
+          gatewayHelloReceived &&
+          connectionGeneration === gatewayConnectionGeneration
+        ) {
+          const pendingParams = state.pendingParams;
+          state.pendingParams = undefined;
+          state.hasPending = false;
+          queueOptionalPublication(method, pendingParams, label);
+        }
+      }
+    });
+    state.inFlight = inFlight;
+  };
 
   const publishInventory = () => {
     if (!gatewayHelloReceived) {
       return;
     }
     if (inventory.skills) {
-      void publishNodeSkills(client, inventory.skills);
+      queueOptionalPublication(NODE_SKILLS_UPDATE_METHOD, { skills: inventory.skills }, "skill");
     }
-    void publishNodePluginTools(client, inventory.pluginTools);
+    queueOptionalPublication(
+      NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+      { tools: inventory.pluginTools },
+      "plugin tool",
+    );
   };
 
   const client = new GatewayClient({
@@ -280,9 +384,12 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       }
       void activeRuntime.invoke(payload);
     },
-    onHelloOk: () => {
+    onHelloOk: (hello) => {
       writeStderrLine(`node host gateway connected: ${url}`);
+      gatewayConnectionGeneration += 1;
       gatewayHelloReceived = true;
+      connectedGatewayProtocol = hello.protocol;
+      optionalPublicationStates = new Map();
       publishInventory();
     },
     onConnectError: (err) => {
@@ -300,7 +407,10 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       });
     },
     onClose: (code, reason) => {
+      gatewayConnectionGeneration += 1;
       gatewayHelloReceived = false;
+      connectedGatewayProtocol = 0;
+      optionalPublicationStates.clear();
       activeRuntime.cancelAll();
       writeStderrLine(`node host gateway closed (${code}): ${reason}`);
     },
@@ -313,6 +423,8 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     },
     onManifestChanged: (manifest) => {
       gatewayHelloReceived = false;
+      connectedGatewayProtocol = 0;
+      optionalPublicationStates.clear();
       client.updateNodeManifest(manifest);
     },
   });

--- a/test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
@@ -1,14 +1,27 @@
 // Proves the Gateway node control plane across real authenticated WebSockets.
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { type RawData, WebSocketServer } from "ws";
 import { startQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../../../packages/gateway-protocol/src/client-info.js";
+import { ConnectErrorDetailCodes } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
+import {
+  ErrorCodes,
+  MIN_CLIENT_PROTOCOL_VERSION,
+  MIN_NODE_PROTOCOL_VERSION,
+  PROTOCOL_VERSION,
+  type HelloOk,
+} from "../../../../packages/gateway-protocol/src/index.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import {
   loadOrCreateDeviceIdentity,
   type DeviceIdentity,
@@ -24,8 +37,13 @@ const NODE_PERMISSIONS = {
   camera: true,
   location: true,
 };
+const FIXTURE_PLUGIN_ID = "qa-gateway-node-rolling-compat";
+const FIXTURE_CAPABILITY = "qa-rolling-surface";
+const FIXTURE_COMMAND = "qa.rolling.echo";
+const FIXTURE_ROUTE = "/qa-rolling-surface";
 
 type GatewayHandle = Awaited<ReturnType<typeof startQaGatewayChild>>;
+type GatewayConnection = Pick<GatewayHandle, "logs" | "runtimeEnv" | "token" | "wsUrl">;
 type NodeRead = {
   nodeId: string;
   displayName?: string;
@@ -51,6 +69,16 @@ type InvocationRecord = {
   nodeId: string;
   command: string;
   params: unknown;
+};
+type ConnectEnvelope = {
+  role: string;
+  mode: string;
+  minProtocol: number;
+  maxProtocol: number;
+};
+type StoppableClient = Pick<GatewayClient, "stopAndWait">;
+type StoppableFixture = {
+  stop: () => Promise<void>;
 };
 
 describe("Gateway node control plane", () => {
@@ -93,6 +121,7 @@ describe("Gateway node control plane", () => {
       });
       const invocations: InvocationRecord[] = [];
       const handlerErrors: Error[] = [];
+      const invocationResponses: Promise<void>[] = [];
       let operator: GatewayClient | undefined;
       let node: GatewayClient | undefined;
 
@@ -106,9 +135,12 @@ describe("Gateway node control plane", () => {
             if (event.event !== "node.invoke.request") {
               return;
             }
-            void respondToInvocation(node, event.payload, invocations).catch((error) => {
-              handlerErrors.push(error instanceof Error ? error : new Error(String(error)));
-            });
+            const response = respondToInvocation(node, event.payload, invocations).catch(
+              (error: unknown) => {
+                handlerErrors.push(error instanceof Error ? error : new Error(String(error)));
+              },
+            );
+            invocationResponses.push(response);
           },
         });
 
@@ -210,6 +242,7 @@ describe("Gateway node control plane", () => {
             params: locationParams,
           },
         ]);
+        await Promise.all(invocationResponses);
         expect(handlerErrors).toEqual([]);
 
         const aliveSentAtMs = Date.now();
@@ -260,6 +293,7 @@ describe("Gateway node control plane", () => {
           { timeout: REQUEST_TIMEOUT_MS, interval: 100 },
         );
       } finally {
+        await Promise.all(invocationResponses);
         await Promise.allSettled([
           ...(node ? [node.stopAndWait({ timeoutMs: 1_000 })] : []),
           ...(operator ? [operator.stopAndWait({ timeoutMs: 1_000 })] : []),
@@ -270,9 +304,327 @@ describe("Gateway node control plane", () => {
       }
     },
   );
+
+  it(
+    "captures the default node protocol envelope with a synthetic v3 overlap fixture",
+    { timeout: REQUEST_TIMEOUT_MS * 2 },
+    async () => {
+      expect(MIN_CLIENT_PROTOCOL_VERSION).toBe(PROTOCOL_VERSION);
+      expect(MIN_NODE_PROTOCOL_VERSION).toBeLessThan(PROTOCOL_VERSION);
+
+      const fixture = await startProtocolEnvelopeFixture();
+      let node: GatewayClient | undefined;
+      let fixtureHello: HelloOk | undefined;
+      try {
+        node = await connectClient({
+          gateway: fixture.gateway,
+          role: "node",
+          clientName: GATEWAY_CLIENT_NAMES.IOS_APP,
+          clientDisplayName: NODE_DISPLAY_NAME,
+          mode: GATEWAY_CLIENT_MODES.NODE,
+          platform: "ios",
+          deviceFamily: "iPhone",
+          scopes: [],
+          deviceIdentity: null,
+          onHelloOk: (value) => {
+            fixtureHello = value;
+          },
+        });
+
+        // hello.protocol reports the fixture Gateway's current server protocol.
+        expect(fixtureHello?.protocol).toBe(MIN_NODE_PROTOCOL_VERSION);
+        expect(fixture.connectFrames).toEqual([
+          {
+            role: "node",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+            minProtocol: MIN_NODE_PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+          },
+        ]);
+
+        await expect(connectOperator(fixture.gateway)).rejects.toThrow(/protocol mismatch/i);
+        expect(fixture.connectFrames).toEqual([
+          {
+            role: "node",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+            minProtocol: MIN_NODE_PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+          },
+          {
+            role: "operator",
+            mode: GATEWAY_CLIENT_MODES.BACKEND,
+            minProtocol: MIN_CLIENT_PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+          },
+        ]);
+      } finally {
+        await stopProtocolEnvelopeFixture(node, fixture);
+      }
+    },
+  );
+
+  it("stops the protocol fixture when client cleanup rejects", async () => {
+    const clientError = new Error("client cleanup failed");
+    const stopFixture = vi.fn(async () => {});
+
+    await expect(
+      stopProtocolEnvelopeFixture(
+        {
+          stopAndWait: vi.fn(async () => {
+            throw clientError;
+          }),
+        },
+        { stop: stopFixture },
+      ),
+    ).rejects.toBe(clientError);
+    expect(stopFixture).toHaveBeenCalledOnce();
+  });
+
+  it(
+    "keeps one paired current client usable across v3-only and v4 envelopes",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      expect(MIN_NODE_PROTOCOL_VERSION).toBe(3);
+      expect(PROTOCOL_VERSION).toBe(4);
+
+      const fixture = await createFixturePlugin();
+      let gateway: GatewayHandle | undefined;
+      let operator: GatewayClient | undefined;
+      let node: GatewayClient | undefined;
+      let proofError: unknown;
+      const cleanupErrors: unknown[] = [];
+      const invocations: InvocationRecord[] = [];
+      const handlerErrors: Error[] = [];
+      const invocationResponses: Promise<void>[] = [];
+
+      try {
+        gateway = await startQaGatewayChild({
+          repoRoot: process.cwd(),
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: ["--import", "tsx", "src/entry.ts"],
+            cwd: process.cwd(),
+            usePackagedPlugins: true,
+          },
+          transportBaseUrl: "http://127.0.0.1",
+          controlUiEnabled: false,
+          runtimeEnvPatch: {
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            OPENCLAW_SKIP_CHANNELS: "1",
+            OPENCLAW_SKIP_PROVIDERS: "1",
+            OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          },
+          mutateConfig: (cfg) => {
+            // Bundled plugins are disabled for this focused proof, so their
+            // configured slots cannot remain while the fixture plugin is merged.
+            const { slots: _bundledSlots, ...plugins } = cfg.plugins ?? {};
+            return withFixturePlugin(
+              {
+                ...cfg,
+                plugins,
+                gateway: {
+                  ...cfg.gateway,
+                  nodes: {
+                    ...cfg.gateway?.nodes,
+                    commands: { allow: ["camera.list", FIXTURE_COMMAND] },
+                  },
+                },
+              },
+              fixture.pluginDir,
+            );
+          },
+        });
+        const identity = loadOrCreateDeviceIdentity({
+          path: path.join(gateway.tempRoot, "rolling-compat-node.sqlite"),
+        });
+        const declaredCaps = ["camera", FIXTURE_CAPABILITY];
+        const declaredCommands = ["camera.list", FIXTURE_COMMAND];
+        const onEvent = (event: { event: string; payload?: unknown }) => {
+          if (event.event !== "node.invoke.request") {
+            return;
+          }
+          const response = respondToInvocation(node, event.payload, invocations).catch(
+            (error: unknown) => {
+              handlerErrors.push(error instanceof Error ? error : new Error(String(error)));
+            },
+          );
+          invocationResponses.push(response);
+        };
+
+        operator = await connectOperator(gateway);
+        let constrainedHello: HelloOk | undefined;
+        node = await connectPairedNode({
+          gateway,
+          identity,
+          operator,
+          caps: declaredCaps,
+          commands: declaredCommands,
+          minProtocol: MIN_NODE_PROTOCOL_VERSION,
+          maxProtocol: MIN_NODE_PROTOCOL_VERSION,
+          onEvent,
+          onHelloOk: (hello) => {
+            constrainedHello = hello;
+          },
+        });
+
+        // The client envelope is constrained to v3; hello reports the v4 server protocol.
+        expect(constrainedHello?.protocol).toBe(PROTOCOL_VERSION);
+        expect(constrainedHello?.pluginSurfaceUrls).toBeUndefined();
+        const legacyListed = await waitForApprovedNode(operator, identity.deviceId, gateway.logs);
+        expect(legacyListed.caps).toEqual(["camera"]);
+        expect(legacyListed.commands).toEqual(["camera.list"]);
+
+        const cameraParams = { includeUnavailable: false };
+        const cameraResult = await invokeNodeCommand({
+          operator,
+          nodeId: identity.deviceId,
+          command: "camera.list",
+          params: cameraParams,
+        });
+        expect(cameraResult).toMatchObject({
+          ok: true,
+          nodeId: identity.deviceId,
+          command: "camera.list",
+          payload: {
+            cameras: [{ id: "back-wide", position: "back" }],
+            received: cameraParams,
+          },
+        });
+
+        await Promise.all(invocationResponses);
+        expect(handlerErrors).toEqual([]);
+        await node.stopAndWait({ timeoutMs: 1_000 });
+        node = undefined;
+        await expectNoPendingPairing(operator, identity.deviceId);
+
+        let currentHello: HelloOk | undefined;
+        node = await connectClient({
+          gateway,
+          role: "node",
+          clientName: GATEWAY_CLIENT_NAMES.IOS_APP,
+          clientDisplayName: NODE_DISPLAY_NAME,
+          mode: GATEWAY_CLIENT_MODES.NODE,
+          platform: "ios",
+          deviceFamily: "iPhone",
+          scopes: [],
+          caps: declaredCaps,
+          commands: declaredCommands,
+          permissions: NODE_PERMISSIONS,
+          deviceIdentity: identity,
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+          onEvent,
+          onHelloOk: (hello) => {
+            currentHello = hello;
+          },
+        });
+
+        expect(currentHello?.protocol).toBe(PROTOCOL_VERSION);
+        const fixtureSurfaceUrl = currentHello?.pluginSurfaceUrls?.[FIXTURE_CAPABILITY];
+        if (!fixtureSurfaceUrl) {
+          throw new Error("v4 hello omitted the fixture plugin surface URL");
+        }
+        expect(new URL(fixtureSurfaceUrl).pathname).toMatch(/^\/__openclaw__\/cap\//);
+        const fixtureSurfaceResponse = await fetch(`${fixtureSurfaceUrl}${FIXTURE_ROUTE}`, {
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
+        expect(fixtureSurfaceResponse.status).toBe(204);
+        await expectNoPendingPairing(operator, identity.deviceId);
+        const currentListed = await waitForConnectedApprovedNode(
+          operator,
+          identity.deviceId,
+          gateway.logs,
+        );
+        expect(currentListed.caps?.toSorted()).toEqual(declaredCaps.toSorted());
+        expect(currentListed.commands?.toSorted()).toEqual(declaredCommands.toSorted());
+
+        const pluginParams = { message: "rolling-compatible" };
+        const pluginResult = await invokeNodeCommand({
+          operator,
+          nodeId: identity.deviceId,
+          command: FIXTURE_COMMAND,
+          params: pluginParams,
+        });
+        expect(pluginResult).toMatchObject({
+          ok: true,
+          nodeId: identity.deviceId,
+          command: FIXTURE_COMMAND,
+          payload: {
+            echoed: pluginParams,
+          },
+        });
+        expect(invocations).toMatchObject([
+          {
+            nodeId: identity.deviceId,
+            command: "camera.list",
+            params: cameraParams,
+          },
+          {
+            nodeId: identity.deviceId,
+            command: FIXTURE_COMMAND,
+            params: pluginParams,
+          },
+        ]);
+        await Promise.all(invocationResponses);
+        expect(handlerErrors).toEqual([]);
+      } catch (error) {
+        proofError = error;
+      } finally {
+        await Promise.all(invocationResponses);
+        const clientCleanup = await Promise.allSettled([
+          ...(node ? [node.stopAndWait({ timeoutMs: 1_000 })] : []),
+          ...(operator ? [operator.stopAndWait({ timeoutMs: 1_000 })] : []),
+        ]);
+        for (const result of clientCleanup) {
+          if (result.status === "rejected") {
+            cleanupErrors.push(result.reason);
+          }
+        }
+        if (gateway) {
+          const tempRoot = gateway.tempRoot;
+          try {
+            await gateway.stop();
+            expect(existsSync(tempRoot)).toBe(false);
+          } catch (error) {
+            cleanupErrors.push(error);
+          }
+        }
+        try {
+          await fixture.cleanup();
+          expect(existsSync(fixture.root)).toBe(false);
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      const failures = proofError === undefined ? cleanupErrors : [proofError, ...cleanupErrors];
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(failures, "gateway node rolling compatibility proof failed");
+      }
+    },
+  );
 });
 
-async function connectOperator(gateway: GatewayHandle): Promise<GatewayClient> {
+async function stopProtocolEnvelopeFixture(
+  node: StoppableClient | undefined,
+  fixture: StoppableFixture,
+): Promise<void> {
+  const results = await Promise.allSettled([
+    ...(node ? [node.stopAndWait({ timeoutMs: 1_000 })] : []),
+    fixture.stop(),
+  ]);
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "protocol envelope fixture cleanup failed");
+  }
+}
+
+async function connectOperator(gateway: GatewayConnection): Promise<GatewayClient> {
   return await connectClient({
     gateway,
     role: "operator",
@@ -285,10 +637,15 @@ async function connectOperator(gateway: GatewayHandle): Promise<GatewayClient> {
 }
 
 async function connectPairedNode(params: {
-  gateway: GatewayHandle;
+  gateway: GatewayConnection;
   identity: DeviceIdentity;
   operator: GatewayClient;
+  caps?: string[];
+  commands?: string[];
+  minProtocol?: number;
+  maxProtocol?: number;
   onEvent: (event: { event: string; payload?: unknown }) => void;
+  onHelloOk?: (hello: HelloOk) => void;
 }): Promise<GatewayClient> {
   const connect = () =>
     connectClient({
@@ -300,11 +657,14 @@ async function connectPairedNode(params: {
       platform: "ios",
       deviceFamily: "iPhone",
       scopes: [],
-      caps: NODE_CAPS,
-      commands: NODE_COMMANDS,
+      caps: params.caps ?? NODE_CAPS,
+      commands: params.commands ?? NODE_COMMANDS,
       permissions: NODE_PERMISSIONS,
       deviceIdentity: params.identity,
+      minProtocol: params.minProtocol,
+      maxProtocol: params.maxProtocol,
       onEvent: params.onEvent,
+      onHelloOk: params.onHelloOk,
     });
   try {
     return await connect();
@@ -318,7 +678,7 @@ async function connectPairedNode(params: {
 }
 
 async function connectClient(params: {
-  gateway: GatewayHandle;
+  gateway: GatewayConnection;
   role: "operator" | "node";
   clientName: typeof GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT | typeof GATEWAY_CLIENT_NAMES.IOS_APP;
   clientDisplayName: string;
@@ -330,11 +690,13 @@ async function connectClient(params: {
   commands?: string[];
   permissions?: Record<string, boolean>;
   deviceIdentity: DeviceIdentity | null;
+  minProtocol?: number;
+  maxProtocol?: number;
   onEvent?: (event: { event: string; payload?: unknown }) => void;
+  onHelloOk?: (hello: HelloOk) => void;
 }): Promise<GatewayClient> {
   return await new Promise<GatewayClient>((resolve, reject) => {
     let settled = false;
-    let timeout: ReturnType<typeof setTimeout>;
     const finish = (error?: Error) => {
       if (settled) {
         return;
@@ -364,13 +726,18 @@ async function connectClient(params: {
       commands: params.commands,
       permissions: params.permissions,
       deviceIdentity: params.deviceIdentity,
+      minProtocol: params.minProtocol,
+      maxProtocol: params.maxProtocol,
       requestTimeoutMs: REQUEST_TIMEOUT_MS,
       onEvent: params.onEvent,
-      onHelloOk: () => finish(),
+      onHelloOk: (hello) => {
+        params.onHelloOk?.(hello);
+        finish();
+      },
       onConnectError: (error) => finish(error),
       onClose: (code, reason) => finish(new Error(`Gateway closed (${code}): ${reason}`)),
     });
-    timeout = setTimeout(
+    const timeout = setTimeout(
       () => finish(new Error(`Gateway client connection timed out:\n${params.gateway.logs()}`)),
       REQUEST_TIMEOUT_MS,
     );
@@ -452,11 +819,32 @@ async function waitForApprovedNode(
   return approved;
 }
 
+async function waitForConnectedApprovedNode(
+  operator: GatewayClient,
+  nodeId: string,
+  logs: () => string,
+): Promise<NodeRead> {
+  let approved: NodeRead | undefined;
+  await vi.waitFor(
+    async () => {
+      approved = await readNode(operator, nodeId);
+      expect(approved, logs()).toMatchObject({
+        nodeId,
+        approvalState: "approved",
+        connected: true,
+        paired: true,
+      });
+    },
+    { timeout: REQUEST_TIMEOUT_MS, interval: 100 },
+  );
+  if (!approved) {
+    throw new Error(`approved node never became visible:\n${logs()}`);
+  }
+  return approved;
+}
+
 async function approvePendingNodeSurface(operator: GatewayClient, nodeId: string): Promise<void> {
-  const nodes = await operator.request<{
-    pending?: Array<{ requestId?: string; nodeId?: string }>;
-  }>("node.pair.list", {}, { timeoutMs: REQUEST_TIMEOUT_MS });
-  for (const pending of nodes.pending ?? []) {
+  for (const pending of await readPendingNodePairings(operator)) {
     if (pending.nodeId === nodeId && pending.requestId) {
       await operator.request(
         "node.pair.approve",
@@ -467,6 +855,28 @@ async function approvePendingNodeSurface(operator: GatewayClient, nodeId: string
   }
 }
 
+async function readPendingNodePairings(
+  operator: GatewayClient,
+): Promise<Array<{ requestId?: string; nodeId?: string }>> {
+  const nodes = await operator.request<{
+    pending?: Array<{ requestId?: string; nodeId?: string }>;
+  }>("node.pair.list", {}, { timeoutMs: REQUEST_TIMEOUT_MS });
+  return nodes.pending ?? [];
+}
+
+async function expectNoPendingPairing(operator: GatewayClient, nodeId: string): Promise<void> {
+  const [devices, nodes] = await Promise.all([
+    operator.request<{
+      pending?: Array<{ deviceId?: string }>;
+    }>("device.pair.list", {}, { timeoutMs: REQUEST_TIMEOUT_MS }),
+    readPendingNodePairings(operator),
+  ]);
+  const devicePending = devices.pending?.some((entry) => entry.deviceId === nodeId) ?? false;
+  const nodePending = nodes.some((entry) => entry.nodeId === nodeId);
+  expect(devicePending).toBe(false);
+  expect(nodePending).toBe(false);
+}
+
 async function readNode(operator: GatewayClient, nodeId: string): Promise<NodeRead | undefined> {
   const result = await operator.request<{ nodes?: NodeRead[] }>(
     "node.list",
@@ -474,6 +884,30 @@ async function readNode(operator: GatewayClient, nodeId: string): Promise<NodeRe
     { timeoutMs: REQUEST_TIMEOUT_MS },
   );
   return result.nodes?.find((entry) => entry.nodeId === nodeId);
+}
+
+async function invokeNodeCommand(params: {
+  operator: GatewayClient;
+  nodeId: string;
+  command: string;
+  params: unknown;
+}): Promise<{
+  ok: boolean;
+  nodeId: string;
+  command: string;
+  payload: unknown;
+}> {
+  return await params.operator.request(
+    "node.invoke",
+    {
+      nodeId: params.nodeId,
+      command: params.command,
+      params: params.params,
+      timeoutMs: REQUEST_TIMEOUT_MS,
+      idempotencyKey: randomUUID(),
+    },
+    { timeoutMs: REQUEST_TIMEOUT_MS },
+  );
 }
 
 async function respondToInvocation(
@@ -504,7 +938,11 @@ async function respondToInvocation(
             longitude: -122.0312,
             received: params,
           }
-        : undefined;
+        : frame.command === FIXTURE_COMMAND
+          ? {
+              echoed: params,
+            }
+          : undefined;
   if (!response) {
     throw new Error(`unexpected node command: ${frame.command}`);
   }
@@ -518,4 +956,227 @@ async function respondToInvocation(
     },
     { timeoutMs: REQUEST_TIMEOUT_MS },
   );
+}
+
+async function createFixturePlugin(): Promise<{
+  root: string;
+  pluginDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-node-rolling-"));
+  const pluginDir = path.join(root, FIXTURE_PLUGIN_ID);
+  try {
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      `${JSON.stringify(
+        {
+          id: FIXTURE_PLUGIN_ID,
+          activation: { onStartup: true },
+          configSchema: { type: "object", additionalProperties: false, properties: {} },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "index.js"),
+      `module.exports = {
+  id: ${JSON.stringify(FIXTURE_PLUGIN_ID)},
+  register(api) {
+    api.registerHttpRoute({
+      path: ${JSON.stringify(FIXTURE_ROUTE)},
+      auth: "plugin",
+      nodeCapability: { surface: ${JSON.stringify(FIXTURE_CAPABILITY)} },
+      handler(_req, res) {
+        res.statusCode = 204;
+        res.end();
+        return true;
+      },
+    });
+    api.registerNodeInvokePolicy({
+      commands: [${JSON.stringify(FIXTURE_COMMAND)}],
+      defaultPlatforms: ["ios"],
+      handle: async (ctx) => await ctx.invokeNode(),
+    });
+  },
+};\n`,
+      "utf8",
+    );
+    return {
+      root,
+      pluginDir,
+      cleanup: () => fs.rm(root, { force: true, recursive: true }),
+    };
+  } catch (error) {
+    try {
+      await fs.rm(root, { force: true, recursive: true });
+    } catch (cleanupError) {
+      const failure = new AggregateError(
+        [error, cleanupError],
+        "fixture plugin setup and cleanup failed",
+      );
+      failure.cause = error;
+      throw failure;
+    }
+    throw error;
+  }
+}
+
+function withFixturePlugin(config: OpenClawConfig, pluginDir: string): OpenClawConfig {
+  return {
+    ...config,
+    plugins: {
+      ...config.plugins,
+      enabled: true,
+      allow: [...new Set([...(config.plugins?.allow ?? []), FIXTURE_PLUGIN_ID])],
+      load: {
+        ...config.plugins?.load,
+        paths: [...new Set([...(config.plugins?.load?.paths ?? []), pluginDir])],
+      },
+      entries: {
+        ...config.plugins?.entries,
+        [FIXTURE_PLUGIN_ID]: { enabled: true },
+      },
+    },
+  };
+}
+
+function parseConnectEnvelope(
+  data: RawData,
+): { id: string; envelope: ConnectEnvelope } | undefined {
+  try {
+    const text = Array.isArray(data)
+      ? Buffer.concat(data.map((chunk) => Buffer.from(chunk))).toString("utf8")
+      : Buffer.isBuffer(data)
+        ? data.toString("utf8")
+        : Buffer.from(data).toString("utf8");
+    const frame = JSON.parse(text);
+    if (!isRecord(frame) || frame.method !== "connect" || typeof frame.id !== "string") {
+      return undefined;
+    }
+    const params = frame.params;
+    if (!isRecord(params) || !isRecord(params.client)) {
+      return undefined;
+    }
+    if (
+      typeof params.role !== "string" ||
+      typeof params.client.mode !== "string" ||
+      typeof params.minProtocol !== "number" ||
+      typeof params.maxProtocol !== "number"
+    ) {
+      return undefined;
+    }
+    return {
+      id: frame.id,
+      envelope: {
+        role: params.role,
+        mode: params.client.mode,
+        minProtocol: params.minProtocol,
+        maxProtocol: params.maxProtocol,
+      },
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function startProtocolEnvelopeFixture(): Promise<{
+  gateway: GatewayConnection;
+  connectFrames: ConnectEnvelope[];
+  stop: () => Promise<void>;
+}> {
+  const connectFrames: ConnectEnvelope[] = [];
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  server.on("connection", (socket) => {
+    socket.send(
+      JSON.stringify({
+        type: "event",
+        event: "connect.challenge",
+        seq: 1,
+        payload: { nonce: "qa-v3-envelope-fixture", ts: Date.now() },
+      }),
+    );
+    socket.on("message", (data) => {
+      const connect = parseConnectEnvelope(data);
+      if (!connect) {
+        return;
+      }
+      connectFrames.push(connect.envelope);
+      const supportsV3 =
+        connect.envelope.minProtocol <= MIN_NODE_PROTOCOL_VERSION &&
+        connect.envelope.maxProtocol >= MIN_NODE_PROTOCOL_VERSION;
+      if (!supportsV3) {
+        socket.send(
+          JSON.stringify({
+            type: "res",
+            id: connect.id,
+            ok: false,
+            error: {
+              code: ErrorCodes.INVALID_REQUEST,
+              message: "protocol mismatch",
+              details: {
+                code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+                clientMinProtocol: connect.envelope.minProtocol,
+                clientMaxProtocol: connect.envelope.maxProtocol,
+                expectedProtocol: MIN_NODE_PROTOCOL_VERSION,
+              },
+            },
+          }),
+        );
+        return;
+      }
+      socket.send(
+        JSON.stringify({
+          type: "res",
+          id: connect.id,
+          ok: true,
+          payload: {
+            type: "hello-ok",
+            protocol: MIN_NODE_PROTOCOL_VERSION,
+            server: { version: "qa-v3-envelope-fixture", connId: randomUUID() },
+            features: { methods: [], events: [] },
+            snapshot: {
+              presence: [],
+              health: {},
+              stateVersion: { presence: 1, health: 1 },
+              uptimeMs: 1,
+            },
+            auth: { role: connect.envelope.role, scopes: [] },
+            policy: {
+              maxPayload: 512 * 1024,
+              maxBufferedBytes: 1024 * 1024,
+              tickIntervalMs: 30_000,
+            },
+          },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("v3 Gateway fixture did not bind a TCP port");
+  }
+  return {
+    connectFrames,
+    gateway: {
+      wsUrl: `ws://127.0.0.1:${address.port}`,
+      token: "qa-v3-gateway-token",
+      runtimeEnv: {},
+      logs: () => JSON.stringify(connectFrames),
+    },
+    async stop() {
+      for (const client of server.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
 }

--- a/test/scripts/gateway-node-compat-evidence.test.ts
+++ b/test/scripts/gateway-node-compat-evidence.test.ts
@@ -1,0 +1,1446 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import * as evidenceModule from "../../scripts/gateway-node-compat-evidence.mjs";
+import {
+  GATEWAY_NODE_COMPAT_CASE_CONTRACTS,
+  GATEWAY_NODE_COMPAT_SCHEMA,
+  buildGatewayNodeCompatCaseId,
+  canonicalizeGatewayNodeCompatEvidence as canonicalizeGatewayNodeCompatEvidenceWithIdentities,
+  validateGatewayNodeCompatEvidence as validateGatewayNodeCompatEvidenceWithIdentities,
+} from "../../scripts/gateway-node-compat-evidence.mjs";
+import type {
+  GatewayNodeCompatArtifactIdentities,
+  GatewayNodeCompatCaseContract,
+  GatewayNodeCompatOutcome,
+} from "../../scripts/gateway-node-compat-evidence.mjs";
+
+const SCRIPT_PATH = "scripts/gateway-node-compat-evidence.mjs";
+const CANDIDATE_PACKAGE_SHA256 = "b".repeat(64);
+const BASELINE_PACKAGE_SHA256 = "d".repeat(64);
+const ARTIFACT_IDENTITIES: GatewayNodeCompatArtifactIdentities = {
+  candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+  baselinePackageSha256: BASELINE_PACKAGE_SHA256,
+};
+const tempRoots: string[] = [];
+
+function validateGatewayNodeCompatEvidence(value: unknown) {
+  return validateGatewayNodeCompatEvidenceWithIdentities(value, ARTIFACT_IDENTITIES);
+}
+
+function canonicalizeGatewayNodeCompatEvidence(value: unknown) {
+  return canonicalizeGatewayNodeCompatEvidenceWithIdentities(value, ARTIFACT_IDENTITIES);
+}
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-gateway-node-compat-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function packagedArtifact(
+  version: string,
+  sourceSha: string,
+  name: string,
+  sha256: string,
+  artifactSeed: string,
+) {
+  return {
+    version,
+    sourceSha,
+    name,
+    sha256,
+    actionsArtifact: {
+      id: Number.parseInt(artifactSeed.repeat(4), 10),
+      name: `${name}-input`,
+      digest: `sha256:${artifactSeed.repeat(64)}`,
+      sizeBytes: 4096,
+      runId: artifactSeed.repeat(9),
+      runAttempt: 2,
+    },
+  };
+}
+
+function installedRuntime(
+  version: string,
+  sourceSha: string,
+  packageSha256: string,
+  identitySha256: string,
+) {
+  return { version, sourceSha, packageSha256, identitySha256 };
+}
+
+function validPassEvidence(): Record<string, any> {
+  const gatewayVersion = "v2026.8.6";
+  const gatewaySourceSha = "a".repeat(40);
+  const nodeVersion = "v2026.5.7";
+  const nodeSourceSha = "c".repeat(40);
+  return {
+    schema: GATEWAY_NODE_COMPAT_SCHEMA,
+    caseId: "linux-x64-candidate-gateway-baseline-node",
+    direction: "candidate-gateway-baseline-node",
+    connection: {
+      transport: "gateway-websocket",
+      role: "node",
+      mode: "node",
+    },
+    gateway: {
+      packagedArtifact: packagedArtifact(
+        gatewayVersion,
+        gatewaySourceSha,
+        "openclaw-candidate.tgz",
+        CANDIDATE_PACKAGE_SHA256,
+        "1",
+      ),
+      installedRuntime: installedRuntime(
+        gatewayVersion,
+        gatewaySourceSha,
+        CANDIDATE_PACKAGE_SHA256,
+        "2".repeat(64),
+      ),
+    },
+    node: {
+      kind: "linux",
+      architecture: "x64",
+      protocolClientId: "node-host",
+      packagedArtifact: packagedArtifact(
+        nodeVersion,
+        nodeSourceSha,
+        "openclaw-baseline.tgz",
+        BASELINE_PACKAGE_SHA256,
+        "3",
+      ),
+      installedRuntime: installedRuntime(
+        nodeVersion,
+        nodeSourceSha,
+        BASELINE_PACKAGE_SHA256,
+        "4".repeat(64),
+      ),
+    },
+    protocol: {
+      gatewayProtocolVersion: 4,
+      gatewayAcceptedNodeMin: 3,
+      protocolClientAdvertisedMin: 3,
+      protocolClientAdvertisedMax: 3,
+      helloProtocol: 4,
+    },
+    operation: {
+      method: "node.invoke",
+      command: "system.which",
+      params: {
+        bins: ["node"],
+      },
+      ok: true,
+      result: {
+        bins: {
+          node: "/usr/bin/node",
+        },
+      },
+    },
+    result: {
+      outcome: "passed",
+      startedAt: "2026-08-06T12:00:00.000Z",
+      completedAt: "2026-08-06T12:00:05.000Z",
+    },
+    producer: {
+      repository: "openclaw/openclaw",
+      workflowPath: ".github/workflows/openclaw-cross-os-release-checks-reusable.yml",
+      workflowSha: "e".repeat(40),
+      runId: "123456789",
+      runAttempt: 2,
+      job: "gateway-node-compat-linux-x64",
+    },
+  };
+}
+
+function deviceInfoOperation() {
+  return {
+    method: "node.invoke",
+    command: "device.info",
+    params: {},
+    ok: true,
+    result: {
+      systemName: "iOS",
+      systemVersion: "18.0",
+    },
+  };
+}
+
+function setNodeKind(
+  evidence: Record<string, any>,
+  kind: "android" | "ios" | "linux" | "macos" | "windows",
+  protocolClientId: string,
+) {
+  evidence.node.kind = kind;
+  evidence.node.protocolClientId = protocolClientId;
+  evidence.caseId = `${kind}-${evidence.node.architecture}-${evidence.direction}`;
+  if (kind === "android" || kind === "ios") {
+    evidence.operation = deviceInfoOperation();
+    evidence.operation.result.systemName = kind === "android" ? "Android" : "iOS";
+  }
+}
+
+function validMismatchEvidence(): Record<string, any> {
+  const evidence = validPassEvidence();
+  const candidateRuntime = runtimeBindingForRole("candidate");
+  evidence.caseId = "linux-x64-candidate-gateway-disjoint-node";
+  evidence.direction = "candidate-gateway-disjoint-node";
+  evidence.node.packagedArtifact = candidateRuntime.packagedArtifact;
+  evidence.node.installedRuntime = candidateRuntime.installedRuntime;
+  evidence.protocol.protocolClientAdvertisedMin = 5;
+  evidence.protocol.protocolClientAdvertisedMax = 5;
+  evidence.protocol.helloProtocol = null;
+  evidence.operation = null;
+  evidence.result = {
+    outcome: "protocol-mismatch",
+    failureCode: "PROTOCOL_MISMATCH",
+    failurePhase: "connect",
+    startedAt: "2026-08-06T12:00:00.000Z",
+    completedAt: "2026-08-06T12:00:01.000Z",
+  };
+  return evidence;
+}
+
+function validBaselineMismatchEvidence(): Record<string, any> {
+  const evidence = validMismatchEvidence();
+  const baselineRuntime = runtimeBindingForRole("baseline");
+  evidence.caseId = "linux-x64-baseline-gateway-disjoint-node";
+  evidence.direction = "baseline-gateway-disjoint-node";
+  evidence.gateway = baselineRuntime;
+  evidence.protocol.gatewayProtocolVersion = 3;
+  evidence.protocol.gatewayAcceptedNodeMin = 3;
+  evidence.protocol.protocolClientAdvertisedMin = 4;
+  evidence.protocol.protocolClientAdvertisedMax = 4;
+  return evidence;
+}
+
+function runtimeBindingForRole(role: "baseline" | "candidate") {
+  const identityFixture = validPassEvidence();
+  return role === "candidate"
+    ? clone(identityFixture.gateway)
+    : {
+        packagedArtifact: clone(identityFixture.node.packagedArtifact),
+        installedRuntime: clone(identityFixture.node.installedRuntime),
+      };
+}
+
+function validEvidenceForContract(contract: GatewayNodeCompatCaseContract): Record<string, any> {
+  const evidence =
+    contract.direction === "baseline-gateway-disjoint-node"
+      ? validBaselineMismatchEvidence()
+      : contract.outcome === "protocol-mismatch"
+        ? validMismatchEvidence()
+        : validPassEvidence();
+  evidence.gateway = runtimeBindingForRole(contract.gatewayArtifactRole);
+  const nodeRuntime = runtimeBindingForRole(contract.nodeArtifactRole);
+  evidence.node.packagedArtifact = nodeRuntime.packagedArtifact;
+  evidence.node.installedRuntime = nodeRuntime.installedRuntime;
+  evidence.direction = contract.direction;
+  evidence.caseId = buildGatewayNodeCompatCaseId({
+    architecture: evidence.node.architecture,
+    direction: contract.direction,
+    kind: evidence.node.kind,
+  });
+  return evidence;
+}
+
+function setOutcome(evidence: Record<string, any>, outcome: GatewayNodeCompatOutcome): void {
+  if (outcome === "passed") {
+    evidence.protocol.helloProtocol = evidence.protocol.gatewayProtocolVersion;
+    evidence.operation = clone(validPassEvidence().operation);
+    evidence.result = clone(validPassEvidence().result);
+    return;
+  }
+  evidence.protocol.helloProtocol = null;
+  evidence.operation = null;
+  evidence.result = clone(validMismatchEvidence().result);
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function runCli(args: string[], timeout?: number) {
+  return spawnSync(
+    process.execPath,
+    [
+      SCRIPT_PATH,
+      ...args,
+      "--candidate-package-sha256",
+      CANDIDATE_PACKAGE_SHA256,
+      "--baseline-package-sha256",
+      BASELINE_PACKAGE_SHA256,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout,
+    },
+  );
+}
+
+function writeMalformedUtf8Evidence(root: string): string {
+  const inputPath = path.join(root, "invalid-utf8.json");
+  const encoded = Buffer.from(JSON.stringify(validPassEvidence()), "utf8");
+  const markerOffset = encoded.indexOf(Buffer.from("/usr/bin/node", "utf8"));
+  expect(markerOffset).toBeGreaterThanOrEqual(0);
+  encoded[markerOffset] = 0x80;
+  writeFileSync(inputPath, encoded);
+  return inputPath;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("gateway node compatibility evidence", () => {
+  it("accepts observed direct WebSocket node invocation evidence", () => {
+    const evidence = validPassEvidence();
+
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it("accepts observed structured protocol mismatch evidence", () => {
+    const evidence = validMismatchEvidence();
+
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it("accepts observed baseline Gateway protocol mismatch evidence", () => {
+    const evidence = validBaselineMismatchEvidence();
+
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it.each(GATEWAY_NODE_COMPAT_CASE_CONTRACTS)(
+    "accepts the $direction case contract",
+    (contract) => {
+      const evidence = validEvidenceForContract(contract);
+
+      expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+    },
+  );
+
+  it.each(
+    GATEWAY_NODE_COMPAT_CASE_CONTRACTS.flatMap((contract) =>
+      (["gateway", "node"] as const).map((subject) => ({ contract, subject })),
+    ),
+  )(
+    "rejects $contract.direction when the $subject artifact has the opposite package identity",
+    ({ contract, subject }) => {
+      const evidence = validEvidenceForContract(contract);
+      const expectedRole =
+        subject === "gateway" ? contract.gatewayArtifactRole : contract.nodeArtifactRole;
+      const oppositeRole = expectedRole === "candidate" ? "baseline" : "candidate";
+      const oppositeRuntime = runtimeBindingForRole(oppositeRole);
+      if (subject === "gateway") {
+        evidence.gateway = oppositeRuntime;
+      } else {
+        evidence.node.packagedArtifact = oppositeRuntime.packagedArtifact;
+        evidence.node.installedRuntime = oppositeRuntime.installedRuntime;
+      }
+
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        new RegExp(`${subject} artifact identity must match the ${expectedRole} package`, "u"),
+      );
+    },
+  );
+
+  it("defines the exact direction and outcome contracts", () => {
+    expect(GATEWAY_NODE_COMPAT_CASE_CONTRACTS).toEqual([
+      {
+        direction: "baseline-gateway-baseline-node",
+        gatewayArtifactRole: "baseline",
+        nodeArtifactRole: "baseline",
+        outcome: "passed",
+      },
+      {
+        direction: "baseline-gateway-candidate-node",
+        gatewayArtifactRole: "baseline",
+        nodeArtifactRole: "candidate",
+        outcome: "passed",
+      },
+      {
+        direction: "baseline-gateway-disjoint-node",
+        gatewayArtifactRole: "baseline",
+        nodeArtifactRole: "candidate",
+        outcome: "protocol-mismatch",
+      },
+      {
+        direction: "candidate-gateway-baseline-node",
+        gatewayArtifactRole: "candidate",
+        nodeArtifactRole: "baseline",
+        outcome: "passed",
+      },
+      {
+        direction: "candidate-gateway-candidate-node",
+        gatewayArtifactRole: "candidate",
+        nodeArtifactRole: "candidate",
+        outcome: "passed",
+      },
+      {
+        direction: "candidate-gateway-disjoint-node",
+        gatewayArtifactRole: "candidate",
+        nodeArtifactRole: "candidate",
+        outcome: "protocol-mismatch",
+      },
+    ]);
+    expect(GATEWAY_NODE_COMPAT_CASE_CONTRACTS.every(Object.isFrozen)).toBe(true);
+    expect(Object.isFrozen(GATEWAY_NODE_COMPAT_CASE_CONTRACTS)).toBe(true);
+  });
+
+  it.each(
+    GATEWAY_NODE_COMPAT_CASE_CONTRACTS.flatMap((contract) =>
+      GATEWAY_NODE_COMPAT_CASE_CONTRACTS.filter(
+        (other) => other.direction !== contract.direction,
+      ).map((other) => ({ contract, contradictoryDirection: other.direction })),
+    ),
+  )(
+    "rejects $contract.direction evidence paired with $contradictoryDirection",
+    ({ contract, contradictoryDirection }) => {
+      const evidence = validEvidenceForContract(contract);
+      evidence.direction = contradictoryDirection;
+
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        /caseId must be .* for direction/u,
+      );
+    },
+  );
+
+  it.each(
+    GATEWAY_NODE_COMPAT_CASE_CONTRACTS.flatMap((contract) =>
+      GATEWAY_NODE_COMPAT_CASE_CONTRACTS.filter(
+        (other) => other.direction !== contract.direction,
+      ).map((other) => ({ contract, contradictoryCase: other })),
+    ),
+  )(
+    "rejects $contract.direction evidence with the $contradictoryCase.direction case ID",
+    ({ contract, contradictoryCase }) => {
+      const evidence = validEvidenceForContract(contract);
+      evidence.caseId = buildGatewayNodeCompatCaseId({
+        architecture: evidence.node.architecture,
+        direction: contradictoryCase.direction,
+        kind: evidence.node.kind,
+      });
+
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        /caseId must be .* for direction/u,
+      );
+    },
+  );
+
+  it.each(GATEWAY_NODE_COMPAT_CASE_CONTRACTS)(
+    "rejects $direction evidence with the contradictory outcome",
+    (contract) => {
+      const evidence = validEvidenceForContract(contract);
+      const contradictoryOutcome = contract.outcome === "passed" ? "protocol-mismatch" : "passed";
+      setOutcome(evidence, contradictoryOutcome);
+
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        new RegExp(`${contract.direction} requires result\\.outcome ${contract.outcome}`, "u"),
+      );
+    },
+  );
+
+  it("builds case IDs from the canonical node topology and direction", () => {
+    expect(
+      buildGatewayNodeCompatCaseId({
+        architecture: "arm64",
+        direction: "baseline-gateway-candidate-node",
+        kind: "ios",
+      }),
+    ).toBe("ios-arm64-baseline-gateway-candidate-node");
+  });
+
+  it.each([
+    ["root", (value: Record<string, any>) => (value.extra = true)],
+    ["connection", (value: Record<string, any>) => (value.connection.extra = true)],
+    ["gateway", (value: Record<string, any>) => (value.gateway.extra = true)],
+    [
+      "gateway package",
+      (value: Record<string, any>) => (value.gateway.packagedArtifact.extra = true),
+    ],
+    [
+      "gateway Actions artifact",
+      (value: Record<string, any>) => (value.gateway.packagedArtifact.actionsArtifact.extra = true),
+    ],
+    [
+      "gateway installed runtime",
+      (value: Record<string, any>) => (value.gateway.installedRuntime.extra = true),
+    ],
+    ["node", (value: Record<string, any>) => (value.node.extra = true)],
+    ["protocol", (value: Record<string, any>) => (value.protocol.extra = true)],
+    ["operation", (value: Record<string, any>) => (value.operation.extra = true)],
+    ["operation result", (value: Record<string, any>) => (value.operation.result.extra = true)],
+    ["result", (value: Record<string, any>) => (value.result.extra = true)],
+    ["producer", (value: Record<string, any>) => (value.producer.extra = true)],
+  ])("rejects unknown keys at the %s level", (_label, mutate) => {
+    const evidence = validPassEvidence();
+    mutate(evidence);
+
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/not allowed/u);
+  });
+
+  it.each([
+    ["case ID", (value: Record<string, any>) => delete value.caseId],
+    ["connection", (value: Record<string, any>) => delete value.connection.mode],
+    [
+      "package artifact",
+      (value: Record<string, any>) => delete value.gateway.packagedArtifact.sha256,
+    ],
+    [
+      "Actions artifact",
+      (value: Record<string, any>) => delete value.gateway.packagedArtifact.actionsArtifact.digest,
+    ],
+    [
+      "installed runtime",
+      (value: Record<string, any>) => delete value.gateway.installedRuntime.identitySha256,
+    ],
+    [
+      "installed package",
+      (value: Record<string, any>) => delete value.gateway.installedRuntime.packageSha256,
+    ],
+    ["node", (value: Record<string, any>) => delete value.node.kind],
+    ["protocol", (value: Record<string, any>) => delete value.protocol.helloProtocol],
+    ["operation", (value: Record<string, any>) => delete value.operation.command],
+    ["result", (value: Record<string, any>) => delete value.result.completedAt],
+    ["producer", (value: Record<string, any>) => delete value.producer.job],
+  ])("rejects missing keys at the %s level", (_label, mutate) => {
+    const evidence = validPassEvidence();
+    mutate(evidence);
+
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/is required/u);
+  });
+
+  it("requires a stable bounded case ID and supported direction", () => {
+    for (const caseId of ["Linux-X64", "-leading", "contains/slash", "x".repeat(129)]) {
+      const evidence = validPassEvidence();
+      evidence.caseId = caseId;
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/caseId/u);
+    }
+
+    for (const unsupportedDirection of [
+      "old-to-new",
+      "baseline-gateway-disjoint-client",
+      "disjoint-gateway-baseline-node",
+    ]) {
+      const evidence = validPassEvidence();
+      evidence.direction = unsupportedDirection;
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        /direction is unsupported/u,
+      );
+    }
+  });
+
+  it("requires direct Gateway WebSocket role=node mode=node", () => {
+    for (const [field, value, message] of [
+      ["transport", "watch-node-http", /transport must be gateway-websocket/u],
+      ["role", "operator", /role must be node/u],
+      ["mode", "ui", /mode must be node/u],
+    ] as const) {
+      const evidence = validPassEvidence();
+      evidence.connection[field] = value;
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(message);
+    }
+  });
+
+  it.each([
+    ["android", "openclaw-android"],
+    ["ios", "openclaw-ios"],
+  ] as const)("accepts the %s direct node with a device.info proof", (kind, protocolClientId) => {
+    const evidence = validPassEvidence();
+    setNodeKind(evidence, kind, protocolClientId);
+
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it("accepts iPadOS device.info evidence for the iOS node family", () => {
+    const evidence = validPassEvidence();
+    setNodeKind(evidence, "ios", "openclaw-ios");
+    evidence.operation.result.systemName = "iPadOS";
+
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it.each([
+    ["android", "openclaw-android", "iOS", "Android"],
+    ["android", "openclaw-android", "iPadOS", "Android"],
+    ["ios", "openclaw-ios", "Android", "iOS"],
+  ] as const)(
+    "rejects crossed device.info systemName evidence for %s",
+    (kind, protocolClientId, crossedSystemName, expectedSystemName) => {
+      const evidence = validPassEvidence();
+      setNodeKind(evidence, kind, protocolClientId);
+      evidence.operation.result.systemName = crossedSystemName;
+
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        new RegExp(
+          `${kind} nodes require operation\\.result\\.systemName ${expectedSystemName}`,
+          "u",
+        ),
+      );
+    },
+  );
+
+  it.each([
+    ["linux", "node-host"],
+    ["macos", "openclaw-macos"],
+    ["windows", "node-host"],
+  ] as const)("accepts the %s direct node with a system.which proof", (kind, protocolClientId) => {
+    const evidence = validPassEvidence();
+    setNodeKind(evidence, kind, protocolClientId);
+
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it.each(["watchos", "wearos"])("rejects the %s non-WebSocket-node topology", (kind) => {
+    const evidence = validPassEvidence();
+    evidence.node.kind = kind;
+
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/node.kind is unsupported/u);
+  });
+
+  it("rejects removed proxy concepts and incorrect client topology", () => {
+    const proxy = validPassEvidence();
+    proxy.node.proxy = { kind: "android" };
+    expect(() => validateGatewayNodeCompatEvidence(proxy)).toThrow(/node.proxy is not allowed/u);
+
+    const wrongClient = validPassEvidence();
+    wrongClient.node.kind = "windows";
+    wrongClient.node.protocolClientId = "openclaw-ios";
+    expect(() => validateGatewayNodeCompatEvidence(wrongClient)).toThrow(
+      /windows nodes require protocol client node-host/u,
+    );
+  });
+
+  it("requires lowercase package, runtime, source, and Actions identities", () => {
+    const invalidCases: Array<[string, (value: Record<string, any>) => void, RegExp]> = [
+      [
+        "source SHA",
+        (value) => (value.gateway.packagedArtifact.sourceSha = "A".repeat(40)),
+        /sourceSha is invalid/u,
+      ],
+      [
+        "package SHA",
+        (value) => (value.node.packagedArtifact.sha256 = "D".repeat(64)),
+        /sha256 is invalid/u,
+      ],
+      [
+        "installed package SHA",
+        (value) => (value.node.installedRuntime.packageSha256 = "D".repeat(64)),
+        /packageSha256 is invalid/u,
+      ],
+      [
+        "runtime identity",
+        (value) => (value.node.installedRuntime.identitySha256 = "z".repeat(64)),
+        /identitySha256 is invalid/u,
+      ],
+      [
+        "Actions digest",
+        (value) => (value.gateway.packagedArtifact.actionsArtifact.digest = "b".repeat(64)),
+        /digest is invalid/u,
+      ],
+    ];
+    for (const [_label, mutate, message] of invalidCases) {
+      const evidence = validPassEvidence();
+      mutate(evidence);
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(message);
+    }
+  });
+
+  it("requires complete positive Actions artifact binding", () => {
+    for (const [field, value] of [
+      ["id", 0],
+      ["sizeBytes", 0],
+      ["runAttempt", 0],
+      ["runId", "01"],
+    ] as const) {
+      const evidence = validPassEvidence();
+      evidence.gateway.packagedArtifact.actionsArtifact[field] = value;
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        /positive integer|is invalid/u,
+      );
+    }
+
+    for (const name of ["../candidate", "artifact/candidate", "artifact\\candidate", ".", ".."]) {
+      const evidence = validPassEvidence();
+      evidence.gateway.packagedArtifact.actionsArtifact.name = name;
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/must be a basename/u);
+    }
+  });
+
+  it("binds the installed runtime to its package while keeping runtime identity distinct", () => {
+    const version = validPassEvidence();
+    version.node.installedRuntime.version = "v2026.8.6";
+    expect(() => validateGatewayNodeCompatEvidence(version)).toThrow(
+      /installedRuntime.version must match packaged artifact version/u,
+    );
+
+    const source = validPassEvidence();
+    source.gateway.installedRuntime.sourceSha = "f".repeat(40);
+    expect(() => validateGatewayNodeCompatEvidence(source)).toThrow(
+      /installedRuntime.sourceSha must match packaged artifact sourceSha/u,
+    );
+
+    const packageDigest = validPassEvidence();
+    packageDigest.gateway.installedRuntime.packageSha256 = "f".repeat(64);
+    expect(() => validateGatewayNodeCompatEvidence(packageDigest)).toThrow(
+      /installedRuntime.packageSha256 must match packaged artifact sha256/u,
+    );
+
+    const distinctIdentity = validPassEvidence();
+    expect(distinctIdentity.gateway.installedRuntime.identitySha256).not.toBe(
+      distinctIdentity.gateway.packagedArtifact.sha256,
+    );
+    expect(validateGatewayNodeCompatEvidence(distinctIdentity)).toBe(distinctIdentity);
+  });
+
+  it("requires positive ordered observed protocol fields", () => {
+    const zero = validPassEvidence();
+    zero.protocol.gatewayProtocolVersion = 0;
+    expect(() => validateGatewayNodeCompatEvidence(zero)).toThrow(/positive integer/u);
+
+    const gatewayRange = validPassEvidence();
+    gatewayRange.protocol.gatewayAcceptedNodeMin = 5;
+    expect(() => validateGatewayNodeCompatEvidence(gatewayRange)).toThrow(
+      /must equal protocol.gatewayProtocolVersion or its N-1 floor/u,
+    );
+
+    const nodeRange = validPassEvidence();
+    nodeRange.protocol.protocolClientAdvertisedMin = 4;
+    nodeRange.protocol.protocolClientAdvertisedMax = 3;
+    expect(() => validateGatewayNodeCompatEvidence(nodeRange)).toThrow(
+      /must not exceed protocol.protocolClientAdvertisedMax/u,
+    );
+  });
+
+  it.each([
+    ["above the current protocol", 5, 5],
+    ["below the accepted node floor", 1, 2],
+  ])("rejects passed evidence advertising a range %s", (_label, minProtocol, maxProtocol) => {
+    const evidence = validPassEvidence();
+    evidence.protocol.protocolClientAdvertisedMin = minProtocol;
+    evidence.protocol.protocolClientAdvertisedMax = maxProtocol;
+
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+      /passed evidence requires the advertised protocol range to include an accepted Gateway protocol/u,
+    );
+  });
+
+  it.each([
+    ["the accepted node floor", 3, 3],
+    ["the current protocol", 4, 4],
+    ["both accepted protocols", 3, 4],
+  ])("rejects protocol-mismatch evidence advertising %s", (_label, minProtocol, maxProtocol) => {
+    const evidence = validMismatchEvidence();
+    evidence.protocol.protocolClientAdvertisedMin = minProtocol;
+    evidence.protocol.protocolClientAdvertisedMax = maxProtocol;
+
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+      /protocol-mismatch evidence requires the advertised protocol range to exclude accepted Gateway protocols/u,
+    );
+  });
+
+  it.each([
+    ["the accepted node floor", 3, 3],
+    ["the current protocol", 4, 4],
+    ["both accepted protocols", 3, 4],
+  ])("accepts passed evidence advertising %s", (_label, minProtocol, maxProtocol) => {
+    const evidence = validPassEvidence();
+    evidence.protocol.protocolClientAdvertisedMin = minProtocol;
+    evidence.protocol.protocolClientAdvertisedMax = maxProtocol;
+
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it("rejects desktop pass evidence without a matching hello and successful system.which invoke", () => {
+    const staleHello = validPassEvidence();
+    staleHello.protocol.helloProtocol = 3;
+    expect(() => validateGatewayNodeCompatEvidence(staleHello)).toThrow(
+      /helloProtocol to equal gatewayProtocolVersion/u,
+    );
+
+    for (const [mutate, message] of [
+      [(value: Record<string, any>) => (value.operation = null), /operation must be an object/u],
+      [
+        (value: Record<string, any>) => (value.operation.method = "gateway.status"),
+        /method must be node.invoke/u,
+      ],
+      [
+        (value: Record<string, any>) => (value.operation.command = "system.run"),
+        /linux nodes require operation.command system.which/u,
+      ],
+      [
+        (value: Record<string, any>) => (value.operation.params.bins = []),
+        /must contain 1 to 32 requested binaries/u,
+      ],
+      [
+        (value: Record<string, any>) => (value.operation.params.bins = ["node", "node"]),
+        /must not contain duplicates/u,
+      ],
+      [(value: Record<string, any>) => (value.operation.ok = false), /operation.ok must be true/u],
+      [
+        (value: Record<string, any>) => (value.operation.result.bins = {}),
+        /must contain 1 to 32 resolved binaries/u,
+      ],
+      [
+        (value: Record<string, any>) => (value.operation.result.bins.node = ""),
+        /bounded non-control string/u,
+      ],
+      [
+        (value: Record<string, any>) => (value.operation.result.bins = { bun: "/usr/bin/bun" }),
+        /was not requested/u,
+      ],
+    ] as const) {
+      const evidence = validPassEvidence();
+      mutate(evidence);
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(message);
+    }
+  });
+
+  it.each([
+    ["android", "openclaw-android"],
+    ["ios", "openclaw-ios"],
+  ] as const)("requires a successful device.info invoke for %s pass evidence", (kind, clientId) => {
+    const evidence = validPassEvidence();
+    setNodeKind(evidence, kind, clientId);
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+
+    const desktopOperation = clone(evidence);
+    desktopOperation.operation = clone(validPassEvidence().operation);
+    expect(() => validateGatewayNodeCompatEvidence(desktopOperation)).toThrow(
+      new RegExp(`${kind} nodes require operation\\.command device\\.info`, "u"),
+    );
+
+    const extraParams = clone(evidence);
+    extraParams.operation.params.notificationPermission = "denied";
+    expect(() => validateGatewayNodeCompatEvidence(extraParams)).toThrow(
+      /operation.params.notificationPermission is not allowed/u,
+    );
+
+    const emptySystemName = clone(evidence);
+    emptySystemName.operation.result.systemName = "";
+    expect(() => validateGatewayNodeCompatEvidence(emptySystemName)).toThrow(
+      /operation.result.systemName must be a bounded non-control string/u,
+    );
+
+    const payload = clone(evidence);
+    delete payload.operation.result.systemVersion;
+    expect(() => validateGatewayNodeCompatEvidence(payload)).toThrow(
+      /operation.result.systemVersion is required/u,
+    );
+  });
+
+  it.each([
+    ["android", "openclaw-android"],
+    ["ios", "openclaw-ios"],
+  ] as const)(
+    "does not require notification permission for %s compatibility evidence",
+    (kind, clientId) => {
+      const evidence = validPassEvidence();
+      setNodeKind(evidence, kind, clientId);
+
+      expect(evidence.operation.command).toBe("device.info");
+      expect(evidence.operation.params).toEqual({});
+      expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+    },
+  );
+
+  it("rejects false-green protocol mismatch evidence", () => {
+    const hello = validMismatchEvidence();
+    hello.protocol.helloProtocol = 4;
+    expect(() => validateGatewayNodeCompatEvidence(hello)).toThrow(/helloProtocol to be null/u);
+
+    const operation = validMismatchEvidence();
+    operation.operation = clone(validPassEvidence().operation);
+    expect(() => validateGatewayNodeCompatEvidence(operation)).toThrow(/operation to be null/u);
+
+    const code = validMismatchEvidence();
+    code.result.failureCode = "AUTH_FAILED";
+    expect(() => validateGatewayNodeCompatEvidence(code)).toThrow(/PROTOCOL_MISMATCH/u);
+
+    const phase = validMismatchEvidence();
+    phase.result.failurePhase = "websocket-handshake";
+    expect(() => validateGatewayNodeCompatEvidence(phase)).toThrow(/failurePhase connect/u);
+
+    const missingCode = validMismatchEvidence();
+    delete missingCode.result.failureCode;
+    expect(() => validateGatewayNodeCompatEvidence(missingCode)).toThrow(
+      /result.failureCode is required/u,
+    );
+  });
+
+  it("requires the accepted node floor to be the Gateway protocol or N-1", () => {
+    const staleFloor = validPassEvidence();
+    staleFloor.protocol.gatewayAcceptedNodeMin = 1;
+    staleFloor.protocol.protocolClientAdvertisedMin = 1;
+    staleFloor.protocol.protocolClientAdvertisedMax = 1;
+    expect(() => validateGatewayNodeCompatEvidence(staleFloor)).toThrow(
+      /must equal protocol\.gatewayProtocolVersion or its N-1 floor/u,
+    );
+
+    const currentOnly = validPassEvidence();
+    currentOnly.protocol.gatewayAcceptedNodeMin = 4;
+    currentOnly.protocol.protocolClientAdvertisedMin = 4;
+    currentOnly.protocol.protocolClientAdvertisedMax = 4;
+    expect(validateGatewayNodeCompatEvidence(currentOnly)).toBe(currentOnly);
+
+    const versionThree = validBaselineMismatchEvidence();
+    expect(validateGatewayNodeCompatEvidence(versionThree)).toBe(versionThree);
+  });
+
+  it("requires canonical ordered timestamps", () => {
+    const nonCanonical = validPassEvidence();
+    nonCanonical.result.startedAt = "2026-08-06T12:00:00Z";
+    expect(() => validateGatewayNodeCompatEvidence(nonCanonical)).toThrow(
+      /canonical ISO timestamp/u,
+    );
+
+    const reversed = validPassEvidence();
+    reversed.result.completedAt = "2026-08-06T11:59:59.000Z";
+    expect(() => validateGatewayNodeCompatEvidence(reversed)).toThrow(/must not precede/u);
+
+    const extremeYears = validPassEvidence();
+    extremeYears.result.startedAt = "+010000-01-01T00:00:00.000Z";
+    extremeYears.result.completedAt = "-000001-01-01T00:00:00.000Z";
+    expect(() => validateGatewayNodeCompatEvidence(extremeYears)).toThrow(/must not precede/u);
+  });
+
+  it("rejects invalid producer identity fields", () => {
+    for (const repositoryValue of [
+      "openclaw",
+      "openclaw/",
+      "/openclaw",
+      "openclaw/..",
+      "./openclaw",
+      "owner//repo",
+      "owner/repo/extra",
+      "owner\\repo",
+    ]) {
+      const repository = validPassEvidence();
+      repository.producer.repository = repositoryValue;
+      expect(() => validateGatewayNodeCompatEvidence(repository)).toThrow(/producer.repository/u);
+    }
+
+    for (const workflowPath of [
+      "../workflow.yml",
+      ".github/workflows//release.yml",
+      ".github/workflows/./release.yml",
+      ".github/workflows/../release.yml",
+      ".github\\workflows\\release.yml",
+      ".github/workflows/release.json",
+    ]) {
+      const workflow = validPassEvidence();
+      workflow.producer.workflowPath = workflowPath;
+      expect(() => validateGatewayNodeCompatEvidence(workflow)).toThrow(/producer.workflowPath/u);
+    }
+
+    const run = validPassEvidence();
+    run.producer.runId = "01";
+    expect(() => validateGatewayNodeCompatEvidence(run)).toThrow(/producer.runId is invalid/u);
+  });
+
+  it("canonicalizes to exact deterministic fixture bytes", () => {
+    const evidence = validPassEvidence();
+    const shuffled = {
+      result: clone(evidence.result),
+      protocol: clone(evidence.protocol),
+      node: clone(evidence.node),
+      schema: evidence.schema,
+      producer: clone(evidence.producer),
+      operation: clone(evidence.operation),
+      gateway: clone(evidence.gateway),
+      direction: evidence.direction,
+      connection: clone(evidence.connection),
+      caseId: evidence.caseId,
+    };
+
+    const canonical = canonicalizeGatewayNodeCompatEvidence(shuffled);
+    const expected = `{
+  "caseId": "linux-x64-candidate-gateway-baseline-node",
+  "connection": {
+    "mode": "node",
+    "role": "node",
+    "transport": "gateway-websocket"
+  },
+  "direction": "candidate-gateway-baseline-node",
+  "gateway": {
+    "installedRuntime": {
+      "identitySha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "packageSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "version": "v2026.8.6"
+    },
+    "packagedArtifact": {
+      "actionsArtifact": {
+        "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "id": 1111,
+        "name": "openclaw-candidate.tgz-input",
+        "runAttempt": 2,
+        "runId": "111111111",
+        "sizeBytes": 4096
+      },
+      "name": "openclaw-candidate.tgz",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sourceSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "version": "v2026.8.6"
+    }
+  },
+  "node": {
+    "architecture": "x64",
+    "installedRuntime": {
+      "identitySha256": "4444444444444444444444444444444444444444444444444444444444444444",
+      "packageSha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "sourceSha": "cccccccccccccccccccccccccccccccccccccccc",
+      "version": "v2026.5.7"
+    },
+    "kind": "linux",
+    "packagedArtifact": {
+      "actionsArtifact": {
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "id": 3333,
+        "name": "openclaw-baseline.tgz-input",
+        "runAttempt": 2,
+        "runId": "333333333",
+        "sizeBytes": 4096
+      },
+      "name": "openclaw-baseline.tgz",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "sourceSha": "cccccccccccccccccccccccccccccccccccccccc",
+      "version": "v2026.5.7"
+    },
+    "protocolClientId": "node-host"
+  },
+  "operation": {
+    "command": "system.which",
+    "method": "node.invoke",
+    "ok": true,
+    "params": {
+      "bins": [
+        "node"
+      ]
+    },
+    "result": {
+      "bins": {
+        "node": "/usr/bin/node"
+      }
+    }
+  },
+  "producer": {
+    "job": "gateway-node-compat-linux-x64",
+    "repository": "openclaw/openclaw",
+    "runAttempt": 2,
+    "runId": "123456789",
+    "workflowPath": ".github/workflows/openclaw-cross-os-release-checks-reusable.yml",
+    "workflowSha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "protocol": {
+    "gatewayAcceptedNodeMin": 3,
+    "gatewayProtocolVersion": 4,
+    "helloProtocol": 4,
+    "protocolClientAdvertisedMax": 3,
+    "protocolClientAdvertisedMin": 3
+  },
+  "result": {
+    "completedAt": "2026-08-06T12:00:05.000Z",
+    "outcome": "passed",
+    "startedAt": "2026-08-06T12:00:00.000Z"
+  },
+  "schema": "openclaw.gateway-node-compat/v1"
+}
+`;
+
+    expect(Buffer.from(canonical)).toEqual(Buffer.from(expected));
+    expect(canonicalizeGatewayNodeCompatEvidence(JSON.parse(canonical))).toBe(canonical);
+  });
+
+  it.each([
+    ["root caseId", (value: Record<string, any>) => value, "caseId"],
+    [
+      "nested protocol floor",
+      (value: Record<string, any>) => value.protocol,
+      "gatewayAcceptedNodeMin",
+    ],
+  ] as const)("rejects a non-enumerable required %s", (_label, selectOwner, key) => {
+    const evidence = validPassEvidence();
+    const owner = selectOwner(evidence);
+    const descriptor = Object.getOwnPropertyDescriptor(owner, key);
+    Object.defineProperty(owner, key, {
+      ...descriptor,
+      enumerable: false,
+    });
+
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+      new RegExp(`${key} must be enumerable`, "u"),
+    );
+  });
+
+  it("rejects accessor-backed required evidence before canonicalization", () => {
+    const evidence = validPassEvidence();
+    const caseId = evidence.caseId;
+    let getterCalls = 0;
+    Object.defineProperty(evidence, "caseId", {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1;
+        return caseId;
+      },
+    });
+
+    expect(() => canonicalizeGatewayNodeCompatEvidence(evidence)).toThrow(
+      /caseId must be a JSON data property/u,
+    );
+    expect(getterCalls).toBe(0);
+  });
+
+  it.each([
+    [
+      "requested binary",
+      (evidence: Record<string, any>, getter: () => string) => {
+        Object.defineProperty(evidence.operation.params.bins, "0", {
+          enumerable: true,
+          get: getter,
+        });
+      },
+      /operation\.params\.bins\.0 must be a JSON data property/u,
+    ],
+    [
+      "resolved binary",
+      (evidence: Record<string, any>, getter: () => string) => {
+        Object.defineProperty(evidence.operation.result.bins, "node", {
+          enumerable: true,
+          get: getter,
+        });
+      },
+      /operation\.result\.bins\.node must be a JSON data property/u,
+    ],
+  ] as const)("rejects an accessor-backed %s without invoking it", (_label, install, message) => {
+    const evidence = validPassEvidence();
+    let getterCalls = 0;
+    install(evidence, () => {
+      getterCalls += 1;
+      return "node";
+    });
+
+    expect(() => canonicalizeGatewayNodeCompatEvidence(evidence)).toThrow(message);
+    expect(getterCalls).toBe(0);
+  });
+
+  it("rejects inherited serialization hooks without invoking them", () => {
+    const evidence = validPassEvidence();
+    let hookCalls = 0;
+    Object.setPrototypeOf(evidence.operation.result.bins, {
+      toJSON: () => {
+        hookCalls += 1;
+        return evidence.operation.result.bins;
+      },
+    });
+
+    expect(() => canonicalizeGatewayNodeCompatEvidence(evidence)).toThrow(
+      /operation\.result\.bins must use a plain JSON data container/u,
+    );
+    expect(hookCalls).toBe(0);
+  });
+
+  it("rejects array serialization hooks inherited through Object.prototype", () => {
+    let hookCalls = 0;
+    const priorDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "toJSON");
+    Reflect.defineProperty(Object.prototype, "toJSON", {
+      configurable: true,
+      value: () => {
+        hookCalls += 1;
+        return [];
+      },
+    });
+    try {
+      expect(() => canonicalizeGatewayNodeCompatEvidence([])).toThrow(
+        /gateway-node compatibility evidence must not inherit a JSON serialization hook/u,
+      );
+      expect(hookCalls).toBe(0);
+    } finally {
+      if (priorDescriptor) {
+        Reflect.defineProperty(Object.prototype, "toJSON", priorDescriptor);
+      } else {
+        Reflect.deleteProperty(Object.prototype, "toJSON");
+      }
+    }
+  });
+
+  it("rejects proxies without invoking reflection traps", () => {
+    const evidence = validPassEvidence();
+    let trapCalls = 0;
+    evidence.operation.result.bins = new Proxy(evidence.operation.result.bins, {
+      getPrototypeOf: (target) => {
+        trapCalls += 1;
+        return Reflect.getPrototypeOf(target);
+      },
+      ownKeys: (target) => {
+        trapCalls += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
+
+    expect(() => canonicalizeGatewayNodeCompatEvidence(evidence)).toThrow(
+      /operation\.result\.bins must use a plain JSON data container/u,
+    );
+    expect(trapCalls).toBe(0);
+  });
+
+  it("rejects non-JSON required values before canonicalization", () => {
+    const evidence = validPassEvidence();
+    evidence.caseId = undefined;
+
+    expect(() => canonicalizeGatewayNodeCompatEvidence(evidence)).toThrow(
+      /caseId must be JSON representable/u,
+    );
+  });
+
+  it("rejects required evidence inherited from a prototype", () => {
+    const evidence = validPassEvidence();
+    const inheritedCaseId = evidence.caseId;
+    delete evidence.caseId;
+    Object.setPrototypeOf(evidence, { caseId: inheritedCaseId });
+
+    expect(() => canonicalizeGatewayNodeCompatEvidence(evidence)).toThrow(
+      /must use a plain JSON data container/u,
+    );
+  });
+
+  it("enforces the 64 KiB input limit", () => {
+    const evidence = validPassEvidence();
+    evidence.gateway.packagedArtifact.version = "x".repeat(65 * 1024);
+
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/exceeds 65536 bytes/u);
+  });
+
+  it("rejects compact input whose canonical form exceeds 64 KiB", () => {
+    const evidence = validPassEvidence();
+    const bins = Array.from({ length: 16 }, (_, index) => `node-${index}`);
+    evidence.operation.params.bins = bins;
+    evidence.operation.result.bins = Object.fromEntries(
+      bins.map((bin, index) => [bin, `/tmp/${"x".repeat(3_881)}-${index}`]),
+    );
+    const compact = JSON.stringify(evidence);
+    const pretty = `${JSON.stringify(evidence, null, 2)}\n`;
+
+    expect(Buffer.byteLength(compact)).toBeLessThanOrEqual(64 * 1024);
+    expect(Buffer.byteLength(pretty)).toBeGreaterThan(64 * 1024);
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/exceeds 65536 bytes/u);
+
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "compact.json");
+    const outputPath = path.join(root, "canonical.json");
+    writeFileSync(inputPath, compact, "utf8");
+
+    const result = runCli(["canonicalize", "--input", inputPath, "--output", outputPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("exceeds 65536 bytes");
+    expect(() => readFileSync(outputPath, "utf8")).toThrow();
+  });
+
+  it("validates and canonicalizes evidence through the CLI", () => {
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "input.json");
+    const outputPath = path.join(root, "output.json");
+    writeFileSync(inputPath, JSON.stringify(validPassEvidence()), "utf8");
+
+    const validateResult = runCli(["validate", inputPath]);
+    expect(validateResult.status).toBe(0);
+    expect(validateResult.stdout).toBe("valid\n");
+    expect(validateResult.stderr).toBe("");
+
+    const canonicalizeResult = runCli([
+      "canonicalize",
+      "--output",
+      outputPath,
+      "--input",
+      inputPath,
+    ]);
+    expect(canonicalizeResult.status).toBe(0);
+    expect(canonicalizeResult.stdout).toBe("");
+    expect(canonicalizeResult.stderr).toBe("");
+    expect(readFileSync(outputPath, "utf8")).toBe(
+      canonicalizeGatewayNodeCompatEvidence(validPassEvidence()),
+    );
+  });
+
+  it("rejects malformed UTF-8 bytes during CLI validation", () => {
+    const inputPath = writeMalformedUtf8Evidence(makeTempRoot());
+
+    const result = runCli(["validate", inputPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must be valid UTF-8");
+  });
+
+  it("rejects malformed UTF-8 bytes before CLI canonicalization writes output", () => {
+    const root = makeTempRoot();
+    const inputPath = writeMalformedUtf8Evidence(root);
+    const outputPath = path.join(root, "canonical.json");
+
+    const result = runCli(["canonicalize", "--input", inputPath, "--output", outputPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must be valid UTF-8");
+    expect(() => readFileSync(outputPath, "utf8")).toThrow(/ENOENT/u);
+  });
+
+  it("atomically canonicalizes when input and output are the same file", () => {
+    const root = makeTempRoot();
+    const evidencePath = path.join(root, "evidence.json");
+    writeFileSync(evidencePath, JSON.stringify(validPassEvidence()), "utf8");
+
+    const result = runCli(["canonicalize", "--input", evidencePath, "--output", evidencePath]);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(evidencePath, "utf8")).toBe(
+      canonicalizeGatewayNodeCompatEvidence(validPassEvidence()),
+    );
+    expect(readdirSync(root).filter((entry) => entry.includes(".tmp-"))).toEqual([]);
+  });
+
+  it("preserves an existing destination when validation fails", () => {
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "invalid.json");
+    const outputPath = path.join(root, "evidence.json");
+    const invalid = validPassEvidence();
+    invalid.operation.ok = false;
+    writeFileSync(inputPath, JSON.stringify(invalid), "utf8");
+    writeFileSync(outputPath, "existing evidence\n", "utf8");
+
+    const result = runCli(["canonicalize", "--input", inputPath, "--output", outputPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(readFileSync(outputPath, "utf8")).toBe("existing evidence\n");
+    expect(readdirSync(root).filter((entry) => entry.includes(".tmp-"))).toEqual([]);
+  });
+
+  it("cleans the same-directory temp file when atomic replacement fails", () => {
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "input.json");
+    const outputPath = path.join(root, "destination");
+    const markerPath = path.join(outputPath, "marker.txt");
+    writeFileSync(inputPath, JSON.stringify(validPassEvidence()), "utf8");
+    mkdirSync(outputPath);
+    writeFileSync(markerPath, "keep\n", "utf8");
+
+    const result = runCli(["canonicalize", "--input", inputPath, "--output", outputPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(readFileSync(markerPath, "utf8")).toBe("keep\n");
+    expect(readdirSync(root).filter((entry) => entry.includes(".tmp-"))).toEqual([]);
+  });
+
+  it("requires CLI input to be a regular file", () => {
+    const root = makeTempRoot();
+
+    const result = runCli(["validate", root]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("input must be a regular file");
+  });
+
+  it.skipIf(process.platform === "win32")("rejects symlink CLI input", () => {
+    const root = makeTempRoot();
+    const targetPath = path.join(root, "target.json");
+    const inputPath = path.join(root, "input.json");
+    writeFileSync(targetPath, JSON.stringify(validPassEvidence()), "utf8");
+    symlinkSync(targetPath, inputPath);
+
+    const result = runCli(["validate", inputPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("input must be a regular file");
+  });
+
+  it.skipIf(process.platform === "win32")("rejects FIFO CLI input without blocking", () => {
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "evidence.json");
+    const makeFifo = spawnSync("mkfifo", [inputPath], { encoding: "utf8" });
+    expect(makeFifo.status).toBe(0);
+
+    const result = runCli(["validate", inputPath], 1_000);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("input must be a regular file");
+  });
+
+  it("rejects oversized CLI input before parsing", () => {
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "oversized.json");
+    writeFileSync(inputPath, `${JSON.stringify(validPassEvidence())}${" ".repeat(65 * 1024)}`);
+
+    const result = runCli(["validate", inputPath]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("exceeds 65536 bytes");
+  });
+
+  it("prints one stack-free error line for CLI failures", () => {
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "invalid.json");
+    writeFileSync(inputPath, "{\nnot-json\n", "utf8");
+
+    const result = runCli(["validate", inputPath]);
+    const lines = result.stderr.trimEnd().split("\n");
+
+    expect(result.status).not.toBe(0);
+    expect(lines).toHaveLength(1);
+    expect(result.stderr).not.toContain("\n    at ");
+  });
+
+  it("sanitizes terminal controls from attacker-controlled CLI errors", () => {
+    const root = makeTempRoot();
+    const inputPath = path.join(root, "invalid.json");
+    const invalid = validPassEvidence();
+    invalid["owned\u001b]0;gateway evidence\u0007\u009b31m\u007f\u2028\u2029"] = true;
+    writeFileSync(inputPath, JSON.stringify(invalid), "utf8");
+
+    const result = runCli(["validate", inputPath]);
+    const errorLine = result.stderr.trimEnd();
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toBe(`${errorLine}\n`);
+    expect(errorLine.length).toBeLessThanOrEqual(512);
+    expect(
+      Array.from(errorLine).some((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return (
+          codePoint <= 0x1f ||
+          (codePoint >= 0x7f && codePoint <= 0x9f) ||
+          codePoint === 0x2028 ||
+          codePoint === 0x2029
+        );
+      }),
+    ).toBe(false);
+    expect(errorLine).toContain("gateway evidence");
+  });
+
+  it("keeps declaration value exports aligned with runtime exports", () => {
+    const declaration = readFileSync("scripts/gateway-node-compat-evidence.d.mts", "utf8");
+    const declaredValueExports = Array.from(
+      declaration.matchAll(/export (?:declare )?(?:const|function) ([A-Za-z0-9_]+)/gu),
+      (match) => match[1],
+    ).toSorted(compareStrings);
+
+    expect(Object.keys(evidenceModule).toSorted(compareStrings)).toEqual(declaredValueExports);
+  });
+});

--- a/test/scripts/gateway-node-compat-evidence.test.ts
+++ b/test/scripts/gateway-node-compat-evidence.test.ts
@@ -26,11 +26,19 @@ import type {
 } from "../../scripts/gateway-node-compat-evidence.mjs";
 
 const SCRIPT_PATH = "scripts/gateway-node-compat-evidence.mjs";
-const CANDIDATE_PACKAGE_SHA256 = "b".repeat(64);
-const BASELINE_PACKAGE_SHA256 = "d".repeat(64);
+const GATEWAY_CANDIDATE_PACKAGE_SHA256 = "b".repeat(64);
+const GATEWAY_BASELINE_PACKAGE_SHA256 = "d".repeat(64);
+const NODE_CANDIDATE_PACKAGE_SHA256 = "f".repeat(64);
+const NODE_BASELINE_PACKAGE_SHA256 = "9".repeat(64);
 const ARTIFACT_IDENTITIES: GatewayNodeCompatArtifactIdentities = {
-  candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
-  baselinePackageSha256: BASELINE_PACKAGE_SHA256,
+  gateway: {
+    candidatePackageSha256: GATEWAY_CANDIDATE_PACKAGE_SHA256,
+    baselinePackageSha256: GATEWAY_BASELINE_PACKAGE_SHA256,
+  },
+  node: {
+    candidatePackageSha256: NODE_CANDIDATE_PACKAGE_SHA256,
+    baselinePackageSha256: NODE_BASELINE_PACKAGE_SHA256,
+  },
 };
 const tempRoots: string[] = [];
 
@@ -40,6 +48,23 @@ function validateGatewayNodeCompatEvidence(value: unknown) {
 
 function canonicalizeGatewayNodeCompatEvidence(value: unknown) {
   return canonicalizeGatewayNodeCompatEvidenceWithIdentities(value, ARTIFACT_IDENTITIES);
+}
+
+function hasUnsafeDiagnosticCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029 ||
+      codePoint === 0x061c ||
+      codePoint === 0x200e ||
+      codePoint === 0x200f ||
+      (codePoint >= 0x202a && codePoint <= 0x202e) ||
+      (codePoint >= 0x2066 && codePoint <= 0x2069)
+    );
+  });
 }
 
 function makeTempRoot(): string {
@@ -98,14 +123,14 @@ function validPassEvidence(): Record<string, any> {
       packagedArtifact: packagedArtifact(
         gatewayVersion,
         gatewaySourceSha,
-        "openclaw-candidate.tgz",
-        CANDIDATE_PACKAGE_SHA256,
+        "openclaw-gateway-candidate.tgz",
+        GATEWAY_CANDIDATE_PACKAGE_SHA256,
         "1",
       ),
       installedRuntime: installedRuntime(
         gatewayVersion,
         gatewaySourceSha,
-        CANDIDATE_PACKAGE_SHA256,
+        GATEWAY_CANDIDATE_PACKAGE_SHA256,
         "2".repeat(64),
       ),
     },
@@ -116,14 +141,14 @@ function validPassEvidence(): Record<string, any> {
       packagedArtifact: packagedArtifact(
         nodeVersion,
         nodeSourceSha,
-        "openclaw-baseline.tgz",
-        BASELINE_PACKAGE_SHA256,
+        "openclaw-node-baseline.tgz",
+        NODE_BASELINE_PACKAGE_SHA256,
         "3",
       ),
       installedRuntime: installedRuntime(
         nodeVersion,
         nodeSourceSha,
-        BASELINE_PACKAGE_SHA256,
+        NODE_BASELINE_PACKAGE_SHA256,
         "4".repeat(64),
       ),
     },
@@ -192,7 +217,7 @@ function setNodeKind(
 
 function validMismatchEvidence(): Record<string, any> {
   const evidence = validPassEvidence();
-  const candidateRuntime = runtimeBindingForRole("candidate");
+  const candidateRuntime = runtimeBindingForRole("node", "candidate");
   evidence.caseId = "linux-x64-candidate-gateway-disjoint-node";
   evidence.direction = "candidate-gateway-disjoint-node";
   evidence.node.packagedArtifact = candidateRuntime.packagedArtifact;
@@ -213,7 +238,7 @@ function validMismatchEvidence(): Record<string, any> {
 
 function validBaselineMismatchEvidence(): Record<string, any> {
   const evidence = validMismatchEvidence();
-  const baselineRuntime = runtimeBindingForRole("baseline");
+  const baselineRuntime = runtimeBindingForRole("gateway", "baseline");
   evidence.caseId = "linux-x64-baseline-gateway-disjoint-node";
   evidence.direction = "baseline-gateway-disjoint-node";
   evidence.gateway = baselineRuntime;
@@ -224,14 +249,37 @@ function validBaselineMismatchEvidence(): Record<string, any> {
   return evidence;
 }
 
-function runtimeBindingForRole(role: "baseline" | "candidate") {
+function runtimeBindingForRole(
+  owner: "gateway" | "node",
+  role: "baseline" | "candidate",
+): Record<string, any> {
   const identityFixture = validPassEvidence();
-  return role === "candidate"
-    ? clone(identityFixture.gateway)
-    : {
-        packagedArtifact: clone(identityFixture.node.packagedArtifact),
-        installedRuntime: clone(identityFixture.node.installedRuntime),
-      };
+  const roleFixture = role === "candidate" ? identityFixture.gateway : identityFixture.node;
+  const packageSha256 =
+    ARTIFACT_IDENTITIES[owner][
+      role === "candidate" ? "candidatePackageSha256" : "baselinePackageSha256"
+    ];
+  const seed = (
+    {
+      gateway: { baseline: "5", candidate: "1" },
+      node: { baseline: "3", candidate: "6" },
+    } as const
+  )[owner][role];
+  return {
+    packagedArtifact: packagedArtifact(
+      roleFixture.packagedArtifact.version,
+      roleFixture.packagedArtifact.sourceSha,
+      `openclaw-${owner}-${role}.tgz`,
+      packageSha256,
+      seed,
+    ),
+    installedRuntime: installedRuntime(
+      roleFixture.installedRuntime.version,
+      roleFixture.installedRuntime.sourceSha,
+      packageSha256,
+      `${Number(seed) + 1}`.repeat(64),
+    ),
+  };
 }
 
 function validEvidenceForContract(contract: GatewayNodeCompatCaseContract): Record<string, any> {
@@ -241,8 +289,8 @@ function validEvidenceForContract(contract: GatewayNodeCompatCaseContract): Reco
       : contract.outcome === "protocol-mismatch"
         ? validMismatchEvidence()
         : validPassEvidence();
-  evidence.gateway = runtimeBindingForRole(contract.gatewayArtifactRole);
-  const nodeRuntime = runtimeBindingForRole(contract.nodeArtifactRole);
+  evidence.gateway = runtimeBindingForRole("gateway", contract.gatewayArtifactRole);
+  const nodeRuntime = runtimeBindingForRole("node", contract.nodeArtifactRole);
   evidence.node.packagedArtifact = nodeRuntime.packagedArtifact;
   evidence.node.installedRuntime = nodeRuntime.installedRuntime;
   evidence.direction = contract.direction;
@@ -280,10 +328,14 @@ function runCli(args: string[], timeout?: number) {
     [
       SCRIPT_PATH,
       ...args,
-      "--candidate-package-sha256",
-      CANDIDATE_PACKAGE_SHA256,
-      "--baseline-package-sha256",
-      BASELINE_PACKAGE_SHA256,
+      "--gateway-candidate-package-sha256",
+      GATEWAY_CANDIDATE_PACKAGE_SHA256,
+      "--gateway-baseline-package-sha256",
+      GATEWAY_BASELINE_PACKAGE_SHA256,
+      "--node-candidate-package-sha256",
+      NODE_CANDIDATE_PACKAGE_SHA256,
+      "--node-baseline-package-sha256",
+      NODE_BASELINE_PACKAGE_SHA256,
     ],
     {
       cwd: process.cwd(),
@@ -328,6 +380,31 @@ describe("gateway node compatibility evidence", () => {
     expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
   });
 
+  it("rejects bidi controls from canonical evidence values", () => {
+    for (const control of [
+      "\u061c",
+      "\u200e",
+      "\u200f",
+      "\u2028",
+      "\u2029",
+      "\u202a",
+      "\u202b",
+      "\u202c",
+      "\u202d",
+      "\u202e",
+      "\u2066",
+      "\u2067",
+      "\u2068",
+      "\u2069",
+    ]) {
+      const evidence = validPassEvidence();
+      evidence.producer.job = `gateway${control}job`;
+      expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+        /producer.job must be a bounded non-control string/u,
+      );
+    }
+  });
+
   it.each(GATEWAY_NODE_COMPAT_CASE_CONTRACTS)(
     "accepts the $direction case contract",
     (contract) => {
@@ -348,7 +425,7 @@ describe("gateway node compatibility evidence", () => {
       const expectedRole =
         subject === "gateway" ? contract.gatewayArtifactRole : contract.nodeArtifactRole;
       const oppositeRole = expectedRole === "candidate" ? "baseline" : "candidate";
-      const oppositeRuntime = runtimeBindingForRole(oppositeRole);
+      const oppositeRuntime = runtimeBindingForRole(subject, oppositeRole);
       if (subject === "gateway") {
         evidence.gateway = oppositeRuntime;
       } else {
@@ -358,6 +435,44 @@ describe("gateway node compatibility evidence", () => {
 
       expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
         new RegExp(`${subject} artifact identity must match the ${expectedRole} package`, "u"),
+      );
+    },
+  );
+
+  it("binds independently packaged Gateway and node candidate artifacts", () => {
+    const contract = GATEWAY_NODE_COMPAT_CASE_CONTRACTS.find(
+      ({ direction }) => direction === "candidate-gateway-candidate-node",
+    );
+    expect(contract).toBeDefined();
+    const evidence = validEvidenceForContract(contract!);
+
+    expect(evidence.gateway.packagedArtifact.sha256).toBe(GATEWAY_CANDIDATE_PACKAGE_SHA256);
+    expect(evidence.node.packagedArtifact.sha256).toBe(NODE_CANDIDATE_PACKAGE_SHA256);
+    expect(evidence.gateway.packagedArtifact.sha256).not.toBe(
+      evidence.node.packagedArtifact.sha256,
+    );
+    expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+
+    evidence.node.packagedArtifact.sha256 = GATEWAY_CANDIDATE_PACKAGE_SHA256;
+    evidence.node.installedRuntime.packageSha256 = GATEWAY_CANDIDATE_PACKAGE_SHA256;
+    expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(
+      /node artifact identity must match the candidate package/u,
+    );
+  });
+
+  it.each(["gateway", "node"] as const)(
+    "requires distinct candidate and baseline %s identities",
+    (owner) => {
+      const identities = clone(ARTIFACT_IDENTITIES);
+      identities[owner].baselinePackageSha256 = identities[owner].candidatePackageSha256;
+
+      expect(() =>
+        validateGatewayNodeCompatEvidenceWithIdentities(validPassEvidence(), identities),
+      ).toThrow(
+        new RegExp(
+          `artifact identities\\.${owner} candidate and baseline package identities must differ`,
+          "u",
+        ),
       );
     },
   );
@@ -495,6 +610,53 @@ describe("gateway node compatibility evidence", () => {
     mutate(evidence);
 
     expect(() => validateGatewayNodeCompatEvidence(evidence)).toThrow(/not allowed/u);
+  });
+
+  it("sanitizes hostile unknown keys in imported validation errors", () => {
+    const evidence = validPassEvidence();
+    evidence[
+      "owned\u001b]0;gateway evidence\u0007\u009b31m\u007f\u2028\u2029\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+    ] = true;
+
+    let error: unknown;
+    try {
+      validateGatewayNodeCompatEvidence(evidence);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = error instanceof Error ? error.message : "";
+    expect(message).toContain("gateway-node compatibility evidence.owned");
+    expect(message).toContain("gateway evidence");
+    expect(message).toContain("is not allowed");
+    expect(message.length).toBeLessThanOrEqual(200);
+    expect(hasUnsafeDiagnosticCharacter(message)).toBe(false);
+  });
+
+  it("sanitizes hostile keys in early JSON-tree validation errors", () => {
+    for (const key of [
+      "owned\u001b]0;tree\u0007\u2028\u2029\u202e",
+      Symbol("owned\u001b]0;tree\u0007\u2028\u2029\u202e"),
+    ]) {
+      const evidence = validPassEvidence();
+      Object.defineProperty(evidence, key, {
+        enumerable: true,
+        value: typeof key === "string" ? Number.POSITIVE_INFINITY : true,
+      });
+
+      let error: unknown;
+      try {
+        validateGatewayNodeCompatEvidence(evidence);
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      const message = error instanceof Error ? error.message : "";
+      expect(message).toContain("owned ]0;tree");
+      expect(hasUnsafeDiagnosticCharacter(message)).toBe(false);
+    }
   });
 
   it.each([
@@ -814,6 +976,26 @@ describe("gateway node compatibility evidence", () => {
     }
   });
 
+  it("sanitizes hostile result keys in imported validation errors", () => {
+    const evidence = validPassEvidence();
+    evidence.operation.result.bins = {};
+    evidence.operation.result.bins[
+      "node\u001b]0;gateway result\u0007\u009b31m\u007f\u2028\u2029\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+    ] = "/usr/bin/node";
+
+    let error: unknown;
+    try {
+      validateGatewayNodeCompatEvidence(evidence);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = error instanceof Error ? error.message : "";
+    expect(message).toBe("operation.result.bins key must be a bounded non-control string");
+    expect(hasUnsafeDiagnosticCharacter(message)).toBe(false);
+  });
+
   it.each([
     ["android", "openclaw-android"],
     ["ios", "openclaw-ios"],
@@ -943,6 +1125,7 @@ describe("gateway node compatibility evidence", () => {
       ".github/workflows//release.yml",
       ".github/workflows/./release.yml",
       ".github/workflows/../release.yml",
+      ".github/workflows/nested/release.yml",
       ".github\\workflows\\release.yml",
       ".github/workflows/release.json",
     ]) {
@@ -991,12 +1174,12 @@ describe("gateway node compatibility evidence", () => {
       "actionsArtifact": {
         "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
         "id": 1111,
-        "name": "openclaw-candidate.tgz-input",
+        "name": "openclaw-gateway-candidate.tgz-input",
         "runAttempt": 2,
         "runId": "111111111",
         "sizeBytes": 4096
       },
-      "name": "openclaw-candidate.tgz",
+      "name": "openclaw-gateway-candidate.tgz",
       "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "sourceSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "version": "v2026.8.6"
@@ -1006,7 +1189,7 @@ describe("gateway node compatibility evidence", () => {
     "architecture": "x64",
     "installedRuntime": {
       "identitySha256": "4444444444444444444444444444444444444444444444444444444444444444",
-      "packageSha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "packageSha256": "9999999999999999999999999999999999999999999999999999999999999999",
       "sourceSha": "cccccccccccccccccccccccccccccccccccccccc",
       "version": "v2026.5.7"
     },
@@ -1015,13 +1198,13 @@ describe("gateway node compatibility evidence", () => {
       "actionsArtifact": {
         "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
         "id": 3333,
-        "name": "openclaw-baseline.tgz-input",
+        "name": "openclaw-node-baseline.tgz-input",
         "runAttempt": 2,
         "runId": "333333333",
         "sizeBytes": 4096
       },
-      "name": "openclaw-baseline.tgz",
-      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "name": "openclaw-node-baseline.tgz",
+      "sha256": "9999999999999999999999999999999999999999999999999999999999999999",
       "sourceSha": "cccccccccccccccccccccccccccccccccccccccc",
       "version": "v2026.5.7"
     },
@@ -1281,6 +1464,15 @@ describe("gateway node compatibility evidence", () => {
     );
   });
 
+  it("prints mandatory artifact identity flags in CLI usage", () => {
+    const result = runCli(["unsupported"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "validate <file> --gateway-candidate-package-sha256 <sha256> --gateway-baseline-package-sha256 <sha256> --node-candidate-package-sha256 <sha256> --node-baseline-package-sha256 <sha256>",
+    );
+  });
+
   it("rejects malformed UTF-8 bytes during CLI validation", () => {
     const inputPath = writeMalformedUtf8Evidence(makeTempRoot());
 
@@ -1394,16 +1586,20 @@ describe("gateway node compatibility evidence", () => {
     expect(result.stderr).toContain("exceeds 65536 bytes");
   });
 
-  it("prints one stack-free error line for CLI failures", () => {
+  it("prints a fixed stack-free error and the standard failure trailer", () => {
     const root = makeTempRoot();
     const inputPath = path.join(root, "invalid.json");
-    writeFileSync(inputPath, "{\nnot-json\n", "utf8");
+    writeFileSync(inputPath, '{"privatePath":"/internal/secret"} trailing', "utf8");
 
     const result = runCli(["validate", inputPath]);
     const lines = result.stderr.trimEnd().split("\n");
 
     expect(result.status).not.toBe(0);
-    expect(lines).toHaveLength(1);
+    expect(lines).toEqual([
+      "gateway-node compatibility evidence must be valid JSON",
+      "[gateway-node-compat-evidence] FAILED (exit 1)",
+    ]);
+    expect(result.stderr).not.toContain("/internal/secret");
     expect(result.stderr).not.toContain("\n    at ");
   });
 
@@ -1411,26 +1607,19 @@ describe("gateway node compatibility evidence", () => {
     const root = makeTempRoot();
     const inputPath = path.join(root, "invalid.json");
     const invalid = validPassEvidence();
-    invalid["owned\u001b]0;gateway evidence\u0007\u009b31m\u007f\u2028\u2029"] = true;
+    invalid[
+      "owned\u001b]0;gateway evidence\u0007\u009b31m\u007f\u2028\u2029\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+    ] = true;
     writeFileSync(inputPath, JSON.stringify(invalid), "utf8");
 
     const result = runCli(["validate", inputPath]);
-    const errorLine = result.stderr.trimEnd();
+    const lines = result.stderr.trimEnd().split("\n");
+    const errorLine = lines[0] ?? "";
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toBe(`${errorLine}\n`);
+    expect(lines.at(-1)).toBe("[gateway-node-compat-evidence] FAILED (exit 1)");
     expect(errorLine.length).toBeLessThanOrEqual(512);
-    expect(
-      Array.from(errorLine).some((character) => {
-        const codePoint = character.codePointAt(0) ?? 0;
-        return (
-          codePoint <= 0x1f ||
-          (codePoint >= 0x7f && codePoint <= 0x9f) ||
-          codePoint === 0x2028 ||
-          codePoint === 0x2029
-        );
-      }),
-    ).toBe(false);
+    expect(hasUnsafeDiagnosticCharacter(errorLine)).toBe(false);
     expect(errorLine).toContain("gateway evidence");
   });
 
@@ -1438,7 +1627,7 @@ describe("gateway node compatibility evidence", () => {
     const declaration = readFileSync("scripts/gateway-node-compat-evidence.d.mts", "utf8");
     const declaredValueExports = Array.from(
       declaration.matchAll(/export (?:declare )?(?:const|function) ([A-Za-z0-9_]+)/gu),
-      (match) => match[1],
+      (match) => match[1] ?? "",
     ).toSorted(compareStrings);
 
     expect(Object.keys(evidenceModule).toSorted(compareStrings)).toEqual(declaredValueExports);


### PR DESCRIPTION
Depends on https://github.com/openclaw/openclaw/pull/119991

## What Problem This Solves

Release compatibility producers need one strict evidence contract that records the exact Gateway and node artifacts, the installed runtimes that actually connected, and an observed compatibility outcome without deriving a false green from protocol-range overlap.

## Why This Change Was Made

Defines `openclaw.gateway-node-compat/v1` for direct Gateway WebSocket clients:

- direct node role/mode transport for Android, iOS, Linux, macOS, and Windows
- six explicit candidate/baseline directions, including disjoint-node rejection against both Gateways
- independently scoped Gateway/node package identities, each separated from installed runtime identity
- Actions artifact/run provenance, package SHA-256, source SHA, observed ranges, Gateway protocol, and hello protocol
- successful Android and iOS evidence requires an observed `node.invoke device.info`
- successful Linux, macOS, and Windows evidence requires an observed `node.invoke system.which`
- rejected evidence requires structured `PROTOCOL_MISMATCH`, no hello, and no operation
- bounded deterministic canonical output with atomic replacement

Watch direct and Wear proxy intentionally require separate transport-specific contracts. External artifact/run provenance is recorded but independently verified by later stack PRs.

## User Impact

No runtime behavior changes. Release automation gains a strict direct-node evidence format without conflating WebSocket, Watch HTTP, or Wear proxy transports.

## Evidence

- Exact head: `e26ef9ec93be95e77299ae0373ee35ea00d75f96`
- Focused validator and CLI tests: 181/181 passed
- Script declaration contracts: 255/255 passed
- Targeted formatting, syntax validation, signatures, and `git diff --check`: passed
- Autoreview through P2: clean, confidence 0.95
- Local ClawSweeper on the exact PR range: no line-level findings, security cleared, patch correct at confidence 0.90
- The local root test-type lane no longer reports the declaration-alignment error; its full run is blocked by the unchanged parent dependency mismatch at `packages/terminal-core/src/ansi.ts:194`
- The repo-native changed gate is additionally blocked before changed-surface checks by an unrelated parent max-lines ratchet
- Earlier whole-stack and Crabbox runs remain supplementary pre-repair evidence and are not claimed as exact-head proof
- Downstream stack PRs still use the former shared two-hash API and require a separate update; this PR does not claim stack integration proof

Punchcard-Session: cobalt-timber-orchard-d1
