### PR TITLE
fix: honor --thinking off for custom openai-completions providers

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -239,7 +239,29 @@ describe("OpenAI-compatible completions params", () => {
     },
   );
 
-  it("omits reasoning_effort when deepseek-format compatibility disables it", async () => {
+    it("omits reasoning_effort for the default payload shape when thinking is off", async () => {
+    // Regression for #119959: a model configured with reasoning: true and no
+    // special thinkingFormat (the shape used by plain self-hosted openai-completions
+    // endpoints, e.g. vLLM) must honor an explicit off/none request instead of
+    // always emitting the resolved (default "high") effort.
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+    const compatibleModel = {
+      ...reasoningModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://third-party.test/v1",
+      compat: { supportsReasoningEffort: true },
+    } satisfies Model<"openai-completions">;
+
+    await streamOpenAICompletions(compatibleModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "off",
+    }).result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning");
+    });
+
+it("omits reasoning_effort when deepseek-format compatibility disables it", async () => {
     mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
     const compatibleModel = {
       ...reasoningModel,

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -2027,6 +2027,12 @@ export function buildOpenAICompletionsParams(
     }
   }
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
+  // An explicit "off"/"none" request must fully suppress reasoning_effort/reasoning
+  // below -- without this, a model configured with reasoning: true always emits a
+  // resolved effort value (defaulting to "high") regardless of the requested level.
+  const completionsReasoningEnabled = isOpenAICompletionsThinkingEnabled(
+    completionsReasoningEffort,
+  );
   const resolvedCompletionsReasoningEffort = completionsReasoningEffort
     ? resolveOpenAIReasoningEffortForModel({
         model,
@@ -2063,7 +2069,8 @@ export function buildOpenAICompletionsParams(
   } else if (
     compat.thinkingFormat === "openrouter" &&
     model.reasoning &&
-    resolvedCompletionsReasoningEffort
+    resolvedCompletionsReasoningEffort &&
+    completionsReasoningEnabled
   ) {
     params.reasoning = {
       effort: resolvedCompletionsReasoningEffort,
@@ -2073,7 +2080,8 @@ export function buildOpenAICompletionsParams(
     model.reasoning &&
     compat.supportsReasoningEffort &&
     !handledQwenThinkingFormat &&
-    !omitChatCompletionsToolReasoningEffort
+    !omitChatCompletionsToolReasoningEffort &&
+    completionsReasoningEnabled
   ) {
     params.reasoning_effort = resolvedCompletionsReasoningEffort;
   }


### PR DESCRIPTION
Closes #119959

## What Problem This Solves

Fixes an issue where users running a self-hosted or custom `openai-completions` provider (e.g. a vLLM endpoint configured with `reasoning: true`) would still get model "thinking" output even after explicitly requesting `--thinking off`. The flag was silently ignored for this transport.

## Why This Change Was Made

`buildOpenAICompletionsParams` computed a resolved reasoning effort and attached `reasoning_effort`/`reasoning` to the request whenever `model.reasoning` was `true`, without ever checking whether the caller had actually requested `off`/`none`. Every other special-cased thinking format in the same function (Qwen, Together, GPT-5.6 tool-safety) already guards this correctly; the plain/default reasoning_effort and openrouter-format branches did not. This change adds a `completionsReasoningEnabled` check, reusing the existing `isOpenAICompletionsThinkingEnabled` helper, and gates both branches on it.

## User Impact

Setting `--thinking off` (or `reasoningEffort: "none"`) on any custom `openai-completions` provider configured with `reasoning: true` now actually disables reasoning, instead of silently defaulting to "high" effort. No behavior change for providers/models that don't set `model.reasoning: true`.

## Evidence

- Added a regression test in `packages/ai/src/providers/openai-completions.test.ts` covering the exact shape from the bug report: a `reasoning: true` model with no special `thinkingFormat`, requesting `reasoningEffort: "off"`, asserting neither `reasoning_effort` nor `reasoning` end up in the outgoing payload.
- I did not have a full `pnpm install` workspace available to run the complete suite here. I ran a TypeScript syntax check on both changed files (0 diagnostics) but could not execute `pnpm test` locally. Treating CI as the source of truth for this PR; happy to fix up anything that surfaces.
This PR was drafted with AI assistance (Claude). I reviewed the diagnosis and diff and understand what the code does, flagging per the AI-assisted PR guidance in CONTRIBUTING.md.