### PR TITLE
fix(qqbot): partial config edits no longer resurrect backed-up credentials

### DIFF
--- a/extensions/qqbot/src/channel.credential-recovery.test.ts
+++ b/extensions/qqbot/src/channel.credential-recovery.test.ts
@@ -1,0 +1,121 @@
+// QQBot tests cover backup recovery eligibility at the channel lifecycle boundary.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedQQBotAccount } from "./types.js";
+
+const { loadCredentialBackupMock, startGatewayMock, writeConfigMock } = vi.hoisted(() => ({
+  loadCredentialBackupMock: vi.fn<(accountId?: string) => unknown>(),
+  startGatewayMock: vi.fn<(options: unknown) => Promise<void>>(() => new Promise<void>(() => {})),
+  writeConfigMock: vi.fn<(runtime: unknown, cfg: unknown) => Promise<void>>(async () => {}),
+}));
+
+vi.mock("./engine/config/credential-backup.js", () => ({
+  loadCredentialBackup: (accountId?: string) => loadCredentialBackupMock(accountId),
+  saveCredentialBackup: vi.fn(),
+}));
+
+vi.mock("./bridge/gateway.js", () => ({
+  startGateway: (options: unknown) => startGatewayMock(options),
+}));
+
+vi.mock("./bridge/runtime.js", () => ({
+  getQQBotRuntime: () => ({}),
+}));
+
+vi.mock("./bridge/narrowing.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bridge/narrowing.js")>()),
+  writeOpenClawConfigThroughRuntime: (runtime: unknown, cfg: unknown) =>
+    writeConfigMock(runtime, cfg),
+}));
+
+import { qqbotPlugin } from "./channel.js";
+
+function makeAccount(overrides: Partial<ResolvedQQBotAccount>): ResolvedQQBotAccount {
+  return {
+    accountId: "default",
+    appId: "",
+    clientSecret: "",
+    enabled: true,
+    markdownSupport: true,
+    secretSource: "none",
+    config: {},
+    ...overrides,
+  };
+}
+
+function startAccount(account: ResolvedQQBotAccount, cfg: Record<string, unknown>) {
+  const start = qqbotPlugin.gateway?.startAccount;
+  if (!start) {
+    throw new Error("expected QQBot gateway startAccount");
+  }
+  void start({
+    account,
+    accountId: account.accountId,
+    cfg,
+    runtime: {},
+    abortSignal: new AbortController().signal,
+    getStatus: () => ({
+      accountId: account.accountId,
+      running: true,
+      connected: false,
+      lastConnectedAt: null,
+      lastError: null,
+    }),
+    setStatus: vi.fn(),
+  } as never);
+}
+
+describe("QQBot credential backup recovery", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    startGatewayMock.mockImplementation(() => new Promise<void>(() => {}));
+  });
+
+  it("keeps partial live credentials authoritative over a stale backup", async () => {
+    loadCredentialBackupMock.mockReturnValue({
+      accountId: "default",
+      appId: "old-app",
+      clientSecret: "old-secret",
+    });
+    const cfg = { channels: { qqbot: { appId: "new-app" } } };
+    const account = makeAccount({ appId: "new-app" });
+
+    expect(qqbotPlugin.config.isConfigured?.(account, cfg as never)).toBe(false);
+    expect(qqbotPlugin.config.describeAccount?.(account, cfg as never)?.configured).toBe(false);
+
+    startAccount(account, cfg);
+    await vi.waitFor(() => expect(startGatewayMock).toHaveBeenCalledOnce());
+
+    expect(writeConfigMock).not.toHaveBeenCalled();
+    expect(startGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({ appId: "new-app", clientSecret: "" }),
+      }),
+    );
+  });
+
+  it("restores a backup when all live credential inputs are absent", async () => {
+    loadCredentialBackupMock.mockReturnValue({
+      accountId: "default",
+      appId: "backup-app",
+      clientSecret: "backup-secret",
+    });
+    const cfg = { channels: { qqbot: {} } };
+    const account = makeAccount({});
+
+    expect(qqbotPlugin.config.isConfigured?.(account, cfg as never)).toBe(true);
+    expect(qqbotPlugin.config.describeAccount?.(account, cfg as never)?.configured).toBe(true);
+
+    startAccount(account, cfg);
+    await vi.waitFor(() => expect(startGatewayMock).toHaveBeenCalledOnce());
+
+    expect(writeConfigMock).toHaveBeenCalledOnce();
+    expect(startGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({
+          appId: "backup-app",
+          clientSecret: "backup-secret",
+        }),
+      }),
+    );
+  });
+});

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -228,6 +228,42 @@ function persistAccountCredentialSnapshot(account: ResolvedQQBotAccount): void {
   }
 }
 
+type QQBotCredentialRecoveryState =
+  | { kind: "configured" }
+  | { kind: "recoverable"; appId: string; clientSecret: string }
+  | { kind: "partial" }
+  | { kind: "missing" };
+
+function hasConfiguredQQBotSecretInput(account: ResolvedQQBotAccount): boolean {
+  const configuredSecret = account.config.clientSecret;
+  return (
+    account.secretSource !== "none" ||
+    Boolean(normalizeOptionalString(account.clientSecret)) ||
+    (typeof configuredSecret === "string"
+      ? Boolean(normalizeOptionalString(configuredSecret))
+      : configuredSecret !== undefined && configuredSecret !== null) ||
+    Boolean(normalizeOptionalString(account.config.clientSecretFile))
+  );
+}
+
+function resolveQQBotCredentialRecoveryState(
+  account: ResolvedQQBotAccount | undefined,
+): QQBotCredentialRecoveryState {
+  if (!account) {
+    return { kind: "missing" };
+  }
+  if (qqbotConfigAdapter.isConfigured(account)) {
+    return { kind: "configured" };
+  }
+  if (normalizeOptionalString(account.appId) || hasConfiguredQQBotSecretInput(account)) {
+    return { kind: "partial" };
+  }
+  const backup = loadCredentialBackup(account.accountId);
+  return backup?.appId && backup.clientSecret
+    ? { kind: "recoverable", appId: backup.appId, clientSecret: backup.clientSecret }
+    : { kind: "missing" };
+}
+
 function shouldSuppressLocalQQBotApprovalPrompt(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -266,21 +302,18 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
   doctor: qqbotDoctor,
   config: {
     ...qqbotConfigAdapter,
-    /**
-     * Treat an account as configured when either the live config has
-     * credentials OR a recoverable credential backup exists. This mirrors
-     * the standalone plugin and lets the gateway survive a hot upgrade
-     * that wiped openclaw.json mid-flight.
-     */
+    /** A backup is eligible only after complete credential loss, never partial edits. */
     isConfigured: (account: ResolvedQQBotAccount | undefined) => {
-      if (qqbotConfigAdapter.isConfigured(account)) {
-        return true;
-      }
-      if (!account) {
-        return false;
-      }
-      const backup = loadCredentialBackup(account.accountId);
-      return Boolean(backup?.appId && backup?.clientSecret);
+      const state = resolveQQBotCredentialRecoveryState(account);
+      return state.kind === "configured" || state.kind === "recoverable";
+    },
+    describeAccount: (account: ResolvedQQBotAccount | undefined) => {
+      const description = qqbotConfigAdapter.describeAccount(account);
+      const state = resolveQQBotCredentialRecoveryState(account);
+      return {
+        ...description,
+        configured: state.kind === "configured" || state.kind === "recoverable",
+      };
     },
   },
   setupContract: qqbotSetupContract,
@@ -339,29 +372,25 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
       let { account, cfg } = ctx;
       const { abortSignal, log } = ctx;
 
-      // Recover credentials from the per-account backup if the live
-      // config is missing appId/secret (e.g. a hot-upgrade wiped
-      // openclaw.json). We only restore when both fields are empty so a
-      // user's intentional clear isn't silently undone.
-      if (!account.appId || !account.clientSecret) {
-        const backup = loadCredentialBackup(account.accountId);
-        if (backup?.appId && backup?.clientSecret) {
-          try {
-            const nextCfg = applyQQBotAccountConfig(cfg, account.accountId, {
-              appId: backup.appId,
-              clientSecret: backup.clientSecret,
-            });
-            await writeOpenClawConfigThroughRuntime(getQQBotRuntime(), nextCfg);
-            cfg = nextCfg;
-            account = resolveQQBotAccount(nextCfg, account.accountId);
-            log?.info(
-              `[qqbot:${account.accountId}] Restored credentials from backup (appId=${account.appId})`,
-            );
-          } catch (err) {
-            log?.error(
-              `[qqbot:${account.accountId}] Failed to restore credentials from backup: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
+      // Recover only after complete credential loss. A partially edited live
+      // identity is authoritative and must never be replaced by a stale backup.
+      const credentialState = resolveQQBotCredentialRecoveryState(account);
+      if (credentialState.kind === "recoverable") {
+        try {
+          const nextCfg = applyQQBotAccountConfig(cfg, account.accountId, {
+            appId: credentialState.appId,
+            clientSecret: credentialState.clientSecret,
+          });
+          await writeOpenClawConfigThroughRuntime(getQQBotRuntime(), nextCfg);
+          cfg = nextCfg;
+          account = resolveQQBotAccount(nextCfg, account.accountId);
+          log?.info(
+            `[qqbot:${account.accountId}] Restored credentials from backup (appId=${account.appId})`,
+          );
+        } catch (err) {
+          log?.error(
+            `[qqbot:${account.accountId}] Failed to restore credentials from backup: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
       }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a QQ bot account with a partially edited config (an appId typed but secret not yet saved, or a secret file path pointing nowhere) would be treated as "configured via backup" and start with stale backed-up credentials — masking the operator's in-progress edit and connecting with credentials they were trying to replace. The recovery decision was a loose truthiness check spread across `isConfigured` and the monitor start path, and `describeAccount` disagreed with `isConfigured` about backup-recoverable accounts.

## Why This Change Was Made

Credential recovery is now a closed discriminated union owned by one resolver (`configured` / `recoverable` / `partial` / `missing`): a backup is only eligible after complete credential loss (hot upgrade wiping `openclaw.json`), never when any credential input is present. `isConfigured`, `describeAccount`, and the startup recovery path all read the same state, so status surfaces and runtime behavior cannot disagree.

## User Impact

QQ bot survives a config wipe via its per-account backup exactly as before, but a partial config edit no longer silently connects with old credentials.

## Evidence

- `node scripts/run-vitest.mjs extensions/qqbot/src/channel.credential-recovery.test.ts` — new regression suite passes (recoverable-after-wipe, partial-config-not-recovered).
- Codex autoreview (gpt-5.6-sol, high) over the change bundle: clean, no actionable findings.
