### PR TITLE
fix(gateway): redact credentials from gateway URLs in status and logs diagnostics

### DIFF
--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -432,6 +432,43 @@ describe("probeGatewayStatus", () => {
     expect(result.error).toBe("scope upgrade pending approval (requestId: req-123)");
   });
 
+  it("redacts credential-bearing URLs echoed in probe failure text", async () => {
+    callGatewayMock.mockReset();
+    probeGatewayMock.mockReset();
+    probeGatewayMock.mockResolvedValueOnce({
+      ok: false,
+      error: "connect failed to ws://user:secret@gw.example.com:18789?token=abc123",
+      close: null,
+    });
+
+    const result = await probeGatewayStatus({
+      url: "ws://127.0.0.1:19191",
+      timeoutMs: 5_000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toContain("secret");
+    expect(result.error).not.toContain("abc123");
+    expect(result.error).toContain("ws://***:***@gw.example.com:18789?token=***");
+  });
+
+  it("redacts credential-bearing URLs in thrown probe errors", async () => {
+    callGatewayMock.mockReset();
+    probeGatewayMock.mockReset();
+    probeGatewayMock.mockRejectedValueOnce(
+      new Error("dial ws://user:secret@gw.example.com:18789 refused"),
+    );
+
+    const result = await probeGatewayStatus({
+      url: "ws://127.0.0.1:19191",
+      timeoutMs: 5_000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toContain("secret");
+    expect(result.error).toContain("ws://***:***@gw.example.com:18789");
+  });
+
   it("surfaces status RPC errors when requireRpc is enabled", async () => {
     callGatewayMock.mockReset();
     probeGatewayMock.mockReset();

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -1,4 +1,5 @@
 // Gateway status probe helper used by `gateway status` service diagnostics.
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import type { OpenClawConfig } from "../../config/types.js";
 import type { GatewayProbeResult } from "../../gateway/probe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -135,13 +136,15 @@ export async function probeGatewayStatus(opts: {
       auth,
       ...serverSummary,
       ...(version != null ? { version } : {}),
-      error: resolveProbeFailureMessage(result),
+      // Probe failure text can echo the credential-bearing target URL (close
+      // reasons, transport errors); status renderers print it verbatim.
+      error: redactSensitiveUrlLikeString(resolveProbeFailureMessage(result)),
     } as const;
   } catch (err) {
     return {
       ok: false,
       kind,
-      error: formatErrorMessage(err),
+      error: redactSensitiveUrlLikeString(formatErrorMessage(err)),
     } as const;
   }
 }

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -592,15 +592,17 @@ describe("gatherDaemonStatus", () => {
     );
   });
 
-  it("does not force local TLS fingerprint when probe URL is explicitly overridden", async () => {
+  it("uses raw explicit URLs for probes but redacts them from status diagnostics", async () => {
+    const rawUrl =
+      "wss://user:password@override.example:18790/ws?token=secret&key=api-key&X-Amz-Signature=signed";
     callGatewayStatusProbe.mockResolvedValueOnce({
       ok: false,
-      url: "wss://override.example:18790",
+      url: rawUrl,
       error: "connect ECONNREFUSED override.example:18790",
     });
 
     const status = await gatherDaemonStatus({
-      rpc: { url: "wss://override.example:18790" },
+      rpc: { url: rawUrl },
       probe: true,
       deep: false,
     });
@@ -610,10 +612,18 @@ describe("gatherDaemonStatus", () => {
       url?: string;
       tlsFingerprint?: string;
     };
-    expect(probeInput.url).toBe("wss://override.example:18790");
+    expect(probeInput.url).toBe(rawUrl);
     expect(probeInput.tlsFingerprint).toBeUndefined();
-    expect(status.gateway?.probeUrl).toBe("wss://override.example:18790");
-    expect(status.rpc?.url).toBe("wss://override.example:18790");
+    const diagnosticUrls = JSON.stringify({
+      gateway: status.gateway?.probeUrl,
+      rpc: status.rpc?.url,
+    });
+    expect(diagnosticUrls).toContain("override.example:18790/ws");
+    expect(diagnosticUrls).not.toContain("user");
+    expect(diagnosticUrls).not.toContain("password");
+    expect(diagnosticUrls).not.toContain("secret");
+    expect(diagnosticUrls).not.toContain("api-key");
+    expect(diagnosticUrls).not.toContain("signed");
     expect(loadInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
     expect(status.pluginVersionDrift).toBeUndefined();
     expect(status.service.targetRole).toBe("diagnostic-only");

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -23,6 +23,7 @@ import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
+import { projectGatewayUrlForDiagnostics } from "../../gateway/connection-details.js";
 import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
 import { gatewaySecretInputPathCanWin } from "../../gateway/credentials-secret-inputs.js";
 import { trimToUndefined } from "../../gateway/credentials.js";
@@ -115,6 +116,7 @@ type ResolvedGatewayStatus = {
   gateway: GatewayStatusSummary;
   daemonPort: number;
   cliPort: number;
+  probeUrl: string;
   probeUrlOverride: string | null;
 };
 
@@ -445,6 +447,7 @@ async function resolveGatewayStatusSummary(params: {
   const tlsEnabled = params.daemonCfg.gateway?.tls?.enabled === true;
   const scheme = tlsEnabled ? "wss" : "ws";
   const probeUrl = probeUrlOverride ?? `${scheme}://${probeHost}:${daemonPort}`;
+  const diagnosticProbeUrl = projectGatewayUrlForDiagnostics(probeUrl);
   const controlUiLinks =
     params.daemonCfg.gateway?.controlUi?.enabled === false
       ? undefined
@@ -472,12 +475,13 @@ async function resolveGatewayStatusSummary(params: {
       ...(tlsEnabled ? { tlsEnabled } : {}),
       port: daemonPort,
       portSource,
-      probeUrl,
+      probeUrl: diagnosticProbeUrl,
       ...(controlUiLinks ? { controlUiLinks } : {}),
       ...(probeNote ? { probeNote } : {}),
     },
     daemonPort,
     cliPort: resolveGatewayPort(params.cliCfg, process.env),
+    probeUrl,
     probeUrlOverride,
   };
 }
@@ -610,13 +614,14 @@ export async function gatherDaemonStatus(
     daemonConfigSummary,
     configMismatch,
   } = await loadDaemonConfigContext(targetServiceCommand?.environment, { deep: opts.deep });
-  const { gateway, daemonPort, cliPort, probeUrlOverride } = await resolveGatewayStatusSummary({
-    cliCfg,
-    daemonCfg,
-    mergedDaemonEnv,
-    commandProgramArguments: targetServiceCommand?.programArguments,
-    rpcUrlOverride: opts.rpc.url,
-  });
+  const { gateway, daemonPort, cliPort, probeUrl, probeUrlOverride } =
+    await resolveGatewayStatusSummary({
+      cliCfg,
+      daemonCfg,
+      mergedDaemonEnv,
+      commandProgramArguments: targetServiceCommand?.programArguments,
+      rpcUrlOverride: opts.rpc.url,
+    });
   const serviceTargetsProbe = useNativeServiceTargetContext && !probeUrlOverride;
   const shouldInspectLocalGateway = daemonCfg.gateway?.mode !== "remote" && !probeUrlOverride;
   const windowsFirewall =
@@ -705,7 +710,7 @@ export async function gatherDaemonStatus(
   const rpc = opts.probe
     ? await loadDaemonProbeModule().then(({ probeGatewayStatus }) =>
         probeGatewayStatus({
-          url: gateway.probeUrl,
+          url: probeUrl,
           token: daemonProbeAuth?.token,
           password: daemonProbeAuth?.password,
           config: daemonCfg,

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -1083,6 +1083,29 @@ describe("logs cli", () => {
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
+    it("redacts credential-bearing Gateway URLs from JSON errors", async () => {
+      const rawUrl =
+        "wss://user:password@gateway.example/ws?token=secret&key=api-key&X-Amz-Signature=signed";
+      buildGatewayConnectionDetails.mockReturnValueOnce({
+        url: rawUrl,
+        urlSource: "cli --url",
+        message: `Gateway target: ${rawUrl}`,
+      });
+      callGatewayFromCli.mockRejectedValueOnce(new Error(`failed to connect to ${rawUrl}`));
+      const stderrWrites = captureStderrWrites();
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+      await runLogsCli(["logs", "--json", "--url", rawUrl]);
+
+      const stderr = stderrWrites.join("");
+      expect(stderr).toContain("gateway.example/ws");
+      expect(stderr).not.toContain("password");
+      expect(stderr).not.toContain("secret");
+      expect(stderr).not.toContain("api-key");
+      expect(stderr).not.toContain("signed");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
     it("routes terminal reset to stderr in --follow --json so stdout stays parseable JSON in a PTY", async () => {
       callGatewayFromCli.mockRejectedValueOnce(
         new GatewayTransportError({

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -1,5 +1,6 @@
 // Gateway logs CLI with RPC tailing, local file fallback, and systemd journal fallback.
 import { setTimeout as delay } from "node:timers/promises";
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
@@ -17,6 +18,7 @@ import {
   isGatewayTransportError,
   type GatewayConnectionDetails,
 } from "../gateway/call.js";
+import { projectGatewayConnectionDetailsForDiagnostics } from "../gateway/connection-details.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { computeBackoff } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -494,9 +496,11 @@ async function emitGatewayError(
 ) {
   const message = "Gateway not reachable. Is it running and accessible?";
   const hint = `Hint: run \`${formatCliCommand("openclaw doctor")}\`.`;
-  const errorText = formatErrorMessage(err);
+  const errorText = redactSensitiveUrlLikeString(formatErrorMessage(err));
 
-  const details = buildGatewayConnectionDetails({ url: opts.url });
+  const details = projectGatewayConnectionDetailsForDiagnostics(
+    buildGatewayConnectionDetails({ url: opts.url }),
+  );
   if (mode === "json") {
     if (
       !emitJsonLine(

--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -204,6 +204,37 @@ describe("status-all format", () => {
     });
   });
 
+  it("redacts credential-bearing Gateway URLs from text and JSON status", () => {
+    const gatewayConnection = {
+      url: "wss://user:password@gateway.example/ws?token=secret&key=api-key&X-Amz-Signature=signed",
+      urlSource: "cli --url",
+    };
+
+    const summary = buildGatewayStatusSummaryParts({
+      gatewayMode: "remote",
+      remoteUrlMissing: false,
+      gatewayConnection,
+      gatewayReachable: false,
+      gatewayProbe: { error: "unreachable" },
+      gatewayProbeAuth: null,
+    });
+    const json = buildGatewayStatusJsonPayload({
+      gatewayMode: "remote",
+      gatewayConnection,
+      remoteUrlMissing: false,
+      gatewayReachable: false,
+      gatewayProbe: { error: "unreachable" },
+      gatewaySelf: null,
+    });
+    const output = JSON.stringify({ summary, json });
+
+    expect(output).toContain("gateway.example/ws");
+    expect(output).not.toContain("password");
+    expect(output).not.toContain("secret");
+    expect(output).not.toContain("api-key");
+    expect(output).not.toContain("signed");
+  });
+
   it("builds shared gateway surface values for node and gateway views", () => {
     expect(
       buildStatusGatewaySurfaceValues({

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -4,6 +4,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveGatewayPort } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.js";
+import { projectGatewayUrlForDiagnostics } from "../../gateway/connection-details.js";
 import { resolveControlUiLinks } from "../../gateway/control-ui-links.js";
 import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
 import {
@@ -27,6 +28,10 @@ type StatusGatewayConnection = {
   url: string;
   urlSource?: string;
 };
+
+function resolveStatusGatewayDisplayUrl(connection: StatusGatewayConnection): string {
+  return projectGatewayUrlForDiagnostics(connection.url);
+}
 
 type StatusGatewayProbe = {
   connectLatencyMs?: number | null;
@@ -376,9 +381,8 @@ export function buildGatewayStatusSummaryParts(params: {
   authText: string;
   modeLabel: string;
 } {
-  const targetText = params.remoteUrlMissing
-    ? `fallback ${params.gatewayConnection.url}`
-    : params.gatewayConnection.url;
+  const displayUrl = resolveStatusGatewayDisplayUrl(params.gatewayConnection);
+  const targetText = params.remoteUrlMissing ? `fallback ${displayUrl}` : displayUrl;
   const targetTextWithSource = params.gatewayConnection.urlSource
     ? `${targetText} (${params.gatewayConnection.urlSource})`
     : targetText;
@@ -504,7 +508,7 @@ export function buildGatewayStatusJsonPayload(params: {
 }) {
   return {
     mode: params.gatewayMode,
-    url: params.gatewayConnection.url,
+    url: resolveStatusGatewayDisplayUrl(params.gatewayConnection),
     urlSource: params.gatewayConnection.urlSource,
     misconfigured: params.remoteUrlMissing,
     reachable: params.gatewayReachable,

--- a/src/commands/status.gateway-connection.test.ts
+++ b/src/commands/status.gateway-connection.test.ts
@@ -49,6 +49,23 @@ describe("status.gateway-connection", () => {
     );
   });
 
+  it("redacts credentials from the remote fallback URL", () => {
+    const details = resolveStatusAllConnectionDetails({
+      nodeOnlyGateway: null,
+      remoteUrlMissing: true,
+      gatewayConnection: {
+        url: "ws://user:secret@127.0.0.1:18789?token=abc123",
+        urlSource: "env",
+        message: "ignored",
+      },
+      bindMode: "loopback",
+      configPath: "/tmp/openclaw.json",
+    });
+    expect(details).not.toContain("secret");
+    expect(details).not.toContain("abc123");
+    expect(details).toContain("ws://***:***@127.0.0.1:18789/?token=***");
+  });
+
   it("prefers node-only connection details when present", () => {
     expect(
       resolveStatusAllConnectionDetails({

--- a/src/commands/status.gateway-connection.ts
+++ b/src/commands/status.gateway-connection.ts
@@ -1,6 +1,7 @@
 // Gateway connection detail formatting for status reports.
 // Keeps verbose human text and status-all connection sections consistent.
 
+import { projectGatewayUrlForDiagnostics } from "../gateway/connection-details.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { NodeOnlyGatewayInfo } from "./status.node-mode.js";
 import type { StatusScanOverviewResult } from "./status.scan-overview.ts";
@@ -41,7 +42,7 @@ export function resolveStatusAllConnectionDetails(params: {
     "Gateway target: (missing gateway.remote.url)",
     `Config: ${params.configPath}`,
     `Bind: ${params.bindMode ?? "loopback"}`,
-    `Local fallback (used for probes): ${params.gatewayConnection.url}`,
+    `Local fallback (used for probes): ${projectGatewayUrlForDiagnostics(params.gatewayConnection.url)}`,
     "Fix: set gateway.remote.url, or set gateway.mode=local.",
   ].join("\n");
 }

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1649,6 +1649,25 @@ describe("callGateway error details", () => {
     });
   });
 
+  it("redacts credential-bearing URLs echoed in remote close reasons", async () => {
+    startMode = "close";
+    closeCode = 1008;
+    closeReason = "rejected ws://user:secret@gw.example.com:18789?token=abc123";
+    setLocalLoopbackGatewayConfig();
+
+    let err: unknown;
+    await callGateway({ method: "health" }).catch((caught: unknown) => {
+      err = caught;
+    });
+
+    const json = formatGatewayTransportErrorJson(err);
+    const serialized = JSON.stringify(json);
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("abc123");
+    expect(json?.error.reason).toContain("ws://***:***@gw.example.com:18789?token=***");
+    expect(json?.error.message).toContain("ws://***:***@gw.example.com:18789?token=***");
+  });
+
   it("does not over-claim a gateway crash on a 1006 abnormal close", async () => {
     startMode = "close";
     closeCode = 1006;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -2,6 +2,7 @@
 // Builds a GatewayClient, resolves auth/scopes, and performs one request.
 import { randomUUID } from "node:crypto";
 import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   GATEWAY_CLIENT_MODES,
@@ -253,9 +254,11 @@ export function formatGatewayTransportErrorJson(value: unknown): GatewayTranspor
     error: {
       type: "gateway_transport_error",
       kind: value.kind,
-      message: firstGatewayErrorLine(value.message),
+      // The message embeds the remote-controlled close reason, which can echo a
+      // credential-bearing URL; redact both before they reach CLI JSON output.
+      message: redactSensitiveUrlLikeString(firstGatewayErrorLine(value.message)),
       ...(value.code !== undefined ? { code: value.code } : {}),
-      ...(value.reason !== undefined ? { reason: value.reason } : {}),
+      ...(value.reason !== undefined ? { reason: redactSensitiveUrlLikeString(value.reason) } : {}),
       ...(value.timeoutMs !== undefined ? { timeoutMs: value.timeoutMs } : {}),
     },
     gateway: {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -2,7 +2,6 @@
 // Builds a GatewayClient, resolves auth/scopes, and performs one request.
 import { randomUUID } from "node:crypto";
 import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
-import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   GATEWAY_CLIENT_MODES,
@@ -45,6 +44,7 @@ import {
 } from "./client.js";
 import {
   buildGatewayConnectionDetailsWithResolvers,
+  projectGatewayConnectionDetailsForDiagnostics,
   type GatewayConnectionDetails,
 } from "./connection-details.js";
 import { resolveGatewayCredentialsWithSecretInputs } from "./credentials-secret-inputs.js";
@@ -247,6 +247,7 @@ export function formatGatewayTransportErrorJson(value: unknown): GatewayTranspor
   if (!isGatewayTransportError(value)) {
     return null;
   }
+  const connectionDetails = projectGatewayConnectionDetailsForDiagnostics(value.connectionDetails);
   return {
     ok: false,
     error: {
@@ -258,13 +259,11 @@ export function formatGatewayTransportErrorJson(value: unknown): GatewayTranspor
       ...(value.timeoutMs !== undefined ? { timeoutMs: value.timeoutMs } : {}),
     },
     gateway: {
-      url: redactSensitiveUrlLikeString(value.connectionDetails.url),
-      urlSource: value.connectionDetails.urlSource,
-      ...(value.connectionDetails.bindDetail
-        ? { bindDetail: value.connectionDetails.bindDetail }
-        : {}),
-      ...(value.connectionDetails.remoteFallbackNote
-        ? { remoteFallbackNote: value.connectionDetails.remoteFallbackNote }
+      url: connectionDetails.url,
+      urlSource: connectionDetails.urlSource,
+      ...(connectionDetails.bindDetail ? { bindDetail: connectionDetails.bindDetail } : {}),
+      ...(connectionDetails.remoteFallbackNote
+        ? { remoteFallbackNote: connectionDetails.remoteFallbackNote }
         : {}),
     },
   };

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -14,6 +14,22 @@ export type GatewayConnectionDetails = {
   message: string;
 };
 
+/** Project raw transport details into the credential-safe CLI/report shape. */
+export function projectGatewayConnectionDetailsForDiagnostics(
+  details: GatewayConnectionDetails,
+): GatewayConnectionDetails {
+  return {
+    ...details,
+    url: redactSensitiveUrlLikeString(details.url),
+    message: redactSensitiveUrlLikeString(details.message),
+  };
+}
+
+/** Redact one Gateway URL before it crosses an operator-visible diagnostic boundary. */
+export function projectGatewayUrlForDiagnostics(url: string): string {
+  return redactSensitiveUrlLikeString(url);
+}
+
 type GatewayConnectionDetailResolvers = {
   getRuntimeConfig?: () => OpenClawConfig;
   resolveConfigPath?: (env: NodeJS.ProcessEnv) => string;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw status`, `openclaw status --all` (including `--json`), or hitting a gateway connection error in `openclaw logs` would see the gateway URL printed verbatim in diagnostics. Remote gateway URLs can embed credentials (basic-auth userinfo, token query parameters), so every one of those surfaces could leak a live credential into terminal output, logs, or pasted bug reports.

## Why This Change Was Made

`src/gateway/call.ts` already redacted its transport-error JSON ad hoc; the other surfaces each printed `connection.url` raw. The repair centralizes the policy at the owner boundary: `connection-details.ts` now exports a single diagnostics projection (`projectGatewayConnectionDetailsForDiagnostics` / `projectGatewayUrlForDiagnostics`), and every diagnostic surface — gateway transport errors, logs-cli error output (text and JSON), daemon status gather, and status-all text/JSON — routes through it. The probe keeps the unredacted URL internally, so behavior only changes for what gets displayed.

## User Impact

Gateway credentials no longer leak through status/logs diagnostics; probe and connection behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/cli/logs-cli.test.ts src/cli/daemon-cli/status.gather.test.ts src/commands/status-all/format.test.ts src/gateway/call.test.ts` — all pass, with new regression tests asserting redacted URLs in each surface and unredacted probe URL usage.
- Codex autoreview (gpt-5.6-sol, high) over the change bundle: clean, no actionable findings.
