### PR TITLE
fix(acpx): stop/start races cannot resurrect a stopped embedded runtime

### DIFF
--- a/extensions/acpx/register.runtime.test.ts
+++ b/extensions/acpx/register.runtime.test.ts
@@ -61,6 +61,14 @@ function restoreEnv(): void {
   }
 }
 
+function createDeferred() {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function createServiceContext() {
   return {
     workspaceDir: "/tmp/openclaw-acpx-register-test",
@@ -150,6 +158,55 @@ describe("acpx register runtime service", () => {
 
     expect(realServiceStopMock).toHaveBeenCalledWith(ctx);
     expect(runtimeRegistry.get("acpx")).toBeUndefined();
+  });
+
+  it("waits for in-flight activation before completing shutdown", async () => {
+    delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME;
+    const startEntered = createDeferred();
+    const releaseStart = createDeferred();
+    realServiceStartMock.mockImplementationOnce(async () => {
+      startEntered.resolve();
+      await releaseStart.promise;
+      runtimeRegistry.set("acpx", { runtime: realRuntime });
+    });
+    const ctx = createServiceContext();
+    const service = createAcpxRuntimeService();
+
+    await service.start(ctx as never);
+    const deferredRuntime = runtimeRegistry.get("acpx")?.runtime as {
+      ensureSession(input: { sessionKey: string; agent: string; mode: string }): Promise<unknown>;
+    };
+    const activation = deferredRuntime.ensureSession({
+      sessionKey: "agent:codex:acp:shutdown-race",
+      agent: "codex",
+      mode: "oneshot",
+    });
+    const activationResult = activation.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await startEntered.promise;
+
+    const stopping = service.stop?.(ctx as never);
+    await Promise.resolve();
+    expect(realServiceStopMock).not.toHaveBeenCalled();
+
+    releaseStart.resolve();
+    await stopping;
+
+    expect(await activationResult).toEqual(
+      expect.objectContaining({ message: "ACPX runtime service stopped during activation" }),
+    );
+    expect(realServiceStopMock).toHaveBeenCalledOnce();
+    expect(realServiceStopMock).toHaveBeenCalledWith(ctx);
+    expect(runtimeRegistry.get("acpx")).toBeUndefined();
+    await expect(
+      deferredRuntime.ensureSession({
+        sessionKey: "agent:codex:acp:stale-proxy",
+        agent: "codex",
+        mode: "oneshot",
+      }),
+    ).rejects.toThrow("ACPX runtime service is not started");
   });
 
   it("keeps the explicit runtime skip env as the only outer startup skip", async () => {

--- a/extensions/acpx/register.runtime.test.ts
+++ b/extensions/acpx/register.runtime.test.ts
@@ -5,6 +5,11 @@ const { runtimeRegistry } = vi.hoisted(() => ({
   runtimeRegistry: new Map<string, { runtime: unknown }>(),
 }));
 
+type BackendLifecycle = {
+  publish: (backend: { runtime: unknown }) => void;
+  retract: (runtime: unknown) => void;
+};
+
 const { realRuntime, realServiceStartMock, realServiceStopMock, createRealServiceMock } =
   vi.hoisted(() => {
     const runtime = {
@@ -21,17 +26,29 @@ const { realRuntime, realServiceStartMock, realServiceStopMock, createRealServic
       isHealthy: vi.fn(() => true),
       probeAvailability: vi.fn(async () => {}),
     };
-    const start = vi.fn(async () => {
-      runtimeRegistry.set("acpx", { runtime });
+    const start = vi.fn(async (_ctx: unknown, backendLifecycle?: BackendLifecycle) => {
+      if (backendLifecycle) {
+        backendLifecycle.publish({ runtime });
+      } else {
+        runtimeRegistry.set("acpx", { runtime });
+      }
     });
-    const stop = vi.fn(async () => {
-      runtimeRegistry.delete("acpx");
+    const stop = vi.fn(async (_ctx: unknown, backendLifecycle?: BackendLifecycle) => {
+      if (backendLifecycle) {
+        backendLifecycle.retract(runtime);
+      } else {
+        runtimeRegistry.delete("acpx");
+      }
     });
     return {
       realRuntime: runtime,
       realServiceStartMock: start,
       realServiceStopMock: stop,
-      createRealServiceMock: vi.fn(() => ({ id: "real-acpx-runtime", start, stop })),
+      createRealServiceMock: vi.fn((params: { backendLifecycle?: BackendLifecycle } = {}) => ({
+        id: "real-acpx-runtime",
+        start: (ctx: unknown) => start(ctx, params.backendLifecycle),
+        stop: (ctx: unknown) => stop(ctx, params.backendLifecycle),
+      })),
     };
   });
 
@@ -129,10 +146,16 @@ describe("acpx register runtime service", () => {
       sessionKey: "agent:codex:acp:test",
     });
 
-    expect(createRealServiceMock).toHaveBeenCalledWith({
-      pluginConfig: { timeoutSeconds: 10 },
-    });
-    expect(realServiceStartMock).toHaveBeenCalledWith(ctx);
+    expect(createRealServiceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backendLifecycle: expect.objectContaining({
+          publish: expect.any(Function),
+          retract: expect.any(Function),
+        }),
+        pluginConfig: { timeoutSeconds: 10 },
+      }),
+    );
+    expect(realServiceStartMock).toHaveBeenCalledWith(ctx, expect.any(Object));
     expect(runtimeRegistry.get("acpx")?.runtime).toBe(realRuntime);
     expect(ctx.logger.info).toHaveBeenCalledWith("embedded acpx runtime backend registered lazily");
 
@@ -156,18 +179,18 @@ describe("acpx register runtime service", () => {
 
     await service.stop?.(ctx as never);
 
-    expect(realServiceStopMock).toHaveBeenCalledWith(ctx);
+    expect(realServiceStopMock).toHaveBeenCalledWith(ctx, expect.any(Object));
     expect(runtimeRegistry.get("acpx")).toBeUndefined();
   });
 
-  it("waits for in-flight activation before completing shutdown", async () => {
+  it("rejects stale publication after stop invalidates the deferred backend", async () => {
     delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME;
     const startEntered = createDeferred();
-    const releaseStart = createDeferred();
-    realServiceStartMock.mockImplementationOnce(async () => {
+    const releasePublication = createDeferred();
+    realServiceStartMock.mockImplementationOnce(async (_ctx, backendLifecycle) => {
       startEntered.resolve();
-      await releaseStart.promise;
-      runtimeRegistry.set("acpx", { runtime: realRuntime });
+      await releasePublication.promise;
+      backendLifecycle?.publish({ runtime: realRuntime });
     });
     const ctx = createServiceContext();
     const service = createAcpxRuntimeService();
@@ -191,14 +214,16 @@ describe("acpx register runtime service", () => {
     await Promise.resolve();
     expect(realServiceStopMock).not.toHaveBeenCalled();
 
-    releaseStart.resolve();
+    releasePublication.resolve();
     await stopping;
 
     expect(await activationResult).toEqual(
-      expect.objectContaining({ message: "ACPX runtime service stopped during activation" }),
+      expect.objectContaining({
+        message: "ACPX runtime service stopped during activation",
+      }),
     );
     expect(realServiceStopMock).toHaveBeenCalledOnce();
-    expect(realServiceStopMock).toHaveBeenCalledWith(ctx);
+    expect(realServiceStopMock).toHaveBeenCalledWith(ctx, expect.any(Object));
     expect(runtimeRegistry.get("acpx")).toBeUndefined();
     await expect(
       deferredRuntime.ensureSession({
@@ -207,6 +232,92 @@ describe("acpx register runtime service", () => {
         mode: "oneshot",
       }),
     ).rejects.toThrow("ACPX runtime service is not started");
+  });
+
+  it("keeps a successor generation registered when old cleanup finishes late", async () => {
+    delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME;
+    const published = createDeferred();
+    const releaseProbe = createDeferred();
+    realServiceStartMock.mockImplementationOnce(async (_ctx, backendLifecycle) => {
+      if (!backendLifecycle) {
+        throw new Error("expected outer backend lifecycle");
+      }
+      backendLifecycle.publish({ runtime: realRuntime });
+      published.resolve();
+      await releaseProbe.promise;
+    });
+    const ctx = createServiceContext();
+    const generationA = createAcpxRuntimeService();
+
+    await generationA.start(ctx as never);
+    const deferredRuntimeA = runtimeRegistry.get("acpx")?.runtime as {
+      ensureSession(input: { sessionKey: string; agent: string; mode: string }): Promise<unknown>;
+    };
+    const activation = deferredRuntimeA.ensureSession({
+      sessionKey: "agent:codex:acp:generation-a",
+      agent: "codex",
+      mode: "oneshot",
+    });
+    const activationResult = activation.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await published.promise;
+    expect(runtimeRegistry.get("acpx")?.runtime).toBe(realRuntime);
+
+    let concurrentCallSettled = false;
+    const concurrentCallResult = deferredRuntimeA
+      .ensureSession({
+        sessionKey: "agent:codex:acp:generation-a-concurrent",
+        agent: "codex",
+        mode: "oneshot",
+      })
+      .then(
+        () => {
+          concurrentCallSettled = true;
+          return null;
+        },
+        (error: unknown) => {
+          concurrentCallSettled = true;
+          return error;
+        },
+      );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(concurrentCallSettled).toBe(false);
+
+    const stoppingA = generationA.stop?.(ctx as never);
+    expect(runtimeRegistry.get("acpx")).toBeUndefined();
+
+    const generationB = createAcpxRuntimeService();
+    await generationB.start(ctx as never);
+    const deferredRuntimeB = runtimeRegistry.get("acpx")?.runtime;
+    expect(deferredRuntimeB).toBeTruthy();
+    expect(deferredRuntimeB).not.toBe(deferredRuntimeA);
+    expect(deferredRuntimeB).not.toBe(realRuntime);
+    expect(concurrentCallSettled).toBe(false);
+
+    releaseProbe.resolve();
+    await stoppingA;
+
+    expect(await activationResult).toEqual(
+      expect.objectContaining({ message: "ACPX runtime service stopped during activation" }),
+    );
+    expect(await concurrentCallResult).toEqual(
+      expect.objectContaining({ message: "ACPX runtime service stopped during activation" }),
+    );
+    expect(runtimeRegistry.get("acpx")?.runtime).toBe(deferredRuntimeB);
+    await expect(
+      deferredRuntimeA.ensureSession({
+        sessionKey: "agent:codex:acp:stale-generation-a",
+        agent: "codex",
+        mode: "oneshot",
+      }),
+    ).rejects.toThrow("ACPX runtime service is not started");
+
+    await generationB.stop?.(ctx as never);
+    expect(runtimeRegistry.get("acpx")).toBeUndefined();
   });
 
   it("keeps the explicit runtime skip env as the only outer startup skip", async () => {

--- a/extensions/acpx/register.runtime.ts
+++ b/extensions/acpx/register.runtime.ts
@@ -15,13 +15,15 @@ import { createLazyAcpRuntimeProxy } from "./src/runtime-proxy.js";
 const ACPX_BACKEND_ID = "acpx";
 
 type RealAcpxServiceModule = typeof import("./src/service.js");
-type CreateAcpxRuntimeServiceParams = NonNullable<
+type InnerAcpxRuntimeServiceParams = NonNullable<
   Parameters<RealAcpxServiceModule["createAcpxRuntimeService"]>[0]
 >;
+type CreateAcpxRuntimeServiceParams = Omit<InnerAcpxRuntimeServiceParams, "backendLifecycle">;
 
 type DeferredServiceState = {
   ctx: OpenClawPluginServiceContext | null;
   lifecycleRevision: number;
+  ownedRuntime: AcpRuntime | null;
   params: CreateAcpxRuntimeServiceParams;
   realRuntime: AcpRuntime | null;
   realService: OpenClawPluginService | null;
@@ -31,9 +33,16 @@ type DeferredServiceState = {
 
 const loadServiceModule = createLazyRuntimeModule(() => import("./src/service.js"));
 
+function unregisterOwnedRuntime(runtime: AcpRuntime | null): void {
+  if (runtime && getAcpRuntimeBackend(ACPX_BACKEND_ID)?.runtime === runtime) {
+    unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+  }
+}
+
 async function startRealService(
   state: DeferredServiceState,
   lifecycleRevision: number,
+  deferredRuntime: AcpRuntime,
 ): Promise<AcpRuntime> {
   if (state.lifecycleRevision !== lifecycleRevision || !state.ctx) {
     throw new Error("ACPX runtime service is not started");
@@ -41,23 +50,49 @@ async function startRealService(
   if (state.realRuntime) {
     return state.realRuntime;
   }
+  if (state.startPromise) {
+    return await state.startPromise;
+  }
   const ctx = state.ctx;
-  state.startPromise ??= (async () => {
+  state.startPromise = (async () => {
+    let publishedRuntime: AcpRuntime | null = null;
     const { createAcpxRuntimeService: createAcpxRuntimeServiceLocal } = await loadServiceModule();
-    const service = createAcpxRuntimeServiceLocal(state.params);
+    const service = createAcpxRuntimeServiceLocal({
+      ...state.params,
+      backendLifecycle: {
+        publish(backend) {
+          if (state.lifecycleRevision !== lifecycleRevision || state.ctx !== ctx) {
+            throw new Error("ACPX runtime service stopped during activation");
+          }
+          if (getAcpRuntimeBackend(ACPX_BACKEND_ID)?.runtime !== deferredRuntime) {
+            throw new Error("ACPX runtime service lost registry ownership during activation");
+          }
+          // Publication is a synchronous compare-and-replace: another plugin
+          // generation cannot be adopted between the ownership check and write.
+          registerAcpRuntimeBackend({ id: ACPX_BACKEND_ID, ...backend });
+          publishedRuntime = backend.runtime;
+          state.ownedRuntime = backend.runtime;
+        },
+        retract(runtime) {
+          unregisterOwnedRuntime(runtime);
+        },
+      },
+    });
     state.realService = service;
     await service.start(ctx);
-    // The real service registers its backend during start. Only the current
-    // outer lifecycle may publish that runtime after the async boundary.
     if (state.lifecycleRevision !== lifecycleRevision || state.ctx !== ctx) {
       throw new Error("ACPX runtime service stopped during activation");
     }
-    const backend = getAcpRuntimeBackend(ACPX_BACKEND_ID);
-    if (!backend?.runtime) {
+    if (!publishedRuntime) {
       throw new Error("ACPX runtime service did not register an ACP backend");
     }
-    state.realRuntime = backend.runtime;
-    return state.realRuntime;
+    if (getAcpRuntimeBackend(ACPX_BACKEND_ID)?.runtime !== publishedRuntime) {
+      throw new Error("ACPX runtime service lost registry ownership during activation");
+    }
+    // Registry publication intentionally precedes the startup probe, but callers
+    // must keep sharing the start promise until the inner service is fully ready.
+    state.realRuntime = publishedRuntime;
+    return publishedRuntime;
   })();
   try {
     return await state.startPromise;
@@ -71,8 +106,10 @@ async function startRealService(
 }
 
 function createDeferredRuntime(state: DeferredServiceState, lifecycleRevision: number): AcpRuntime {
-  const resolveRuntime = () => startRealService(state, lifecycleRevision);
-  return createLazyAcpRuntimeProxy(resolveRuntime);
+  const deferredRuntime = createLazyAcpRuntimeProxy(() =>
+    startRealService(state, lifecycleRevision, deferredRuntime),
+  );
+  return deferredRuntime;
 }
 
 /** Creates the plugin service that registers ACPX as an ACP runtime backend. */
@@ -82,6 +119,7 @@ export function createAcpxRuntimeService(
   const state: DeferredServiceState = {
     ctx: null,
     lifecycleRevision: 0,
+    ownedRuntime: null,
     params,
     realRuntime: null,
     realService: null,
@@ -103,9 +141,11 @@ export function createAcpxRuntimeService(
       state.lifecycleRevision += 1;
       const lifecycleRevision = state.lifecycleRevision;
       state.ctx = ctx;
+      const deferredRuntime = createDeferredRuntime(state, lifecycleRevision);
+      state.ownedRuntime = deferredRuntime;
       registerAcpRuntimeBackend({
         id: ACPX_BACKEND_ID,
-        runtime: createDeferredRuntime(state, lifecycleRevision),
+        runtime: deferredRuntime,
       });
       ctx.logger.info("embedded acpx runtime backend registered lazily");
     },
@@ -118,14 +158,16 @@ export function createAcpxRuntimeService(
       // service still owns cleanup, but it can no longer become the active runtime.
       state.lifecycleRevision += 1;
       state.ctx = null;
-      unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+      const ownedRuntime = state.ownedRuntime;
+      unregisterOwnedRuntime(ownedRuntime);
       const startPromise = state.startPromise;
       state.stopPromise = (async () => {
         await startPromise?.catch(() => undefined);
         try {
           await state.realService?.stop?.(ctx);
         } finally {
-          unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+          unregisterOwnedRuntime(ownedRuntime);
+          state.ownedRuntime = null;
           state.realRuntime = null;
           state.realService = null;
           state.startPromise = null;

--- a/extensions/acpx/register.runtime.ts
+++ b/extensions/acpx/register.runtime.ts
@@ -21,26 +21,37 @@ type CreateAcpxRuntimeServiceParams = NonNullable<
 
 type DeferredServiceState = {
   ctx: OpenClawPluginServiceContext | null;
+  lifecycleRevision: number;
   params: CreateAcpxRuntimeServiceParams;
   realRuntime: AcpRuntime | null;
   realService: OpenClawPluginService | null;
   startPromise: Promise<AcpRuntime> | null;
+  stopPromise: Promise<void> | null;
 };
 
 const loadServiceModule = createLazyRuntimeModule(() => import("./src/service.js"));
 
-async function startRealService(state: DeferredServiceState): Promise<AcpRuntime> {
+async function startRealService(
+  state: DeferredServiceState,
+  lifecycleRevision: number,
+): Promise<AcpRuntime> {
+  if (state.lifecycleRevision !== lifecycleRevision || !state.ctx) {
+    throw new Error("ACPX runtime service is not started");
+  }
   if (state.realRuntime) {
     return state.realRuntime;
   }
-  if (!state.ctx) {
-    throw new Error("ACPX runtime service is not started");
-  }
+  const ctx = state.ctx;
   state.startPromise ??= (async () => {
     const { createAcpxRuntimeService: createAcpxRuntimeServiceLocal } = await loadServiceModule();
     const service = createAcpxRuntimeServiceLocal(state.params);
     state.realService = service;
-    await service.start(state.ctx as OpenClawPluginServiceContext);
+    await service.start(ctx);
+    // The real service registers its backend during start. Only the current
+    // outer lifecycle may publish that runtime after the async boundary.
+    if (state.lifecycleRevision !== lifecycleRevision || state.ctx !== ctx) {
+      throw new Error("ACPX runtime service stopped during activation");
+    }
     const backend = getAcpRuntimeBackend(ACPX_BACKEND_ID);
     if (!backend?.runtime) {
       throw new Error("ACPX runtime service did not register an ACP backend");
@@ -51,14 +62,16 @@ async function startRealService(state: DeferredServiceState): Promise<AcpRuntime
   try {
     return await state.startPromise;
   } catch (error) {
-    state.startPromise = null;
-    state.realService = null;
+    if (state.lifecycleRevision === lifecycleRevision) {
+      state.startPromise = null;
+      state.realService = null;
+    }
     throw error;
   }
 }
 
-function createDeferredRuntime(state: DeferredServiceState): AcpRuntime {
-  const resolveRuntime = () => startRealService(state);
+function createDeferredRuntime(state: DeferredServiceState, lifecycleRevision: number): AcpRuntime {
+  const resolveRuntime = () => startRealService(state, lifecycleRevision);
   return createLazyAcpRuntimeProxy(resolveRuntime);
 }
 
@@ -68,10 +81,12 @@ export function createAcpxRuntimeService(
 ): OpenClawPluginService {
   const state: DeferredServiceState = {
     ctx: null,
+    lifecycleRevision: 0,
     params,
     realRuntime: null,
     realService: null,
     startPromise: null,
+    stopPromise: null,
   };
 
   return {
@@ -81,24 +96,46 @@ export function createAcpxRuntimeService(
         ctx.logger.info("skipping embedded acpx runtime backend (OPENCLAW_SKIP_ACPX_RUNTIME=1)");
         return;
       }
+      if (state.stopPromise) {
+        await state.stopPromise;
+      }
 
+      state.lifecycleRevision += 1;
+      const lifecycleRevision = state.lifecycleRevision;
       state.ctx = ctx;
       registerAcpRuntimeBackend({
         id: ACPX_BACKEND_ID,
-        runtime: createDeferredRuntime(state),
+        runtime: createDeferredRuntime(state, lifecycleRevision),
       });
       ctx.logger.info("embedded acpx runtime backend registered lazily");
     },
     async stop(ctx) {
-      if (state.realService) {
-        await state.realService.stop?.(ctx);
-      } else {
-        unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+      if (state.stopPromise) {
+        return await state.stopPromise;
       }
+
+      // Invalidate every deferred proxy before waiting for startup. The in-flight
+      // service still owns cleanup, but it can no longer become the active runtime.
+      state.lifecycleRevision += 1;
       state.ctx = null;
-      state.realRuntime = null;
-      state.realService = null;
-      state.startPromise = null;
+      unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+      const startPromise = state.startPromise;
+      state.stopPromise = (async () => {
+        await startPromise?.catch(() => undefined);
+        try {
+          await state.realService?.stop?.(ctx);
+        } finally {
+          unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+          state.realRuntime = null;
+          state.realService = null;
+          state.startPromise = null;
+        }
+      })();
+      try {
+        await state.stopPromise;
+      } finally {
+        state.stopPromise = null;
+      }
     },
   };
 }

--- a/extensions/acpx/register.runtime.ts
+++ b/extensions/acpx/register.runtime.ts
@@ -106,8 +106,8 @@ async function startRealService(
 }
 
 function createDeferredRuntime(state: DeferredServiceState, lifecycleRevision: number): AcpRuntime {
-  const deferredRuntime = createLazyAcpRuntimeProxy(() =>
-    startRealService(state, lifecycleRevision, deferredRuntime),
+  const deferredRuntime: AcpRuntime = createLazyAcpRuntimeProxy(
+    (): Promise<AcpRuntime> => startRealService(state, lifecycleRevision, deferredRuntime),
   );
   return deferredRuntime;
 }

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -71,12 +71,6 @@ const { acpxRuntimeConstructorMock, createAgentRegistryMock, createFileSessionSt
 
 vi.mock("../runtime-api.js", () => ({
   getAcpRuntimeBackend: (id: string) => runtimeRegistry.get(id),
-  registerAcpRuntimeBackend: (entry: { id: string; runtime: unknown; healthy?: () => boolean }) => {
-    runtimeRegistry.set(entry.id, entry);
-  },
-  unregisterAcpRuntimeBackend: (id: string) => {
-    runtimeRegistry.delete(id);
-  },
 }));
 
 vi.mock("./runtime.js", () => ({
@@ -173,10 +167,23 @@ function createOpenKeyedStore(ctx: OpenClawPluginServiceContext) {
 
 function createAcpxRuntimeService(
   ctx: OpenClawPluginServiceContext,
-  params: Parameters<typeof createRealAcpxRuntimeService>[0] = {},
+  params: Omit<Parameters<typeof createRealAcpxRuntimeService>[0], "backendLifecycle"> & {
+    backendLifecycle?: Parameters<typeof createRealAcpxRuntimeService>[0]["backendLifecycle"];
+  } = {},
 ) {
+  const backendLifecycle = params.backendLifecycle ?? {
+    publish(backend: { runtime: unknown; healthy?: () => boolean }) {
+      runtimeRegistry.set("acpx", backend);
+    },
+    retract(runtime: unknown) {
+      if (runtimeRegistry.get("acpx")?.runtime === runtime) {
+        runtimeRegistry.delete("acpx");
+      }
+    },
+  };
   return createRealAcpxRuntimeService({
     ...params,
+    backendLifecycle,
     openKeyedStore: params.openKeyedStore ?? createOpenKeyedStore(ctx),
   });
 }

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -205,6 +205,14 @@ function createMockRuntime(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createDeferred() {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function createStartupTraceRecorder() {
   const measured: string[] = [];
   const details: Array<{
@@ -264,6 +272,49 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
 
     expect(getAcpRuntimeBackend("acpx")).toBeUndefined();
+  });
+
+  it("publishes before probing and retracts the exact runtime through the injected lifecycle", async () => {
+    delete process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE;
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const probeStarted = createDeferred();
+    const releaseProbe = createDeferred();
+    const events: string[] = [];
+    const runtime = createMockRuntime({
+      probeAvailability: vi.fn(async () => {
+        events.push("probe");
+        probeStarted.resolve();
+        await releaseProbe.promise;
+      }),
+    });
+    const publish = vi.fn((backend: { runtime: unknown; healthy?: () => boolean }) => {
+      events.push("publish");
+      expect(backend.runtime).toBe(runtime);
+      expect(backend.healthy?.()).toBe(true);
+    });
+    const retract = vi.fn((ownedRuntime: unknown) => {
+      events.push("retract");
+      expect(ownedRuntime).toBe(runtime);
+    });
+    const service = createAcpxRuntimeService(ctx, {
+      backendLifecycle: { publish, retract },
+      runtimeFactory: () => runtime as never,
+    });
+
+    const starting = service.start(ctx) as Promise<void>;
+    await probeStarted.promise;
+
+    expect(events).toEqual(["publish", "probe"]);
+    expect(publish).toHaveBeenCalledOnce();
+    expect(getAcpRuntimeBackend("acpx")).toBeUndefined();
+
+    await service.stop?.(ctx);
+    expect(retract).toHaveBeenCalledWith(runtime);
+    expect(events).toEqual(["publish", "probe", "retract"]);
+
+    releaseProbe.resolve();
+    await starting;
   });
 
   it("skips the startup probe and does not advertise backend health when explicitly disabled", async () => {

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -20,7 +20,6 @@ import type {
   OpenClawPluginServiceContext,
   PluginLogger,
 } from "../runtime-api.js";
-import { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "../runtime-api.js";
 import { prepareAcpxCodexAuthConfig } from "./codex-auth-bridge.js";
 import { DEFAULT_ACPX_TIMEOUT_SECONDS } from "./config-schema.js";
 import {
@@ -58,7 +57,6 @@ type AcpxRuntimeLike = AcpRuntime & {
 };
 const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
 const SKIP_RUNTIME_PROBE_ENV = "OPENCLAW_SKIP_ACPX_RUNTIME_PROBE";
-const ACPX_BACKEND_ID = "acpx";
 
 type AcpxRuntimeFactoryParams = {
   pluginConfig: ResolvedAcpxPluginConfig;
@@ -74,7 +72,7 @@ type AcpxBackendLifecycle = {
 };
 
 type CreateAcpxRuntimeServiceParams = {
-  backendLifecycle?: AcpxBackendLifecycle;
+  backendLifecycle: AcpxBackendLifecycle;
   pluginConfig?: unknown;
   openKeyedStore?: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
   runtimeFactory?: (params: AcpxRuntimeFactoryParams) => AcpxRuntimeLike | Promise<AcpxRuntimeLike>;
@@ -330,7 +328,7 @@ async function reapOpenAcpxProcessLeases(params: {
 
 /** Create the ACPX plugin service that owns runtime registration and cleanup. */
 export function createAcpxRuntimeService(
-  params: CreateAcpxRuntimeServiceParams = {},
+  params: CreateAcpxRuntimeServiceParams,
 ): OpenClawPluginService {
   let runtime: AcpxRuntimeLike | null = null;
   let lifecycleRevision = 0;
@@ -421,11 +419,7 @@ export function createAcpxRuntimeService(
           runtime: startedRuntime,
           ...(shouldProbeRuntime ? { healthy: () => runtime?.isHealthy() ?? false } : {}),
         };
-        if (params.backendLifecycle) {
-          params.backendLifecycle.publish(backend);
-        } else {
-          registerAcpRuntimeBackend({ id: ACPX_BACKEND_ID, ...backend });
-        }
+        params.backendLifecycle.publish(backend);
         ctx.logger.info(`embedded acpx runtime backend registered (cwd: ${pluginConfig.cwd})`);
       });
 
@@ -470,10 +464,8 @@ export function createAcpxRuntimeService(
     },
     async stop(_ctx: OpenClawPluginServiceContext): Promise<void> {
       lifecycleRevision += 1;
-      if (runtime && params.backendLifecycle) {
+      if (runtime) {
         params.backendLifecycle.retract(runtime);
-      } else if (!params.backendLifecycle) {
-        unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
       }
       runtime = null;
     },

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -68,7 +68,13 @@ type AcpxRuntimeFactoryParams = {
   logger?: PluginLogger;
 };
 
+type AcpxBackendLifecycle = {
+  publish: (backend: { runtime: AcpRuntime; healthy?: () => boolean }) => void;
+  retract: (runtime: AcpRuntime) => void;
+};
+
 type CreateAcpxRuntimeServiceParams = {
+  backendLifecycle?: AcpxBackendLifecycle;
   pluginConfig?: unknown;
   openKeyedStore?: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
   runtimeFactory?: (params: AcpxRuntimeFactoryParams) => AcpxRuntimeLike | Promise<AcpxRuntimeLike>;
@@ -411,11 +417,15 @@ export function createAcpxRuntimeService(
         ["probeAgent", pluginConfig.probeAgent ?? "default"],
       ]);
       await measureAcpxStartup(ctx, "backend.register", () => {
-        registerAcpRuntimeBackend({
-          id: ACPX_BACKEND_ID,
+        const backend = {
           runtime: startedRuntime,
           ...(shouldProbeRuntime ? { healthy: () => runtime?.isHealthy() ?? false } : {}),
-        });
+        };
+        if (params.backendLifecycle) {
+          params.backendLifecycle.publish(backend);
+        } else {
+          registerAcpRuntimeBackend({ id: ACPX_BACKEND_ID, ...backend });
+        }
         ctx.logger.info(`embedded acpx runtime backend registered (cwd: ${pluginConfig.cwd})`);
       });
 
@@ -460,7 +470,11 @@ export function createAcpxRuntimeService(
     },
     async stop(_ctx: OpenClawPluginServiceContext): Promise<void> {
       lifecycleRevision += 1;
-      unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+      if (runtime && params.backendLifecycle) {
+        params.backendLifecycle.retract(runtime);
+      } else if (!params.backendLifecycle) {
+        unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+      }
       runtime = null;
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes a lifecycle race in the acpx plugin's deferred runtime service. The service registers a lazy proxy at start and only boots the real ACP runtime on first use. If the service was stopped (plugin reload, gateway shutdown) while that first activation was in flight, the activation continued, re-registered the backend, and published a runtime for a service that had already been stopped — leaving a zombie ACP backend running with no owner. Stop also cleared shared state (`startPromise`, `realService`) that the in-flight start was still using, and a quick stop→start could interleave with the previous stop's cleanup.

## Why This Change Was Made

Lifecycle ownership is made explicit with a revision counter: each start takes a new revision, deferred proxies capture it, and only the current revision may publish a runtime after any async boundary (activation past a stopped revision throws instead of resurrecting). Stop invalidates every outstanding proxy first, then awaits in-flight startup before stopping the real service, and always unregisters/clears in a `finally`. A subsequent start awaits the previous `stopPromise`, so restart cannot interleave with teardown.

## User Impact

Reloading or stopping the acpx plugin can no longer leave an orphaned embedded ACP runtime running, and rapid restart cycles are deterministic.

## Evidence

- `node scripts/run-vitest.mjs extensions/acpx/register.runtime.test.ts` — passes with new regression tests: stop-during-activation throws and does not publish; restart after stop-during-activation starts a fresh runtime; stop awaits in-flight start's cleanup.
- Codex autoreview (gpt-5.6-sol, high) over the change bundle: clean, no actionable findings.
