### PR TITLE
improve(release): verify Linux Gateway-node compatibility

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -101,11 +101,6 @@ on:
         required: false
         default: ""
         type: string
-      gateway_node_compat_producer_job_name:
-        description: Exact Actions job name that uploads the compatibility input artifacts
-        required: false
-        default: prepare
-        type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
         required: false
@@ -210,11 +205,6 @@ on:
         required: false
         default: ""
         type: string
-      gateway_node_compat_producer_job_name:
-        description: Exact Actions job name that uploads the compatibility input artifacts
-        required: false
-        default: prepare
-        type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
         required: false
@@ -237,7 +227,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: openclaw-cross-os-release-checks-${{ inputs.ref }}-${{ inputs.provider }}-${{ inputs.mode }}
+  group: openclaw-cross-os-release-checks-${{ inputs.ref }}-${{ inputs.provider }}-${{ inputs.mode }}-${{ inputs.suite_filter || 'all' }}
   cancel-in-progress: ${{ inputs.ref == 'main' }}
 
 env:
@@ -274,7 +264,6 @@ jobs:
       candidate_preparation_enabled: ${{ steps.matrix.outputs.candidate_preparation_enabled }}
       cross_os_release_checks_enabled: ${{ steps.matrix.outputs.cross_os_release_checks_enabled }}
       gateway_node_compat_enabled: ${{ steps.matrix.outputs.gateway_node_compat_enabled }}
-      gateway_node_compat_producer_job_name: ${{ inputs.gateway_node_compat_producer_job_name }}
       gateway_node_compat_producer_run_attempt: ${{ github.run_attempt }}
       matrix: ${{ steps.matrix.outputs.value }}
       packaged_upgrade_enabled: ${{ steps.matrix.outputs.packaged_upgrade_enabled }}
@@ -1110,8 +1099,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        architecture: [x64, arm64]
-    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || inputs.ubuntu_runner || vars.OPENCLAW_RELEASE_CHECKS_UBUNTU_RUNNER || 'ubuntu-24.04' }}
+        include:
+          - architecture: x64
+            runner: ubuntu-24.04
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 75
     steps:
       - name: Checkout workflow repo
@@ -1189,6 +1182,7 @@ jobs:
           }
 
       - name: Produce six canonical compatibility cases
+        id: produce_compat
         working-directory: workflow
         env:
           BASELINE_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.compat_baseline_artifact_digest }}
@@ -1204,7 +1198,6 @@ jobs:
           BASELINE_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.compat_baseline_artifact_run_id }}
           CANDIDATE_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.candidate_artifact_run_attempt }}
           CANDIDATE_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.candidate_artifact_run_id }}
-          GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME: ${{ needs.prepare.outputs.gateway_node_compat_producer_job_name }}
           GATEWAY_NODE_COMPAT_RUN_WORKFLOW_REF: ${{ github.workflow_ref }}
           GATEWAY_NODE_COMPAT_WORKFLOW_SHA: ${{ needs.prepare.outputs.workflow_ref }}
           OUTPUT_DIR: ${{ runner.temp }}/gateway-node-compat/evidence
@@ -1213,7 +1206,6 @@ jobs:
           node scripts/openclaw-cross-os-release-checks.ts \
             --gateway-node-compat true \
             --gateway-node-compat-output-dir "$OUTPUT_DIR" \
-            --gateway-node-compat-producer-job-name "$GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME" \
             --candidate-tgz "$ROOT/candidate/$CANDIDATE_FILE_NAME" \
             --candidate-version "$CANDIDATE_VERSION" \
             --candidate-source-sha "$CANDIDATE_SOURCE_SHA" \
@@ -1243,9 +1235,13 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Gateway/node compatibility diagnostics
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.produce_compat.outcome != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openclaw-gateway-node-linux-compat-diagnostics-${{ matrix.architecture }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/gateway-node-compat/evidence/logs/*.log
-          if-no-files-found: ignore
+          path: |
+            ${{ runner.temp }}/gateway-node-compat/evidence/diagnostics/producer-failure.json
+            ${{ runner.temp }}/gateway-node-compat/evidence/diagnostics/raw/*.json
+            ${{ runner.temp }}/gateway-node-compat/evidence/*.json
+            ${{ runner.temp }}/gateway-node-compat/evidence/logs/*.log
+          if-no-files-found: error

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -101,6 +101,11 @@ on:
         required: false
         default: ""
         type: string
+      gateway_node_compat_producer_job_name:
+        description: Exact Actions job name that uploads the compatibility input artifacts
+        required: false
+        default: prepare
+        type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
         required: false
@@ -205,6 +210,11 @@ on:
         required: false
         default: ""
         type: string
+      gateway_node_compat_producer_job_name:
+        description: Exact Actions job name that uploads the compatibility input artifacts
+        required: false
+        default: prepare
+        type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
         required: false
@@ -248,6 +258,12 @@ jobs:
       baseline_file_name: ${{ steps.baseline_metadata.outputs.file_name }}
       baseline_sha256: ${{ steps.baseline_metadata.outputs.sha256 }}
       baseline_spec: ${{ steps.baseline.outputs.value }}
+      compat_baseline_artifact_digest: ${{ steps.upload_compat_baseline.outputs.artifact-digest }}
+      compat_baseline_artifact_id: ${{ steps.upload_compat_baseline.outputs.artifact-id }}
+      compat_baseline_artifact_run_attempt: ${{ github.run_attempt }}
+      compat_baseline_artifact_run_id: ${{ github.run_id }}
+      compat_baseline_file_name: openclaw-2026.5.7.tgz
+      compat_baseline_sha256: ${{ steps.compat_baseline_metadata.outputs.sha256 }}
       candidate_artifact_digest: ${{ steps.upload_candidate.outputs.artifact-digest }}
       candidate_artifact_id: ${{ steps.upload_candidate.outputs.artifact-id }}
       candidate_artifact_run_attempt: ${{ github.run_attempt }}
@@ -255,34 +271,16 @@ jobs:
       candidate_file_name: ${{ steps.candidate_metadata.outputs.file_name }}
       candidate_sha256: ${{ steps.candidate_metadata.outputs.sha256 }}
       candidate_version: ${{ steps.candidate_metadata.outputs.version }}
+      candidate_preparation_enabled: ${{ steps.matrix.outputs.candidate_preparation_enabled }}
+      cross_os_release_checks_enabled: ${{ steps.matrix.outputs.cross_os_release_checks_enabled }}
+      gateway_node_compat_enabled: ${{ steps.matrix.outputs.gateway_node_compat_enabled }}
+      gateway_node_compat_producer_job_name: ${{ inputs.gateway_node_compat_producer_job_name }}
+      gateway_node_compat_producer_run_attempt: ${{ github.run_attempt }}
       matrix: ${{ steps.matrix.outputs.value }}
+      packaged_upgrade_enabled: ${{ steps.matrix.outputs.packaged_upgrade_enabled }}
       source_sha: ${{ steps.candidate_metadata.outputs.source_sha }}
       workflow_ref: ${{ steps.workflow_ref.outputs.value }}
     steps:
-      - name: Validate provider secret availability
-        env:
-          PROVIDER: ${{ inputs.provider }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
-        run: |
-          set -euo pipefail
-          case "${PROVIDER}" in
-            openai)
-              [[ -n "${OPENAI_API_KEY}" ]] || { echo "Missing OPENAI_API_KEY secret." >&2; exit 1; }
-              ;;
-            anthropic)
-              [[ -n "${ANTHROPIC_API_KEY}" ]] || { echo "Missing ANTHROPIC_API_KEY secret." >&2; exit 1; }
-              ;;
-            minimax)
-              [[ -n "${MINIMAX_API_KEY}" ]] || { echo "Missing MINIMAX_API_KEY secret." >&2; exit 1; }
-              ;;
-            *)
-              echo "Unsupported provider: ${PROVIDER}" >&2
-              exit 1
-              ;;
-          esac
-
       - name: Resolve workflow ref
         id: workflow_ref
         env:
@@ -389,8 +387,86 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Resolve runner matrix
+        id: matrix
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_SUITE_FILTER: ${{ inputs.suite_filter }}
+          INPUT_UBUNTU_RUNNER: ${{ inputs.ubuntu_runner }}
+          INPUT_WINDOWS_RUNNER: ${{ inputs.windows_runner }}
+          INPUT_MACOS_RUNNER: ${{ inputs.macos_runner }}
+          VAR_UBUNTU_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_UBUNTU_RUNNER }}
+          VAR_WINDOWS_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_WINDOWS_RUNNER }}
+          VAR_MACOS_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_MACOS_RUNNER }}
+        run: |
+          set -euo pipefail
+          SELECTION_JSON="$(
+            node --experimental-strip-types workflow/scripts/openclaw-cross-os-release-checks.ts \
+              --resolve-selection true \
+              --ref "${INPUT_REF}" \
+              --mode "${INPUT_MODE}" \
+              --suite-filter "${INPUT_SUITE_FILTER}" \
+              --ubuntu-runner "${INPUT_UBUNTU_RUNNER}" \
+              --windows-runner "${INPUT_WINDOWS_RUNNER}" \
+              --macos-runner "${INPUT_MACOS_RUNNER}"
+          )"
+          matrix="$(jq -ce '.matrix | select(type == "object")' <<<"$SELECTION_JSON")"
+          candidate_preparation_enabled="$(jq -er '.candidatePreparationEnabled | select(type == "boolean") | tostring' <<<"$SELECTION_JSON")"
+          cross_os_release_checks_enabled="$(jq -er '.crossOsReleaseChecksEnabled | select(type == "boolean") | tostring' <<<"$SELECTION_JSON")"
+          gateway_node_compat_enabled="$(jq -er '.gatewayNodeCompatEnabled | select(type == "boolean") | tostring' <<<"$SELECTION_JSON")"
+          packaged_upgrade_enabled="$(jq -er '.packagedUpgradeEnabled | select(type == "boolean") | tostring' <<<"$SELECTION_JSON")"
+          for value in \
+            "$matrix" \
+            "$candidate_preparation_enabled" \
+            "$cross_os_release_checks_enabled" \
+            "$gateway_node_compat_enabled" \
+            "$packaged_upgrade_enabled"; do
+            [[ -n "$value" ]] || {
+              echo "Cross-OS selection output is blank." >&2
+              exit 1
+            }
+          done
+          {
+            echo "value=$matrix"
+            echo "candidate_preparation_enabled=$candidate_preparation_enabled"
+            echo "cross_os_release_checks_enabled=$cross_os_release_checks_enabled"
+            echo "gateway_node_compat_enabled=$gateway_node_compat_enabled"
+            echo "packaged_upgrade_enabled=$packaged_upgrade_enabled"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate provider secret availability
+        if: steps.matrix.outputs.cross_os_release_checks_enabled == 'true'
+        env:
+          PROVIDER: ${{ inputs.provider }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+        run: |
+          set -euo pipefail
+          case "${PROVIDER}" in
+            openai)
+              [[ -n "${OPENAI_API_KEY}" ]] || { echo "Missing OPENAI_API_KEY secret." >&2; exit 1; }
+              ;;
+            anthropic)
+              [[ -n "${ANTHROPIC_API_KEY}" ]] || { echo "Missing ANTHROPIC_API_KEY secret." >&2; exit 1; }
+              ;;
+            minimax)
+              [[ -n "${MINIMAX_API_KEY}" ]] || { echo "Missing MINIMAX_API_KEY secret." >&2; exit 1; }
+              ;;
+            *)
+              echo "Unsupported provider: ${PROVIDER}" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Validate provided candidate artifact binding
-        if: inputs.candidate_artifact_name != '' || inputs.candidate_artifact_id != '' || inputs.candidate_artifact_digest != '' || inputs.candidate_artifact_run_id != '' || inputs.candidate_artifact_run_attempt != '' || inputs.candidate_file_name != '' || inputs.candidate_sha256 != '' || inputs.candidate_version != '' || inputs.candidate_source_sha != ''
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true' && (inputs.candidate_artifact_name != '' || inputs.candidate_artifact_id != '' || inputs.candidate_artifact_digest != '' || inputs.candidate_artifact_run_id != '' || inputs.candidate_artifact_run_attempt != '' || inputs.candidate_file_name != '' || inputs.candidate_sha256 != '' || inputs.candidate_version != '' || inputs.candidate_source_sha != '')
         env:
           ARTIFACT_DIGEST: ${{ inputs.candidate_artifact_digest }}
           ARTIFACT_ID: ${{ inputs.candidate_artifact_id }}
@@ -458,7 +534,7 @@ jobs:
             }
 
       - name: Checkout public source ref
-        if: inputs.candidate_artifact_name == ''
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true' && inputs.candidate_artifact_name == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.OPENCLAW_REPOSITORY }}
@@ -469,12 +545,8 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       - name: Setup pnpm
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true'
         uses: ./workflow/.github/actions/setup-pnpm-store-cache
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -483,17 +555,18 @@ jobs:
           use-actions-cache: ${{ inputs.candidate_artifact_name == '' && 'true' || 'false' }}
 
       - name: Ensure pnpm store cache directory exists
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true'
         run: mkdir -p "$(pnpm store path --silent)"
 
       - name: Install workflow validation dependencies
-        if: inputs.candidate_artifact_name != ''
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true' && inputs.candidate_artifact_name != ''
         working-directory: workflow
         env:
           CI: "true"
         run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Build candidate artifact once
-        if: inputs.candidate_artifact_name == ''
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true' && inputs.candidate_artifact_name == ''
         env:
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare
         run: |
@@ -503,7 +576,7 @@ jobs:
             --output-dir "${OUTPUT_DIR}"
 
       - name: Download provided candidate artifact
-        if: inputs.candidate_artifact_name != ''
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true' && inputs.candidate_artifact_name != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ inputs.candidate_artifact_id }}
@@ -512,7 +585,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Resolve provided candidate package
-        if: inputs.candidate_artifact_name != ''
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true' && inputs.candidate_artifact_name != ''
         env:
           INPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/input
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package
@@ -570,7 +643,7 @@ jobs:
           NODE
 
       - name: Resolve baseline package spec
-        if: ${{ inputs.mode != 'fresh' }}
+        if: steps.matrix.outputs.packaged_upgrade_enabled == 'true'
         id: baseline
         env:
           INPUT_PREVIOUS_VERSION: ${{ inputs.previous_version }}
@@ -584,7 +657,7 @@ jobs:
           echo "value=openclaw@${BASELINE_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Pack baseline artifact
-        if: ${{ inputs.mode != 'fresh' }}
+        if: steps.matrix.outputs.packaged_upgrade_enabled == 'true'
         env:
           BASELINE_SPEC: ${{ steps.baseline.outputs.value }}
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/baseline
@@ -593,6 +666,7 @@ jobs:
           timeout --preserve-status 300s npm pack --ignore-scripts --json "${BASELINE_SPEC}" --pack-destination "${OUTPUT_DIR}" > "${OUTPUT_DIR}/pack.json"
 
       - name: Capture candidate metadata
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true'
         id: candidate_metadata
         env:
           CANDIDATE_JSON: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/candidate.json
@@ -636,7 +710,7 @@ jobs:
           NODE
 
       - name: Capture baseline metadata
-        if: ${{ inputs.mode != 'fresh' }}
+        if: steps.matrix.outputs.packaged_upgrade_enabled == 'true'
         id: baseline_metadata
         working-directory: workflow
         env:
@@ -671,6 +745,7 @@ jobs:
           NODE
 
       - name: Upload candidate artifact
+        if: steps.matrix.outputs.candidate_preparation_enabled == 'true'
         id: upload_candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -679,7 +754,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload baseline artifact
-        if: ${{ inputs.mode != 'fresh' }}
+        if: steps.matrix.outputs.packaged_upgrade_enabled == 'true'
         id: upload_baseline
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -687,32 +762,30 @@ jobs:
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/baseline/${{ steps.baseline_metadata.outputs.file_name }}
           if-no-files-found: error
 
-      - name: Resolve runner matrix
-        id: matrix
+      - name: Pack Gateway compatibility baseline
+        if: steps.matrix.outputs.gateway_node_compat_enabled == 'true'
+        id: compat_baseline_metadata
         env:
-          INPUT_REF: ${{ inputs.ref }}
-          INPUT_MODE: ${{ inputs.mode }}
-          INPUT_SUITE_FILTER: ${{ inputs.suite_filter }}
-          INPUT_UBUNTU_RUNNER: ${{ inputs.ubuntu_runner }}
-          INPUT_WINDOWS_RUNNER: ${{ inputs.windows_runner }}
-          INPUT_MACOS_RUNNER: ${{ inputs.macos_runner }}
-          VAR_UBUNTU_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_UBUNTU_RUNNER }}
-          VAR_WINDOWS_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_WINDOWS_RUNNER }}
-          VAR_MACOS_RUNNER: ${{ vars.OPENCLAW_RELEASE_CHECKS_MACOS_RUNNER }}
+          OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/gateway-compat-baseline
         run: |
-          MATRIX_JSON="$(bash workflow/scripts/github/run-openclaw-cross-os-release-checks.sh \
-            --resolve-matrix \
-            --ref "${INPUT_REF}" \
-            --mode "${INPUT_MODE}" \
-            --suite-filter "${INPUT_SUITE_FILTER}" \
-            --ubuntu-runner "${INPUT_UBUNTU_RUNNER}" \
-            --windows-runner "${INPUT_WINDOWS_RUNNER}" \
-            --macos-runner "${INPUT_MACOS_RUNNER}")"
-          echo "value=${MATRIX_JSON}" >> "$GITHUB_OUTPUT"
+          mkdir -p "$OUTPUT_DIR"
+          timeout --preserve-status 300s npm pack --ignore-scripts --json openclaw@2026.5.7 --pack-destination "$OUTPUT_DIR" >"$OUTPUT_DIR/pack.json"
+          test -f "$OUTPUT_DIR/openclaw-2026.5.7.tgz"
+          echo "sha256=$(sha256sum "$OUTPUT_DIR/openclaw-2026.5.7.tgz" | cut -d' ' -f1)" >>"$GITHUB_OUTPUT"
+
+      - name: Upload Gateway compatibility baseline
+        if: steps.matrix.outputs.gateway_node_compat_enabled == 'true'
+        id: upload_compat_baseline
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-gateway-compat-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/gateway-compat-baseline/openclaw-2026.5.7.tgz
+          if-no-files-found: error
 
   cross_os_release_checks:
     name: "${{ matrix.display_name }} / ${{ matrix.suite_label }}"
     needs: prepare
+    if: needs.prepare.outputs.cross_os_release_checks_enabled == 'true'
     continue-on-error: ${{ inputs.advisory }}
     strategy:
       fail-fast: false
@@ -1028,3 +1101,151 @@ jobs:
           name: openclaw-cross-os-release-checks-${{ matrix.artifact_name }}-${{ matrix.suite }}-${{ github.run_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
           if-no-files-found: error
+
+  gateway_node_linux_compat:
+    name: Gateway/node packaged compatibility / Linux / ${{ matrix.architecture }}
+    needs: prepare
+    if: needs.prepare.outputs.gateway_node_compat_enabled == 'true'
+    continue-on-error: ${{ inputs.advisory }}
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: [x64, arm64]
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || inputs.ubuntu_runner || vars.OPENCLAW_RELEASE_CHECKS_UBUNTU_RUNNER || 'ubuntu-24.04' }}
+    timeout-minutes: 75
+    steps:
+      - name: Checkout workflow repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ env.OPENCLAW_REPOSITORY }}
+          ref: ${{ needs.prepare.outputs.workflow_ref }}
+          path: workflow
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        uses: ./workflow/.github/actions/setup-pnpm-store-cache
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-file: workflow/package.json
+          lockfile-path: workflow/pnpm-lock.yaml
+          use-actions-cache: "false"
+
+      - name: Install trusted observer dependencies
+        working-directory: workflow
+        env:
+          CI: "true"
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
+      - name: Download candidate package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare.outputs.candidate_artifact_id }}
+          path: ${{ runner.temp }}/gateway-node-compat/candidate
+
+      - name: Download pinned baseline package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare.outputs.compat_baseline_artifact_id }}
+          path: ${{ runner.temp }}/gateway-node-compat/baseline
+
+      - name: Capture current-run artifact provenance
+        env:
+          CANDIDATE_ARTIFACT_ID: ${{ needs.prepare.outputs.candidate_artifact_id }}
+          BASELINE_ARTIFACT_ID: ${{ needs.prepare.outputs.compat_baseline_artifact_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ needs.prepare.outputs.gateway_node_compat_producer_run_attempt }}
+          GH_TOKEN: ${{ github.token }}
+          METADATA_DIR: ${{ runner.temp }}/gateway-node-compat/metadata
+        run: |
+          set -euo pipefail
+          mkdir -p "$METADATA_DIR"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${CANDIDATE_ARTIFACT_ID}" >"$METADATA_DIR/candidate-artifact.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${BASELINE_ARTIFACT_ID}" >"$METADATA_DIR/baseline-artifact.json"
+          [[ "$PRODUCER_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Gateway/node compatibility producer run attempt is invalid"
+            exit 1
+          }
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${PRODUCER_RUN_ATTEMPT}" >"$METADATA_DIR/run.json"
+          mkdir -p "$METADATA_DIR/jobs"
+          collected=0
+          for page in $(seq 1 10); do
+            page_path="$METADATA_DIR/jobs/page-${page}.json"
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${PRODUCER_RUN_ATTEMPT}/jobs?per_page=100&page=${page}" >"$page_path"
+            page_count="$(jq -er '.jobs | length | select(. <= 100)' "$page_path")"
+            total_count="$(jq -er '.total_count | select(type == "number" and . >= 0 and . <= 1000)' "$page_path")"
+            collected=$((collected + page_count))
+            if (( collected >= total_count )); then
+              break
+            fi
+          done
+          (( collected == total_count )) || {
+            echo "::error::Actions workflow job inventory exceeds the bounded ten-page fetch"
+            exit 1
+          }
+
+      - name: Produce six canonical compatibility cases
+        working-directory: workflow
+        env:
+          BASELINE_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.compat_baseline_artifact_digest }}
+          BASELINE_FILE_NAME: ${{ needs.prepare.outputs.compat_baseline_file_name }}
+          BASELINE_SHA256: ${{ needs.prepare.outputs.compat_baseline_sha256 }}
+          CANDIDATE_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.candidate_artifact_digest }}
+          CANDIDATE_FILE_NAME: ${{ needs.prepare.outputs.candidate_file_name }}
+          CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
+          CANDIDATE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          CANDIDATE_VERSION: ${{ needs.prepare.outputs.candidate_version }}
+          GATEWAY_NODE_COMPAT_EXPECTED_ARCH: ${{ matrix.architecture }}
+          BASELINE_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.compat_baseline_artifact_run_attempt }}
+          BASELINE_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.compat_baseline_artifact_run_id }}
+          CANDIDATE_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.candidate_artifact_run_attempt }}
+          CANDIDATE_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.candidate_artifact_run_id }}
+          GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME: ${{ needs.prepare.outputs.gateway_node_compat_producer_job_name }}
+          GATEWAY_NODE_COMPAT_RUN_WORKFLOW_REF: ${{ github.workflow_ref }}
+          GATEWAY_NODE_COMPAT_WORKFLOW_SHA: ${{ needs.prepare.outputs.workflow_ref }}
+          OUTPUT_DIR: ${{ runner.temp }}/gateway-node-compat/evidence
+          ROOT: ${{ runner.temp }}/gateway-node-compat
+        run: |
+          node scripts/openclaw-cross-os-release-checks.ts \
+            --gateway-node-compat true \
+            --gateway-node-compat-output-dir "$OUTPUT_DIR" \
+            --gateway-node-compat-producer-job-name "$GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME" \
+            --candidate-tgz "$ROOT/candidate/$CANDIDATE_FILE_NAME" \
+            --candidate-version "$CANDIDATE_VERSION" \
+            --candidate-source-sha "$CANDIDATE_SOURCE_SHA" \
+            --candidate-sha256 "$CANDIDATE_SHA256" \
+            --candidate-artifact-digest "$CANDIDATE_ARTIFACT_DIGEST" \
+            --candidate-artifact-run-id "$CANDIDATE_ARTIFACT_RUN_ID" \
+            --candidate-artifact-run-attempt "$CANDIDATE_ARTIFACT_RUN_ATTEMPT" \
+            --candidate-artifact-metadata "$ROOT/metadata/candidate-artifact.json" \
+            --candidate-workflow-run-metadata "$ROOT/metadata/run.json" \
+            --candidate-workflow-jobs-metadata "$ROOT/metadata/jobs" \
+            --compat-baseline-tgz "$ROOT/baseline/$BASELINE_FILE_NAME" \
+            --compat-baseline-version "2026.5.7" \
+            --compat-baseline-source-sha "" \
+            --compat-baseline-sha256 "$BASELINE_SHA256" \
+            --compat-baseline-artifact-digest "$BASELINE_ARTIFACT_DIGEST" \
+            --compat-baseline-artifact-run-id "$BASELINE_ARTIFACT_RUN_ID" \
+            --compat-baseline-artifact-run-attempt "$BASELINE_ARTIFACT_RUN_ATTEMPT" \
+            --compat-baseline-artifact-metadata "$ROOT/metadata/baseline-artifact.json" \
+            --compat-baseline-workflow-run-metadata "$ROOT/metadata/run.json" \
+            --compat-baseline-workflow-jobs-metadata "$ROOT/metadata/jobs"
+
+      - name: Upload Gateway/node compatibility evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-gateway-node-linux-compat-${{ matrix.architecture }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/gateway-node-compat/evidence/*.json
+          if-no-files-found: error
+
+      - name: Upload Gateway/node compatibility diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-gateway-node-linux-compat-diagnostics-${{ matrix.architecture }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/gateway-node-compat/evidence/logs/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -814,6 +814,7 @@ jobs:
       candidate_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
       candidate_version: ${{ needs.prepare_release_package.outputs.package_version }}
       candidate_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
+      gateway_node_compat_producer_job_name: cross_os_release_checks / prepare
       openai_model: openai/gpt-5.6-luna
       ubuntu_runner: ubuntu-24.04
       windows_runner: windows-2025

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -814,7 +814,6 @@ jobs:
       candidate_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
       candidate_version: ${{ needs.prepare_release_package.outputs.package_version }}
       candidate_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
-      gateway_node_compat_producer_job_name: cross_os_release_checks / prepare
       openai_model: openai/gpt-5.6-luna
       ubuntu_runner: ubuntu-24.04
       windows_runner: windows-2025

--- a/scripts/gateway-node-compat-case.ts
+++ b/scripts/gateway-node-compat-case.ts
@@ -38,6 +38,10 @@ const GATEWAY_GID = 65532;
 const NODE_UID = 65533;
 const NODE_GID = 65533;
 const CLI_OUTPUT_LIMIT_BYTES = 1024 * 1024;
+const CLI_FAILURE_SUMMARY_LIMIT = 512;
+const CHILD_STOP_GRACE_MS = 5_000;
+const CHILD_KILL_WAIT_MS = 5_000;
+const childExitPromises = new WeakMap<ChildProcess, Promise<number>>();
 const SYSTEM_WHICH_OPERATION = {
   command: "system.which",
   params: { bins: ["node"] },
@@ -131,17 +135,26 @@ async function main() {
     try {
       let operation: unknown = null;
       if (input.outcome === "passed") {
-        operation = await approveAndInvoke({
+        let latestCliFailure: string | null = null;
+        await approveAndInvoke({
           caseId: input.caseId,
-          cli: (args) =>
-            cliJson(
+          cli: async (args) => {
+            const result = await cliJson(
               gateway.cli,
               gatewayCliArgs(args, `ws://127.0.0.1:${GATEWAY_PORT}`, token),
               gatewayEnv,
-            ),
+            );
+            // Polling may fail transiently; retain the latest bounded failure for a terminal error.
+            if (result.failure) {
+              latestCliFailure = result.failure;
+            }
+            return result.value;
+          },
+          cliFailureSummary: () => latestCliFailure,
           nodeChild: startNode(),
           startNode,
         });
+        operation = observer.readOperation();
       } else {
         const disjointHome = prepareRuntimeHome({
           root: runtimeRoot,
@@ -181,11 +194,11 @@ async function main() {
       await observer.close();
     }
   } finally {
-    for (const child of children) {
-      child.kill("SIGTERM");
+    try {
+      await Promise.all([...children].map((child) => stopChild(child)));
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true });
     }
-    await Promise.all([...children].map(waitForExit));
-    rmSync(runtimeRoot, { recursive: true, force: true });
   }
 }
 
@@ -276,6 +289,7 @@ function start(
     gid,
   });
   children.add(child);
+  void waitForExit(child);
   child.once("close", () => children.delete(child));
   return child;
 }
@@ -283,7 +297,7 @@ function start(
 async function waitForPort(port: number, child: ChildProcess) {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
-    if (child.exitCode !== null) {
+    if (isChildTerminal(child)) {
       throw new Error(`Gateway exited before opening port ${port}.`);
     }
     const connected = await new Promise<boolean>((resolvePromise) => {
@@ -310,6 +324,7 @@ async function waitForPort(port: number, child: ChildProcess) {
 export async function approveAndInvoke(params: {
   caseId: string;
   cli: (args: string[]) => Promise<unknown>;
+  cliFailureSummary?: () => string | null;
   nodeChild: ChildProcess;
   startNode: () => ChildProcess;
   stopNode?: (child: ChildProcess) => Promise<void>;
@@ -324,13 +339,17 @@ export async function approveAndInvoke(params: {
   const approvedDeviceRequests = new Set<string>();
   const approvedNodeRequests = new Set<string>();
   let nodeChild = params.nodeChild;
+  const failure = (message: string) => {
+    const summary = params.cliFailureSummary?.();
+    return new Error(summary ? `${message} Last CLI failure: ${summary}` : message);
+  };
   const matchesNode = (entry: unknown) =>
     isRecord(entry) &&
     entry.displayName === params.caseId &&
     (entry.role === "node" || (Array.isArray(entry.roles) && entry.roles.includes("node")));
   while (now() < deadline) {
-    if (nodeChild.exitCode !== null) {
-      throw new Error("Node exited before invocation.");
+    if (isChildTerminal(nodeChild)) {
+      throw failure("Node exited before invocation.");
     }
 
     const devices = await params.cli(["devices", "list"]);
@@ -430,7 +449,7 @@ export async function approveAndInvoke(params: {
       JSON.stringify(operation.params),
     ]);
     if (!isRecord(result) || result.ok !== true || result.command !== operation.command) {
-      throw new Error(`Approved node operation failed for ${params.caseId}.`);
+      throw failure(`Approved node operation failed for ${params.caseId}.`);
     }
     const payload = isRecord(result.payload) ? result.payload : {};
     const bins = isRecord(payload.bins) ? payload.bins : {};
@@ -445,7 +464,7 @@ export async function approveAndInvoke(params: {
       result: { bins: { node: bins.node } },
     };
   }
-  throw new Error(`Timed out invoking ${params.caseId}.`);
+  throw failure(`Timed out invoking ${params.caseId}.`);
 }
 
 export function resolveApprovedNodeOperation(node: unknown) {
@@ -461,15 +480,60 @@ export function resolveApprovedNodeOperation(node: unknown) {
   return commands.includes(SYSTEM_WHICH_OPERATION.command) ? SYSTEM_WHICH_OPERATION : null;
 }
 
+export function buildObservedNodeOperation(requestPayload: unknown, resultParams: unknown) {
+  const request = isRecord(requestPayload) ? requestPayload : {};
+  const result = isRecord(resultParams) ? resultParams : {};
+  const requestParams =
+    typeof request.paramsJSON === "string" ? JSON.parse(request.paramsJSON) : undefined;
+  const resultPayload =
+    typeof result.payloadJSON === "string" ? JSON.parse(result.payloadJSON) : result.payload;
+  if (
+    typeof request.id !== "string" ||
+    typeof request.nodeId !== "string" ||
+    request.command !== SYSTEM_WHICH_OPERATION.command ||
+    !isDeepStrictEqual(requestParams, SYSTEM_WHICH_OPERATION.params) ||
+    result.id !== request.id ||
+    result.nodeId !== request.nodeId ||
+    result.ok !== true ||
+    !isRecord(resultPayload) ||
+    !isRecord(resultPayload.bins) ||
+    typeof resultPayload.bins.node !== "string" ||
+    !resultPayload.bins.node
+  ) {
+    throw new Error("Observer did not capture one matching successful node invocation.");
+  }
+  return {
+    method: "node.invoke",
+    command: request.command,
+    params: requestParams,
+    ok: true,
+    result: { bins: { node: resultPayload.bins.node } },
+  };
+}
+
 function gatewayCliArgs(args: string[], url: string, token: string) {
   return [...args, "--json", "--url", url, "--token", token];
 }
 
-async function stopChild(child: ChildProcess) {
-  if (child.exitCode === null) {
+export function isChildTerminal(child: Pick<ChildProcess, "exitCode" | "signalCode">): boolean {
+  return child.exitCode != null || child.signalCode != null;
+}
+
+export async function stopChild(
+  child: ChildProcess,
+  options: { graceMs?: number; killWaitMs?: number } = {},
+) {
+  const exit = waitForExit(child);
+  if (!isChildTerminal(child)) {
     child.kill("SIGTERM");
   }
-  await waitForExit(child);
+  if (await waitForExitWithin(exit, options.graceMs ?? CHILD_STOP_GRACE_MS)) {
+    return;
+  }
+  child.kill("SIGKILL");
+  if (!(await waitForExitWithin(exit, options.killWaitMs ?? CHILD_KILL_WAIT_MS))) {
+    throw new Error("Child process did not exit after SIGKILL.");
+  }
 }
 
 async function cliJson(command: string, args: string[], env: NodeJS.ProcessEnv) {
@@ -479,6 +543,7 @@ async function cliJson(command: string, args: string[], env: NodeJS.ProcessEnv) 
     uid: GATEWAY_UID,
     gid: GATEWAY_GID,
   });
+  const exit = waitForExit(child);
   const stdout: Buffer[] = [];
   const stderr: Buffer[] = [];
   let capturedBytes = 0;
@@ -497,15 +562,96 @@ async function cliJson(command: string, args: string[], env: NodeJS.ProcessEnv) 
   };
   child.stdout.on("data", capture(stdout));
   child.stderr.on("data", capture(stderr));
-  const status = await waitForExit(child);
+  const status: number = await exit;
   if (exceededLimit) {
     throw new Error(`CLI output exceeded ${CLI_OUTPUT_LIMIT_BYTES} bytes.`);
   }
   if (status !== 0) {
-    return null;
+    return {
+      value: null,
+      failure: formatCliFailureDiagnostic({
+        args,
+        status,
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      }),
+    };
   }
   const text = Buffer.concat(stdout).toString("utf8").trim();
-  return text ? (JSON.parse(text) as unknown) : null;
+  return {
+    value: text ? (JSON.parse(text) as unknown) : null,
+    failure: null,
+  };
+}
+
+export function formatCliFailureDiagnostic(params: {
+  args: string[];
+  status: number;
+  stderr: string;
+}) {
+  let stderr = stripTerminalSequences(params.stderr);
+  for (let index = 0; index < params.args.length; index += 1) {
+    if (params.args[index] === "--token") {
+      const secret = params.args[index + 1];
+      if (secret) {
+        stderr = stderr.replaceAll(secret, "[redacted]");
+      }
+    }
+  }
+  const sanitized = stderr.replace(/\s+/gu, " ").trim() || "(no stderr)";
+  const bounded =
+    sanitized.length <= CLI_FAILURE_SUMMARY_LIMIT
+      ? sanitized
+      : `${sanitized.slice(0, CLI_FAILURE_SUMMARY_LIMIT - 3)}...`;
+  return `exit ${params.status}: ${bounded}`;
+}
+
+function stripTerminalSequences(value: string) {
+  let result = "";
+  for (let index = 0; index < value.length;) {
+    const codePoint = value.codePointAt(index) ?? 0;
+    const width = codePoint > 0xffff ? 2 : 1;
+    const nextCodeUnit = value.charCodeAt(index + width);
+    if ((codePoint === 0x1b && nextCodeUnit === 0x5b) || codePoint === 0x9b) {
+      index += codePoint === 0x1b ? 2 : 1;
+      while (index < value.length) {
+        const codeUnit = value.charCodeAt(index++);
+        if (codeUnit >= 0x40 && codeUnit <= 0x7e) {
+          break;
+        }
+      }
+      continue;
+    }
+    if ((codePoint === 0x1b && nextCodeUnit === 0x5d) || codePoint === 0x9d) {
+      index += codePoint === 0x1b ? 2 : 1;
+      while (index < value.length) {
+        const codeUnit = value.charCodeAt(index++);
+        if (codeUnit === 0x07) {
+          break;
+        }
+        if (codeUnit === 0x1b && value.charCodeAt(index) === 0x5c) {
+          index += 1;
+          break;
+        }
+      }
+      continue;
+    }
+    if (codePoint === 0x1b) {
+      index += Math.min(2, value.length - index);
+      continue;
+    }
+    if (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    ) {
+      result += " ";
+    } else {
+      result += String.fromCodePoint(codePoint);
+    }
+    index += width;
+  }
+  return result;
 }
 
 async function runDisjointClient(
@@ -734,6 +880,8 @@ async function startObserver(gatewayToken: string) {
   let expectedDevice: ObserverDeviceIdentity | undefined;
   let upstreamUrl = "";
   let observation: Observation | undefined;
+  let invocationRequest: unknown;
+  let invocationResult: unknown;
   let inconsistent = false;
   let pendingDisjointCredential: string | undefined;
   let resolveBootstrap: (() => void) | undefined;
@@ -838,6 +986,13 @@ async function startObserver(gatewayToken: string) {
         downstream.terminate();
         return;
       }
+      if (frame.method === "node.invoke.result") {
+        if (invocationResult !== undefined) {
+          inconsistent = true;
+        } else {
+          invocationResult = frame.params;
+        }
+      }
       if (upstream.readyState === WebSocket.OPEN) {
         upstream.send(data, { binary: isBinary });
       } else {
@@ -854,6 +1009,12 @@ async function startObserver(gatewayToken: string) {
       if (frame.event === "connect.challenge") {
         const payload = isRecord(frame.payload) ? frame.payload : {};
         nonce = typeof payload.nonce === "string" ? payload.nonce : "";
+      } else if (frame.event === "node.invoke.request") {
+        if (invocationRequest !== undefined) {
+          inconsistent = true;
+        } else {
+          invocationRequest = frame.payload;
+        }
       } else if (observation && frame.id === connectId) {
         const payload = isRecord(frame.payload) ? frame.payload : {};
         if (payload.type === "hello-ok" && Number.isSafeInteger(payload.protocol)) {
@@ -878,15 +1039,10 @@ async function startObserver(gatewayToken: string) {
   });
   return {
     async captureExpectedIdentity(child: ChildProcess) {
-      await Promise.race([
+      await captureExpectedIdentity({
         bootstrap,
-        waitForExit(child).then((status) => {
-          throw new Error(`Node identity bootstrap exited with status ${status}.`);
-        }),
-        delay(30_000).then(() => {
-          throw new Error("Timed out capturing the intended node device identity.");
-        }),
-      ]);
+        childExit: waitForExit(child),
+      });
     },
     activate(value: string) {
       if (!expectedDevice || !value) {
@@ -907,6 +1063,12 @@ async function startObserver(gatewayToken: string) {
       }
       return observation;
     },
+    readOperation() {
+      if (inconsistent) {
+        throw new Error("Observer did not capture one consistent node invocation.");
+      }
+      return buildObservedNodeOperation(invocationRequest, invocationResult);
+    },
     close: async () => {
       for (const socket of server.clients) {
         socket.terminate();
@@ -926,6 +1088,31 @@ async function startObserver(gatewayToken: string) {
 
 function normalizeDeviceMetadata(value: unknown) {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+export async function captureExpectedIdentity(params: {
+  bootstrap: Promise<void>;
+  childExit: Promise<number>;
+  timeoutMs?: number;
+}) {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error("Timed out capturing the intended node device identity."));
+    }, params.timeoutMs ?? 30_000);
+    timeout.unref();
+  });
+  try {
+    await Promise.race([
+      params.bootstrap,
+      params.childExit.then((status) => {
+        throw new Error(`Node identity bootstrap exited with status ${status}.`);
+      }),
+      timeoutPromise,
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export function normalizeMismatch(observation: Observation, legacyVersion?: string) {
@@ -994,12 +1181,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function waitForExit(child: ChildProcess) {
+function waitForExit(child: ChildProcess): Promise<number> {
+  const observed = childExitPromises.get(child);
+  if (observed) {
+    return observed;
+  }
   if (child.exitCode !== null) {
     return Promise.resolve(child.exitCode);
   }
-  return new Promise<number>((resolvePromise) => {
+  const exit = new Promise<number>((resolvePromise) => {
     child.once("close", (status) => resolvePromise(status ?? 1));
     child.once("error", () => resolvePromise(1));
+  });
+  childExitPromises.set(child, exit);
+  return exit;
+}
+
+async function waitForExitWithin(exit: Promise<number>, timeoutMs: number) {
+  return new Promise<boolean>((resolvePromise) => {
+    const finish = (exited: boolean) => {
+      clearTimeout(timer);
+      resolvePromise(exited);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    timer.unref();
+    void exit.then(() => finish(true));
   });
 }

--- a/scripts/gateway-node-compat-case.ts
+++ b/scripts/gateway-node-compat-case.ts
@@ -1,0 +1,1005 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createPublicKey, randomUUID, timingSafeEqual, verify } from "node:crypto";
+import {
+  chmodSync,
+  chownSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createConnection } from "node:net";
+import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
+
+type CaseInput = {
+  caseId: string;
+  gateway: "baseline" | "candidate";
+  node: "baseline" | "candidate";
+  outcome: "passed" | "protocol-mismatch";
+};
+type Observation = {
+  clientMin: number;
+  clientMax: number;
+  helloProtocol: number | null;
+  identity: { clientId: string; mode: string; platform: string; role: string };
+  protocolError: unknown;
+};
+
+const GATEWAY_PORT = 18789;
+const OBSERVER_PORT = 18790;
+const GATEWAY_UID = 65532;
+const GATEWAY_GID = 65532;
+const NODE_UID = 65533;
+const NODE_GID = 65533;
+const CLI_OUTPUT_LIMIT_BYTES = 1024 * 1024;
+const SYSTEM_WHICH_OPERATION = {
+  command: "system.which",
+  params: { bins: ["node"] },
+} as const;
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  await main();
+}
+
+async function main() {
+  const inputPath = process.argv[2];
+  const outputPath = process.argv[3];
+  if (!inputPath || !outputPath) {
+    throw new Error("usage: gateway-node-compat-case.ts <input.json> <output.json>");
+  }
+  const input = JSON.parse(readFileSync(inputPath, "utf8")) as CaseInput;
+  const architecture = process.env.OPENCLAW_GATEWAY_NODE_ARCH;
+  if ((architecture !== "arm64" && architecture !== "x64") || process.arch !== architecture) {
+    throw new Error(`Container architecture ${process.arch} does not match ${architecture}.`);
+  }
+  const token = randomUUID().replaceAll("-", "");
+  const children = new Set<ChildProcess>();
+  const startedAt = new Date().toISOString();
+  const runtimeRoot = createRuntimeRoot();
+  try {
+    const gateway = runtime(input.gateway);
+    const node = runtime(input.node);
+    const gatewayEnv = runtimeEnv(
+      prepareRuntimeHome({
+        root: runtimeRoot,
+        name: "gateway",
+        uid: GATEWAY_UID,
+        gid: GATEWAY_GID,
+      }),
+      gateway.binDir,
+      token,
+    );
+    const nodeEnv = runtimeEnv(
+      prepareRuntimeHome({
+        root: runtimeRoot,
+        name: "node",
+        uid: NODE_UID,
+        gid: NODE_GID,
+      }),
+      node.binDir,
+      token,
+    );
+    const observer = await startObserver(token);
+    const startNode = () =>
+      start(
+        node.cli,
+        [
+          "node",
+          "run",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          String(OBSERVER_PORT),
+          "--node-id",
+          input.caseId,
+          "--display-name",
+          input.caseId,
+        ],
+        nodeEnv,
+        children,
+        NODE_UID,
+        NODE_GID,
+      );
+    const bootstrapNode = startNode();
+    await observer.captureExpectedIdentity(bootstrapNode);
+    await stopChild(bootstrapNode);
+
+    const gatewayChild = start(
+      gateway.cli,
+      [
+        "gateway",
+        "run",
+        "--bind",
+        "loopback",
+        "--port",
+        String(GATEWAY_PORT),
+        "--force",
+        "--allow-unconfigured",
+      ],
+      gatewayEnv,
+      children,
+      GATEWAY_UID,
+      GATEWAY_GID,
+    );
+    await waitForPort(GATEWAY_PORT, gatewayChild);
+    observer.activate(`ws://127.0.0.1:${GATEWAY_PORT}`);
+    try {
+      let operation: unknown = null;
+      if (input.outcome === "passed") {
+        operation = await approveAndInvoke({
+          caseId: input.caseId,
+          cli: (args) =>
+            cliJson(
+              gateway.cli,
+              gatewayCliArgs(args, `ws://127.0.0.1:${GATEWAY_PORT}`, token),
+              gatewayEnv,
+            ),
+          nodeChild: startNode(),
+          startNode,
+        });
+      } else {
+        const disjointHome = prepareRuntimeHome({
+          root: runtimeRoot,
+          name: "disjoint",
+          uid: NODE_UID,
+          gid: NODE_GID,
+        });
+        await runDisjointClient(
+          node.packageRoot,
+          token,
+          observer.authorizeDisjointProbe(),
+          disjointHome,
+          runtimeEnv(disjointHome, "", token),
+          children,
+          NODE_UID,
+          NODE_GID,
+        );
+      }
+      const observation = validateObservedIdentity(observer.read());
+      const mismatch =
+        input.outcome === "protocol-mismatch"
+          ? normalizeMismatch(observation, input.gateway === "baseline" ? "2026.5.7" : undefined)
+          : null;
+      writeFileSync(
+        outputPath,
+        `${JSON.stringify({
+          observation,
+          operation,
+          mismatch,
+          architecture,
+          startedAt,
+          completedAt: new Date().toISOString(),
+        })}\n`,
+        { encoding: "utf8", mode: 0o644 },
+      );
+    } finally {
+      await observer.close();
+    }
+  } finally {
+    for (const child of children) {
+      child.kill("SIGTERM");
+    }
+    await Promise.all([...children].map(waitForExit));
+    rmSync(runtimeRoot, { recursive: true, force: true });
+  }
+}
+
+function runtime(id: "baseline" | "candidate") {
+  const prefix = `/runtimes/${id}`;
+  return {
+    binDir: join(prefix, "bin"),
+    cli: join(prefix, "bin", "openclaw"),
+    packageRoot: join(prefix, "lib", "node_modules", "openclaw"),
+  };
+}
+
+function createRuntimeRoot() {
+  const root = mkdtempSync("/tmp/openclaw-gateway-node-compat-");
+  chmodSync(root, 0o711);
+  assertTrustedRuntimeRoot(root, 0, 0);
+  return root;
+}
+
+function assertTrustedRuntimeRoot(root: string, uid: number, gid: number) {
+  const stat = lstatSync(root);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    stat.uid !== uid ||
+    stat.gid !== gid ||
+    (stat.mode & 0o022) !== 0
+  ) {
+    throw new Error("Gateway/node compatibility runtime root is not trusted.");
+  }
+}
+
+export function prepareRuntimeHome(
+  params: {
+    root: string;
+    name: string;
+    uid: number;
+    gid: number;
+    rootUid?: number;
+    rootGid?: number;
+  },
+  chown: typeof chownSync = chownSync,
+) {
+  const rootUid = params.rootUid ?? 0;
+  const rootGid = params.rootGid ?? 0;
+  assertTrustedRuntimeRoot(params.root, rootUid, rootGid);
+  const home = join(params.root, params.name);
+  if (lstatSync(home, { throwIfNoEntry: false })) {
+    throw new Error(`Refusing existing runtime home ${params.name}.`);
+  }
+  mkdirSync(home, { mode: 0o700 });
+  const created = lstatSync(home);
+  if (
+    created.isSymbolicLink() ||
+    !created.isDirectory() ||
+    created.uid !== rootUid ||
+    created.gid !== rootGid
+  ) {
+    throw new Error(`Runtime home ${params.name} was not created by the trusted supervisor.`);
+  }
+  chown(home, params.uid, params.gid);
+  return home;
+}
+
+function runtimeEnv(home: string, binDir: string, gatewayToken: string) {
+  return {
+    HOME: home,
+    PATH: `${binDir}:${process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin"}`,
+    OPENCLAW_CONFIG_PATH: join(home, "openclaw.json"),
+    OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+    OPENCLAW_HOME: home,
+    OPENCLAW_STATE_DIR: join(home, ".openclaw"),
+  };
+}
+
+function start(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  children: Set<ChildProcess>,
+  uid: number,
+  gid: number,
+) {
+  const child = spawn(command, args, {
+    env,
+    stdio: ["ignore", "inherit", "inherit"],
+    uid,
+    gid,
+  });
+  children.add(child);
+  child.once("close", () => children.delete(child));
+  return child;
+}
+
+async function waitForPort(port: number, child: ChildProcess) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Gateway exited before opening port ${port}.`);
+    }
+    const connected = await new Promise<boolean>((resolvePromise) => {
+      const socket = createConnection({ host: "127.0.0.1", port });
+      socket.setTimeout(250);
+      socket.once("connect", () => {
+        socket.destroy();
+        resolvePromise(true);
+      });
+      socket.once("timeout", () => {
+        socket.destroy();
+        resolvePromise(false);
+      });
+      socket.once("error", () => resolvePromise(false));
+    });
+    if (connected) {
+      return;
+    }
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for port ${port}.`);
+}
+
+export async function approveAndInvoke(params: {
+  caseId: string;
+  cli: (args: string[]) => Promise<unknown>;
+  nodeChild: ChildProcess;
+  startNode: () => ChildProcess;
+  stopNode?: (child: ChildProcess) => Promise<void>;
+  now?: () => number;
+  wait?: (milliseconds: number) => Promise<unknown>;
+  timeoutMs?: number;
+}) {
+  const now = params.now ?? Date.now;
+  const wait = params.wait ?? delay;
+  const stopNode = params.stopNode ?? stopChild;
+  const deadline = now() + (params.timeoutMs ?? 60_000);
+  const approvedDeviceRequests = new Set<string>();
+  const approvedNodeRequests = new Set<string>();
+  let nodeChild = params.nodeChild;
+  const matchesNode = (entry: unknown) =>
+    isRecord(entry) &&
+    entry.displayName === params.caseId &&
+    (entry.role === "node" || (Array.isArray(entry.roles) && entry.roles.includes("node")));
+  while (now() < deadline) {
+    if (nodeChild.exitCode !== null) {
+      throw new Error("Node exited before invocation.");
+    }
+
+    const devices = await params.cli(["devices", "list"]);
+    const pendingDevices =
+      isRecord(devices) && Array.isArray(devices.pending)
+        ? devices.pending.filter(matchesNode)
+        : [];
+    const pairedDevices =
+      isRecord(devices) && Array.isArray(devices.paired) ? devices.paired.filter(matchesNode) : [];
+    if (pendingDevices.length > 1 || pairedDevices.length > 1) {
+      throw new Error(`Multiple device pairings matched ${params.caseId}.`);
+    }
+    const pendingDevice = pendingDevices[0];
+    const pairedDevice = pairedDevices[0];
+    const pendingDeviceId =
+      isRecord(pendingDevice) && typeof pendingDevice.deviceId === "string"
+        ? pendingDevice.deviceId
+        : "";
+    const pairedDeviceId =
+      isRecord(pairedDevice) && typeof pairedDevice.deviceId === "string"
+        ? pairedDevice.deviceId
+        : "";
+    if (pendingDeviceId && pairedDeviceId && pendingDeviceId !== pairedDeviceId) {
+      throw new Error(`Multiple device pairings matched ${params.caseId}.`);
+    }
+    const deviceRequestId =
+      isRecord(pendingDevice) && typeof pendingDevice.requestId === "string"
+        ? pendingDevice.requestId
+        : "";
+    if (deviceRequestId && !approvedDeviceRequests.has(deviceRequestId)) {
+      const approved = await params.cli(["devices", "approve", deviceRequestId]);
+      if (approved) {
+        approvedDeviceRequests.add(deviceRequestId);
+        await stopNode(nodeChild);
+        nodeChild = params.startNode();
+      }
+      await wait(250);
+      continue;
+    }
+    const deviceId = pairedDeviceId;
+    if (!deviceId) {
+      await wait(250);
+      continue;
+    }
+
+    const pending = await params.cli(["nodes", "pending"]);
+    if (Array.isArray(pending)) {
+      const requests = pending.filter(
+        (entry) =>
+          isRecord(entry) &&
+          (entry.nodeId === deviceId || entry.nodeId === params.caseId) &&
+          entry.displayName === params.caseId,
+      );
+      if (requests.length > 1) {
+        throw new Error(`Multiple pending requests matched ${params.caseId}.`);
+      }
+      const requestId = requests[0]?.requestId;
+      if (typeof requestId === "string" && !approvedNodeRequests.has(requestId)) {
+        const approved = await params.cli(["nodes", "approve", requestId]);
+        if (approved) {
+          approvedNodeRequests.add(requestId);
+          await stopNode(nodeChild);
+          nodeChild = params.startNode();
+        }
+        await wait(250);
+        continue;
+      }
+    }
+
+    const status = await params.cli(["nodes", "status"]);
+    const nodes =
+      isRecord(status) && Array.isArray(status.nodes)
+        ? status.nodes.filter(
+            (entry) =>
+              isRecord(entry) && (entry.nodeId === deviceId || entry.displayName === params.caseId),
+          )
+        : [];
+    if (nodes.length > 1) {
+      throw new Error(`Multiple connected nodes matched ${params.caseId}.`);
+    }
+    const node = nodes[0];
+    const operation = resolveApprovedNodeOperation(node);
+    const nodeId = isRecord(node) && typeof node.nodeId === "string" ? node.nodeId : "";
+    if (!operation || !nodeId) {
+      await wait(250);
+      continue;
+    }
+
+    const result = await params.cli([
+      "nodes",
+      "invoke",
+      "--node",
+      nodeId,
+      "--command",
+      operation.command,
+      "--params",
+      JSON.stringify(operation.params),
+    ]);
+    if (!isRecord(result) || result.ok !== true || result.command !== operation.command) {
+      throw new Error(`Approved node operation failed for ${params.caseId}.`);
+    }
+    const payload = isRecord(result.payload) ? result.payload : {};
+    const bins = isRecord(payload.bins) ? payload.bins : {};
+    if (typeof bins.node !== "string" || !bins.node) {
+      throw new Error(`Approved node operation returned no node binary for ${params.caseId}.`);
+    }
+    return {
+      method: "node.invoke",
+      command: operation.command,
+      params: operation.params,
+      ok: true,
+      result: { bins: { node: bins.node } },
+    };
+  }
+  throw new Error(`Timed out invoking ${params.caseId}.`);
+}
+
+export function resolveApprovedNodeOperation(node: unknown) {
+  if (!isRecord(node) || node.paired !== true || node.connected !== true) {
+    return null;
+  }
+  if (typeof node.approvalState === "string" && node.approvalState !== "approved") {
+    return null;
+  }
+  const commands = Array.isArray(node.commands)
+    ? node.commands.filter((command): command is string => typeof command === "string")
+    : [];
+  return commands.includes(SYSTEM_WHICH_OPERATION.command) ? SYSTEM_WHICH_OPERATION : null;
+}
+
+function gatewayCliArgs(args: string[], url: string, token: string) {
+  return [...args, "--json", "--url", url, "--token", token];
+}
+
+async function stopChild(child: ChildProcess) {
+  if (child.exitCode === null) {
+    child.kill("SIGTERM");
+  }
+  await waitForExit(child);
+}
+
+async function cliJson(command: string, args: string[], env: NodeJS.ProcessEnv) {
+  const child = spawn(command, args, {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    uid: GATEWAY_UID,
+    gid: GATEWAY_GID,
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  let capturedBytes = 0;
+  let exceededLimit = false;
+  const capture = (target: Buffer[]) => (chunk: unknown) => {
+    const bytes = Buffer.from(chunk as Uint8Array);
+    const remaining = CLI_OUTPUT_LIMIT_BYTES - capturedBytes;
+    if (remaining > 0) {
+      target.push(bytes.subarray(0, remaining));
+      capturedBytes += Math.min(bytes.length, remaining);
+    }
+    if (bytes.length > remaining) {
+      exceededLimit = true;
+      child.kill("SIGKILL");
+    }
+  };
+  child.stdout.on("data", capture(stdout));
+  child.stderr.on("data", capture(stderr));
+  const status = await waitForExit(child);
+  if (exceededLimit) {
+    throw new Error(`CLI output exceeded ${CLI_OUTPUT_LIMIT_BYTES} bytes.`);
+  }
+  if (status !== 0) {
+    return null;
+  }
+  const text = Buffer.concat(stdout).toString("utf8").trim();
+  return text ? (JSON.parse(text) as unknown) : null;
+}
+
+async function runDisjointClient(
+  packageRoot: string,
+  gatewayToken: string,
+  observerCredential: string,
+  home: string,
+  env: NodeJS.ProcessEnv,
+  children: Set<ChildProcess>,
+  uid: number,
+  gid: number,
+) {
+  const runtimeUrl = pathToFileURL(
+    join(packageRoot, "dist", "plugin-sdk", "gateway-runtime.js"),
+  ).href;
+  const scriptPath = join(home, "disjoint-client.mjs");
+  writeFileSync(
+    scriptPath,
+    `
+const { GatewayClient } = await import(${JSON.stringify(runtimeUrl)});
+const timeout = setTimeout(() => process.exit(1), 15000);
+const client = new GatewayClient({
+  url: \`ws://127.0.0.1:${OBSERVER_PORT}/?observer_probe=\${encodeURIComponent(process.env.OPENCLAW_OBSERVER_PROBE_CREDENTIAL ?? "")}\`,
+  token: ${JSON.stringify(gatewayToken)},
+  clientName: "node-host", clientVersion: "gateway-node-compat-disjoint",
+  platform: "linux", mode: "node", role: "node", scopes: [], caps: [],
+  commands: ["system.which"], minProtocol: 1, maxProtocol: 2,
+  onConnectError: () => { clearTimeout(timeout); client.stop(); process.exit(0); },
+  onHelloOk: () => process.exit(1),
+});
+client.start();
+`,
+    { encoding: "utf8", mode: 0o644 },
+  );
+  try {
+    const child = start(
+      process.execPath,
+      [scriptPath],
+      {
+        ...env,
+        OPENCLAW_OBSERVER_PROBE_CREDENTIAL: observerCredential,
+      },
+      children,
+      uid,
+      gid,
+    );
+    if ((await waitForExit(child)) !== 0) {
+      throw new Error("Disjoint client did not receive a protocol mismatch.");
+    }
+  } finally {
+    rmSync(scriptPath, { force: true });
+  }
+}
+
+type ObserverDeviceIdentity = { id: string; publicKey: string };
+
+export function consumeOneTimeObserverCredential(presented: string, expected: string | undefined) {
+  const presentedBytes = Buffer.from(presented);
+  const expectedBytes = Buffer.from(expected ?? "");
+  if (
+    !expected ||
+    presentedBytes.length !== expectedBytes.length ||
+    !timingSafeEqual(presentedBytes, expectedBytes)
+  ) {
+    throw new Error("Observer rejected an unauthorized or reused disjoint probe.");
+  }
+}
+
+export function validateDisjointObserverConnect(
+  frame: Record<string, unknown>,
+  gatewayToken: string,
+) {
+  const connect = isRecord(frame.params) ? frame.params : {};
+  const client = isRecord(connect.client) ? connect.client : {};
+  const auth = isRecord(connect.auth) ? connect.auth : {};
+  if (
+    frame.method !== "connect" ||
+    typeof frame.id !== "string" ||
+    connect.minProtocol !== 1 ||
+    connect.maxProtocol !== 2 ||
+    connect.role !== "node" ||
+    client.id !== "node-host" ||
+    client.mode !== "node" ||
+    client.platform !== "linux" ||
+    auth.token !== gatewayToken
+  ) {
+    throw new Error("Observer rejected an invalid disjoint protocol probe.");
+  }
+  return {
+    clientMin: 1,
+    clientMax: 2,
+    helloProtocol: null,
+    identity: {
+      clientId: "node-host",
+      mode: "node",
+      platform: "linux",
+      role: "node",
+    },
+    protocolError: null,
+  } satisfies Observation;
+}
+
+export function validateObserverConnectCredential(
+  frame: Record<string, unknown>,
+  params: {
+    expectedDevice?: ObserverDeviceIdentity;
+    gatewayToken: string;
+    nonce: string;
+    usedSignatures?: Set<string>;
+  },
+) {
+  const connect = isRecord(frame.params) ? frame.params : {};
+  const client = isRecord(connect.client) ? connect.client : {};
+  const auth = isRecord(connect.auth) ? connect.auth : {};
+  const device = isRecord(connect.device) ? connect.device : {};
+  const scopes =
+    Array.isArray(connect.scopes) && connect.scopes.every((scope) => typeof scope === "string")
+      ? (connect.scopes as string[])
+      : [];
+  const signatureToken =
+    typeof auth.token === "string"
+      ? auth.token
+      : typeof auth.deviceToken === "string"
+        ? auth.deviceToken
+        : typeof auth.bootstrapToken === "string"
+          ? auth.bootstrapToken
+          : "";
+  if (
+    frame.method !== "connect" ||
+    typeof frame.id !== "string" ||
+    typeof connect.minProtocol !== "number" ||
+    !Number.isSafeInteger(connect.minProtocol) ||
+    typeof connect.maxProtocol !== "number" ||
+    !Number.isSafeInteger(connect.maxProtocol) ||
+    typeof connect.role !== "string" ||
+    typeof client.id !== "string" ||
+    typeof client.mode !== "string" ||
+    typeof client.platform !== "string" ||
+    typeof device.id !== "string" ||
+    typeof device.publicKey !== "string" ||
+    typeof device.signature !== "string" ||
+    !Number.isSafeInteger(device.signedAt) ||
+    device.nonce !== params.nonce ||
+    signatureToken !== params.gatewayToken
+  ) {
+    throw new Error("Observer rejected an invalid node session credential.");
+  }
+  if (
+    params.expectedDevice &&
+    (device.id !== params.expectedDevice.id || device.publicKey !== params.expectedDevice.publicKey)
+  ) {
+    throw new Error("Observer rejected a node session from an unexpected device identity.");
+  }
+  if (params.usedSignatures?.has(device.signature)) {
+    throw new Error("Observer rejected a reused node session credential.");
+  }
+  const payloadBase = {
+    deviceId: device.id,
+    clientId: client.id,
+    clientMode: client.mode,
+    role: connect.role,
+    scopes,
+    signedAtMs: Number(device.signedAt),
+    token: signatureToken,
+    nonce: params.nonce,
+  };
+  const payloads = [
+    [
+      "v3",
+      payloadBase.deviceId,
+      payloadBase.clientId,
+      payloadBase.clientMode,
+      payloadBase.role,
+      payloadBase.scopes.join(","),
+      String(payloadBase.signedAtMs),
+      payloadBase.token,
+      payloadBase.nonce,
+      normalizeDeviceMetadata(client.platform),
+      normalizeDeviceMetadata(client.deviceFamily),
+    ].join("|"),
+    [
+      "v2",
+      payloadBase.deviceId,
+      payloadBase.clientId,
+      payloadBase.clientMode,
+      payloadBase.role,
+      payloadBase.scopes.join(","),
+      String(payloadBase.signedAtMs),
+      payloadBase.token,
+      payloadBase.nonce,
+    ].join("|"),
+  ];
+  const publicKey = createPublicKey({
+    key: Buffer.concat([
+      Buffer.from("302a300506032b6570032100", "hex"),
+      Buffer.from(device.publicKey, "base64url"),
+    ]),
+    format: "der",
+    type: "spki",
+  });
+  const signature = Buffer.from(device.signature, "base64url");
+  if (!payloads.some((payload) => verify(null, Buffer.from(payload), publicKey, signature))) {
+    throw new Error("Observer rejected an invalid node session signature.");
+  }
+  params.usedSignatures?.add(device.signature);
+  return {
+    device: { id: device.id, publicKey: device.publicKey },
+    observation: {
+      clientMin: connect.minProtocol,
+      clientMax: connect.maxProtocol,
+      helloProtocol: null,
+      identity: {
+        clientId: client.id,
+        mode: client.mode,
+        platform: client.platform,
+        role: connect.role,
+      },
+      protocolError: null,
+    } satisfies Observation,
+  };
+}
+
+async function startObserver(gatewayToken: string) {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: OBSERVER_PORT });
+  const usedSignatures = new Set<string>();
+  let expectedDevice: ObserverDeviceIdentity | undefined;
+  let upstreamUrl = "";
+  let observation: Observation | undefined;
+  let inconsistent = false;
+  let pendingDisjointCredential: string | undefined;
+  let resolveBootstrap: (() => void) | undefined;
+  let rejectBootstrap: ((error: Error) => void) | undefined;
+  const bootstrap = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolveBootstrap = resolvePromise;
+    rejectBootstrap = rejectPromise;
+  });
+  server.on("connection", (downstream, request) => {
+    if (!upstreamUrl) {
+      if (expectedDevice) {
+        downstream.terminate();
+        return;
+      }
+      const nonce = randomUUID();
+      downstream.send(
+        JSON.stringify({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce, ts: Date.now() },
+        }),
+      );
+      downstream.once("message", (data) => {
+        try {
+          const captured = validateObserverConnectCredential(parseFrame(data), {
+            gatewayToken,
+            nonce,
+            usedSignatures,
+          });
+          expectedDevice = captured.device;
+          resolveBootstrap?.();
+        } catch (error) {
+          inconsistent = true;
+          rejectBootstrap?.(error instanceof Error ? error : new Error(String(error)));
+        } finally {
+          downstream.terminate();
+        }
+      });
+      return;
+    }
+
+    const upstream = new WebSocket(upstreamUrl);
+    const pending: Array<{ data: RawData; isBinary: boolean }> = [];
+    const presentedDisjointCredential = new URL(
+      request.url ?? "/",
+      "http://observer.invalid",
+    ).searchParams.get("observer_probe");
+    let isDisjointProbe = false;
+    if (presentedDisjointCredential) {
+      try {
+        consumeOneTimeObserverCredential(presentedDisjointCredential, pendingDisjointCredential);
+        pendingDisjointCredential = undefined;
+        isDisjointProbe = true;
+      } catch {
+        inconsistent = true;
+        downstream.terminate();
+        upstream.terminate();
+        return;
+      }
+    }
+    let connectId = "";
+    let authenticated = false;
+    let nonce = "";
+    downstream.on("message", (data, isBinary) => {
+      const frame = parseFrame(data);
+      if (!authenticated) {
+        if (!isDisjointProbe && (!nonce || !expectedDevice)) {
+          inconsistent = true;
+          downstream.terminate();
+          return;
+        }
+        let capturedObservation: Observation;
+        try {
+          capturedObservation = isDisjointProbe
+            ? validateDisjointObserverConnect(frame, gatewayToken)
+            : validateObserverConnectCredential(frame, {
+                expectedDevice,
+                gatewayToken,
+                nonce,
+                usedSignatures,
+              }).observation;
+        } catch {
+          inconsistent = true;
+          downstream.terminate();
+          return;
+        }
+        inconsistent ||= Boolean(
+          observation && !isDeepStrictEqual(observation.identity, capturedObservation.identity),
+        );
+        observation = capturedObservation;
+        connectId = frame.id as string;
+        authenticated = true;
+        if (upstream.readyState === WebSocket.OPEN) {
+          upstream.send(data, { binary: isBinary });
+        } else {
+          pending.push({ data, isBinary });
+        }
+        return;
+      }
+      if (frame.method === "connect") {
+        inconsistent = true;
+        downstream.terminate();
+        return;
+      }
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.send(data, { binary: isBinary });
+      } else {
+        pending.push({ data, isBinary });
+      }
+    });
+    upstream.on("open", () => {
+      for (const message of pending.splice(0)) {
+        upstream.send(message.data, { binary: message.isBinary });
+      }
+    });
+    upstream.on("message", (data, isBinary) => {
+      const frame = parseFrame(data);
+      if (frame.event === "connect.challenge") {
+        const payload = isRecord(frame.payload) ? frame.payload : {};
+        nonce = typeof payload.nonce === "string" ? payload.nonce : "";
+      } else if (observation && frame.id === connectId) {
+        const payload = isRecord(frame.payload) ? frame.payload : {};
+        if (payload.type === "hello-ok" && Number.isSafeInteger(payload.protocol)) {
+          observation.helloProtocol = payload.protocol as number;
+          observation.protocolError = null;
+        } else if (Object.hasOwn(frame, "error")) {
+          observation.protocolError = frame.error;
+          observation.helloProtocol = null;
+        }
+      }
+      if (downstream.readyState === WebSocket.OPEN) {
+        downstream.send(data, { binary: isBinary });
+      }
+    });
+    upstream.on("close", (code, reason) => downstream.close(code, reason.toString()));
+    upstream.on("error", () => downstream.terminate());
+    downstream.on("close", () => upstream.close());
+  });
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    server.once("listening", resolvePromise);
+    server.once("error", rejectPromise);
+  });
+  return {
+    async captureExpectedIdentity(child: ChildProcess) {
+      await Promise.race([
+        bootstrap,
+        waitForExit(child).then((status) => {
+          throw new Error(`Node identity bootstrap exited with status ${status}.`);
+        }),
+        delay(30_000).then(() => {
+          throw new Error("Timed out capturing the intended node device identity.");
+        }),
+      ]);
+    },
+    activate(value: string) {
+      if (!expectedDevice || !value) {
+        throw new Error("Observer cannot activate before capturing the intended node identity.");
+      }
+      upstreamUrl = value;
+    },
+    authorizeDisjointProbe() {
+      if (pendingDisjointCredential) {
+        throw new Error("Observer already has a pending disjoint probe credential.");
+      }
+      pendingDisjointCredential = randomUUID();
+      return pendingDisjointCredential;
+    },
+    read() {
+      if (!observation || inconsistent) {
+        throw new Error("Observer did not capture one consistent node connection.");
+      }
+      return observation;
+    },
+    close: async () => {
+      for (const socket of server.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        server.close((error) => {
+          if (error) {
+            rejectPromise(error);
+            return;
+          }
+          resolvePromise();
+        });
+      });
+    },
+  };
+}
+
+function normalizeDeviceMetadata(value: unknown) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+export function normalizeMismatch(observation: Observation, legacyVersion?: string) {
+  if (observation.clientMin !== 1 || observation.clientMax !== 2) {
+    throw new Error("Disjoint client did not advertise exact protocol range 1..2.");
+  }
+  const error = isRecord(observation.protocolError) ? observation.protocolError : {};
+  const outer = isRecord(error.details) ? error.details : {};
+  const details = Object.hasOwn(outer, "code")
+    ? outer
+    : isRecord(outer.details)
+      ? outer.details
+      : {};
+  if (
+    legacyVersion === "2026.5.7" &&
+    Object.keys(outer).length === 1 &&
+    outer.expectedProtocol === 3
+  ) {
+    return {
+      code: "PROTOCOL_MISMATCH",
+      clientMinProtocol: 1,
+      clientMaxProtocol: 2,
+      expectedProtocol: outer.expectedProtocol,
+    };
+  }
+  if (
+    details.code !== "PROTOCOL_MISMATCH" ||
+    details.clientMinProtocol !== 1 ||
+    details.clientMaxProtocol !== 2 ||
+    !Number.isSafeInteger(details.expectedProtocol) ||
+    Number(details.expectedProtocol) <= observation.clientMax
+  ) {
+    throw new Error("Gateway did not return matching structured PROTOCOL_MISMATCH.");
+  }
+  return details;
+}
+
+export function validateObservedIdentity(observation: Observation) {
+  if (
+    observation.identity.role !== "node" ||
+    observation.identity.mode !== "node" ||
+    observation.identity.clientId !== "node-host" ||
+    observation.identity.platform !== "linux"
+  ) {
+    throw new Error("Observed connect identity is not a Linux node-host session.");
+  }
+  return observation;
+}
+
+function parseFrame(data: unknown) {
+  try {
+    const text = Buffer.isBuffer(data)
+      ? data.toString("utf8")
+      : Array.isArray(data)
+        ? Buffer.concat(data.map((part) => Buffer.from(part))).toString("utf8")
+        : Buffer.from(data as Uint8Array).toString("utf8");
+    const value: unknown = JSON.parse(text);
+    return isRecord(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+// This script runs as a standalone read-only mount outside workspace package resolution.
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function waitForExit(child: ChildProcess) {
+  if (child.exitCode !== null) {
+    return Promise.resolve(child.exitCode);
+  }
+  return new Promise<number>((resolvePromise) => {
+    child.once("close", (status) => resolvePromise(status ?? 1));
+    child.once("error", () => resolvePromise(1));
+  });
+}

--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -410,7 +410,7 @@ export function resolveRunnerMatrix(params: {
         }),
       ),
   );
-  if (include.length === 0 && !suiteFilter.matchesGatewayNodeCompat) {
+  if (include.length === 0 && suiteFilter.requestsCrossOsSuites) {
     throw new Error(
       `cross_os_suite_filter ${JSON.stringify(params.suiteFilter ?? "")} did not match any ${params.mode} suite.`,
     );
@@ -454,6 +454,7 @@ export function parseCrossOsSuiteFilter(rawFilter: string) {
     return {
       matches: () => true,
       matchesGatewayNodeCompat: true,
+      requestsCrossOsSuites: true,
       tokens,
     };
   }
@@ -497,6 +498,7 @@ export function parseCrossOsSuiteFilter(rawFilter: string) {
         return osMatches && suiteMatches;
       }),
     matchesGatewayNodeCompat: matchers.some((matcher) => matcher.gatewayNodeCompat),
+    requestsCrossOsSuites: matchers.some((matcher) => !matcher.gatewayNodeCompat),
     tokens,
   };
 }

--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -108,6 +108,7 @@ const SUPPORTED_SUITES = new Set<CrossOsSuite>([
   "dev-update",
 ]);
 const SUPPORTED_OS_IDS = new Set<CrossOsOsId>(["ubuntu", "windows", "macos"]);
+const GATEWAY_NODE_COMPAT_SUITE_FILTER = "gateway-node-compat";
 
 export const CROSS_OS_AGENT_TURN_TIMEOUT_SECONDS = parsePositiveIntegerEnv(
   "OPENCLAW_CROSS_OS_AGENT_TURN_TIMEOUT_SECONDS",
@@ -409,13 +410,38 @@ export function resolveRunnerMatrix(params: {
         }),
       ),
   );
-  if (include.length === 0) {
+  if (include.length === 0 && !suiteFilter.matchesGatewayNodeCompat) {
     throw new Error(
       `cross_os_suite_filter ${JSON.stringify(params.suiteFilter ?? "")} did not match any ${params.mode} suite.`,
     );
   }
   return {
     include,
+  };
+}
+
+export function resolveCrossOsReleaseSelection(params: {
+  mode: string;
+  ref: string;
+  suiteFilter?: string;
+  ubuntuRunner?: string;
+  windowsRunner?: string;
+  macosRunner?: string;
+  varUbuntuRunner?: string;
+  varWindowsRunner?: string;
+  varMacosRunner?: string;
+}) {
+  const matrix = resolveRunnerMatrix(params);
+  const gatewayNodeCompatEnabled = parseCrossOsSuiteFilter(
+    params.suiteFilter ?? "",
+  ).matchesGatewayNodeCompat;
+  const crossOsReleaseChecksEnabled = matrix.include.length > 0;
+  return {
+    matrix,
+    crossOsReleaseChecksEnabled,
+    gatewayNodeCompatEnabled,
+    candidatePreparationEnabled: crossOsReleaseChecksEnabled || gatewayNodeCompatEnabled,
+    packagedUpgradeEnabled: matrix.include.some((entry) => entry.suite === "packaged-upgrade"),
   };
 }
 
@@ -427,16 +453,20 @@ export function parseCrossOsSuiteFilter(rawFilter: string) {
   if (tokens.length === 0) {
     return {
       matches: () => true,
+      matchesGatewayNodeCompat: true,
       tokens,
     };
   }
 
   const matchers = tokens.map((token) => {
+    if (token === GATEWAY_NODE_COMPAT_SUITE_FILTER) {
+      return { osId: "", suite: "", gatewayNodeCompat: true };
+    }
     if (SUPPORTED_SUITES.has(token as CrossOsSuite)) {
-      return { osId: "", suite: token as CrossOsSuite };
+      return { osId: "", suite: token as CrossOsSuite, gatewayNodeCompat: false };
     }
     if (SUPPORTED_OS_IDS.has(token as CrossOsOsId)) {
-      return { osId: token as CrossOsOsId, suite: "" };
+      return { osId: token as CrossOsOsId, suite: "", gatewayNodeCompat: false };
     }
     for (const separator of ["/", ":", "-"]) {
       const matchedOs = [...SUPPORTED_OS_IDS].find((osId) =>
@@ -449,20 +479,24 @@ export function parseCrossOsSuiteFilter(rawFilter: string) {
       if (!SUPPORTED_SUITES.has(suite as CrossOsSuite)) {
         break;
       }
-      return { osId: matchedOs, suite: suite as CrossOsSuite };
+      return { osId: matchedOs, suite: suite as CrossOsSuite, gatewayNodeCompat: false };
     }
     throw new Error(
-      `Unsupported cross_os_suite_filter token ${JSON.stringify(token)}. Use an OS id, suite id, or os/suite pair such as windows/packaged-upgrade.`,
+      `Unsupported cross_os_suite_filter token ${JSON.stringify(token)}. Use gateway-node-compat, an OS id, suite id, or os/suite pair such as windows/packaged-upgrade.`,
     );
   });
 
   return {
     matches: (osId: CrossOsOsId, suite: CrossOsSuite) =>
       matchers.some((matcher) => {
+        if (matcher.gatewayNodeCompat) {
+          return false;
+        }
         const osMatches = !matcher.osId || matcher.osId === osId;
         const suiteMatches = !matcher.suite || matcher.suite === suite;
         return osMatches && suiteMatches;
       }),
+    matchesGatewayNodeCompat: matchers.some((matcher) => matcher.gatewayNodeCompat),
     tokens,
   };
 }

--- a/scripts/lib/cross-os-release-checks/gateway-node-compat.ts
+++ b/scripts/lib/cross-os-release-checks/gateway-node-compat.ts
@@ -1,0 +1,733 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isRecord } from "../../../packages/normalization-core/src/record-coerce.ts";
+import {
+  buildGatewayNodeCompatCaseId,
+  canonicalizeGatewayNodeCompatEvidence,
+} from "../../gateway-node-compat-evidence.mjs";
+import {
+  readBoundedRegularFile,
+  validateActionsArtifactBinding,
+  validateActionsArtifactProducerJob,
+  type ArtifactBinding,
+} from "../actions-artifact-archive.mjs";
+import type { ParsedArgs } from "./config.ts";
+import { readInstalledMetadata } from "./install.ts";
+import { runManagedContainer } from "./managed-container.ts";
+
+const NODE_IMAGE =
+  "node:24-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d";
+const WORKFLOW_PATH = ".github/workflows/openclaw-cross-os-release-checks-reusable.yml";
+const ACTIONS_JOBS_PAGE_LIMIT = 10;
+const ACTIONS_JOBS_PER_PAGE = 100;
+const CASE_RUNNER_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../gateway-node-compat-case.ts",
+);
+
+type RuntimeId = "baseline" | "candidate";
+type Architecture = "arm64" | "x64";
+type PackageSelection = {
+  actionsArtifact: {
+    id: number;
+    name: string;
+    digest: string;
+    sizeBytes: number;
+    runId: string;
+    runAttempt: number;
+  };
+  fileName: string;
+  sha256: string;
+  sourceSha: string | null;
+  tgzPath: string;
+  version: string;
+};
+type PreparedRuntime = ReturnType<typeof readPreparedRuntime>;
+type RuntimeProtocolContract = {
+  gatewayProtocol: number;
+  nodeMinProtocol: number;
+  nodeMaxProtocol: number;
+};
+type CompatCase = {
+  caseId: string;
+  direction: string;
+  gateway: RuntimeId;
+  node: RuntimeId;
+  outcome: "passed" | "protocol-mismatch";
+};
+
+export async function runGatewayNodeCompatProducer(args: ParsedArgs, env = process.env) {
+  const architecture = resolveArchitecture(process.arch);
+  if (env.GATEWAY_NODE_COMPAT_EXPECTED_ARCH !== architecture) {
+    throw new Error("Gateway/node compatibility runner architecture does not match its matrix.");
+  }
+  const outputDir = resolveRequiredPath(args, "gateway-node-compat-output-dir");
+  mkdirSync(outputDir, { recursive: true });
+  const candidate = readPackageSelection(args, "candidate");
+  const baseline = readPackageSelection(args, "compat-baseline");
+  if (baseline.version !== "2026.5.7") {
+    throw new Error("Gateway/node compatibility baseline must be openclaw@2026.5.7.");
+  }
+  const producer = readProducer(env);
+  const producerJobName = resolveGatewayNodeCompatProducerJobName(
+    args["gateway-node-compat-producer-job-name"],
+  );
+  validateCurrentRunArtifact(candidate, args, "candidate", producer, producerJobName);
+  validateCurrentRunArtifact(baseline, args, "compat-baseline", producer, producerJobName);
+
+  const workDir = mkdtempSync(join(tmpdir(), "openclaw-gateway-node-compat-"));
+  const preparedDir = join(workDir, "prepared");
+  const casesDir = join(workDir, "cases");
+  const logsDir = join(outputDir, "logs");
+  mkdirSync(preparedDir, { recursive: true });
+  try {
+    await prepareRuntimes({
+      baseline,
+      candidate,
+      logPath: join(logsDir, "prepare.log"),
+      preparedDir,
+    });
+    const runtimes = {
+      baseline: readPreparedRuntime("baseline", preparedDir, baseline),
+      candidate: readPreparedRuntime("candidate", preparedDir, candidate),
+    };
+    for (const compatCase of buildCases(architecture)) {
+      const caseDir = join(casesDir, compatCase.caseId);
+      mkdirSync(caseDir, { recursive: true });
+      const inputPath = join(caseDir, "input.json");
+      const resultPath = join(caseDir, "result.json");
+      writeFileSync(inputPath, `${JSON.stringify(compatCase)}\n`, {
+        encoding: "utf8",
+        mode: 0o644,
+      });
+      await runManagedContainer({
+        name: `openclaw-gateway-node-compat-${compatCase.caseId}-${randomBytes(6).toString("hex")}`,
+        logPath: join(logsDir, `${compatCase.caseId}.log`),
+        timeoutMs: 5 * 60_000,
+        args: buildCaseContainerArgs({ architecture, caseDir, inputPath, preparedDir }),
+      });
+      const result = parseCaseResult(
+        readBoundedRegularFile(resultPath, {
+          label: `${compatCase.caseId} result`,
+          maxBytes: 64 * 1024,
+        }),
+        architecture,
+      );
+      validateCaseProtocolContract(compatCase, result, {
+        gateway: runtimes[compatCase.gateway].protocol,
+        node: runtimes[compatCase.node].protocol,
+      });
+      const evidence = buildEvidence({
+        architecture,
+        runtimes,
+        compatCase,
+        producer,
+        result,
+      });
+      const serialized = canonicalizeGatewayNodeCompatEvidence(evidence);
+      const destination = join(outputDir, `${compatCase.caseId}.json`);
+      const temporary = `${destination}.tmp-${randomBytes(8).toString("hex")}`;
+      writeFileSync(temporary, serialized, { encoding: "utf8", mode: 0o600 });
+      renameSync(temporary, destination);
+    }
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+export function buildCases(
+  architecture: Architecture = resolveArchitecture(process.arch),
+): CompatCase[] {
+  return (
+    [
+      ["candidate-gateway-candidate-node", "candidate", "candidate", "passed"],
+      ["candidate-gateway-baseline-node", "candidate", "baseline", "passed"],
+      ["baseline-gateway-candidate-node", "baseline", "candidate", "passed"],
+      ["baseline-gateway-baseline-node", "baseline", "baseline", "passed"],
+      ["candidate-gateway-disjoint-node", "candidate", "candidate", "protocol-mismatch"],
+      ["baseline-gateway-disjoint-node", "baseline", "candidate", "protocol-mismatch"],
+    ] as const
+  ).map(([direction, gateway, node, outcome]) => ({
+    caseId: buildGatewayNodeCompatCaseId({ architecture, direction, kind: "linux" }),
+    direction,
+    gateway,
+    node,
+    outcome,
+  }));
+}
+
+function readPackageSelection(args: ParsedArgs, prefix: string): PackageSelection {
+  const tgzPath = resolveRequiredPath(args, `${prefix}-tgz`);
+  const metadata = readJsonFile(resolveRequiredPath(args, `${prefix}-artifact-metadata`));
+  const artifact: Record<string, unknown> = isRecord(metadata) ? metadata : {};
+  const id = requirePositiveInteger(artifact.id, `${prefix} artifact id`);
+  const sizeBytes = requirePositiveInteger(artifact.size_in_bytes, `${prefix} artifact size`);
+  const name = requireString(artifact.name, `${prefix} artifact name`);
+  const digest = requirePattern(
+    artifact.digest,
+    `${prefix} artifact digest`,
+    /^sha256:[a-f0-9]{64}$/u,
+  );
+  return {
+    actionsArtifact: {
+      id,
+      name,
+      digest,
+      sizeBytes,
+      runId: requirePattern(
+        args[`${prefix}-artifact-run-id`],
+        `${prefix} run id`,
+        /^[1-9][0-9]*$/u,
+      ),
+      runAttempt: requirePositiveInteger(
+        Number(args[`${prefix}-artifact-run-attempt`]),
+        `${prefix} run attempt`,
+      ),
+    },
+    fileName: basename(tgzPath),
+    sha256: requirePattern(args[`${prefix}-sha256`], `${prefix} sha256`, /^[a-f0-9]{64}$/u),
+    sourceSha:
+      args[`${prefix}-source-sha`] === ""
+        ? null
+        : requirePattern(args[`${prefix}-source-sha`], `${prefix} source sha`, /^[a-f0-9]{40}$/u),
+    tgzPath,
+    version: requireString(args[`${prefix}-version`], `${prefix} version`),
+  };
+}
+
+function readProducer(env: NodeJS.ProcessEnv) {
+  return {
+    repository: requirePattern(
+      env.GITHUB_REPOSITORY,
+      "GITHUB_REPOSITORY",
+      /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u,
+    ),
+    workflowSha: requirePattern(
+      env.GATEWAY_NODE_COMPAT_WORKFLOW_SHA,
+      "GATEWAY_NODE_COMPAT_WORKFLOW_SHA",
+      /^[a-f0-9]{40}$/u,
+    ),
+    runSha: requirePattern(env.GITHUB_SHA, "GITHUB_SHA", /^[a-f0-9]{40}$/u),
+    runWorkflowPath: parseWorkflowPath(
+      requireString(
+        env.GATEWAY_NODE_COMPAT_RUN_WORKFLOW_REF,
+        "GATEWAY_NODE_COMPAT_RUN_WORKFLOW_REF",
+      ),
+      requirePattern(
+        env.GITHUB_REPOSITORY,
+        "GITHUB_REPOSITORY",
+        /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u,
+      ),
+    ),
+    runId: requirePattern(env.GITHUB_RUN_ID, "GITHUB_RUN_ID", /^[1-9][0-9]*$/u),
+    runAttempt: requirePositiveInteger(Number(env.GITHUB_RUN_ATTEMPT), "GITHUB_RUN_ATTEMPT"),
+    job: requireString(env.GITHUB_JOB, "GITHUB_JOB"),
+    workflowEvent: requireString(env.GITHUB_EVENT_NAME, "GITHUB_EVENT_NAME"),
+    workflowHeadBranch: requireString(
+      env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME,
+      "GitHub head branch",
+    ),
+  };
+}
+
+function validateCurrentRunArtifact(
+  selection: PackageSelection,
+  args: ParsedArgs,
+  prefix: string,
+  producer: ReturnType<typeof readProducer>,
+  producerJobName: string,
+) {
+  if (!isSameRunArtifact(selection.actionsArtifact, producer)) {
+    throw new Error(`${prefix} artifact must come from this workflow run, not a future attempt.`);
+  }
+  if (sha256File(selection.tgzPath) !== selection.sha256) {
+    throw new Error(`${prefix} package SHA-256 mismatch.`);
+  }
+  const workflowRun = readJsonFile(resolveRequiredPath(args, `${prefix}-workflow-run-metadata`));
+  const workflowJobs = readWorkflowJobsMetadata(
+    resolveRequiredPath(args, `${prefix}-workflow-jobs-metadata`),
+  );
+  const expected: ArtifactBinding = {
+    artifactDigest: `sha256:${requirePattern(
+      args[`${prefix}-artifact-digest`],
+      `${prefix} artifact digest`,
+      /^[a-f0-9]{64}$/u,
+    )}`,
+    artifactId: selection.actionsArtifact.id,
+    artifactName: selection.actionsArtifact.name,
+    artifactSizeBytes: selection.actionsArtifact.sizeBytes,
+    consumerRunAttempt: producer.runAttempt,
+    producerJobName,
+    repository: producer.repository,
+    runStatePolicy: "same-run-producer-success",
+    runAttempt: selection.actionsArtifact.runAttempt,
+    runId: Number(selection.actionsArtifact.runId),
+    workflowEvent: producer.workflowEvent,
+    workflowHeadBranch: producer.workflowHeadBranch,
+    workflowPath: producer.runWorkflowPath,
+    workflowSha: producer.runSha,
+  };
+  validateActionsArtifactBinding({
+    artifactMetadata: readJsonFile(resolveRequiredPath(args, `${prefix}-artifact-metadata`)),
+    expected,
+    workflowRun,
+  });
+  validateActionsArtifactProducerJob({ expected, workflowJobs });
+}
+
+export function resolveGatewayNodeCompatProducerJobName(value: unknown) {
+  return requireString(value, "gateway-node-compat-producer-job-name");
+}
+
+async function prepareRuntimes(params: {
+  baseline: PackageSelection;
+  candidate: PackageSelection;
+  logPath: string;
+  preparedDir: string;
+}) {
+  await runManagedContainer({
+    name: `openclaw-gateway-node-compat-prepare-${process.pid}`,
+    logPath: params.logPath,
+    timeoutMs: 30 * 60_000,
+    args: [
+      "--network",
+      "bridge",
+      "--user",
+      containerUser(),
+      "--mount",
+      `type=bind,src=${params.candidate.tgzPath},dst=/input/candidate.tgz,readonly`,
+      "--mount",
+      `type=bind,src=${params.baseline.tgzPath},dst=/input/baseline.tgz,readonly`,
+      "--mount",
+      `type=bind,src=${params.preparedDir},dst=/prepared`,
+      NODE_IMAGE,
+      "sh",
+      "-euc",
+      [
+        "export HOME=/tmp npm_config_cache=/tmp/npm-cache",
+        "npm install --global --prefix /prepared/candidate --ignore-scripts /input/candidate.tgz",
+        "npm install --global --prefix /prepared/baseline --ignore-scripts /input/baseline.tgz",
+      ].join("\n"),
+    ],
+  });
+}
+
+function readPreparedRuntime(id: RuntimeId, preparedDir: string, selection: PackageSelection) {
+  const prefix = join(preparedDir, id);
+  const installed = readInstalledMetadata(prefix);
+  const sourceSha = selection.sourceSha ?? installed.commit;
+  if (
+    installed.version !== selection.version ||
+    !sourceSha ||
+    (selection.sourceSha !== null && installed.commit !== sourceSha)
+  ) {
+    throw new Error(`${id} installed runtime identity does not match its package tuple.`);
+  }
+  return {
+    binding: {
+      packagedArtifact: {
+        version: selection.version,
+        sourceSha,
+        name: selection.fileName,
+        sha256: selection.sha256,
+        actionsArtifact: selection.actionsArtifact,
+      },
+      installedRuntime: {
+        version: installed.version,
+        sourceSha,
+        packageSha256: selection.sha256,
+        identitySha256: sha256RuntimeTree(prefix),
+      },
+    },
+    protocol: readInstalledRuntimeProtocolContract(prefix),
+  };
+}
+
+function readInstalledRuntimeProtocolContract(prefix: string): RuntimeProtocolContract {
+  const distDir = join(prefix, "lib", "node_modules", "openclaw", "dist");
+  const contracts = readdirSync(distDir)
+    .filter((entry) => /^version-[A-Za-z0-9_-]+\.js$/u.test(entry))
+    .map((entry) =>
+      parseRuntimeProtocolContract(
+        readBoundedRegularFile(join(distDir, entry), {
+          label: `${entry} protocol metadata`,
+          maxBytes: 64 * 1024,
+        }).toString("utf8"),
+      ),
+    )
+    .filter((contract): contract is RuntimeProtocolContract => contract !== null);
+  if (contracts.length !== 1) {
+    throw new Error("Installed runtime protocol metadata is missing or ambiguous.");
+  }
+  return contracts[0]!;
+}
+
+export function parseRuntimeProtocolContract(source: string): RuntimeProtocolContract | null {
+  const gatewayMatch = /\bconst PROTOCOL_VERSION = ([1-9][0-9]*);/u.exec(source);
+  if (!gatewayMatch) {
+    return null;
+  }
+  const gatewayProtocol = Number(gatewayMatch[1]);
+  const nodeMinMatch = /\bconst MIN_NODE_PROTOCOL_VERSION = ([1-9][0-9]*);/u.exec(source);
+  const nodeMinProtocol = nodeMinMatch ? Number(nodeMinMatch[1]) : gatewayProtocol;
+  if (
+    !Number.isSafeInteger(gatewayProtocol) ||
+    !Number.isSafeInteger(nodeMinProtocol) ||
+    nodeMinProtocol > gatewayProtocol
+  ) {
+    throw new Error("Installed runtime protocol metadata is invalid.");
+  }
+  return {
+    gatewayProtocol,
+    nodeMinProtocol,
+    nodeMaxProtocol: gatewayProtocol,
+  };
+}
+
+export function buildCaseContainerArgs(params: {
+  architecture: Architecture;
+  caseDir: string;
+  inputPath: string;
+  preparedDir: string;
+}) {
+  return [
+    "--network",
+    "none",
+    "--read-only",
+    "--cpus",
+    "2",
+    "--memory",
+    "2g",
+    "--memory-swap",
+    "2g",
+    "--pids-limit",
+    "256",
+    "--cap-drop",
+    "ALL",
+    "--cap-add",
+    "SETUID",
+    "--cap-add",
+    "SETGID",
+    "--cap-add",
+    "DAC_OVERRIDE",
+    "--cap-add",
+    "CHOWN",
+    "--cap-add",
+    "KILL",
+    "--security-opt",
+    "no-new-privileges:true",
+    "--user",
+    "0:0",
+    "--tmpfs",
+    "/tmp:rw,nosuid,nodev,size=256m",
+    "--mount",
+    `type=bind,src=${params.preparedDir},dst=/runtimes,readonly`,
+    "--mount",
+    `type=bind,src=${CASE_RUNNER_PATH},dst=/case.ts,readonly`,
+    "--mount",
+    `type=bind,src=${resolveTrustedWsPath()},dst=/node_modules/ws,readonly`,
+    "--mount",
+    `type=bind,src=${params.inputPath},dst=/input.json,readonly`,
+    "--mount",
+    `type=bind,src=${params.caseDir},dst=/out`,
+    "--env",
+    `OPENCLAW_GATEWAY_NODE_ARCH=${params.architecture}`,
+    NODE_IMAGE,
+    "node",
+    "--experimental-strip-types",
+    "/case.ts",
+    "/input.json",
+    "/out/result.json",
+  ];
+}
+
+function resolveTrustedWsPath() {
+  return dirname(createRequire(import.meta.url).resolve("ws/package.json"));
+}
+
+export function parseCaseResult(
+  bytes: Buffer,
+  expectedArchitecture: Architecture,
+): Record<string, unknown> {
+  const value: unknown = JSON.parse(bytes.toString("utf8"));
+  if (!isRecord(value) || !isRecord(value.observation)) {
+    throw new Error("Gateway/node compatibility case result is invalid.");
+  }
+  const identity = isRecord(value.observation.identity) ? value.observation.identity : {};
+  if (value.architecture !== expectedArchitecture) {
+    throw new Error("Case result does not match the container architecture.");
+  }
+  if (
+    identity.role !== "node" ||
+    identity.mode !== "node" ||
+    identity.clientId !== "node-host" ||
+    identity.platform !== "linux"
+  ) {
+    throw new Error("Observed connect identity is not a Linux node-host session.");
+  }
+  return value;
+}
+
+export function validateCaseProtocolContract(
+  compatCase: Pick<CompatCase, "gateway" | "node" | "outcome">,
+  result: Record<string, unknown>,
+  protocols: { gateway: RuntimeProtocolContract; node: RuntimeProtocolContract },
+) {
+  const observation = isRecord(result.observation) ? result.observation : {};
+  if (compatCase.outcome === "protocol-mismatch") {
+    const mismatch = isRecord(result.mismatch) ? result.mismatch : {};
+    if (
+      observation.clientMin !== 1 ||
+      observation.clientMax !== 2 ||
+      mismatch.expectedProtocol !== protocols.gateway.gatewayProtocol
+    ) {
+      throw new Error("Disjoint compatibility case does not match the exact 1..2 contract.");
+    }
+    return result;
+  }
+  if (
+    observation.clientMin !== protocols.node.nodeMinProtocol ||
+    observation.clientMax !== protocols.node.nodeMaxProtocol ||
+    observation.helloProtocol !== protocols.gateway.gatewayProtocol
+  ) {
+    throw new Error("Packaged compatibility case does not match its exact protocol contract.");
+  }
+  return result;
+}
+
+export function isSameRunArtifact(
+  artifact: Pick<PackageSelection["actionsArtifact"], "runId" | "runAttempt">,
+  producer: Pick<ReturnType<typeof readProducer>, "runId" | "runAttempt">,
+) {
+  return artifact.runId === producer.runId && artifact.runAttempt <= producer.runAttempt;
+}
+
+function buildEvidence(params: {
+  architecture: Architecture;
+  runtimes: Record<RuntimeId, PreparedRuntime>;
+  compatCase: CompatCase;
+  producer: ReturnType<typeof readProducer>;
+  result: Record<string, unknown>;
+}) {
+  const observation = params.result.observation as Record<string, unknown>;
+  const passed = params.compatCase.outcome === "passed";
+  const mismatch: Record<string, unknown> = isRecord(params.result.mismatch)
+    ? params.result.mismatch
+    : {};
+  const gatewayProtocolVersion = passed ? observation.helloProtocol : mismatch.expectedProtocol;
+  if (!Number.isSafeInteger(gatewayProtocolVersion)) {
+    throw new Error(`${params.compatCase.caseId} did not observe a Gateway protocol.`);
+  }
+  return {
+    schema: "openclaw.gateway-node-compat/v1",
+    caseId: params.compatCase.caseId,
+    direction: params.compatCase.direction,
+    connection: { transport: "gateway-websocket", role: "node", mode: "node" },
+    gateway: params.runtimes[params.compatCase.gateway].binding,
+    node: {
+      kind: "linux",
+      architecture: params.architecture,
+      protocolClientId: "node-host",
+      ...params.runtimes[params.compatCase.node].binding,
+    },
+    protocol: {
+      gatewayProtocolVersion,
+      gatewayAcceptedNodeMin: 3,
+      protocolClientAdvertisedMin: observation.clientMin,
+      protocolClientAdvertisedMax: observation.clientMax,
+      helloProtocol: passed ? observation.helloProtocol : null,
+    },
+    operation: passed ? params.result.operation : null,
+    result: passed
+      ? {
+          outcome: "passed",
+          startedAt: params.result.startedAt,
+          completedAt: params.result.completedAt,
+        }
+      : {
+          outcome: "protocol-mismatch",
+          failureCode: "PROTOCOL_MISMATCH",
+          failurePhase: "connect",
+          startedAt: params.result.startedAt,
+          completedAt: params.result.completedAt,
+        },
+    producer: {
+      repository: params.producer.repository,
+      workflowPath: WORKFLOW_PATH,
+      workflowSha: params.producer.workflowSha,
+      runId: params.producer.runId,
+      runAttempt: params.producer.runAttempt,
+      job: params.producer.job,
+    },
+  };
+}
+
+function readJsonFile(path: string) {
+  const bytes = readBoundedRegularFile(path, {
+    label: basename(path),
+    maxBytes: 2 * 1024 * 1024,
+  });
+  return JSON.parse(bytes.toString("utf8")) as unknown;
+}
+
+function readWorkflowJobsMetadata(path: string) {
+  const stat = lstatSync(path);
+  if (!stat.isDirectory()) {
+    return readJsonFile(path);
+  }
+  const entries = readdirSync(path).toSorted((left, right) => {
+    const leftPage = Number(/^page-([1-9][0-9]*)\.json$/u.exec(left)?.[1] ?? 0);
+    const rightPage = Number(/^page-([1-9][0-9]*)\.json$/u.exec(right)?.[1] ?? 0);
+    return leftPage - rightPage;
+  });
+  if (
+    entries.length < 1 ||
+    entries.length > ACTIONS_JOBS_PAGE_LIMIT ||
+    entries.some((entry, index) => entry !== `page-${index + 1}.json`)
+  ) {
+    throw new Error("Actions workflow job pages are missing, non-contiguous, or excessive.");
+  }
+  return mergeActionsWorkflowJobPages(entries.map((entry) => readJsonFile(join(path, entry))));
+}
+
+export function mergeActionsWorkflowJobPages(pages: unknown[]) {
+  if (pages.length < 1 || pages.length > ACTIONS_JOBS_PAGE_LIMIT) {
+    throw new Error("Actions workflow job page count is outside the approved range.");
+  }
+  let totalCount: number | undefined;
+  const jobs: Record<string, unknown>[] = [];
+  const ids = new Set<number>();
+  for (const page of pages) {
+    if (!isRecord(page) || !Number.isSafeInteger(page.total_count) || !Array.isArray(page.jobs)) {
+      throw new Error("Actions workflow job page is invalid.");
+    }
+    const pageTotal = Number(page.total_count);
+    if (
+      pageTotal < 0 ||
+      pageTotal > ACTIONS_JOBS_PAGE_LIMIT * ACTIONS_JOBS_PER_PAGE ||
+      page.jobs.length > ACTIONS_JOBS_PER_PAGE ||
+      (totalCount !== undefined && pageTotal !== totalCount)
+    ) {
+      throw new Error("Actions workflow job page total is unstable or outside the approved range.");
+    }
+    totalCount = pageTotal;
+    for (const job of page.jobs) {
+      if (!isRecord(job) || !Number.isSafeInteger(job.id) || Number(job.id) < 1) {
+        throw new Error("Actions workflow job entry is invalid.");
+      }
+      const id = Number(job.id);
+      if (ids.has(id)) {
+        throw new Error("Actions workflow job inventory contains a duplicate job id.");
+      }
+      ids.add(id);
+      jobs.push(job);
+    }
+  }
+  if (totalCount === undefined || jobs.length !== totalCount) {
+    throw new Error("Actions workflow jobs inventory is incomplete.");
+  }
+  return { total_count: totalCount, jobs };
+}
+
+function sha256File(path: string) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+export function sha256RuntimeTree(root: string) {
+  const hash = createHash("sha256");
+  const visit = (path: string) => {
+    const relativePath = relative(root, path).split("\\").join("/");
+    const stat = lstatSync(path);
+    if (stat.isDirectory()) {
+      hash.update(`directory\0${relativePath}\0`);
+      for (const entry of readdirSync(path).toSorted((left, right) =>
+        left.localeCompare(right, "en"),
+      )) {
+        visit(join(path, entry));
+      }
+      return;
+    }
+    if (stat.isSymbolicLink()) {
+      hash.update(`symlink\0${relativePath}\0${readlinkSync(path)}\0`);
+      return;
+    }
+    if (!stat.isFile()) {
+      throw new Error(`Installed runtime contains unsupported entry: ${relativePath}`);
+    }
+    hash.update(`file\0${relativePath}\0${stat.mode & 0o777}\0${stat.size}\0`);
+    hash.update(readFileSync(path));
+    hash.update("\0");
+  };
+  visit(root);
+  return hash.digest("hex");
+}
+
+function resolveRequiredPath(args: ParsedArgs, key: string) {
+  return resolve(requireString(args[key], key));
+}
+
+function resolveArchitecture(value: string): Architecture {
+  if (value === "x64" || value === "arm64") {
+    return value;
+  }
+  throw new Error(`Gateway/node compatibility requires x64 or arm64, got ${value}.`);
+}
+
+function containerUser() {
+  const uid = process.getuid?.() ?? 65532;
+  const gid = process.getgid?.() ?? 65532;
+  if (uid === 0 || gid === 0) {
+    throw new Error("Gateway/node compatibility containers require an unprivileged runner.");
+  }
+  return `${uid}:${gid}`;
+}
+
+function requireString(value: unknown, label: string) {
+  if (typeof value !== "string" || !value.trim() || value.trim() !== value) {
+    throw new Error(`${label} must be a non-empty trimmed string.`);
+  }
+  return value;
+}
+
+function requirePattern(value: unknown, label: string, pattern: RegExp) {
+  const normalized = requireString(value, label);
+  if (!pattern.test(normalized)) {
+    throw new Error(`${label} is invalid.`);
+  }
+  return normalized;
+}
+
+function requirePositiveInteger(value: unknown, label: string) {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return Number(value);
+}
+
+function parseWorkflowPath(workflowRef: string, repository: string) {
+  const prefix = `${repository}/`;
+  const at = workflowRef.lastIndexOf("@");
+  const path = at >= 0 ? workflowRef.slice(0, at) : workflowRef;
+  if (!path.startsWith(prefix)) {
+    throw new Error("GATEWAY_NODE_COMPAT_RUN_WORKFLOW_REF repository is invalid.");
+  }
+  const workflowPath = path.slice(prefix.length);
+  if (!/^\.github\/workflows\/[A-Za-z0-9_./-]+\.ya?ml$/u.test(workflowPath)) {
+    throw new Error("GATEWAY_NODE_COMPAT_RUN_WORKFLOW_REF path is invalid.");
+  }
+  return workflowPath;
+}

--- a/scripts/lib/cross-os-release-checks/gateway-node-compat.ts
+++ b/scripts/lib/cross-os-release-checks/gateway-node-compat.ts
@@ -28,10 +28,18 @@ import {
 import type { ParsedArgs } from "./config.ts";
 import { readInstalledMetadata } from "./install.ts";
 import { runManagedContainer } from "./managed-container.ts";
+import { trimForSummary } from "./shared.ts";
 
 const NODE_IMAGE =
   "node:24-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d";
 const WORKFLOW_PATH = ".github/workflows/openclaw-cross-os-release-checks-reusable.yml";
+// Jobs API names gain caller prefixes, while called-workflow step names stay stable.
+// The two publication steps identify this producer without caller-owned literals.
+const PRODUCER_ARTIFACT_STEP_NAMES = [
+  "Upload candidate artifact",
+  "Upload Gateway compatibility baseline",
+] as const;
+const PRODUCER_FAILURE_SCHEMA = "openclaw.gateway-node-compat-producer-failure/v1";
 const ACTIONS_JOBS_PAGE_LIMIT = 10;
 const ACTIONS_JOBS_PER_PAGE = 100;
 const CASE_RUNNER_PATH = resolve(
@@ -71,28 +79,39 @@ type CompatCase = {
 };
 
 export async function runGatewayNodeCompatProducer(args: ParsedArgs, env = process.env) {
+  const outputDir = resolveRequiredPath(args, "gateway-node-compat-output-dir");
+  const logsDir = join(outputDir, "logs");
+  mkdirSync(logsDir, { recursive: true });
+  try {
+    await produceGatewayNodeCompatEvidence(args, env, outputDir, logsDir);
+  } catch (error) {
+    writeGatewayNodeCompatFailureDiagnostic(outputDir, error);
+    throw error;
+  }
+}
+
+async function produceGatewayNodeCompatEvidence(
+  args: ParsedArgs,
+  env: NodeJS.ProcessEnv,
+  outputDir: string,
+  logsDir: string,
+) {
   const architecture = resolveArchitecture(process.arch);
   if (env.GATEWAY_NODE_COMPAT_EXPECTED_ARCH !== architecture) {
     throw new Error("Gateway/node compatibility runner architecture does not match its matrix.");
   }
-  const outputDir = resolveRequiredPath(args, "gateway-node-compat-output-dir");
-  mkdirSync(outputDir, { recursive: true });
   const candidate = readPackageSelection(args, "candidate");
   const baseline = readPackageSelection(args, "compat-baseline");
   if (baseline.version !== "2026.5.7") {
     throw new Error("Gateway/node compatibility baseline must be openclaw@2026.5.7.");
   }
   const producer = readProducer(env);
-  const producerJobName = resolveGatewayNodeCompatProducerJobName(
-    args["gateway-node-compat-producer-job-name"],
-  );
-  validateCurrentRunArtifact(candidate, args, "candidate", producer, producerJobName);
-  validateCurrentRunArtifact(baseline, args, "compat-baseline", producer, producerJobName);
+  validateCurrentRunArtifact(candidate, args, "candidate", producer);
+  validateCurrentRunArtifact(baseline, args, "compat-baseline", producer);
 
   const workDir = mkdtempSync(join(tmpdir(), "openclaw-gateway-node-compat-"));
   const preparedDir = join(workDir, "prepared");
   const casesDir = join(workDir, "cases");
-  const logsDir = join(outputDir, "logs");
   mkdirSync(preparedDir, { recursive: true });
   try {
     await prepareRuntimes({
@@ -120,13 +139,12 @@ export async function runGatewayNodeCompatProducer(args: ParsedArgs, env = proce
         timeoutMs: 5 * 60_000,
         args: buildCaseContainerArgs({ architecture, caseDir, inputPath, preparedDir }),
       });
-      const result = parseCaseResult(
-        readBoundedRegularFile(resultPath, {
-          label: `${compatCase.caseId} result`,
-          maxBytes: 64 * 1024,
-        }),
-        architecture,
-      );
+      const resultBytes = readBoundedRegularFile(resultPath, {
+        label: `${compatCase.caseId} result`,
+        maxBytes: 64 * 1024,
+      });
+      writeGatewayNodeCompatRawResultDiagnostic(outputDir, compatCase.caseId, resultBytes);
+      const result = parseCaseResult(resultBytes, architecture);
       validateCaseProtocolContract(compatCase, result, {
         gateway: runtimes[compatCase.gateway].protocol,
         node: runtimes[compatCase.node].protocol,
@@ -138,15 +156,68 @@ export async function runGatewayNodeCompatProducer(args: ParsedArgs, env = proce
         producer,
         result,
       });
-      const serialized = canonicalizeGatewayNodeCompatEvidence(evidence);
+      const serialized = canonicalizeProducedGatewayNodeCompatEvidence(
+        evidence,
+        candidate,
+        baseline,
+      );
       const destination = join(outputDir, `${compatCase.caseId}.json`);
-      const temporary = `${destination}.tmp-${randomBytes(8).toString("hex")}`;
-      writeFileSync(temporary, serialized, { encoding: "utf8", mode: 0o600 });
-      renameSync(temporary, destination);
+      writeAtomicFile(destination, serialized);
     }
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }
+}
+
+export function canonicalizeProducedGatewayNodeCompatEvidence(
+  evidence: unknown,
+  candidate: Pick<PackageSelection, "sha256">,
+  baseline: Pick<PackageSelection, "sha256">,
+) {
+  return canonicalizeGatewayNodeCompatEvidence(evidence, {
+    candidatePackageSha256: candidate.sha256,
+    baselinePackageSha256: baseline.sha256,
+  });
+}
+
+export function writeGatewayNodeCompatFailureDiagnostic(
+  outputDir: string,
+  error: unknown,
+  completedAt = new Date(),
+) {
+  const diagnosticsDir = join(outputDir, "diagnostics");
+  mkdirSync(diagnosticsDir, { recursive: true });
+  const errorName =
+    error instanceof Error && error.name.trim() ? trimForSummary(error.name) : "Error";
+  const errorMessage =
+    trimForSummary(error instanceof Error ? error.message : String(error)) ||
+    "Unknown Gateway/node compatibility producer failure.";
+  writeAtomicFile(
+    join(diagnosticsDir, "producer-failure.json"),
+    `${JSON.stringify(
+      {
+        schema: PRODUCER_FAILURE_SCHEMA,
+        status: "failed",
+        completedAt: completedAt.toISOString(),
+        error: {
+          name: errorName,
+          message: errorMessage,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+export function writeGatewayNodeCompatRawResultDiagnostic(
+  outputDir: string,
+  caseId: string,
+  result: Buffer,
+) {
+  const rawDir = join(outputDir, "diagnostics", "raw");
+  mkdirSync(rawDir, { recursive: true });
+  writeAtomicFile(join(rawDir, `${caseId}.json`), result);
 }
 
 export function buildCases(
@@ -249,7 +320,6 @@ function validateCurrentRunArtifact(
   args: ParsedArgs,
   prefix: string,
   producer: ReturnType<typeof readProducer>,
-  producerJobName: string,
 ) {
   if (!isSameRunArtifact(selection.actionsArtifact, producer)) {
     throw new Error(`${prefix} artifact must come from this workflow run, not a future attempt.`);
@@ -261,6 +331,7 @@ function validateCurrentRunArtifact(
   const workflowJobs = readWorkflowJobsMetadata(
     resolveRequiredPath(args, `${prefix}-workflow-jobs-metadata`),
   );
+  const producerJobName = resolveGatewayNodeCompatProducerJobName(workflowJobs);
   const expected: ArtifactBinding = {
     artifactDigest: `sha256:${requirePattern(
       args[`${prefix}-artifact-digest`],
@@ -290,7 +361,31 @@ function validateCurrentRunArtifact(
 }
 
 export function resolveGatewayNodeCompatProducerJobName(value: unknown) {
-  return requireString(value, "gateway-node-compat-producer-job-name");
+  if (!isRecord(value) || !Array.isArray(value.jobs)) {
+    throw new Error("Actions workflow jobs response must be an object.");
+  }
+  const matches = value.jobs.filter((job) => {
+    if (!isRecord(job) || !Array.isArray(job.steps)) {
+      return false;
+    }
+    const steps = job.steps;
+    return PRODUCER_ARTIFACT_STEP_NAMES.every(
+      (requiredName) =>
+        steps.filter(
+          (step) =>
+            isRecord(step) &&
+            step.name === requiredName &&
+            step.status === "completed" &&
+            step.conclusion === "success",
+        ).length === 1,
+    );
+  });
+  if (matches.length !== 1) {
+    throw new Error(
+      "Actions workflow jobs must contain one unique compatibility artifact producer.",
+    );
+  }
+  return requireString(matches[0]!.name, "Gateway/node compatibility artifact producer job name");
 }
 
 async function prepareRuntimes(params: {
@@ -529,9 +624,6 @@ function buildEvidence(params: {
     ? params.result.mismatch
     : {};
   const gatewayProtocolVersion = passed ? observation.helloProtocol : mismatch.expectedProtocol;
-  if (!Number.isSafeInteger(gatewayProtocolVersion)) {
-    throw new Error(`${params.compatCase.caseId} did not observe a Gateway protocol.`);
-  }
   return {
     schema: "openclaw.gateway-node-compat/v1",
     caseId: params.compatCase.caseId,
@@ -544,13 +636,13 @@ function buildEvidence(params: {
       protocolClientId: "node-host",
       ...params.runtimes[params.compatCase.node].binding,
     },
-    protocol: {
+    protocol: buildGatewayNodeCompatProtocolEvidence({
+      caseId: params.compatCase.caseId,
       gatewayProtocolVersion,
-      gatewayAcceptedNodeMin: 3,
-      protocolClientAdvertisedMin: observation.clientMin,
-      protocolClientAdvertisedMax: observation.clientMax,
-      helloProtocol: passed ? observation.helloProtocol : null,
-    },
+      gatewayRuntime: params.runtimes[params.compatCase.gateway].protocol,
+      observation,
+      passed,
+    }),
     operation: passed ? params.result.operation : null,
     result: passed
       ? {
@@ -573,6 +665,25 @@ function buildEvidence(params: {
       runAttempt: params.producer.runAttempt,
       job: params.producer.job,
     },
+  };
+}
+
+export function buildGatewayNodeCompatProtocolEvidence(params: {
+  caseId: string;
+  gatewayProtocolVersion: unknown;
+  gatewayRuntime: RuntimeProtocolContract;
+  observation: Record<string, unknown>;
+  passed: boolean;
+}) {
+  if (!Number.isSafeInteger(params.gatewayProtocolVersion)) {
+    throw new Error(`${params.caseId} did not observe a Gateway protocol.`);
+  }
+  return {
+    gatewayProtocolVersion: params.gatewayProtocolVersion,
+    gatewayAcceptedNodeMin: params.gatewayRuntime.nodeMinProtocol,
+    protocolClientAdvertisedMin: params.observation.clientMin,
+    protocolClientAdvertisedMax: params.observation.clientMax,
+    helloProtocol: params.passed ? params.observation.helloProtocol : null,
   };
 }
 
@@ -645,6 +756,16 @@ export function mergeActionsWorkflowJobPages(pages: unknown[]) {
 
 function sha256File(path: string) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function writeAtomicFile(destination: string, contents: string | Uint8Array) {
+  const temporary = `${destination}.tmp-${randomBytes(8).toString("hex")}`;
+  try {
+    writeFileSync(temporary, contents, { encoding: "utf8", mode: 0o600 });
+    renameSync(temporary, destination);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
 }
 
 export function sha256RuntimeTree(root: string) {

--- a/scripts/lib/cross-os-release-checks/managed-container.ts
+++ b/scripts/lib/cross-os-release-checks/managed-container.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { runManagedCommand } from "../managed-child-process.mjs";
+
+function appendTail(current: string, chunk: unknown) {
+  const next = Buffer.from(current + Buffer.from(chunk as Uint8Array).toString("utf8"));
+  return next.subarray(-(64 * 1024)).toString("utf8");
+}
+
+export async function runManagedContainer(params: {
+  args: string[];
+  logPath: string;
+  name: string;
+  timeoutMs: number;
+  runCommand?: typeof runManagedCommand;
+}) {
+  if (!/^openclaw-[a-z0-9-]+$/u.test(params.name)) {
+    throw new Error(`Invalid managed container name: ${params.name}`);
+  }
+  const runCommand = params.runCommand ?? runManagedCommand;
+  let diagnostic = "";
+  let probeOutput = "";
+  const run = (args: string[], timeoutMs: number, capture = false, probe = false) =>
+    runCommand({
+      bin: "docker",
+      args,
+      stdio: capture ? ["ignore", "pipe", "pipe"] : "ignore",
+      timeoutMs,
+      requireProcessTreeExit: true,
+      onReady: capture
+        ? (child) => {
+            child.stdout?.on("data", (chunk) => {
+              diagnostic = appendTail(diagnostic, chunk);
+              if (probe) {
+                probeOutput = appendTail(probeOutput, chunk);
+              }
+            });
+            child.stderr?.on("data", (chunk) => {
+              diagnostic = appendTail(diagnostic, chunk);
+            });
+          }
+        : undefined,
+    });
+  let status = 1;
+  let failure: unknown;
+  let cleanupFailed: boolean;
+  try {
+    status = await run(
+      ["run", "--name", params.name, "--rm", "--log-driver", "none", ...params.args],
+      params.timeoutMs,
+      true,
+    );
+  } catch (error) {
+    failure = error;
+  } finally {
+    await run(["rm", "--force", params.name], 30_000).catch(() => undefined);
+    const probeStatus = await run(
+      ["ps", "--all", "--quiet", "--filter", `name=^/${params.name}$`],
+      30_000,
+      true,
+      true,
+    ).catch(() => -1);
+    cleanupFailed = probeStatus !== 0 || probeOutput.trim() !== "";
+  }
+  mkdirSync(dirname(params.logPath), { recursive: true });
+  const redacted = diagnostic
+    .replaceAll(/Bearer\s+\S+/giu, "Bearer [redacted]")
+    .replaceAll(/[A-Za-z0-9_-]{32,}/gu, "[redacted]");
+  writeFileSync(params.logPath, redacted, "utf8");
+  if (cleanupFailed) {
+    throw new Error(
+      `Managed container ${params.name} remained or cleanup could not be verified.\n${redacted}`,
+    );
+  }
+  if (failure || status !== 0) {
+    const reason = failure instanceof Error ? failure.message : `status ${status}`;
+    throw new Error(`Managed container ${params.name} failed: ${reason}.\n${redacted}`, {
+      cause: failure,
+    });
+  }
+}

--- a/scripts/lib/cross-os-release-checks/managed-container.ts
+++ b/scripts/lib/cross-os-release-checks/managed-container.ts
@@ -1,5 +1,6 @@
-import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { runManagedCommand } from "../managed-child-process.mjs";
 
 function appendTail(current: string, chunk: unknown) {
@@ -43,24 +44,47 @@ export async function runManagedContainer(params: {
     });
   let status = 1;
   let failure: unknown;
-  let cleanupFailed: boolean;
+  let cleanupFailed = false;
+  const ownershipDir = mkdtempSync(join(tmpdir(), "openclaw-managed-container-"));
+  const cidfile = join(ownershipDir, "container.cid");
   try {
     status = await run(
-      ["run", "--name", params.name, "--rm", "--log-driver", "none", ...params.args],
+      [
+        "run",
+        "--cidfile",
+        cidfile,
+        "--name",
+        params.name,
+        "--rm",
+        "--log-driver",
+        "none",
+        ...params.args,
+      ],
       params.timeoutMs,
       true,
     );
   } catch (error) {
     failure = error;
   } finally {
-    await run(["rm", "--force", params.name], 30_000).catch(() => undefined);
-    const probeStatus = await run(
-      ["ps", "--all", "--quiet", "--filter", `name=^/${params.name}$`],
-      30_000,
-      true,
-      true,
-    ).catch(() => -1);
-    cleanupFailed = probeStatus !== 0 || probeOutput.trim() !== "";
+    // A name collision must never let this invocation remove another owner's container.
+    const ownedContainerId = (() => {
+      try {
+        return readFileSync(cidfile, "utf8").trim();
+      } catch {
+        return "";
+      }
+    })();
+    if (ownedContainerId) {
+      await run(["rm", "--force", ownedContainerId], 30_000).catch(() => undefined);
+      const probeStatus = await run(
+        ["ps", "--all", "--quiet", "--filter", `id=${ownedContainerId}`],
+        30_000,
+        true,
+        true,
+      ).catch(() => -1);
+      cleanupFailed = probeStatus !== 0 || probeOutput.trim() !== "";
+    }
+    rmSync(ownershipDir, { recursive: true, force: true });
   }
   mkdirSync(dirname(params.logPath), { recursive: true });
   const redacted = diagnostic

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -10,6 +10,7 @@ import {
   isSupportedCrossOsSuite,
   parseArgs,
   readRunnerOverrideEnv,
+  resolveCrossOsReleaseSelection,
   resolveProviderConfig,
   resolveRunnerMatrix,
 } from "./lib/cross-os-release-checks/config.ts";
@@ -49,6 +50,33 @@ function isMainModule() {
 
 async function main(argv: string[]) {
   const args = parseArgs(argv);
+
+  if (args["gateway-node-compat"] === "true") {
+    const { runGatewayNodeCompatProducer } =
+      await import("./lib/cross-os-release-checks/gateway-node-compat.ts");
+    await runGatewayNodeCompatProducer(args);
+    return;
+  }
+
+  if (args["resolve-selection"] === "true") {
+    const mode = args["mode"] ?? "both";
+    const ref = args["ref"]?.trim() || "main";
+    const runnerOverrideEnv = readRunnerOverrideEnv(process.env);
+    process.stdout.write(
+      `${JSON.stringify(
+        resolveCrossOsReleaseSelection({
+          mode,
+          ref,
+          ubuntuRunner: args["ubuntu-runner"],
+          windowsRunner: args["windows-runner"],
+          macosRunner: args["macos-runner"],
+          suiteFilter: args["suite-filter"],
+          ...runnerOverrideEnv,
+        }),
+      )}\n`,
+    );
+    return;
+  }
 
   if (args["resolve-matrix"] === "true") {
     const mode = args["mode"] ?? "both";

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1834,6 +1834,7 @@ const dockerDigests = "src/docker-image-digests.test.ts";
 const openaiChatToolsE2e = "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts";
 const npmPostpublish = "test/openclaw-npm-postpublish-verify.test.ts";
 const crossOsReleaseChecks = "openclaw-cross-os-release-checks";
+const gatewayNodeLinuxCompat = "gateway-node-linux-compat";
 const runNode = "src/infra/run-node.test.ts";
 const pluginSdkEntryOwners = [
   "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
@@ -1851,6 +1852,7 @@ const pluginSdkEntryOwners = [
 // Keep only genuinely ambiguous paths explicit; conventional discovery owns
 // unambiguous scripts and direct imports without a second inventory.
 const EXACT_TOOLING_TARGETS = new Map([
+  ["scripts/gateway-node-compat-case.ts", [gatewayNodeLinuxCompat]],
   [
     ".github/workflows/mantis-telegram-live.yml",
     ["mantis-telegram-desktop-proof-workflow", packageAcceptance, workflowGuards],
@@ -2036,7 +2038,13 @@ const SEMANTIC_TOOLING_TARGET_PATTERNS = [
   ],
   [
     /^\.github\/workflows\/openclaw-release-checks\.yml$/u,
-    [packageAcceptance, crossOsReleaseChecks, pluginPrerelease, installDocker],
+    [
+      packageAcceptance,
+      crossOsReleaseChecks,
+      gatewayNodeLinuxCompat,
+      pluginPrerelease,
+      installDocker,
+    ],
   ],
   [/^\.github\/workflows\/docker-release\.yml$/u, ["src/dockerfile.test.ts"]],
   [/^\.github\/workflows\/install-smoke\.yml$/u, ["install-smoke-no-push-workflow", installDocker]],
@@ -2045,7 +2053,12 @@ const SEMANTIC_TOOLING_TARGET_PATTERNS = [
   [/^\.github\/workflows\/tui-pty\.yml$/u, [packageAcceptance]],
   [
     /^\.github\/workflows\/openclaw-cross-os-release-checks-reusable\.yml$/u,
-    [crossOsReleaseChecks, "openclaw-cross-os-release-workflow", packageAcceptance],
+    [
+      crossOsReleaseChecks,
+      gatewayNodeLinuxCompat,
+      "openclaw-cross-os-release-workflow",
+      packageAcceptance,
+    ],
   ],
   [
     /^\.github\/workflows\/(?:openclaw-release-publish|package-acceptance)\.yml$/u,
@@ -2718,7 +2731,10 @@ function resolveToolingTestTargets(changedPath, cwd = process.cwd()) {
   const crossOsReleaseTargets =
     implementationPath === "scripts/openclaw-cross-os-release-checks.ts" ||
     implementationPath.startsWith("scripts/lib/cross-os-release-checks/")
-      ? ["test/scripts/openclaw-cross-os-release-checks.test.ts"]
+      ? [
+          "test/scripts/openclaw-cross-os-release-checks.test.ts",
+          "test/scripts/gateway-node-linux-compat.test.ts",
+        ]
       : null;
   const explicitTargets =
     (changedPath === "Dockerfile"

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2734,6 +2734,9 @@ function resolveToolingTestTargets(changedPath, cwd = process.cwd()) {
       ? [
           "test/scripts/openclaw-cross-os-release-checks.test.ts",
           "test/scripts/gateway-node-linux-compat.test.ts",
+          ...(implementationPath === "scripts/lib/cross-os-release-checks/gateway-node-compat.ts"
+            ? ["test/scripts/gateway-node-compat-evidence.test.ts"]
+            : []),
         ]
       : null;
   const explicitTargets =

--- a/test/scripts/gateway-node-compat-evidence.test.ts
+++ b/test/scripts/gateway-node-compat-evidence.test.ts
@@ -24,6 +24,7 @@ import type {
   GatewayNodeCompatCaseContract,
   GatewayNodeCompatOutcome,
 } from "../../scripts/gateway-node-compat-evidence.mjs";
+import { canonicalizeProducedGatewayNodeCompatEvidence } from "../../scripts/lib/cross-os-release-checks/gateway-node-compat.ts";
 
 const SCRIPT_PATH = "scripts/gateway-node-compat-evidence.mjs";
 const CANDIDATE_PACKAGE_SHA256 = "b".repeat(64);
@@ -314,6 +315,24 @@ describe("gateway node compatibility evidence", () => {
     const evidence = validPassEvidence();
 
     expect(validateGatewayNodeCompatEvidence(evidence)).toBe(evidence);
+  });
+
+  it("canonicalizes producer evidence against both package identities", () => {
+    const evidence = validPassEvidence();
+    const canonical = canonicalizeProducedGatewayNodeCompatEvidence(
+      evidence,
+      { sha256: CANDIDATE_PACKAGE_SHA256 },
+      { sha256: BASELINE_PACKAGE_SHA256 },
+    );
+
+    expect(JSON.parse(canonical)).toEqual(evidence);
+    expect(() =>
+      canonicalizeProducedGatewayNodeCompatEvidence(
+        evidence,
+        { sha256: BASELINE_PACKAGE_SHA256 },
+        { sha256: CANDIDATE_PACKAGE_SHA256 },
+      ),
+    ).toThrow(/gateway artifact identity must match the candidate package/u);
   });
 
   it("accepts observed structured protocol mismatch evidence", () => {
@@ -1438,7 +1457,7 @@ describe("gateway node compatibility evidence", () => {
     const declaration = readFileSync("scripts/gateway-node-compat-evidence.d.mts", "utf8");
     const declaredValueExports = Array.from(
       declaration.matchAll(/export (?:declare )?(?:const|function) ([A-Za-z0-9_]+)/gu),
-      (match) => match[1],
+      (match) => match[1]!,
     ).toSorted(compareStrings);
 
     expect(Object.keys(evidenceModule).toSorted(compareStrings)).toEqual(declaredValueExports);

--- a/test/scripts/gateway-node-linux-compat.test.ts
+++ b/test/scripts/gateway-node-linux-compat.test.ts
@@ -1,0 +1,1090 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { generateKeyPairSync, sign } from "node:crypto";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  approveAndInvoke,
+  consumeOneTimeObserverCredential,
+  normalizeMismatch,
+  prepareRuntimeHome,
+  resolveApprovedNodeOperation,
+  validateDisjointObserverConnect,
+  validateObserverConnectCredential,
+  validateObservedIdentity,
+} from "../../scripts/gateway-node-compat-case.ts";
+import {
+  buildCaseContainerArgs,
+  buildCases,
+  isSameRunArtifact,
+  mergeActionsWorkflowJobPages,
+  parseCaseResult,
+  parseRuntimeProtocolContract,
+  resolveGatewayNodeCompatProducerJobName,
+  sha256RuntimeTree,
+  validateCaseProtocolContract,
+} from "../../scripts/lib/cross-os-release-checks/gateway-node-compat.ts";
+import { runManagedContainer } from "../../scripts/lib/cross-os-release-checks/managed-container.ts";
+
+const validObservation = {
+  clientMin: 1,
+  clientMax: 2,
+  helloProtocol: null,
+  identity: {
+    clientId: "node-host",
+    mode: "node",
+    platform: "linux",
+    role: "node",
+  },
+  protocolError: null,
+};
+
+describe("Gateway/node Linux compatibility producer", () => {
+  it.each(["x64", "arm64"] as const)("defines all six %s contracts", (architecture) => {
+    const cases = buildCases(architecture);
+    expect(cases).toHaveLength(6);
+    expect(new Set(cases.map((entry) => entry.caseId)).size).toBe(6);
+    expect(cases.map((entry) => [entry.direction, entry.outcome])).toEqual([
+      ["candidate-gateway-candidate-node", "passed"],
+      ["candidate-gateway-baseline-node", "passed"],
+      ["baseline-gateway-candidate-node", "passed"],
+      ["baseline-gateway-baseline-node", "passed"],
+      ["candidate-gateway-disjoint-node", "protocol-mismatch"],
+      ["baseline-gateway-disjoint-node", "protocol-mismatch"],
+    ]);
+    expect(cases.every((entry) => entry.caseId.startsWith(`linux-${architecture}-`))).toBe(true);
+  });
+
+  it("accepts artifacts from this run at or before the consumer attempt", () => {
+    const producer = { runId: "123", runAttempt: 2 };
+    expect(isSameRunArtifact({ runId: "123", runAttempt: 2 }, producer)).toBe(true);
+    expect(isSameRunArtifact({ runId: "123", runAttempt: 1 }, producer)).toBe(true);
+    expect(isSameRunArtifact({ runId: "122", runAttempt: 2 }, producer)).toBe(false);
+    expect(isSameRunArtifact({ runId: "123", runAttempt: 3 }, producer)).toBe(false);
+  });
+
+  it("accepts any exact producer job identity supplied by workflow provenance", () => {
+    expect(resolveGatewayNodeCompatProducerJobName("prepare")).toBe("prepare");
+    expect(resolveGatewayNodeCompatProducerJobName("cross_os_release_checks / prepare")).toBe(
+      "cross_os_release_checks / prepare",
+    );
+    expect(resolveGatewayNodeCompatProducerJobName("release / arbitrary reusable job")).toBe(
+      "release / arbitrary reusable job",
+    );
+    for (const value of ["", " prepare", "cross_os_release_checks / prepare "]) {
+      expect(() => resolveGatewayNodeCompatProducerJobName(value)).toThrow();
+    }
+  });
+
+  it("derives gateway and node protocol contracts from installed runtime metadata", () => {
+    expect(parseRuntimeProtocolContract("const PROTOCOL_VERSION = 3;\n")).toEqual({
+      gatewayProtocol: 3,
+      nodeMinProtocol: 3,
+      nodeMaxProtocol: 3,
+    });
+    expect(
+      parseRuntimeProtocolContract(
+        [
+          "const PROTOCOL_VERSION = 4;",
+          "const MIN_NODE_PROTOCOL_VERSION = 3;",
+          "export { PROTOCOL_VERSION, MIN_NODE_PROTOCOL_VERSION };",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      gatewayProtocol: 4,
+      nodeMinProtocol: 3,
+      nodeMaxProtocol: 4,
+    });
+    expect(parseRuntimeProtocolContract("const OTHER_VERSION = 4;\n")).toBeNull();
+  });
+
+  it("builds an unprivileged isolated case container with read-only runtimes", () => {
+    const args = buildCaseContainerArgs({
+      architecture: "arm64",
+      caseDir: "/tmp/case",
+      inputPath: "/tmp/case/input.json",
+      preparedDir: "/tmp/prepared",
+    });
+    expect(args).toContain("none");
+    expect(args).toContain("--read-only");
+    expect(args).toContain("--cpus");
+    expect(args).toContain("--memory");
+    expect(args).toContain("--pids-limit");
+    expect(args).toContain("ALL");
+    expect(args.filter((entry) => entry === "--cap-add")).toHaveLength(5);
+    expect(args).toContain("SETUID");
+    expect(args).toContain("SETGID");
+    expect(args).toContain("DAC_OVERRIDE");
+    expect(args).toContain("CHOWN");
+    expect(args).toContain("KILL");
+    expect(args).toContain("no-new-privileges:true");
+    expect(args).toContain("type=bind,src=/tmp/prepared,dst=/runtimes,readonly");
+    expect(args.some((entry) => entry.endsWith("dst=/node_modules/ws,readonly"))).toBe(true);
+    expect(args).toContain("0:0");
+    expect(args).toContain("OPENCLAW_GATEWAY_NODE_ARCH=arm64");
+    expect(args.join(" ")).not.toMatch(/TOKEN|SECRET|KEY/u);
+  });
+
+  it("prepares host-cleanable runtimes without root-owned bind-mount files", () => {
+    const source = readFileSync(
+      "scripts/lib/cross-os-release-checks/gateway-node-compat.ts",
+      "utf8",
+    );
+    expect(source).toContain("process.getuid?.()");
+    expect(source).toContain("require an unprivileged runner");
+    expect(source).toContain("npm_config_cache=/tmp/npm-cache");
+  });
+
+  it("separates package-controlled processes from the trusted observer output owner", () => {
+    const source = readFileSync("scripts/gateway-node-compat-case.ts", "utf8");
+    expect(source).toContain("const GATEWAY_UID = 65532");
+    expect(source).toContain("const NODE_UID = 65533");
+    expect(source).toContain("uid: GATEWAY_UID");
+    expect(source).toContain("const runtimeRoot = createRuntimeRoot()");
+    expect(source).toContain('name: "node"');
+    expect(source).toContain("lstatSync(home, { throwIfNoEntry: false })");
+    expect(source).toMatch(/children,\s+NODE_UID,\s+NODE_GID/u);
+    expect(source).toContain("chown(home, params.uid, params.gid)");
+    expect(source).toContain("CLI_OUTPUT_LIMIT_BYTES");
+    expect(source.match(/mode: 0o644/g)).toHaveLength(2);
+    expect(source).not.toContain("const home = `/tmp/${name}`");
+    expect(source).not.toContain('requireFromRuntime("ws")');
+    expect(source.indexOf("const bootstrapNode = startNode()")).toBeLessThan(
+      source.indexOf("const gatewayChild = start("),
+    );
+  });
+
+  it("rejects a malicious node-home symlink before chowning its target", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gateway-node-home-"));
+    const root = join(dir, "runtime");
+    const target = join(dir, "out");
+    mkdirSync(root, { mode: 0o711 });
+    chmodSync(root, 0o711);
+    mkdirSync(target);
+    writeFileSync(join(target, "owned.txt"), "unchanged\n");
+    symlinkSync(target, join(root, "node"), "dir");
+    const targetBefore = statSync(target);
+    let chownCalled = false;
+    try {
+      expect(() =>
+        prepareRuntimeHome(
+          {
+            root,
+            name: "node",
+            uid: 65533,
+            gid: 65533,
+            rootUid: process.getuid?.() ?? targetBefore.uid,
+            rootGid: process.getgid?.() ?? targetBefore.gid,
+          },
+          () => {
+            chownCalled = true;
+          },
+        ),
+      ).toThrow(/Refusing existing runtime home node/u);
+      expect(chownCalled).toBe(false);
+      expect(lstatSync(join(root, "node")).isSymbolicLink()).toBe(true);
+      expect(statSync(target)).toMatchObject({
+        uid: targetBefore.uid,
+        gid: targetBefore.gid,
+      });
+      expect(readFileSync(join(target, "owned.txt"), "utf8")).toBe("unchanged\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("binds each observed node session to the bootstrapped device's one-time signature", () => {
+    const gatewayToken = "gateway-token";
+    const nonce = "observer-nonce";
+    const signedAt = 1234;
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    const publicKeyRaw = publicKey.export({ format: "der", type: "spki" }).subarray(-32);
+    const deviceId = "expected-device";
+    const payload = [
+      "v3",
+      deviceId,
+      "node-host",
+      "node",
+      "node",
+      "",
+      String(signedAt),
+      gatewayToken,
+      nonce,
+      "linux",
+      "",
+    ].join("|");
+    const signature = sign(null, Buffer.from(payload), privateKey).toString("base64url");
+    const connect = {
+      id: "connect-1",
+      method: "connect",
+      params: {
+        auth: { token: gatewayToken },
+        client: { id: "node-host", mode: "node", platform: "linux" },
+        device: {
+          id: deviceId,
+          nonce,
+          publicKey: publicKeyRaw.toString("base64url"),
+          signature,
+          signedAt,
+        },
+        maxProtocol: 4,
+        minProtocol: 3,
+        role: "node",
+        scopes: [],
+      },
+    };
+    const usedSignatures = new Set<string>();
+    const captured = validateObserverConnectCredential(connect, {
+      gatewayToken,
+      nonce,
+      usedSignatures,
+    });
+    expect(captured.device).toEqual({
+      id: deviceId,
+      publicKey: publicKeyRaw.toString("base64url"),
+    });
+    expect(() =>
+      validateObserverConnectCredential(connect, {
+        expectedDevice: captured.device,
+        gatewayToken,
+        nonce,
+        usedSignatures,
+      }),
+    ).toThrow(/reused/u);
+    expect(() =>
+      validateObserverConnectCredential(
+        {
+          ...connect,
+          params: {
+            ...connect.params,
+            device: { ...connect.params.device, id: "forged-device" },
+          },
+        },
+        {
+          expectedDevice: captured.device,
+          gatewayToken,
+          nonce,
+          usedSignatures: new Set(),
+        },
+      ),
+    ).toThrow(/unexpected device identity/u);
+  });
+
+  it("authorizes exactly one supervisor-created disjoint protocol probe", () => {
+    const credential = "one-time-observer-credential";
+    expect(consumeOneTimeObserverCredential(credential, credential)).toBeUndefined();
+    expect(() => consumeOneTimeObserverCredential(credential, undefined)).toThrow(/reused/u);
+    expect(() => consumeOneTimeObserverCredential("forged", credential)).toThrow(/unauthorized/u);
+
+    const frame = {
+      id: "disjoint-connect",
+      method: "connect",
+      params: {
+        auth: { token: "gateway-token" },
+        client: { id: "node-host", mode: "node", platform: "linux" },
+        maxProtocol: 2,
+        minProtocol: 1,
+        role: "node",
+      },
+    };
+    expect(validateDisjointObserverConnect(frame, "gateway-token")).toMatchObject({
+      clientMin: 1,
+      clientMax: 2,
+      identity: {
+        clientId: "node-host",
+        mode: "node",
+        platform: "linux",
+        role: "node",
+      },
+    });
+    expect(() =>
+      validateDisjointObserverConnect(
+        {
+          ...frame,
+          params: { ...frame.params, maxProtocol: 3 },
+        },
+        "gateway-token",
+      ),
+    ).toThrow(/invalid disjoint protocol probe/u);
+  });
+
+  it("accepts the pinned baseline's exact legacy 1..2 mismatch", () => {
+    expect(
+      normalizeMismatch(
+        {
+          ...validObservation,
+          protocolError: { details: { expectedProtocol: 3 } },
+        },
+        "2026.5.7",
+      ),
+    ).toEqual({
+      code: "PROTOCOL_MISMATCH",
+      clientMinProtocol: 1,
+      clientMaxProtocol: 2,
+      expectedProtocol: 3,
+    });
+  });
+
+  it("accepts a structured Gateway mismatch and rejects an overstated range", () => {
+    const protocolError = {
+      details: {
+        code: "PROTOCOL_MISMATCH",
+        clientMinProtocol: 1,
+        clientMaxProtocol: 2,
+        expectedProtocol: 4,
+      },
+    };
+    expect(normalizeMismatch({ ...validObservation, protocolError })).toMatchObject({
+      expectedProtocol: 4,
+    });
+    expect(() =>
+      normalizeMismatch({
+        ...validObservation,
+        clientMin: 2,
+        protocolError,
+      }),
+    ).toThrow(/exact protocol range 1\.\.2/u);
+    expect(() =>
+      normalizeMismatch({
+        ...validObservation,
+        protocolError: { details: { expectedProtocol: 3 } },
+      }),
+    ).toThrow(/structured PROTOCOL_MISMATCH/u);
+    expect(() =>
+      normalizeMismatch({
+        ...validObservation,
+        protocolError: {
+          details: {
+            code: "PROTOCOL_MISMATCH",
+            clientMinProtocol: 1,
+            clientMaxProtocol: 2,
+            expectedProtocol: 2,
+          },
+        },
+      }),
+    ).toThrow(/structured PROTOCOL_MISMATCH/u);
+    expect(() =>
+      normalizeMismatch(
+        {
+          ...validObservation,
+          protocolError: { details: { expectedProtocol: 4 } },
+        },
+        "2026.5.7",
+      ),
+    ).toThrow(/structured PROTOCOL_MISMATCH/u);
+  });
+
+  it("requires the observer's Linux node identity", () => {
+    expect(validateObservedIdentity(validObservation)).toBe(validObservation);
+    expect(() =>
+      validateObservedIdentity({
+        ...validObservation,
+        identity: { ...validObservation.identity, role: "operator" },
+      }),
+    ).toThrow(/Linux node-host/u);
+  });
+
+  it("waits through delayed repeated approvals before invoking the advertised operation", async () => {
+    const calls: string[][] = [];
+    let deviceListCalls = 0;
+    let nodeStatusCalls = 0;
+    let restarts = 0;
+    let stops = 0;
+    const stoppedNodes: ChildProcess[] = [];
+    const initialNode = { exitCode: null } as ChildProcess;
+    const restartedNode = { exitCode: null } as ChildProcess;
+    const cli = async (args: string[]) => {
+      calls.push(args);
+      if (args[0] === "devices" && args[1] === "list") {
+        deviceListCalls += 1;
+        if (deviceListCalls === 1) {
+          return { pending: [], paired: [] };
+        }
+        if (deviceListCalls <= 3) {
+          return {
+            pending: [
+              {
+                requestId: "device-request",
+                deviceId: "node-device",
+                displayName: "compat-case",
+                role: "node",
+              },
+            ],
+            paired: [],
+          };
+        }
+        return {
+          pending: [],
+          paired: [
+            {
+              deviceId: "node-device",
+              displayName: "compat-case",
+              roles: ["node"],
+            },
+          ],
+        };
+      }
+      if (args[0] === "devices" && args[1] === "approve") {
+        return { requestId: args[2] };
+      }
+      if (args[0] === "nodes" && args[1] === "pending") {
+        return [
+          {
+            requestId: "node-request",
+            nodeId: "node-device",
+            displayName: "compat-case",
+          },
+        ];
+      }
+      if (args[0] === "nodes" && args[1] === "approve") {
+        return { requestId: args[2] };
+      }
+      if (args[0] === "nodes" && args[1] === "status") {
+        nodeStatusCalls += 1;
+        return {
+          nodes: [
+            {
+              nodeId: "node-device",
+              displayName: "compat-case",
+              paired: true,
+              connected: true,
+              approvalState: "approved",
+              commands: nodeStatusCalls === 1 ? [] : ["system.which"],
+            },
+          ],
+        };
+      }
+      if (args[0] === "nodes" && args[1] === "invoke") {
+        return {
+          ok: true,
+          command: "system.which",
+          payload: { bins: { node: "/usr/bin/node" } },
+        };
+      }
+      throw new Error(`Unexpected CLI args: ${args.join(" ")}`);
+    };
+
+    await expect(
+      approveAndInvoke({
+        caseId: "compat-case",
+        cli,
+        nodeChild: initialNode,
+        startNode: () => {
+          restarts += 1;
+          return restartedNode;
+        },
+        stopNode: async (child) => {
+          stoppedNodes.push(child);
+          stops += 1;
+        },
+        now: (() => {
+          let value = 0;
+          return () => value++;
+        })(),
+        wait: async () => {},
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({
+      method: "node.invoke",
+      command: "system.which",
+      params: { bins: ["node"] },
+      ok: true,
+      result: { bins: { node: "/usr/bin/node" } },
+    });
+    expect(restarts).toBe(2);
+    expect(stops).toBe(2);
+    expect(stoppedNodes).toEqual([initialNode, restartedNode]);
+    expect(calls.filter((args) => args[0] === "devices" && args[1] === "approve")).toEqual([
+      ["devices", "approve", "device-request"],
+    ]);
+    expect(calls.filter((args) => args[0] === "nodes" && args[1] === "approve")).toEqual([
+      ["nodes", "approve", "node-request"],
+    ]);
+    expect(calls.filter((args) => args[0] === "nodes" && args[1] === "status")).toHaveLength(2);
+    expect(calls.filter((args) => args[0] === "nodes" && args[1] === "invoke")).toEqual([
+      [
+        "nodes",
+        "invoke",
+        "--node",
+        "node-device",
+        "--command",
+        "system.which",
+        "--params",
+        '{"bins":["node"]}',
+      ],
+    ]);
+  });
+
+  it("derives only the cross-version system.which operation from approved capabilities", () => {
+    expect(
+      resolveApprovedNodeOperation({
+        nodeId: "baseline-node",
+        paired: true,
+        connected: true,
+        commands: ["system.which"],
+      }),
+    ).toEqual({
+      command: "system.which",
+      params: { bins: ["node"] },
+    });
+    expect(
+      resolveApprovedNodeOperation({
+        nodeId: "candidate-node",
+        paired: true,
+        connected: true,
+        approvalState: "approved",
+        commands: ["system.which", "system.run"],
+      }),
+    ).toEqual({
+      command: "system.which",
+      params: { bins: ["node"] },
+    });
+    for (const node of [
+      { paired: false, connected: true, commands: ["system.which"] },
+      { paired: true, connected: false, commands: ["system.which"] },
+      {
+        paired: true,
+        connected: true,
+        approvalState: "pending-approval",
+        commands: ["system.which"],
+      },
+      { paired: true, connected: true, commands: ["system.run"] },
+    ]) {
+      expect(resolveApprovedNodeOperation(node)).toBeNull();
+    }
+  });
+
+  it("rejects case output with a forged connect identity", () => {
+    expect(() =>
+      parseCaseResult(
+        Buffer.from(
+          JSON.stringify({
+            architecture: "x64",
+            observation: {
+              ...validObservation,
+              identity: { ...validObservation.identity, clientId: "forged" },
+            },
+          }),
+        ),
+        "x64",
+      ),
+    ).toThrow(/Linux node-host/u);
+  });
+
+  it("rejects evidence from a different container architecture", () => {
+    expect(() =>
+      parseCaseResult(
+        Buffer.from(JSON.stringify({ architecture: "x64", observation: validObservation })),
+        "arm64",
+      ),
+    ).toThrow(/container architecture/u);
+  });
+
+  it("requires the exact candidate, baseline, and disjoint protocol tuples", () => {
+    const candidate = { gatewayProtocol: 4, nodeMinProtocol: 3, nodeMaxProtocol: 4 };
+    const baseline = { gatewayProtocol: 3, nodeMinProtocol: 3, nodeMaxProtocol: 3 };
+    for (const [gateway, node, clientMax, helloProtocol] of [
+      ["candidate", "candidate", 4, 4],
+      ["candidate", "baseline", 3, 4],
+      ["baseline", "candidate", 4, 3],
+      ["baseline", "baseline", 3, 3],
+    ] as const) {
+      const passed = {
+        observation: {
+          ...validObservation,
+          clientMin: 3,
+          clientMax,
+          helloProtocol,
+        },
+      };
+      expect(
+        validateCaseProtocolContract({ gateway, node, outcome: "passed" }, passed, {
+          gateway: gateway === "candidate" ? candidate : baseline,
+          node: node === "candidate" ? candidate : baseline,
+        }),
+      ).toBe(passed);
+    }
+    expect(() =>
+      validateCaseProtocolContract(
+        { gateway: "candidate", node: "candidate", outcome: "passed" },
+        {
+          observation: {
+            ...validObservation,
+            clientMax: 4,
+            clientMin: 2,
+            helloProtocol: 4,
+          },
+        },
+        { gateway: candidate, node: candidate },
+      ),
+    ).toThrow(/exact protocol contract/u);
+    expect(() =>
+      validateCaseProtocolContract(
+        { gateway: "candidate", node: "baseline", outcome: "passed" },
+        {
+          observation: {
+            ...validObservation,
+            clientMin: 3,
+            clientMax: 3,
+            helloProtocol: 3,
+          },
+        },
+        { gateway: candidate, node: baseline },
+      ),
+    ).toThrow(/exact protocol contract/u);
+    expect(
+      validateCaseProtocolContract(
+        { gateway: "baseline", node: "candidate", outcome: "protocol-mismatch" },
+        {
+          mismatch: { expectedProtocol: 3 },
+          observation: { ...validObservation },
+        },
+        { gateway: baseline, node: candidate },
+      ),
+    ).toMatchObject({ mismatch: { expectedProtocol: 3 } });
+    expect(() =>
+      validateCaseProtocolContract(
+        { gateway: "candidate", node: "candidate", outcome: "protocol-mismatch" },
+        {
+          mismatch: { expectedProtocol: 3 },
+          observation: { ...validObservation },
+        },
+        { gateway: candidate, node: candidate },
+      ),
+    ).toThrow(/exact 1\.\.2 contract/u);
+  });
+
+  it("merges bounded Actions job pages with stable totals and unique ids", () => {
+    const firstPage = {
+      total_count: 101,
+      jobs: Array.from({ length: 100 }, (_, index) => ({ id: index + 1 })),
+    };
+    const secondPage = { total_count: 101, jobs: [{ id: 101 }] };
+    expect(mergeActionsWorkflowJobPages([firstPage, secondPage])).toMatchObject({
+      total_count: 101,
+      jobs: expect.arrayContaining([{ id: 1 }, { id: 101 }]),
+    });
+    expect(() =>
+      mergeActionsWorkflowJobPages([
+        firstPage,
+        { total_count: 102, jobs: [{ id: 101 }, { id: 102 }] },
+      ]),
+    ).toThrow(/unstable/u);
+    expect(() =>
+      mergeActionsWorkflowJobPages([firstPage, { total_count: 101, jobs: [{ id: 100 }] }]),
+    ).toThrow(/duplicate/u);
+  });
+
+  it.each([
+    ["success", 0],
+    ["nonzero", 7],
+  ] as const)("removes the managed container after %s", async (_label, runStatus) => {
+    const calls: string[][] = [];
+    await runManagedContainer({
+      args: ["image", "true"],
+      logPath: join(process.cwd(), ".local", `managed-container-${runStatus}.log`),
+      name: `openclaw-managed-test-${runStatus}`,
+      timeoutMs: 1_000,
+      runCommand: async ({ args }) => {
+        calls.push(args ?? []);
+        if (args?.[0] === "run") {
+          return runStatus;
+        }
+        return 0;
+      },
+    }).catch((error: unknown) => {
+      if (runStatus === 0) {
+        throw error;
+      }
+    });
+    expect(calls.find((args) => args[0] === "run")?.slice(0, 7)).toEqual([
+      "run",
+      "--name",
+      `openclaw-managed-test-${runStatus}`,
+      "--rm",
+      "--log-driver",
+      "none",
+      "image",
+    ]);
+    expect(calls.some((args) => args[0] === "rm" && args[1] === "--force")).toBe(true);
+    expect(calls.some((args) => args[0] === "ps" && args.includes("--quiet"))).toBe(true);
+  });
+
+  it("removes the managed container after a real runner SIGTERM", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-managed-container-sigterm-"));
+    const binDir = join(dir, "bin");
+    const callsPath = join(dir, "calls.log");
+    const readyPath = join(dir, "ready");
+    const dockerPath = join(binDir, "docker");
+    const helperUrl = pathToFileURL(
+      resolve("scripts/lib/cross-os-release-checks/managed-container.ts"),
+    ).href;
+    mkdirSync(binDir);
+    writeFileSync(
+      dockerPath,
+      `#!/bin/sh
+set -eu
+case "$1" in
+  run)
+    echo ready >"$OPENCLAW_TEST_READY"
+    trap 'exit 143' TERM INT HUP
+    while :; do sleep 1; done
+    ;;
+  rm|ps)
+    echo "$1" >>"$OPENCLAW_TEST_CALLS"
+    exit 0
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`,
+      "utf8",
+    );
+    chmodSync(dockerPath, 0o755);
+    const runnerScript = `
+import { runManagedContainer } from ${JSON.stringify(helperUrl)};
+await runManagedContainer({
+  args: ["image", "true"],
+  logPath: ${JSON.stringify(join(dir, "managed.log"))},
+  name: "openclaw-managed-test-real-sigterm",
+  timeoutMs: 60_000,
+});
+`;
+    const runner = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", runnerScript],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          OPENCLAW_TEST_CALLS: callsPath,
+          OPENCLAW_TEST_READY: readyPath,
+        },
+        stdio: "ignore",
+      },
+    );
+    try {
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline && !readOptional(readyPath)) {
+        await delay(25);
+      }
+      expect(readOptional(readyPath)).toBe("ready\n");
+      runner.kill("SIGTERM");
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        const timer = setTimeout(() => rejectPromise(new Error("runner did not exit")), 10_000);
+        runner.once("close", () => {
+          clearTimeout(timer);
+          resolvePromise();
+        });
+      });
+      expect(readOptional(callsPath).trim().split("\n")).toEqual(["rm", "ps"]);
+    } finally {
+      if (runner.exitCode === null) {
+        runner.kill("SIGKILL");
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes the managed container after timeout", async () => {
+    const calls: string[][] = [];
+    await expect(
+      runManagedContainer({
+        args: ["image", "true"],
+        logPath: join(process.cwd(), ".local", "managed-container-timeout.log"),
+        name: "openclaw-managed-test-timeout",
+        timeoutMs: 1,
+        runCommand: async ({ args }) => {
+          calls.push(args ?? []);
+          if (args?.[0] === "run") {
+            throw Object.assign(new Error("timeout"), { code: "ETIMEDOUT" });
+          }
+          return 0;
+        },
+      }),
+    ).rejects.toThrow(/failed/u);
+    expect(calls.some((args) => args[0] === "rm" && args[1] === "--force")).toBe(true);
+  });
+
+  it("fails when container cleanup cannot be verified", async () => {
+    await expect(
+      runManagedContainer({
+        args: ["image", "true"],
+        logPath: join(process.cwd(), ".local", "managed-container-probe.log"),
+        name: "openclaw-managed-test-probe",
+        timeoutMs: 1_000,
+        runCommand: async ({ args }) => (args?.[0] === "ps" ? 125 : 0),
+      }),
+    ).rejects.toThrow(/cleanup could not be verified/u);
+  });
+
+  it("consumes current-run artifacts without repacking or re-uploading them", () => {
+    type WorkflowStep = Record<string, unknown> & {
+      env?: Record<string, unknown>;
+      if?: string;
+      name?: string;
+      run?: string;
+      uses?: string;
+      with?: Record<string, unknown>;
+    };
+    type WorkflowJob = {
+      "continue-on-error"?: string;
+      if?: string;
+      outputs?: Record<string, unknown>;
+      "runs-on"?: string;
+      steps: WorkflowStep[];
+      strategy?: { matrix: { architecture: string[] } };
+    };
+    const workflow = parse(
+      readFileSync(".github/workflows/openclaw-cross-os-release-checks-reusable.yml", "utf8"),
+    ) as {
+      on: {
+        workflow_call: { inputs: Record<string, Record<string, unknown>> };
+        workflow_dispatch: { inputs: Record<string, Record<string, unknown>> };
+      };
+      jobs: {
+        cross_os_release_checks: WorkflowJob;
+        gateway_node_linux_compat: WorkflowJob & {
+          "runs-on": string;
+          strategy: { matrix: { architecture: string[] } };
+        };
+        prepare: WorkflowJob & { outputs: Record<string, unknown> };
+      };
+    };
+    const job = workflow.jobs.gateway_node_linux_compat;
+    const prepare = workflow.jobs.prepare;
+    expect(job.if).toBe("needs.prepare.outputs.gateway_node_compat_enabled == 'true'");
+    expect(job["continue-on-error"]).toBe("${{ inputs.advisory }}");
+    expect(job.strategy.matrix.architecture).toEqual(["x64", "arm64"]);
+    expect(job["runs-on"]).toContain("ubuntu-24.04-arm");
+    const installIndex = job.steps.findIndex(
+      (step) => step.name === "Install trusted observer dependencies",
+    );
+    const producerIndex = job.steps.findIndex(
+      (step) => step.name === "Produce six canonical compatibility cases",
+    );
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(installIndex).toBeLessThan(producerIndex);
+    expect(job.steps[installIndex]?.run).toBe(
+      "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
+    );
+    const serialized = JSON.stringify(job);
+    const executionSteps = JSON.stringify(
+      job.steps.filter((step) => !String(step.uses).startsWith("actions/upload-artifact")),
+    );
+    expect(serialized).toContain("actions/download-artifact");
+    expect(executionSteps).not.toContain("actions/upload-artifact");
+    expect(executionSteps).not.toContain("npm pack");
+    const producer = job.steps.find(
+      (step) => step.name === "Produce six canonical compatibility cases",
+    );
+    expect(producer?.run).not.toContain("${{ needs.prepare.outputs");
+    expect(producer?.env).not.toHaveProperty("GH_TOKEN");
+    expect(producer?.env).toHaveProperty(
+      "GATEWAY_NODE_COMPAT_EXPECTED_ARCH",
+      "${{ matrix.architecture }}",
+    );
+    expect(producer?.env).toHaveProperty(
+      "GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME",
+      "${{ needs.prepare.outputs.gateway_node_compat_producer_job_name }}",
+    );
+    expect(producer?.env).toHaveProperty(
+      "CANDIDATE_ARTIFACT_RUN_ATTEMPT",
+      "${{ needs.prepare.outputs.candidate_artifact_run_attempt }}",
+    );
+    expect(producer?.env).toHaveProperty(
+      "BASELINE_ARTIFACT_RUN_ATTEMPT",
+      "${{ needs.prepare.outputs.compat_baseline_artifact_run_attempt }}",
+    );
+    expect(producer?.run).toContain(
+      '--gateway-node-compat-producer-job-name "$GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME"',
+    );
+    expect(producer?.run).toContain('--candidate-workflow-jobs-metadata "$ROOT/metadata/jobs"');
+    const provenance = job.steps.find(
+      (step) => step.name === "Capture current-run artifact provenance",
+    );
+    expect(provenance?.run).toContain("for page in $(seq 1 10)");
+    expect(provenance?.run).toContain("per_page=100&page=${page}");
+    expect(provenance?.run).toContain("attempts/${PRODUCER_RUN_ATTEMPT}");
+    expect(provenance?.run).toContain("collected == total_count");
+    const matrixSteps = prepare.steps.filter((step) => step.name === "Resolve runner matrix");
+    expect(matrixSteps).toHaveLength(1);
+    const matrix = matrixSteps[0]!;
+    expect(matrix.run).toContain("--resolve-selection true");
+    expect(matrix.run).toContain("set -euo pipefail");
+    expect(matrix.run).toContain("jq -ce");
+    expect(matrix.run).toContain("jq -er");
+    expect(matrix.run).toContain('[[ -n "$value" ]]');
+    expect(matrix.run).toContain("candidate_preparation_enabled=");
+    expect(matrix.run).toContain("packaged_upgrade_enabled=");
+    expect(matrix.run).toContain("cross_os_release_checks_enabled=");
+    expect(matrix.run).toContain("gateway_node_compat_enabled=");
+    expect(prepare.outputs.gateway_node_compat_producer_run_attempt).toBe(
+      "${{ github.run_attempt }}",
+    );
+    expect(prepare.outputs.gateway_node_compat_producer_job_name).toBe(
+      "${{ inputs.gateway_node_compat_producer_job_name }}",
+    );
+    const matrixIndex = prepare.steps.indexOf(matrix);
+    for (const name of [
+      "Validate provider secret availability",
+      "Validate provided candidate artifact binding",
+      "Checkout public source ref",
+      "Setup pnpm",
+      "Install workflow validation dependencies",
+      "Build candidate artifact once",
+      "Resolve baseline package spec",
+      "Pack Gateway compatibility baseline",
+    ]) {
+      expect(matrixIndex).toBeLessThan(prepare.steps.findIndex((step) => step.name === name));
+    }
+    expect(
+      prepare.steps.find((step) => step.name === "Validate provider secret availability")?.if,
+    ).toBe("steps.matrix.outputs.cross_os_release_checks_enabled == 'true'");
+    for (const name of [
+      "Validate provided candidate artifact binding",
+      "Checkout public source ref",
+      "Setup pnpm",
+      "Ensure pnpm store cache directory exists",
+      "Install workflow validation dependencies",
+      "Build candidate artifact once",
+      "Download provided candidate artifact",
+      "Resolve provided candidate package",
+      "Capture candidate metadata",
+      "Upload candidate artifact",
+    ]) {
+      expect(String(prepare.steps.find((step) => step.name === name)?.if)).toContain(
+        "steps.matrix.outputs.candidate_preparation_enabled == 'true'",
+      );
+    }
+    for (const name of [
+      "Resolve baseline package spec",
+      "Pack baseline artifact",
+      "Capture baseline metadata",
+      "Upload baseline artifact",
+    ]) {
+      expect(prepare.steps.find((step) => step.name === name)?.if).toBe(
+        "steps.matrix.outputs.packaged_upgrade_enabled == 'true'",
+      );
+    }
+    expect(workflow.jobs.cross_os_release_checks.if).toBe(
+      "needs.prepare.outputs.cross_os_release_checks_enabled == 'true'",
+    );
+    for (const trigger of ["workflow_call", "workflow_dispatch"] as const) {
+      expect(workflow.on[trigger].inputs.gateway_node_compat_producer_job_name).toMatchObject({
+        default: "prepare",
+        type: "string",
+      });
+    }
+    const diagnostics = job.steps.find(
+      (step) => step.name === "Upload Gateway/node compatibility diagnostics",
+    );
+    expect(diagnostics?.if).toBe("${{ failure() }}");
+    const evidenceUpload = job.steps.find(
+      (step) => step.name === "Upload Gateway/node compatibility evidence",
+    );
+    expect(evidenceUpload?.with).toHaveProperty(
+      "name",
+      "openclaw-gateway-node-linux-compat-${{ matrix.architecture }}-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
+    for (const name of [
+      "Pack Gateway compatibility baseline",
+      "Upload Gateway compatibility baseline",
+    ]) {
+      expect(prepare.steps.find((step) => step.name === name)?.if).toBe(
+        "steps.matrix.outputs.gateway_node_compat_enabled == 'true'",
+      );
+    }
+
+    const releaseWorkflow = parse(
+      readFileSync(".github/workflows/openclaw-release-checks.yml", "utf8"),
+    ) as {
+      jobs: {
+        cross_os_release_checks: { with?: Record<string, unknown> };
+      };
+    };
+    expect(
+      releaseWorkflow.jobs.cross_os_release_checks.with?.gateway_node_compat_producer_job_name,
+    ).toBe("cross_os_release_checks / prepare");
+  });
+
+  it("does not load Gateway compatibility dependencies for non-compat modes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-gateway-node-loader-"));
+    try {
+      const loaderPath = join(dir, "reject-gateway-compat-loader.mjs");
+      writeFileSync(
+        loaderPath,
+        `export async function resolve(specifier, context, nextResolve) {
+  if (specifier.endsWith("/gateway-node-compat.ts")) {
+    throw new Error("Gateway compatibility module loaded outside compatibility mode");
+  }
+  return nextResolve(specifier, context);
+}
+`,
+        "utf8",
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--loader",
+          loaderPath,
+          "scripts/openclaw-cross-os-release-checks.ts",
+          "--resolve-matrix",
+          "true",
+          "--mode",
+          "fresh",
+        ],
+        { cwd: process.cwd(), encoding: "utf8" },
+      );
+      expect(result.stderr).not.toContain(
+        "Gateway compatibility module loaded outside compatibility mode",
+      );
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({ include: expect.any(Array) });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("hashes the complete installed runtime tree deterministically", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-runtime-tree-"));
+    try {
+      mkdirSync(join(dir, "dist"));
+      writeFileSync(join(dir, "openclaw.mjs"), "launcher\n");
+      writeFileSync(join(dir, "dist", "runtime.js"), "one\n");
+      const first = sha256RuntimeTree(dir);
+      expect(sha256RuntimeTree(dir)).toBe(first);
+      writeFileSync(join(dir, "dist", "runtime.js"), "two\n");
+      expect(sha256RuntimeTree(dir)).not.toBe(first);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+function readOptional(path: string) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}

--- a/test/scripts/gateway-node-linux-compat.test.ts
+++ b/test/scripts/gateway-node-linux-compat.test.ts
@@ -5,6 +5,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   statSync,
@@ -15,14 +16,19 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
 import {
   approveAndInvoke,
+  buildObservedNodeOperation,
+  captureExpectedIdentity,
   consumeOneTimeObserverCredential,
+  formatCliFailureDiagnostic,
+  isChildTerminal,
   normalizeMismatch,
   prepareRuntimeHome,
   resolveApprovedNodeOperation,
+  stopChild,
   validateDisjointObserverConnect,
   validateObserverConnectCredential,
   validateObservedIdentity,
@@ -30,6 +36,7 @@ import {
 import {
   buildCaseContainerArgs,
   buildCases,
+  buildGatewayNodeCompatProtocolEvidence,
   isSameRunArtifact,
   mergeActionsWorkflowJobPages,
   parseCaseResult,
@@ -37,8 +44,11 @@ import {
   resolveGatewayNodeCompatProducerJobName,
   sha256RuntimeTree,
   validateCaseProtocolContract,
+  writeGatewayNodeCompatFailureDiagnostic,
+  writeGatewayNodeCompatRawResultDiagnostic,
 } from "../../scripts/lib/cross-os-release-checks/gateway-node-compat.ts";
 import { runManagedContainer } from "../../scripts/lib/cross-os-release-checks/managed-container.ts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const validObservation = {
   clientMin: 1,
@@ -52,6 +62,7 @@ const validObservation = {
   },
   protocolError: null,
 };
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("Gateway/node Linux compatibility producer", () => {
   it.each(["x64", "arm64"] as const)("defines all six %s contracts", (architecture) => {
@@ -77,17 +88,85 @@ describe("Gateway/node Linux compatibility producer", () => {
     expect(isSameRunArtifact({ runId: "123", runAttempt: 3 }, producer)).toBe(false);
   });
 
-  it("accepts any exact producer job identity supplied by workflow provenance", () => {
-    expect(resolveGatewayNodeCompatProducerJobName("prepare")).toBe("prepare");
-    expect(resolveGatewayNodeCompatProducerJobName("cross_os_release_checks / prepare")).toBe(
+  it("derives the artifact producer name without caller-owned literals", () => {
+    const producerSteps = [
+      {
+        name: "Upload candidate artifact",
+        status: "completed",
+        conclusion: "success",
+      },
+      {
+        name: "Upload Gateway compatibility baseline",
+        status: "completed",
+        conclusion: "success",
+      },
+    ];
+    for (const name of [
+      "prepare",
       "cross_os_release_checks / prepare",
-    );
-    expect(resolveGatewayNodeCompatProducerJobName("release / arbitrary reusable job")).toBe(
-      "release / arbitrary reusable job",
-    );
-    for (const value of ["", " prepare", "cross_os_release_checks / prepare "]) {
-      expect(() => resolveGatewayNodeCompatProducerJobName(value)).toThrow();
+      "release / cross_os_release_checks / prepare",
+    ]) {
+      expect(
+        resolveGatewayNodeCompatProducerJobName({
+          total_count: 2,
+          jobs: [
+            { id: 1, name: "unrelated / prepare", steps: [] },
+            { id: 2, name, steps: producerSteps },
+          ],
+        }),
+      ).toBe(name);
     }
+    expect(() =>
+      resolveGatewayNodeCompatProducerJobName({
+        total_count: 2,
+        jobs: [
+          { id: 1, name: "prepare", steps: producerSteps },
+          { id: 2, name: "other / prepare", steps: producerSteps },
+        ],
+      }),
+    ).toThrow(/one unique compatibility artifact producer/u);
+    expect(() =>
+      resolveGatewayNodeCompatProducerJobName({
+        total_count: 1,
+        jobs: [{ id: 1, name: "cross_os_release_checks / prepare", steps: [] }],
+      }),
+    ).toThrow(/one unique compatibility artifact producer/u);
+  });
+
+  it("writes one atomic bounded producer failure diagnostic", () => {
+    const root = tempDirs.make("gateway-node-producer-failure-");
+    try {
+      writeGatewayNodeCompatFailureDiagnostic(
+        root,
+        new Error(`canonicalization failed ${"x".repeat(1_000)}`),
+        new Date("2026-08-08T12:00:00.000Z"),
+      );
+      const diagnosticsDir = join(root, "diagnostics");
+      expect(readdirSync(diagnosticsDir)).toEqual(["producer-failure.json"]);
+      expect(
+        JSON.parse(readFileSync(join(diagnosticsDir, "producer-failure.json"), "utf8")),
+      ).toEqual({
+        schema: "openclaw.gateway-node-compat-producer-failure/v1",
+        status: "failed",
+        completedAt: "2026-08-08T12:00:00.000Z",
+        error: {
+          name: "Error",
+          message: expect.stringMatching(/^canonicalization failed x+\.\.\.$/u),
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves bounded raw case output before validation", () => {
+    const root = tempDirs.make("gateway-node-raw-result-");
+    const result = Buffer.from('{"observation":{"helloProtocol":99}}\n');
+    writeGatewayNodeCompatRawResultDiagnostic(root, "linux-x64-candidate-node", result);
+
+    expect(readFileSync(join(root, "diagnostics", "raw", "linux-x64-candidate-node.json"))).toEqual(
+      result,
+    );
   });
 
   it("derives gateway and node protocol contracts from installed runtime metadata", () => {
@@ -110,6 +189,31 @@ describe("Gateway/node Linux compatibility producer", () => {
       nodeMaxProtocol: 4,
     });
     expect(parseRuntimeProtocolContract("const OTHER_VERSION = 4;\n")).toBeNull();
+  });
+
+  it.each([
+    { gatewayProtocol: 5, nodeMinProtocol: 4, nodeMaxProtocol: 5 },
+    { gatewayProtocol: 5, nodeMinProtocol: 5, nodeMaxProtocol: 5 },
+  ])("records the parsed Gateway node floor for $nodeMinProtocol..5", (gatewayRuntime) => {
+    expect(
+      buildGatewayNodeCompatProtocolEvidence({
+        caseId: "linux-x64-candidate-gateway-candidate-node",
+        gatewayProtocolVersion: 5,
+        gatewayRuntime,
+        observation: {
+          clientMin: gatewayRuntime.nodeMinProtocol,
+          clientMax: 5,
+          helloProtocol: 5,
+        },
+        passed: true,
+      }),
+    ).toEqual({
+      gatewayProtocolVersion: 5,
+      gatewayAcceptedNodeMin: gatewayRuntime.nodeMinProtocol,
+      protocolClientAdvertisedMin: gatewayRuntime.nodeMinProtocol,
+      protocolClientAdvertisedMax: 5,
+      helloProtocol: 5,
+    });
   });
 
   it("builds an unprivileged isolated case container with read-only runtimes", () => {
@@ -529,6 +633,96 @@ describe("Gateway/node Linux compatibility producer", () => {
     ]);
   });
 
+  it("attaches bounded redacted CLI failure context to terminal errors", async () => {
+    const secret = "gateway-secret";
+    const escapedSecret = "gateway-\u001b[31msecret";
+    const summary = formatCliFailureDiagnostic({
+      args: ["nodes", "status", "--token", secret],
+      status: 7,
+      stderr: `\u001b[31mauth failed for ${escapedSecret}${"x".repeat(600)}\u0007`,
+    });
+    expect(summary).toContain("exit 7: auth failed for [redacted]");
+    expect(summary).not.toContain(secret);
+    expect(
+      Array.from(summary).every((character) => {
+        const codePoint = character.codePointAt(0)!;
+        return codePoint > 0x1f && (codePoint < 0x7f || codePoint > 0x9f);
+      }),
+    ).toBe(true);
+    expect(summary.length).toBeLessThanOrEqual(520);
+
+    let tick = 0;
+    await expect(
+      approveAndInvoke({
+        caseId: "compat-case",
+        cli: async () => null,
+        cliFailureSummary: () => summary,
+        nodeChild: { exitCode: null, signalCode: null } as ChildProcess,
+        startNode: () => ({ exitCode: null, signalCode: null }) as ChildProcess,
+        now: () => tick++,
+        wait: async () => {},
+        timeoutMs: 2,
+      }),
+    ).rejects.toThrow(`Timed out invoking compat-case. Last CLI failure: ${summary}`);
+  });
+
+  it("derives operation evidence only from correlated observer frames", () => {
+    const request = {
+      id: "invoke-1",
+      nodeId: "node-device",
+      command: "system.which",
+      paramsJSON: '{"bins":["node"]}',
+    };
+    const result = {
+      id: "invoke-1",
+      nodeId: "node-device",
+      ok: true,
+      payloadJSON: '{"bins":{"node":"/usr/bin/node"}}',
+    };
+    expect(buildObservedNodeOperation(request, result)).toEqual({
+      method: "node.invoke",
+      command: "system.which",
+      params: { bins: ["node"] },
+      ok: true,
+      result: { bins: { node: "/usr/bin/node" } },
+    });
+    expect(() => buildObservedNodeOperation(request, { ...result, id: "forged" })).toThrow(
+      /matching successful node invocation/u,
+    );
+    expect(() => buildObservedNodeOperation(undefined, result)).toThrow(
+      /matching successful node invocation/u,
+    );
+  });
+
+  it("treats signal exits as terminal and bounds child shutdown", async () => {
+    expect(isChildTerminal({ exitCode: null, signalCode: "SIGTERM" })).toBe(true);
+    if (process.platform === "win32") {
+      return;
+    }
+    const child = spawn(
+      process.execPath,
+      ["-e", "process.on('SIGTERM', () => {}); console.log('ready'); setInterval(() => {}, 1000);"],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    let closed = false;
+    child.once("close", () => {
+      closed = true;
+    });
+    try {
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        child.stdout?.once("data", () => resolvePromise());
+        child.once("error", rejectPromise);
+      });
+      await stopChild(child, { graceMs: 25, killWaitMs: 1_000 });
+      expect(child.signalCode).toBe("SIGKILL");
+      expect(closed).toBe(true);
+    } finally {
+      if (!isChildTerminal(child)) {
+        child.kill("SIGKILL");
+      }
+    }
+  });
+
   it("derives only the cross-version system.which operation from approved capabilities", () => {
     expect(
       resolveApprovedNodeOperation({
@@ -702,6 +896,8 @@ describe("Gateway/node Linux compatibility producer", () => {
       runCommand: async ({ args }) => {
         calls.push(args ?? []);
         if (args?.[0] === "run") {
+          const cidfile = args[args.indexOf("--cidfile") + 1];
+          writeFileSync(cidfile!, `owned-${runStatus}\n`);
           return runStatus;
         }
         return 0;
@@ -711,8 +907,10 @@ describe("Gateway/node Linux compatibility producer", () => {
         throw error;
       }
     });
-    expect(calls.find((args) => args[0] === "run")?.slice(0, 7)).toEqual([
+    expect(calls.find((args) => args[0] === "run")?.slice(0, 9)).toEqual([
       "run",
+      "--cidfile",
+      expect.any(String),
       "--name",
       `openclaw-managed-test-${runStatus}`,
       "--rm",
@@ -721,7 +919,26 @@ describe("Gateway/node Linux compatibility producer", () => {
       "image",
     ]);
     expect(calls.some((args) => args[0] === "rm" && args[1] === "--force")).toBe(true);
-    expect(calls.some((args) => args[0] === "ps" && args.includes("--quiet"))).toBe(true);
+    expect(calls.some((args) => args[0] === "ps" && args.includes("id=owned-" + runStatus))).toBe(
+      true,
+    );
+  });
+
+  it("does not remove a same-name container when docker run never creates the requested one", async () => {
+    const calls: string[][] = [];
+    await expect(
+      runManagedContainer({
+        args: ["image", "true"],
+        logPath: join(process.cwd(), ".local", "managed-container-name-conflict.log"),
+        name: "openclaw-managed-test-name-conflict",
+        timeoutMs: 1_000,
+        runCommand: async ({ args }) => {
+          calls.push(args ?? []);
+          return args?.[0] === "run" ? 125 : 0;
+        },
+      }),
+    ).rejects.toThrow(/failed/u);
+    expect(calls.map((args) => args[0])).toEqual(["run"]);
   });
 
   it("removes the managed container after a real runner SIGTERM", async () => {
@@ -743,6 +960,15 @@ describe("Gateway/node Linux compatibility producer", () => {
 set -eu
 case "$1" in
   run)
+    cidfile=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--cidfile" ]; then
+        cidfile="$2"
+        break
+      fi
+      shift
+    done
+    echo owned-sigterm >"$cidfile"
     echo ready >"$OPENCLAW_TEST_READY"
     trap 'exit 143' TERM INT HUP
     while :; do sleep 1; done
@@ -805,6 +1031,19 @@ await runManagedContainer({
     }
   });
 
+  it("clears the node identity bootstrap timeout after a quick capture", async () => {
+    vi.useFakeTimers();
+    try {
+      await captureExpectedIdentity({
+        bootstrap: Promise.resolve(),
+        childExit: new Promise<number>(() => {}),
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("removes the managed container after timeout", async () => {
     const calls: string[][] = [];
     await expect(
@@ -822,7 +1061,7 @@ await runManagedContainer({
         },
       }),
     ).rejects.toThrow(/failed/u);
-    expect(calls.some((args) => args[0] === "rm" && args[1] === "--force")).toBe(true);
+    expect(calls.map((args) => args[0])).toEqual(["run"]);
   });
 
   it("fails when container cleanup cannot be verified", async () => {
@@ -832,7 +1071,13 @@ await runManagedContainer({
         logPath: join(process.cwd(), ".local", "managed-container-probe.log"),
         name: "openclaw-managed-test-probe",
         timeoutMs: 1_000,
-        runCommand: async ({ args }) => (args?.[0] === "ps" ? 125 : 0),
+        runCommand: async ({ args }) => {
+          if (args?.[0] === "run") {
+            const cidfile = args[args.indexOf("--cidfile") + 1];
+            writeFileSync(cidfile!, "owned-probe\n");
+          }
+          return args?.[0] === "ps" ? 125 : 0;
+        },
       }),
     ).rejects.toThrow(/cleanup could not be verified/u);
   });
@@ -840,6 +1085,7 @@ await runManagedContainer({
   it("consumes current-run artifacts without repacking or re-uploading them", () => {
     type WorkflowStep = Record<string, unknown> & {
       env?: Record<string, unknown>;
+      id?: string;
       if?: string;
       name?: string;
       run?: string;
@@ -852,11 +1098,14 @@ await runManagedContainer({
       outputs?: Record<string, unknown>;
       "runs-on"?: string;
       steps: WorkflowStep[];
-      strategy?: { matrix: { architecture: string[] } };
+      strategy?: {
+        matrix: { include: Array<{ architecture: string; runner: string }> };
+      };
     };
     const workflow = parse(
       readFileSync(".github/workflows/openclaw-cross-os-release-checks-reusable.yml", "utf8"),
     ) as {
+      concurrency: { "cancel-in-progress": string; group: string };
       on: {
         workflow_call: { inputs: Record<string, Record<string, unknown>> };
         workflow_dispatch: { inputs: Record<string, Record<string, unknown>> };
@@ -865,17 +1114,29 @@ await runManagedContainer({
         cross_os_release_checks: WorkflowJob;
         gateway_node_linux_compat: WorkflowJob & {
           "runs-on": string;
-          strategy: { matrix: { architecture: string[] } };
+          strategy: {
+            matrix: { include: Array<{ architecture: string; runner: string }> };
+          };
         };
         prepare: WorkflowJob & { outputs: Record<string, unknown> };
       };
     };
     const job = workflow.jobs.gateway_node_linux_compat;
     const prepare = workflow.jobs.prepare;
+    expect(workflow.concurrency).toEqual({
+      group:
+        "openclaw-cross-os-release-checks-${{ inputs.ref }}-${{ inputs.provider }}-${{ inputs.mode }}-${{ inputs.suite_filter || 'all' }}",
+      "cancel-in-progress": "${{ inputs.ref == 'main' }}",
+    });
     expect(job.if).toBe("needs.prepare.outputs.gateway_node_compat_enabled == 'true'");
     expect(job["continue-on-error"]).toBe("${{ inputs.advisory }}");
-    expect(job.strategy.matrix.architecture).toEqual(["x64", "arm64"]);
-    expect(job["runs-on"]).toContain("ubuntu-24.04-arm");
+    expect(job.strategy.matrix).toEqual({
+      include: [
+        { architecture: "x64", runner: "ubuntu-24.04" },
+        { architecture: "arm64", runner: "ubuntu-24.04-arm" },
+      ],
+    });
+    expect(job["runs-on"]).toBe("${{ matrix.runner }}");
     const installIndex = job.steps.findIndex(
       (step) => step.name === "Install trusted observer dependencies",
     );
@@ -897,16 +1158,14 @@ await runManagedContainer({
     const producer = job.steps.find(
       (step) => step.name === "Produce six canonical compatibility cases",
     );
+    expect(producer?.id).toBe("produce_compat");
     expect(producer?.run).not.toContain("${{ needs.prepare.outputs");
     expect(producer?.env).not.toHaveProperty("GH_TOKEN");
     expect(producer?.env).toHaveProperty(
       "GATEWAY_NODE_COMPAT_EXPECTED_ARCH",
       "${{ matrix.architecture }}",
     );
-    expect(producer?.env).toHaveProperty(
-      "GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME",
-      "${{ needs.prepare.outputs.gateway_node_compat_producer_job_name }}",
-    );
+    expect(producer?.env).not.toHaveProperty("GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME");
     expect(producer?.env).toHaveProperty(
       "CANDIDATE_ARTIFACT_RUN_ATTEMPT",
       "${{ needs.prepare.outputs.candidate_artifact_run_attempt }}",
@@ -915,9 +1174,7 @@ await runManagedContainer({
       "BASELINE_ARTIFACT_RUN_ATTEMPT",
       "${{ needs.prepare.outputs.compat_baseline_artifact_run_attempt }}",
     );
-    expect(producer?.run).toContain(
-      '--gateway-node-compat-producer-job-name "$GATEWAY_NODE_COMPAT_PRODUCER_JOB_NAME"',
-    );
+    expect(producer?.run).not.toContain("--gateway-node-compat-producer-job-name");
     expect(producer?.run).toContain('--candidate-workflow-jobs-metadata "$ROOT/metadata/jobs"');
     const provenance = job.steps.find(
       (step) => step.name === "Capture current-run artifact provenance",
@@ -941,9 +1198,7 @@ await runManagedContainer({
     expect(prepare.outputs.gateway_node_compat_producer_run_attempt).toBe(
       "${{ github.run_attempt }}",
     );
-    expect(prepare.outputs.gateway_node_compat_producer_job_name).toBe(
-      "${{ inputs.gateway_node_compat_producer_job_name }}",
-    );
+    expect(prepare.outputs).not.toHaveProperty("gateway_node_compat_producer_job_name");
     const matrixIndex = prepare.steps.indexOf(matrix);
     for (const name of [
       "Validate provider secret availability",
@@ -990,15 +1245,19 @@ await runManagedContainer({
       "needs.prepare.outputs.cross_os_release_checks_enabled == 'true'",
     );
     for (const trigger of ["workflow_call", "workflow_dispatch"] as const) {
-      expect(workflow.on[trigger].inputs.gateway_node_compat_producer_job_name).toMatchObject({
-        default: "prepare",
-        type: "string",
-      });
+      expect(workflow.on[trigger].inputs).not.toHaveProperty(
+        "gateway_node_compat_producer_job_name",
+      );
     }
     const diagnostics = job.steps.find(
       (step) => step.name === "Upload Gateway/node compatibility diagnostics",
     );
-    expect(diagnostics?.if).toBe("${{ failure() }}");
+    expect(diagnostics?.if).toBe("${{ failure() && steps.produce_compat.outcome != 'skipped' }}");
+    expect(diagnostics?.with?.path).toContain("diagnostics/producer-failure.json");
+    expect(diagnostics?.with?.path).toContain("diagnostics/raw/*.json");
+    expect(diagnostics?.with?.path).toContain("evidence/*.json");
+    expect(diagnostics?.with?.path).toContain("logs/*.log");
+    expect(diagnostics?.with?.["if-no-files-found"]).toBe("error");
     const evidenceUpload = job.steps.find(
       (step) => step.name === "Upload Gateway/node compatibility evidence",
     );
@@ -1022,9 +1281,9 @@ await runManagedContainer({
         cross_os_release_checks: { with?: Record<string, unknown> };
       };
     };
-    expect(
-      releaseWorkflow.jobs.cross_os_release_checks.with?.gateway_node_compat_producer_job_name,
-    ).toBe("cross_os_release_checks / prepare");
+    expect(releaseWorkflow.jobs.cross_os_release_checks.with).not.toHaveProperty(
+      "gateway_node_compat_producer_job_name",
+    );
   });
 
   it("does not load Gateway compatibility dependencies for non-compat modes", () => {

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -77,6 +77,7 @@ import {
   reserveGatewayPortForLane,
   resolveDashboardAssetUrls,
   resolveCrossOsAgentTurnOptional,
+  resolveCrossOsReleaseSelection,
   runCommand,
   resolveCommandSpawnInvocation,
   resolveExplicitBaselineVersion,
@@ -1378,6 +1379,61 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       "packaged-fresh",
     ]);
   });
+
+  it.each([
+    {
+      name: "default selection",
+      suiteFilter: "",
+      expectedEntries: 12,
+      expectedCrossOs: true,
+      expectedGateway: true,
+      expectedPackagedUpgrade: true,
+    },
+    {
+      name: "focused Gateway/node compatibility",
+      suiteFilter: "gateway_node_compat",
+      expectedEntries: 0,
+      expectedCrossOs: false,
+      expectedGateway: true,
+      expectedPackagedUpgrade: false,
+    },
+    {
+      name: "focused packaged-fresh",
+      suiteFilter: "packaged-fresh",
+      expectedEntries: 3,
+      expectedCrossOs: true,
+      expectedGateway: false,
+      expectedPackagedUpgrade: false,
+    },
+    {
+      name: "mixed Windows upgrade and Gateway/node compatibility",
+      suiteFilter: "windows/packaged-upgrade,gateway-node-compat",
+      expectedEntries: 1,
+      expectedCrossOs: true,
+      expectedGateway: true,
+      expectedPackagedUpgrade: true,
+    },
+  ])(
+    "resolves $name before package preparation",
+    ({
+      suiteFilter,
+      expectedEntries,
+      expectedCrossOs,
+      expectedGateway,
+      expectedPackagedUpgrade,
+    }) => {
+      const selection = resolveCrossOsReleaseSelection({
+        mode: "both",
+        ref: "main",
+        suiteFilter,
+      });
+      expect(selection.matrix.include).toHaveLength(expectedEntries);
+      expect(selection.crossOsReleaseChecksEnabled).toBe(expectedCrossOs);
+      expect(selection.gatewayNodeCompatEnabled).toBe(expectedGateway);
+      expect(selection.candidatePreparationEnabled).toBe(expectedCrossOs || expectedGateway);
+      expect(selection.packagedUpgradeEnabled).toBe(expectedPackagedUpgrade);
+    },
+  );
 
   it("rejects unsupported cross-OS suite filter tokens", () => {
     expect(() => parseCrossOsSuiteFilter("windows/nope")).toThrow(

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -1441,6 +1441,16 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     );
   });
 
+  it("rejects a mixed filter when its cross-OS suite is unavailable in the selected mode", () => {
+    expect(() =>
+      resolveCrossOsReleaseSelection({
+        mode: "fresh",
+        ref: "main",
+        suiteFilter: "packaged-upgrade,gateway-node-compat",
+      }),
+    ).toThrow(/did not match any fresh suite/u);
+  });
+
   it("can rebuild the Windows PATH with or without current-process entries", () => {
     expect(buildWindowsPathBootstrapScript()).toContain("@($env:Path, $userPath, $machinePath)");
     const persistedOnlyScript = buildWindowsPathBootstrapScript({

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -287,7 +287,7 @@ describe("cross-OS release checks workflow", () => {
 
     const resolve = step(prepare, "Resolve provided candidate package");
     expect(step(prepare, "Install workflow validation dependencies")).toMatchObject({
-      if: "inputs.candidate_artifact_name != ''",
+      if: "steps.matrix.outputs.candidate_preparation_enabled == 'true' && inputs.candidate_artifact_name != ''",
       run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
     });
     expect(resolve.run).toContain("resolve-openclaw-package-candidate.mjs");

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1270,8 +1270,39 @@ describe("scripts/test-projects changed-target routing", () => {
       [
         "test/scripts/package-acceptance-workflow.test.ts",
         "test/scripts/openclaw-cross-os-release-checks.test.ts",
+        "test/scripts/gateway-node-linux-compat.test.ts",
         "test/scripts/plugin-prerelease-test-plan.test.ts",
         "test/scripts/test-install-sh-docker.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+    );
+  });
+
+  it("routes Gateway/node compatibility producers and helpers to their owner tests", () => {
+    expectChangedTargets(
+      ["scripts/gateway-node-compat-case.ts"],
+      ["test/scripts/gateway-node-linux-compat.test.ts"],
+    );
+    for (const source of [
+      "scripts/openclaw-cross-os-release-checks.ts",
+      "scripts/lib/cross-os-release-checks/gateway-node-compat.ts",
+      "scripts/lib/cross-os-release-checks/managed-container.ts",
+    ]) {
+      expectChangedTargets(
+        [source],
+        [
+          "test/scripts/openclaw-cross-os-release-checks.test.ts",
+          "test/scripts/gateway-node-linux-compat.test.ts",
+        ],
+      );
+    }
+    expectChangedTargets(
+      [".github/workflows/openclaw-cross-os-release-checks-reusable.yml"],
+      [
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
+        "test/scripts/gateway-node-linux-compat.test.ts",
+        "test/scripts/openclaw-cross-os-release-workflow.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
       ],
     );
@@ -1380,6 +1411,7 @@ describe("scripts/test-projects changed-target routing", () => {
       "scripts/pnpm-runner.d.mts": ["test/scripts/pnpm-runner.test.ts"],
       "scripts/lib/cross-os-release-checks/runtime.ts": [
         "test/scripts/openclaw-cross-os-release-checks.test.ts",
+        "test/scripts/gateway-node-linux-compat.test.ts",
       ],
       "scripts/install.sh": [
         "test/scripts/install-sh.test.ts",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1285,7 +1285,6 @@ describe("scripts/test-projects changed-target routing", () => {
     );
     for (const source of [
       "scripts/openclaw-cross-os-release-checks.ts",
-      "scripts/lib/cross-os-release-checks/gateway-node-compat.ts",
       "scripts/lib/cross-os-release-checks/managed-container.ts",
     ]) {
       expectChangedTargets(
@@ -1296,6 +1295,14 @@ describe("scripts/test-projects changed-target routing", () => {
         ],
       );
     }
+    expectChangedTargets(
+      ["scripts/lib/cross-os-release-checks/gateway-node-compat.ts"],
+      [
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
+        "test/scripts/gateway-node-linux-compat.test.ts",
+        "test/scripts/gateway-node-compat-evidence.test.ts",
+      ],
+    );
     expectChangedTargets(
       [".github/workflows/openclaw-cross-os-release-checks-reusable.yml"],
       [


### PR DESCRIPTION
Depends on https://github.com/openclaw/openclaw/pull/119995

## What Problem This Solves

Release checks did not exercise packaged Gateway/node compatibility across the current v4 protocol and the last shipped v3 node boundary. A green release could therefore miss current-Gateway/old-node, old-Gateway/current-node, or protocol-floor regressions.

## Why This Change Was Made

Adds required Linux x64 and arm64 producers to the reusable cross-OS release workflow. Each installs the candidate package and the immutable `openclaw@2026.5.7` v3 baseline, then records six direct Gateway WebSocket cases:

- candidate Gateway with candidate node
- candidate Gateway with v3 baseline node
- v3 baseline Gateway with candidate node
- v3 baseline Gateway with v3 baseline node
- candidate Gateway rejecting a disjoint node range `[1,2]`
- v3 baseline Gateway rejecting a disjoint node range `[1,2]`

Each passing case observes the real connect/hello exchange and completes `node.invoke system.which`. The accepted node floor is recorded as 3 only after the same Gateway artifact accepts an exact `[3,3]` node and rejects max protocol 2 with structured `PROTOCOL_MISMATCH`.

Artifact provenance is bound to the actual caller workflow, producer attempt, dynamically resolved reusable-workflow job identity, complete paginated job inventory, immutable artifact tuple, package SHA-256, tagged source SHA, and installed runtime identity. Prior-attempt artifacts remain valid during partial workflow reruns. Producer failures write bounded durable diagnostics before failing closed, and successful evidence remains recoverable if the primary artifact upload fails. Advisory release checks keep this lane advisory.

## User Impact

No runtime behavior changes. Release operators gain packaged evidence that current and v3 Gateway/node combinations still connect and execute a real node operation, while protocols older than the supported node floor are rejected.

## Evidence

- Exact commit: `5bce92bfd76aff4184c32acd0dc7565684bc7e8a`
- Gateway/node evidence and producer tests: 211/211 passed
- Cross-OS release workflow tests: 135/135 passed
- Changed-test routing regression: 1/1 passed
- Targeted oxlint: passed with zero warnings
- `actionlint`: passed
- Targeted `oxfmt`: passed
- Script declaration contracts: 255/255 passed
- `git diff --check`: passed
- Autoreview P2 on the exact branch range: no actionable P0-P2 finding
- Local ClawSweeper on `dd9c127a..5bce92bf`: no concrete actionable regression, bug, or security finding; packaged runtime verdict remains inconclusive without Docker/hosted Actions
- `tsgo:scripts` and `tsgo:test:root` reach only unchanged main/sparse-worktree failures in terminal, QA, Android, and omitted UI config files; no changed-surface TypeScript error remains
- Production/workflow delta: +2,515/-65 lines; tests/support: +1,497/-5 lines. The growth is the packaged dual-version producer, authenticated observer, strict Actions provenance, durable diagnostics, lifecycle cleanup, and canonical evidence generation.
- Historical pre-repair AWS Crabbox proof remains useful context but does not cover this SHA.
- Remaining blocker: run the hosted Full Release workflow on `5bce92bfd76aff4184c32acd0dc7565684bc7e8a` and retain the x64/arm64 packaged compatibility artifacts. Local source tests cannot prove reusable-workflow job naming, hosted runner architecture, or artifact upload behavior end to end.

Punchcard-Session: cobalt-timber-orchard-d1
