### PR TITLE
fix(agent-core): preserve explicit reasoning off through Agent Core handoff

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1489,7 +1489,6 @@ packages/agent-core/src/harness/session/session.ts	1
 packages/agent-core/src/harness/session/tool-result-pairing.ts	17
 packages/agent-core/src/harness/session/uuid.ts	1
 packages/agent-core/src/harness/utils/truncate.ts	1
-packages/agent-core/src/reasoning.ts	1
 packages/agent-core/src/turn-interruption.ts	1
 packages/ai/src/api-registry.ts	3
 packages/ai/src/env-api-keys.ts	10

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -3629,7 +3629,7 @@ describe("agentLoop thinking state", () => {
       name: "disables reasoning after leaving Fable",
       initialModel: { ...model, id: "claude-fable-5", thinkingLevelMap: { off: "low" } },
       nextModel: model,
-      expected: ["low", undefined],
+      expected: ["low", "off"],
     },
     {
       name: "uses Fable's low fallback after entering Fable",

--- a/packages/agent-core/src/reasoning.test.ts
+++ b/packages/agent-core/src/reasoning.test.ts
@@ -27,39 +27,45 @@ describe("resolveAgentReasoningOption", () => {
     expect(resolveAgentReasoningOption(makeModel({ off: "low" }), "off")).toBe("low");
   });
 
-  it.each([undefined, null, "none"])("disables reasoning when off maps to %s", (offFallback) => {
-    expect(resolveAgentReasoningOption(makeModel({ off: offFallback }), "off")).toBeUndefined();
+  it.each([undefined, "none"])("preserves explicit off when off maps to %s", (offFallback) => {
+    expect(resolveAgentReasoningOption(makeModel({ off: offFallback }), "off")).toBe("off");
+  });
+
+  it("leaves unsupported off mapping to the transport", () => {
+    expect(resolveAgentReasoningOption(makeModel({ off: null }), "off")).toBeUndefined();
   });
 
   it("preserves enabled thinking levels", () => {
     expect(resolveAgentReasoningOption(makeModel({ off: "low" }), "high")).toBe("high");
   });
 
-  it("preserves explicit off for Sonnet 5 on Anthropic Messages routes", () => {
-    expect(
-      resolveAgentReasoningOption(makeModel(undefined, { id: "claude-sonnet-5" }), "off"),
-    ).toBe("off");
+  it.each(
+    ["claude-sonnet-5", "anthropic.claude-opus-5"].flatMap((id) =>
+      ([undefined, null, "none", "low"] as const).map((off) => ({ id, off })),
+    ),
+  )("retains the native $id exception with off=$off", ({ id, off }) => {
+    expect(resolveAgentReasoningOption(makeModel({ off }, { id }), "off")).toBe(
+      off === "low" ? "low" : "off",
+    );
   });
 
-  it("uses the route-owned Sonnet 5 off mapping when provided", () => {
-    expect(
-      resolveAgentReasoningOption(
-        makeModel({ off: "low" }, { id: "anthropic.claude-sonnet-5" }),
-        "off",
-      ),
-    ).toBe("low");
-  });
-
-  it.each(["anthropic-messages", "bedrock-converse-stream"] as const)(
-    "maps explicit off to low for canonical Fable aliases on %s",
-    (api) => {
+  it.each(
+    (["anthropic-messages", "bedrock-converse-stream"] as const).flatMap((api) =>
+      ([undefined, null] as const).map((off) => ({ api, off })),
+    ),
+  )(
+    "maps explicit off to low for canonical Fable aliases on $api with off=$off",
+    ({ api, off }) => {
       expect(
         resolveAgentReasoningOption(
-          makeModel(undefined, {
-            id: "production-deployment",
-            api,
-            params: { canonicalModelId: "claude-fable-5" },
-          }),
+          makeModel(
+            { off },
+            {
+              id: "production-deployment",
+              api,
+              params: { canonicalModelId: "claude-fable-5" },
+            },
+          ),
           "off",
         ),
       ).toBe("low");

--- a/packages/agent-core/src/reasoning.ts
+++ b/packages/agent-core/src/reasoning.ts
@@ -7,21 +7,6 @@ import {
 } from "@openclaw/llm-core";
 import type { ThinkingLevel } from "./types.js";
 
-type EnabledThinkingLevel = Exclude<NonNullable<SimpleStreamOptions["reasoning"]>, "off">;
-
-const ENABLED_THINKING_LEVELS = new Set<EnabledThinkingLevel>([
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-]);
-
-function isEnabledThinkingLevel(value: unknown): value is EnabledThinkingLevel {
-  return ENABLED_THINKING_LEVELS.has(value as EnabledThinkingLevel);
-}
-
 export function resolveAgentReasoningOption(
   model: Model,
   thinkingLevel: ThinkingLevel,
@@ -35,11 +20,20 @@ export function resolveAgentReasoningOption(
     resolveClaudeFable5ModelIdentity(model)
       ? "low"
       : undefined);
-  if (isEnabledThinkingLevel(offFallback)) {
-    return offFallback;
+  switch (offFallback) {
+    case "minimal":
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+    case "max":
+      return offFallback;
+    default:
+      // Unsupported off keeps transport defaults; native Sonnet/Opus retain their off contract.
+      return model.thinkingLevelMap?.off !== null ||
+        (model.api === "anthropic-messages" &&
+          (resolveClaudeSonnet5ModelIdentity(model) || resolveClaudeOpus5ModelIdentity(model)))
+        ? "off"
+        : undefined;
   }
-  return model.api === "anthropic-messages" &&
-    (resolveClaudeSonnet5ModelIdentity(model) || resolveClaudeOpus5ModelIdentity(model))
-    ? "off"
-    : undefined;
 }

--- a/src/agents/openai-thinking-contract.test.ts
+++ b/src/agents/openai-thinking-contract.test.ts
@@ -1,4 +1,6 @@
 // Verifies session thinking levels reach OpenAI and Codex Responses transports.
+import { createServer } from "node:http";
+import { createLlmRuntime } from "@openclaw/ai";
 import { Agent, type StreamFn } from "openclaw/plugin-sdk/agent-core";
 import {
   createAssistantMessageEventStream,
@@ -9,6 +11,7 @@ import {
   streamSimple,
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
+import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
 
 type ResponsesModel = Model<"openai-responses"> | Model<"openai-chatgpt-responses">;
 
@@ -36,6 +39,73 @@ const codexTestToken = [
 ].join(".");
 
 describe("OpenAI thinking contract", () => {
+  it.each(
+    (["qwen", "qwen-chat-template"] as const).flatMap((thinkingFormat) =>
+      (["managed", "direct"] as const).flatMap((transport) =>
+        ([undefined, null, "low", "none"] as const).flatMap((offFallback) =>
+          ([undefined, "off", "high"] as const).map((thinkingLevel) => ({
+            thinkingFormat,
+            transport,
+            offFallback,
+            thinkingLevel,
+          })),
+        ),
+      ),
+    ),
+  )(
+    "honors Agent $thinkingLevel with off=$offFallback over $transport $thinkingFormat HTTP",
+    async ({ thinkingFormat, transport, offFallback, thinkingLevel }) => {
+      const payload = await captureHttpProviderPayload({
+        api: "openai-completions",
+        thinkingFormat,
+        transport,
+        thinkingLevelMap: { off: offFallback },
+        thinkingLevel,
+        mode: "agent",
+      });
+      const thinking = thinkingFormat === "qwen" ? payload : payload.chat_template_kwargs;
+      expect(thinking).toMatchObject({
+        enable_thinking:
+          thinkingLevel === "high" ||
+          offFallback === "low" ||
+          (offFallback === null && transport === "managed"),
+      });
+    },
+  );
+
+  it("preserves explicit Agent off when a managed Responses request asks for a summary", async () => {
+    for (const thinkingLevel of ["off", "high"] as const) {
+      const payload = await captureHttpProviderPayload({
+        api: "openai-responses",
+        thinkingLevel,
+        reasoningSummary: "auto",
+        mode: "agent",
+      });
+      expect(payload.reasoning).toEqual(
+        thinkingLevel === "off" ? undefined : { effort: "high", summary: "auto" },
+      );
+    }
+  });
+
+  it("retains standalone managed defaults when no reasoning option is supplied", async () => {
+    const completions = await captureHttpProviderPayload({
+      api: "openai-completions",
+      thinkingFormat: "qwen-chat-template",
+      mode: "standalone",
+    });
+    expect(completions.chat_template_kwargs).toMatchObject({ enable_thinking: true });
+    for (const reasoningSummary of [undefined, "auto"] as const) {
+      const responses = await captureHttpProviderPayload({
+        api: "openai-responses",
+        reasoningSummary,
+        mode: "standalone",
+      });
+      expect(responses.reasoning).toEqual(
+        reasoningSummary ? { effort: "high", summary: "auto" } : undefined,
+      );
+    }
+  });
+
   it.each([
     { model: openaiModel, expectedReasoning: "high" },
     { model: codexModel, expectedReasoning: "high" },
@@ -58,7 +128,7 @@ describe("OpenAI thinking contract", () => {
   );
 
   it.each([openaiModel, codexModel])(
-    "does not forward reasoning when session thinkingLevel is off for $provider/$id",
+    "preserves explicit off when session thinkingLevel is off for $provider/$id",
     async (model) => {
       const capturedOptions: SimpleStreamOptions[] = [];
       const agent = new Agent({
@@ -71,7 +141,7 @@ describe("OpenAI thinking contract", () => {
 
       await agent.prompt("hello");
 
-      expect(capturedOptions.map(({ reasoning }) => reasoning)).toStrictEqual([undefined]);
+      expect(capturedOptions.map(({ reasoning }) => reasoning)).toStrictEqual(["off"]);
     },
   );
 
@@ -95,26 +165,131 @@ describe("OpenAI thinking contract", () => {
     expect(payload.reasoning).toEqual({ effort: "high", summary: "auto" });
   });
 
-  it("leaves Codex Responses reasoning absent when agent runtime disables thinking", async () => {
-    const payload = await captureProviderPayload({
-      model: codexModel,
-      streamFn: streamSimple,
-      options: { transport: "sse" },
-    });
+  it.each([undefined, "off"] as const)(
+    "leaves direct Codex Responses reasoning absent for %s",
+    async (reasoning) => {
+      const payload = await captureProviderPayload({
+        model: codexModel,
+        streamFn: streamSimple,
+        options: { transport: "sse", reasoning },
+      });
 
-    expect(payload).not.toHaveProperty("reasoning");
-  });
+      expect(payload).not.toHaveProperty("reasoning");
+    },
+  );
 
-  it("keeps OpenAI Responses reasoning explicitly disabled when agent runtime disables thinking", async () => {
-    const payload = await captureProviderPayload({
-      model: openaiModel,
-      streamFn: streamSimple,
-      options: {},
-    });
+  it.each([undefined, "off"] as const)(
+    "keeps direct OpenAI Responses reasoning disabled for %s",
+    async (reasoning) => {
+      const payload = await captureProviderPayload({
+        model: openaiModel,
+        streamFn: streamSimple,
+        options: { reasoning },
+      });
 
-    expect(payload.reasoning).toEqual({ effort: "none" });
-  });
+      expect(payload.reasoning).toEqual({ effort: "none" });
+    },
+  );
 });
+
+async function captureHttpProviderPayload(params: {
+  api: "openai-completions" | "openai-responses";
+  thinkingFormat?: "qwen" | "qwen-chat-template";
+  transport?: "managed" | "direct";
+  thinkingLevelMap?: Model["thinkingLevelMap"];
+  thinkingLevel?: "off" | "high";
+  reasoningSummary?: "auto";
+  mode: "agent" | "standalone";
+}): Promise<Record<string, unknown>> {
+  let payload: Record<string, unknown> | undefined;
+  const server = createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      payload = JSON.parse(body) as Record<string, unknown>;
+      const event =
+        params.api === "openai-completions"
+          ? {
+              id: "chatcmpl_thinking",
+              choices: [
+                { index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+              ],
+            }
+          : {
+              type: "response.completed",
+              response: { id: "resp_thinking", status: "completed", output: [] },
+            };
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(`data: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`);
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Missing loopback server address");
+    }
+    const model: Model = {
+      id: params.api === "openai-completions" ? "qwen3.6-27b" : "gpt-5.5",
+      name: "Thinking contract model",
+      api: params.api,
+      provider: "local-thinking",
+      baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      reasoning: true,
+      thinkingLevelMap: params.thinkingLevelMap,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 4_096,
+      ...(params.thinkingFormat
+        ? { compat: { thinkingFormat: params.thinkingFormat, supportsReasoningEffort: false } }
+        : {}),
+    };
+    const providerStream =
+      params.transport === "direct"
+        ? streamSimple
+        : resolveEmbeddedAgentStreamFn({
+            llmRuntime: createLlmRuntime(),
+            currentStreamFn: undefined,
+            model,
+            sessionId: "thinking-contract",
+            resolvedApiKey: "synthetic-test-key",
+          });
+    const streamFn: StreamFn = (requestModel, context, options) =>
+      providerStream(requestModel, context, {
+        ...options,
+        apiKey: "synthetic-test-key",
+        ...(params.reasoningSummary ? { reasoningSummary: params.reasoningSummary } : {}),
+      });
+    if (params.mode === "agent") {
+      const agent = new Agent({
+        initialState: { model, thinkingLevel: params.thinkingLevel },
+        streamFn,
+      });
+      await agent.prompt("hello");
+      expect(agent.state.errorMessage).toBeUndefined();
+    } else {
+      const stream = await streamFn(model, {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      });
+      expect((await stream.result()).stopReason).toBe("stop");
+    }
+    if (!payload) {
+      throw new Error("Provider did not receive a request");
+    }
+    return payload;
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
 function createCapturingStreamFn(
   model: ResponsesModel,


### PR DESCRIPTION
## What Problem This Solves

Agents configured with a supported thinking-off selection could still send enabled-thinking requests to managed Qwen providers. The same problem affects the Agent's own default off state. Managed Responses can likewise select high reasoning when a summary is requested, despite the Agent selecting off.

## Why This Change Was Made

The repair belongs in `resolveAgentReasoningOption`, where off intent was discarded as an absent transport option and managed completions defaulted it to high. Model-owned enabled `thinkingLevelMap.off` mappings, the Fable enabled fallback, and native Sonnet/Opus off exceptions remain intact. Ordinary explicit `off: null` mappings still leave the choice to the transport; missing or `none` mappings preserve literal `off`. A single-use Set and casting type guard are replaced by direct switch narrowing. Standalone transport defaults and direct-provider normalization are unchanged.

Production LOC: **+15/-21 (net -6)**. Tests: **+223/-42 (net +181)**. Assertion-baseline maintenance: **-1 line**, recording the removed cast. No new configuration, public API, persistence, or security policy.

## User Impact

Agents no longer silently enable managed-provider thinking after a supported off selection. Models that explicitly declare off unsupported keep their existing provider-owned behavior, including native Anthropic exceptions.

## Evidence

Live inference was verified on head `be39646009c40da4f3d8bb4d84f10155e97afe3f` through the actual `Agent` → embedded stream resolver → managed OpenAI-compatible transport → transparent HTTP proxy → **Ollama 0.33.0 / Qwen3.5:4b**. The temporary model used a 4096-token context. Two serial requests used the same synthetic arithmetic prompt, a 256-token output cap, and a 45-second deadline, with no retries or raw reasoning logged:

| Agent selection | Actual request | HTTP | Reasoning / visible characters | Observed outcome |
| --- | --- | --- | --- | --- |
| `off` | `reasoning_effort: "none"` | 200 | 0 / 3 | Correct answer `323`, terminal `stop`, 4.984 s |
| `high` | `reasoning_effort: "high"` | 200 | 494 / 0 | Terminal `length` at the 256-token cap, 15.574 s; no final answer claimed |

This addresses the latest ClawSweeper rank-up request with actual Qwen inference across the repaired shared Agent handoff, not a generated SSE response. Ollama's supported `reasoning_effort` dialect is **different from vLLM's `qwen-chat-template` dialect**; this is not live vLLM, LM Studio frontend, or chat-template-flag inference proof. The installed standalone llama.cpp backend rejected the available Qwen3.5 model's rope metadata before listening or inference, and the other installed small Qwen templates did not support the flag. No new model was downloaded. The temporary model was unloaded, its server stopped, and temporary storage removed; the original LM Studio and Ollama services remained available with no models loaded.

The regression uses the real `Agent`, `resolveEmbeddedAgentStreamFn`, managed runtime, and provider SDK against a loopback HTTP server returning SSE. It captures the JSON actually received over HTTP, rather than substituting a mocked stream or stopping at an options callback. Only synthetic credentials and a local test endpoint are used; this is not an authenticated vLLM deployment test.

Observed request fields after the repair (unless a mapping is named, the model has no off override):

| Actual request path | Received reasoning fields |
| --- | --- |
| Agent with explicit `off`, declared `qwen` dialect | `enable_thinking: false` |
| Agent with its default `off`, declared `qwen` dialect | `enable_thinking: false` |
| Agent with explicit/default `off`, declared `qwen-chat-template` dialect | `chat_template_kwargs.enable_thinking: false` |
| Direct Qwen with explicit/default Agent `off` and `thinkingLevelMap.off: null` | Corresponding `enable_thinking: false` (unchanged pre-PR behavior) |
| Managed Qwen with explicit/default Agent `off` and `thinkingLevelMap.off: null` | Corresponding `enable_thinking: true` (unchanged absent-option provider default) |
| Agent with `high`, either Qwen dialect | Corresponding `enable_thinking: true` |
| Standalone managed Qwen, no reasoning option | `chat_template_kwargs.enable_thinking: true` (unchanged default) |
| Agent managed Responses with summary `auto` and explicit `off` | No `reasoning` property |
| Agent managed Responses with summary `auto` and `high` | `reasoning: { effort: "high", summary: "auto" }` |
| Standalone managed Responses, no reasoning option | No `reasoning` property without a summary; `high` with summary `auto` (unchanged defaults) |

For the nonnative Responses endpoint, existing payload policy deliberately strips `effort: "none"`; omission is the correct wire assertion, not a claim that the proxy receives `none`. Paired direct-provider regressions separately retain native OpenAI `none` and ChatGPT Responses omission for both absent and explicit-off inputs.

Before the production edit, the same managed HTTP regression had **five failures**: four explicit/default Agent-off Qwen cases sent `true`, and the Responses-summary off case sent `high`. After the repair, all pass.

The subsequent exact-head review identified a real unsupported-off regression in the candidate. An expanded HTTP matrix reproduced **eight failures** across both Qwen dialects and explicit/default Agent off: direct requests changed from disabled to enabled because literal `off` was clamped to a supported level, while managed requests changed from their existing enabled default to disabled. The correction preserves `undefined` for ordinary `off: null` mappings and restores both previous behaviors. It does not impose a new cross-provider default. Native Sonnet/Opus null exceptions and the Fable fallback remain covered.

Initial before/after proof baseline: `0569c6ea6b401ac15cbffa171be664d8dcf08f52`. The branch was refreshed by a normal merge from verified main `42112dd86ec3010cb14011d7514c82063b12974a`. The resulting tested candidate tree is `8878ba9aa90af678734c432cae3ad2f095ef1d04`; all four reviewed code/test files remain byte-identical, and the diff against that main snapshot adds only the single baseline deletion to the reviewed repair.

The refresh addresses an actual CI failure: the refactor removed the old cast, and the assertion ratchet correctly required its allowance to shrink from one to zero. The old contributor branch predates the baseline file, so importing the current main history was necessary to remove that entry safely. No other allowance was changed or increased.

The final head is `48ee817b59b2a42dff3d6d06e4d60d89e75be68f`, a **metadata-only replacement** with that exact same tested tree and main parent. The earlier contributor message contained an obsolete issue-closing reference, while the repository's squash default copies commit messages. The replacement removes that closing reference so #119959 stays open. It retains xiaobao's original author identity and date plus the explicit co-author credit; the previous tip `be39646009c40da4f3d8bb4d84f10155e97afe3f` was backed up before a lease-protected update. No source, test, or baseline content changed. The live results above were collected on that previous head and apply to the identical tree; hosted CI is required again for the new head.

## Validation

All runs used the repository runner with one worker. The focused command was:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/openai-thinking-contract.test.ts \
  packages/agent-core/src/reasoning.test.ts \
  packages/agent-core/src/agent-loop.test.ts \
  --configLoader runner --maxWorkers 1
```

- Focused Agent/reasoning/HTTP contracts: **148 tests passed across 3 files**, including **60 HTTP/direct contracts**.
- Managed-completions, Anthropic, Google, Mistral, simple-option and Bedrock siblings: **266 tests passed across 6 files**; combined **414 tests across 9 files**.
- After the main refresh, the same **148 focused tests passed again on the refreshed tree**, and the canonical assertion-safety ratchet passed against the verified main snapshot. The six sibling files were not rerun for the baseline-only maintenance; all four repair files are unchanged.
- Exact four-file type-aware lint, formatter, and `git diff --check`: clean. This is focused typed lint, not a full-repository typecheck.
- Fresh Codex review through P2 and independent source/contract reviews found no actionable defects in the corrected patch. The metadata-only final head received another clean P2 review.
- Final head `48ee817b59b2a42dff3d6d06e4d60d89e75be68f`: [full CI run 33031330182](https://github.com/openclaw/openclaw/actions/runs/33031330182) passed on its first attempt, including the required CI gate. The complete 256-check inventory has no failures or pending checks; one canceled nonrequired labeling workflow is excluded under repository policy. The latest completed ClawSweeper review on this head accepts the live proof and has no code findings; its remaining exact-head CI request is now satisfied.

The ClawSweeper managed-HTTP evidence requests and unsupported-null mapping finding are addressed, with the additional real-inference evidence and its precise limits above. The suggestion that managed null must disable thinking is intentionally not applied: that would change the transport's preexisting absent-option default. The actual direct-route regression is repaired and both routes are tested. Exact-head checks will be refreshed without rebasing merely for main drift. A real vLLM deployment remains untested; the observed Ollama model output does not establish behavior for an undeclared compatibility dialect. Existing thinking and vLLM documentation already describe the required `thinkingFormat` contract.

## Related issue and credit

Related: #119959. Keep that issue open: its reported configuration does not declare the Qwen compatibility dialect, and its complete runtime case has not been reproduced here. This PR repairs the independently demonstrated Agent handoff defect, not every possible cause of the reported symptom.

Original implementation and contract updates by @xiaobao-k8s. Contributor author identity, original author date, and explicit co-author credit are retained in the metadata-only replacement.

Co-authored-by: xiaobao <dmbjwy@163.com>
