### PR TITLE
fix(gateway): fence superseded reload channel lifetimes

### DIFF
--- a/src/gateway/server-channel-runtime.types.ts
+++ b/src/gateway/server-channel-runtime.types.ts
@@ -12,5 +12,6 @@ export type StartChannelOptions = {
   preserveRestartAttempts?: boolean;
   preserveManualStop?: boolean;
   deferAccountStartUntil?: Promise<void>;
+  lifecycleAbortSignal?: AbortSignal;
   manual?: boolean;
 };

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -433,16 +433,24 @@ describe("server-channels auto restart", () => {
     expect(manager.isAutoRestartScheduled("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
   });
 
-  it("aborts the crashed task's signal before starting its replacement", async () => {
+  it("keeps automatic replacement owned by the original lifecycle generation", async () => {
     const signals: AbortSignal[] = [];
     const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
       signals.push(ctx.abortSignal);
-      throw new Error("crash");
+      if (signals.length === 1) {
+        throw new Error("crash");
+      }
+      await new Promise<void>((resolve) => {
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
     });
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager();
+    const lifecycleAbort = new AbortController();
 
-    await manager.startChannels();
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, {
+      lifecycleAbortSignal: lifecycleAbort.signal,
+    });
     await advanceTimersUntil(
       () => startAccount.mock.calls.length >= 2,
       "expected a crash-loop restart",
@@ -453,6 +461,12 @@ describe("server-channels auto restart", () => {
     // (e.g. a reconnect loop). The replacement must never overlap that lifetime.
     expect(signals[0]?.aborted).toBe(true);
     expect(signals[1]?.aborted).toBe(false);
+
+    lifecycleAbort.abort();
+    await waitForMicrotaskCondition(
+      () => signals[1]?.aborted === true,
+      "expected the replacement to retain lifecycle generation ownership",
+    );
   });
 
   it.each(["resolve", "reject"] as const)(
@@ -748,11 +762,13 @@ describe("server-channels auto restart", () => {
 
     releaseTask.resolve();
     await flushMicrotasks();
-    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    const replacementStart = manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await flushMicrotasks();
     expect(startAccount).toHaveBeenCalledTimes(1);
 
     releaseStopHook.resolve();
     await stopFailure;
+    await replacementStart;
     await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
     expect(startAccount).toHaveBeenCalledTimes(1);
     expect(
@@ -789,11 +805,13 @@ describe("server-channels auto restart", () => {
     await flushMicrotasks();
     expect(stopAccount).toHaveBeenCalledTimes(2);
 
-    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    const replacementStart = manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await flushMicrotasks();
     expect(startAccount).toHaveBeenCalledTimes(1);
 
     stopHooks[1]?.resolve();
     await secondFailure;
+    await replacementStart;
     await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
     expect(startAccount).toHaveBeenCalledTimes(1);
     expect(
@@ -1201,21 +1219,29 @@ describe("server-channels auto restart", () => {
 
   it("does not poison auto-restart state when recovery stop times out", async () => {
     const releaseFirstTask = createDeferred();
-    const startAccount = vi.fn(
-      async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+    const signals: AbortSignal[] = [];
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      signals.push(abortSignal);
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      if (signals.length === 1) {
+        await releaseFirstTask.promise;
+      } else {
         await new Promise<void>((resolve) => {
-          abortSignal.addEventListener("abort", () => {}, { once: true });
-          void releaseFirstTask.promise.then(resolve);
-        }),
-    );
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      }
+    });
     installTestRegistry(
       createTestPlugin({
         startAccount,
       }),
     );
     const manager = createManager();
+    const lifecycleAbort = new AbortController();
 
-    await manager.startChannels();
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, {
+      lifecycleAbortSignal: lifecycleAbort.signal,
+    });
     const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
     await vi.advanceTimersByTimeAsync(5_000);
     await stopTask;
@@ -1238,6 +1264,12 @@ describe("server-channels auto restart", () => {
 
     expect(startAccount).toHaveBeenCalledTimes(2);
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+
+    lifecycleAbort.abort();
+    await waitForMicrotaskCondition(
+      () => signals[1]?.aborted === true,
+      "expected timed-out-stop replacement to retain lifecycle generation ownership",
+    );
   });
 
   it("does not restart when a timed-out recovery stop settles as terminal", async () => {
@@ -2085,6 +2117,35 @@ describe("server-channels auto restart", () => {
     await Promise.all([startTask, stopTask]);
 
     expect(startAccount).not.toHaveBeenCalled();
+  });
+
+  it("starts a successor after an aborted predecessor hands off no task", async () => {
+    const startupGate = createDeferred();
+    const isConfigured = vi.fn(async () => {
+      if (isConfigured.mock.calls.length === 1) {
+        await startupGate.promise;
+      }
+      return true;
+    });
+    const startAccount = vi.fn(async () => await new Promise(() => {}));
+
+    installTestRegistry(createTestPlugin({ startAccount, isConfigured }));
+    const manager = createManager();
+    const predecessorLifecycle = new AbortController();
+
+    const predecessor = manager.startChannel("discord", DEFAULT_ACCOUNT_ID, {
+      lifecycleAbortSignal: predecessorLifecycle.signal,
+    });
+    await Promise.resolve();
+    const successor = manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    predecessorLifecycle.abort();
+    startupGate.resolve();
+    await Promise.all([predecessor, successor]);
+
+    expect(isConfigured).toHaveBeenCalledTimes(2);
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(firstStartAccountContext(startAccount)?.abortSignal.aborted).toBe(false);
   });
 
   it("does not resolve channelRuntime until a channel starts", async () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1,6 +1,7 @@
 /**
  * Server channel lifecycle tests.
  */
+import { getEventListeners } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelIngressUnavailableError } from "../channels/message/ingress-unavailable.js";
 import type {
@@ -1270,6 +1271,33 @@ describe("server-channels auto restart", () => {
       () => signals[1]?.aborted === true,
       "expected timed-out-stop replacement to retain lifecycle generation ownership",
     );
+  });
+
+  it("releases a timed-out predecessor generation listener before forced replacement", async () => {
+    const signals: AbortSignal[] = [];
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      signals.push(abortSignal);
+      await new Promise<void>(() => {});
+    });
+    const stopAccount = vi.fn(async () => {});
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+    const lifecycleAbort = new AbortController();
+    const startOptions = { lifecycleAbortSignal: lifecycleAbort.signal };
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, startOptions);
+    const predecessorStop = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await predecessorStop;
+    expect(getEventListeners(lifecycleAbort.signal, "abort")).toHaveLength(0);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, startOptions);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, startOptions);
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(getEventListeners(lifecycleAbort.signal, "abort")).toHaveLength(1);
+    lifecycleAbort.abort();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(signals[1]?.aborted).toBe(true);
+    expect(stopAccount).toHaveBeenCalledTimes(2);
   });
 
   it("does not restart when a timed-out recovery stop settles as terminal", async () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -781,7 +781,300 @@ describe("server-channels auto restart", () => {
     });
   });
 
-  it("serializes overlapping stops until the last teardown settles", async () => {
+  it("allows replacement after the latest stop succeeds following a rejection", async () => {
+    const stopGates = [createDeferred(), createDeferred()];
+    const startAccount = vi.fn(
+      async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+    const stopAccount = vi.fn(async () => {
+      const callIndex = stopAccount.mock.calls.length - 1;
+      await stopGates[callIndex]?.promise;
+      if (callIndex === 0) {
+        throw new Error("first stop failed");
+      }
+    });
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    const firstStop = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    const secondStop = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    const firstFailure = expect(firstStop).rejects.toThrow("first stop failed");
+    await flushMicrotasks();
+    expect(stopAccount).toHaveBeenCalledOnce();
+
+    stopGates[0]?.resolve();
+    await firstFailure;
+    await waitForMicrotaskCondition(
+      () => stopAccount.mock.calls.length === 2,
+      "expected the replacement stop to follow the rejected attempt",
+    );
+    stopGates[1]?.resolve();
+    await expect(secondStop).resolves.toBeUndefined();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(startAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it("follows a pending latest failure and settles sibling accounts before throwing", async () => {
+    const accountIds = ["broken", "healthy"];
+    const firstBrokenStop = createDeferred();
+    const latestBrokenStop = createDeferred();
+    const healthyTask = createDeferred();
+    let brokenStopCount = 0;
+    const startAccount = vi.fn(
+      async ({ abortSignal, accountId }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener(
+            "abort",
+            () => {
+              if (accountId === "healthy") {
+                void healthyTask.promise.then(resolve);
+              } else {
+                resolve();
+              }
+            },
+            { once: true },
+          );
+        }),
+    );
+    const stopAccount = vi.fn(async ({ accountId }: ChannelGatewayContext<TestAccount>) => {
+      if (accountId !== "broken") {
+        return;
+      }
+      brokenStopCount += 1;
+      if (brokenStopCount === 1) {
+        await firstBrokenStop.promise;
+        throw new Error("first broken stop failed");
+      }
+      await latestBrokenStop.promise;
+      throw new Error("latest broken stop failed");
+    });
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => accountIds,
+        resolveAccount: () => ({ enabled: true, configured: true }),
+        startAccount,
+        stopAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannel("discord");
+    const firstStop = manager.stopChannel("discord", "broken", { manual: false });
+    const firstFailure = expect(firstStop).rejects.toThrow("first broken stop failed");
+    await waitForMicrotaskCondition(
+      () => brokenStopCount === 1,
+      "expected the first broken stop to begin",
+    );
+    const shutdown = manager.stopChannelForShutdown("discord");
+    const secondStop = manager.stopChannel("discord", "broken", { manual: false });
+    const secondFailure = expect(secondStop).rejects.toThrow("latest broken stop failed");
+    let shutdownSettled = false;
+    void shutdown.then(
+      () => {
+        shutdownSettled = true;
+      },
+      () => {
+        shutdownSettled = true;
+      },
+    );
+    await waitForMicrotaskCondition(
+      () => stopAccount.mock.calls.some(([ctx]) => ctx.accountId === "healthy"),
+      "expected shutdown to stop the healthy sibling",
+    );
+
+    firstBrokenStop.resolve();
+    await firstFailure;
+    await waitForMicrotaskCondition(
+      () => brokenStopCount === 2,
+      "expected the replacement broken stop to begin",
+    );
+    latestBrokenStop.resolve();
+    await secondFailure;
+    await flushMicrotasks();
+    expect(shutdownSettled).toBe(false);
+
+    healthyTask.resolve();
+    await expect(shutdown).rejects.toThrow("latest broken stop failed");
+    expect(stopAccount.mock.calls.filter(([ctx]) => ctx.accountId === "broken")).toHaveLength(2);
+    expect(stopAccount.mock.calls.filter(([ctx]) => ctx.accountId === "healthy")).toHaveLength(1);
+  });
+
+  it("follows a successful retry queued behind a timed-out stop", async () => {
+    const releaseTask = createDeferred();
+    const releaseSecondStop = createDeferred();
+    const startAccount = vi.fn(async () => await releaseTask.promise);
+    const stopAccount = vi.fn(async () => {
+      if (stopAccount.mock.calls.length === 2) {
+        await releaseSecondStop.promise;
+      }
+    });
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    const firstStop = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    const secondStop = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await firstStop;
+    await waitForMicrotaskCondition(
+      () => stopAccount.mock.calls.length === 2,
+      "expected the queued retry to begin after the timeout",
+    );
+
+    const shutdown = manager.stopChannelForShutdown("discord");
+    await flushMicrotasks();
+    expect(stopAccount).toHaveBeenCalledTimes(2);
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+    ).toMatchObject({
+      lifecycle: "recovering",
+      lastError: "channel stop timed out after 5000ms",
+    });
+
+    releaseTask.resolve();
+    releaseSecondStop.resolve();
+    await expect(secondStop).resolves.toBeUndefined();
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(stopAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it("joins a settled lifecycle stop during shutdown without stopping twice", async () => {
+    const startAccount = vi.fn(
+      async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+    const stopAccount = vi.fn(async () => {});
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+    const lifecycleAbort = new AbortController();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, {
+      lifecycleAbortSignal: lifecycleAbort.signal,
+    });
+    await flushMicrotasks();
+    lifecycleAbort.abort();
+    await waitForMicrotaskCondition(
+      () =>
+        manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.lifecycle ===
+        "stopped",
+      "expected lifecycle stop to settle",
+    );
+
+    await manager.stopChannelForShutdown("discord");
+
+    expect(stopAccount).toHaveBeenCalledOnce();
+  });
+
+  it("rethrows a settled lifecycle stop failure from the shutdown join", async () => {
+    const startAccount = vi.fn(
+      async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+    const stopAccount = vi.fn(async () => {
+      throw new Error("lifecycle stop failed");
+    });
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+    const lifecycleAbort = new AbortController();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, {
+      lifecycleAbortSignal: lifecycleAbort.signal,
+    });
+    await flushMicrotasks();
+    lifecycleAbort.abort();
+    await waitForMicrotaskCondition(
+      () =>
+        manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.lastError ===
+        "lifecycle stop failed",
+      "expected lifecycle stop failure to settle",
+    );
+    await flushMicrotasks();
+
+    await expect(manager.stopChannelForShutdown("discord")).rejects.toThrow(
+      "lifecycle stop failed",
+    );
+    expect(stopAccount).toHaveBeenCalledOnce();
+  });
+
+  it("joins a timed-out lifecycle stop without replacing its timeout state", async () => {
+    const startAccount = vi.fn(async () => await new Promise<void>(() => {}));
+    const stopAccount = vi.fn(async () => {});
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+    const lifecycleAbort = new AbortController();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, {
+      lifecycleAbortSignal: lifecycleAbort.signal,
+    });
+    await flushMicrotasks();
+    lifecycleAbort.abort();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await manager.stopChannelForShutdown("discord");
+
+    expect(stopAccount).toHaveBeenCalledOnce();
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+    ).toMatchObject({
+      running: false,
+      lifecycle: "recovering",
+      restartPending: true,
+      lastError: "channel stop timed out after 5000ms",
+    });
+  });
+
+  it("stops a successor while it is reserved before task handoff", async () => {
+    const successorGate = createDeferred();
+    const isConfigured = vi.fn(async () => {
+      if (isConfigured.mock.calls.length === 2) {
+        await successorGate.promise;
+      }
+      return true;
+    });
+    const startAccount = vi.fn(
+      async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+    const stopAccount = vi.fn(async () => {});
+    installTestRegistry(createTestPlugin({ isConfigured, startAccount, stopAccount }));
+    const manager = createManager();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    const successor = manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await waitForMicrotaskCondition(
+      () => isConfigured.mock.calls.length === 2,
+      "expected the successor to reach its pre-handoff gate",
+    );
+    const shutdown = manager.stopChannelForShutdown("discord");
+    let shutdownSettled = false;
+    void shutdown.then(() => {
+      shutdownSettled = true;
+    });
+    await waitForMicrotaskCondition(
+      () => stopAccount.mock.calls.length === 2,
+      "expected shutdown to stop the reserved successor",
+    );
+
+    expect(shutdownSettled).toBe(false);
+    expect(startAccount).toHaveBeenCalledOnce();
+    successorGate.resolve();
+    await Promise.all([successor, shutdown]);
+    expect(stopAccount).toHaveBeenCalledTimes(2);
+    expect(startAccount).toHaveBeenCalledOnce();
+  });
+
+  it("returns each overlapping explicit stop's own teardown result", async () => {
     const releaseTask = createDeferred();
     const stopHooks = [createDeferred(), createDeferred()];
     const startAccount = vi.fn(async () => await releaseTask.promise);
@@ -2691,7 +2984,7 @@ describe("server-channels auto restart", () => {
     await Promise.all(channelIds.map((id) => manager.stopChannel(id)));
   });
 
-  it("evicts stale account lifecycle state during whole-channel reload", async () => {
+  it("evicts stale account state and its fulfilled stop receipt during reload", async () => {
     let accountIds = [DEFAULT_ACCOUNT_ID];
     const startAccount = vi.fn(
       async ({ abortSignal }: { abortSignal: AbortSignal }) =>

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -11,6 +11,7 @@ import {
   resolveChannelAccountState,
 } from "../channels/status/account-state.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { withGatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime-context.js";
 import type { GatewayNativeApprovalMethod } from "../infra/approval-gateway-runtime-methods.js";
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
@@ -234,19 +235,21 @@ type ChannelAccountStopState =
   | { status: "stopping"; attempt: Promise<ChannelAccountStopOutcome> }
   | Extract<ChannelAccountStopOutcome, { status: "rejected" }>;
 
-async function waitForDeferredAccountStart(
-  deferred: Promise<void>,
-  abortSignal: AbortSignal,
-): Promise<void> {
-  if (abortSignal.aborted) {
-    return;
+async function waitForChannelLifecycleGate(
+  gate: Promise<unknown>,
+  abortSignal?: AbortSignal,
+): Promise<boolean> {
+  if (!abortSignal) {
+    await gate;
+    return true;
   }
-  await Promise.race([
-    deferred,
-    new Promise<void>((resolve) => {
-      abortSignal.addEventListener("abort", () => resolve(), { once: true });
-    }),
-  ]);
+  const cleanup = new AbortController();
+  try {
+    await Promise.race([gate, waitForAbortSignal(AbortSignal.any([abortSignal, cleanup.signal]))]);
+    return !abortSignal.aborted;
+  } finally {
+    cleanup.abort();
+  }
 }
 
 export type ChannelManager = {
@@ -527,9 +530,26 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       limit: CHANNEL_STARTUP_CONCURRENCY,
       tasks: accountIds.map((id) => async () => {
         const rKey = restartKey(channelId, id);
+        const lifecycleAbortSignal = optsValue.lifecycleAbortSignal;
         // An in-flight or failed plugin teardown may still own resources. Only
         // the last queued attempt or a later successful stop clears this gate.
-        if (store.stops.has(id)) {
+        while (true) {
+          const predecessorStop = store.stops.get(id);
+          const predecessorGate =
+            predecessorStop?.status === "stopping"
+              ? predecessorStop.attempt
+              : store.starting.get(id);
+          if (!predecessorGate) {
+            if (predecessorStop) {
+              return;
+            }
+            break;
+          }
+          if (!(await waitForChannelLifecycleGate(predecessorGate, lifecycleAbortSignal))) {
+            return;
+          }
+        }
+        if (lifecycleAbortSignal?.aborted) {
           return;
         }
         if (store.tasks.has(id)) {
@@ -566,12 +586,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             return;
           }
         }
-        const existingStart = store.starting.get(id);
-        if (existingStart) {
-          await existingStart;
-          return;
-        }
-
         let resolveStart: (() => void) | undefined;
         const startGate = new Promise<void>((resolve) => {
           resolveStart = resolve;
@@ -582,6 +596,19 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         // cannot race into duplicate provider boots for the same account.
         const abort = new AbortController();
         store.aborts.set(id, abort);
+        let lifecycleStopRequested = false;
+        const stopForLifecycleAbort = () => {
+          if (!lifecycleStopRequested) {
+            lifecycleStopRequested = true;
+            // Generation cancellation asks the manager to stop this account.
+            // The plugin run keeps its distinct abort signal until stop owns teardown.
+            void stopChannel(channelId, id, { manual: false }).catch(() => {});
+          }
+        };
+        lifecycleAbortSignal?.addEventListener("abort", stopForLifecycleAbort, { once: true });
+        if (lifecycleAbortSignal?.aborted) {
+          stopForLifecycleAbort();
+        }
         let handedOffTask = false;
         const log = ensureChannelLog(channelId);
         const runtime = ensureChannelRuntime(channelId);
@@ -742,7 +769,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           });
           const task = Promise.resolve().then(async () => {
             if (optsValue.deferAccountStartUntil) {
-              await waitForDeferredAccountStart(optsValue.deferAccountStartUntil, abort.signal);
+              await waitForChannelLifecycleGate(optsValue.deferAccountStartUntil, abort.signal);
             } else if (startupTrace) {
               await waitForChannelStartupHandoff();
             }
@@ -921,6 +948,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 try {
                   await startChannelInternal(channelId, id, {
                     preserveManualStop: true,
+                    lifecycleAbortSignal: optsValue.lifecycleAbortSignal,
                   });
                 } catch {
                   // abort or startup failure — runtime state was recorded by startChannelInternal
@@ -974,6 +1002,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 await startChannelInternal(channelId, id, {
                   preserveRestartAttempts: true,
                   preserveManualStop: true,
+                  lifecycleAbortSignal: optsValue.lifecycleAbortSignal,
                 });
               } catch {
                 // abort or startup failure — next crash will retry
@@ -982,6 +1011,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               }
             })
             .finally(() => {
+              lifecycleAbortSignal?.removeEventListener("abort", stopForLifecycleAbort);
               if (store.tasks.get(id) === trackedPromise) {
                 store.tasks.delete(id);
               }
@@ -1011,6 +1041,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             store.starting.delete(id);
           }
           if (!handedOffTask) {
+            lifecycleAbortSignal?.removeEventListener("abort", stopForLifecycleAbort);
             await cleanupTaskScopedApprovalRuntime("channel startup cleanup failed");
           }
           if (!handedOffTask && store.aborts.get(id) === abort) {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -74,7 +74,7 @@ function waitForChannelStartupHandoff(): Promise<void> {
 type ChannelRuntimeStore = {
   aborts: Map<string, AbortController>;
   starting: Map<string, Promise<void>>;
-  stops: Map<string, ChannelAccountStopState>;
+  stops: Map<string, StopReceipt>;
   tasks: Map<string, Promise<unknown>>;
   runtimes: Map<string, ChannelAccountSnapshot>;
 };
@@ -229,11 +229,18 @@ type StopChannelOptions = {
   manual?: boolean;
 };
 
-type ChannelAccountStopOutcome = { status: "fulfilled" } | { status: "rejected"; error: unknown };
+type StopOutcome = { status: "fulfilled" } | { status: "rejected"; error: unknown };
+type StopReceipt = {
+  status: "stopping" | StopOutcome["status"];
+  outcome: Promise<StopOutcome>;
+  starting?: Promise<void>;
+  abort?: AbortController;
+  task?: Promise<unknown>;
+};
 
-type ChannelAccountStopState =
-  | { status: "stopping"; attempt: Promise<ChannelAccountStopOutcome> }
-  | Extract<ChannelAccountStopOutcome, { status: "rejected" }>;
+function isBlockingStop(receipt: StopReceipt | undefined): boolean {
+  return receipt?.status === "stopping" || receipt?.status === "rejected";
+}
 
 async function waitForChannelLifecycleGate(
   gate: Promise<unknown>,
@@ -261,6 +268,7 @@ export type ChannelManager = {
     opts?: StartChannelOptions,
   ) => Promise<void>;
   stopChannel: (channel: ChannelId, accountId?: string, opts?: StopChannelOptions) => Promise<void>;
+  stopChannelForShutdown: (channel: ChannelId, accountId?: string) => Promise<void>;
   setAutostartSuppression: (suppression: ChannelAutostartSuppression | null) => void;
   getAutostartSuppression: () => ChannelAutostartSuppression | null;
   recoverAutostartSuppression: () => Promise<boolean>;
@@ -464,11 +472,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         activeAccountIds.has(id) ||
         store.aborts.has(id) ||
         store.starting.has(id) ||
-        store.stops.has(id) ||
+        isBlockingStop(store.stops.get(id)) ||
         store.tasks.has(id)
       ) {
         continue;
       }
+      store.stops.delete(id);
       store.runtimes.delete(id);
       restarts.delete(restartKey(channelId, id));
       manuallyStopped.delete(restartKey(channelId, id));
@@ -530,17 +539,21 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       limit: CHANNEL_STARTUP_CONCURRENCY,
       tasks: accountIds.map((id) => async () => {
         const rKey = restartKey(channelId, id);
+        if (!preserveManualStop) {
+          manuallyStopped.delete(rKey);
+        }
         const lifecycleAbortSignal = optsValue.lifecycleAbortSignal;
         // An in-flight or failed plugin teardown may still own resources. Only
         // the last queued attempt or a later successful stop clears this gate.
+        let predecessorStop: StopReceipt | undefined;
         while (true) {
-          const predecessorStop = store.stops.get(id);
+          predecessorStop = store.stops.get(id);
           const predecessorGate =
             predecessorStop?.status === "stopping"
-              ? predecessorStop.attempt
+              ? predecessorStop.outcome
               : store.starting.get(id);
           if (!predecessorGate) {
-            if (predecessorStop) {
+            if (predecessorStop?.status === "rejected") {
               return;
             }
             break;
@@ -555,10 +568,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         if (store.tasks.has(id)) {
           let clearedTimedOutRecoveryTask = false;
           if (recoveryStopTimedOut.has(rKey)) {
-            if (!preserveManualStop) {
-              manuallyStopped.delete(rKey);
-            }
-            if (manuallyStopped.has(rKey)) {
+            if (preserveManualStop && manuallyStopped.has(rKey)) {
               return;
             }
             // When a previous stop timed out and the health monitor is
@@ -590,12 +600,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         const startGate = new Promise<void>((resolve) => {
           resolveStart = resolve;
         });
-        store.starting.set(id, startGate);
-
-        // Reserve the account before the first await so overlapping start calls
-        // cannot race into duplicate provider boots for the same account.
         const abort = new AbortController();
+        // Publish the successor lifetime and consume only the exact completed
+        // predecessor before any startup await can expose a partial reservation.
+        store.starting.set(id, startGate);
         store.aborts.set(id, abort);
+        if (predecessorStop?.status === "fulfilled" && store.stops.get(id) === predecessorStop) {
+          store.stops.delete(id);
+        }
         let lifecycleStopRequested = false;
         const disposeLifecycleListeners = () => {
           lifecycleAbortSignal?.removeEventListener("abort", stopForLifecycleAbort);
@@ -717,10 +729,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               restartPending: false,
             });
             return;
-          }
-
-          if (!preserveManualStop) {
-            manuallyStopped.delete(rKey);
           }
 
           if (abort.signal.aborted || manuallyStopped.has(rKey)) {
@@ -870,7 +878,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               log.error?.(`[${id}] ${message}`);
             })
             .catch((err: unknown) => {
-              if (!isCurrentTask() || store.stops.has(id)) {
+              if (!isCurrentTask() || isBlockingStop(store.stops.get(id))) {
                 return;
               }
               const message = formatErrorMessage(err);
@@ -888,7 +896,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
               // stopChannel owns the failed-teardown snapshot until a later
               // successful stop proves replacement is safe.
-              if (!isCurrentTask() || store.stops.has(id)) {
+              if (!isCurrentTask() || isBlockingStop(store.stops.get(id))) {
                 return;
               }
               setStoppedRuntime(channelId, id, {
@@ -896,7 +904,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               });
             })
             .then(async () => {
-              if (!isCurrentTask() || store.stops.has(id)) {
+              if (!isCurrentTask() || isBlockingStop(store.stops.get(id))) {
                 return;
               }
               if (manuallyStopped.has(rKey)) {
@@ -1069,10 +1077,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     await startChannelInternal(channelId, accountId, optsValue);
   };
 
-  const stopChannel = async (
+  const stopChannelInternal = async (
     channelId: ChannelId,
     accountId?: string,
     optsLocal: StopChannelOptions = {},
+    followLatest = false,
   ) => {
     const manual = optsLocal.manual ?? true;
     const plugin = getChannelPlugin(channelId);
@@ -1086,41 +1095,34 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     if (!accountId && lifecycleIds.size === 0) {
       return;
     }
-    // Fast path: nothing running and no explicit plugin shutdown hook to run.
     if (!plugin?.gateway?.stopAccount && lifecycleIds.size === 0) {
       return;
     }
     const cfg = getRuntimeConfig();
-    const knownIds = new Set<string>([
-      ...lifecycleIds,
-      ...(plugin ? plugin.config.listAccountIds(cfg) : []),
-    ]);
-    if (accountId) {
-      knownIds.clear();
-      knownIds.add(accountId);
+    const knownIds = accountId
+      ? [accountId]
+      : [...new Set([...lifecycleIds, ...(plugin ? plugin.config.listAccountIds(cfg) : [])])];
+    if (manual) {
+      for (const id of knownIds) {
+        manuallyStopped.add(restartKey(channelId, id));
+      }
     }
 
-    // Gate replacement starts before teardown begins. Failures still reject only
-    // after every sibling account has finished its independent lifecycle cleanup.
-    const stopOutcomes = await Promise.all(
-      Array.from(knownIds.values()).map(async (id): Promise<ChannelAccountStopOutcome> => {
-        const rKey = restartKey(channelId, id);
-        if (manual) {
-          manuallyStopped.add(rKey);
-        }
-
-        const runStopAttempt = async (
-          previousOutcome: ChannelAccountStopOutcome,
-        ): Promise<ChannelAccountStopOutcome> => {
-          const abort = store.aborts.get(id);
-          const task = store.tasks.get(id);
-          if (!abort && !task && !plugin?.gateway?.stopAccount) {
-            return previousOutcome;
+    const enqueueStop = (id: string): StopReceipt => {
+      if (manual) manuallyStopped.add(restartKey(channelId, id));
+      const previous = store.stops.get(id);
+      const starting = store.starting.get(id);
+      const abort = store.aborts.get(id);
+      const task = store.tasks.get(id);
+      let receipt: StopReceipt;
+      const outcome = (previous?.outcome ?? Promise.resolve<StopOutcome>({ status: "fulfilled" }))
+        .then(async (): Promise<StopOutcome> => {
+          if (!starting && !abort && !task && !plugin?.gateway?.stopAccount) {
+            return { status: "fulfilled" };
           }
           abort?.abort();
           const log = ensureChannelLog(channelId);
-          const runtime = ensureChannelRuntime(channelId);
-          let outcome: ChannelAccountStopOutcome = { status: "fulfilled" };
+          let result: StopOutcome = { status: "fulfilled" };
           if (plugin?.gateway?.stopAccount) {
             try {
               const account = plugin.config.resolveAccount(cfg, id);
@@ -1128,14 +1130,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 cfg,
                 accountId: id,
                 account,
-                runtime,
+                runtime: ensureChannelRuntime(channelId),
                 abortSignal: abort?.signal ?? new AbortController().signal,
                 log,
                 getStatus: () => getRuntime(channelId, id),
                 setStatus: (next) => setRuntime(channelId, id, next),
               });
             } catch (error) {
-              outcome = { status: "rejected", error };
+              result = { status: "rejected", error };
               log.warn?.(`[${id}] stopAccount failed: ${formatErrorMessage(error)}`);
             }
           }
@@ -1148,7 +1150,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
             );
           }
-          if (outcome.status === "rejected") {
+          const rKey = restartKey(channelId, id);
+          if (result.status === "rejected") {
             recoveryStopTimedOut.delete(rKey);
             recoveryStartRequested.delete(rKey);
             if (stoppedCleanly) {
@@ -1163,26 +1166,24 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               accountId: id,
               running: true,
               restartPending: false,
-              lastError: formatErrorMessage(outcome.error),
+              lastError: formatErrorMessage(result.error),
             });
-            return outcome;
+            return result;
           }
           if (!stoppedCleanly) {
             const stoppedPatch = {
               restartPending: !manual,
               lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
             };
-            if (manual) {
-              setRuntime(channelId, id, {
-                accountId: id,
-                running: true,
-                ...stoppedPatch,
-              });
-            } else {
-              setStoppedRuntime(channelId, id, stoppedPatch);
+            if (!manual) {
               recoveryStopTimedOut.add(rKey);
             }
-            return outcome;
+            if (manual) {
+              setRuntime(channelId, id, { accountId: id, running: true, ...stoppedPatch });
+            } else {
+              setStoppedRuntime(channelId, id, stoppedPatch);
+            }
+            return result;
           }
           recoveryStopTimedOut.delete(rKey);
           recoveryStartRequested.delete(rKey);
@@ -1196,33 +1197,64 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             restartPending: false,
             lastStopAt: Date.now(),
           });
-          return outcome;
-        };
+          return result;
+        })
+        .catch((error): StopOutcome => ({ status: "rejected", error }))
+        .then((result) => {
+          receipt.status = result.status;
+          return result;
+        });
+      receipt = { status: "stopping", outcome, starting, abort, task };
+      store.stops.set(id, receipt);
+      return receipt;
+    };
 
-        const currentStop = store.stops.get(id);
-        const previousStop =
-          currentStop?.status === "stopping"
-            ? currentStop.attempt
-            : Promise.resolve<ChannelAccountStopOutcome>(currentStop ?? { status: "fulfilled" });
-        const stopAttempt = previousStop.then(runStopAttempt);
-        store.stops.set(id, { status: "stopping", attempt: stopAttempt });
-        const outcome = await stopAttempt;
-        const latestStop = store.stops.get(id);
-        if (latestStop?.status === "stopping" && latestStop.attempt === stopAttempt) {
-          if (outcome.status === "rejected") {
-            store.stops.set(id, outcome);
-          } else {
-            store.stops.delete(id);
-          }
+    const followStop = async (id: string): Promise<StopOutcome> => {
+      for (;;) {
+        const receipt = store.stops.get(id);
+        const starting = store.starting.get(id);
+        const abort = store.aborts.get(id);
+        const task = store.tasks.get(id);
+        const covered =
+          receipt &&
+          (!starting || starting === receipt.starting) &&
+          (!abort || abort === receipt.abort) &&
+          (!task || task === receipt.task);
+        if ((starting || abort || task) && !covered) {
+          await enqueueStop(id).outcome;
+          continue;
         }
-        return outcome;
-      }),
+        if (!receipt) {
+          return { status: "fulfilled" };
+        }
+        if (starting) {
+          await starting;
+          continue;
+        }
+        const result = await receipt.outcome;
+        if (store.stops.get(id) === receipt) {
+          return result;
+        }
+      }
+    };
+
+    const outcomes = await Promise.all(
+      knownIds.map((id) => (followLatest ? followStop(id) : enqueueStop(id).outcome)),
     );
-    const failedStop = stopOutcomes.find((outcome) => outcome.status === "rejected");
+    const failedStop = outcomes.find((outcome) => outcome.status === "rejected");
     if (failedStop?.status === "rejected") {
       throw failedStop.error;
     }
   };
+
+  const stopChannel = (
+    channelId: ChannelId,
+    accountId?: string,
+    optsLocal: StopChannelOptions = {},
+  ) => stopChannelInternal(channelId, accountId, optsLocal);
+
+  const stopChannelForShutdown = (channelId: ChannelId, accountId?: string) =>
+    stopChannelInternal(channelId, accountId, {}, true);
 
   const startChannelsWithOptions = async (startOptions: StartChannelOptions = {}) => {
     let releaseAccountStarts: (() => void) | undefined;
@@ -1358,6 +1390,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     startChannels,
     startChannel,
     stopChannel,
+    stopChannelForShutdown,
     setAutostartSuppression: (suppression) => {
       autostartSuppression = suppression;
     },

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -597,7 +597,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         const abort = new AbortController();
         store.aborts.set(id, abort);
         let lifecycleStopRequested = false;
+        const disposeLifecycleListeners = () => {
+          lifecycleAbortSignal?.removeEventListener("abort", stopForLifecycleAbort);
+          abort.signal.removeEventListener("abort", disposeLifecycleListeners);
+        };
         const stopForLifecycleAbort = () => {
+          disposeLifecycleListeners();
           if (!lifecycleStopRequested) {
             lifecycleStopRequested = true;
             // Generation cancellation asks the manager to stop this account.
@@ -606,6 +611,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           }
         };
         lifecycleAbortSignal?.addEventListener("abort", stopForLifecycleAbort, { once: true });
+        abort.signal.addEventListener("abort", disposeLifecycleListeners, { once: true });
         if (lifecycleAbortSignal?.aborted) {
           stopForLifecycleAbort();
         }
@@ -1011,7 +1017,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               }
             })
             .finally(() => {
-              lifecycleAbortSignal?.removeEventListener("abort", stopForLifecycleAbort);
+              disposeLifecycleListeners();
               if (store.tasks.get(id) === trackedPromise) {
                 store.tasks.delete(id);
               }
@@ -1041,7 +1047,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             store.starting.delete(id);
           }
           if (!handedOffTask) {
-            lifecycleAbortSignal?.removeEventListener("abort", stopForLifecycleAbort);
+            disposeLifecycleListeners();
             await cleanupTaskScopedApprovalRuntime("channel startup cleanup failed");
           }
           if (!handedOffTask && store.aborts.get(id) === abort) {

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -403,7 +403,7 @@ export async function prepareGatewayLifecycle(params: {
       tailscaleCleanup: runtimeState.tailscaleCleanup,
       clearSecretsRuntimeSnapshot,
       channelIds,
-      stopChannel,
+      stopChannel: channelManager.stopChannelForShutdown,
       pluginServices: runtimeState.pluginServices,
       postReadySidecars: runtimeState.postReadySidecars,
       cron: runtimeState.cronState.cron,

--- a/src/gateway/server-reload-active-work.ts
+++ b/src/gateway/server-reload-active-work.ts
@@ -7,19 +7,16 @@ import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission
 import { getInspectableActiveTaskRestartBlockers } from "../tasks/task-registry.maintenance.js";
 import { formatActiveTaskRestartBlocker } from "../tasks/task-restart-blocker.js";
 import type { ChannelKind } from "./config-reload-plan.js";
-import {
-  isGatewayReloadGenerationAborted,
-  type GatewayReloadHandlerParams,
-} from "./server-reload-contracts.js";
+import type { GatewayReloadHandlerParams } from "./server-reload-contracts.js";
 
 const CHANNEL_RELOAD_DEFERRAL_POLL_MS = 500;
 const CHANNEL_RELOAD_STILL_PENDING_WARN_MS = 30_000;
 
 export function createGatewayActiveWorkTracker(options: {
   params: GatewayReloadHandlerParams;
-  myGeneration: number;
+  lifecycleAbortSignal: AbortSignal;
 }) {
-  const { params, myGeneration } = options;
+  const { params, lifecycleAbortSignal } = options;
   const getActiveCounts = () => {
     const queueSize = getTotalQueueSize();
     const pendingReplies = getTotalPendingReplies();
@@ -103,14 +100,14 @@ export function createGatewayActiveWorkTracker(options: {
     const startedAt = Date.now();
     let nextStillPendingAt = startedAt + CHANNEL_RELOAD_STILL_PENDING_WARN_MS;
     while (true) {
-      if (!isTransactionCurrent() || isGatewayReloadGenerationAborted(myGeneration)) {
+      if (!isTransactionCurrent() || lifecycleAbortSignal.aborted) {
         return true;
       }
       await new Promise<void>((resolve) => {
         const timer = setTimeout(resolve, CHANNEL_RELOAD_DEFERRAL_POLL_MS);
         timer.unref?.();
       });
-      if (!isTransactionCurrent() || isGatewayReloadGenerationAborted(myGeneration)) {
+      if (!isTransactionCurrent() || lifecycleAbortSignal.aborted) {
         return true;
       }
       const current = getActiveCounts();

--- a/src/gateway/server-reload-channel-restart.ts
+++ b/src/gateway/server-reload-channel-restart.ts
@@ -18,6 +18,7 @@ export async function restartGatewayChannels(options: {
   shouldSkipChannelRestart: boolean;
   skipChannelRestartLogMessage: string;
   pluginReloadAborted: boolean;
+  lifecycleAbortSignal: AbortSignal;
   isLifecycleReloadAborted: () => boolean;
   getChannelAutostartSuppression: () => unknown;
   channelReloadTargets: () => Set<ChannelKind>;
@@ -35,6 +36,7 @@ export async function restartGatewayChannels(options: {
     shouldSkipChannelRestart,
     skipChannelRestartLogMessage,
     pluginReloadAborted,
+    lifecycleAbortSignal,
     isLifecycleReloadAborted,
     getChannelAutostartSuppression,
     channelReloadTargets,
@@ -145,7 +147,9 @@ export async function restartGatewayChannels(options: {
             if (isLifecycleReloadAborted()) {
               continue;
             }
-            await runOutsideGatewayRootWorkAdmission(() => params.startChannel(channel, accountId));
+            await runOutsideGatewayRootWorkAdmission(() =>
+              params.startChannel(channel, accountId, { lifecycleAbortSignal }),
+            );
           } catch (err) {
             accountRestartFailures.push(`${channel}[${accountId}]`);
             params.logChannels.error(
@@ -164,7 +168,9 @@ export async function restartGatewayChannels(options: {
           if (isLifecycleReloadAborted()) {
             return;
           }
-          await runOutsideGatewayRootWorkAdmission(() => params.startChannel(name));
+          await runOutsideGatewayRootWorkAdmission(() =>
+            params.startChannel(name, undefined, { lifecycleAbortSignal }),
+          );
         };
         const restartFailures = await collectChannelOperationFailures({
           channels: channelsToRestart,

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -17,23 +17,24 @@ import type { ActivateRuntimeSecrets } from "./server-startup-config.js";
 import type { HookClientIpConfig } from "./server/hooks-request-handler.js";
 
 let currentReloadGeneration = 0;
-let abortGeneration: number | undefined;
+let currentReloadAbortController: AbortController | undefined;
 
-export function nextGatewayReloadGeneration(): number {
-  return ++currentReloadGeneration;
+export function nextGatewayReloadGeneration() {
+  currentReloadAbortController?.abort();
+  currentReloadAbortController = new AbortController();
+  return {
+    generation: ++currentReloadGeneration,
+    abortSignal: currentReloadAbortController.signal,
+  };
 }
 
 export function isCurrentGatewayReloadGeneration(generation: number): boolean {
   return generation === currentReloadGeneration;
 }
 
-export function isGatewayReloadGenerationAborted(generation: number): boolean {
-  return abortGeneration !== undefined && generation <= abortGeneration;
-}
-
 /** Signal any in-progress deferred channel reload to abort immediately. */
 export function abortPendingChannelReloads(): void {
-  abortGeneration = currentReloadGeneration;
+  currentReloadAbortController?.abort();
 }
 
 export type RuntimeSecretsPreflightParams = Omit<

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1716,14 +1716,18 @@ describe("gateway hot reload superseded tail recovery", () => {
       changedPaths: ["agents.defaults.workspace"],
       hotReasons: ["agents.defaults.workspace"],
     });
+    let transactionCurrent = true;
 
     try {
       await handlers.applyHotReload(
         plan,
         { agents: { defaults: { workspace: "/tmp/a" } } },
         {
-          isCurrent: () => false,
-          publish: async (commit) => await commit(),
+          isCurrent: () => transactionCurrent,
+          publish: async (commit) => {
+            await commit();
+            transactionCurrent = false;
+          },
         },
       );
       await vi.runAllTimersAsync();
@@ -1768,11 +1772,15 @@ describe("gateway hot reload superseded tail recovery", () => {
       changedPaths: ["agents.defaults.workspace"],
       hotReasons: ["agents.defaults.workspace"],
     });
+    let transactionCurrent = true;
 
     try {
       const staleTail = handlers.applyHotReload(plan, configA, {
-        isCurrent: () => false,
-        publish: async (commit) => await commit(),
+        isCurrent: () => transactionCurrent,
+        publish: async (commit) => {
+          await commit();
+          transactionCurrent = false;
+        },
       });
       await vi.advanceTimersByTimeAsync(0);
       expect(hoisted.refreshContextWindowCache).toHaveBeenCalledOnce();
@@ -1948,7 +1956,11 @@ describe("gateway hot reload superseded tail recovery", () => {
     await reloadA;
 
     expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
-    expect(startChannel).toHaveBeenCalledWith("discord");
+    expect(startChannel).toHaveBeenCalledWith(
+      "discord",
+      undefined,
+      expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+    );
     expect(requestRecoveryRestart).not.toHaveBeenCalled();
   });
 
@@ -2762,7 +2774,11 @@ describe("gateway restart deferral preflight", () => {
     }
 
     expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
-    expect(startChannel).toHaveBeenCalledWith("discord");
+    expect(startChannel).toHaveBeenCalledWith(
+      "discord",
+      undefined,
+      expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+    );
     expect(runtimePublished).toBe(true);
     expect(setState).toHaveBeenCalledTimes(1);
   });
@@ -2818,7 +2834,11 @@ describe("gateway restart deferral preflight", () => {
     }
 
     expect(stopChannel).toHaveBeenCalledWith("telegram", undefined, { manual: false });
-    expect(startChannel).toHaveBeenCalledWith("telegram");
+    expect(startChannel).toHaveBeenCalledWith(
+      "telegram",
+      undefined,
+      expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+    );
     expect(logReload.warn).toHaveBeenCalledWith(
       expect.stringContaining("channel reload timeout after"),
     );
@@ -4949,7 +4969,11 @@ describe("gateway plugin hot reload handlers", () => {
     expect(runtimeEnv.env[envKey]).toBeUndefined();
     expect(targetEnv[envKey]).toBeUndefined();
     expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
-    expect(startChannel).toHaveBeenCalledWith("discord");
+    expect(startChannel).toHaveBeenCalledWith(
+      "discord",
+      undefined,
+      expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+    );
   });
 
   it("skips channel work when the candidate env adds a skip flag", async () => {
@@ -5330,6 +5354,9 @@ describe("gateway plugin hot reload handlers", () => {
 
   it("restarts pre-stopped channels when runtime publication fails", async () => {
     const events: string[] = [];
+    const start = vi.fn(async (channel) => {
+      events.push(`start:${channel}`);
+    });
     const publish = vi.fn(async () => {
       throw new Error("publication failed");
     });
@@ -5349,9 +5376,7 @@ describe("gateway plugin hot reload handlers", () => {
         stop: vi.fn(async (channel) => {
           events.push(`stop:${channel}`);
         }),
-        start: vi.fn(async (channel) => {
-          events.push(`start:${channel}`);
-        }),
+        start,
       },
       reloadPlugins,
     );
@@ -5365,6 +5390,11 @@ describe("gateway plugin hot reload handlers", () => {
     ).rejects.toThrow("publication failed");
 
     expect(events).toEqual(["stop:discord", "start:discord"]);
+    expect(start).toHaveBeenCalledWith(
+      "discord",
+      undefined,
+      expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+    );
     expect(handlers.setState).not.toHaveBeenCalled();
   });
 
@@ -5489,8 +5519,16 @@ describe("gateway plugin hot reload handlers", () => {
     expect(logChannels.error).toHaveBeenCalledWith(
       "failed to stop discord channel before plugin reload: stop failed",
     );
-    expect(startChannel).toHaveBeenCalledWith("telegram");
-    expect(startChannel).toHaveBeenCalledWith("discord");
+    expect(startChannel).toHaveBeenCalledWith(
+      "telegram",
+      undefined,
+      expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+    );
+    expect(startChannel).toHaveBeenCalledWith(
+      "discord",
+      undefined,
+      expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+    );
     expect(startRootCounts).toEqual([1, 1]);
     expect(setState).not.toHaveBeenCalled();
   });
@@ -5847,6 +5885,69 @@ describe("deferred channel reload abort generation", () => {
     }
   });
 
+  it.each(["commit entry", "publication edge"] as const)(
+    "fences a superseded generation at the runtime %s after active work drains",
+    async (abortPoint) => {
+      const channels = {
+        start: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      };
+      const commitReached = createDeferredVoid();
+      const releaseCommit = createDeferredVoid();
+      const publish = vi.fn(async (commit: () => Promise<void>) => {
+        if (abortPoint === "publication edge") {
+          commitReached.resolve();
+          await releaseCommit.promise;
+        }
+        await commit();
+      });
+      const reloadPlugins: NonNullable<ReloadHandlerParams["reloadPlugins"]> = async (params) => {
+        await params.beforeReplace(new Set(["whatsapp"]));
+        if (abortPoint === "commit entry") {
+          commitReached.resolve();
+          await releaseCommit.promise;
+        }
+        await params.commitRuntime();
+        return {
+          restartChannels: new Set(),
+          activeChannels: new Set(["whatsapp"]),
+        };
+      };
+      const handlers = createReloadHandlersForTest(undefined, channels, reloadPlugins);
+      hoisted.activeTaskBlockers.push({
+        taskId: `task-blocking-${abortPoint}`,
+        status: "running",
+        runtime: "subagent",
+      });
+      vi.useFakeTimers();
+
+      try {
+        const reloadPromise = handlers.applyHotReload(
+          createPluginReloadPlan(),
+          {},
+          { publish, isCurrent: () => true },
+        );
+        const reloadRejected = expect(reloadPromise).rejects.toThrow(
+          "config hot reload cancelled by config supersession or in-process restart",
+        );
+        await vi.advanceTimersByTimeAsync(10);
+        hoisted.activeTaskBlockers.length = 0;
+        await vi.advanceTimersByTimeAsync(500);
+        await commitReached.promise;
+
+        createReloadHandlersForTest();
+        releaseCommit.resolve();
+        await reloadRejected;
+
+        expect(publish).toHaveBeenCalledTimes(abortPoint === "publication edge" ? 1 : 0);
+        expect(handlers.setState).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        hoisted.activeTaskBlockers.length = 0;
+      }
+    },
+  );
+
   it("does not mark a managed reload applied when restart aborts its deferral", async () => {
     const initialConfig = {
       gateway: { reload: {} },
@@ -5962,7 +6063,11 @@ describe("deferred channel reload abort generation", () => {
       await expect(reloadPromise).resolves.toBeUndefined();
 
       expect(channels.stop).toHaveBeenCalledWith("whatsapp", undefined, { manual: false });
-      expect(channels.start).toHaveBeenCalledWith("whatsapp");
+      expect(channels.start).toHaveBeenCalledWith(
+        "whatsapp",
+        undefined,
+        expect.objectContaining({ lifecycleAbortSignal: expect.anything() }),
+      );
     } finally {
       vi.useRealTimers();
       hoisted.activeTaskBlockers.length = 0;

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -29,7 +29,6 @@ import {
   GatewayHotReloadCancelledError,
   GatewayHotReloadRecoveryError,
   isCurrentGatewayReloadGeneration,
-  isGatewayReloadGenerationAborted,
   nextGatewayReloadGeneration,
   type GatewayHotReloadPublication,
   type GatewayPluginReloadResult,
@@ -49,7 +48,8 @@ import { resolveHookClientIpConfig } from "./server/hook-client-ip-config.js";
 const MCP_RUNTIME_RELOAD_DISPOSE_TIMEOUT_MS = 5_000;
 
 export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) {
-  const myGeneration = nextGatewayReloadGeneration();
+  const reloadGeneration = nextGatewayReloadGeneration();
+  const myGeneration = reloadGeneration.generation;
   const restartRecoveryAvailable =
     params.restartRecoveryAvailable !== false && params.requestRecoveryRestart !== undefined;
 
@@ -59,7 +59,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     formatTaskBlockers,
     getActiveCounts,
     waitForActiveWorkBeforeChannelReload,
-  } = createGatewayActiveWorkTracker({ params, myGeneration });
+  } = createGatewayActiveWorkTracker({
+    params,
+    lifecycleAbortSignal: reloadGeneration.abortSignal,
+  });
 
   const {
     acceptRestartConfig,
@@ -131,7 +134,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const channelsStoppedBeforePluginReload = new Set<ChannelKind>();
     let activePluginChannelsAfterReload: ReadonlySet<ChannelKind> | null = null;
     let pluginReloadAborted = false;
-    const isLifecycleReloadAborted = () => isGatewayReloadGenerationAborted(myGeneration);
+    const isLifecycleReloadAborted = () => reloadGeneration.abortSignal.aborted;
     const isPluginReloadAborted = () =>
       pluginReloadAborted || !isTransactionCurrent() || isLifecycleReloadAborted();
     let runtimeCommitted = false;
@@ -163,7 +166,13 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       if (runtimeCommitted) {
         return;
       }
+      if (isPluginReloadAborted()) {
+        throw new GatewayHotReloadCancelledError();
+      }
       const commit = async () => {
+        if (isPluginReloadAborted()) {
+          throw new GatewayHotReloadCancelledError();
+        }
         if (plan.restartHeartbeat) {
           nextState.heartbeatRunner.updateConfig(nextConfig);
           // Heartbeat cadence lives in system-owned cron monitor jobs;
@@ -335,7 +344,11 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
           channels: [...channelsStoppedBeforePluginReload],
           run: async (channel) => {
             params.logChannels.info(`restarting ${channel} channel after ${reason}`);
-            await runOutsideGatewayRootWorkAdmission(() => params.startChannel(channel));
+            await runOutsideGatewayRootWorkAdmission(() =>
+              params.startChannel(channel, undefined, {
+                lifecycleAbortSignal: reloadGeneration.abortSignal,
+              }),
+            );
             channelsStoppedBeforePluginReload.delete(channel);
           },
           onFailure: (channel, err) => {
@@ -570,6 +583,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       skipChannelRestartLogMessage:
         "skipping channel reload (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)",
       pluginReloadAborted,
+      lifecycleAbortSignal: reloadGeneration.abortSignal,
       isLifecycleReloadAborted,
       getChannelAutostartSuppression,
       channelReloadTargets,


### PR DESCRIPTION
Related: #79487

Follow-up to https://github.com/openclaw/openclaw/pull/94964 by @lzyyzznl, which established reload-generation cancellation. This repair carries that ownership through runtime publication and channel startup.

## What Problem This Solves

Fixes an issue where a superseded Gateway hot-reload generation could continue owning channel startup or teardown after a newer configuration had already taken over. In overlapping reload, timeout, plugin replacement, and shutdown sequences, that stale lifetime could publish or retain channel work beyond its generation.

## Why This Change Was Made

The Gateway reload lifecycle is the architectural owner of generation cancellation, while the channel manager is the sole owner of per-account runtime lifetimes and stop receipts. This change passes the reload generation's abort signal through channel startup, makes `store.stops` the sole latest per-account stop receipt ledger, releases superseded lifecycle listeners, and makes shutdown follow the latest stop/start handoff until the active lifetime is settled.

The canonical path is now one generation-fenced channel lifetime. It removes the split stop-state representation and the separate generation-number polling path. Restart backoff policy, request-admission policy, protocol, config, and public plugin contracts are unchanged.

## User Impact

Operators can apply overlapping hot reloads, replace plugins, and shut down the Gateway without a superseded generation reviving or retaining a channel account. Mixed-account teardown still settles every account before surfacing a failure, and explicit overlapping stop calls retain their own result semantics.

## Evidence

Exact candidate: `a0840f4fa172eb07ab6717acf6c9df59daad1b26`

- Punchcard-Session: cobalt-valley-meadow-mg
- Two independent read-only reviews found no blocking issue on the exact three-commit candidate.
- Focused local Gateway proof passed for channel stop-ledger sequences, reload handlers, hot-reload status, shutdown, and import boundaries.
- Local QA artifacts passed both `config-apply-restart-wakeup` and `plugin-lifecycle-hot-reload`; hydrated exact-head Testbox receipts will be added before landing.
- `origin/main` is six unrelated commits ahead with zero touched-file overlap; no drift-only rebase was performed.
- No `CHANGELOG.md` change.
- No restart-policy work from #109711 or #110024 and no request-admission work from #110709.
- Shared local dependencies have stale `string-width` types that produce baseline TS2554. The base, candidate, and current main all pin `string-width@8.2.2` with identical source; hydrated Testbox changed gates are the branch-health authority.

### Repair accounting

- Root cause: reload-generation cancellation stopped at the reload handler and did not own the channel lifetime through publication, startup, stop receipt replacement, and shutdown joining.
- Architectural owner: Gateway reload generation for cancellation; channel manager for per-account runtime and teardown ownership.
- Canonical fix: one lifecycle abort signal carried into channel startup plus one latest stop receipt per account.
- Removed or separated paths: split stop-state variants and generation-number polling are removed; restart backoff and request admission remain separate policy surfaces.
- Production: +214/-125, net +89. The growth establishes the missing lifecycle ownership boundary and explicit teardown receipt contract.
- Tests: +515/-28, net +487.
- Total: +729/-153, net +576.
- Residual risk: timing-sensitive behavior depends on plugin stop hooks eventually settling or reaching the existing bounded timeout. Regression coverage exercises timeout, retry, stale eviction, mixed-account settlement, successor handoff, plugin teardown, and shutdown follow-latest behavior.
