### PR TITLE
fix(install-policy): stop advertising retired path bypasses

### DIFF
--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -168,16 +168,13 @@ skills, skill dependency installers, and plugin install/update sources.
   Optional allowlist of directories that may contain the policy executable.
 </ParamField>
 
-<ParamField path="security.installPolicy.exec.allowInsecurePath" type="boolean" default="false">
-  Bypasses command path ownership and permission checks. Use only when the
-  path is protected by another mechanism.
-</ParamField>
-
-<ParamField path="security.installPolicy.exec.allowSymlinkCommand" type="boolean" default="false">
-  Allows the configured command path to be a symlink. The resolved target
-  must still satisfy the other path checks. Interpreter script arguments must
-  be direct regular files, not symlinks.
-</ParamField>
+<Note>
+`security.installPolicy.exec.allowInsecurePath` and
+`security.installPolicy.exec.allowSymlinkCommand` were retired. Config validation
+rejects both. The policy command must be a direct regular file on a path whose
+ownership and permissions can be verified; use `trustedDirs` to constrain where
+that executable may live.
+</Note>
 
 The policy receives one JSON object on stdin with `protocolVersion: 1`,
 `openclawVersion`, `targetType`, `targetName`, `sourcePath`, `sourcePathKind`,

--- a/src/security/install-policy.test.ts
+++ b/src/security/install-policy.test.ts
@@ -1,9 +1,10 @@
-// Covers install-policy checks for packages and plugin installs.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+// Covers install-policy checks for packages and plugin installs.
+import { validateConfigObjectRaw } from "../config/validation.js";
 import {
   killPidIfAlive,
   readPidFile,
@@ -690,4 +691,20 @@ describe("runInstallPolicy", () => {
       );
     },
   );
+});
+
+describe("retired install-policy bypass keys", () => {
+  it("rejects the retired bypass keys in config validation", () => {
+    for (const key of ["allowInsecurePath", "allowSymlinkCommand"]) {
+      const result = validateConfigObjectRaw(
+        {
+          security: {
+            installPolicy: { exec: { source: "exec", command: "/bin/echo", [key]: true } },
+          },
+        },
+        { validateBundledChannels: true },
+      );
+      expect(result.ok, key).toBe(false);
+    }
+  });
 });

--- a/src/security/install-policy.ts
+++ b/src/security/install-policy.ts
@@ -267,7 +267,7 @@ async function assertSecureCommandAncestorDirs(params: {
     }
     if (process.platform === "win32" && perms.source === "unknown") {
       throw new Error(
-        `${params.label} parent directory ACL verification unavailable on Windows for ${dir}. Set allowInsecurePath=true for this policy to bypass this check when the path is trusted.`,
+        `${params.label} parent directory ACL verification unavailable on Windows for ${dir}. Point the policy command at a directory whose ACLs can be verified.`,
       );
     }
   }
@@ -277,7 +277,6 @@ async function assertSecureCommandPath(params: {
   targetPath: string;
   label: string;
   trustedDirs?: string[];
-  allowInsecurePath?: boolean;
   allowSymlinkPath?: boolean;
 }): Promise<string> {
   if (!isAbsolutePathname(params.targetPath)) {
@@ -311,10 +310,6 @@ async function assertSecureCommandPath(params: {
       throw new Error(`${params.label} is outside trustedDirs: ${effectivePath}`);
     }
   }
-  if (params.allowInsecurePath) {
-    return effectivePath;
-  }
-
   const perms = await inspectPathPermissions(effectivePath);
   if (!perms.ok) {
     throw new Error(`${params.label} permissions could not be verified: ${effectivePath}`);
@@ -326,7 +321,7 @@ async function assertSecureCommandPath(params: {
 
   if (process.platform === "win32" && perms.source === "unknown") {
     throw new Error(
-      `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Set allowInsecurePath=true for this policy to bypass this check when the path is trusted.`,
+      `${params.label} ACL verification unavailable on Windows for ${effectivePath}. Point the policy command at a path whose ACLs can be verified.`,
     );
   }
 
@@ -345,7 +340,6 @@ async function assertSecurePolicyScriptArg(params: {
   command: string;
   args: string[];
   trustedDirs?: string[];
-  allowInsecurePath?: boolean;
   allowSymlinkPath?: boolean;
 }): Promise<void> {
   const scriptArg = resolvePolicyScriptArg({ command: params.command, args: params.args });
@@ -360,7 +354,6 @@ async function assertSecurePolicyScriptArg(params: {
       targetPath: script.path,
       label: `security.installPolicy.exec.args[${script.index}]`,
       trustedDirs: params.trustedDirs,
-      allowInsecurePath: params.allowInsecurePath,
       allowSymlinkPath: false,
     });
   }
@@ -746,4 +739,3 @@ export async function probeInstallPolicy(params: {
     },
   });
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Part of #120003.

`security.installPolicy.exec.allowInsecurePath` and `allowSymlinkCommand` were retired, but three things still behave as though they exist.

**Config rejects them.** `installPolicy.exec` is a `z.strictObject` (`src/config/zod-schema.root-support.ts:63`) carrying neither key. Verified against the same validator the dead-config-key tests use:

```
INSTALLPOLICY_allowInsecurePath_ACCEPTED=false
INSTALLPOLICY_allowSymlinkCommand_ACCEPTED=false
```

**The docs still advertised them** as settable `ParamField`s with `default="false"` (`docs/tools/skills-config.md:171` and `:176`), so an operator following the page writes a config that fails validation.

**The runtime told operators to set one of them.** Both Windows ACL diagnostics ended with "Set allowInsecurePath=true for this policy to bypass this check when the path is trusted." That instruction cannot be carried out, which is the worst shape for an error message: it reads as actionable and sends the reader to a key the schema refuses.

The bypass was also dead code. `assertSecureCommandPath` still had `if (params.allowInsecurePath) { return effectivePath; }`, but no call site passes it: both real callers (`install-policy.ts:475` and `:487`) pass only `targetPath`, `label`, `trustedDirs`, and `allowSymlinkPath: false`. With config unable to set it either, that early return was unreachable.

## Why This Change Was Made

The three symptoms share one cause, so this fixes the cause rather than the wording alone:

- removed the unreachable `allowInsecurePath` bypass and its parameters, so the code no longer implies a capability that cannot be reached
- rewrote both diagnostics to state what actually resolves the situation, pointing at a path whose ACLs can be verified instead of at a rejected key
- replaced the two doc `ParamField`s with a note saying both keys are retired and rejected, and pointing at `trustedDirs`, which is real and still in the schema

I deliberately did not invent a replacement escape hatch. On Windows with an unverifiable ACL source there is now no config bypass, and saying so plainly is better than sending operators to another key that will not help.

Removing the dead branch brought the file under the line limit, so its grandfathered `/* oxlint-disable max-lines */` suppression became unused and is gone too. That is the direction the contributor guide asks for: shrink the file and drop the suppression, never add one.

## Scope

This covers the docs and runtime-diagnostic half of #120003. The issue also reports that `src/plugins/install.npm-spec.e2e.test.ts` returns `security_scan_failed` before its fixture policy can return `security_scan_blocked` on Homebrew macOS, because the fixture assumes the host Node executable sits on an accepted path. I have not touched that fixture: it is a distinct problem about test-host assumptions rather than about retired keys, and it wants a decision about whether the fixture should stub the path check or the check should treat Homebrew prefixes as trusted. Happy to take it as a follow-up once you say which.

`allowSymlinkPath` is a related observation I left alone: every call site passes `false` today, so the `true` branch is effectively unreachable as well, but it is a genuine safety knob rather than a retired key and removing it is not part of this issue.

## User Impact

Operators reading the skills-config page no longer write rejected keys, and the Windows ACL errors no longer instruct an impossible action. No behavior changes for any configuration that validates today, because the removed branch could not be reached.

Production delta is -10 in `install-policy.ts`, plus docs.

## Evidence

Regression coverage in `src/security/install-policy.test.ts` asserts config validation rejects both retired keys, so the docs and the schema cannot drift apart again silently.

Verification: `src/security/install-policy` 23 tests passing, `tsgo -p tsconfig.core.json` and `tsgo -p test/tsconfig/tsconfig.core.test.json` both clean, oxlint clean on both changed source files, `git diff --check` clean.

I did not reproduce the Windows ACL path itself, since it needs a Windows host with an unverifiable ACL source. The message change is text-only and the removed branch is proven unreachable by the call sites cited above.

AI-assisted: written with AI assistance. I read the schema, both diagnostics, every call site of the affected helpers, and the dead-config-key tests myself before deciding what to remove.
