### PR TITLE
fix(gateway): defer post-ready runtime services

### DIFF
--- a/src/gateway/server-cron-start.ts
+++ b/src/gateway/server-cron-start.ts
@@ -1,0 +1,33 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+import type { GatewayCronReconciliation } from "./server-cron-reconciled.js";
+import type { GatewayCronState } from "./server-cron.js";
+
+/** Starts cron without making the surrounding startup or reload transaction wait. */
+export function startGatewayCronWithLogging(params: {
+  cronState: GatewayCronState;
+  cronReconciliation: GatewayCronReconciliation;
+  reason: "startup" | "reload";
+  config: OpenClawConfig;
+  afterStart?: () => Promise<void>;
+  onStartError?: (error: unknown) => void;
+  logCron: { error: (message: string) => void };
+}): void {
+  const reconciliation = params.cronReconciliation.arm({
+    reason: params.reason,
+    config: params.config,
+    cronState: params.cronState,
+  });
+  void runWithGatewayIndependentRootWorkAdmission(async () => {
+    try {
+      await params.cronState.cron.start();
+      await params.afterStart?.();
+      await reconciliation.complete();
+    } catch (err) {
+      params.logCron.error(`failed to start: ${String(err)}`);
+      // Recovery callbacks must run before this independent root releases its
+      // admission fence; restart and suspension cannot race past this point.
+      params.onStartError?.(err);
+    }
+  }).catch((err: unknown) => params.logCron.error(`failed to enter start root: ${String(err)}`));
+}

--- a/src/gateway/server-idle-task.test.ts
+++ b/src/gateway/server-idle-task.test.ts
@@ -22,6 +22,43 @@ describe("scheduleGatewayIdleTask", () => {
     await vi.advanceTimersByTimeAsync(10);
     await Promise.resolve();
     expect(run).toHaveBeenCalledOnce();
-    handle.stop();
+    await handle.stop();
+  });
+
+  it("keeps stop pending after the timer fires until child work settles", async () => {
+    vi.useFakeTimers();
+    let finishRun: (() => void) | undefined;
+    const run = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRun = resolve;
+        }),
+    );
+    const handle = scheduleGatewayIdleTask({
+      delayMs: 10,
+      retryDelayMs: 5,
+      isClosing: () => false,
+      isBusy: () => false,
+      run,
+      log: { warn: vi.fn() },
+      errorMessage: "idle task failed",
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce());
+
+    let stopSettled = false;
+    const stop = handle.stop().then(() => {
+      stopSettled = true;
+    });
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+
+    if (!finishRun) {
+      throw new Error("Expected idle task resolver to be initialized");
+    }
+    finishRun();
+    await stop;
+    expect(stopSettled).toBe(true);
   });
 });

--- a/src/gateway/server-idle-task.ts
+++ b/src/gateway/server-idle-task.ts
@@ -5,7 +5,7 @@ type GatewayIdleTaskLogger = {
 };
 
 export type GatewayIdleTaskHandle = {
-  stop: () => void;
+  stop: () => Promise<void>;
 };
 
 /** Schedules one low-priority task, retrying until the gateway has no active request roots. */
@@ -20,6 +20,8 @@ export function scheduleGatewayIdleTask(params: {
 }): GatewayIdleTaskHandle {
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
   const schedule = (delayMs: number) => {
     if (stopped || params.isClosing()) {
       return;
@@ -33,18 +35,29 @@ export function scheduleGatewayIdleTask(params: {
         schedule(params.retryDelayMs);
         return;
       }
-      void runWithGatewayIndependentRootWorkAdmission(async () => {
-        if (stopped || params.isClosing()) {
-          return;
-        }
-        // Recheck inside admission so work that arrived while this task was
-        // joining the root set gets priority over non-urgent maintenance.
-        if (params.isBusy()) {
-          schedule(params.retryDelayMs);
-          return;
-        }
-        await params.run();
-      }).catch((error: unknown) => params.log.warn(`${params.errorMessage}: ${String(error)}`));
+      // Publish the join handle before child code can re-enter gateway shutdown.
+      const task = Promise.resolve().then(() =>
+        runWithGatewayIndependentRootWorkAdmission(async () => {
+          if (stopped || params.isClosing()) {
+            return;
+          }
+          // Recheck inside admission so work that arrived while this task was
+          // joining the root set gets priority over non-urgent maintenance.
+          if (params.isBusy()) {
+            schedule(params.retryDelayMs);
+            return;
+          }
+          await params.run();
+        }),
+      );
+      const settled = task
+        .catch((error: unknown) => params.log.warn(`${params.errorMessage}: ${String(error)}`))
+        .finally(() => {
+          if (inFlight === settled) {
+            inFlight = null;
+          }
+        });
+      inFlight = settled;
     }, delayMs);
     timer.unref?.();
   };
@@ -56,6 +69,8 @@ export function scheduleGatewayIdleTask(params: {
         clearTimeout(timer);
         timer = null;
       }
+      stopPromise ??= inFlight ?? Promise.resolve();
+      return stopPromise;
     },
   };
 }

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -89,20 +89,21 @@ describe("gateway startup import boundaries", () => {
 
   it("defers retained plugin generation cleanup to the post-ready idle scheduler", () => {
     const serverImpl = readServerImplementation();
+    const scheduledServices = readSource("src/gateway/server-startup-scheduled-services.ts");
     const cleanup = readSource("src/gateway/server-retained-plugin-cleanup.ts");
     const importBoundary = serverImpl.indexOf("type LoadGatewayModelCatalog");
-    const serverStart = serverImpl.indexOf("export async function startGatewayServer");
-    const postReadyStart = serverImpl.indexOf("scheduleGatewayPostReadyMaintenance({", serverStart);
-    const cleanupCall = serverImpl.lastIndexOf("cleanupRetainedPluginInstallGenerations(");
+    const postReadyStart = scheduledServices.indexOf("scheduleGatewayPostReadyMaintenance({");
+    const cleanupCall = scheduledServices.lastIndexOf("cleanupRetainedPluginInstallGenerations(");
 
     expect(importBoundary).toBeGreaterThan(-1);
     expect(serverImpl.slice(0, importBoundary)).not.toContain("managed-npm-retention");
     expect(serverImpl.slice(0, importBoundary)).not.toContain("installed-plugin-index-records");
+    expect(serverImpl).toContain('from "./server-startup-scheduled-services.js"');
     expect(cleanup).toContain('import("../plugins/managed-npm-retention.js")');
     expect(cleanup).toContain('import("../plugins/installed-plugin-index-records.js")');
-    expect(postReadyStart).toBeGreaterThan(serverStart);
+    expect(postReadyStart).toBeGreaterThan(-1);
     expect(cleanupCall).toBeGreaterThan(postReadyStart);
-    expect(serverImpl.slice(postReadyStart, cleanupCall + 300)).not.toContain(
+    expect(scheduledServices.slice(postReadyStart, cleanupCall + 300)).not.toContain(
       "startupConfigLoad.pluginMetadataSnapshot?.index.installRecords",
     );
     expect(cleanup).toContain("loadInstalledPluginIndexInstallRecordsSync()");
@@ -132,8 +133,31 @@ describe("gateway startup import boundaries", () => {
     expect(workerStartup.match(/loadWorkerEnvironmentRuntimeModule\(\)/gu)).toHaveLength(3);
   });
 
+  it("keeps the managed reload watcher separate from the hot-reload graph", () => {
+    const startupFinish = readSource("src/gateway/server-startup-finish.ts");
+    const managedReload = readSource("src/gateway/server-reload-managed.ts");
+    const hotReload = readSource("src/gateway/server-reload-hot.ts");
+    const reloadBarrel = readSource("src/gateway/server-reload-handlers.ts");
+
+    expect(startupFinish).toContain('import("./server-reload-managed.js")');
+    expect(startupFinish).not.toContain('import("./server-reload-handlers.js")');
+    expect(managedReload).toContain('import("./server-reload-hot.js")');
+    expect(managedReload).not.toContain('from "./server-reload-hot.js"');
+    expect(managedReload).toContain('from "./server-runtime-startup-services.js"');
+    expect(managedReload).not.toContain('from "./server-runtime-services.js"');
+    expect(hotReload).toContain('from "./server-cron-start.js"');
+    expect(hotReload).not.toContain('from "./server-runtime-services.js"');
+    expect(reloadBarrel).toContain(
+      'export { createGatewayReloadHandlers } from "./server-reload-hot.js"',
+    );
+    expect(reloadBarrel).toContain(
+      'export { startManagedGatewayConfigReloader } from "./server-reload-managed.js"',
+    );
+  });
+
   it("fences config reload before gateway teardown and gateway_stop hooks", () => {
     const serverImpl = readServerImplementation();
+    const scheduledServices = readSource("src/gateway/server-startup-scheduled-services.ts");
     const closeStart = /close:\s*async\s*\([^)]*\)\s*=>/u.exec(serverImpl)?.index ?? -1;
     const hookStart = serverImpl.indexOf("runGlobalGatewayStopSafely", closeStart);
     const reloadStopStart = serverImpl.indexOf("await beginClosePrelude();", closeStart);
@@ -142,9 +166,6 @@ describe("gateway startup import boundaries", () => {
     const markHelperEnd = serverImpl.indexOf("};", markHelperStart);
     const beginHelperStart = serverImpl.indexOf("const beginClosePrelude = async () => {");
     const beginHelperEnd = serverImpl.indexOf("};", beginHelperStart);
-    const postReadyStart = serverImpl.indexOf("scheduleGatewayPostReadyMaintenance({");
-    const postReadyEnd = serverImpl.indexOf("});", postReadyStart);
-    const postReadyBlock = serverImpl.slice(postReadyStart, postReadyEnd);
 
     expect(closeStart).toBeGreaterThan(-1);
     expect(reloadStopStart).toBeGreaterThan(closeStart);
@@ -152,13 +173,10 @@ describe("gateway startup import boundaries", () => {
     expect(reloadStopStart).toBeLessThan(hookStart);
     expect(markHelperStart).toBeGreaterThan(-1);
     expect(serverImpl.slice(markHelperStart, markHelperEnd)).toContain(
-      "clearPostReadyMaintenanceTimer();",
+      "void stopScheduledServicesForClose();",
     );
     expect(serverImpl.slice(markHelperStart, markHelperEnd)).toContain(
       "cronReconciliation.invalidate();",
-    );
-    expect(serverImpl.slice(markHelperStart, markHelperEnd)).toContain(
-      "void stopOutboundDeliveryRecoveryForClose();",
     );
     expect(beginHelperStart).toBeGreaterThan(-1);
     expect(serverImpl.slice(beginHelperStart, beginHelperEnd)).toContain(
@@ -168,13 +186,13 @@ describe("gateway startup import boundaries", () => {
       "stopConfigReloaderForClose().catch",
     );
     expect(serverImpl.slice(beginHelperStart, beginHelperEnd)).toContain(
-      "stopOutboundDeliveryRecoveryForClose(),",
+      "stopScheduledServicesForClose(),",
     );
-    expect(postReadyStart).toBeGreaterThan(-1);
-    expect(postReadyBlock).toContain("isClosing: () => lifecycle.closePreludeStarted");
-    expect(postReadyBlock).toContain("if (lifecycle.closePreludeStarted)");
-    expect(postReadyBlock).toContain(
-      "shouldStartCron: () => !lifecycle.closePreludeStarted && !cronStartState.handled",
+    expect(scheduledServices).toContain("scheduleGatewayPostReadyMaintenance({");
+    expect(scheduledServices).toContain("isClosing: () => stopped");
+    expect(scheduledServices).toContain("if (stopped)");
+    expect(scheduledServices).toContain(
+      "shouldStartCron: () => !stopped && params.shouldStartCron()",
     );
   });
 });

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -283,24 +283,10 @@ export async function prepareGatewayLifecycle(params: {
       }
     },
   });
-  const postReadyState: {
-    maintenanceTimer: ReturnType<typeof setTimeout> | null;
-    retainedPluginCleanupHandle: { stop: () => void } | null;
-  } = {
-    maintenanceTimer: null,
-    retainedPluginCleanupHandle: null,
-  };
-  const clearPostReadyMaintenanceTimer = () => {
-    if (!postReadyState.maintenanceTimer) {
-      return;
-    }
-    clearTimeout(postReadyState.maintenanceTimer);
-    postReadyState.maintenanceTimer = null;
-  };
-  let outboundDeliveryRecoveryStopPromise: Promise<void> | null = null;
-  const stopOutboundDeliveryRecoveryForClose = () => {
-    outboundDeliveryRecoveryStopPromise ??= runtimeState.stopOutboundDeliveryRecovery();
-    return outboundDeliveryRecoveryStopPromise;
+  let scheduledServicesStopPromise: Promise<void> | null = null;
+  const stopScheduledServicesForClose = () => {
+    scheduledServicesStopPromise ??= runtimeState.scheduledServices.stop();
+    return scheduledServicesStopPromise;
   };
   let mediaCleanupStopPromise: ReturnType<typeof runtimeState.stopMediaCleanup> | null = null;
   const stopMediaCleanupForClose = () => {
@@ -311,7 +297,7 @@ export async function prepareGatewayLifecycle(params: {
     lifecycle.closePreludeStarted = true;
     // Fence background owners before any awaited close step can tear down the
     // plugin/channel or shared-state runtime they still need.
-    void stopOutboundDeliveryRecoveryForClose();
+    void stopScheduledServicesForClose();
     void stopMediaCleanupForClose();
     runtimeState.controlUiSessionPullRequests?.stop();
     runtimeState.sessionViewerPresence?.stop();
@@ -319,9 +305,6 @@ export async function prepareGatewayLifecycle(params: {
     startupState.dispatchReady = false;
     gatewayInstanceRuntimeRef.current?.close();
     cronReconciliation.invalidate();
-    clearPostReadyMaintenanceTimer();
-    postReadyState.retainedPluginCleanupHandle?.stop();
-    postReadyState.retainedPluginCleanupHandle = null;
   };
   let configReloaderStopPromise: Promise<void> | null = null;
   const stopConfigReloaderForClose = () => {
@@ -334,7 +317,7 @@ export async function prepareGatewayLifecycle(params: {
     // Owners are fenced synchronously above. Join them before any runtime they
     // can publish into is torn down.
     await Promise.all([
-      stopOutboundDeliveryRecoveryForClose(),
+      stopScheduledServicesForClose(),
       stopMediaCleanupForClose(),
       stopConfigReloaderForClose().catch(() => {}),
     ]);
@@ -520,7 +503,6 @@ export async function prepareGatewayLifecycle(params: {
     runtimeState,
     pluginHostServices,
     lifecycle,
-    postReadyState,
     cronReconciliation,
     beginClosePrelude,
     runClosePrelude,

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -4,11 +4,26 @@
  * candidate seam. This keeps request caching coupled to the actual watcher
  * lifecycle instead of individual config writers.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
-import { startManagedGatewayConfigReloader } from "./server-reload-handlers.js";
+import type { GatewayReloadPlan } from "./config-reload-plan.js";
+import type { GatewayConfigReloadTransactionOwnership } from "./config-reload.js";
+import {
+  GatewayConfigReloadSupersededError,
+  type GatewayPluginReloadResult,
+} from "./server-reload-contracts.js";
+import { startManagedGatewayConfigReloader } from "./server-reload-managed.js";
+
+type ConfigAcceptedCallback = (
+  nextConfig: OpenClawConfig,
+  ownership: GatewayConfigReloadTransactionOwnership,
+  sourceConfig: OpenClawConfig,
+  acceptance: {
+    runtimeApplied: boolean;
+    publishSource?: () => Promise<() => Promise<void>>;
+  },
+) => void | (() => Promise<void>) | Promise<void | (() => Promise<void>)>;
 
 const hoisted = vi.hoisted(() => ({
   hotReloadStatus: { current: "active" as "active" | "disabled" },
@@ -20,12 +35,41 @@ const hoisted = vi.hoisted(() => ({
         changedPaths: readonly string[];
       }) => void)
     | undefined,
+  onConfigCandidateObserved: undefined as (() => void) | undefined,
+  onConfigChange: undefined as
+    | ((plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>)
+    | undefined,
+  onConfigAccepted: undefined as ConfigAcceptedCallback | undefined,
   notifyPluginMetadataChanged: vi.fn(),
   stop: vi.fn(async () => {}),
+  reloadHandlers: {
+    applyHotReload: vi.fn(async () => {}),
+    acceptRestartConfig: vi.fn(() => ({ retireRejectedRestart: false })),
+    beginGatewayRestartLifecycle: vi.fn(() => ({ settle: vi.fn() })),
+    pauseGatewayRestartForConfigCandidate: vi.fn(),
+    publishAppliedConfigHash: vi.fn(),
+    publishAcceptedRestartTarget: vi.fn(() => ({
+      ownership: { reject: vi.fn() },
+      conservativeDebt: null,
+    })),
+    publishDeferredAppliedConfigHash: vi.fn(),
+    recordAcceptedRestartTarget: vi.fn(() => ({ reject: vi.fn() })),
+    requestGatewayRestart: vi.fn(() => ({
+      status: "accepted" as const,
+      settle: vi.fn(),
+    })),
+    restoreConservativeRestartDebt: vi.fn(),
+    stopRestartRetries: vi.fn(),
+  },
+  createGatewayReloadHandlers: vi.fn(),
 }));
 
 vi.mock("./config-get-response.js", () => ({
   invalidateConfigGetResponseCache: hoisted.invalidateConfigGetResponseCache,
+}));
+
+vi.mock("./server-reload-hot.js", () => ({
+  createGatewayReloadHandlers: hoisted.createGatewayReloadHandlers,
 }));
 
 vi.mock("./config-reload.js", async () => {
@@ -39,8 +83,17 @@ vi.mock("./config-reload.js", async () => {
           persistedHash: string | null;
           changedPaths: readonly string[];
         }) => void;
+        onConfigCandidateObserved?: () => void;
+        onConfigChange?: (
+          plan: GatewayReloadPlan,
+          nextConfig: OpenClawConfig,
+        ) => void | Promise<void>;
+        onConfigAccepted?: ConfigAcceptedCallback;
       }) => {
         hoisted.onConfigCandidateCommitted = options.onConfigCandidateCommitted;
+        hoisted.onConfigCandidateObserved = options.onConfigCandidateObserved;
+        hoisted.onConfigChange = options.onConfigChange;
+        hoisted.onConfigAccepted = options.onConfigAccepted;
         return {
           stop: hoisted.stop,
           hotReloadStatus: () => hoisted.hotReloadStatus.current,
@@ -51,73 +104,114 @@ vi.mock("./config-reload.js", async () => {
   };
 });
 
-describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
-  it("forwards live status and invalidates config.get on watcher commit", async () => {
-    const initialConfig = { session: { store: "/tmp/sessions.json" } } as OpenClawConfig;
-    const broadcast = vi.fn();
-    const reloader = startManagedGatewayConfigReloader({
-      minimalTestGateway: false,
-      initialConfig,
-      initialCompareConfig: initialConfig,
-      initialSnapshotRawHash: null,
-      initialAuthoredConfig: {},
-      initialSnapshotValid: true,
-      initialSnapshotIssues: [],
-      initialInternalWriteHash: null,
-      watchPath: "/tmp/openclaw.json",
-      readSnapshot: vi.fn() as never,
-      promoteSnapshot: vi.fn(async () => true) as never,
-      subscribeToWrites: vi.fn(() => () => {}) as never,
-      deps: {} as never,
-      broadcast,
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
+type ManagedReloaderParams = Parameters<typeof startManagedGatewayConfigReloader>[0];
+
+function startTestManagedReloader(overrides: Partial<ManagedReloaderParams> = {}) {
+  const initialConfig = { session: { store: "/tmp/sessions.json" } } as OpenClawConfig;
+  return startManagedGatewayConfigReloader({
+    minimalTestGateway: false,
+    initialConfig,
+    initialCompareConfig: initialConfig,
+    initialSnapshotRawHash: null,
+    initialAuthoredConfig: {},
+    initialSnapshotValid: true,
+    initialSnapshotIssues: [],
+    initialInternalWriteHash: null,
+    watchPath: "/tmp/openclaw.json",
+    readSnapshot: vi.fn() as never,
+    promoteSnapshot: vi.fn(async () => true) as never,
+    subscribeToWrites: vi.fn(() => () => {}) as never,
+    deps: {} as never,
+    broadcast: vi.fn(),
+    getState: () => ({
+      hooksConfig: {} as never,
+      hookClientIpConfig: {} as never,
+      heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+      cronState: {
+        cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+        storePath: "/tmp/cron.json",
+        cronEnabled: false,
+      } as never,
+      channelHealthMonitor: null,
+    }),
+    setState: vi.fn(),
+    startChannel: vi.fn(async () => {}),
+    stopChannel: vi.fn(async () => {}),
+    reloadPlugins: vi.fn(
+      async (): Promise<GatewayPluginReloadResult> => ({
+        restartChannels: new Set(),
+        activeChannels: new Set(),
       }),
-      setState: vi.fn(),
-      startChannel: vi.fn(async () => {}),
-      stopChannel: vi.fn(async () => {}),
-      reloadPlugins: vi.fn(
-        async (): Promise<GatewayPluginReloadResult> => ({
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        }),
-      ),
-      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      logChannels: { info: vi.fn(), error: vi.fn() },
-      logCron: { error: vi.fn() },
-      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      cronReconciliation: {
-        arm: () => ({ complete: async () => {} }),
-        invalidate: vi.fn(),
-      },
-      channelManager: {} as never,
-      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
-        sourceConfig: config,
-        config,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        webTools: {},
-      })) as never,
-      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
-      sharedGatewaySessionGenerationState: { current: undefined, required: null },
-      prepareTerminalConfig: vi.fn(),
-      reconcileTerminalSessions: vi.fn(),
-      commitTerminalConfig: vi.fn(),
-      acceptTerminalConfig: vi.fn(),
-      clients: [],
-    });
+    ),
+    logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    logChannels: { info: vi.fn(), error: vi.fn() },
+    logCron: { error: vi.fn() },
+    logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    cronReconciliation: {
+      arm: () => ({ complete: async () => {} }),
+      invalidate: vi.fn(),
+    },
+    channelManager: {} as never,
+    activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
+      sourceConfig: config,
+      config,
+      authStores: [],
+      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      warnings: [],
+      webTools: {},
+    })) as never,
+    resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+    sharedGatewaySessionGenerationState: { current: undefined, required: null },
+    prepareTerminalConfig: vi.fn(),
+    reconcileTerminalSessions: vi.fn(),
+    commitTerminalConfig: vi.fn(),
+    acceptTerminalConfig: vi.fn(),
+    clients: [],
+    ...overrides,
+  });
+}
+
+function createHotReloadPlan(): GatewayReloadPlan {
+  return {
+    changedPaths: ["logging.level"],
+    restartGateway: false,
+    restartReasons: [],
+    hotReasons: ["logging.level"],
+    reloadHooks: false,
+    restartGmailWatcher: false,
+    restartCron: false,
+    restartHeartbeat: false,
+    restartHealthMonitor: false,
+    reloadPlugins: false,
+    restartChannels: new Set(),
+    disposeMcpRuntimes: false,
+    noopPaths: [],
+  };
+}
+
+describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
+  beforeEach(() => {
+    hoisted.hotReloadStatus.current = "active";
+    hoisted.onConfigCandidateCommitted = undefined;
+    hoisted.onConfigCandidateObserved = undefined;
+    hoisted.onConfigChange = undefined;
+    hoisted.onConfigAccepted = undefined;
+    hoisted.invalidateConfigGetResponseCache.mockClear();
+    hoisted.notifyPluginMetadataChanged.mockClear();
+    hoisted.stop.mockClear();
+    hoisted.reloadHandlers.pauseGatewayRestartForConfigCandidate.mockClear();
+    hoisted.reloadHandlers.stopRestartRetries.mockClear();
+    hoisted.createGatewayReloadHandlers.mockReset();
+    hoisted.createGatewayReloadHandlers.mockReturnValue(hoisted.reloadHandlers);
+  });
+
+  it("forwards live status and invalidates config.get on watcher commit", async () => {
+    const broadcast = vi.fn();
+    const reloader = startTestManagedReloader({ broadcast });
 
     expect(reloader.hotReloadStatus).toBeTypeOf("function");
     expect(reloader.hotReloadStatus?.()).toBe("active");
+    expect(hoisted.createGatewayReloadHandlers).not.toHaveBeenCalled();
 
     // Flip the underlying watcher's live state without recreating the managed
     // handle — a copied/snapshotted value would stay stuck on "active".
@@ -138,5 +232,156 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
 
     await reloader.stop();
     expect(hoisted.stop).toHaveBeenCalledOnce();
+    expect(hoisted.createGatewayReloadHandlers).not.toHaveBeenCalled();
+    expect(hoisted.reloadHandlers.stopRestartRetries).not.toHaveBeenCalled();
+  });
+
+  it("accepts a baseline-only transaction without loading handlers", async () => {
+    const reloader = startTestManagedReloader();
+    const onConfigAccepted = hoisted.onConfigAccepted;
+    if (!onConfigAccepted) {
+      throw new Error("Expected managed reloader to register onConfigAccepted");
+    }
+    const config = { logging: { level: "info" } } as OpenClawConfig;
+    const rollback = vi.fn(async () => {});
+    const publishSource = vi.fn(async () => rollback);
+    const ownership = {
+      isCurrent: () => true,
+      reapplyRuntimeOverlays: (candidate: OpenClawConfig) => candidate,
+      publishRuntimeEnv: vi.fn(),
+      rollbackRuntimeEnv: vi.fn(),
+      commitRuntimeEnv: vi.fn(),
+      markRuntimeCommitted: vi.fn(),
+    } satisfies GatewayConfigReloadTransactionOwnership;
+
+    await expect(
+      onConfigAccepted(config, ownership, config, {
+        runtimeApplied: true,
+        publishSource,
+      }),
+    ).resolves.toBe(rollback);
+
+    expect(publishSource).toHaveBeenCalledOnce();
+    expect(hoisted.createGatewayReloadHandlers).not.toHaveBeenCalled();
+    await reloader.stop();
+  });
+
+  it("does not load handlers when a pending candidate is stopped before reload", async () => {
+    const reloader = startTestManagedReloader();
+
+    hoisted.onConfigCandidateObserved?.();
+    await reloader.stop();
+
+    expect(hoisted.createGatewayReloadHandlers).not.toHaveBeenCalled();
+    expect(hoisted.reloadHandlers.stopRestartRetries).not.toHaveBeenCalled();
+  });
+
+  it("preserves the first lazy initialization error", async () => {
+    const reloader = startTestManagedReloader();
+    const loadError = new Error("hot reload module unavailable");
+    hoisted.createGatewayReloadHandlers.mockImplementationOnce(() => {
+      throw loadError;
+    });
+
+    const onConfigChange = hoisted.onConfigChange;
+    if (!onConfigChange) {
+      throw new Error("Expected managed reloader to register onConfigChange");
+    }
+    const plan = createHotReloadPlan();
+    await expect(onConfigChange(plan, {})).rejects.toBe(loadError);
+    await expect(onConfigChange(plan, {})).rejects.toBe(loadError);
+
+    expect(hoisted.createGatewayReloadHandlers).toHaveBeenCalledOnce();
+    await reloader.stop();
+  });
+
+  it("supersedes a lazy initialization failure after shutdown starts", async () => {
+    const reloader = startTestManagedReloader();
+    const loadError = new Error("hot reload module unavailable during shutdown");
+    hoisted.createGatewayReloadHandlers.mockImplementationOnce(() => {
+      throw loadError;
+    });
+    const onConfigChange = hoisted.onConfigChange;
+    if (!onConfigChange) {
+      throw new Error("Expected managed reloader to register onConfigChange");
+    }
+
+    const reload = onConfigChange(createHotReloadPlan(), {});
+    const stop = reloader.stop();
+
+    await expect(reload).rejects.toBeInstanceOf(GatewayConfigReloadSupersededError);
+    await stop;
+    expect(hoisted.createGatewayReloadHandlers).toHaveBeenCalledOnce();
+    expect(hoisted.reloadHandlers.stopRestartRetries).not.toHaveBeenCalled();
+  });
+
+  it("stops a handler generation that resolves during shutdown", async () => {
+    const prepareTerminalConfig = vi.fn();
+    const reloader = startTestManagedReloader({ prepareTerminalConfig });
+    const onConfigChange = hoisted.onConfigChange;
+    if (!onConfigChange) {
+      throw new Error("Expected managed reloader to register onConfigChange");
+    }
+
+    const reload = onConfigChange(createHotReloadPlan(), {});
+    const stop = reloader.stop();
+
+    await expect(reload).rejects.toThrow("config reload superseded");
+    await stop;
+    expect(hoisted.createGatewayReloadHandlers).toHaveBeenCalledOnce();
+    expect(hoisted.reloadHandlers.stopRestartRetries).toHaveBeenCalledOnce();
+    expect(prepareTerminalConfig).not.toHaveBeenCalled();
+  });
+
+  it("supersedes the first reload when another candidate arrives during initialization", async () => {
+    const prepareTerminalConfig = vi.fn();
+    const reloader = startTestManagedReloader({ prepareTerminalConfig });
+    const onConfigChange = hoisted.onConfigChange;
+    if (!onConfigChange) {
+      throw new Error("Expected managed reloader to register onConfigChange");
+    }
+    const plan = createHotReloadPlan();
+    const firstConfig = { logging: { level: "info" } } as OpenClawConfig;
+    const secondConfig = { logging: { level: "debug" } } as OpenClawConfig;
+
+    hoisted.onConfigCandidateObserved?.();
+    const firstReload = onConfigChange(plan, firstConfig);
+    hoisted.onConfigCandidateObserved?.();
+
+    await expect(firstReload).rejects.toThrow("config reload superseded");
+    await onConfigChange(plan, secondConfig);
+
+    expect(hoisted.createGatewayReloadHandlers).toHaveBeenCalledOnce();
+    expect(hoisted.reloadHandlers.pauseGatewayRestartForConfigCandidate).toHaveBeenCalledOnce();
+    expect(prepareTerminalConfig).toHaveBeenCalledOnce();
+    expect(prepareTerminalConfig).toHaveBeenCalledWith(plan, secondConfig);
+
+    await reloader.stop();
+  });
+
+  it("creates one handler generation on the first valid reload", async () => {
+    const initialConfig = { session: { store: "/tmp/sessions.json" } } as OpenClawConfig;
+    const prepareTerminalConfig = vi.fn();
+    const reloader = startTestManagedReloader({ prepareTerminalConfig });
+
+    hoisted.onConfigCandidateObserved?.();
+    expect(hoisted.createGatewayReloadHandlers).not.toHaveBeenCalled();
+
+    const onConfigChange = hoisted.onConfigChange;
+    if (!onConfigChange) {
+      throw new Error("Expected managed reloader to register onConfigChange");
+    }
+    const plan = createHotReloadPlan();
+    await Promise.all([onConfigChange(plan, initialConfig), onConfigChange(plan, initialConfig)]);
+
+    expect(hoisted.createGatewayReloadHandlers).toHaveBeenCalledOnce();
+    expect(hoisted.reloadHandlers.pauseGatewayRestartForConfigCandidate).toHaveBeenCalledOnce();
+    expect(prepareTerminalConfig).toHaveBeenCalledTimes(2);
+
+    hoisted.onConfigCandidateObserved?.();
+    expect(hoisted.reloadHandlers.pauseGatewayRestartForConfigCandidate).toHaveBeenCalledTimes(2);
+
+    await reloader.stop();
+    expect(hoisted.reloadHandlers.stopRestartRetries).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -21,6 +21,7 @@ import {
 } from "./config-reload-recovery.js";
 import type { GatewayReloadPlan } from "./config-reload.js";
 import { commitHooksConfigReload, resolveHooksConfig } from "./hooks.js";
+import { startGatewayCronWithLogging } from "./server-cron-start.js";
 import { buildGatewayCronService } from "./server-cron.js";
 import { applyGatewayLaneConcurrency, resolveGatewayLaneConcurrency } from "./server-lanes.js";
 import { createGatewayActiveWorkTracker } from "./server-reload-active-work.js";
@@ -43,7 +44,6 @@ import {
   disposeMcpRuntimesWithTimeout,
   resetPreparedModelRuntimeStateForHotReload,
 } from "./server-reload-utils.js";
-import { startGatewayCronWithLogging } from "./server-runtime-services.js";
 import { resolveHookClientIpConfig } from "./server/hook-client-ip-config.js";
 
 const MCP_RUNTIME_RELOAD_DISPOSE_TIMEOUT_MS = 5_000;

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -1,6 +1,8 @@
+import { setRuntimeConfigAppliedHash } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { getActiveSecretsRuntimeSnapshotRevision } from "../secrets/runtime-state.js";
+import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { invalidateConfigGetResponseCache } from "./config-get-response.js";
 import {
   startGatewayConfigReloader,
@@ -22,7 +24,6 @@ import {
   type ManagedGatewayConfigReloaderParams,
   type RuntimeSecretsPreflightParams,
 } from "./server-reload-contracts.js";
-import { createGatewayReloadHandlers } from "./server-reload-hot.js";
 import {
   createManagedReloadSecretHandlers,
   isRuntimeSecretsPreparationCurrent,
@@ -31,7 +32,7 @@ import {
   assertIrreversibleReloadPlanHasRecoveryOwner,
   restoreCanonicalSecretRefs,
 } from "./server-reload-utils.js";
-import { startGatewayChannelHealthMonitor } from "./server-runtime-services.js";
+import { startGatewayChannelHealthMonitor } from "./server-runtime-startup-services.js";
 import {
   captureSharedGatewaySessionGenerationOwnership,
   disconnectStaleSharedGatewayAuthClients,
@@ -39,6 +40,10 @@ import {
   setRequiredSharedGatewaySessionGenerationIfOwned,
   type SharedGatewaySessionGenerationOwnership,
 } from "./server-shared-auth-generation.js";
+
+type GatewayReloadHandlers = ReturnType<
+  typeof import("./server-reload-hot.js").createGatewayReloadHandlers
+>;
 
 export function startManagedGatewayConfigReloader(
   params: ManagedGatewayConfigReloaderParams,
@@ -110,50 +115,74 @@ export function startManagedGatewayConfigReloader(
     activeGmailRestartAbortController = abortController;
     return abortController;
   };
-  const {
-    applyHotReload,
-    acceptRestartConfig,
-    beginGatewayRestartLifecycle,
-    pauseGatewayRestartForConfigCandidate,
-    publishAppliedConfigHash,
-    publishAcceptedRestartTarget,
-    publishDeferredAppliedConfigHash,
-    recordAcceptedRestartTarget,
-    requestGatewayRestart,
-    restoreConservativeRestartDebt,
-    stopRestartRetries,
-  } = createGatewayReloadHandlers({
-    deps: params.deps,
-    broadcast: params.broadcast,
-    getState: params.getState,
-    setState: params.setState,
-    startChannel: params.startChannel,
-    stopChannel: params.stopChannel,
-    getChannelAutostartSuppression: params.getChannelAutostartSuppression,
-    stopPostReadySidecars: params.stopPostReadySidecars,
-    reloadPlugins: params.reloadPlugins,
-    logHooks: params.logHooks,
-    logChannels: params.logChannels,
-    logCron: params.logCron,
-    logReload: params.logReload,
-    cronReconciliation: params.cronReconciliation,
-    createGmailRestartAbortController,
-    clearGmailRestartAbortController: (abortController) => {
-      if (activeGmailRestartAbortController === abortController) {
-        activeGmailRestartAbortController = null;
+  let reloadHandlers: GatewayReloadHandlers | null = null;
+  let configCandidatePending = false;
+  let configCandidateGeneration = 0;
+  const reloadHandlersLoader = createLazyPromiseLoader(
+    async (): Promise<GatewayReloadHandlers> => {
+      const { createGatewayReloadHandlers } = await import("./server-reload-hot.js");
+      const handlers = createGatewayReloadHandlers({
+        deps: params.deps,
+        broadcast: params.broadcast,
+        getState: params.getState,
+        setState: params.setState,
+        startChannel: params.startChannel,
+        stopChannel: params.stopChannel,
+        getChannelAutostartSuppression: params.getChannelAutostartSuppression,
+        stopPostReadySidecars: params.stopPostReadySidecars,
+        reloadPlugins: params.reloadPlugins,
+        logHooks: params.logHooks,
+        logChannels: params.logChannels,
+        logCron: params.logCron,
+        logReload: params.logReload,
+        cronReconciliation: params.cronReconciliation,
+        createGmailRestartAbortController,
+        clearGmailRestartAbortController: (abortController) => {
+          if (activeGmailRestartAbortController === abortController) {
+            activeGmailRestartAbortController = null;
+          }
+        },
+        ...(params.onCronRestart ? { onCronRestart: params.onCronRestart } : {}),
+        ...(params.requestRecoveryRestart
+          ? { requestRecoveryRestart: params.requestRecoveryRestart }
+          : {}),
+        restartRecoveryAvailable,
+        createHealthMonitor: (config) =>
+          startGatewayChannelHealthMonitor({
+            cfg: config,
+            channelManager: params.channelManager,
+          }),
+      });
+      reloadHandlers = handlers;
+      if (stopped) {
+        handlers.stopRestartRetries();
+        abortPendingChannelReloads();
+      } else if (configCandidatePending) {
+        configCandidatePending = false;
+        handlers.pauseGatewayRestartForConfigCandidate();
       }
+      return handlers;
     },
-    ...(params.onCronRestart ? { onCronRestart: params.onCronRestart } : {}),
-    ...(params.requestRecoveryRestart
-      ? { requestRecoveryRestart: params.requestRecoveryRestart }
-      : {}),
-    restartRecoveryAvailable,
-    createHealthMonitor: (config) =>
-      startGatewayChannelHealthMonitor({
-        cfg: config,
-        channelManager: params.channelManager,
-      }),
-  });
+    { cacheRejections: true },
+  );
+  const loadReloadHandlers = async (): Promise<GatewayReloadHandlers> => {
+    if (stopped) {
+      throw new GatewayConfigReloadSupersededError();
+    }
+    let handlers: GatewayReloadHandlers;
+    try {
+      handlers = await reloadHandlersLoader.load();
+    } catch (error) {
+      if (stopped) {
+        throw new GatewayConfigReloadSupersededError();
+      }
+      throw error;
+    }
+    if (stopped) {
+      throw new GatewayConfigReloadSupersededError();
+    }
+    return handlers;
+  };
   const runManagedRestart = async (
     plan: GatewayReloadPlan,
     nextConfig: OpenClawConfig,
@@ -168,6 +197,8 @@ export function startManagedGatewayConfigReloader(
         throw new GatewayConfigReloadSupersededError();
       }
     };
+    assertCurrent();
+    const { beginGatewayRestartLifecycle, requestGatewayRestart } = await loadReloadHandlers();
     assertCurrent();
     const restartLifecycle = beginGatewayRestartLifecycle();
     let preparation:
@@ -305,7 +336,7 @@ export function startManagedGatewayConfigReloader(
       params,
       prepareRuntimeCandidate,
       tryPrepareRuntimeSecrets,
-      applyHotReload,
+      applyHotReload: async (...args) => (await loadReloadHandlers()).applyHotReload(...args),
     });
 
   const configReloader = startGatewayConfigReloader({
@@ -335,12 +366,37 @@ export function startManagedGatewayConfigReloader(
     readSnapshot: params.readSnapshot,
     promoteSnapshot: async (snapshot, _reason) => await params.promoteSnapshot(snapshot),
     subscribeToWrites: params.subscribeToWrites,
-    onConfigCandidateObserved: pauseGatewayRestartForConfigCandidate,
-    onConfigChange: (plan, nextConfig) => {
+    onConfigCandidateObserved: () => {
+      configCandidateGeneration += 1;
+      if (reloadHandlers) {
+        reloadHandlers.pauseGatewayRestartForConfigCandidate();
+        return;
+      }
+      // Invalid candidates should not load the hot graph. Carry the pause into
+      // the first accepted transaction, before any handler state is consumed.
+      configCandidatePending = true;
+    },
+    onConfigChange: async (plan, nextConfig) => {
+      const candidateGeneration = configCandidateGeneration;
       assertIrreversibleReloadPlanHasRecoveryOwner(plan, restartRecoveryAvailable);
+      await loadReloadHandlers();
+      if (candidateGeneration !== configCandidateGeneration) {
+        throw new GatewayConfigReloadSupersededError();
+      }
       params.prepareTerminalConfig(plan, applyRuntimeConfigOverrides(nextConfig));
     },
     onConfigAccepted: async (nextConfig, transactionOwnership, sourceConfig, acceptance) => {
+      const handlers = reloadHandlers;
+      if (!handlers) {
+        return await acceptance.publishSource?.();
+      }
+      const {
+        acceptRestartConfig,
+        publishAcceptedRestartTarget,
+        publishDeferredAppliedConfigHash,
+        recordAcceptedRestartTarget,
+        restoreConservativeRestartDebt,
+      } = handlers;
       const assertCurrent = () => {
         if (!transactionOwnership.isCurrent()) {
           throw new GatewayConfigReloadSupersededError();
@@ -438,7 +494,13 @@ export function startManagedGatewayConfigReloader(
       }
     },
     onConfigApplied: (_plan, nextConfig) => params.commitTerminalConfig(nextConfig),
-    onConfigRevisionApplied: publishAppliedConfigHash,
+    onConfigRevisionApplied: (hash) => {
+      if (reloadHandlers) {
+        reloadHandlers.publishAppliedConfigHash(hash);
+        return;
+      }
+      setRuntimeConfigAppliedHash(hash);
+    },
     onEffectiveConfigUnchanged,
     onNoopConfigCommit,
     onHotReload,
@@ -453,7 +515,7 @@ export function startManagedGatewayConfigReloader(
   return {
     stop: async () => {
       stopped = true;
-      stopRestartRetries();
+      reloadHandlers?.stopRestartRetries();
       // Release managed waiters before the base reloader joins every active transaction.
       abortPendingChannelReloads();
       abortActiveGmailRestart();

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -10,6 +10,7 @@ import {
   waitForMediaCleanupDrains,
 } from "./server-media-cleanup-lifecycle.js";
 import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
+import type { GatewayScheduledServicesLifecycleOwner } from "./server-startup-scheduled-services.js";
 
 // Mutable server handles track timers, sidecars, subscriptions, and service
 // cleanup hooks that shutdown/reload code must stop exactly once.
@@ -33,6 +34,7 @@ export type GatewayServerMutableState = {
   skillCuratorCleanup: () => void;
   heartbeatRunner: HeartbeatRunner;
   stopOutboundDeliveryRecovery: () => Promise<void>;
+  scheduledServices: GatewayScheduledServicesLifecycleOwner;
   stopGatewayUpdateCheck: () => void;
   tailscaleCleanup: (() => Promise<void>) | null;
   postReadySidecars: GatewayPostReadySidecarHandle[];
@@ -72,6 +74,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
       updateConfig: (_cfg: OpenClawConfig) => {},
     } satisfies HeartbeatRunner,
     stopOutboundDeliveryRecovery: async () => {},
+    scheduledServices: { stop: async () => {} },
     stopGatewayUpdateCheck: () => {},
     tailscaleCleanup: null as (() => Promise<void>) | null,
     postReadySidecars: [],

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -681,7 +681,7 @@ describe("server-runtime-services", () => {
     expect(recordPostReadyMemory).toHaveBeenCalledTimes(1);
   });
 
-  it("returns a cancellable post-ready maintenance timer", async () => {
+  it("returns a cancellable post-ready maintenance handle", async () => {
     vi.useFakeTimers();
     const startMaintenance = vi.fn(async () => null);
     const onStarted = vi.fn();
@@ -693,11 +693,47 @@ describe("server-runtime-services", () => {
       }),
     );
 
-    clearTimeout(handle);
+    await handle.stop();
     await vi.advanceTimersByTimeAsync(25);
 
     expect(onStarted).not.toHaveBeenCalled();
     expect(startMaintenance).not.toHaveBeenCalled();
+  });
+
+  it("keeps maintenance stop pending after the timer fires until child work settles", async () => {
+    vi.useFakeTimers();
+    let finishMaintenance: ((maintenance: null) => void) | undefined;
+    const startMaintenance = vi.fn(
+      () =>
+        new Promise<null>((resolve) => {
+          finishMaintenance = resolve;
+        }),
+    );
+    const handle = scheduleGatewayPostReadyMaintenance(
+      createPostReadyMaintenanceScheduleParams({
+        delayMs: 25,
+        startMaintenance,
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await waitForFast(() => expect(startMaintenance).toHaveBeenCalledOnce());
+
+    let stopSettled = false;
+    const stop = handle.stop().then(() => {
+      stopSettled = true;
+    });
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    if (!finishMaintenance) {
+      throw new Error("Expected maintenance resolver to be initialized");
+    }
+    finishMaintenance(null);
+    await stop;
+    expect(stopSettled).toBe(true);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
   it("runs a scheduled idle task in an independent admitted root", async () => {
@@ -791,7 +827,7 @@ describe("server-runtime-services", () => {
       errorMessage: "idle task failed",
     });
 
-    handle.stop();
+    await handle.stop();
     await vi.advanceTimersByTimeAsync(25);
 
     expect(run).not.toHaveBeenCalled();

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -19,6 +19,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import { startSessionUpstreamMonitor } from "../sessions/session-upstream-monitor.js";
 import type { GatewayCronReconciliation } from "./server-cron-reconciled.js";
+import { startGatewayCronWithLogging } from "./server-cron-start.js";
 import type { GatewayCronState } from "./server-cron.js";
 import type { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 import {
@@ -31,6 +32,7 @@ export {
   startGatewayRuntimeServices,
   type GatewayChannelManager,
 } from "./server-runtime-startup-services.js";
+export { startGatewayCronWithLogging };
 
 type GatewayPostReadyLogger = {
   warn: (message: string) => void;
@@ -38,35 +40,9 @@ type GatewayPostReadyLogger = {
 export type GatewayMaintenanceHandles = NonNullable<
   Awaited<ReturnType<typeof startGatewayMaintenanceTimers>>
 >;
-
-/** Starts cron without making the surrounding startup or reload transaction wait. */
-export function startGatewayCronWithLogging(params: {
-  cronState: GatewayCronState;
-  cronReconciliation: GatewayCronReconciliation;
-  reason: "startup" | "reload";
-  config: OpenClawConfig;
-  afterStart?: () => Promise<void>;
-  onStartError?: (error: unknown) => void;
-  logCron: { error: (message: string) => void };
-}): void {
-  const reconciliation = params.cronReconciliation.arm({
-    reason: params.reason,
-    config: params.config,
-    cronState: params.cronState,
-  });
-  void runWithGatewayIndependentRootWorkAdmission(async () => {
-    try {
-      await params.cronState.cron.start();
-      await params.afterStart?.();
-      await reconciliation.complete();
-    } catch (err) {
-      params.logCron.error(`failed to start: ${String(err)}`);
-      // Recovery callbacks must run before this independent root releases its
-      // admission fence; restart and suspension cannot race past this point.
-      params.onStartError?.(err);
-    }
-  }).catch((err: unknown) => params.logCron.error(`failed to enter start root: ${String(err)}`));
-}
+export type GatewayPostReadyMaintenanceHandle = {
+  stop: () => Promise<void>;
+};
 
 async function clearGatewayMaintenanceHandles(
   maintenance: GatewayMaintenanceHandles | null,
@@ -118,7 +94,7 @@ export async function runGatewayPostReadyMaintenance(params: {
   params.recordPostReadyMemory();
 }
 
-/** Schedules post-ready maintenance and cancels/cleans handles if shutdown wins the race. */
+/** Schedules post-ready maintenance and joins it when shutdown wins the race. */
 export function scheduleGatewayPostReadyMaintenance(params: {
   delayMs: number;
   isClosing: () => boolean;
@@ -133,53 +109,78 @@ export function scheduleGatewayPostReadyMaintenance(params: {
   logCron: { error: (message: string) => void };
   log: GatewayPostReadyLogger;
   recordPostReadyMemory: () => void;
-}): ReturnType<typeof setTimeout> {
-  const timer = setTimeout(() => {
+}): GatewayPostReadyMaintenanceHandle {
+  let stopped = false;
+  let inFlight: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+    timer = null;
     params.onStarted?.();
-    if (params.isClosing()) {
+    if (stopped || params.isClosing()) {
       return;
     }
-    void runWithGatewayIndependentRootWorkAdmission(async () =>
-      runGatewayPostReadyMaintenance({
-        startMaintenance: async () => {
-          if (params.isClosing()) {
-            return null;
-          }
-          const maintenance = await params.startMaintenance();
-          if (params.isClosing()) {
-            // Maintenance can allocate intervals before shutdown is observed; clear them here
-            // instead of handing live timers to a closing gateway.
-            await clearGatewayMaintenanceHandles(maintenance);
-            return null;
-          }
-          return maintenance;
-        },
-        applyMaintenance: async (maintenance) => {
-          if (params.isClosing()) {
-            await clearGatewayMaintenanceHandles(maintenance);
-            return;
-          }
-          await params.applyMaintenance(maintenance);
-        },
-        shouldStartCron: () => !params.isClosing() && params.shouldStartCron(),
-        markCronStartHandled: params.markCronStartHandled,
-        cronState: params.cronState,
-        cronReconciliation: params.cronReconciliation,
-        cronConfig: params.cronConfig,
-        logCron: params.logCron,
-        log: params.log,
-        recordPostReadyMemory: () => {
-          if (!params.isClosing()) {
-            params.recordPostReadyMemory();
-          }
-        },
-      }),
-    ).catch((err: unknown) =>
-      params.log.warn(`gateway post-ready maintenance deferred task failed: ${String(err)}`),
+    // Publish the join handle before child code can re-enter gateway shutdown.
+    const task = Promise.resolve().then(() =>
+      runWithGatewayIndependentRootWorkAdmission(async () =>
+        runGatewayPostReadyMaintenance({
+          startMaintenance: async () => {
+            if (stopped || params.isClosing()) {
+              return null;
+            }
+            const maintenance = await params.startMaintenance();
+            if (stopped || params.isClosing()) {
+              // Maintenance can allocate intervals before shutdown is observed; clear them here
+              // instead of handing live timers to a closing gateway.
+              await clearGatewayMaintenanceHandles(maintenance);
+              return null;
+            }
+            return maintenance;
+          },
+          applyMaintenance: async (maintenance) => {
+            if (stopped || params.isClosing()) {
+              await clearGatewayMaintenanceHandles(maintenance);
+              return;
+            }
+            await params.applyMaintenance(maintenance);
+          },
+          shouldStartCron: () => !stopped && !params.isClosing() && params.shouldStartCron(),
+          markCronStartHandled: params.markCronStartHandled,
+          cronState: params.cronState,
+          cronReconciliation: params.cronReconciliation,
+          cronConfig: params.cronConfig,
+          logCron: params.logCron,
+          log: params.log,
+          recordPostReadyMemory: () => {
+            if (!stopped && !params.isClosing()) {
+              params.recordPostReadyMemory();
+            }
+          },
+        }),
+      ),
     );
+    const settled = task
+      .catch((err: unknown) =>
+        params.log.warn(`gateway post-ready maintenance deferred task failed: ${String(err)}`),
+      )
+      .finally(() => {
+        if (inFlight === settled) {
+          inFlight = null;
+        }
+      });
+    inFlight = settled;
   }, params.delayMs);
   timer.unref?.();
-  return timer;
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      stopPromise ??= inFlight ?? Promise.resolve();
+      return stopPromise;
+    },
+  };
 }
 
 const RECOVERY_SHUTDOWN_STILL_PENDING_WARN_MS = 5_000;

--- a/src/gateway/server-startup-context-cache-prewarm.ts
+++ b/src/gateway/server-startup-context-cache-prewarm.ts
@@ -50,7 +50,7 @@ export function scheduleContextCachePrewarm(params: {
   return {
     stop: () => {
       stopped = true;
-      idleTask.stop();
+      return idleTask.stop();
     },
   };
 }

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -10,8 +10,6 @@ import { isNixMode } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
-import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
-import { createLazyPromise } from "../shared/lazy-runtime.js";
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import { collectGatewayProcessMemoryUsageMb, finishGatewayRestartTrace } from "./restart-trace.js";
 import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
@@ -26,6 +24,7 @@ import {
   enforceSharedGatewaySessionGenerationForConfigWrite,
   getRequiredSharedGatewaySessionGeneration,
 } from "./server-shared-auth-generation.js";
+import { createGatewayScheduledServicesController } from "./server-startup-scheduled-services.js";
 import {
   getHealthCache,
   getHealthVersion,
@@ -34,7 +33,6 @@ import {
 
 type GatewayCoreRuntime = Awaited<ReturnType<typeof startGatewayCoreRuntime>>;
 type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
-const [POST_READY_MAINTENANCE_DELAY_MS, RETAINED_PLUGIN_CLEANUP_DELAY_MS] = [250, 30_000];
 export async function finishGatewayStartup(params: {
   coreRuntime: GatewayCoreRuntime;
   port: number;
@@ -177,7 +175,6 @@ export async function finishGatewayStartup(params: {
     preauthConnectionBudget,
     releaseStartupAccountStarts,
     cronReconciliation,
-    postReadyState,
     cronStartState,
     prepareReloadCandidate,
     startupLastGoodSnapshot,
@@ -371,41 +368,53 @@ export async function finishGatewayStartup(params: {
   startupState.dispatchReady = true;
   startupTrace.mark("http.bound");
   const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
-  let postAttachRuntimeReturned = false;
-  let scheduledServicesActivated = false;
-  const loadScheduledServicesModule = createLazyPromise(
-    () => import("./server-runtime-services.js"),
-    { cacheRejections: true },
-  );
-  const activateScheduledServicesWhenReady = () => {
-    if (
-      lifecycle.closePreludeStarted ||
-      !postAttachRuntimeReturned ||
-      !startupState.sidecarsReady ||
-      scheduledServicesActivated
-    ) {
-      return;
-    }
-    scheduledServicesActivated = true;
-    void loadScheduledServicesModule().then((gatewayRuntimeServices) => {
+  const scheduledServices = createGatewayScheduledServicesController({
+    minimalTestGateway,
+    deps,
+    getConfig: getRuntimeConfig,
+    getCronState: () => runtimeState.cronState,
+    waitForPostReadyWork: params.waitForPostReadyWork,
+    sessionDeliveryRecoveryMaxEnqueuedAt,
+    cronReconciliation,
+    shouldStartCron: () => !lifecycle.closePreludeStarted && !cronStartState.handled,
+    markCronStartHandled: () => {
+      cronStartState.handled = true;
+    },
+    startMaintenance: async () => {
       if (lifecycle.closePreludeStarted) {
+        return null;
+      }
+      return await earlyRuntime.startMaintenance();
+    },
+    applyMaintenance: async (maintenance) => {
+      if (lifecycle.closePreludeStarted) {
+        clearInterval(maintenance.tickInterval);
+        clearInterval(maintenance.healthInterval);
+        clearInterval(maintenance.dedupeCleanup);
+        await maintenance.stopMediaCleanup();
+        clearInterval(maintenance.worktreeCleanup);
+        maintenance.skillCuratorCleanup();
         return;
       }
-      const activated = gatewayRuntimeServices.activateGatewayScheduledServices({
-        minimalTestGateway,
-        cfgAtStart,
-        deps,
-        sessionDeliveryRecoveryMaxEnqueuedAt,
-        cronState: runtimeState.cronState,
-        cronReconciliation,
-        startCron: false,
-        logCron,
-        log,
-      });
-      runtimeState.heartbeatRunner = activated.heartbeatRunner;
-      runtimeState.stopOutboundDeliveryRecovery = activated.stopOutboundDeliveryRecovery;
-    });
-  };
+      runtimeState.tickInterval = maintenance.tickInterval;
+      runtimeState.healthInterval = maintenance.healthInterval;
+      runtimeState.dedupeCleanup = maintenance.dedupeCleanup;
+      // Publish the stop owner before cleanup can touch SQLite or state paths;
+      // shutdown may begin immediately after this synchronous handoff.
+      runtimeState.stopMediaCleanup = maintenance.stopMediaCleanup;
+      runtimeState.worktreeCleanup = maintenance.worktreeCleanup;
+      runtimeState.skillCuratorCleanup = maintenance.skillCuratorCleanup;
+      maintenance.startMediaCleanup();
+    },
+    recordPostReadyMemory: () => {
+      startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
+    },
+    logCron,
+    log,
+  });
+  runtimeState.scheduledServices = scheduledServices;
+  runtimeState.heartbeatRunner = scheduledServices.heartbeatRunner;
+  runtimeState.stopOutboundDeliveryRecovery = scheduledServices.stopOutboundDeliveryRecovery;
   ({
     stopGatewayUpdateCheck: runtimeState.stopGatewayUpdateCheck,
     tailscaleCleanup: runtimeState.tailscaleCleanup,
@@ -514,7 +523,7 @@ export async function finishGatewayStartup(params: {
             : {}),
           onSidecarsReady: () => {
             startupState.sidecarsReady = true;
-            activateScheduledServicesWhenReady();
+            scheduledServices.markSidecarsReady();
           },
           isClosing: () => lifecycle.closePreludeStarted,
           startupTrace,
@@ -539,10 +548,8 @@ export async function finishGatewayStartup(params: {
       startOpenClawDatabaseIntegrityVerifier({ env: process.env }),
     );
   }
-  postAttachRuntimeReturned = true;
-  activateScheduledServicesWhenReady();
 
-  const { startManagedGatewayConfigReloader } = await import("./server-reload-handlers.js");
+  const { startManagedGatewayConfigReloader } = await import("./server-reload-managed.js");
   runtimeState.configReloader = startManagedGatewayConfigReloader({
     minimalTestGateway,
     initialConfig: cfgAtStart,
@@ -633,70 +640,4 @@ export async function finishGatewayStartup(params: {
   await promoteConfigSnapshotToLastKnownGood(startupLastGoodSnapshot).catch((err: unknown) => {
     log.warn(`gateway: failed to promote config last-known-good backup: ${String(err)}`);
   });
-  if (!minimalTestGateway) {
-    const gatewayRuntimeServices = await loadScheduledServicesModule();
-    postReadyState.maintenanceTimer = gatewayRuntimeServices.scheduleGatewayPostReadyMaintenance({
-      delayMs: POST_READY_MAINTENANCE_DELAY_MS,
-      isClosing: () => lifecycle.closePreludeStarted,
-      onStarted: () => {
-        postReadyState.maintenanceTimer = null;
-      },
-      startMaintenance: async () => {
-        if (lifecycle.closePreludeStarted) {
-          return null;
-        }
-        return earlyRuntime.startMaintenance();
-      },
-      applyMaintenance: async (maintenance) => {
-        if (lifecycle.closePreludeStarted) {
-          clearInterval(maintenance.tickInterval);
-          clearInterval(maintenance.healthInterval);
-          clearInterval(maintenance.dedupeCleanup);
-          await maintenance.stopMediaCleanup();
-          clearInterval(maintenance.worktreeCleanup);
-          maintenance.skillCuratorCleanup();
-          return;
-        }
-        runtimeState.tickInterval = maintenance.tickInterval;
-        runtimeState.healthInterval = maintenance.healthInterval;
-        runtimeState.dedupeCleanup = maintenance.dedupeCleanup;
-        // Publish the stop owner before cleanup can touch SQLite or state paths;
-        // shutdown may begin immediately after this synchronous handoff.
-        runtimeState.stopMediaCleanup = maintenance.stopMediaCleanup;
-        runtimeState.worktreeCleanup = maintenance.worktreeCleanup;
-        runtimeState.skillCuratorCleanup = maintenance.skillCuratorCleanup;
-        maintenance.startMediaCleanup();
-      },
-      shouldStartCron: () => !lifecycle.closePreludeStarted && !cronStartState.handled,
-      markCronStartHandled: () => {
-        cronStartState.handled = true;
-      },
-      cronState: runtimeState.cronState,
-      cronReconciliation,
-      cronConfig: cfgAtStart,
-      logCron,
-      log,
-      recordPostReadyMemory: () => {
-        startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
-      },
-    });
-    // The loop closes the previous server before this generation starts, so retired
-    // plugin installs are safe to remove. Wait for an idle window and resolve current
-    // install paths at execution time so cleanup cannot remove active code or delay a turn.
-    postReadyState.retainedPluginCleanupHandle = gatewayRuntimeServices.scheduleGatewayIdleTask({
-      delayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
-      retryDelayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
-      isClosing: () => lifecycle.closePreludeStarted,
-      isBusy: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }) > 0,
-      run: async () => {
-        const { cleanupRetainedPluginInstallGenerations } =
-          await import("./server-retained-plugin-cleanup.js");
-        await cleanupRetainedPluginInstallGenerations({ log });
-      },
-      log,
-      errorMessage: "retained npm generation cleanup failed",
-    });
-  } else {
-    startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
-  }
 }

--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -110,7 +110,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
       agentIds: ["main", "research"],
       maxRows: 2_000,
     });
-    sidecar.stop();
+    await sidecar.stop();
   });
 
   it("waits for gateway readiness before warming handler data", async () => {
@@ -134,7 +134,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     releaseGatewayReady();
     await vi.runAllTimersAsync();
     expect(load).toHaveBeenCalledOnce();
-    sidecar.stop();
+    await sidecar.stop();
   });
 
   it("waits for admitted request work before warming handler data", async () => {
@@ -158,7 +158,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     expect(load).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
     await vi.waitFor(() => expect(load).toHaveBeenCalledOnce());
-    sidecar.stop();
+    await sidecar.stop();
   });
 
   it("stays stopped when readiness arrives after shutdown", async () => {
@@ -177,7 +177,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     });
 
     await vi.advanceTimersToNextTimerAsync();
-    sidecar.stop();
+    await sidecar.stop();
     releaseGatewayReady();
     await vi.runAllTimersAsync();
 
@@ -259,8 +259,9 @@ describe("scheduleGatewayHandlerPrewarm", () => {
 
     await vi.advanceTimersToNextTimerAsync();
     expect(first).toHaveBeenCalledOnce();
-    sidecar.stop();
+    const stop = sidecar.stop();
     releaseFirst();
+    await stop;
     await vi.runAllTimersAsync();
 
     expect(second).not.toHaveBeenCalled();

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -17,7 +17,7 @@ type GatewayHandlerPrewarmItem = {
 };
 
 type GatewayHandlerPrewarmHandle = {
-  stop: () => void;
+  stop: () => Promise<void>;
 };
 
 async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: string): Promise<void> {
@@ -157,8 +157,9 @@ export function scheduleGatewayHandlerPrewarm(params: {
   return {
     stop: () => {
       stopped = true;
-      idleTask?.stop();
+      const activeIdleTask = idleTask;
       idleTask = undefined;
+      return activeIdleTask?.stop() ?? Promise.resolve();
     },
   };
 }

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -364,8 +364,9 @@ function scheduleAgentRuntimePluginPrewarm(params: {
   return {
     stop: () => {
       stopped = true;
-      idleTask?.stop();
+      const activeIdleTask = idleTask;
       idleTask = undefined;
+      return activeIdleTask?.stop();
     },
   };
 }

--- a/src/gateway/server-startup-scheduled-services.test.ts
+++ b/src/gateway/server-startup-scheduled-services.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred, type Deferred } from "../shared/deferred.js";
+import { createGatewayScheduledServicesController } from "./server-startup-scheduled-services.js";
+
+type ControllerParams = Parameters<typeof createGatewayScheduledServicesController>[0];
+type ScheduledServicesModule = Awaited<
+  ReturnType<NonNullable<ControllerParams["loadScheduledServicesModule"]>>
+>;
+
+function createHarness(
+  options: {
+    moduleLoad?: Deferred<ScheduledServicesModule>;
+    sessionDeliveryRecoveryMaxEnqueuedAt?: number;
+    minimalTestGateway?: boolean;
+    stopPostReadyMaintenance?: () => Promise<void>;
+    stopRetainedPluginCleanup?: () => Promise<void>;
+  } = {},
+) {
+  const postReady = createDeferred();
+  let currentConfig = { marker: "initial" } as never;
+  let currentCronState = { marker: "initial-cron" } as never;
+  const activeHeartbeatRunner = {
+    updateConfig: vi.fn(),
+    stop: vi.fn(),
+  };
+  const stopOutboundDeliveryRecovery = vi.fn(async () => {});
+  const activateGatewayScheduledServices = vi.fn(() => ({
+    heartbeatRunner: activeHeartbeatRunner,
+    stopOutboundDeliveryRecovery,
+  }));
+  const stopPostReadyMaintenance = vi.fn(options.stopPostReadyMaintenance ?? (async () => {}));
+  const scheduleGatewayPostReadyMaintenance = vi.fn(() => {
+    return { stop: stopPostReadyMaintenance };
+  });
+  const stopRetainedPluginCleanup = vi.fn(options.stopRetainedPluginCleanup ?? (async () => {}));
+  const scheduleGatewayIdleTask = vi.fn(() => ({ stop: stopRetainedPluginCleanup }));
+  const recordPostReadyMemory = vi.fn();
+  const runtimeModule = {
+    activateGatewayScheduledServices,
+    scheduleGatewayPostReadyMaintenance,
+    scheduleGatewayIdleTask,
+  } as ScheduledServicesModule;
+  const loadScheduledServicesModule = vi.fn(
+    () => options.moduleLoad?.promise ?? Promise.resolve(runtimeModule),
+  );
+  const log = {
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  const controller = createGatewayScheduledServicesController({
+    minimalTestGateway: options.minimalTestGateway ?? false,
+    deps: {} as never,
+    getConfig: () => currentConfig,
+    getCronState: () => currentCronState,
+    waitForPostReadyWork: () => postReady.promise,
+    sessionDeliveryRecoveryMaxEnqueuedAt: options.sessionDeliveryRecoveryMaxEnqueuedAt ?? 123,
+    cronReconciliation: {} as never,
+    shouldStartCron: () => true,
+    markCronStartHandled: vi.fn(),
+    startMaintenance: vi.fn(async () => null),
+    applyMaintenance: vi.fn(),
+    recordPostReadyMemory,
+    logCron: { error: vi.fn() },
+    log,
+    loadScheduledServicesModule,
+  });
+
+  return {
+    controller,
+    postReady,
+    runtimeModule,
+    loadScheduledServicesModule,
+    activateGatewayScheduledServices,
+    scheduleGatewayPostReadyMaintenance,
+    scheduleGatewayIdleTask,
+    activeHeartbeatRunner,
+    stopOutboundDeliveryRecovery,
+    stopPostReadyMaintenance,
+    stopRetainedPluginCleanup,
+    recordPostReadyMemory,
+    log,
+    setCurrentConfig: (config: unknown) => {
+      currentConfig = config as never;
+    },
+    setCurrentCronState: (cronState: unknown) => {
+      currentCronState = cronState as never;
+    },
+  };
+}
+
+async function waitForActivation(harness: ReturnType<typeof createHarness>): Promise<void> {
+  await vi.waitFor(() => {
+    expect(harness.activateGatewayScheduledServices).toHaveBeenCalledTimes(1);
+  });
+}
+
+describe("gateway scheduled services startup controller", () => {
+  it("samples post-ready memory in minimal mode without sidecars or a runtime import", async () => {
+    const harness = createHarness({ minimalTestGateway: true });
+
+    await Promise.resolve();
+    expect(harness.recordPostReadyMemory).not.toHaveBeenCalled();
+
+    harness.postReady.resolve();
+    await vi.waitFor(() => {
+      expect(harness.recordPostReadyMemory).toHaveBeenCalledTimes(1);
+    });
+
+    expect(harness.loadScheduledServicesModule).not.toHaveBeenCalled();
+    expect(harness.activateGatewayScheduledServices).not.toHaveBeenCalled();
+    await harness.controller.stop();
+  });
+
+  it.each(["post-ready-first", "sidecars-first"] as const)(
+    "returns immediately and waits for both latches when %s",
+    async (order) => {
+      const harness = createHarness();
+
+      if (order === "post-ready-first") {
+        harness.postReady.resolve();
+      } else {
+        harness.controller.markSidecarsReady();
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(harness.loadScheduledServicesModule).not.toHaveBeenCalled();
+
+      if (order === "post-ready-first") {
+        harness.controller.markSidecarsReady();
+      } else {
+        harness.postReady.resolve();
+      }
+      await waitForActivation(harness);
+
+      expect(harness.loadScheduledServicesModule).toHaveBeenCalledTimes(1);
+      expect(harness.scheduleGatewayPostReadyMaintenance).toHaveBeenCalledTimes(1);
+      expect(harness.scheduleGatewayIdleTask).toHaveBeenCalledTimes(1);
+      await harness.controller.stop();
+    },
+  );
+
+  it("activates once with current config, current cron state, and the bind-time cutoff", async () => {
+    const harness = createHarness({ sessionDeliveryRecoveryMaxEnqueuedAt: 456 });
+    const currentConfig = { marker: "current" };
+    const acceptedHeartbeatConfig = { marker: "current" };
+    const currentCronState = { marker: "current-cron" };
+    const stableHeartbeatRunner = harness.controller.heartbeatRunner;
+    harness.setCurrentConfig(currentConfig);
+    harness.setCurrentCronState(currentCronState);
+    stableHeartbeatRunner.updateConfig(acceptedHeartbeatConfig as never);
+
+    harness.controller.markSidecarsReady();
+    harness.postReady.resolve();
+    await waitForActivation(harness);
+
+    expect(harness.activateGatewayScheduledServices).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfgAtStart: currentConfig,
+        cronState: currentCronState,
+        sessionDeliveryRecoveryMaxEnqueuedAt: 456,
+        startCron: false,
+      }),
+    );
+    expect(harness.activeHeartbeatRunner.updateConfig).toHaveBeenCalledWith(
+      acceptedHeartbeatConfig,
+    );
+    expect(harness.controller.heartbeatRunner).toBe(stableHeartbeatRunner);
+
+    const laterConfig = { marker: "later" };
+    stableHeartbeatRunner.updateConfig(laterConfig as never);
+    expect(harness.activeHeartbeatRunner.updateConfig).toHaveBeenLastCalledWith(laterConfig);
+    await harness.controller.stop();
+  });
+
+  it("keeps repeated readiness signals to one import and activation", async () => {
+    const harness = createHarness();
+
+    harness.controller.markSidecarsReady();
+    harness.controller.markSidecarsReady();
+    harness.postReady.resolve();
+    harness.postReady.resolve();
+    await waitForActivation(harness);
+    harness.controller.markSidecarsReady();
+    await Promise.resolve();
+
+    expect(harness.loadScheduledServicesModule).toHaveBeenCalledTimes(1);
+    expect(harness.activateGatewayScheduledServices).toHaveBeenCalledTimes(1);
+    await harness.controller.stop();
+  });
+
+  it("lets close win before the post-ready barrier", async () => {
+    const harness = createHarness();
+
+    const firstStop = harness.controller.stop();
+    const secondStop = harness.controller.stop();
+    expect(secondStop).toBe(firstStop);
+    await firstStop;
+
+    harness.controller.markSidecarsReady();
+    harness.postReady.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.loadScheduledServicesModule).not.toHaveBeenCalled();
+    expect(harness.activateGatewayScheduledServices).not.toHaveBeenCalled();
+  });
+
+  it("joins a pending import and prevents late activation after close", async () => {
+    const moduleLoad = createDeferred<ScheduledServicesModule>();
+    const harness = createHarness({ moduleLoad });
+    harness.controller.markSidecarsReady();
+    harness.postReady.resolve();
+    await vi.waitFor(() => {
+      expect(harness.loadScheduledServicesModule).toHaveBeenCalledTimes(1);
+    });
+
+    let stopSettled = false;
+    const stop = harness.controller.stop().then(() => {
+      stopSettled = true;
+    });
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+
+    moduleLoad.resolve(harness.runtimeModule);
+    await stop;
+
+    expect(harness.activateGatewayScheduledServices).not.toHaveBeenCalled();
+    expect(harness.scheduleGatewayPostReadyMaintenance).not.toHaveBeenCalled();
+    expect(harness.scheduleGatewayIdleTask).not.toHaveBeenCalled();
+  });
+
+  it("stops activated services and deferred cleanup once", async () => {
+    const harness = createHarness();
+    harness.controller.markSidecarsReady();
+    harness.postReady.resolve();
+    await waitForActivation(harness);
+
+    const firstStop = harness.controller.stop();
+    const secondStop = harness.controller.stop();
+    expect(secondStop).toBe(firstStop);
+    await firstStop;
+    harness.controller.heartbeatRunner.stop();
+    await harness.controller.stopOutboundDeliveryRecovery();
+
+    expect(harness.activeHeartbeatRunner.stop).toHaveBeenCalledTimes(1);
+    expect(harness.stopOutboundDeliveryRecovery).toHaveBeenCalledTimes(1);
+    expect(harness.stopPostReadyMaintenance).toHaveBeenCalledTimes(1);
+    expect(harness.stopRetainedPluginCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("joins already-started scheduled children before the lifecycle stop settles", async () => {
+    const maintenance = createDeferred();
+    const retainedCleanup = createDeferred();
+    const harness = createHarness({
+      stopPostReadyMaintenance: () => maintenance.promise,
+      stopRetainedPluginCleanup: () => retainedCleanup.promise,
+    });
+    harness.controller.markSidecarsReady();
+    harness.postReady.resolve();
+    await waitForActivation(harness);
+
+    let stopSettled = false;
+    const stop = harness.controller.stop().then(() => {
+      stopSettled = true;
+    });
+    await vi.waitFor(() => {
+      expect(harness.stopPostReadyMaintenance).toHaveBeenCalledTimes(1);
+      expect(harness.stopRetainedPluginCleanup).toHaveBeenCalledTimes(1);
+    });
+    expect(stopSettled).toBe(false);
+
+    maintenance.resolve();
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+
+    retainedCleanup.resolve();
+    await stop;
+    expect(stopSettled).toBe(true);
+  });
+
+  it("reports a cached module rejection through the lifecycle owner", async () => {
+    const moduleLoad = createDeferred<ScheduledServicesModule>();
+    const harness = createHarness({ moduleLoad });
+    harness.controller.markSidecarsReady();
+    harness.postReady.resolve();
+    await vi.waitFor(() => {
+      expect(harness.loadScheduledServicesModule).toHaveBeenCalledTimes(1);
+    });
+
+    moduleLoad.reject(new Error("module unavailable"));
+    await vi.waitFor(() => {
+      expect(harness.log.error).toHaveBeenCalledWith(
+        "gateway scheduled services failed to start: Error: module unavailable",
+      );
+    });
+    await expect(harness.controller.stop()).resolves.toBeUndefined();
+
+    expect(harness.loadScheduledServicesModule).toHaveBeenCalledTimes(1);
+    expect(harness.activateGatewayScheduledServices).not.toHaveBeenCalled();
+    expect(harness.scheduleGatewayPostReadyMaintenance).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-startup-scheduled-services.ts
+++ b/src/gateway/server-startup-scheduled-services.ts
@@ -1,0 +1,241 @@
+import type { CliDeps } from "../cli/deps.types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import { createDeferred } from "../shared/deferred.js";
+import { createLazyPromise } from "../shared/lazy-runtime.js";
+import type { GatewayCronReconciliation } from "./server-cron-reconciled.js";
+import type { GatewayCronState } from "./server-cron.js";
+import type { GatewayRuntimeServiceLogger } from "./server-runtime-service-shared.js";
+import type {
+  GatewayMaintenanceHandles,
+  GatewayIdleTaskHandle,
+  GatewayPostReadyMaintenanceHandle,
+} from "./server-runtime-services.js";
+
+const POST_READY_MAINTENANCE_DELAY_MS = 250;
+const RETAINED_PLUGIN_CLEANUP_DELAY_MS = 30_000;
+
+type GatewayScheduledServicesModule = Pick<
+  typeof import("./server-runtime-services.js"),
+  | "activateGatewayScheduledServices"
+  | "scheduleGatewayIdleTask"
+  | "scheduleGatewayPostReadyMaintenance"
+>;
+
+type GatewayScheduledServicesLogger = GatewayRuntimeServiceLogger & {
+  warn: (message: string) => void;
+};
+
+type GatewayScheduledServicesController = {
+  heartbeatRunner: HeartbeatRunner;
+  stopOutboundDeliveryRecovery: () => Promise<void>;
+  markSidecarsReady: () => void;
+  stop: () => Promise<void>;
+};
+
+export type GatewayScheduledServicesLifecycleOwner = Pick<
+  GatewayScheduledServicesController,
+  "stop"
+>;
+
+/** Owns deferred scheduled-service activation and every handle it publishes. */
+export function createGatewayScheduledServicesController(params: {
+  minimalTestGateway: boolean;
+  deps: CliDeps;
+  getConfig: () => OpenClawConfig;
+  getCronState: () => GatewayCronState;
+  waitForPostReadyWork: () => Promise<void>;
+  sessionDeliveryRecoveryMaxEnqueuedAt: number;
+  cronReconciliation: GatewayCronReconciliation;
+  shouldStartCron: () => boolean;
+  markCronStartHandled: () => void;
+  startMaintenance: () => Promise<GatewayMaintenanceHandles | null>;
+  applyMaintenance: (maintenance: GatewayMaintenanceHandles) => Promise<void> | void;
+  recordPostReadyMemory: () => void;
+  logCron: { error: (message: string) => void };
+  log: GatewayScheduledServicesLogger;
+  loadScheduledServicesModule?: () => Promise<GatewayScheduledServicesModule>;
+}): GatewayScheduledServicesController {
+  const sidecarsReady = createDeferred();
+  const closeStarted = createDeferred();
+  const loadScheduledServicesModule = createLazyPromise(
+    params.loadScheduledServicesModule ?? (() => import("./server-runtime-services.js")),
+    { cacheRejections: true },
+  );
+
+  let stopped = false;
+  let sidecarsReadyMarked = false;
+  let activeHeartbeatRunner: HeartbeatRunner | null = null;
+  let activeHeartbeatStopped = false;
+  let pendingHeartbeatConfig: OpenClawConfig | null = null;
+  let activeOutboundRecoveryStop: (() => Promise<void>) | null = null;
+  let outboundRecoveryStopRequested = false;
+  let outboundRecoveryStopPromise: Promise<void> | null = null;
+  let maintenanceHandle: GatewayPostReadyMaintenanceHandle | null = null;
+  let maintenanceStopPromise: Promise<void> | null = null;
+  let retainedPluginCleanupHandle: GatewayIdleTaskHandle | null = null;
+  let retainedPluginCleanupStopPromise: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
+
+  const stopActiveHeartbeat = () => {
+    if (activeHeartbeatStopped || !activeHeartbeatRunner) {
+      return;
+    }
+    activeHeartbeatStopped = true;
+    activeHeartbeatRunner.stop();
+  };
+
+  const stopOutboundDeliveryRecovery = (): Promise<void> => {
+    outboundRecoveryStopRequested = true;
+    if (outboundRecoveryStopPromise) {
+      return outboundRecoveryStopPromise;
+    }
+    if (!activeOutboundRecoveryStop) {
+      return Promise.resolve();
+    }
+    outboundRecoveryStopPromise = activeOutboundRecoveryStop();
+    return outboundRecoveryStopPromise;
+  };
+
+  const heartbeatRunner: HeartbeatRunner = {
+    updateConfig: (config) => {
+      if (stopped) {
+        return;
+      }
+      if (activeHeartbeatRunner) {
+        activeHeartbeatRunner.updateConfig(config);
+        return;
+      }
+      // Reload can commit before the post-ready barrier opens. Retain that
+      // accepted config until the real runner exists instead of dropping it.
+      pendingHeartbeatConfig = config;
+    },
+    stop: () => {
+      void stop();
+    },
+  };
+
+  const waitForActivationGate = async (): Promise<boolean> => {
+    const activationReady = params.minimalTestGateway
+      ? params.waitForPostReadyWork().then(() => true)
+      : Promise.all([params.waitForPostReadyWork(), sidecarsReady.promise]).then(() => true);
+    return await Promise.race([activationReady, closeStarted.promise.then(() => false)]);
+  };
+
+  const schedulePostReadyWork = (
+    gatewayRuntimeServices: GatewayScheduledServicesModule,
+    cronState: GatewayCronState,
+    config: OpenClawConfig,
+  ) => {
+    maintenanceHandle = gatewayRuntimeServices.scheduleGatewayPostReadyMaintenance({
+      delayMs: POST_READY_MAINTENANCE_DELAY_MS,
+      isClosing: () => stopped,
+      startMaintenance: params.startMaintenance,
+      applyMaintenance: params.applyMaintenance,
+      shouldStartCron: () => !stopped && params.shouldStartCron(),
+      markCronStartHandled: params.markCronStartHandled,
+      cronState,
+      cronReconciliation: params.cronReconciliation,
+      cronConfig: config,
+      logCron: params.logCron,
+      log: params.log,
+      recordPostReadyMemory: params.recordPostReadyMemory,
+    });
+    // Resolve install paths only in the idle task. The active plugin
+    // generation can change between startup and cleanup.
+    retainedPluginCleanupHandle = gatewayRuntimeServices.scheduleGatewayIdleTask({
+      delayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
+      retryDelayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
+      isClosing: () => stopped,
+      isBusy: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }) > 0,
+      run: async () => {
+        const { cleanupRetainedPluginInstallGenerations } =
+          await import("./server-retained-plugin-cleanup.js");
+        await cleanupRetainedPluginInstallGenerations({ log: params.log });
+      },
+      log: params.log,
+      errorMessage: "retained npm generation cleanup failed",
+    });
+  };
+
+  const stopPublishedScheduledChildren = async (): Promise<void> => {
+    if (maintenanceHandle && !maintenanceStopPromise) {
+      maintenanceStopPromise = maintenanceHandle.stop();
+    }
+    if (retainedPluginCleanupHandle && !retainedPluginCleanupStopPromise) {
+      retainedPluginCleanupStopPromise = retainedPluginCleanupHandle.stop();
+    }
+    await Promise.all([maintenanceStopPromise, retainedPluginCleanupStopPromise]);
+  };
+
+  const activationTask = (async () => {
+    if (!(await waitForActivationGate()) || stopped) {
+      return;
+    }
+    if (params.minimalTestGateway) {
+      params.recordPostReadyMemory();
+      return;
+    }
+    const gatewayRuntimeServices = await loadScheduledServicesModule();
+    if (stopped) {
+      return;
+    }
+    const config = params.getConfig();
+    const cronState = params.getCronState();
+    const activated = gatewayRuntimeServices.activateGatewayScheduledServices({
+      minimalTestGateway: params.minimalTestGateway,
+      cfgAtStart: config,
+      deps: params.deps,
+      sessionDeliveryRecoveryMaxEnqueuedAt: params.sessionDeliveryRecoveryMaxEnqueuedAt,
+      cronState,
+      cronReconciliation: params.cronReconciliation,
+      startCron: false,
+      logCron: params.logCron,
+      log: params.log,
+    });
+    activeHeartbeatRunner = activated.heartbeatRunner;
+    activeOutboundRecoveryStop = activated.stopOutboundDeliveryRecovery;
+    const retainedHeartbeatConfig = pendingHeartbeatConfig;
+    pendingHeartbeatConfig = null;
+    if (retainedHeartbeatConfig && retainedHeartbeatConfig !== config) {
+      activeHeartbeatRunner.updateConfig(retainedHeartbeatConfig);
+    }
+    if (outboundRecoveryStopRequested) {
+      void stopOutboundDeliveryRecovery();
+    }
+    schedulePostReadyWork(gatewayRuntimeServices, cronState, config);
+  })().catch((error: unknown) => {
+    params.log.error(`gateway scheduled services failed to start: ${String(error)}`);
+  });
+
+  const stop = (): Promise<void> => {
+    if (stopPromise) {
+      return stopPromise;
+    }
+    stopped = true;
+    closeStarted.resolve();
+    const scheduledChildrenStop = stopPublishedScheduledChildren();
+    stopActiveHeartbeat();
+    stopPromise = Promise.all([activationTask, scheduledChildrenStop]).then(async () => {
+      // Import can settle after close starts. Recheck the late-published
+      // delegates before resolving the lifecycle fence.
+      stopActiveHeartbeat();
+      await Promise.all([stopPublishedScheduledChildren(), stopOutboundDeliveryRecovery()]);
+    });
+    return stopPromise;
+  };
+
+  return {
+    heartbeatRunner,
+    stopOutboundDeliveryRecovery,
+    markSidecarsReady: () => {
+      if (sidecarsReadyMarked) {
+        return;
+      }
+      sidecarsReadyMarked = true;
+      sidecarsReady.resolve();
+    },
+    stop,
+  };
+}


### PR DESCRIPTION
Related: #119087

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where constrained gateways could log readiness and then spend
roughly another 1.6 seconds materializing post-ready runtime-service and
hot-reload module graphs before `/readyz` became usable.

Root cause: gateway startup still owned deferred service work through split
booleans, inline timers, and eager reload-facade imports. The timer helpers also
dropped their child promises once callbacks fired, so shutdown could finish the
scheduled-services stop fence while already-started maintenance or idle work was
still using plugin, channel, or shared SQLite runtime state.

## Why This Change Was Made

The gateway startup lifecycle now has one scheduled-services controller. It
waits for the post-ready and sidecar barriers, lazy-loads runtime services,
owns heartbeat/recovery/maintenance/idle handles, and joins every published
child before close proceeds to plugin, channel, agent-resource, or shared-state
teardown.

The canonical fix also:

- publishes joinable maintenance and idle promises before child work can
  re-enter shutdown;
- lazy-loads the hot-reload handler graph only when a reload requires it;
- moves cron startup into a lightweight helper so managed reload does not
  import runtime services;
- removes the inline `postReadyState` timer/cleanup path, split scheduled
  activation booleans, duplicate lifecycle recovery shutdown, and eager reload
  ownership.

Best-fix judgment: yes. The repair lives at the lifecycle boundary that creates,
publishes, and stops these services. Moving `/readyz` earlier would make
readiness untruthful. Leaf-level import trimming would retain the wrong owner.
Consumer guards, scattered delays, or caches would duplicate policy and leave
the shutdown race intact.

Production vs test LOC:

- production: +548 / -268, net +280;
- tests: +736 / -91, net +645;
- total: +1284 / -359, net +925.

The positive production delta is the explicit lifecycle owner, lazy module
boundary, and race-safe child joining. It replaces 268 lines of split inline
ownership and duplicate shutdown paths.

## User Impact

Exact-head one-CPU packaged proof reduced the ready-log to `/readyz` p50 from
1656.6857 ms to 217.3726 ms, an approximately 86.9% reduction, while keeping
`/readyz` truthful.

No config, protocol, storage, migration, or operator-action surface changes.

## Evidence

- Exact implementation base: `70f84286c9ae20fd47dcf775b55ebb99296794de`
- Exact PR head: `025dd6a0950cfec034e78750e2707bcd5dc713a6`
- Focused exact-head gateway suite: 437/437 tests passed across 10 affected
  files. The regressions fire the maintenance and idle timers, block child
  work, call `stop()`, and prove shutdown stays pending until both children
  complete.
- Exact-head `pnpm build` passed. The fresh packaged proof independently built
  and validated the package tarball before measuring it.
- `git diff --check`, targeted formatting, dead-export scans, private-data
  scrub, and fresh autoreview passed with no findings.
- Exact-head packaged proof:
  https://crabbox.openclaw.ai/portal/runs/run_f5fb5a56b8d1
- Exact-main baseline:
  https://crabbox.openclaw.ai/portal/runs/run_2bc9a6156370
- Exact-head ready-log to `/readyz`: p50 217.3726 ms, range
  205.1151-410.3084 ms, three cold runs pinned with `taskset -c 0` and the Node
  compile cache disabled.
- Package SHA-256:
  `1bdca5e50f76935b15cdcd94db69ad5a0f0bae958ee66fa2df50db06db265fe8`
- Proof SHA-256:
  `bbef378fada7932a505ff5e4927d308549b4ed555d2174e641ed240f3f6590b0`
- Evidence SHA-256:
  `c543cbfe7c5dbbe0a1902e04c6053b7bebe8fe19db90462ec1724c2169659f65`
- Downloaded artifact-bundle SHA-256:
  `c7812dea89aa3550c1f3d829ca551ea2b61d4a73bf1e5b67562d88cee38ae563`
- Exact-SHA hosted release-gate run used by repo-native prepare:
  https://github.com/openclaw/openclaw/actions/runs/31122939433

Build and proof caveats:

- The earlier OXC install failure was shared hydration contamination from an
  inherited modules/virtual-store environment, not a defect in the tracked
  exact-main lockfile. Draft PR #119704 owns that hydration lane. This proof
  used isolated package-manager paths and completed successfully.
- The local sparse worktree initially omitted two tracked Control UI config
  files. Restoring the worktree metadata/files allowed the exact-head build to
  pass; no production workaround was added.
- Earlier candidate run `run_e03fe342ab58` did not measure the final committed
  head and is superseded by `run_f5fb5a56b8d1`.

Punchcard-Session: frost-timber-meadow-w6
