### PR TITLE
fix(ai): mark interrupted stream usage as unavailable

### DIFF
--- a/packages/ai/src/providers/anthropic-usage.ts
+++ b/packages/ai/src/providers/anthropic-usage.ts
@@ -110,6 +110,8 @@ export function applyAnthropicMessageStartUsage(
   target: Usage,
   payload: AnthropicUsagePayload,
 ): AnthropicPromptUsageSnapshot | undefined {
+  // Any provider usage payload is measured, even when individual buckets are zero.
+  target.usageReport = { state: "available" };
   const promptUsage = readAnthropicPromptUsageSnapshot(payload);
   const promptTokens = promptUsage
     ? promptUsage.input + promptUsage.cacheRead + promptUsage.cacheWrite
@@ -158,6 +160,9 @@ export function applyAnthropicMessageDeltaUsage(
   messageStartPromptUsage: AnthropicPromptUsageSnapshot | undefined,
 ): void {
   const usage = payload ?? {};
+  if (payload) {
+    target.usageReport = { state: "available" };
+  }
   const inputTokens = readAnthropicUsageTokenCount(usage.input_tokens);
   if (inputTokens !== undefined) {
     target.input = inputTokens;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -661,6 +661,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         output.content = [];
       }
       output.stopReason = requestOptions?.signal?.aborted ? "aborted" : "error";
+      if (output.usage.usageReport?.state !== "available") {
+        output.usage.usageReport = { state: "unavailable" };
+      }
       // A bare JSON.stringify here dies on the circular error objects HTTP/socket
       // layers raise, and the throw escapes this catch so stream.end() never runs
       // and the consumer hangs. formatProviderError guards that conversion, matching

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -450,6 +450,9 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
         delete (block as { index?: number }).index;
       }
     }
+    if (output.usage.usageReport?.state !== "available") {
+      output.usage.usageReport = { state: "unavailable" };
+    }
     const failure = options?.signal?.aborted ? transportAbortError(options.signal) : error;
     assignTransportErrorDetails(output, failure, options?.signal);
     const formattedError = formatProviderError(failure);
@@ -808,6 +811,7 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
         cacheWrite: 0,
         totalTokens:
           chunk.usageMetadata.totalTokenCount ?? promptTokens + outputTokens + toolUsePromptTokens,
+        usageReport: { state: "available" },
         cost: {
           input: 0,
           output: 0,

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -195,6 +195,9 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
       // Failed or canceled generations must never retain partially repaired tool calls.
       output.content = output.content.filter((block) => block.type !== "toolCall");
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+      if (output.usage.usageReport?.state !== "available") {
+        output.usage.usageReport = { state: "unavailable" };
+      }
       output.errorMessage = formatMistralError(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
@@ -612,6 +615,7 @@ async function consumeChatStream(
       output.usage.totalTokens =
         chunk.usage.totalTokens ||
         output.usage.input + output.usage.output + output.usage.cacheRead;
+      output.usage.usageReport = { state: "available" };
       calculateCost(model, output.usage);
     }
 

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -510,6 +510,11 @@ export const streamOpenAICodexResponses: StreamFunction<
         delete (block as { partialJson?: string }).partialJson;
       }
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+      // Responses usage arrives only on terminal events; mid-stream failure
+      // must not leave the zero placeholder looking like measured usage.
+      if (output.usage.usageReport?.state !== "available") {
+        output.usage.usageReport = { state: "unavailable" };
+      }
       output.errorMessage =
         normalizedError instanceof Error ? normalizedError.message : String(normalizedError);
       stream.push({ type: "error", reason: output.stopReason, error: output });

--- a/packages/ai/src/providers/openai-completions-usage-parity.test.ts
+++ b/packages/ai/src/providers/openai-completions-usage-parity.test.ts
@@ -179,7 +179,7 @@ describe.each([
   it.each(scenarios)("preserves $name", async (scenario) => {
     installUsageChunk(scenario);
     const result = await createStream().result();
-    const expectedUsage = { ...scenario.expectedUsage };
+    const expectedUsage = { ...scenario.expectedUsage, usageReport: { state: "available" } };
     if (!preservesReasoningTokens) {
       delete expectedUsage.reasoningTokens;
       expect(result.usage).not.toHaveProperty("reasoningTokens");
@@ -190,5 +190,41 @@ describe.each([
     if (scenario.expectedCost !== undefined) {
       expect(result.usage.cost.total).toBeCloseTo(scenario.expectedCost, 10);
     }
+  });
+
+  it("marks usageReport unavailable when the stream ends before the usage chunk", async () => {
+    const contentChunk = {
+      id: "chatcmpl-interrupted",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: model.id,
+      choices: [
+        {
+          index: 0,
+          delta: { role: "assistant", content: "Partial content." },
+          finish_reason: null,
+        },
+      ],
+    } as ChatCompletionChunk;
+    // Content arrives, but the stream ends without the terminal include_usage chunk —
+    // the same shape as a proxy timeout/reset after content blocks.
+    const body = `data: ${JSON.stringify(contentChunk)}\n\n`;
+    configureAiTransportHost({
+      buildModelFetch: () => async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+    });
+
+    const result = await createStream().result();
+    expect(result.usage).toMatchObject({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      usageReport: { state: "unavailable" },
+    });
   });
 });

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -406,6 +406,7 @@ describe("OpenAI-compatible completions params", () => {
 
     expect(result.usage.cost.total).toBe(0);
     expect(result.usage.cost.totalOrigin).toBe("provider-billed");
+    expect(result.usage.usageReport).toEqual({ state: "available" });
   });
 
   it("keeps the catalog estimate for an invalid provider-reported usage cost", async () => {
@@ -454,6 +455,13 @@ describe("OpenAI-compatible completions params", () => {
       expect(result.errorMessage).toContain("provider=openai");
       expect(result.errorMessage).toContain("api=openai-completions");
       expect(result.errorMessage).toContain("model=gpt-5.5");
+      // No usage payload arrived; zero placeholders must not look measured.
+      expect(result.usage).toMatchObject({
+        input: 0,
+        output: 0,
+        totalTokens: 0,
+        usageReport: { state: "unavailable" },
+      });
       const signal = (mockOpenAIOptionsRef.requests[0] as { signal?: AbortSignal } | undefined)
         ?.signal;
       expect(signal?.aborted).toBe(true);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -607,6 +607,11 @@ export const streamOpenAICompletions: StreamFunction<
     } catch (error) {
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
       finalizeOpenAICompletionsToolCalls(output, { allowSilentToolCallPromotion: false });
+      // OpenAI sends usage only on the final chunk; a mid-stream failure must not
+      // leave the zero placeholder looking like measured usage.
+      if (output.usage.usageReport?.state !== "available") {
+        output.usage.usageReport = { state: "unavailable" };
+      }
       for (const block of output.content) {
         delete (block as { index?: number }).index;
         // Streaming scratch buffers are only used during parsing; never persist them.

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -623,6 +623,11 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
   } catch (error) {
     cleanStreamingScratchBuffers(output);
     output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+    // Responses usage arrives only on terminal events; mid-stream failure
+    // must not leave the zero placeholder looking like measured usage.
+    if (output.usage.usageReport?.state !== "available") {
+      output.usage.usageReport = { state: "unavailable" };
+    }
     output.errorMessage = params.formatError(error);
     stream.push({ type: "error", reason: output.stopReason, error: output });
     stream.end();

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -63,6 +63,13 @@ describe("OpenAI Responses provider", () => {
     }).result();
 
     expect(result.stopReason).toBe("error");
+    // Fail before a terminal usage event: zeros are unmeasured, not free.
+    expect(result.usage).toMatchObject({
+      input: 0,
+      output: 0,
+      totalTokens: 0,
+      usageReport: { state: "unavailable" },
+    });
     expect(openAiMockState.configs).toHaveLength(1);
     expect((openAiMockState.configs[0] as { fetch?: unknown }).fetch).toBe(hostFetch);
   });

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -98,6 +98,7 @@ import {
   createWritableTransportEventStream,
   failTransportStream,
   finalizeTransportStream,
+  markTransportUsageReportUnavailableUnlessReported,
   mergeTransportHeaders,
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
@@ -176,6 +177,7 @@ type MutableAssistantOutput = {
     cacheRead: number;
     cacheWrite: number;
     cacheWrite1h?: number;
+    usageReport?: { state: "available" | "unavailable" };
     contextUsage?: ContextUsage;
     totalTokens: number;
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
@@ -1723,6 +1725,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             for (const block of output.content) {
               delete block.index;
             }
+            markTransportUsageReportUnavailableUnlessReported(output.usage);
           },
         });
       }

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -84,7 +84,11 @@ import {
   type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
-import { failTransportStream, finalizeTransportStream } from "./transport-stream-shared.js";
+import {
+  failTransportStream,
+  finalizeTransportStream,
+  markTransportUsageReportUnavailableUnlessReported,
+} from "./transport-stream-shared.js";
 import {
   CHARS_PER_TOKEN_ESTIMATE,
   estimateStringChars,
@@ -367,6 +371,9 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           error,
           cleanup: () => {
             output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+            // OpenAI sends usage only on the final chunk; a mid-stream failure
+            // must not leave the zero placeholder looking like measured usage.
+            markTransportUsageReportUnavailableUnlessReported(output.usage);
             finalizeOpenAICompletionsToolCalls(output, { allowSilentToolCallPromotion: false });
           },
         });
@@ -858,6 +865,9 @@ async function processOpenAICompletionsStream(
   if (output.stopReason === "toolUse") {
     tagPendingCommentaryText(output.content);
   }
+  // Terminal usage arrives only on the final include_usage chunk. If none
+  // arrived, the zero placeholder must not look like measured usage.
+  markTransportUsageReportUnavailableUnlessReported(output.usage);
 }
 
 function shouldFilterDeepSeekDsmlText(compat: ReturnType<typeof getCompat>) {

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -54,6 +54,7 @@ import { log } from "./openai-transport-shared.js";
 import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
 import {
   assignTransportErrorDetails,
+  markTransportUsageReportUnavailableUnlessReported,
   mergeTransportMetadata,
   transportAbortError,
 } from "./transport-stream-shared.js";
@@ -263,6 +264,9 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             summarizeOpenAITransportError(error),
         );
         assignTransportErrorDetails(output, error, options?.signal);
+        // Responses usage arrives only on terminal events; mid-stream failure
+        // must not leave the zero placeholder looking like measured usage.
+        markTransportUsageReportUnavailableUnlessReported(output.usage);
         stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
         stream.end();
       } finally {

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -285,6 +285,8 @@ export function createResponsesTerminalController(params: {
       output.usage = {
         ...usage,
         ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+        // Terminal Responses events carry provider usage when present.
+        usageReport: { state: "available" },
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
       };
     }

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -56,6 +56,7 @@ export type MutableAssistantOutput = {
     cacheRead: number;
     cacheWrite: number;
     reasoningTokens?: number;
+    usageReport?: NonNullable<Usage["usageReport"]>;
     totalTokens: number;
     cost: Usage["cost"];
   };
@@ -93,6 +94,8 @@ export function parseOpenAICompletionsUsage(
     Number.isFinite(reasoningTokens)
       ? { reasoningTokens }
       : {}),
+    // Provider sent a usage payload; zeros here are measured, not stream placeholders.
+    usageReport: { state: "available" },
     totalTokens: input + output + cacheRead + cacheWrite,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   };

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -17,6 +17,8 @@ type TransportUsage = {
   cacheRead: number;
   cacheWrite: number;
   contextUsage?: ContextUsage;
+  /** Absent until a provider usage payload arrives or the stream fails without one. */
+  usageReport?: NonNullable<Usage["usageReport"]>;
   totalTokens: number;
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
 };
@@ -109,6 +111,26 @@ export function createEmptyTransportUsage(): TransportUsage {
     totalTokens: 0,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   };
+}
+
+type UsageReportCarrier = {
+  usageReport?: NonNullable<Usage["usageReport"]>;
+};
+
+/** Mark token buckets as provider-reported (call only after a real usage payload). */
+export function markTransportUsageReportAvailable(usage: UsageReportCarrier): void {
+  usage.usageReport = { state: "available" };
+}
+
+/**
+ * Streams initialize usage to zero before any provider payload. On error/abort,
+ * keep an already-reported payload; otherwise mark the zeros as unmeasured.
+ */
+export function markTransportUsageReportUnavailableUnlessReported(usage: UsageReportCarrier): void {
+  if (usage.usageReport?.state === "available") {
+    return;
+  }
+  usage.usageReport = { state: "unavailable" };
 }
 
 export function createWritableTransportEventStream() {

--- a/packages/gateway-protocol/src/schema/worker-protocol-primitives.ts
+++ b/packages/gateway-protocol/src/schema/worker-protocol-primitives.ts
@@ -70,6 +70,11 @@ export const WorkerTranscriptUsageSchema = closedObject({
   output: Type.Number({ minimum: 0 }),
   cacheRead: Type.Number({ minimum: 0 }),
   cacheWrite: Type.Number({ minimum: 0 }),
+  usageReport: Type.Optional(
+    closedObject({
+      state: Type.Union([Type.Literal("available"), Type.Literal("unavailable")]),
+    }),
+  ),
   contextUsage: Type.Optional(
     Type.Union([
       closedObject({

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -277,6 +277,12 @@ export interface Usage {
   cacheTelemetry?: { state: "available" | "unavailable" };
   /** Subset of `cacheWrite` written with 1-hour retention when reported. */
   cacheWrite1h?: number;
+  /**
+   * Whether input/output/cache/totalTokens reflect a provider-reported usage
+   * payload. Streams that fail before the terminal usage chunk must set
+   * `unavailable` so zero placeholders are not treated as measured usage.
+   */
+  usageReport?: { state: "available" | "unavailable" };
   /** Exact context snapshot for the final provider iteration. */
   contextUsage?:
     | { state: "available"; promptTokens: number; totalTokens: number }

--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -97,6 +97,13 @@ describe("normalizeUsage", () => {
     expect(hasNonzeroUsage({ reasoningTokens: 1 })).toBe(true);
     expect(hasNonzeroUsage({ input: 1 })).toBe(true);
     expect(hasNonzeroUsage({ total: 1 })).toBe(true);
+    expect(
+      hasNonzeroUsage({
+        input: 12,
+        output: 3,
+        usageReport: { state: "unavailable" },
+      }),
+    ).toBe(false);
   });
 
   it("does not clamp derived session total tokens to the context window", () => {

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -370,6 +370,16 @@ describe("hasNonzeroUsage", () => {
   it("returns false for undefined usage", () => {
     expect(hasNonzeroUsage(undefined)).toBe(false);
   });
+
+  it("returns false when usageReport is unavailable even if buckets are positive", () => {
+    expect(
+      hasNonzeroUsage({
+        input: 10,
+        output: 4,
+        usageReport: { state: "unavailable" },
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("derivePromptTokens", () => {

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -15,6 +15,7 @@ export type UsageLike = {
   cacheRead?: number;
   cacheWrite?: number;
   contextUsage?: ContextUsage;
+  usageReport?: { state: "available" | "unavailable" };
   total?: number;
   // Common alternates across providers/SDKs.
   inputTokens?: number;
@@ -60,6 +61,8 @@ export type NormalizedUsage = {
   cacheRead?: number;
   cacheWrite?: number;
   contextUsage?: ContextUsage;
+  /** Mirrors Usage.usageReport when the provider payload provenance is known. */
+  usageReport?: { state: "available" | "unavailable" };
   reasoningTokens?: number;
   total?: number;
 };
@@ -109,6 +112,10 @@ export function makeZeroUsageSnapshot(): AssistantUsageSnapshot {
 /** Return true when any normalized usage bucket is positive. */
 export function hasNonzeroUsage(usage?: NormalizedUsage | null): usage is NormalizedUsage {
   if (!usage) {
+    return false;
+  }
+  // Unmeasured stream placeholders must not count as accounting usage.
+  if (usage.usageReport?.state === "unavailable") {
     return false;
   }
   return (
@@ -218,12 +225,18 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   );
   const total = normalizeTokenCount(raw.total ?? raw.totalTokens ?? raw.total_tokens);
 
+  const usageReport =
+    raw.usageReport?.state === "available" || raw.usageReport?.state === "unavailable"
+      ? ({ state: raw.usageReport.state } as const)
+      : undefined;
+
   if (
     input === undefined &&
     output === undefined &&
     cacheRead === undefined &&
     cacheWrite === undefined &&
     contextUsage === undefined &&
+    usageReport === undefined &&
     reasoningTokens === undefined &&
     total === undefined
   ) {
@@ -236,6 +249,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     cacheRead,
     cacheWrite,
     ...(contextUsage ? { contextUsage } : {}),
+    ...(usageReport ? { usageReport } : {}),
     ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
     total,
   };

--- a/src/gateway/worker-environments/inference-terminal-message.ts
+++ b/src/gateway/worker-environments/inference-terminal-message.ts
@@ -56,6 +56,9 @@ export function projectWorkerInferenceTerminalMessage(params: {
       output: usage.output,
       cacheRead: usage.cacheRead,
       cacheWrite: usage.cacheWrite,
+      ...(usage.usageReport?.state === "available" || usage.usageReport?.state === "unavailable"
+        ? { usageReport: { state: usage.usageReport.state } }
+        : {}),
       ...(usage.contextUsage?.state === "available"
         ? {
             contextUsage: {

--- a/src/gateway/worker-environments/transcript-commit.ts
+++ b/src/gateway/worker-environments/transcript-commit.ts
@@ -137,6 +137,9 @@ function buildCommittedMessage(
       output: message.usage.output,
       cacheRead: message.usage.cacheRead,
       cacheWrite: message.usage.cacheWrite,
+      ...(message.usage.usageReport
+        ? { usageReport: structuredClone(message.usage.usageReport) }
+        : {}),
       ...(message.usage.contextUsage
         ? { contextUsage: structuredClone(message.usage.contextUsage) }
         : {}),

--- a/src/worker/transcript-message.ts
+++ b/src/worker/transcript-message.ts
@@ -78,6 +78,9 @@ export function cloneUsage(
       output: message.usage.output,
       cacheRead: message.usage.cacheRead,
       cacheWrite: message.usage.cacheWrite,
+      ...(message.usage.usageReport
+        ? { usageReport: structuredClone(message.usage.usageReport) }
+        : {}),
       ...(message.usage.contextUsage
         ? { contextUsage: structuredClone(message.usage.contextUsage) }
         : {}),


### PR DESCRIPTION
fix(ai): report unknown usage when streaming fails before usage chunk

Closes #119244

## What Problem This Solves

Fixes an issue where users running OpenAI (and other streaming) model turns would see **0 tokens / $0 cost** when a stream failed or dropped before the final usage chunk arrived.

Affected workflow: streaming model usage accounting (session totals, cost rollups, transcript usage) after proxy timeouts, connection resets, or other mid-stream failures.

## Why This Change Was Made

Provider streams often initialize usage to zeros and only fill real counts from a terminal usage payload. On interrupt, those zeros were still emitted as if measured.

This change records provenance with `usageReport: { state: "available" | "unavailable" }` (same style as `contextUsage` / `cacheTelemetry`): set `available` only after a real provider usage payload; set `unavailable` when a stream ends or fails without one. Downstream accounting treats `unavailable` as non-measured so placeholder zeros are not billed or accumulated.

Non-goals: client-side token estimation; changing successful-turn totals when the provider does report usage.

## User Impact

- Interrupted / incomplete streams no longer look free or zero-cost by default.
- Successful turns that include provider usage keep reporting real token and cost numbers (`usageReport: available`).
- Operators and cost tooling can distinguish **unmeasured** usage from a true zero-token turn.

## Evidence

Focused tests (local):

```text
packages/ai/src/providers/openai-completions-usage-parity.test.ts
packages/ai/src/providers/openai-completions.test.ts
packages/ai/src/providers/openai-responses.test.ts
src/agents/usage.normalization.test.ts
src/agents/usage.test.ts
→ 76 + 58 passed
Coverage includes:
- stream ends before usage chunk → usageReport: unavailable with zero buckets
- first-event timeout / responses construct failure → unavailable
- provider-reported usage success → available
- hasNonzeroUsage rejects unavailable even if buckets are positive