### PR TITLE
fix(qa): invalidate stale profile evidence before planning

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -19,6 +19,7 @@ const {
   runQaDockerUp,
   defaultQaRuntimeModelForMode,
   readQaScenarioPack,
+  createQaArtifactRunId,
 } = vi.hoisted(() => ({
   runQaManualLane: vi.fn(),
   runQaFlowSuiteFromRuntime: vi.fn(),
@@ -33,6 +34,11 @@ const {
   defaultQaRuntimeModelForMode:
     vi.fn<(mode: string, options?: { alternate?: boolean }) => string>(),
   readQaScenarioPack: vi.fn<() => QaScenarioPack>(),
+  createQaArtifactRunId: vi.fn(),
+}));
+
+vi.mock("./artifact-run-id.js", () => ({
+  createQaArtifactRunId,
 }));
 
 vi.mock("./manual-lane.runtime.js", () => ({
@@ -340,6 +346,7 @@ describe("qa cli runtime", () => {
       (mode: string, options?: { alternate?: boolean }) =>
         defaultQaProviderModelForMode(mode as QaProviderModeInput, options),
     );
+    createQaArtifactRunId.mockReturnValue("cli-runtime-test");
     readQaScenarioPack.mockClear();
     runQaSuite.mockImplementation(async (params) => {
       const observedCells = executionCellsForSuiteParams(params);
@@ -731,7 +738,7 @@ describe("qa cli runtime", () => {
       });
 
       await runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
         outputDir: ".artifacts/qa-e2e/smoke-ci",
         profile: "smoke-ci",
         surface: "telegram",
@@ -745,8 +752,8 @@ describe("qa cli runtime", () => {
 
       const suiteArgs = mockFirstObjectArg(runQaSuite);
       expectFields(suiteArgs, {
-        repoRoot: path.resolve("/tmp/openclaw-repo"),
-        outputDir: path.resolve("/tmp/openclaw-repo", ".artifacts/qa-e2e/smoke-ci"),
+        repoRoot: suiteArtifactsDir,
+        outputDir: path.join(suiteArtifactsDir, ".artifacts/qa-e2e/smoke-ci"),
         transportId: "qa-channel",
         channelDriver: "crabline",
         providerMode: "mock-openai",
@@ -813,9 +820,135 @@ describe("qa cli runtime", () => {
     }
   });
 
+  it("invalidates implicit default profile evidence before execution", async () => {
+    const outputDir = path.join(
+      suiteArtifactsDir,
+      ".artifacts",
+      "qa-e2e",
+      "suite-cli-runtime-test",
+    );
+    const evidencePath = path.join(outputDir, QA_EVIDENCE_FILENAME);
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(evidencePath, JSON.stringify({ stale: true }), "utf8");
+    runQaSuite.mockImplementationOnce(async (params) => {
+      expect(params?.outputDir).toBe(outputDir);
+      await expect(fs.stat(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+      throw new Error("profile suite failed");
+    });
+
+    await expect(
+      runQaProfileCommand({
+        repoRoot: suiteArtifactsDir,
+        profile: "smoke-ci",
+        surface: "telegram",
+        category: "telegram.native-controls-and-approvals",
+        scenarioIds: ["telegram-commands-command"],
+      }),
+    ).rejects.toThrow("profile suite failed");
+
+    await expect(fs.stat(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes canonical evidence when profile evidence planning fails", async () => {
+    const outputDir = path.join(suiteArtifactsDir, "profile-planning-failure");
+    const evidencePath = path.join(outputDir, QA_EVIDENCE_FILENAME);
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(evidencePath, JSON.stringify({ stale: true }), "utf8");
+    runQaSuite.mockImplementationOnce(async (params) => {
+      const expectedCells = executionCellsForSuiteParams(params);
+      await fs.writeFile(evidencePath, JSON.stringify({ unfinished: true }), "utf8");
+      return flowSuiteRuntimeResult({
+        evidencePath,
+        expectedCells,
+        observedCells: [
+          ...expectedCells,
+          {
+            scenarioId: "unexpected-scenario",
+            executionKind: "flow",
+            channel: null,
+          },
+        ],
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+      });
+    });
+
+    await expect(
+      runQaProfileCommand({
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile-planning-failure",
+        profile: "smoke-ci",
+        surface: "telegram",
+        category: "telegram.native-controls-and-approvals",
+        scenarioIds: ["telegram-commands-command"],
+      }),
+    ).rejects.toThrow("unexpected execution cells invalidate evidence");
+
+    await expect(fs.stat(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not leave reused profile evidence after suite failure", async () => {
+    const outputDir = path.join(suiteArtifactsDir, "profile-suite-failure");
+    const evidencePath = path.join(outputDir, QA_EVIDENCE_FILENAME);
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(evidencePath, JSON.stringify({ stale: true }), "utf8");
+    runQaSuite.mockImplementationOnce(async () => {
+      await fs.writeFile(evidencePath, JSON.stringify({ stale: false, result: "pass" }), "utf8");
+      throw new Error("profile suite failed");
+    });
+
+    await expect(
+      runQaProfileCommand({
+        repoRoot: suiteArtifactsDir,
+        outputDir: "profile-suite-failure",
+        profile: "smoke-ci",
+        surface: "telegram",
+        category: "telegram.native-controls-and-approvals",
+        scenarioIds: ["telegram-commands-command"],
+      }),
+    ).rejects.toThrow("profile suite failed");
+
+    await expect(fs.stat(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rewrites reused profile evidence and preserves the direct-flow watch URL", async () => {
+    const outputDir = path.join(suiteArtifactsDir, "profile-success");
+    const evidencePath = path.join(outputDir, QA_EVIDENCE_FILENAME);
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(evidencePath, JSON.stringify({ stale: true }), "utf8");
+    runQaSuite.mockImplementationOnce(async (params) => {
+      await expect(fs.stat(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await fs.writeFile(evidencePath, await fs.readFile(suiteEvidencePath, "utf8"), "utf8");
+      return flowSuiteRuntimeResult({
+        evidencePath,
+        observedCells: executionCellsForSuiteParams(params),
+        reportPath: suiteReportPath,
+        summaryPath: suiteSummaryPath,
+      });
+    });
+
+    await runQaProfileCommand({
+      repoRoot: suiteArtifactsDir,
+      outputDir: "profile-success",
+      profile: "smoke-ci",
+      surface: "telegram",
+      category: "telegram.native-controls-and-approvals",
+      scenarioIds: ["telegram-commands-command"],
+    });
+
+    const evidence = JSON.parse(await fs.readFile(evidencePath, "utf8")) as {
+      profile?: unknown;
+      stale?: unknown;
+    };
+    expect(evidence.profile).toBe("smoke-ci");
+    expect(evidence.stale).toBeUndefined();
+    expectWriteContains(stdoutWrite, "QA suite watch: http://127.0.0.1:43124");
+    expectWriteContains(stdoutWrite, `QA profile scorecard: ${evidencePath}`);
+  });
+
   it("passes non-Crabline profile channel drivers as declarative suite metadata", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
       profile: "release",
       surface: "agent-runtime",
       category: "agent-runtime.agent-turn-execution",
@@ -829,7 +962,7 @@ describe("qa cli runtime", () => {
 
   it("keeps portable channel scenarios in driver-selected profile runs", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
       profile: "release",
       surface: "channels",
       providerMode: "mock-openai",
@@ -847,7 +980,7 @@ describe("qa cli runtime", () => {
 
   it("runs the all profile through the live taxonomy profile path", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
       profile: "all",
       surface: "agent-runtime",
       category: "agent-runtime.agent-turn-execution",
@@ -906,7 +1039,7 @@ describe("qa cli runtime", () => {
 
       try {
         await runQaProfileCommand({
-          repoRoot: "/tmp/openclaw-repo",
+          repoRoot: suiteArtifactsDir,
           profile: "all",
           surface: "media",
           category: "media.media-generation",
@@ -935,7 +1068,7 @@ describe("qa cli runtime", () => {
     });
 
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
       profile: "smoke-ci",
     });
 
@@ -960,7 +1093,7 @@ describe("qa cli runtime", () => {
   it("rejects explicit profile selections incompatible with the profile channel", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
         profile: "smoke-ci",
         scenarioIds: ["control-ui-qa-channel-image-roundtrip"],
       }),
@@ -973,7 +1106,7 @@ describe("qa cli runtime", () => {
 
   it("dispatches the Matrix restart scenario through the Crabline smoke profile", async () => {
     await runQaProfileCommand({
-      repoRoot: "/tmp/openclaw-repo",
+      repoRoot: suiteArtifactsDir,
       profile: "smoke-ci",
       scenarioIds: ["matrix-restart-resume"],
     });
@@ -989,7 +1122,7 @@ describe("qa cli runtime", () => {
   it("rejects qa profile runs that do not match taxonomy categories", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
         profile: "smoke-ci",
         surface: "unknown-surface",
       }),
@@ -1002,7 +1135,7 @@ describe("qa cli runtime", () => {
   it("rejects qa profile scenario filters outside the selected taxonomy categories", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
         profile: "smoke-ci",
         category: "channels.outbound-delivery-and-reply-pipeline",
         scenarioIds: ["not-a-real-scenario"],
@@ -1016,7 +1149,7 @@ describe("qa cli runtime", () => {
   it("rejects qa profile runs whose profile is not declared in taxonomy.yaml", async () => {
     await expect(
       runQaProfileCommand({
-        repoRoot: "/tmp/openclaw-repo",
+        repoRoot: suiteArtifactsDir,
         profile: "nightly",
       }),
     ).rejects.toThrow(

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -36,6 +36,7 @@ import {
 } from "./coverage-report.js";
 import { buildQaDockerHarnessImage, writeQaDockerHarnessFiles } from "./docker-harness.js";
 import { runQaDockerUp } from "./docker-up.runtime.js";
+import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
 import type { QaCliBackendAuthMode } from "./gateway-child.js";
 import {
   createMockJsonlReplayCellRunner,
@@ -102,7 +103,11 @@ import {
   runQaSuite,
   runQaSuiteWithInfraRetry,
 } from "./suite-launch.runtime.js";
-import { resolveQaSuiteScenarioChannel, resolveQaSuiteScenarioChannels } from "./suite-planning.js";
+import {
+  resolveQaSuiteOutputDir,
+  resolveQaSuiteScenarioChannel,
+  resolveQaSuiteScenarioChannels,
+} from "./suite-planning.js";
 import {
   readQaSuiteFailedOrSkippedScenarioCountFromFile,
   resolveQaReportOnlyOptionalScenarioNames as resolveQaReportOnlyOptionalScenarioNamesFromCatalog,
@@ -627,6 +632,9 @@ export async function runQaLabSelfCheckCommand(opts: QaLabSelfCheckCommandOption
 
 export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const outputDir = await resolveQaSuiteOutputDir(repoRoot, opts.outputDir);
+  const canonicalEvidencePath = path.join(outputDir, QA_EVIDENCE_FILENAME);
+  await fs.rm(canonicalEvidencePath, { force: true });
   const scenarioPack = readQaScenarioPack();
   const scorecardReport = readQaScorecardTaxonomyReport(scenarioPack.scenarios);
   const profile = normalizeQaRunProfile(
@@ -714,58 +722,67 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
     );
   }
 
-  process.stdout.write(
-    `QA run profile: ${profile}; categories: ${categories.length}; scenarios: ${scenarios.length}\n`,
-  );
-  let evidencePath: string | undefined;
-  let expectedCells: QaProfileEvidencePlan["expectedCells"] = [];
-  let observedCells: QaProfileEvidencePlan["observedCells"] = [];
-  await withTemporaryQaProfileEnv(profile, async () => {
-    const suiteResult = await runQaSuiteCommand({
-      repoRoot,
-      outputDir: opts.outputDir,
-      evidenceMode: opts.evidenceMode,
-      transportId: opts.transportId,
-      providerMode,
-      primaryModel: opts.primaryModel,
-      alternateModel: opts.alternateModel,
-      fastMode: opts.fastMode,
-      failFast: opts.failFast,
-      scenarioIds: scenarios.map((scenario) => scenario.id),
-      explicitScenarioSelection: requestedScenarioIds.length > 0,
-      concurrency: opts.concurrency,
-      allowFailures: opts.allowFailures,
-      channelDriver: profileReport.channelDriver,
-      expandScenarioChannels: true,
+  try {
+    process.stdout.write(
+      `QA run profile: ${profile}; categories: ${categories.length}; scenarios: ${scenarios.length}\n`,
+    );
+    let evidencePath: string | undefined;
+    let expectedCells: QaProfileEvidencePlan["expectedCells"] = [];
+    let observedCells: QaProfileEvidencePlan["observedCells"] = [];
+    await withTemporaryQaProfileEnv(profile, async () => {
+      const suiteResult = await runQaSuiteCommandWithOutputDir(
+        {
+          repoRoot,
+          evidenceMode: opts.evidenceMode,
+          transportId: opts.transportId,
+          providerMode,
+          primaryModel: opts.primaryModel,
+          alternateModel: opts.alternateModel,
+          fastMode: opts.fastMode,
+          failFast: opts.failFast,
+          scenarioIds: scenarios.map((scenario) => scenario.id),
+          explicitScenarioSelection: requestedScenarioIds.length > 0,
+          concurrency: opts.concurrency,
+          allowFailures: opts.allowFailures,
+          channelDriver: profileReport.channelDriver,
+          expandScenarioChannels: true,
+        },
+        outputDir,
+      );
+      evidencePath =
+        suiteResult && "evidencePath" in suiteResult ? suiteResult.evidencePath : undefined;
+      expectedCells =
+        suiteResult && "expectedCells" in suiteResult ? suiteResult.expectedCells : [];
+      observedCells =
+        suiteResult && "observedCells" in suiteResult ? suiteResult.observedCells : [];
     });
-    evidencePath =
-      suiteResult && "evidencePath" in suiteResult ? suiteResult.evidencePath : undefined;
-    expectedCells = suiteResult && "expectedCells" in suiteResult ? suiteResult.expectedCells : [];
-    observedCells = suiteResult && "observedCells" in suiteResult ? suiteResult.observedCells : [];
-  });
-  if (!evidencePath) {
-    throw new Error("qa run --qa-profile did not produce qa-evidence.json.");
+    if (!evidencePath) {
+      throw new Error("qa run --qa-profile did not produce qa-evidence.json.");
+    }
+    const profilePlan = qaProfileEvidencePlan.build({
+      profile,
+      membershipScenarios: taxonomyScenarios,
+      selectedScenarios: scenarios,
+      excludedScenarios: executionSelection.excludedScenarios,
+      expectedCells,
+      observedCells,
+    });
+    await attachQaProfileScorecardEvidenceToFile({
+      evidencePath,
+      evidenceMode: opts.evidenceMode,
+      profile,
+      profilePlan,
+      filters: {
+        surface: opts.surface,
+        category: opts.category,
+      },
+      categories,
+    });
+    process.stdout.write(`QA profile scorecard: ${evidencePath}\n`);
+  } catch (error) {
+    await fs.rm(canonicalEvidencePath, { force: true });
+    throw error;
   }
-  const profilePlan = qaProfileEvidencePlan.build({
-    profile,
-    membershipScenarios: taxonomyScenarios,
-    selectedScenarios: scenarios,
-    excludedScenarios: executionSelection.excludedScenarios,
-    expectedCells,
-    observedCells,
-  });
-  await attachQaProfileScorecardEvidenceToFile({
-    evidencePath,
-    evidenceMode: opts.evidenceMode,
-    profile,
-    profilePlan,
-    filters: {
-      surface: opts.surface,
-      category: opts.category,
-    },
-    categories,
-  });
-  process.stdout.write(`QA profile scorecard: ${evidencePath}\n`);
 }
 
 function selectQaScenarioDefinitionsForChannelResolution(params: {
@@ -854,8 +871,12 @@ function resolveQaReportOnlyOptionalScenarioNames(params: {
   return resolveQaReportOnlyOptionalScenarioNamesFromCatalog(readQaScenarioPack().scenarios);
 }
 
-export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
+async function runQaSuiteCommandWithOutputDir(
+  opts: QaSuiteCommandOptions,
+  resolvedOutputDir?: string,
+) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const outputDir = resolvedOutputDir ?? resolveRepoRelativeOutputDir(repoRoot, opts.outputDir);
   const transportId = normalizeQaTransportId(opts.transportId);
   const runner = (opts.runner ?? "host").trim().toLowerCase();
   const runtimePair = parseQaRuntimePair(opts.runtimePair);
@@ -985,7 +1006,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     const thinkingDefault = parseQaThinkingLevel("--thinking", opts.thinking);
     const result = await runQaMultipass({
       repoRoot,
-      outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
+      outputDir,
       transportId,
       ...(opts.providerMode !== undefined ? { providerMode } : {}),
       primaryModel,
@@ -1040,7 +1061,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
   const thinkingDefault = parseQaThinkingLevel("--thinking", opts.thinking);
   const runtimeResult = await runQaSuite({
     repoRoot,
-    outputDir: resolveRepoRelativeOutputDir(repoRoot, opts.outputDir),
+    outputDir,
     evidenceMode: opts.evidenceMode,
     transportId,
     channelDriver,
@@ -1129,6 +1150,10 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     }
   }
   return undefined;
+}
+
+export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
+  return await runQaSuiteCommandWithOutputDir(opts);
 }
 
 export async function runQaParityReportCommand(opts: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed or invalid QA profile run could leave a previously successful `qa-evidence.json` in the reused output directory, allowing later planning or release automation to mistake stale evidence for the current run's result.

Related context:

- #119957 and #119868 are broad open drafts with semantic overlap; this PR supersedes only their stale-success evidence portion.
- #119761 is merged complementary execution-attestation work.
- #119572 is merged complementary workflow-timeout and status-artifact work.

## Why This Change Was Made

The root cause was lifecycle ownership: `runQaProfileCommand` consumed the canonical profile evidence path without first invalidating evidence owned by an earlier run, and failure paths did not reliably remove partially rewritten evidence.

The canonical fix resolves the output directory once at profile-run entry, removes the canonical evidence before planning or execution, passes that resolved directory through the suite command, and removes canonical evidence again on any profile planning, suite, or attachment failure. The QA profile command remains the lifecycle owner. No paths were removed.

Production LOC: +79/-54 (net +25). Test LOC: +146/-13.

## User Impact

Operators and release automation can trust that a failed QA profile run cannot appear successful because an older run left canonical evidence behind. Successful runs still write the profile scorecard and preserve the direct-flow watch URL.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/cli.runtime.test.ts` - 144 tests passed.
- `git diff --check HEAD^ HEAD` - passed.
- `node_modules/.bin/oxfmt --check extensions/qa-lab/src/cli.runtime.ts extensions/qa-lab/src/cli.runtime.test.ts` - passed for both files.
- Commit-mode autoreview for `28376512747a04bd22ec8c027e9a11f0c0e882f6` - clean, no accepted/actionable findings.
- Exact scope: `extensions/qa-lab/src/cli.runtime.ts` and `extensions/qa-lab/src/cli.runtime.test.ts`.
- No `CHANGELOG.md` change; release-note context is captured here.

AI-assisted: yes.

Punchcard-Session: cobalt-valley-meadow-mg
