### PR TITLE
fix(ai): truncated Anthropic streams error; proxies exempt from message_stop contract

### DIFF
--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -1663,6 +1663,43 @@ describe("anthropic transport stream", () => {
     expect(result.errorMessage).toBe("Anthropic stream ended before message_stop");
   });
 
+  it("accepts proxy provider streams that end without message_stop", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_proxy", usage: { input_tokens: 3, output_tokens: 0 } },
+        },
+        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "proxy answer" },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 3, output_tokens: 2 },
+        },
+      ]),
+    );
+
+    // Proxy identity: non-anthropic provider through a custom endpoint is not
+    // held to the first-party message_stop framing contract.
+    const result = await runTransportStream(
+      makeAnthropicTransportModel({
+        provider: "openrouter",
+        baseUrl: "https://proxy.example.com/v1",
+      }),
+      { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+      { apiKey: "sk-proxy" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.errorMessage).toBeUndefined();
+  });
+
   it("defers a pre-tool text block's text_end until it carries the commentary phase", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -352,7 +352,20 @@ describe("anthropic transport stream", () => {
         };
       },
     });
-    guardedFetchMock.mockResolvedValue(createSseResponse());
+    guardedFetchMock.mockResolvedValue(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_default", usage: { input_tokens: 0, output_tokens: 0 } },
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+        { type: "message_stop" },
+      ]),
+    );
   });
 
   afterEach(() => {
@@ -1618,6 +1631,38 @@ describe("anthropic transport stream", () => {
     expect(result.errorMessage).toBe("Anthropic stream ended before message_stop");
   });
 
+  it("rejects ordinary Anthropic output when the stream ends before message_stop", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_partial", usage: { input_tokens: 3, output_tokens: 0 } },
+        },
+        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "truncated answer" },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 3, output_tokens: 2 },
+        },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("Anthropic stream ended before message_stop");
+  });
+
   it("defers a pre-tool text block's text_end until it carries the commentary phase", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
@@ -1817,6 +1862,7 @@ describe("anthropic transport stream", () => {
           delta: { stop_reason: "tool_use" },
           usage: { input_tokens: 10, output_tokens: 5 },
         },
+        { type: "message_stop" },
       ]),
     );
     const model = makeAnthropicTransportModel({
@@ -2171,7 +2217,7 @@ describe("anthropic transport stream", () => {
     {
       label: "the stream ends before content_block_stop",
       response: () => createSseResponse(createInterruptedThinkingEvents()),
-      stopReason: "stop",
+      stopReason: "error",
     },
     {
       label: "the provider errors before content_block_stop",

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -1686,7 +1686,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             flushPendingTextEnds();
           }
         }
-        if (refusalBuffer && !sawMessageStop) {
+        // Anthropic completes every SSE response with message_stop. Compatible
+        // proxy providers are not held to that first-party transport contract.
+        if (isDirectAnthropicModel(model) && !sawMessageStop) {
           throw new Error("Anthropic stream ended before message_stop");
         }
         if (transportOptions.signal?.aborted) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an inverted guard in the Anthropic SSE transport. The "stream ended before message_stop" check only fired when a refusal buffer happened to be non-empty — so a genuinely truncated first-party Anthropic stream (dropped connection mid-response) passed silently as a complete message, while Anthropic-compatible proxy providers that legitimately end their stream without a `message_stop` event could fail on refusal-ish content. Both directions were wrong: silent truncation on the strict contract, spurious errors on the lenient one.

## Why This Change Was Made

The invariant belongs to the transport contract owner. Anthropic's first-party API completes every SSE response with `message_stop` (per their streaming docs), so direct Anthropic models now always enforce it. Compatible proxies aren't held to that first-party framing contract, so `isDirectAnthropicModel` gates the check instead of the incidental refusal-buffer state.

## User Impact

Truncated Anthropic streams surface as errors instead of silently delivering partial replies; proxy-routed Anthropic-compatible models stop hitting spurious message_stop failures.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/transports/anthropic-transport-stream.test.ts` — passes, with new regression tests: direct model + truncated stream throws (with and without refusal content); proxy model + no message_stop succeeds.
- Codex autoreview (gpt-5.6-sol, high) over the change bundle: clean, no actionable findings.
