### PR TITLE
fix(ui): show Pi logo in session catalog

### DIFF
--- a/ui/public/provider-icons/ATTRIBUTION.md
+++ b/ui/public/provider-icons/ATTRIBUTION.md
@@ -17,6 +17,13 @@ content otherwise match the cited upstream files.
 
 Provider names and marks remain the property of their respective owners.
 
+## Pi icon
+
+`ProviderIcon-pi.svg` is a metadata-cleaned copy of the official Pi logo:
+
+- Source: https://pi.dev/logo.svg
+- Press kit: https://pi.dev/press-kit
+
 ## LM Studio icon
 
 `ProviderIcon-lmstudio.svg` is the official monochrome outline icon published

--- a/ui/public/provider-icons/ProviderIcon-pi.svg
+++ b/ui/public/provider-icons/ProviderIcon-pi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <path fill="#fff" fill-rule="evenodd" d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"/>
+  <path fill="#fff" d="M517.36 400H634.72V634.72H517.36Z"/>
+</svg>

--- a/ui/src/components/provider-icon.ts
+++ b/ui/src/components/provider-icon.ts
@@ -49,6 +49,7 @@ const PROVIDER_ICON_NAMES = new Set([
   "opencodego",
   "openrouter",
   "perplexity",
+  "pi",
   "poe",
   "qoder",
   "sakana",

--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -116,6 +116,23 @@ suite("OpenCode and Pi external session catalogs", () => {
     });
 
     await page.goto(`${server.baseUrl}chat`);
+    await expect
+      .poll(() =>
+        page
+          .locator('[data-session-section="catalog:opencode"] [data-provider-icon="opencode"]')
+          .count(),
+      )
+      .toBe(1);
+    await expect
+      .poll(() =>
+        page.locator('[data-session-section="catalog:pi"] [data-provider-icon="pi"]').count(),
+      )
+      .toBe(1);
+    const piIconResponse = await page.request.get(
+      new URL("provider-icons/ProviderIcon-pi.svg", server.baseUrl).toString(),
+    );
+    expect(piIconResponse.ok()).toBe(true);
+
     await page.getByText("OpenCode release review", { exact: true }).click();
     await expect.poll(() => page.getByText("OpenCode transcript loaded").count()).toBe(1);
     await page.getByText("Pi architecture notes", { exact: true }).click();

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5931,7 +5931,8 @@ td.data-table-key-col {
 }
 
 .provider-brand-icon[data-provider-icon="opencode"],
-.provider-brand-icon[data-provider-icon="opencodego"] {
+.provider-brand-icon[data-provider-icon="opencodego"],
+.provider-brand-icon[data-provider-icon="pi"] {
   color: var(--text-strong);
 }
 /* Shared working-claw motion: chat and settings use the same body flex and

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -166,6 +166,8 @@ describe("AppSidebar session catalog pagination", () => {
   it.each([
     { id: "claude", label: "Claude Code" },
     { id: "codex", label: "Codex" },
+    { id: "opencode", label: "OpenCode" },
+    { id: "pi", label: "Pi" },
   ])("groups $label catalog rows by their owning host", async ({ id, label }) => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with Pi external sessions would see no provider mark beside the Pi catalog heading in the Control UI sidebar, even though the sibling Claude Code, Codex, and OpenCode catalogs show their identities.

## Why This Change Was Made

The Pi catalog already exposes the stable `pi` identity consumed by the shared Control UI provider-icon registry, so this change adds the official Pi mark at that existing owner boundary rather than changing plugin metadata or the Gateway protocol. OpenCode already has a complete provider icon and remains covered as a sibling surface.

## User Impact

Pi session catalogs now display a distinct Pi logo in the sidebar, making coding-session sources easier to scan without changing transcript navigation or view-only behavior.

## Evidence

**Before**

<img width="1148" height="1058" alt="Pi catalog before: no provider mark" src="https://github.com/user-attachments/assets/55496b31-2d9b-4d3f-a999-942f900817fa" />

**After**

<img width="1148" height="1058" alt="Pi catalog after: official Pi mark" src="https://github.com/user-attachments/assets/e03b3ee1-dfdc-4486-9171-db03cf18ffd9" />

- The browser screenshots use the same non-sensitive OpenCode + Pi mock Gateway fixture.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 237 tests passed.
- `OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/control-ui-e2e/pi-logo node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/external-session-catalogs.e2e.test.ts` — browser-driven catalog scenario passed; Pi and OpenCode marks rendered, the Pi SVG returned successfully, both transcripts opened, and the composer stayed view-only.
- `pnpm ui:build` — production bundle, precompressed-asset verification, and Control UI performance gate passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo` — passed.
- Targeted `oxfmt`, `stylelint`, and `git diff --check` — passed.
- Codex autoreview (`gpt-5.6-sol`, high reasoning) — clean; no accepted/actionable findings.
- Source-blind behavior validation — all five clauses passed. The operator Gateway at `ws://127.0.0.1:18789` was offline, so live-profile verification was unavailable; the isolated browser scenario used non-sensitive fixture data.
- Remote changed-path delegation was unavailable because the local Blacksmith CLI and managed Crabbox broker authentication were not present; trusted-source local fallback proof above completed successfully.

AI-assisted: yes (Claude Code). A redacted transcript was offered and intentionally omitted.
