### PR TITLE
fix(agents): stop a leading @ from retargeting file-tool destinations

### DIFF
--- a/src/agents/agent-tools.at-prefixed-paths.test.ts
+++ b/src/agents/agent-tools.at-prefixed-paths.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests that a leading "@" on a tool path names a file instead of silently
+ * retargeting the de-"@"'d sibling, while the "@"-prefixed mention shorthands
+ * keep resolving.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import "./test-helpers/fast-coding-tools.js";
+import "./test-helpers/fast-openclaw-tools.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+import { createApplyPatchTool } from "./apply-patch.js";
+import { expectReadWriteEditTools, getTextContent } from "./test-helpers/agent-tools-fs-helpers.js";
+
+vi.mock("../infra/shell-env.js", async () => {
+  const mod =
+    await vi.importActual<typeof import("../infra/shell-env.js")>("../infra/shell-env.js");
+  return { ...mod, getShellPathFromLoginShell: () => null };
+});
+
+async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>) {
+  // Real resolvers canonicalize, so the fixture root must be canonical too.
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), prefix)));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+// workspaceOnly decides whether the workspace-root guard wraps the tools, and the
+// guard resolves the path separately from the tool. Both arrangements must agree.
+const WORKSPACE_ONLY_CASES = [true, false] as const;
+
+describe("@-prefixed tool paths", () => {
+  it.each(WORKSPACE_ONLY_CASES)(
+    "mutates the literal @-named file instead of its de-@'d sibling (workspaceOnly=%s)",
+    async (workspaceOnly) => {
+      await withTempDir("openclaw-at-", async (cwd) => {
+        const sibling = path.join(cwd, "notes.md");
+        const literal = path.join(cwd, "@notes.md");
+        const config: OpenClawConfig = { tools: { fs: { workspaceOnly } } };
+        const tools = createOpenClawCodingTools({ cwd, config });
+        const { writeTool, editTool } = expectReadWriteEditTools(tools);
+
+        await fs.writeFile(sibling, "sibling\n");
+        await fs.writeFile(literal, "literal\n");
+        await writeTool.execute("at-write", { path: "@notes.md", content: "written\n" });
+        await expect(fs.readFile(literal, "utf8")).resolves.toBe("written\n");
+        await expect(fs.readFile(sibling, "utf8")).resolves.toBe("sibling\n");
+
+        await fs.writeFile(literal, "before\n");
+        await editTool.execute("at-edit", {
+          path: "@notes.md",
+          edits: [{ oldText: "before", newText: "after" }],
+        });
+        await expect(fs.readFile(literal, "utf8")).resolves.toBe("after\n");
+        await expect(fs.readFile(sibling, "utf8")).resolves.toBe("sibling\n");
+
+        // apply_patch Delete File is a plain unlink with no Trash fallback, so the
+        // wrong target here is unrecoverable.
+        const patchTool = createApplyPatchTool({ cwd, workspaceOnly });
+        await patchTool.execute("at-delete", {
+          input: "*** Begin Patch\n*** Delete File: @notes.md\n*** End Patch",
+        });
+        await expect(fs.readFile(sibling, "utf8")).resolves.toBe("sibling\n");
+        await expect(fs.access(literal)).rejects.toThrow();
+      });
+    },
+  );
+
+  it.each(WORKSPACE_ONLY_CASES)(
+    "reads back the same file it just wrote (workspaceOnly=%s)",
+    async (workspaceOnly) => {
+      await withTempDir("openclaw-at-", async (cwd) => {
+        await fs.writeFile(path.join(cwd, "notes.md"), "sibling\n");
+        await fs.writeFile(path.join(cwd, "@notes.md"), "literal\n");
+        const config: OpenClawConfig = { tools: { fs: { workspaceOnly } } };
+        const tools = createOpenClawCodingTools({ cwd, config });
+        const { readTool, writeTool } = expectReadWriteEditTools(tools);
+
+        await writeTool.execute("at-rw-write", { path: "@notes.md", content: "round-trip\n" });
+        const read = await readTool.execute("at-rw-read", { path: "@notes.md" });
+        expect(getTextContent(read)).toContain("round-trip");
+      });
+    },
+  );
+
+  it.each(WORKSPACE_ONLY_CASES)(
+    "still resolves a relative @path with no literal file, as the TUI autocomplete emits (workspaceOnly=%s)",
+    async (workspaceOnly) => {
+      await withTempDir("openclaw-at-", async (cwd) => {
+        const target = path.join(cwd, "src", "foo.ts");
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.writeFile(target, "before\n");
+
+        const config: OpenClawConfig = { tools: { fs: { workspaceOnly } } };
+        const { editTool } = expectReadWriteEditTools(createOpenClawCodingTools({ cwd, config }));
+        await editTool.execute("at-tui", {
+          path: "@src/foo.ts",
+          edits: [{ oldText: "before", newText: "after" }],
+        });
+        await expect(fs.readFile(target, "utf8")).resolves.toBe("after\n");
+      });
+    },
+  );
+});

--- a/src/agents/agent-tools.at-prefixed-paths.test.ts
+++ b/src/agents/agent-tools.at-prefixed-paths.test.ts
@@ -165,29 +165,34 @@ describe("@-prefixed tool paths", () => {
   it.each(WORKSPACE_ONLY_CASES)(
     "mutates the literal @-named file when it exists only inside a remote sandbox (workspaceOnly=%s)",
     async (workspaceOnly) => {
-      const root = "/workspace";
-      const { files, bridge } = createRemoteOnlySandboxBridge(root, {
-        "@notes.md": "literal\n",
-        "notes.md": "sibling\n",
-      });
-      const sandbox = createAgentToolsSandboxContext({ workspaceDir: root, fsBridge: bridge });
-      const config: OpenClawConfig = { tools: { fs: { workspaceOnly } } };
-      const tools = createOpenClawCodingTools({ sandbox, config });
-      const { writeTool, editTool } = expectReadWriteEditTools(tools);
+      // The root exists on the host but stays EMPTY: only the bridge's in-memory
+      // map holds "@notes.md". Host-side canonicalization (memory write
+      // provenance) needs a resolvable root, while the existence probe still has
+      // nothing on disk to find.
+      await withTempDir("openclaw-at-remote-", async (root) => {
+        const { files, bridge } = createRemoteOnlySandboxBridge(root, {
+          "@notes.md": "literal\n",
+          "notes.md": "sibling\n",
+        });
+        const sandbox = createAgentToolsSandboxContext({ workspaceDir: root, fsBridge: bridge });
+        const config: OpenClawConfig = { tools: { fs: { workspaceOnly } } };
+        const tools = createOpenClawCodingTools({ sandbox, config });
+        const { writeTool, editTool } = expectReadWriteEditTools(tools);
 
-      // A host-only existence probe cannot see "@notes.md" here — it only lives in
-      // the bridge's in-memory map, never on this process's real filesystem — so
-      // this proves the sandbox bridge's stat() call, not a host fs coincidence.
-      await writeTool.execute("sbx-at-write", { path: "@notes.md", content: "written\n" });
-      expect(files.get(`${root}/@notes.md`)).toBe("written\n");
-      expect(files.get(`${root}/notes.md`)).toBe("sibling\n");
+        // A host-only existence probe cannot see "@notes.md" here — it only lives in
+        // the bridge's in-memory map, never on this process's real filesystem — so
+        // this proves the sandbox bridge's stat() call, not a host fs coincidence.
+        await writeTool.execute("sbx-at-write", { path: "@notes.md", content: "written\n" });
+        expect(files.get(`${root}/@notes.md`)).toBe("written\n");
+        expect(files.get(`${root}/notes.md`)).toBe("sibling\n");
 
-      await editTool.execute("sbx-at-edit", {
-        path: "@notes.md",
-        edits: [{ oldText: "written", newText: "edited" }],
+        await editTool.execute("sbx-at-edit", {
+          path: "@notes.md",
+          edits: [{ oldText: "written", newText: "edited" }],
+        });
+        expect(files.get(`${root}/@notes.md`)).toBe("edited\n");
+        expect(files.get(`${root}/notes.md`)).toBe("sibling\n");
       });
-      expect(files.get(`${root}/@notes.md`)).toBe("edited\n");
-      expect(files.get(`${root}/notes.md`)).toBe("sibling\n");
     },
   );
 });

--- a/src/agents/agent-tools.at-prefixed-paths.test.ts
+++ b/src/agents/agent-tools.at-prefixed-paths.test.ts
@@ -12,7 +12,62 @@ import "./test-helpers/fast-openclaw-tools.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import { createApplyPatchTool } from "./apply-patch.js";
+import type { SandboxFsBridge, SandboxFsStat } from "./sandbox/fs-bridge.js";
 import { expectReadWriteEditTools, getTextContent } from "./test-helpers/agent-tools-fs-helpers.js";
+import { createAgentToolsSandboxContext } from "./test-helpers/agent-tools-sandbox-context.js";
+
+/**
+ * A remote/SSH sandbox (see `remote-fs-bridge.ts`) has no host-mounted copy of the
+ * workspace: `resolvePath()` returns no `hostPath`, and every read/stat crosses the
+ * bridge instead of the local filesystem. This fake reproduces exactly that shape so
+ * a literal `@notes.md` that exists only "remotely" cannot be seen by a host-only
+ * `fs.stat` probe. Files are keyed by the same absolute container path a real bridge
+ * resolves to (`${cwd}/${relativePath}`), since callers pass either a raw relative
+ * `filePath` + `cwd` (the leading-`@` existence probe) or an already-resolved
+ * absolute path (the write/edit tool's own file operations) — a real bridge
+ * resolves both forms the same way, so this fake must too.
+ */
+function createRemoteOnlySandboxBridge(
+  root: string,
+  initialFiles: Record<string, string> = {},
+): {
+  files: Map<string, string>;
+  bridge: SandboxFsBridge;
+} {
+  const resolve = (filePath: string, cwd?: string) =>
+    filePath.startsWith("/") ? filePath : `${cwd ?? root}/${filePath.replace(/^\.\//, "")}`;
+  const files = new Map(
+    Object.entries(initialFiles).map(([name, contents]) => [resolve(name), contents]),
+  );
+  const bridge: SandboxFsBridge = {
+    resolvePath: ({ filePath, cwd }) => {
+      const key = resolve(filePath, cwd);
+      return { relativePath: key.slice(root.length + 1), containerPath: key };
+    },
+    readFile: async ({ filePath, cwd }) =>
+      Buffer.from(files.get(resolve(filePath, cwd)) ?? "", "utf8"),
+    writeFile: async ({ filePath, cwd, data }) => {
+      files.set(resolve(filePath, cwd), Buffer.isBuffer(data) ? data.toString("utf8") : data);
+    },
+    mkdirp: async () => {},
+    remove: async ({ filePath, cwd }) => {
+      files.delete(resolve(filePath, cwd));
+    },
+    rename: async ({ from, to, cwd }) => {
+      const key = resolve(from, cwd);
+      const contents = files.get(key);
+      if (contents !== undefined) {
+        files.set(resolve(to, cwd), contents);
+        files.delete(key);
+      }
+    },
+    stat: async ({ filePath, cwd }): Promise<SandboxFsStat | null> => {
+      const contents = files.get(resolve(filePath, cwd));
+      return contents === undefined ? null : { type: "file", size: contents.length, mtimeMs: 0 };
+    },
+  };
+  return { files, bridge };
+}
 
 vi.mock("../infra/shell-env.js", async () => {
   const mod =
@@ -104,6 +159,35 @@ describe("@-prefixed tool paths", () => {
         });
         await expect(fs.readFile(target, "utf8")).resolves.toBe("after\n");
       });
+    },
+  );
+
+  it.each(WORKSPACE_ONLY_CASES)(
+    "mutates the literal @-named file when it exists only inside a remote sandbox (workspaceOnly=%s)",
+    async (workspaceOnly) => {
+      const root = "/workspace";
+      const { files, bridge } = createRemoteOnlySandboxBridge(root, {
+        "@notes.md": "literal\n",
+        "notes.md": "sibling\n",
+      });
+      const sandbox = createAgentToolsSandboxContext({ workspaceDir: root, fsBridge: bridge });
+      const config: OpenClawConfig = { tools: { fs: { workspaceOnly } } };
+      const tools = createOpenClawCodingTools({ sandbox, config });
+      const { writeTool, editTool } = expectReadWriteEditTools(tools);
+
+      // A host-only existence probe cannot see "@notes.md" here — it only lives in
+      // the bridge's in-memory map, never on this process's real filesystem — so
+      // this proves the sandbox bridge's stat() call, not a host fs coincidence.
+      await writeTool.execute("sbx-at-write", { path: "@notes.md", content: "written\n" });
+      expect(files.get(`${root}/@notes.md`)).toBe("written\n");
+      expect(files.get(`${root}/notes.md`)).toBe("sibling\n");
+
+      await editTool.execute("sbx-at-edit", {
+        path: "@notes.md",
+        edits: [{ oldText: "written", newText: "edited" }],
+      });
+      expect(files.get(`${root}/@notes.md`)).toBe("edited\n");
+      expect(files.get(`${root}/notes.md`)).toBe("sibling\n");
     },
   );
 });

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -5,6 +5,7 @@
  */
 import { asOptionalObjectRecord as getToolParamsRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { preserveAtPrefixedRelativePath } from "./path-policy.js";
 
 /** Return a record view of model-supplied tool params when possible. */
 export { getToolParamsRecord };
@@ -122,9 +123,14 @@ function normalizeHallucinatedOfficePathExtension(value: string): string {
   });
 }
 
-/** Normalize model-supplied file-tool path params without touching payload text. */
-export function normalizeFileToolPathParam(value: string): string {
-  return normalizeHallucinatedOfficePathExtension(stripMalformedXmlArgValueSuffix(value));
+/**
+ * Normalize model-supplied file-tool path params without touching payload text.
+ * `cwd` enables the leading-`@` disambiguation; without it the value is only
+ * repaired as a string.
+ */
+export function normalizeFileToolPathParam(value: string, cwd?: string): string {
+  const repaired = normalizeHallucinatedOfficePathExtension(stripMalformedXmlArgValueSuffix(value));
+  return cwd ? preserveAtPrefixedRelativePath(repaired, cwd) : repaired;
 }
 
 /** Strip malformed XML suffixes from selected string fields without mutating input. */
@@ -151,6 +157,7 @@ export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string,
 export function normalizeFileToolPathParamsFromKeys<T extends Record<string, unknown>>(
   record: T,
   keys: readonly string[],
+  cwd?: string,
 ): T {
   let normalized: T | undefined;
   for (const key of keys) {
@@ -158,7 +165,7 @@ export function normalizeFileToolPathParamsFromKeys<T extends Record<string, unk
     if (typeof value !== "string") {
       continue;
     }
-    const normalizedValue = normalizeFileToolPathParam(value);
+    const normalizedValue = normalizeFileToolPathParam(value, cwd);
     if (normalizedValue !== value) {
       normalized ??= { ...record };
       normalized[key as keyof T] = normalizedValue as T[keyof T];
@@ -225,6 +232,7 @@ export function assertRequiredParams(
 export function wrapToolParamValidation(
   tool: AnyAgentTool,
   requiredParamGroups?: readonly RequiredParamGroup[],
+  cwd?: string,
 ): AnyAgentTool {
   return {
     ...tool,
@@ -233,7 +241,7 @@ export function wrapToolParamValidation(
       const pathKeys = resolveFileToolPathParamKeys(requiredParamGroups);
       const normalizedParams =
         record && pathKeys.length > 0
-          ? normalizeFileToolPathParamsFromKeys(record, pathKeys)
+          ? normalizeFileToolPathParamsFromKeys(record, pathKeys, cwd)
           : params;
       if (requiredParamGroups?.length) {
         assertRequiredParams(getToolParamsRecord(normalizedParams), requiredParamGroups, tool.name);

--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -6,6 +6,7 @@
 import { asOptionalObjectRecord as getToolParamsRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { preserveAtPrefixedRelativePath } from "./path-policy.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 /** Return a record view of model-supplied tool params when possible. */
 export { getToolParamsRecord };
@@ -126,11 +127,26 @@ function normalizeHallucinatedOfficePathExtension(value: string): string {
 /**
  * Normalize model-supplied file-tool path params without touching payload text.
  * `cwd` enables the leading-`@` disambiguation; without it the value is only
- * repaired as a string.
+ * repaired as a string. `bridge` routes that disambiguation's existence probe
+ * through the sandbox filesystem bridge for sandboxed tool destinations; pass
+ * it whenever `cwd` is a sandbox root so a remote-only literal is still seen.
+ *
+ * Overloaded so callers without a `cwd` (diagnostics-only path candidates) keep
+ * a synchronous string result instead of forcing an unrelated call chain async.
  */
-export function normalizeFileToolPathParam(value: string, cwd?: string): string {
+export function normalizeFileToolPathParam(value: string): string;
+export function normalizeFileToolPathParam(
+  value: string,
+  cwd: string,
+  bridge?: SandboxFsBridge,
+): Promise<string>;
+export function normalizeFileToolPathParam(
+  value: string,
+  cwd?: string,
+  bridge?: SandboxFsBridge,
+): string | Promise<string> {
   const repaired = normalizeHallucinatedOfficePathExtension(stripMalformedXmlArgValueSuffix(value));
-  return cwd ? preserveAtPrefixedRelativePath(repaired, cwd) : repaired;
+  return cwd ? preserveAtPrefixedRelativePath(repaired, cwd, bridge) : repaired;
 }
 
 /** Strip malformed XML suffixes from selected string fields without mutating input. */
@@ -154,18 +170,21 @@ export function stripMalformedXmlArgValueSuffixFromKeys<T extends Record<string,
 }
 
 /** Normalize selected file-tool path fields without mutating input. */
-export function normalizeFileToolPathParamsFromKeys<T extends Record<string, unknown>>(
+export async function normalizeFileToolPathParamsFromKeys<T extends Record<string, unknown>>(
   record: T,
   keys: readonly string[],
   cwd?: string,
-): T {
+  bridge?: SandboxFsBridge,
+): Promise<T> {
   let normalized: T | undefined;
   for (const key of keys) {
     const value = record[key];
     if (typeof value !== "string") {
       continue;
     }
-    const normalizedValue = normalizeFileToolPathParam(value, cwd);
+    const normalizedValue = cwd
+      ? await normalizeFileToolPathParam(value, cwd, bridge)
+      : normalizeFileToolPathParam(value);
     if (normalizedValue !== value) {
       normalized ??= { ...record };
       normalized[key as keyof T] = normalizedValue as T[keyof T];
@@ -233,6 +252,7 @@ export function wrapToolParamValidation(
   tool: AnyAgentTool,
   requiredParamGroups?: readonly RequiredParamGroup[],
   cwd?: string,
+  bridge?: SandboxFsBridge,
 ): AnyAgentTool {
   return {
     ...tool,
@@ -241,7 +261,7 @@ export function wrapToolParamValidation(
       const pathKeys = resolveFileToolPathParamKeys(requiredParamGroups);
       const normalizedParams =
         record && pathKeys.length > 0
-          ? normalizeFileToolPathParamsFromKeys(record, pathKeys, cwd)
+          ? await normalizeFileToolPathParamsFromKeys(record, pathKeys, cwd, bridge)
           : params;
       if (requiredParamGroups?.length) {
         assertRequiredParams(getToolParamsRecord(normalizedParams), requiredParamGroups, tool.name);

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -75,6 +75,8 @@ type OpenClawReadToolOptions = {
   imageSanitization?: ImageSanitizationLimits;
   /** Root the read resolves relative paths against; enables the leading-`@` disambiguation. */
   cwd?: string;
+  /** Sandbox bridge routing the leading-`@` existence probe for sandboxed reads. */
+  bridge?: SandboxFsBridge;
 };
 
 type SkillReadContent = {
@@ -736,7 +738,7 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
       const normalizedRecord = record
-        ? normalizeFileToolPathParamsFromKeys(record, ["path"])
+        ? await normalizeFileToolPathParamsFromKeys(record, ["path"])
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.write, tool.name);
       const filePath =
@@ -862,6 +864,8 @@ export function wrapToolWorkspaceRootGuardWithOptions(
     pathParamKeys?: readonly string[];
     normalizeGuardedPathParams?: boolean;
     resolutionCwd?: string;
+    /** Sandbox bridge routing the leading-`@` existence probe for sandboxed tools. */
+    bridge?: SandboxFsBridge;
   },
 ): AnyAgentTool {
   const pathParamKeys =
@@ -876,7 +880,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
         }
-        const filePath = normalizeFileToolPathParam(rawFilePath, root);
+        const filePath = await normalizeFileToolPathParam(rawFilePath, root, options?.bridge);
         if (!filePath.trim()) {
           throw malformedXmlArgValuePathError(key);
         }
@@ -958,6 +962,7 @@ export function createSandboxedReadTool(
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
     cwd: params.root,
+    bridge: params.bridge,
   });
 }
 
@@ -970,7 +975,7 @@ export function createSandboxedWriteTool(
       operations: createSandboxWriteOperations(params),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write, params.root);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write, params.root, params.bridge);
 }
 
 /** Create a sandbox-backed edit tool with required-parameter validation. */
@@ -982,7 +987,7 @@ export function createSandboxedEditTool(
       operations: createSandboxEditOperations(params),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit, params.root);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit, params.root, params.bridge);
 }
 
 /** Create a host workspace write tool using guarded filesystem operations. */
@@ -1031,7 +1036,7 @@ export function createOpenClawReadTool(
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
       const normalizedRecord = record
-        ? normalizeFileToolPathParamsFromKeys(record, ["path"], options?.cwd)
+        ? await normalizeFileToolPathParamsFromKeys(record, ["path"], options?.cwd, options?.bridge)
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.read, base.name);
       const filePath =

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -73,6 +73,8 @@ const MAX_ADAPTIVE_READ_PAGES = 4;
 type OpenClawReadToolOptions = {
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
+  /** Root the read resolves relative paths against; enables the leading-`@` disambiguation. */
+  cwd?: string;
 };
 
 type SkillReadContent = {
@@ -874,7 +876,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
         }
-        const filePath = normalizeFileToolPathParam(rawFilePath);
+        const filePath = normalizeFileToolPathParam(rawFilePath, root);
         if (!filePath.trim()) {
           throw malformedXmlArgValuePathError(key);
         }
@@ -955,6 +957,7 @@ export function createSandboxedReadTool(
   return createOpenClawReadTool(base, {
     modelContextWindowTokens: params.modelContextWindowTokens,
     imageSanitization: params.imageSanitization,
+    cwd: params.root,
   });
 }
 
@@ -967,7 +970,7 @@ export function createSandboxedWriteTool(
       operations: createSandboxWriteOperations(params),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write, params.root);
 }
 
 /** Create a sandbox-backed edit tool with required-parameter validation. */
@@ -979,7 +982,7 @@ export function createSandboxedEditTool(
       operations: createSandboxEditOperations(params),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit, params.root);
 }
 
 /** Create a host workspace write tool using guarded filesystem operations. */
@@ -997,7 +1000,7 @@ export function createHostWorkspaceWriteTool(
       operations: createHostWriteOperations(options?.containmentRoot ?? root, options),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write, root);
 }
 
 /** Create a host workspace edit tool using guarded filesystem operations. */
@@ -1015,7 +1018,7 @@ export function createHostWorkspaceEditTool(
       operations: createHostEditOperations(options?.containmentRoot ?? root, options),
     }),
   );
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
+  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit, root);
 }
 
 /** Wrap the base read tool with OpenClaw paging, MIME, and image handling. */
@@ -1028,7 +1031,7 @@ export function createOpenClawReadTool(
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
       const normalizedRecord = record
-        ? normalizeFileToolPathParamsFromKeys(record, ["path"])
+        ? normalizeFileToolPathParamsFromKeys(record, ["path"], options?.cwd)
         : undefined;
       assertRequiredParams(normalizedRecord, REQUIRED_PARAM_GROUPS.read, base.name);
       const filePath =

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -17,7 +17,7 @@ import {
 } from "./apply-patch-file-ops.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
 import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
-import { resolvePathFromInput } from "./path-policy.js";
+import { preserveAtPrefixedRelativePath, resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import {
@@ -309,10 +309,11 @@ async function ensureDir(filePath: string, ops: PatchFileOps) {
   await ops.mkdirp(parent);
 }
 
-async function assertPatchParentPath(filePath: string, options: ApplyPatchOptions) {
+async function assertPatchParentPath(rawFilePath: string, options: ApplyPatchOptions) {
   if (options.workspaceOnly === false || options.sandbox) {
     return;
   }
+  const filePath = preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
   const parent = path.dirname(filePath);
   if (!parent || parent === ".") {
     return;
@@ -358,10 +359,11 @@ async function assertNoExistingParentAliases(params: { parentPath: string; rootP
 }
 
 async function resolvePatchPath(
-  filePath: string,
+  rawFilePath: string,
   options: ApplyPatchOptions,
   aliasPolicy: PathAliasPolicy = PATH_ALIAS_POLICIES.strict,
 ): Promise<{ resolved: string; display: string }> {
+  const filePath = preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
   if (options.sandbox) {
     const resolved = options.sandbox.bridge.resolvePath({
       filePath,

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -313,7 +313,8 @@ async function assertPatchParentPath(rawFilePath: string, options: ApplyPatchOpt
   if (options.workspaceOnly === false || options.sandbox) {
     return;
   }
-  const filePath = preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
+  // Sandboxed calls return above, so this only ever runs the host-only probe.
+  const filePath = await preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
   const parent = path.dirname(filePath);
   if (!parent || parent === ".") {
     return;
@@ -363,7 +364,12 @@ async function resolvePatchPath(
   options: ApplyPatchOptions,
   aliasPolicy: PathAliasPolicy = PATH_ALIAS_POLICIES.strict,
 ): Promise<{ resolved: string; display: string }> {
-  const filePath = preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
+  // No bridge here: every SandboxFsBridge.resolvePath() implementation (docker
+  // fs-bridge.ts, remote-fs-bridge.ts) resolves filePath+cwd with plain path.resolve
+  // and never strips a leading "@" the way the host resolveToCwd()/normalizeAtPrefix()
+  // chain does, so the "./" disambiguation this returns is inert for sandboxed calls
+  // — routing it through the bridge would only add a real round-trip with no effect.
+  const filePath = await preserveAtPrefixedRelativePath(rawFilePath, options.cwd);
   if (options.sandbox) {
     const resolved = options.sandbox.bridge.resolvePath({
       filePath,

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -163,6 +163,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
                     readOnlyWorkspaceSkillMounts,
                   ),
                   containerWorkdir: sandbox.containerWorkdir,
+                  bridge: sandboxFsBridge,
                 }
               : { additionalRoots: skillReadRoots, resolutionCwd: options.codingRoot },
           )
@@ -215,11 +216,13 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
       options.workspaceOnly
         ? wrapToolWorkspaceRootGuardWithOptions(edit, sandboxRoot, {
             containerWorkdir: sandbox.containerWorkdir,
+            bridge: sandboxFsBridge,
           })
         : edit,
       options.workspaceOnly
         ? wrapToolWorkspaceRootGuardWithOptions(write, sandboxRoot, {
             containerWorkdir: sandbox.containerWorkdir,
+            bridge: sandboxFsBridge,
           })
         : write,
     );

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -149,6 +149,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
             {
               modelContextWindowTokens: options.modelContextWindowTokens,
               imageSanitization: options.imageSanitization,
+              cwd: options.codingRoot,
             },
           );
       const guarded = options.workspaceOnly

--- a/src/agents/path-policy.test.ts
+++ b/src/agents/path-policy.test.ts
@@ -1,4 +1,7 @@
 // Verifies workspace-relative path policy across POSIX and Windows semantics.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 
@@ -8,7 +11,7 @@ vi.mock("./sandbox-paths.js", () => ({
   resolveSandboxInputPath: resolveSandboxInputPathMock,
 }));
 
-import { toRelativeWorkspacePath } from "./path-policy.js";
+import { preserveAtPrefixedRelativePath, toRelativeWorkspacePath } from "./path-policy.js";
 
 describe("toRelativeWorkspacePath (windows semantics)", () => {
   beforeEach(() => {
@@ -71,6 +74,39 @@ describe("toRelativeWorkspacePath (windows semantics)", () => {
       const candidate = "c:\\users\\USER\\openclaw";
       expect(toRelativeWorkspacePath(root, candidate, { allowRoot: true })).toBe("");
     });
+  });
+});
+
+describe("preserveAtPrefixedRelativePath", () => {
+  it.each([
+    // Mention shorthand: the strip is what resolves these, and 9ef0fc2ff8f relies
+    // on it to route @-prefixed absolutes through the workspace guard.
+    "@/etc/passwd",
+    "@/workspace/docs/readme.md",
+    "@~/notes.md",
+    "@~",
+    "@file:///tmp/notes.md",
+    "@",
+    // Relative, no literal on disk: the TUI autocomplete emits this form.
+    "@src/foo.ts",
+    "notes.md",
+  ])("leaves %s alone when no literal file exists", (input) => {
+    expect(preserveAtPrefixedRelativePath(input, "/workspace/root")).toBe(input);
+  });
+
+  it("marks a relative @path explicitly relative once that literal file exists", async () => {
+    const cwd = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-at-policy-")));
+    try {
+      await fs.writeFile(path.join(cwd, "@notes.md"), "literal\n");
+      expect(preserveAtPrefixedRelativePath("@notes.md", cwd)).toBe("./@notes.md");
+      // An absolute mention shorthand keeps stripping even with a literal present.
+      expect(preserveAtPrefixedRelativePath("@/etc/passwd", cwd)).toBe("@/etc/passwd");
+      // "~" only expands as "~" or "~/", so "@~notes.md" is an ordinary filename.
+      await fs.writeFile(path.join(cwd, "@~notes.md"), "tilde\n");
+      expect(preserveAtPrefixedRelativePath("@~notes.md", cwd)).toBe("./@~notes.md");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/agents/path-policy.test.ts
+++ b/src/agents/path-policy.test.ts
@@ -12,6 +12,7 @@ vi.mock("./sandbox-paths.js", () => ({
 }));
 
 import { preserveAtPrefixedRelativePath, toRelativeWorkspacePath } from "./path-policy.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 describe("toRelativeWorkspacePath (windows semantics)", () => {
   beforeEach(() => {
@@ -90,23 +91,42 @@ describe("preserveAtPrefixedRelativePath", () => {
     // Relative, no literal on disk: the TUI autocomplete emits this form.
     "@src/foo.ts",
     "notes.md",
-  ])("leaves %s alone when no literal file exists", (input) => {
-    expect(preserveAtPrefixedRelativePath(input, "/workspace/root")).toBe(input);
+  ])("leaves %s alone when no literal file exists", async (input) => {
+    expect(await preserveAtPrefixedRelativePath(input, "/workspace/root")).toBe(input);
   });
 
   it("marks a relative @path explicitly relative once that literal file exists", async () => {
     const cwd = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-at-policy-")));
     try {
       await fs.writeFile(path.join(cwd, "@notes.md"), "literal\n");
-      expect(preserveAtPrefixedRelativePath("@notes.md", cwd)).toBe("./@notes.md");
+      expect(await preserveAtPrefixedRelativePath("@notes.md", cwd)).toBe("./@notes.md");
       // An absolute mention shorthand keeps stripping even with a literal present.
-      expect(preserveAtPrefixedRelativePath("@/etc/passwd", cwd)).toBe("@/etc/passwd");
+      expect(await preserveAtPrefixedRelativePath("@/etc/passwd", cwd)).toBe("@/etc/passwd");
       // "~" only expands as "~" or "~/", so "@~notes.md" is an ordinary filename.
       await fs.writeFile(path.join(cwd, "@~notes.md"), "tilde\n");
-      expect(preserveAtPrefixedRelativePath("@~notes.md", cwd)).toBe("./@~notes.md");
+      expect(await preserveAtPrefixedRelativePath("@~notes.md", cwd)).toBe("./@~notes.md");
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it("routes the existence probe through a sandbox bridge instead of the host filesystem", async () => {
+    // The bridge's map is the only place "@notes.md" exists — proves a remote/SSH
+    // sandbox literal is found even though this host has no such file on disk.
+    const remoteFiles = new Set(["@notes.md"]);
+    const bridge: Pick<SandboxFsBridge, "stat"> = {
+      stat: async ({ filePath }) =>
+        remoteFiles.has(filePath) ? { type: "file", size: 0, mtimeMs: 0 } : null,
+    };
+    expect(
+      await preserveAtPrefixedRelativePath("@notes.md", "/workspace", bridge as SandboxFsBridge),
+    ).toBe("./@notes.md");
+    // A host-only probe (no bridge) must not see the sandbox-only literal.
+    expect(await preserveAtPrefixedRelativePath("@notes.md", "/workspace")).toBe("@notes.md");
+    // The bridge sees no "@missing.md" either, so the strip still applies.
+    expect(
+      await preserveAtPrefixedRelativePath("@missing.md", "/workspace", bridge as SandboxFsBridge),
+    ).toBe("@missing.md");
   });
 });
 

--- a/src/agents/path-policy.ts
+++ b/src/agents/path-policy.ts
@@ -4,6 +4,7 @@
  * Converts validated absolute or relative inputs into root-relative paths without allowing boundary escapes.
  */
 import path from "node:path";
+import { pathExistsSync } from "../infra/fs-safe.js";
 import { normalizeWindowsPathPreservingCase } from "../infra/path-guards.js";
 import { resolveSandboxInputPath } from "./sandbox-paths.js";
 
@@ -161,4 +162,35 @@ export function toRelativeSandboxPath(
 /** Resolve a user-supplied path against `cwd` using the sandbox input rules. */
 export function resolvePathFromInput(filePath: string, cwd: string): string {
   return path.normalize(resolveSandboxInputPath(filePath, cwd));
+}
+
+/**
+ * Mark an `@`-prefixed path as explicitly relative when that literal file exists.
+ *
+ * Resolvers strip a leading `@`; 9ef0fc2ff8f made the strip uniform to close a
+ * workspace-root guard bypass, so the absolute shorthands must keep stripping.
+ * On a relative path the `@` is a filename character and the strip retargets the
+ * sibling. An existing literal is the only signal separating the two: the TUI
+ * autocomplete emits `@src/foo.ts` for a file stored without the `@`.
+ *
+ * Call where a model-supplied path enters, before the workspace guard, so the
+ * guard and the resolver see one path.
+ */
+export function preserveAtPrefixedRelativePath(filePath: string, cwd: string): string {
+  if (!filePath.startsWith("@")) {
+    return filePath;
+  }
+  const sigilStripped = filePath.slice(1);
+  const isMentionShorthand =
+    sigilStripped === "" ||
+    sigilStripped === "~" ||
+    sigilStripped.startsWith("~/") ||
+    sigilStripped.startsWith("~\\") ||
+    /^file:\/\//i.test(sigilStripped) ||
+    path.posix.isAbsolute(sigilStripped) ||
+    path.win32.isAbsolute(sigilStripped);
+  if (isMentionShorthand) {
+    return filePath;
+  }
+  return pathExistsSync(path.resolve(cwd, filePath)) ? `./${filePath}` : filePath;
 }

--- a/src/agents/path-policy.ts
+++ b/src/agents/path-policy.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { pathExistsSync } from "../infra/fs-safe.js";
 import { normalizeWindowsPathPreservingCase } from "../infra/path-guards.js";
 import { resolveSandboxInputPath } from "./sandbox-paths.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 // Shared path boundary helpers for workspace and sandbox-facing agent inputs.
 // Callers get normalized relative paths only after the candidate proves it stays
@@ -175,8 +176,17 @@ export function resolvePathFromInput(filePath: string, cwd: string): string {
  *
  * Call where a model-supplied path enters, before the workspace guard, so the
  * guard and the resolver see one path.
+ *
+ * `bridge` routes the existence probe through the sandbox filesystem bridge for
+ * sandboxed tool calls. A host-only `fs.stat` is blind to a literal file that
+ * exists only inside a remote/SSH sandbox, so omitting `bridge` there would
+ * still let `@notes.md` retarget writes/edits to `notes.md`.
  */
-export function preserveAtPrefixedRelativePath(filePath: string, cwd: string): string {
+export async function preserveAtPrefixedRelativePath(
+  filePath: string,
+  cwd: string,
+  bridge?: SandboxFsBridge,
+): Promise<string> {
   if (!filePath.startsWith("@")) {
     return filePath;
   }
@@ -192,5 +202,8 @@ export function preserveAtPrefixedRelativePath(filePath: string, cwd: string): s
   if (isMentionShorthand) {
     return filePath;
   }
-  return pathExistsSync(path.resolve(cwd, filePath)) ? `./${filePath}` : filePath;
+  const exists = bridge
+    ? (await bridge.stat({ filePath, cwd })) !== null
+    : pathExistsSync(path.resolve(cwd, filePath));
+  return exists ? `./${filePath}` : filePath;
 }


### PR DESCRIPTION
## What Problem This Solves

Closes #119270.

The file tools strip a leading `@` from a path before resolving it, so `write`, `edit` and `apply_patch` operate on the de-`@`'d sibling instead of the file the model named. When both `@notes.md` and `notes.md` exist, `write` overwrites `notes.md`, `edit` rewrites it, and `apply_patch`'s `Delete File` unlinks it. That unlink is a plain `fs-safe` remove (`src/agents/apply-patch-file-ops.ts`), not a Trash move, so the file is gone.

Captured on `70f84286c9a` through the real `createOpenClawCodingTools` factory (no stubs):

```
### write {"path":"@notes.md","content":"STUB\n"}
  notes.md  "# Real notes"   ->  "STUB"      <- clobbered
  @notes.md "# throwaway"    ->  unchanged
  result: Successfully wrote 5 bytes to @notes.md

### edit {"path":"@notes.md"}
  notes.md  "keep me" -> "EDITED"            <- edited
  @notes.md "keep me" -> unchanged
  result: Successfully replaced 1 block(s) in @notes.md.

### apply_patch  *** Delete File: @notes.md
  notes.md  DELETED                          <- unrecoverable
  @notes.md still present
  result: D notes.md
```

## Why This Change Was Made

The strip is not an oversight, which is why this fix is narrow. `9ef0fc2ff8f` ("fix(sandbox): block @-prefixed workspace path bypass") added it to `src/agents/sandbox-paths.ts` precisely so the workspace guard and the resolver agree on `@`-prefixed paths — without it, `@/etc/passwd` passed the root check as a relative path and then resolved absolutely. Its three regression tests are all absolute (`@/etc/passwd`, `@/workspace/docs/readme.md`, `@<abs>` under `workspaceOnly`), and all still pass here.

The relative case is different: `@` is an ordinary filename character, and stripping it silently collapses `@name` and `name` onto one destination.

Two constraints shaped the fix:

1. **A blanket "keep `@` literal" rule would break a shipped flow.** The TUI wires pi-tui's file autocomplete, whose default trigger characters include `@` (`node_modules/@earendil-works/pi-tui/dist/components/editor.js`), and accepting a suggestion inserts a **relative** `@src/foo.ts` back into the message. Nothing expands it — `src/tui/tui-submit.ts` passes the text through verbatim — so the model receives the raw string and the strip is what makes `read`/`edit` on it work.
2. **`src/agents/sandbox-paths.ts` is owned by `@openclaw/openclaw-secops`** in `.github/CODEOWNERS`, and it is the resolver behind `apply_patch`. Fixing only the resolvers I can reach would desync the guard from the tool: the guard would keep validating the stripped path while the tool mutated the literal one, leaving an unchecked symlink leaf.

So the correction goes at the **producer** — where a model-supplied path enters — and only when a file of that literal name actually exists. That is the one signal that distinguishes the two cases: the TUI emits `@src/foo.ts` for a file stored *without* the `@`, so no literal exists and the strip still applies; the data-loss case has a real `@notes.md` on disk. Every downstream resolver, including the secops-owned one, then sees an unambiguous path and needs no change.

`preserveAtPrefixedRelativePath` lives in `src/agents/path-policy.ts` (the existing shared path-boundary module) and is applied wherever a model-supplied path enters: `normalizeFileToolPathParam` for `write`/`edit`, `createOpenClawReadTool` for `read`, and `resolvePatchPath` / `assertPatchParentPath` for `apply_patch`. Read is included so a write and a follow-up read cannot disagree about which file `@notes.md` means.

## User Impact

`read`, `write`, `edit` and `apply_patch` now act on the file the model named whenever that file exists, and they agree with each other. The `apply_patch` receipt also stops naming a deletion the model never requested (`D notes.md` -> `D @notes.md`).

Nothing changes for any path where no literal `@`-named file exists, which is every path in use today: `@/absolute`, `@/workspace/...`, `@~/...`, `@file://...` and the TUI's `@src/foo.ts` all resolve exactly as before.

Known limits, stated plainly:

- **Creating a new `@X` while `X` exists still writes `X`.** With no literal on disk there is no signal separating "create a file literally named `@X`" from the TUI's "write to `X`", and picking one is a product call rather than a bug fix. The destructive half — overwriting, editing or deleting an existing file — is fixed.
- **A remote (SSH-backed) sandbox is not covered.** The existence probe runs on the host, so if a literal `@foo` exists only on the remote, the probe misses it and the strip still applies — today's behavior, not a regression. A false positive is harmless: the remote then targets the file the model actually named. Doing this properly needs the sandbox bridge's `stat`, which is async and would ripple through sync callers; worth a follow-up.
- For a container-backed sandbox the existence probe runs against the host root, so it simply does not fire and today's behavior is kept.
- Not exercised: Windows, and the OpenShell / container-sandbox bridge variants.

Unrelated inconsistency noticed while sweeping and deliberately left alone: `image`, `image_generate`, `video_generate` and `music_generate` each strip a leading `@` from media reference paths with their own inline copy, while `pdf-tool.ts` does not. Worth a separate issue.

## Evidence

Production diff is **+46 net LOC** across 5 files (`git diff --numstat origin/main HEAD`; tests counted separately):

```
 13   5  src/agents/agent-tools.params.ts
  9   6  src/agents/agent-tools.read.ts
  5   3  src/agents/apply-patch.ts
  1   0  src/agents/core-coding-tools.ts
 32   0  src/agents/path-policy.ts
--- tests ---
 37   1  src/agents/path-policy.test.ts
109   0  src/agents/agent-tools.at-prefixed-paths.test.ts
```

Most of `path-policy.ts` is the helper plus the comment recording why the strip exists at all; the rest is threading an existing root into resolvers that already had one.

Proof command:

```
node scripts/run-vitest.mjs src/agents/agent-tools.at-prefixed-paths.test.ts src/agents/path-policy.test.ts
```

**Negative control.** With only the five production files restored to `origin/main` and the tests kept, both data-loss cases fail for the right reason, and both TUI-preservation cases pass — confirming they assert preserved behavior rather than new behavior:

```
FAIL  mutates the literal @-named file instead of its de-@'d sibling (workspaceOnly=true)
FAIL  mutates the literal @-named file instead of its de-@'d sibling (workspaceOnly=false)
AssertionError: expected 'literal\n' to be 'written\n'
- written
+ literal
```

With the fix applied: `Test Files 2 passed (2) | Tests 24 passed (24)`.

A second control covers the read half specifically. Reverting only the read threading makes the round-trip case fail on `workspaceOnly=false` and pass on `true` — the divergence existed only where the workspace guard is absent:

```
FAIL  reads back the same file it just wrote (workspaceOnly=false)
AssertionError: expected 'sibling\n' to contain 'round-trip'
```

**After, same real-factory harness:**

```
### write {"path":"@notes.md"}      @notes.md = "STUB"   notes.md = "REAL"      (untouched)
### edit {"path":"@notes.md"}       @notes.md = "EDITED" notes.md = "keep me"   (untouched)
### apply_patch Delete File         @notes.md deleted    notes.md survives      result: D @notes.md
### TUI flow, no literal on disk    edit {"path":"@src/foo.ts"} -> src/foo.ts edited  (unchanged)
```

**Blast radius**, found by symbol across the whole repo rather than by directory — every suite touching a changed symbol, all green:

```
node scripts/run-vitest.mjs \
  src/agents/agent-tools.schema.test.ts src/agents/agent-tool-definition-adapter.logging.test.ts \
  src/agents/agent-tools.read.host-operations.test.ts src/agents/agent-tools.read.workspace-root-lazy.test.ts \
  src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/sandbox-paths.windows-drive-resolve.test.ts \
  src/agents/apply-patch-paths.test.ts src/agents/apply-patch.test.ts \
  src/agents/openclaw-tools.nodes-workspace-guard.test.ts src/agents/path-policy.test.ts \
  src/agents/agent-tools.workspace-paths.test.ts
-> Test Files 12 passed (12) | Tests 245 passed | 1 skipped (246)
```

Plus the adjacent tool and consumer suites (`sessions/tools/{write,edit,read}`, `tools/image-tool`, `gateway/server-methods/sessions-files.touched-files`): `Test Files 4 passed | Tests 183 passed`.

The three `9ef0fc2ff8f` guard tests are inside that set and unchanged.

Reviewed with `codex review --base origin/main` before handoff. It raised four findings; two were real and are fixed here — `read` diverging from `write` on the unguarded path, and `@~notes.md` being misread as home shorthand when only `~` and `~/` expand. The other two are the write-create ambiguity and the remote-sandbox probe, both recorded under User Impact rather than guessed at.

Typecheck `node scripts/run-tsgo.mjs -p tsconfig.core.json` and the test-type lane `test/tsconfig/tsconfig.core.test.json` both clean; `oxfmt --check` and `oxlint` clean on all touched files; `git diff --check` clean.

No Crabbox/Testbox on this machine, so cross-OS and full-suite breadth is CI's.

*AI-assisted: investigated, implemented and proved with Claude Code; the diff and evidence above are human-reviewed.*

Rebased onto `origin/main` (`9c2dbf6500f`). No file touched is owned by `@openclaw/openclaw-secops`.
