### PR TITLE
fix(cron): on-exit watcher retries transient failures instead of silently dropping the watch

### DIFF
--- a/src/gateway/cron-exit-watchers.test.ts
+++ b/src/gateway/cron-exit-watchers.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../cron/types.js";
@@ -202,15 +203,18 @@ describe("createCronExitWatchers", () => {
     expect(w.activeJobIds()).toEqual(["job-a"]);
   });
 
-  it("releases the slot without firing when run.wait() rejects (fail closed on unknown outcome)", async () => {
+  it("retries with backoff without firing when run.wait() rejects (fail closed on unknown outcome)", async () => {
     const { supervisor, runs } = makeFakeSupervisor();
     const persistCompletion = vi.fn(async () => {});
     const fireOnExit = vi.fn(async () => {});
+    const updateWatcherState = vi.fn(async () => {});
     const w = createCronExitWatchers({
       getProcessSupervisor: () => supervisor as never,
       persistCompletion,
       fireOnExit,
+      updateWatcherState,
       logger: noopLogger,
+      retryBackoffMs: [0],
     });
 
     w.reconcile([onExitJob("job-a")]);
@@ -227,12 +231,56 @@ describe("createCronExitWatchers", () => {
     // Fail closed: no fire, no persisted terminal state on an unknown outcome.
     expect(fireOnExit).not.toHaveBeenCalled();
     expect(persistCompletion).not.toHaveBeenCalled();
-    // Slot released so a subsequent reconcile can re-arm the job.
-    expect(w.activeJobIds()).toEqual([]);
-    w.reconcile([onExitJob("job-a")]);
+    // The failure is recorded on job state, and the slot stays reserved as the
+    // retry placeholder instead of silently dropping the watch.
+    expect(updateWatcherState).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "job-a" }),
+      expect.objectContaining({ consecutiveErrors: 1 }),
+    );
+    expect(w.activeJobIds()).toEqual(["job-a"]);
+    // The backoff timer re-arms without an external reconcile.
+    await delay(5);
     await flush();
     expect(supervisor.spawn).toHaveBeenCalledTimes(2);
     expect(w.activeJobIds()).toEqual(["job-a"]);
+  });
+
+  it("retries with backoff when spawn fails and stops retrying once cancelled", async () => {
+    const { supervisor, runs } = makeFakeSupervisor();
+    supervisor.spawn.mockRejectedValueOnce(new Error("spawn blew up"));
+    const updateWatcherState = vi.fn(async () => {});
+    const w = createCronExitWatchers({
+      getProcessSupervisor: () => supervisor as never,
+      persistCompletion: vi.fn(async () => {}),
+      fireOnExit: vi.fn(async () => {}),
+      updateWatcherState,
+      logger: noopLogger,
+      retryBackoffMs: [0],
+    });
+
+    w.reconcile([onExitJob("job-a")]);
+    await flush();
+    expect(updateWatcherState).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "job-a" }),
+      expect.objectContaining({ consecutiveErrors: 1 }),
+    );
+    // Backoff re-arm succeeds on the second spawn.
+    await delay(5);
+    await flush();
+    expect(supervisor.spawn).toHaveBeenCalledTimes(2);
+    expect(w.activeJobIds()).toEqual(["job-a"]);
+
+    // Cancelling clears any pending retry timer; once the cancelled child
+    // settles, the slot is released and no further spawns happen.
+    w.cancel("job-a");
+    expectDefined(runs[0], "runs[0] test invariant").deferred.resolve({
+      exitCode: null,
+      reason: "cancelled",
+    });
+    await delay(5);
+    await flush();
+    expect(supervisor.spawn).toHaveBeenCalledTimes(2);
+    expect(w.activeJobIds()).toEqual([]);
   });
 
   it("replaces the watcher when the watched command changes", async () => {

--- a/src/gateway/cron-exit-watchers.ts
+++ b/src/gateway/cron-exit-watchers.ts
@@ -10,6 +10,7 @@ import { resolveExitWatchShell } from "./cron-exit-watch-shell.js";
  * watch ends and the job fires like any other exit.
  */
 const ON_EXIT_WATCH_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+const ON_EXIT_WATCH_RETRY_BACKOFF_MS = [1_000, 5_000, 30_000, 5 * 60_000] as const;
 
 type Logger = {
   info: (obj: unknown, msg?: string) => void;
@@ -48,10 +49,19 @@ export function createCronExitWatchers(params: {
   getProcessSupervisor: () => ProcessSupervisor;
   persistCompletion: (job: OnExitCronJob) => Promise<(() => void) | void>;
   fireOnExit: (job: CronJob, exit: CronExitResult) => void | Promise<void>;
+  updateWatcherState?: (
+    job: OnExitCronJob,
+    patch: Pick<CronJob["state"], "lastError" | "consecutiveErrors">,
+  ) => Promise<CronJob | void>;
   logger: Logger;
   shell?: { command: string; argsFor: (command: string) => string[] };
+  retryBackoffMs?: readonly number[];
 }): CronExitWatchers {
   const shell = params.shell ?? resolveExitWatchShell();
+  const retryBackoffMs =
+    params.retryBackoffMs && params.retryBackoffMs.length > 0
+      ? params.retryBackoffMs
+      : ON_EXIT_WATCH_RETRY_BACKOFF_MS;
   // jobId -> watcher state. `armToken` identifies the current arm so an async
   // spawn/wait that loses ownership (the job was cancelled or re-armed for a
   // changed command) becomes a no-op. The slot is reserved synchronously in
@@ -67,6 +77,8 @@ export function createCronExitWatchers(params: {
     lifecycleSettled: boolean;
     command: string;
     cwd: string | undefined;
+    consecutiveFailures: number;
+    retryTimer: NodeJS.Timeout | undefined;
   };
   const active = new Map<string, WatcherSlot>();
   // A cancelled child can keep running until the supervisor observes exit.
@@ -80,6 +92,10 @@ export function createCronExitWatchers(params: {
       return;
     }
     slot.cancelled = true;
+    if (slot.retryTimer) {
+      clearTimeout(slot.retryTimer);
+      slot.retryTimer = undefined;
+    }
     if (!slot.lifecycleSettled) {
       settlingCancelledSlots.add(slot);
     }
@@ -98,7 +114,7 @@ export function createCronExitWatchers(params: {
     }
   };
 
-  const arm = (job: OnExitCronJob) => {
+  const arm = (job: OnExitCronJob, consecutiveFailures = 0) => {
     const command = job.schedule.command;
     const cwd = job.schedule.cwd;
     const armToken: object = {};
@@ -114,9 +130,58 @@ export function createCronExitWatchers(params: {
       lifecycleSettled: false,
       command,
       cwd,
+      consecutiveFailures,
+      retryTimer: undefined,
     };
     active.set(job.id, slot);
     const owns = () => active.get(job.id) === slot && slot.armToken === armToken;
+    const persistWatcherState = async (
+      patch: Pick<CronJob["state"], "lastError" | "consecutiveErrors">,
+    ) => {
+      if (!params.updateWatcherState) {
+        return;
+      }
+      try {
+        const updated = await params.updateWatcherState(slot.job, patch);
+        if (owns() && updated && isWatchableExitJob(updated)) {
+          slot.job = updated;
+        }
+      } catch (err) {
+        params.logger.warn(
+          { err: String(err), jobId: slot.job.id },
+          "cron-exit: failed to persist watcher state",
+        );
+      }
+    };
+    const scheduleRetry = async (error: unknown, phase: "spawn" | "wait") => {
+      if (!owns() || slot.cancelled) {
+        return;
+      }
+      slot.consecutiveFailures += 1;
+      const errorText = `${phase} failed: ${String(error)}`;
+      await persistWatcherState({
+        lastError: `cron on-exit watcher ${errorText}`,
+        consecutiveErrors: slot.consecutiveFailures,
+      });
+      if (!owns() || slot.cancelled) {
+        return;
+      }
+      const delayMs =
+        retryBackoffMs[Math.min(slot.consecutiveFailures - 1, retryBackoffMs.length - 1)]!;
+      slot.retryTimer = setTimeout(() => {
+        slot.retryTimer = undefined;
+        if (!owns() || slot.cancelled) {
+          return;
+        }
+        active.delete(slot.job.id);
+        arm(slot.job, slot.consecutiveFailures);
+      }, delayMs);
+      slot.retryTimer.unref?.();
+      params.logger.warn(
+        { err: String(error), jobId: slot.job.id, retryInMs: delayMs },
+        `cron-exit: watcher ${phase} failed; retry scheduled`,
+      );
+    };
     void (async () => {
       let run: ManagedRun;
       try {
@@ -136,10 +201,10 @@ export function createCronExitWatchers(params: {
           captureOutput: true,
         });
       } catch (err) {
-        if (owns()) {
-          active.delete(job.id);
-        }
-        params.logger.warn({ err: String(err), jobId: job.id }, "cron-exit: watcher spawn failed");
+        // Keep the slot reserved as the retry placeholder; scheduleRetry re-arms
+        // with backoff so a transient supervisor failure cannot silently drop
+        // the watch (the job would otherwise never fire with no recorded cause).
+        await scheduleRetry(err, "spawn");
         return;
       }
       if (!owns()) {
@@ -161,15 +226,9 @@ export function createCronExitWatchers(params: {
         exit = await run.wait();
       } catch (err) {
         // run.wait() rejected (e.g. supervisor error) rather than resolving with
-        // an exit. Release the slot so a future reconcile can re-arm, and avoid
-        // an unhandled rejection. FAIL CLOSED: do not fire on an unknown outcome.
-        if (owns()) {
-          active.delete(job.id);
-        }
-        params.logger.warn(
-          { err: String(err), jobId: job.id },
-          "cron-exit: run.wait() rejected; released watcher slot without firing",
-        );
+        // an exit. FAIL CLOSED: do not fire on an unknown outcome; scheduleRetry
+        // re-arms the watch with backoff instead of dropping it silently.
+        await scheduleRetry(err, "wait");
         return;
       }
       if (!owns()) {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1154,6 +1154,10 @@ export function buildGatewayCronService(params: {
         }),
       );
     },
+    updateWatcherState: async (job, patch) =>
+      await runWithGatewayIndependentRootWorkAdmission(
+        async () => await cron.update(job.id, { state: patch }),
+      ),
     logger: cronLogger,
   });
   const updateCron = cron.update.bind(cron);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1155,9 +1155,25 @@ export function buildGatewayCronService(params: {
       );
     },
     updateWatcherState: async (job, patch) =>
-      await runWithGatewayIndependentRootWorkAdmission(
-        async () => await cron.update(job.id, { state: patch }),
-      ),
+      await runWithGatewayIndependentRootWorkAdmission(async () => {
+        try {
+          // Same identity guard as persistCompletion: a watcher whose job was
+          // edited/replaced must not write failure state onto the successor
+          // (which could push it into failure backoff or auto-disable).
+          return await cron.updateWithPrecondition(job.id, { state: patch }, (current) => {
+            if (
+              !current.enabled ||
+              current.schedule.kind !== "on-exit" ||
+              current.updatedAtMs !== job.updatedAtMs
+            ) {
+              throw new Error("cron on-exit job changed before watcher-state write");
+            }
+          });
+        } catch {
+          // Stale watcher identity is a no-op, not an error to surface.
+          return undefined;
+        }
+      }),
     logger: cronLogger,
   });
   const updateCron = cron.update.bind(cron);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a cron `on-exit` job could silently never fire: if the process supervisor failed while spawning the watcher child or `run.wait()` rejected (supervisor restart, transient resource error), the watcher slot was released with only a warn log. No state was recorded on the job, no retry happened, and the operator saw a job that just never triggered — the worst bug class per repo doctrine (action ends with no visible outcome and no recorded reason).

## Why This Change Was Made

The watcher is the lifecycle owner of the watch, so the repair lives there: spawn and wait failures now route through a `scheduleRetry` path that records `lastError`/`consecutiveErrors` on the job state (persisted through the gateway cron service via `cron.update`) and re-arms the watch with bounded backoff (1s → 5s → 30s → 5m). Cancellation clears any pending retry timer so hot-reload/removal semantics are unchanged. Fail-closed behavior on unknown exit outcomes is preserved — retries never fire the job.

## User Impact

`on-exit` cron jobs survive transient supervisor failures instead of silently dying, and `openclaw cron` state shows the failure reason while retrying.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/cron-exit-watchers` — 17 tests pass, including two new regression tests: wait-rejection retries with recorded state and no fire; spawn-failure retries then stops cleanly on cancel.
- `node scripts/run-vitest.mjs src/gateway/server-cron` — 64 tests pass with the `updateWatcherState` wiring.
- Codex autoreview (gpt-5.6-sol, high) over the change bundle: clean, no actionable findings.
