### PR TITLE
fix(openai-completions): honor thinking off in reasoning payloads

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -5,6 +5,7 @@ import { configureAiTransportHost } from "../host.js";
 import type { Context, Model, SimpleStreamOptions, TextContent } from "../types.js";
 import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
+import type { OpenAIReasoningEffort } from "./openai-reasoning-effort.js";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
@@ -236,6 +237,37 @@ describe("OpenAI-compatible completions params", () => {
 
       expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject(expected);
       expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
+    },
+  );
+
+  it.each([
+    { thinkingFormat: "zai", expected: { thinking: { type: "disabled" } } },
+    { thinkingFormat: "qwen", expected: { enable_thinking: false } },
+    { thinkingFormat: "deepseek", expected: { thinking: { type: "disabled" } } },
+    { thinkingFormat: "together", expected: { reasoning: { enabled: false } } },
+  ] as const)(
+    "treats reasoningEffort off as disabled for $thinkingFormat payloads",
+    async ({ thinkingFormat, expected }) => {
+      // "off" is OpenClaw's own disable token; a self-hosted catalog carries no
+      // reasoningEffortMap or thinkingLevelMap, so it reaches the provider
+      // unmapped and must not be mistaken for an enabled effort value.
+      mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+      const compatibleModel = {
+        ...reasoningModel,
+        provider: "custom-openai-compatible",
+        baseUrl: "https://third-party.test/v1",
+        compat: { thinkingFormat, supportsReasoningEffort: true },
+      } satisfies Model<"openai-completions">;
+
+      await streamOpenAICompletions(compatibleModel, context, {
+        apiKey: "sk-test",
+        // "off" is OpenClaw's disable token. It is outside OpenAIReasoningEffort,
+        // but config-sourced levels reach the provider unmapped, which is exactly
+        // the case this pins.
+        reasoningEffort: "off" as unknown as OpenAIReasoningEffort,
+      }).result();
+
+      expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject(expected);
     },
   );
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -851,7 +851,12 @@ function buildParams(
       : (reasoningEffortMap[options.reasoningEffort] ??
         thinkingLevelMap?.[options.reasoningEffort] ??
         options.reasoningEffort);
-  const reasoningEnabled = reasoningEffort !== undefined && reasoningEffort !== "none";
+  // Reuse the shared predicate rather than re-deriving it: it already treats
+  // OpenClaw's "off" token and the provider-side "none" as disabled. A
+  // self-hosted catalog carries no reasoningEffortMap or thinkingLevelMap, so
+  // "off" arrives here unmapped and must not read as an enabled effort value.
+  const reasoningEnabled =
+    reasoningEffort !== undefined && isOpenAICompletionsThinkingEnabled(reasoningEffort);
   const offReasoningEffort = reasoningEffortMap.off ?? model.thinkingLevelMap?.off;
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {


### PR DESCRIPTION
## What Problem This Solves

Related: #119959. This PR does NOT resolve that issue; the `/thinking off` flow is owned by `packages/agent-core/src/reasoning.ts` and is addressed by #120020. This change repairs the separate direct-provider branch described below.

With `reasoning: true` in a model config, `--thinking off` is ignored and the model keeps reasoning. The reporter hit this on a self-hosted vLLM qwen model.

The cause is in `buildParams` in `packages/ai/src/providers/openai-completions.ts`. It decides whether reasoning is on with a hand-rolled check:

```ts
const reasoningEnabled = reasoningEffort !== undefined && reasoningEffort !== "none";
```

`"none"` is the provider-side spelling. OpenClaw's own disable token is `"off"` (`ModelThinkingLevel = "off" | ThinkingLevel`). A self-hosted catalog carries neither `compat.reasoningEffortMap` nor `thinkingLevelMap`, so `resolveOpenAIReasoningEffortMap` returns `{}`, `"off"` falls through both lookups unmapped, and `"off" !== "none"` evaluates true. The payload is then built as reasoning-enabled and the request sends `enable_thinking: true`.

The same file already had the correct predicate 400 lines earlier, at `openai-completions.ts:460`:

```ts
isOpenAICompletionsThinkingEnabled(options.reasoningEffort)
```

which is `normalized !== "off" && normalized !== "none"`. So one file held two different notions of "thinking enabled", and the payload builder used the wrong one.

**Broader than reported.** The issue describes qwen, but the flag feeds every thinking-format branch below it, so `zai`, `qwen`, `deepseek`, and `together` were all affected. My reproduction fails on all four before the fix:

```
× treats reasoningEffort off as disabled for 'zai' payloads
× treats reasoningEffort off as disabled for 'qwen' payloads
× treats reasoningEffort off as disabled for 'deepseek' payloads
× treats reasoningEffort off as disabled for 'together' payloads
Tests  4 failed | 59 passed (63)
```

## Why This Change Was Made

Rather than extend the hand-rolled condition with `&& reasoningEffort !== "off"`, this reuses the predicate the repo already owns:

```ts
const reasoningEnabled =
  reasoningEffort !== undefined && isOpenAICompletionsThinkingEnabled(reasoningEffort);
```

That helper is already imported in this file and already used at line 460, so the change removes the duplicate policy instead of adding a second copy of it. If the set of disable tokens ever changes, there is now one place to change.

I did not widen `OpenAIReasoningEffort` to include `"off"`. The union is the provider-facing vocabulary, and `"off"` is deliberately not part of it; the value arrives from operator config through a boundary the type does not police, which is exactly why line 460 already guards for it defensively. Making the payload builder agree with that existing guard is the smaller and more honest fix.

## User Impact

`--thinking off` and `/thinking off` now actually disable reasoning for OpenAI-compatible models configured with `reasoning: true`, across all four thinking formats. Operators on self-hosted catalogs are the ones affected, since a catalog with an explicit `reasoningEffortMap` or `thinkingLevelMap` entry for `off` already mapped the value before it reached this check.

No config, schema, or default surface changes. Production delta is +5/-1 in one file, four lines of which are the comment.

## Evidence

Coverage added to `packages/ai/src/providers/openai-completions.test.ts` as a sibling of the existing `"treats reasoningEffort none as disabled"` table, so both the provider spelling and OpenClaw's own token are pinned side by side for all four formats. That existing table is why this slipped: `"none"` was covered and `"off"` never was.

Confirmed the new cases pin the fix by reverting the predicate to the old comparison and rerunning: 4 failed / 59 passed, then 63/63 restored.

Verification: `packages/ai/src/providers` 37 files / 794 tests, `packages/ai` 62 files / 1222 tests, oxlint clean on both changed files, `tsgo -p tsconfig.core.json` and `tsgo -p test/tsconfig/tsconfig.core.test.json` both clean, `git diff --check` clean.

I did not run this against a live vLLM endpoint. The assertion is on the constructed request payload, which is where the reported symptom originates, and the reporter's own repro is the config plus `--thinking off`.

AI-assisted: written with AI assistance. I traced the effort-map resolution, the payload builder, and both existing thinking-enabled predicates myself before choosing which one to reuse.

