### PR TITLE
improve(release): bind Gateway-node compatibility evidence

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -404,7 +404,7 @@ jobs:
   prepare_release_candidate:
     name: Prepare shared release candidate
     needs: [resolve_target, evidence_reuse]
-    if: ${{ always() && needs.resolve_target.result == 'success' && needs.evidence_reuse.outputs.reuse != 'true' && inputs.release_package_spec == '' && inputs.package_acceptance_package_spec == '' && contains(fromJSON('["all","plugin-prerelease","release-checks","cross-os","live-e2e","package"]'), inputs.rerun_group) }}
+    if: ${{ always() && needs.resolve_target.result == 'success' && needs.evidence_reuse.outputs.reuse != 'true' && inputs.release_package_spec == '' && contains(fromJSON('["all","plugin-prerelease","release-checks","cross-os","live-e2e","package"]'), inputs.rerun_group) }}
     permissions:
       actions: read
       contents: read
@@ -875,7 +875,7 @@ jobs:
               if [[ -n "${CODEX_PLUGIN_SPEC// }" ]]; then
                 args+=(-f codex_plugin_spec="$CODEX_PLUGIN_SPEC")
               fi
-              if [[ -n "${CANDIDATE_ARTIFACT_JSON// }" ]]; then
+              if [[ -n "${CANDIDATE_ARTIFACT_JSON// }" && -z "${PACKAGE_ACCEPTANCE_PACKAGE_SPEC// }" ]]; then
                 args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")
               fi
               dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-release-checks"
@@ -967,10 +967,34 @@ jobs:
     # so it does not cancel healthy release checks before their final verifier.
     timeout-minutes: 240
     outputs:
+      candidate_package_sha256: ${{ steps.release_package_candidate.outputs.sha256 || needs.prepare_release_candidate.outputs.package_sha256 }}
       run_id: ${{ steps.dispatch.outputs.run_id }}
       url: ${{ steps.dispatch.outputs.url }}
       conclusion: ${{ steps.dispatch.outputs.conclusion }}
     steps:
+      - name: Checkout trusted package resolver
+        if: ${{ inputs.release_package_spec != '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: workflow
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: false
+
+      - name: Resolve release package candidate
+        id: release_package_candidate
+        if: ${{ inputs.release_package_spec != '' }}
+        env:
+          RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
+        run: |
+          set -euo pipefail
+          node workflow/scripts/resolve-openclaw-package-candidate.mjs \
+            --source npm \
+            --package-spec "$RELEASE_PACKAGE_SPEC" \
+            --output-dir "${RUNNER_TEMP}/full-release-package-candidate" \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Dispatch and monitor release checks
         id: dispatch
         env:
@@ -990,7 +1014,7 @@ jobs:
           RERUN_GROUP: ${{ inputs.rerun_group }}
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}
-          RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
+          RELEASE_PACKAGE_SPEC: ${{ steps.release_package_candidate.outputs.package_version && format('openclaw@{0}', steps.release_package_candidate.outputs.package_version) || inputs.release_package_spec }}
           PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ inputs.package_acceptance_package_spec }}
           CODEX_PLUGIN_SPEC: ${{ inputs.codex_plugin_spec }}
           CANDIDATE_ARTIFACT_JSON: ${{ needs.prepare_release_candidate.outputs.candidate_artifact_json }}
@@ -1061,7 +1085,7 @@ jobs:
       ]
     if: always()
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 20
     steps:
       - name: Verify child workflow results
         env:
@@ -1491,90 +1515,68 @@ jobs:
 
           exit "$failed"
 
-      - name: Request release evidence update
-        if: ${{ inputs.dispatch_release_evidence }}
+      - name: Checkout Gateway/node compatibility selector and collector
+        if: ${{ success() && needs.evidence_reuse.outputs.reuse != 'true' && needs.release_checks.outputs.run_id != '' && contains(fromJSON('["all","release-checks","cross-os"]'), inputs.rerun_group) }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: workflow
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: false
+
+      - name: Select Gateway/node compatibility mode
+        id: gateway_node_compat_selection
+        if: ${{ success() && needs.evidence_reuse.outputs.reuse != 'true' && needs.release_checks.outputs.run_id != '' && contains(fromJSON('["all","release-checks","cross-os"]'), inputs.rerun_group) }}
         env:
-          RELEASES_DISPATCH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_DISPATCH_TOKEN }}
-          TARGET_REF: ${{ inputs.ref }}
-          PACKAGE_SPEC: ${{ inputs.evidence_package_spec || inputs.npm_telegram_package_spec }}
-          GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
-          RELEASE_CHECKS_RESULT: ${{ needs.release_checks.result }}
-          EVIDENCE_REUSE: ${{ needs.evidence_reuse.outputs.reuse }}
-          EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
-          EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
+          CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [[ "$RELEASE_CHECKS_RESULT" == "skipped" && "$EVIDENCE_REUSE" != "true" ]]; then
-            echo "Release checks were skipped by rerun group; skipping automatic release evidence update."
-            exit 0
-          fi
-          notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE} after child workflows completed; the parent summary re-checks current child run conclusions."
-          if [[ "$EVIDENCE_REUSE" == "true" && -n "${EVIDENCE_ROOT_RUN_ID// }" ]]; then
-            notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE}, which reused green product evidence from chain-root run ${EVIDENCE_ROOT_RUN_ID} under policy ${EVIDENCE_POLICY}."
-          fi
-          if [[ -z "${RELEASES_DISPATCH_TOKEN// }" ]]; then
-            echo "OPENCLAW_RELEASES_DISPATCH_TOKEN is not configured; skipping automatic release evidence update."
-            exit 0
-          fi
-
-          evidence_package_spec="$PACKAGE_SPEC"
-          if [[ -z "${evidence_package_spec// }" ]]; then
-            tag_ref="${TARGET_REF#refs/tags/}"
-            if [[ "$tag_ref" =~ ^v([0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-(alpha|beta)\.[1-9][0-9]*)|(-[1-9][0-9]*))?)$ ]]; then
-              evidence_package_spec="openclaw@${BASH_REMATCH[1]}"
-            fi
-          fi
-
-          release_id="${TARGET_REF#refs/tags/}"
-          release_id="${release_id#v}"
-          if [[ "$evidence_package_spec" =~ ^openclaw@(.+)$ ]]; then
-            release_id="${BASH_REMATCH[1]}"
-          fi
-          release_id="$(printf '%s' "$release_id" | tr '/:@ ' '----' | tr -cd 'A-Za-z0-9._-')"
-          if [[ -z "$release_id" ]]; then
-            echo "::warning::Could not derive release evidence id from target ref '${TARGET_REF}'; skipping automatic release evidence update."
-            exit 0
-          fi
-
-          payload="$(
-            jq -cn \
-              --arg full_validation_run_id "$GITHUB_RUN_ID_VALUE" \
-              --arg release_id "$release_id" \
-              --arg release_ref "$TARGET_REF" \
-              --arg package_spec "$evidence_package_spec" \
-              --arg notes "$notes" \
-              '{
-                event_type: "openclaw_full_release_validation_completed",
-                client_payload: {
-                  full_validation_run_id: $full_validation_run_id,
-                  release_id: $release_id,
-                  release_ref: $release_ref,
-                  package_spec: $package_spec,
-                  notes: $notes
-                }
-              }'
+          selected="$(
+            node --experimental-strip-types workflow/scripts/openclaw-cross-os-release-checks.ts \
+              --resolve-gateway-node-compat-selection true \
+              --suite-filter "$CROSS_OS_SUITE_FILTER"
           )"
+          case "$selected" in
+            true)
+              if [[ "$WORKFLOW_FULL_REF" == refs/heads/tideclaw/alpha/* ]]; then
+                mode="advisory"
+              else
+                mode="required"
+              fi
+              ;;
+            false)
+              mode="not-selected"
+              ;;
+            *)
+              echo "Unexpected Gateway/node compatibility selection: $selected" >&2
+              exit 1
+              ;;
+          esac
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
 
-          if ! curl --fail-with-body \
-            --connect-timeout 10 \
-            --max-time 30 \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${RELEASES_DISPATCH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/openclaw/releases/dispatches \
-            -d "$payload"; then
-            echo "::warning::Automatic release evidence dispatch failed; child workflow validation remains authoritative."
-            {
-              echo "### Release evidence dispatch failed"
-              echo
-              echo "Child workflow validation remains authoritative. Backfill durable evidence from \`openclaw/releases\`:"
-              echo
-              echo "\`\`\`bash"
-              echo "gh workflow run openclaw-release-evidence-from-full-validation.yml --repo openclaw/releases --ref main -f full_validation_run_id=${GITHUB_RUN_ID_VALUE} -f release_id=${release_id} -f release_ref=${TARGET_REF} -f package_spec=${evidence_package_spec}"
-              echo "\`\`\`"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+      - name: Collect Gateway/node compatibility evidence
+        if: ${{ success() && steps.gateway_node_compat_selection.outputs.selected == 'true' }}
+        env:
+          CANDIDATE_PACKAGE_SHA256: ${{ needs.release_checks.outputs.candidate_package_sha256 }}
+          GATEWAY_NODE_COMPAT_MODE: ${{ steps.gateway_node_compat_selection.outputs.mode }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_CHECKS_RUN_ID: ${{ needs.release_checks.outputs.run_id }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/full-release-validation"
+          node workflow/scripts/gateway-node-compat-release-evidence.mjs collect \
+            --candidate-package-sha256 "${CANDIDATE_PACKAGE_SHA256}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --run-id "${RELEASE_CHECKS_RUN_ID}" \
+            --workflow-sha "${GITHUB_SHA}" \
+            --target-sha "${TARGET_SHA}" \
+            --mode "${GATEWAY_NODE_COMPAT_MODE}" \
+            --retry-deadline-ms "900000" \
+            --output "${RUNNER_TEMP}/full-release-validation/gateway-node-compatibility.json"
 
       - name: Write release validation manifest
         if: ${{ success() }}
@@ -1609,10 +1611,28 @@ jobs:
           NPM_TELEGRAM_PROVIDER_MODE: ${{ inputs.npm_telegram_provider_mode }}
           NPM_TELEGRAM_SCENARIO: ${{ inputs.npm_telegram_scenario }}
           ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog || (inputs.target_context_ref == '' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')) }}
+          DISPATCH_RELEASE_EVIDENCE: ${{ inputs.dispatch_release_evidence }}
+          EVIDENCE_PACKAGE_SPEC: ${{ inputs.evidence_package_spec }}
+          FALLBACK_EVIDENCE_PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec }}
+          GATEWAY_NODE_COMPAT_MODE: ${{ steps.gateway_node_compat_selection.outputs.mode || 'not-selected' }}
+          GATEWAY_NODE_COMPAT_PATH: ${{ runner.temp }}/full-release-validation/gateway-node-compatibility.json
         run: |
           set -euo pipefail
           manifest_dir="${RUNNER_TEMP}/full-release-validation"
           mkdir -p "$manifest_dir"
+          if [[ ! -f "$GATEWAY_NODE_COMPAT_PATH" ]]; then
+            printf 'null\n' > "$GATEWAY_NODE_COMPAT_PATH"
+          fi
+          release_evidence_package_spec="$EVIDENCE_PACKAGE_SPEC"
+          if [[ -z "${release_evidence_package_spec// }" ]]; then
+            release_evidence_package_spec="$FALLBACK_EVIDENCE_PACKAGE_SPEC"
+          fi
+          if [[ -z "${release_evidence_package_spec// }" ]]; then
+            tag_ref="${TARGET_REF#refs/tags/}"
+            if [[ "$tag_ref" =~ ^v([0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-(alpha|beta)\.[1-9][0-9]*)|(-[1-9][0-9]*))?)$ ]]; then
+              release_evidence_package_spec="openclaw@${BASH_REMATCH[1]}"
+            fi
+          fi
           if [[ "$EVIDENCE_REUSE" == "true" ]]; then
             # Inherit the evidence manifest (profile, soak, child runs) so future
             # reuse lookups and evidence consumers keep resolving the chain root.
@@ -1629,6 +1649,8 @@ jobs:
               --arg evidenceRootRunId "$EVIDENCE_ROOT_RUN_ID" \
               --arg evidenceSha "$EVIDENCE_SHA" \
               --arg evidencePolicy "$EVIDENCE_POLICY" \
+              --arg dispatchReleaseEvidence "$DISPATCH_RELEASE_EVIDENCE" \
+              --arg releaseEvidencePackageSpec "$release_evidence_package_spec" \
               --argjson evidenceChangedPaths "$EVIDENCE_CHANGED_PATHS" \
               '. + {
                 version: 3,
@@ -1646,6 +1668,11 @@ jobs:
                   selectedRunId: $evidenceRunId,
                   evidenceSha: $evidenceSha,
                   changedPaths: $evidenceChangedPaths
+                },
+                releaseEvidencePublication: {
+                  requested: ($dispatchReleaseEvidence == "true"),
+                  releaseRef: $targetRef,
+                  packageSpec: $releaseEvidencePackageSpec
                 },
                 controls: ((.controls // {}) + {
                   performanceReportPublication: "artifact-only"
@@ -1684,6 +1711,10 @@ jobs:
             --arg npmTelegramProviderMode "$NPM_TELEGRAM_PROVIDER_MODE" \
             --arg npmTelegramScenario "$NPM_TELEGRAM_SCENARIO" \
             --arg allowUnreleasedChangelog "$ALLOW_UNRELEASED_CHANGELOG" \
+            --arg dispatchReleaseEvidence "$DISPATCH_RELEASE_EVIDENCE" \
+            --arg releaseEvidencePackageSpec "$release_evidence_package_spec" \
+            --arg gatewayNodeCompatibilityMode "$GATEWAY_NODE_COMPAT_MODE" \
+            --slurpfile gatewayNodeCompatibility "$GATEWAY_NODE_COMPAT_PATH" \
             '{
               version: 3,
               workflowName: $workflowName,
@@ -1712,10 +1743,16 @@ jobs:
                 npmTelegramScenario: $npmTelegramScenario,
                 allowUnreleasedChangelog: $allowUnreleasedChangelog
               },
+              releaseEvidencePublication: {
+                requested: ($dispatchReleaseEvidence == "true"),
+                releaseRef: $targetRef,
+                packageSpec: $releaseEvidencePackageSpec
+              },
               controls: {
                 stableSoakRequired: ($releaseProfile == "stable" or $releaseProfile == "full"),
                 performanceBlocking: ($releaseProfile != "beta"),
-                performanceReportPublication: "artifact-only"
+                performanceReportPublication: "artifact-only",
+                gatewayNodeCompatibility: $gatewayNodeCompatibilityMode
               },
               childRuns: {
                 normalCi: $normalCiRunId,
@@ -1728,14 +1765,18 @@ jobs:
                   blocking: ($releaseProfile != "beta")
                 }
               }
-            }' > "${manifest_dir}/full-release-validation-manifest.json"
+            }
+            | if $gatewayNodeCompatibility[0] == null
+              then .
+              else . + {gatewayNodeCompatibility: $gatewayNodeCompatibility[0]}
+              end' > "${manifest_dir}/full-release-validation-manifest.json"
 
       - name: Upload release validation manifest
         if: ${{ success() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-validation-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/full-release-validation
+          path: ${{ runner.temp }}/full-release-validation/full-release-validation-manifest.json
           if-no-files-found: error
 
       - name: Upload legacy release validation manifest alias
@@ -1743,6 +1784,6 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-validation-${{ github.run_id }}
-          path: ${{ runner.temp }}/full-release-validation
+          path: ${{ runner.temp }}/full-release-validation/full-release-validation-manifest.json
           if-no-files-found: error
           overwrite: true

--- a/.github/workflows/release-evidence-publication.yml
+++ b/.github/workflows/release-evidence-publication.yml
@@ -1,0 +1,140 @@
+name: Release Evidence Publication
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] trusted post-completion release publisher; the job verifies repository, workflow, exact run tuple, main lineage, manifest intent, and all child evidence before using the dispatch token
+    workflows:
+      - Full Release Validation
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: release-evidence-publication-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  publish:
+    name: Publish validated release evidence
+    if: >
+      github.repository == 'openclaw/openclaw' &&
+      github.event.workflow_run.repository.full_name == 'openclaw/openclaw' &&
+      github.event.workflow_run.name == 'Full Release Validation' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout trusted publication verifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Verify exact completed release evidence
+        id: publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARENT_RUN_ID: ${{ github.event.workflow_run.id }}
+          RELEASES_DISPATCH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          evidence="${RUNNER_TEMP}/release-evidence.json"
+          node scripts/release-ci-summary.mjs \
+            --validate-run "$PARENT_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --trusted-workflow-ref main \
+            --json > "$evidence"
+          node scripts/release-evidence-publication.mjs prepare \
+            --event "$GITHUB_EVENT_PATH" \
+            --evidence "$evidence" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Dispatch release evidence publication
+        if: steps.publication.outputs.should_dispatch == 'true'
+        env:
+          FULL_VALIDATION_RUN_ID: ${{ steps.publication.outputs.full_validation_run_id }}
+          HEAD_SHA: ${{ steps.publication.outputs.head_sha }}
+          NOTES: ${{ steps.publication.outputs.notes }}
+          PACKAGE_SPEC: ${{ steps.publication.outputs.package_spec }}
+          PUBLICATION_KEY: ${{ steps.publication.outputs.publication_key }}
+          RELEASE_ID: ${{ steps.publication.outputs.release_id }}
+          RELEASE_REF: ${{ steps.publication.outputs.release_ref }}
+          RUN_ATTEMPT: ${{ steps.publication.outputs.run_attempt }}
+          UPDATED_AT: ${{ steps.publication.outputs.updated_at }}
+          RELEASES_DISPATCH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          [[ -n "${RELEASES_DISPATCH_TOKEN// }" ]] || {
+            echo "OPENCLAW_RELEASES_DISPATCH_TOKEN is required for requested release evidence publication." >&2
+            exit 1
+          }
+          payload="$(
+            jq -cn \
+              --arg full_validation_run_id "$FULL_VALIDATION_RUN_ID" \
+              --arg full_validation_run_attempt "$RUN_ATTEMPT" \
+              --arg full_validation_head_sha "$HEAD_SHA" \
+              --arg full_validation_updated_at "$UPDATED_AT" \
+              --arg release_id "$RELEASE_ID" \
+              --arg release_ref "$RELEASE_REF" \
+              --arg package_spec "$PACKAGE_SPEC" \
+              --arg notes "$NOTES" \
+              --arg publication_key "$PUBLICATION_KEY" \
+              '{
+                event_type: "openclaw_full_release_validation_completed",
+                client_payload: {
+                  full_validation_run_id: $full_validation_run_id,
+                  full_validation_run_attempt: $full_validation_run_attempt,
+                  full_validation_head_sha: $full_validation_head_sha,
+                  full_validation_updated_at: $full_validation_updated_at,
+                  release_id: $release_id,
+                  release_ref: $release_ref,
+                  package_spec: $package_spec,
+                  notes: $notes,
+                  publication_key: $publication_key
+                }
+              }'
+          )"
+          curl --fail-with-body \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${RELEASES_DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/openclaw/releases/dispatches \
+            -d "$payload"
+
+      - name: Confirm durable release evidence publication
+        if: steps.publication.outputs.should_dispatch == 'true'
+        env:
+          FULL_VALIDATION_RUN_ID: ${{ steps.publication.outputs.full_validation_run_id }}
+          HEAD_SHA: ${{ steps.publication.outputs.head_sha }}
+          PACKAGE_SPEC: ${{ steps.publication.outputs.package_spec }}
+          RELEASE_ID: ${{ steps.publication.outputs.release_id }}
+          RELEASE_REF: ${{ steps.publication.outputs.release_ref }}
+          RELEASES_DISPATCH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_DISPATCH_TOKEN }}
+          RUN_ATTEMPT: ${{ steps.publication.outputs.run_attempt }}
+          UPDATED_AT: ${{ steps.publication.outputs.updated_at }}
+        run: |
+          node scripts/release-evidence-publication.mjs confirm \
+            --run-id "$FULL_VALIDATION_RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
+            --head-sha "$HEAD_SHA" \
+            --updated-at "$UPDATED_AT" \
+            --release-id "$RELEASE_ID" \
+            --release-ref "$RELEASE_REF" \
+            --package-spec "$PACKAGE_SPEC"

--- a/scripts/gateway-node-compat-release-evidence.d.mts
+++ b/scripts/gateway-node-compat-release-evidence.d.mts
@@ -1,0 +1,128 @@
+import type {
+  GatewayNodeCompatEvidence,
+  GatewayNodeCompatProducer,
+} from "./gateway-node-compat-evidence.mjs";
+import type { ArtifactBinding } from "./lib/actions-artifact-archive.mjs";
+
+export const GATEWAY_NODE_COMPAT_RELEASE_SCHEMA: string;
+export const GATEWAY_NODE_COMPAT_BASELINE_VERSION: "2026.5.7";
+export const GATEWAY_NODE_COMPAT_BASELINE_TAG: "v2026.5.7";
+export const GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA: string;
+export const GATEWAY_NODE_COMPAT_BASELINE_SHA256: string;
+export const GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY: string;
+export const GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW: string;
+export const GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW: string;
+export const GATEWAY_NODE_COMPAT_PRODUCER_JOB: string;
+
+export type GatewayNodeCompatFileSummary = {
+  caseId: string;
+  direction: GatewayNodeCompatEvidence["direction"];
+  outcome: GatewayNodeCompatEvidence["result"]["outcome"];
+  gatewayVersion: string;
+  nodeVersion: string;
+  gatewayProtocolVersion: number;
+  gatewayAcceptedNodeMin: number;
+  protocolClientAdvertisedMin: number;
+  protocolClientAdvertisedMax: number;
+  helloProtocol: number | null;
+  path: string;
+  sha256: string;
+  sizeBytes: number;
+};
+
+export type GatewayNodeCompatManifestEvidence = {
+  architecture: "x64";
+  artifact: {
+    digest: string;
+    id: number;
+    name: string;
+    producerJob: string;
+    repository: string;
+    runAttempt: number;
+    runId: string;
+    sizeBytes: number;
+    workflowPath: string;
+    workflowSha: string;
+  };
+  baseline: {
+    npmIntegrity: string;
+    sha256: string;
+    sourceSha: string;
+    tag: "v2026.5.7";
+    version: "2026.5.7";
+  };
+  baselineVersion: "2026.5.7";
+  files: GatewayNodeCompatFileSummary[];
+  platform: "linux";
+  producer: GatewayNodeCompatProducer;
+  schema: string;
+  targetSha: string;
+};
+
+export function validateGatewayNodeCompatEvidenceSet(
+  files: Map<string, Uint8Array>,
+  expected: {
+    candidatePackageSha256: string;
+    repository: string;
+    runAttempt: number;
+    runId: string | number;
+    targetSha: string;
+    workflowSha: string;
+  },
+): {
+  baseline: GatewayNodeCompatManifestEvidence["baseline"];
+  baselineVersion: "2026.5.7";
+  files: GatewayNodeCompatFileSummary[];
+  producer: GatewayNodeCompatProducer;
+  targetSha: string;
+};
+
+export function selectGatewayNodeCompatArtifact(params: {
+  artifacts: Array<Record<string, unknown>>;
+  jobs: Array<Record<string, unknown>>;
+  required: boolean;
+  run: Record<string, unknown>;
+}):
+  | {
+      artifact: Record<string, unknown>;
+      job: Record<string, unknown>;
+      runAttempt: number;
+    }
+  | undefined;
+
+export function collectGatewayNodeCompatReleaseEvidence(
+  params: {
+    now?: () => number;
+    onWarning?: (message: string) => void;
+    repository: string;
+    retryDeadlineMs?: number;
+    retryDelayMs?: number;
+    runId: string | number;
+    sleep?: (delayMs: number) => Promise<void>;
+    targetSha: string;
+    token?: string;
+    workflowSha: string;
+  } & (
+    | { candidatePackageSha256?: never; mode: "not-selected" }
+    | { candidatePackageSha256: string; mode: "advisory" | "required" }
+  ),
+  client?: {
+    getArtifacts(runId: string, repository: string): Promise<Array<Record<string, unknown>>>;
+    getJobs(runId: string, repository: string): Promise<Array<Record<string, unknown>>>;
+    getRun(runId: string, repository: string): Promise<Record<string, unknown>>;
+    readArtifact(expected: ArtifactBinding): Promise<{ files: Map<string, Buffer> }>;
+  },
+): Promise<GatewayNodeCompatManifestEvidence | null>;
+
+export function createGatewayNodeCompatReleaseEvidenceClient(token?: string): {
+  getArtifacts(runId: string, repository: string): Promise<Array<Record<string, unknown>>>;
+  getJobs(runId: string, repository: string): Promise<Array<Record<string, unknown>>>;
+  getRun(runId: string, repository: string): Promise<Record<string, unknown>>;
+  readArtifact(expected: ArtifactBinding): Promise<{ files: Map<string, Buffer> }>;
+};
+
+export function validateGatewayNodeCompatManifestEvidence(
+  value: unknown,
+): GatewayNodeCompatManifestEvidence;
+
+export function renderGatewayNodeCompatSummary(value: unknown): string;

--- a/scripts/gateway-node-compat-release-evidence.mjs
+++ b/scripts/gateway-node-compat-release-evidence.mjs
@@ -1,0 +1,915 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
+import {
+  canonicalizeGatewayNodeCompatEvidence,
+  validateGatewayNodeCompatEvidence,
+} from "./gateway-node-compat-evidence.mjs";
+import {
+  describeActionsArtifactFiles,
+  readPublicationArtifactArchive,
+} from "./lib/actions-artifact-archive.mjs";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
+import { plainGhEnv, resolvePlainGhBin } from "./lib/plain-gh.mjs";
+
+export const GATEWAY_NODE_COMPAT_RELEASE_SCHEMA =
+  "openclaw.gateway-node-compat-release-evidence/v1";
+export const GATEWAY_NODE_COMPAT_BASELINE_VERSION = "2026.5.7";
+export const GATEWAY_NODE_COMPAT_BASELINE_TAG = "v2026.5.7";
+export const GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA = "eeef4864494f859838fec1586bedbab1f8fa5702";
+export const GATEWAY_NODE_COMPAT_BASELINE_SHA256 =
+  "1fe195d8e3928062cfaf7f9ef616670cde25b35ea9631fcae5f8aaf8be2986fd";
+export const GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY =
+  "sha512-hjvpgconK20YltQPrzDY6cehjM8ijQyZnLKhqLBTngiFEPum9gmXwCDsrisPEXVRFtzuMhap+w6zSEmSQ1047Q==";
+export const GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW =
+  ".github/workflows/openclaw-release-checks.yml";
+export const GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW =
+  ".github/workflows/openclaw-cross-os-release-checks-reusable.yml";
+export const GATEWAY_NODE_COMPAT_PRODUCER_JOB =
+  "cross_os_release_checks / Gateway/node packaged compatibility / Linux / x64";
+
+const MAX_PAGES = 10;
+const PAGE_SIZE = 100;
+const MAX_ARCHIVE_BYTES = 512 * 1024;
+const MAX_EVIDENCE_BYTES = 64 * 1024;
+const DEFAULT_COLLECTION_RETRY_DELAY_MS = 5_000;
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const ACTIONS_DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
+const POSITIVE_DECIMAL_PATTERN = /^[1-9][0-9]*$/u;
+const CASE_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/u;
+const COLLECTION_MODES = new Set(["advisory", "not-selected", "required"]);
+const TRANSIENT_COLLECTION_ERROR_PATTERN =
+  /(?:ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|fetch failed|HTTP 5[0-9][0-9]|rate limit|secondary rate limit|timed? out|timeout|no eligible successful producer|inventory (?:is incomplete|changed during pagination))/iu;
+const REQUIRED_ROWS = [
+  ["baseline-gateway-baseline-node", "passed"],
+  ["baseline-gateway-candidate-node", "passed"],
+  ["baseline-gateway-disjoint-node", "protocol-mismatch"],
+  ["candidate-gateway-baseline-node", "passed"],
+  ["candidate-gateway-candidate-node", "passed"],
+  ["candidate-gateway-disjoint-node", "protocol-mismatch"],
+];
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requireExactKeys(value, label, keys) {
+  const expected = new Set(keys);
+  const actual = Object.keys(value);
+  if (actual.length !== expected.size || actual.some((key) => !expected.has(key))) {
+    throw new Error(`${label} has an invalid shape`);
+  }
+}
+
+function requireString(value, label, pattern, maxLength = 4096) {
+  if (typeof value !== "string" || value.length === 0 || value.trim() !== value) {
+    throw new Error(`${label} must be a non-empty trimmed string`);
+  }
+  if (value.length > maxLength) {
+    throw new Error(`${label} is too long`);
+  }
+  if (pattern && !pattern.test(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function requireCollectionMode(value) {
+  const mode = requireString(value, "Gateway/node compatibility collection mode", undefined, 32);
+  if (!COLLECTION_MODES.has(mode)) {
+    throw new Error("Gateway/node compatibility collection mode is invalid");
+  }
+  return mode;
+}
+
+function workflowPath(value) {
+  return requireString(value, "workflow path").split("@", 1)[0];
+}
+
+function evidencePath(direction) {
+  return `linux-x64-${direction}.json`;
+}
+
+function artifactName(runId, runAttempt) {
+  return `openclaw-gateway-node-linux-compat-x64-${runId}-${runAttempt}`;
+}
+
+function directionRoles(direction) {
+  return {
+    gateway: direction.startsWith("candidate-") ? "candidate" : "baseline",
+    node: direction.includes("-baseline-node") ? "baseline" : "candidate",
+  };
+}
+
+function canonicalIdentity(value) {
+  return JSON.stringify(value);
+}
+
+function validateRuntimeRole(binding, role, targetSha) {
+  const packaged = binding.packagedArtifact;
+  const installed = binding.installedRuntime;
+  if (role === "candidate") {
+    if (packaged.sourceSha !== targetSha || installed.sourceSha !== targetSha) {
+      throw new Error("candidate runtime source SHA does not match the Full Release target SHA");
+    }
+    return;
+  }
+  if (
+    packaged.version !== GATEWAY_NODE_COMPAT_BASELINE_VERSION ||
+    installed.version !== GATEWAY_NODE_COMPAT_BASELINE_VERSION ||
+    packaged.sourceSha !== GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA ||
+    installed.sourceSha !== GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA ||
+    packaged.sha256 !== GATEWAY_NODE_COMPAT_BASELINE_SHA256 ||
+    installed.packageSha256 !== GATEWAY_NODE_COMPAT_BASELINE_SHA256
+  ) {
+    throw new Error("baseline runtime provenance is not canonical");
+  }
+}
+
+function validateSharedIdentity(current, expected, label) {
+  const identity = canonicalIdentity(current);
+  if (expected.value === undefined) {
+    expected.value = identity;
+  } else if (identity !== expected.value) {
+    throw new Error(`${label} must be identical across all six evidence rows`);
+  }
+}
+
+export function validateGatewayNodeCompatEvidenceSet(files, expected) {
+  if (!(files instanceof Map)) {
+    throw new Error("Gateway/node compatibility artifact files must be a Map");
+  }
+  const repository = requireString(
+    expected.repository,
+    "expected repository",
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u,
+  );
+  const targetSha = requireString(expected.targetSha, "expected target SHA", SHA_PATTERN);
+  const artifactIdentities = {
+    baselinePackageSha256: GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+    candidatePackageSha256: requireString(
+      expected.candidatePackageSha256,
+      "expected candidate package SHA-256",
+      SHA256_PATTERN,
+    ),
+  };
+  const workflowSha = requireString(expected.workflowSha, "expected workflow SHA", SHA_PATTERN);
+  const runId = requireString(String(expected.runId), "expected run ID", POSITIVE_DECIMAL_PATTERN);
+  const runAttempt = requirePositiveInteger(expected.runAttempt, "expected run attempt");
+  const descriptors = describeActionsArtifactFiles(files);
+  const expectedPaths = REQUIRED_ROWS.map(([direction]) => evidencePath(direction));
+  if (
+    descriptors.length !== expectedPaths.length ||
+    descriptors.some((descriptor, index) => descriptor.path !== expectedPaths[index])
+  ) {
+    throw new Error("Gateway/node compatibility artifact must contain the exact six-row inventory");
+  }
+
+  const producerIdentity = {};
+  const candidateIdentity = {};
+  const baselineIdentity = {};
+  const summaries = [];
+  for (const [direction, outcome] of REQUIRED_ROWS) {
+    const filePath = evidencePath(direction);
+    const bytes = files.get(filePath);
+    if (!bytes) {
+      throw new Error(`Gateway/node compatibility evidence is missing ${filePath}`);
+    }
+    const text = Buffer.from(bytes).toString("utf8");
+    let evidence;
+    try {
+      evidence = JSON.parse(text);
+    } catch (error) {
+      throw new Error(`${filePath} is not valid JSON`, { cause: error });
+    }
+    validateGatewayNodeCompatEvidence(evidence, artifactIdentities);
+    if (canonicalizeGatewayNodeCompatEvidence(evidence, artifactIdentities) !== text) {
+      throw new Error(`${filePath} is not canonical Gateway/node compatibility evidence`);
+    }
+    if (
+      evidence.caseId !== filePath.slice(0, -".json".length) ||
+      evidence.direction !== direction ||
+      evidence.result.outcome !== outcome ||
+      evidence.node.kind !== "linux" ||
+      evidence.node.architecture !== "x64"
+    ) {
+      throw new Error(`${filePath} does not match its required Linux/x64 matrix row`);
+    }
+    const producer = evidence.producer;
+    if (
+      producer.repository !== repository ||
+      producer.workflowPath !== GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW ||
+      producer.workflowSha !== workflowSha ||
+      producer.runId !== runId ||
+      producer.runAttempt !== runAttempt ||
+      producer.job !== "gateway_node_linux_compat"
+    ) {
+      throw new Error(`${filePath} producer tuple does not match the selected artifact`);
+    }
+    validateSharedIdentity(producer, producerIdentity, "producer tuple");
+
+    const roles = directionRoles(direction);
+    for (const [role, binding] of [
+      [roles.gateway, evidence.gateway],
+      [roles.node, evidence.node],
+    ]) {
+      const runtimeBinding = {
+        installedRuntime: binding.installedRuntime,
+        packagedArtifact: binding.packagedArtifact,
+      };
+      validateRuntimeRole(runtimeBinding, role, targetSha);
+      validateSharedIdentity(
+        runtimeBinding,
+        role === "candidate" ? candidateIdentity : baselineIdentity,
+        `${role} runtime binding`,
+      );
+    }
+
+    const descriptor = descriptors.find((entry) => entry.path === filePath);
+    if (!descriptor) {
+      throw new Error(`Gateway/node compatibility evidence summary is missing ${filePath}`);
+    }
+    summaries.push({
+      caseId: evidence.caseId,
+      direction,
+      outcome,
+      gatewayVersion: evidence.gateway.installedRuntime.version,
+      nodeVersion: evidence.node.installedRuntime.version,
+      gatewayProtocolVersion: evidence.protocol.gatewayProtocolVersion,
+      gatewayAcceptedNodeMin: evidence.protocol.gatewayAcceptedNodeMin,
+      protocolClientAdvertisedMin: evidence.protocol.protocolClientAdvertisedMin,
+      protocolClientAdvertisedMax: evidence.protocol.protocolClientAdvertisedMax,
+      helloProtocol: evidence.protocol.helloProtocol,
+      path: descriptor.path,
+      sha256: descriptor.sha256,
+      sizeBytes: descriptor.sizeBytes,
+    });
+  }
+  return {
+    baseline: {
+      npmIntegrity: GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY,
+      sha256: GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+      sourceSha: GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA,
+      tag: GATEWAY_NODE_COMPAT_BASELINE_TAG,
+      version: GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+    },
+    baselineVersion: GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+    files: summaries,
+    producer: JSON.parse(producerIdentity.value),
+    targetSha,
+  };
+}
+
+function validateRun(run, expected, requireSuccessfulRun) {
+  const value = requireObject(run, "release-check run");
+  if (
+    String(value.id) !== String(expected.runId) ||
+    value.event !== "workflow_dispatch" ||
+    value.status !== "completed" ||
+    (requireSuccessfulRun
+      ? value.conclusion !== "success"
+      : typeof value.conclusion !== "string" || value.conclusion.length === 0) ||
+    value.head_sha !== expected.workflowSha ||
+    workflowPath(value.path) !== GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW ||
+    value.repository?.full_name !== expected.repository ||
+    value.head_repository?.full_name !== expected.repository
+  ) {
+    throw new Error("release-check run does not match the immutable compatibility tuple");
+  }
+  requirePositiveInteger(value.run_attempt, "release-check run attempt");
+  requireString(value.head_branch, "release-check head branch");
+  return value;
+}
+
+export function selectGatewayNodeCompatArtifact({ artifacts, jobs, required, run }) {
+  if (!Array.isArray(artifacts) || !Array.isArray(jobs)) {
+    throw new Error("Gateway/node compatibility Actions inventories must be arrays");
+  }
+  const currentAttempt = requirePositiveInteger(run.run_attempt, "release-check run attempt");
+  const runId = String(run.id);
+  const producerJobs = jobs.filter(
+    (job) =>
+      job?.name === GATEWAY_NODE_COMPAT_PRODUCER_JOB &&
+      String(job.run_id) === runId &&
+      Number.isSafeInteger(job.run_attempt) &&
+      job.run_attempt <= currentAttempt,
+  );
+  const namedArtifacts = artifacts.filter(
+    (artifact) =>
+      typeof artifact?.name === "string" &&
+      artifact.name.startsWith(`openclaw-gateway-node-linux-compat-x64-${runId}-`),
+  );
+  const attempts = [...new Set(producerJobs.map((job) => job.run_attempt))].toSorted(
+    (left, right) => right - left,
+  );
+  for (const attempt of attempts) {
+    const matchingJobs = producerJobs.filter((job) => job.run_attempt === attempt);
+    if (matchingJobs.length !== 1) {
+      throw new Error(
+        `Gateway/node compatibility producer job is not unique for attempt ${attempt}`,
+      );
+    }
+    const matchingArtifacts = namedArtifacts.filter(
+      (artifact) => artifact.name === artifactName(runId, attempt),
+    );
+    if (matchingArtifacts.length > 1) {
+      throw new Error(`Gateway/node compatibility artifact is not unique for attempt ${attempt}`);
+    }
+    const [job] = matchingJobs;
+    const [artifact] = matchingArtifacts;
+    if (
+      job.status === "completed" &&
+      job.conclusion === "success" &&
+      artifact &&
+      artifact.expired === false
+    ) {
+      return { artifact, job, runAttempt: attempt };
+    }
+  }
+  if (required || producerJobs.length > 0 || namedArtifacts.length > 0) {
+    throw new Error("Gateway/node compatibility evidence has no eligible successful producer");
+  }
+  return undefined;
+}
+
+function validateArtifactMetadata(artifact, run, runAttempt) {
+  const value = requireObject(artifact, "Gateway/node compatibility artifact");
+  const runId = String(run.id);
+  if (
+    !Number.isSafeInteger(value.id) ||
+    value.id < 1 ||
+    value.name !== artifactName(runId, runAttempt) ||
+    !ACTIONS_DIGEST_PATTERN.test(String(value.digest ?? "")) ||
+    !Number.isSafeInteger(value.size_in_bytes) ||
+    value.size_in_bytes < 1 ||
+    value.expired !== false ||
+    String(value.workflow_run?.id) !== runId ||
+    value.workflow_run?.head_sha !== run.head_sha
+  ) {
+    throw new Error("Gateway/node compatibility artifact metadata is invalid");
+  }
+  return value;
+}
+
+function buildArtifactBinding(artifact, run, runAttempt, repository) {
+  return {
+    artifactDigest: artifact.digest,
+    artifactId: artifact.id,
+    artifactName: artifact.name,
+    artifactSizeBytes: artifact.size_in_bytes,
+    producerJobName: GATEWAY_NODE_COMPAT_PRODUCER_JOB,
+    repository,
+    runAttempt,
+    runId: Number(run.id),
+    runStatePolicy: "completed-producer-success",
+    workflowEvent: run.event,
+    workflowHeadBranch: run.head_branch,
+    workflowPath: GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW,
+    workflowSha: run.head_sha,
+  };
+}
+
+export async function collectGatewayNodeCompatReleaseEvidence(params, client) {
+  const mode = requireCollectionMode(params.mode);
+  if (mode === "not-selected") {
+    return null;
+  }
+  const onWarning = typeof params.onWarning === "function" ? params.onWarning : () => {};
+  const retryDeadlineMs =
+    params.retryDeadlineMs === undefined
+      ? undefined
+      : requirePositiveInteger(params.retryDeadlineMs, "collection retry deadline");
+  const retryDelayMs =
+    params.retryDelayMs === undefined
+      ? DEFAULT_COLLECTION_RETRY_DELAY_MS
+      : requirePositiveInteger(params.retryDelayMs, "collection retry delay");
+  const now = typeof params.now === "function" ? params.now : Date.now;
+  const sleep =
+    typeof params.sleep === "function"
+      ? params.sleep
+      : (delayMs) =>
+          new Promise((resolvePromise) => {
+            setTimeout(resolvePromise, delayMs);
+          });
+  const deadlineAt = retryDeadlineMs === undefined ? undefined : now() + retryDeadlineMs;
+  const evidenceClient =
+    client ?? createGatewayNodeCompatReleaseEvidenceClient(params.token, { deadlineAt, now });
+  let lastError;
+  for (;;) {
+    if (deadlineAt !== undefined && lastError !== undefined && now() >= deadlineAt) {
+      break;
+    }
+    try {
+      return await collectSelectedGatewayNodeCompatReleaseEvidence(
+        params,
+        evidenceClient,
+        mode === "required",
+      );
+    } catch (error) {
+      lastError = error;
+      const remainingMs = deadlineAt === undefined ? 0 : deadlineAt - now();
+      if (
+        deadlineAt === undefined ||
+        remainingMs <= 0 ||
+        !TRANSIENT_COLLECTION_ERROR_PATTERN.test(
+          error instanceof Error ? error.message : String(error),
+        )
+      ) {
+        break;
+      }
+      await sleep(Math.min(retryDelayMs, remainingMs));
+    }
+  }
+  const finalError =
+    deadlineAt !== undefined && deadlineAt - now() <= 0
+      ? new Error("Gateway/node compatibility evidence collection retry deadline was exhausted", {
+          cause: lastError,
+        })
+      : lastError;
+  if (mode === "required") {
+    throw finalError;
+  }
+  onWarning(finalError instanceof Error ? finalError.message : String(finalError));
+  return null;
+}
+
+async function collectSelectedGatewayNodeCompatReleaseEvidence(params, client, required) {
+  const expected = {
+    candidatePackageSha256: requireString(
+      params.candidatePackageSha256,
+      "candidate package SHA-256",
+      SHA256_PATTERN,
+    ),
+    repository: requireString(
+      params.repository,
+      "repository",
+      /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u,
+    ),
+    runId: requireString(String(params.runId), "release-check run ID", POSITIVE_DECIMAL_PATTERN),
+    targetSha: requireString(params.targetSha, "target SHA", SHA_PATTERN),
+    workflowSha: requireString(params.workflowSha, "workflow SHA", SHA_PATTERN),
+  };
+  const evidenceClient = client ?? createGatewayNodeCompatReleaseEvidenceClient(params.token);
+  const run = validateRun(
+    await evidenceClient.getRun(expected.runId, expected.repository),
+    expected,
+    required,
+  );
+  const [artifacts, jobs] = await Promise.all([
+    evidenceClient.getArtifacts(expected.runId, expected.repository),
+    evidenceClient.getJobs(expected.runId, expected.repository),
+  ]);
+  const selected = selectGatewayNodeCompatArtifact({
+    artifacts,
+    jobs,
+    required,
+    run,
+  });
+  if (!selected) {
+    throw new Error("Gateway/node compatibility evidence has no eligible successful producer");
+  }
+  const artifact = validateArtifactMetadata(selected.artifact, run, selected.runAttempt);
+  const binding = buildArtifactBinding(artifact, run, selected.runAttempt, expected.repository);
+  const archive = await evidenceClient.readArtifact(binding);
+  const set = validateGatewayNodeCompatEvidenceSet(archive.files, {
+    candidatePackageSha256: expected.candidatePackageSha256,
+    repository: expected.repository,
+    runAttempt: selected.runAttempt,
+    runId: expected.runId,
+    targetSha: expected.targetSha,
+    workflowSha: expected.workflowSha,
+  });
+  return validateGatewayNodeCompatManifestEvidence({
+    architecture: "x64",
+    artifact: {
+      digest: artifact.digest,
+      id: artifact.id,
+      name: artifact.name,
+      producerJob: GATEWAY_NODE_COMPAT_PRODUCER_JOB,
+      repository: expected.repository,
+      runAttempt: selected.runAttempt,
+      runId: expected.runId,
+      sizeBytes: artifact.size_in_bytes,
+      workflowPath: GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW,
+      workflowSha: expected.workflowSha,
+    },
+    baseline: set.baseline,
+    baselineVersion: set.baselineVersion,
+    files: set.files,
+    platform: "linux",
+    producer: set.producer,
+    schema: GATEWAY_NODE_COMPAT_RELEASE_SCHEMA,
+    targetSha: set.targetSha,
+  });
+}
+
+function remainingCollectionDeadlineMs(options) {
+  if (options.deadlineAt === undefined) {
+    return 60_000;
+  }
+  const remainingMs = Math.floor(options.deadlineAt - options.now());
+  if (remainingMs <= 0) {
+    throw new Error("Gateway/node compatibility evidence collection retry deadline was exhausted");
+  }
+  return Math.min(60_000, remainingMs);
+}
+
+function createDeadlineFetch(options) {
+  if (options.deadlineAt === undefined) {
+    return undefined;
+  }
+  return async (input, init = {}) => {
+    const deadlineSignal = AbortSignal.timeout(remainingCollectionDeadlineMs(options));
+    const signal = init.signal ? AbortSignal.any([init.signal, deadlineSignal]) : deadlineSignal;
+    return await fetch(input, { ...init, signal });
+  };
+}
+
+function runGhJson(args, options) {
+  return JSON.parse(
+    execFileSync(resolvePlainGhBin(), args, {
+      encoding: "utf8",
+      env: plainGhEnv(),
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: remainingCollectionDeadlineMs(options),
+    }),
+  );
+}
+
+function readPaginatedCollection(repository, path, field, options) {
+  const items = [];
+  const ids = new Set();
+  let totalCount;
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const response = runGhJson(
+      ["api", `repos/${repository}/${path}${separator}per_page=${PAGE_SIZE}&page=${page}`],
+      options,
+    );
+    const pageItems = response[field];
+    if (!Array.isArray(pageItems) || !Number.isSafeInteger(response.total_count)) {
+      throw new Error(`GitHub ${field} inventory is invalid`);
+    }
+    if (totalCount === undefined) {
+      totalCount = response.total_count;
+    } else if (response.total_count !== totalCount) {
+      throw new Error(`GitHub ${field} inventory changed during pagination`);
+    }
+    for (const item of pageItems) {
+      if (!Number.isSafeInteger(item?.id) || ids.has(item.id)) {
+        throw new Error(`GitHub ${field} inventory contains duplicate or invalid IDs`);
+      }
+      ids.add(item.id);
+      items.push(item);
+    }
+    if (pageItems.length < PAGE_SIZE) {
+      break;
+    }
+  }
+  if (items.length !== totalCount) {
+    throw new Error(`GitHub ${field} inventory is incomplete`);
+  }
+  return items;
+}
+
+export function createGatewayNodeCompatReleaseEvidenceClient(
+  token = process.env.GH_TOKEN,
+  options = {},
+) {
+  const githubToken = requireString(token, "GitHub token");
+  const deadlineOptions = {
+    deadlineAt: options.deadlineAt,
+    now: typeof options.now === "function" ? options.now : Date.now,
+  };
+  return {
+    async getArtifacts(runId, repository) {
+      return readPaginatedCollection(
+        repository,
+        `actions/runs/${runId}/artifacts`,
+        "artifacts",
+        deadlineOptions,
+      );
+    },
+    async getJobs(runId, repository) {
+      return readPaginatedCollection(
+        repository,
+        `actions/runs/${runId}/jobs?filter=all`,
+        "jobs",
+        deadlineOptions,
+      );
+    },
+    async getRun(runId, repository) {
+      return runGhJson(["api", `repos/${repository}/actions/runs/${runId}`], deadlineOptions);
+    },
+    async readArtifact(expected) {
+      return readPublicationArtifactArchive({
+        archivePolicy: {
+          expectedEntries: REQUIRED_ROWS.map(([direction]) => evidencePath(direction)),
+          maxArchiveBytes: MAX_ARCHIVE_BYTES,
+          maxEntryBytes: () => MAX_EVIDENCE_BYTES,
+          maxExpandedBytes: REQUIRED_ROWS.length * MAX_EVIDENCE_BYTES,
+        },
+        expected,
+        fetchImpl: createDeadlineFetch(deadlineOptions),
+        maxArchiveBytes: MAX_ARCHIVE_BYTES,
+        timeoutMs: remainingCollectionDeadlineMs(deadlineOptions),
+        token: githubToken,
+      });
+    },
+  };
+}
+
+export function validateGatewayNodeCompatManifestEvidence(value) {
+  const evidence = requireObject(value, "Gateway/node compatibility manifest evidence");
+  requireExactKeys(evidence, "Gateway/node compatibility manifest evidence", [
+    "architecture",
+    "artifact",
+    "baseline",
+    "baselineVersion",
+    "files",
+    "platform",
+    "producer",
+    "schema",
+    "targetSha",
+  ]);
+  if (
+    evidence.schema !== GATEWAY_NODE_COMPAT_RELEASE_SCHEMA ||
+    evidence.platform !== "linux" ||
+    evidence.architecture !== "x64" ||
+    evidence.baselineVersion !== GATEWAY_NODE_COMPAT_BASELINE_VERSION
+  ) {
+    throw new Error("Gateway/node compatibility manifest evidence is unsupported");
+  }
+  const baseline = requireObject(evidence.baseline, "Gateway/node compatibility baseline");
+  requireExactKeys(baseline, "Gateway/node compatibility baseline", [
+    "npmIntegrity",
+    "sha256",
+    "sourceSha",
+    "tag",
+    "version",
+  ]);
+  if (
+    baseline.version !== GATEWAY_NODE_COMPAT_BASELINE_VERSION ||
+    baseline.tag !== GATEWAY_NODE_COMPAT_BASELINE_TAG ||
+    baseline.sourceSha !== GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA ||
+    baseline.sha256 !== GATEWAY_NODE_COMPAT_BASELINE_SHA256 ||
+    baseline.npmIntegrity !== GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY
+  ) {
+    throw new Error("Gateway/node compatibility baseline provenance is unsupported");
+  }
+  requireString(evidence.targetSha, "Gateway/node compatibility target SHA", SHA_PATTERN);
+  const artifact = requireObject(evidence.artifact, "Gateway/node compatibility artifact binding");
+  requireExactKeys(artifact, "Gateway/node compatibility artifact binding", [
+    "digest",
+    "id",
+    "name",
+    "producerJob",
+    "repository",
+    "runAttempt",
+    "runId",
+    "sizeBytes",
+    "workflowPath",
+    "workflowSha",
+  ]);
+  requirePositiveInteger(artifact.id, "Gateway/node compatibility artifact ID");
+  requireString(
+    artifact.digest,
+    "Gateway/node compatibility artifact digest",
+    ACTIONS_DIGEST_PATTERN,
+  );
+  requirePositiveInteger(artifact.sizeBytes, "Gateway/node compatibility artifact size");
+  requireString(
+    artifact.runId,
+    "Gateway/node compatibility artifact run ID",
+    POSITIVE_DECIMAL_PATTERN,
+  );
+  requirePositiveInteger(artifact.runAttempt, "Gateway/node compatibility artifact run attempt");
+  if (
+    artifact.name !== artifactName(artifact.runId, artifact.runAttempt) ||
+    artifact.producerJob !== GATEWAY_NODE_COMPAT_PRODUCER_JOB ||
+    artifact.workflowPath !== GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW
+  ) {
+    throw new Error("Gateway/node compatibility artifact binding is invalid");
+  }
+  requireString(
+    artifact.repository,
+    "Gateway/node compatibility artifact repository",
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u,
+  );
+  requireString(
+    artifact.workflowSha,
+    "Gateway/node compatibility artifact workflow SHA",
+    SHA_PATTERN,
+  );
+  const producer = requireObject(evidence.producer, "Gateway/node compatibility producer");
+  requireExactKeys(producer, "Gateway/node compatibility producer", [
+    "job",
+    "repository",
+    "runAttempt",
+    "runId",
+    "workflowPath",
+    "workflowSha",
+  ]);
+  if (
+    producer.repository !== artifact.repository ||
+    producer.runId !== artifact.runId ||
+    producer.runAttempt !== artifact.runAttempt ||
+    producer.workflowPath !== GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW ||
+    producer.workflowSha !== artifact.workflowSha ||
+    producer.job !== "gateway_node_linux_compat"
+  ) {
+    throw new Error("Gateway/node compatibility producer does not match its artifact binding");
+  }
+  if (!Array.isArray(evidence.files) || evidence.files.length !== REQUIRED_ROWS.length) {
+    throw new Error("Gateway/node compatibility manifest must summarize six evidence files");
+  }
+  for (const [index, [direction, outcome]] of REQUIRED_ROWS.entries()) {
+    const file = requireObject(
+      evidence.files[index],
+      `Gateway/node compatibility file summary ${index}`,
+    );
+    requireExactKeys(file, `Gateway/node compatibility file summary ${index}`, [
+      "caseId",
+      "direction",
+      "outcome",
+      "gatewayVersion",
+      "nodeVersion",
+      "gatewayProtocolVersion",
+      "gatewayAcceptedNodeMin",
+      "protocolClientAdvertisedMin",
+      "protocolClientAdvertisedMax",
+      "helloProtocol",
+      "path",
+      "sha256",
+      "sizeBytes",
+    ]);
+    if (
+      file.caseId !== file.path.slice(0, -".json".length) ||
+      file.direction !== direction ||
+      file.outcome !== outcome ||
+      file.path !== evidencePath(direction)
+    ) {
+      throw new Error("Gateway/node compatibility file summaries are not canonical");
+    }
+    requireString(file.caseId, "Gateway/node compatibility file case ID", CASE_ID_PATTERN, 128);
+    requireString(
+      file.gatewayVersion,
+      "Gateway/node compatibility Gateway version",
+      undefined,
+      128,
+    );
+    requireString(file.nodeVersion, "Gateway/node compatibility node version", undefined, 128);
+    const gatewayProtocolVersion = requirePositiveInteger(
+      file.gatewayProtocolVersion,
+      "Gateway/node compatibility Gateway protocol version",
+    );
+    const gatewayAcceptedNodeMin = requirePositiveInteger(
+      file.gatewayAcceptedNodeMin,
+      "Gateway/node compatibility Gateway accepted node minimum",
+    );
+    const protocolClientAdvertisedMin = requirePositiveInteger(
+      file.protocolClientAdvertisedMin,
+      "Gateway/node compatibility client advertised minimum",
+    );
+    const protocolClientAdvertisedMax = requirePositiveInteger(
+      file.protocolClientAdvertisedMax,
+      "Gateway/node compatibility client advertised maximum",
+    );
+    if (
+      gatewayAcceptedNodeMin > gatewayProtocolVersion ||
+      protocolClientAdvertisedMin > protocolClientAdvertisedMax
+    ) {
+      throw new Error("Gateway/node compatibility protocol summary is invalid");
+    }
+    if (outcome === "passed") {
+      if (file.helloProtocol !== gatewayProtocolVersion) {
+        throw new Error("Gateway/node compatibility passed summary has an invalid hello protocol");
+      }
+    } else if (
+      file.helloProtocol !== null ||
+      !(
+        gatewayAcceptedNodeMin > protocolClientAdvertisedMax ||
+        protocolClientAdvertisedMin > gatewayProtocolVersion
+      )
+    ) {
+      throw new Error("Gateway/node compatibility mismatch summary is not disjoint");
+    }
+    requireString(file.sha256, "Gateway/node compatibility file SHA-256", SHA256_PATTERN);
+    requirePositiveInteger(file.sizeBytes, "Gateway/node compatibility file size");
+  }
+  return evidence;
+}
+
+export function renderGatewayNodeCompatSummary(value) {
+  const evidence = validateGatewayNodeCompatManifestEvidence(value);
+  return [
+    "### Gateway/node compatibility",
+    "",
+    `- Artifact: \`${evidence.artifact.name}\` (\`${evidence.artifact.digest}\`)`,
+    `- Producer attempt: \`${evidence.artifact.runId}/${evidence.artifact.runAttempt}\``,
+    `- Target SHA: \`${evidence.targetSha}\``,
+    `- Baseline: \`${evidence.baseline.tag}\` @ \`${evidence.baseline.sourceSha}\``,
+    `- Baseline tarball: \`${evidence.baseline.sha256}\``,
+    "",
+    "| Direction | Gateway | Node | Gateway protocol | Accepted min | Client range | Hello | Outcome | SHA-256 |",
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |",
+    ...evidence.files.map(
+      (file) =>
+        `| \`${file.direction}\` | \`${file.gatewayVersion}\` | \`${file.nodeVersion}\` | \`${file.gatewayProtocolVersion}\` | \`${file.gatewayAcceptedNodeMin}\` | \`${file.protocolClientAdvertisedMin}-${file.protocolClientAdvertisedMax}\` | \`${file.helloProtocol ?? "none"}\` | \`${file.outcome}\` | \`${file.sha256}\` |`,
+    ),
+    "",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const [command, ...args] = argv;
+  if (command !== "collect") {
+    throw new Error(
+      "usage: gateway-node-compat-release-evidence.mjs collect [--candidate-package-sha256 sha256] --repository owner/repo --run-id id --workflow-sha sha --target-sha sha --mode required|advisory|not-selected --retry-deadline-ms milliseconds --output file",
+    );
+  }
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (
+      [
+        "--output",
+        "--candidate-package-sha256",
+        "--repository",
+        "--mode",
+        "--retry-deadline-ms",
+        "--run-id",
+        "--target-sha",
+        "--workflow-sha",
+      ].includes(argument)
+    ) {
+      options[argument.slice(2).replaceAll("-", "_")] = args[++index];
+    } else {
+      throw new Error(`unknown or incomplete argument: ${argument}`);
+    }
+  }
+  requireCollectionMode(options.mode);
+  if (options.retry_deadline_ms !== undefined) {
+    options.retry_deadline_ms = requirePositiveInteger(
+      Number(options.retry_deadline_ms),
+      "collection retry deadline",
+    );
+  }
+  for (const key of ["mode", "output", "repository", "run_id", "target_sha", "workflow_sha"]) {
+    if (!options[key]) {
+      throw new Error(`--${key.replaceAll("_", "-")} is required`);
+    }
+  }
+  if (options.mode !== "not-selected" && !options.candidate_package_sha256) {
+    throw new Error("--candidate-package-sha256 is required for selected evidence");
+  }
+  return options;
+}
+
+async function main(argv) {
+  const options = parseArgs(argv);
+  const evidence = await collectGatewayNodeCompatReleaseEvidence({
+    candidatePackageSha256: options.candidate_package_sha256,
+    mode: options.mode,
+    onWarning(message) {
+      const escaped = message
+        .replaceAll("%", "%25")
+        .replaceAll("\r", "%0D")
+        .replaceAll("\n", "%0A");
+      console.error(`::warning title=Gateway/node compatibility evidence::${escaped}`);
+    },
+    repository: options.repository,
+    retryDeadlineMs: options.retry_deadline_ms,
+    runId: options.run_id,
+    targetSha: options.target_sha,
+    workflowSha: options.workflow_sha,
+  });
+  writeFileSync(options.output, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+  if (evidence && process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `${renderGatewayNodeCompatSummary(evidence)}\n`,
+    );
+  }
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  await main(process.argv.slice(2)).catch((/** @type {unknown} */ error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/github/find-reusable-release-validation.sh
+++ b/scripts/github/find-reusable-release-validation.sh
@@ -211,6 +211,10 @@ for ((index = 0; index < run_count; index += 1)); do
       and .evidenceReuse == null
       and .rerunGroup == "all"
       and .controls.performanceReportPublication == "artifact-only"
+      and .controls.gatewayNodeCompatibility == "required"
+      and (.gatewayNodeCompatibility | type == "object")
+      and .gatewayNodeCompatibility.schema == "openclaw.gateway-node-compat-release-evidence/v1"
+      and (.gatewayNodeCompatibility.files | type == "array" and length == 6)
       and .conclusions.current == "success"
       and .conclusions.root == "success"
       and .conclusions.allRequiredSucceeded == true

--- a/scripts/lib/actions-artifact-archive.d.mts
+++ b/scripts/lib/actions-artifact-archive.d.mts
@@ -16,7 +16,7 @@ export type ArtifactBinding = {
   artifactName: string;
   artifactSizeBytes: number;
   repository: string;
-  runStatePolicy: "completed-success" | "same-run-producer-success";
+  runStatePolicy: "completed-producer-success" | "completed-success" | "same-run-producer-success";
   runAttempt: number;
   runId: number;
   workflowEvent: string;

--- a/scripts/lib/actions-artifact-archive.mjs
+++ b/scripts/lib/actions-artifact-archive.mjs
@@ -135,6 +135,11 @@ function assertWorkflowPath(value) {
   return workflowPath;
 }
 
+function canonicalWorkflowPath(value) {
+  // REST may qualify the path with @ref; repository, branch, and SHA remain bound below.
+  return assertWorkflowPath(assertTrimmedString(value, "workflow path").split("@", 1)[0]);
+}
+
 function assertRepository(value) {
   const repository = assertTrimmedString(value, "GitHub repository");
   if (!REPOSITORY_RE.test(repository)) {
@@ -667,7 +672,11 @@ function requireExpectedBinding(params) {
     "workflow head branch",
   );
   const runStatePolicy = assertTrimmedString(expected.runStatePolicy, "workflow run-state policy");
-  if (runStatePolicy !== "completed-success" && runStatePolicy !== "same-run-producer-success") {
+  if (
+    runStatePolicy !== "completed-producer-success" &&
+    runStatePolicy !== "completed-success" &&
+    runStatePolicy !== "same-run-producer-success"
+  ) {
     throw new Error(`Unsupported workflow run-state policy: ${runStatePolicy}`);
   }
   const consumerRunAttempt =
@@ -675,9 +684,16 @@ function requireExpectedBinding(params) {
       ? assertPositiveInteger(expected.consumerRunAttempt, "consumer workflow run attempt")
       : undefined;
   const producerJobName =
-    runStatePolicy === "same-run-producer-success"
+    expected.producerJobName !== undefined
       ? assertTrimmedString(expected.producerJobName, "producer job name")
       : undefined;
+  if (
+    (runStatePolicy === "completed-producer-success" ||
+      runStatePolicy === "same-run-producer-success") &&
+    producerJobName === undefined
+  ) {
+    throw new Error(`Producer job name is required for ${runStatePolicy}.`);
+  }
   if (consumerRunAttempt !== undefined && runAttempt > consumerRunAttempt) {
     throw new Error("Producer workflow run attempt must not be newer than the consumer attempt.");
   }
@@ -726,7 +742,7 @@ export function validateActionsArtifactBinding(params) {
     run.head_sha !== expected.workflowSha ||
     run.head_branch !== expected.workflowHeadBranch ||
     run.event !== expected.workflowEvent ||
-    run.path !== expected.workflowPath ||
+    canonicalWorkflowPath(run.path) !== expected.workflowPath ||
     run.repository?.full_name !== expected.repository ||
     run.head_repository?.full_name !== expected.repository
   ) {
@@ -735,6 +751,14 @@ export function validateActionsArtifactBinding(params) {
   if (expected.runStatePolicy === "completed-success") {
     if (run.status !== "completed" || run.conclusion !== "success") {
       throw new Error("Actions workflow run does not match the immutable publication tuple.");
+    }
+  } else if (expected.runStatePolicy === "completed-producer-success") {
+    if (
+      run.status !== "completed" ||
+      typeof run.conclusion !== "string" ||
+      run.conclusion.length === 0
+    ) {
+      throw new Error("Producer workflow attempt must be completed.");
     }
   } else if (expected.runAttempt === expected.consumerRunAttempt) {
     // Environment protection reports the active workflow as waiting until the
@@ -754,7 +778,7 @@ export function validateActionsArtifactBinding(params) {
 
 export function validateActionsArtifactProducerJob(params) {
   const expected = requireExpectedBinding(params);
-  if (expected.runStatePolicy !== "same-run-producer-success") {
+  if (expected.producerJobName === undefined) {
     return expected;
   }
   const response = params.workflowJobs;
@@ -890,6 +914,55 @@ async function fetchBoundedJson(url, request, params) {
   return value;
 }
 
+async function fetchWorkflowJobs(apiRoot, expected, request, retry) {
+  const jobs = [];
+  const jobIds = new Set();
+  let totalCount;
+  for (let page = 1; page <= 10; page += 1) {
+    const pageSuffix = page === 1 ? "" : `&page=${page}`;
+    const response = await runBoundedRetry(
+      `GitHub Actions producer jobs page ${page}`,
+      () =>
+        fetchBoundedJson(
+          `${apiRoot}/actions/runs/${expected.runId}/attempts/${expected.runAttempt}/jobs?per_page=100${pageSuffix}`,
+          request,
+          {
+            label: `GitHub Actions producer jobs page ${page}`,
+            maxBytes: DEFAULT_MAX_JSON_BYTES,
+          },
+        ),
+      retry,
+    );
+    if (
+      !Number.isSafeInteger(response.total_count) ||
+      response.total_count < 0 ||
+      !Array.isArray(response.jobs)
+    ) {
+      throw new Error("Actions workflow jobs inventory is incomplete.");
+    }
+    if (totalCount === undefined) {
+      totalCount = response.total_count;
+    } else if (response.total_count !== totalCount) {
+      throw new Error("Actions workflow jobs inventory changed during pagination.");
+    }
+    for (const job of response.jobs) {
+      if (!Number.isSafeInteger(job?.id) || jobIds.has(job.id)) {
+        throw new Error("Actions workflow jobs inventory contains duplicate or invalid job IDs.");
+      }
+      jobIds.add(job.id);
+      jobs.push(job);
+    }
+    if (response.jobs.length < 100) {
+      break;
+    }
+  }
+  const workflowJobs = { jobs, total_count: totalCount ?? 0 };
+  if (workflowJobs.jobs.length !== workflowJobs.total_count) {
+    throw new Error("Actions workflow jobs inventory is incomplete.");
+  }
+  return workflowJobs;
+}
+
 export async function downloadActionsArtifactArchive(params) {
   const expected = requireExpectedBinding(params);
   const token = assertTrimmedString(params.token, "GitHub token");
@@ -947,20 +1020,8 @@ export async function downloadActionsArtifactArchive(params) {
   );
   validateActionsArtifactBinding({ artifactMetadata, expected, workflowRun });
   let workflowJobs;
-  if (expected.runStatePolicy === "same-run-producer-success") {
-    workflowJobs = await runBoundedRetry(
-      "GitHub Actions producer jobs",
-      () =>
-        fetchBoundedJson(
-          `${apiRoot}/actions/runs/${expected.runId}/attempts/${expected.runAttempt}/jobs?per_page=100`,
-          request,
-          {
-            label: "GitHub Actions producer jobs",
-            maxBytes: DEFAULT_MAX_JSON_BYTES,
-          },
-        ),
-      retry,
-    );
+  if (expected.producerJobName !== undefined) {
+    workflowJobs = await fetchWorkflowJobs(apiRoot, expected, request, retry);
     validateActionsArtifactProducerJob({ expected, workflowJobs });
   }
 

--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -501,6 +501,10 @@ export function parseCrossOsSuiteFilter(rawFilter: string) {
   };
 }
 
+export function shouldRunGatewayNodeCompat(rawFilter: string) {
+  return parseCrossOsSuiteFilter(rawFilter).matchesGatewayNodeCompat;
+}
+
 function normalizeCrossOsSuiteFilterToken(token: string) {
   return token
     .trim()

--- a/scripts/release-ci-summary.d.mts
+++ b/scripts/release-ci-summary.d.mts
@@ -89,6 +89,16 @@ export function validateParentManifest(
         selectedRunId: string;
       }
     | undefined;
+  gatewayNodeCompatibility:
+    | import("./gateway-node-compat-release-evidence.mjs").GatewayNodeCompatManifestEvidence
+    | undefined;
+  releaseEvidencePublication:
+    | {
+        packageSpec: string;
+        releaseRef: string;
+        requested: boolean;
+      }
+    | undefined;
   releaseProfile: string;
   rerunGroup: string;
   runAttempt: number;
@@ -207,7 +217,15 @@ export type ReleaseRunEvidence = {
   children: Array<Record<string, unknown>>;
   directRoot: boolean;
   evidenceReuse: Record<string, unknown> | null;
+  gatewayNodeCompatibility:
+    | import("./gateway-node-compat-release-evidence.mjs").GatewayNodeCompatManifestEvidence
+    | null;
   producerOnTrustedMainLineage: boolean;
+  releaseEvidencePublication: {
+    packageSpec: string;
+    releaseRef: string;
+    requested: boolean;
+  } | null;
   releaseProfile: string;
   repository: string;
   rerunGroup: string;

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -10,6 +10,11 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import {
+  renderGatewayNodeCompatSummary,
+  validateGatewayNodeCompatManifestEvidence,
+} from "./gateway-node-compat-release-evidence.mjs";
+import { shouldRunGatewayNodeCompat } from "./lib/cross-os-release-checks/config.ts";
 import { plainGhEnv, resolvePlainGhBin } from "./lib/plain-gh.mjs";
 
 const DEFAULT_REPO = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
@@ -27,6 +32,8 @@ const MAX_MANIFEST_ENTRY_LIST_BYTES = 8 * 1024;
 // the workflow budget.
 const GH_COMMAND_TIMEOUT_MS = 60_000;
 const SUCCESSFUL_PARENT_JOB_CONCLUSIONS = new Set(["neutral", "skipped", "success"]);
+const GATEWAY_NODE_COMPAT_SELECTED_RERUN_GROUPS = new Set(["all", "cross-os", "release-checks"]);
+const GATEWAY_NODE_COMPAT_MODES = new Set(["advisory", "not-selected", "required"]);
 
 const CHILD_DISPATCHES = [
   {
@@ -369,6 +376,7 @@ function manifestEvidenceIdentity(manifest) {
   return canonicalJson({
     childRunIds: manifest.childRunIds,
     controls: manifest.controls,
+    gatewayNodeCompatibility: manifest.gatewayNodeCompatibility,
     releaseProfile: manifest.releaseProfile,
     rerunGroup: manifest.rerunGroup,
     runReleaseSoak: manifest.runReleaseSoak,
@@ -440,6 +448,78 @@ export function validateParentManifest(value, expected) {
           value.validationInputs,
           "release validation manifest validation inputs",
         );
+  const crossOsSuiteFilter = validationInputs?.crossOsSuiteFilter;
+  if (crossOsSuiteFilter !== undefined && typeof crossOsSuiteFilter !== "string") {
+    throw new Error("release validation manifest cross-OS suite filter is invalid");
+  }
+  const gatewayNodeCompatibilityMode = controls.gatewayNodeCompatibility;
+  if (
+    gatewayNodeCompatibilityMode !== undefined &&
+    !GATEWAY_NODE_COMPAT_MODES.has(gatewayNodeCompatibilityMode)
+  ) {
+    throw new Error("release validation manifest Gateway/node compatibility control is invalid");
+  }
+  const gatewayNodeCompatibilitySelected =
+    GATEWAY_NODE_COMPAT_SELECTED_RERUN_GROUPS.has(rerunGroup) &&
+    shouldRunGatewayNodeCompat(crossOsSuiteFilter ?? "");
+  const expectedGatewayNodeCompatibilityMode = !gatewayNodeCompatibilitySelected
+    ? "not-selected"
+    : workflowFullRef?.startsWith("refs/heads/tideclaw/alpha/")
+      ? "advisory"
+      : "required";
+  if (
+    gatewayNodeCompatibilityMode !== undefined &&
+    gatewayNodeCompatibilityMode !== expectedGatewayNodeCompatibilityMode
+  ) {
+    throw new Error(
+      "release validation manifest Gateway/node compatibility control is inconsistent",
+    );
+  }
+  const gatewayNodeCompatibility =
+    value.gatewayNodeCompatibility === undefined
+      ? undefined
+      : validateGatewayNodeCompatManifestEvidence(value.gatewayNodeCompatibility);
+  if (gatewayNodeCompatibility?.targetSha !== undefined && value.evidenceReuse === undefined) {
+    if (gatewayNodeCompatibility.targetSha !== targetSha) {
+      throw new Error("release validation manifest Gateway/node compatibility target SHA mismatch");
+    }
+    if (gatewayNodeCompatibility.artifact.workflowSha !== workflowSha) {
+      throw new Error(
+        "release validation manifest Gateway/node compatibility workflow SHA mismatch",
+      );
+    }
+  }
+  if (gatewayNodeCompatibilityMode === "required" && !gatewayNodeCompatibility) {
+    throw new Error("release validation manifest requires Gateway/node compatibility evidence");
+  }
+  if (gatewayNodeCompatibilityMode === "not-selected" && gatewayNodeCompatibility) {
+    throw new Error(
+      "release validation manifest includes unselected Gateway/node compatibility evidence",
+    );
+  }
+  let releaseEvidencePublication;
+  if (value.releaseEvidencePublication !== undefined) {
+    const publication = normalizeJsonObject(
+      value.releaseEvidencePublication,
+      "release validation manifest release evidence publication",
+    );
+    const keys = Object.keys(publication).toSorted();
+    if (
+      JSON.stringify(keys) !== JSON.stringify(["packageSpec", "releaseRef", "requested"]) ||
+      typeof publication.requested !== "boolean" ||
+      typeof publication.releaseRef !== "string" ||
+      typeof publication.packageSpec !== "string" ||
+      publication.releaseRef.trim() !== publication.releaseRef ||
+      publication.packageSpec.trim() !== publication.packageSpec
+    ) {
+      throw new Error("release validation manifest release evidence publication is invalid");
+    }
+    releaseEvidencePublication = {
+      packageSpec: publication.packageSpec,
+      releaseRef: publication.releaseRef,
+      requested: publication.requested,
+    };
+  }
   const childRuns = value.childRuns;
   if (!childRuns || typeof childRuns !== "object" || Array.isArray(childRuns)) {
     throw new Error("release validation manifest childRuns is invalid");
@@ -457,6 +537,14 @@ export function validateParentManifest(value, expected) {
     ),
     releaseChecks: normalizeOptionalRunId(childRuns.releaseChecks, "release checks run ID"),
   };
+  if (
+    gatewayNodeCompatibility &&
+    gatewayNodeCompatibility.artifact.runId !== childRunIds.releaseChecks
+  ) {
+    throw new Error(
+      "release validation manifest Gateway/node compatibility release-check run ID mismatch",
+    );
+  }
   let evidenceReuse;
   if (value.evidenceReuse !== undefined) {
     const reuse = normalizeJsonObject(
@@ -490,7 +578,9 @@ export function validateParentManifest(value, expected) {
     childRunIds,
     controls,
     evidenceReuse,
+    gatewayNodeCompatibility,
     releaseProfile,
+    releaseEvidencePublication,
     rerunGroup,
     runAttempt: Number(value.runAttempt),
     runId: String(value.runId),
@@ -1420,7 +1510,9 @@ export function validateReleaseRunEvidence(
           selectedRunId: reuse.selectedRunId,
         }
       : null,
+    gatewayNodeCompatibility: rootEvidence.manifest.gatewayNodeCompatibility ?? null,
     manifest: rootEvidence.manifestJson,
+    releaseEvidencePublication: currentEvidence.manifest.releaseEvidencePublication ?? null,
     releaseProfile: rootEvidence.manifest.releaseProfile,
     repository: normalizedRepository,
     rerunGroup: rootEvidence.manifest.rerunGroup,
@@ -1767,6 +1859,9 @@ async function main() {
       sourceManifest.rerunGroup,
       sourceManifest.validationInputs,
     );
+    if (sourceManifest.gatewayNodeCompatibility) {
+      console.log(renderGatewayNodeCompatSummary(sourceManifest.gatewayNodeCompatibility));
+    }
     const expectedChildren = expectedSelectedChildDispatches(
       sourceManifest.runId,
       sourceManifest.runAttempt,

--- a/scripts/release-evidence-publication.d.mts
+++ b/scripts/release-evidence-publication.d.mts
@@ -1,0 +1,28 @@
+export type ReleaseEvidencePublicationAssessment =
+  | {
+      reason: string;
+      shouldDispatch: false;
+    }
+  | {
+      fullValidationRunId: string;
+      headSha: string;
+      notes: string;
+      packageSpec: string;
+      publicationKey: string;
+      reason: "requested";
+      releaseId: string;
+      releaseRef: string;
+      runAttempt: number;
+      shouldDispatch: true;
+      updatedAt: string;
+    };
+
+export function assessReleaseEvidencePublication(params: {
+  event: unknown;
+  evidence: unknown;
+}): ReleaseEvidencePublicationAssessment;
+
+export function publishedReleaseEvidenceMatches(
+  value: unknown,
+  expected: Extract<ReleaseEvidencePublicationAssessment, { shouldDispatch: true }>,
+): boolean;

--- a/scripts/release-evidence-publication.mjs
+++ b/scripts/release-evidence-publication.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
+
+const REPOSITORY = "openclaw/openclaw";
+const RELEASES_REPOSITORY = "openclaw/releases";
+const WORKFLOW_NAME = "Full Release Validation";
+const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
+const RELEASE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+const PACKAGE_SPEC_PATTERN =
+  /^openclaw@([0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(?:(?:-(?:alpha|beta)\.[1-9][0-9]*)|(?:-[1-9][0-9]*))?)$/u;
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(Number(value)) || Number(value) < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return Number(value);
+}
+
+function requireTrimmedString(value, label) {
+  if (typeof value !== "string" || value.trim() !== value) {
+    throw new Error(`${label} must be a trimmed string`);
+  }
+  return value;
+}
+
+function hasControlCharacter(value) {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+    );
+  });
+}
+
+function workflowPath(value) {
+  return requireTrimmedString(value, "workflow path").split("@", 1)[0];
+}
+
+function releaseIdFor(publication) {
+  const packageMatch = publication.packageSpec.match(PACKAGE_SPEC_PATTERN);
+  const raw =
+    packageMatch?.[1] ?? publication.releaseRef.replace(/^refs\/tags\//u, "").replace(/^v/u, "");
+  if (!RELEASE_ID_PATTERN.test(raw)) {
+    throw new Error("release evidence publication cannot derive a safe release ID");
+  }
+  return raw;
+}
+
+function validatePublicationSource(proof) {
+  const directRoot = proof.directRoot;
+  const evidenceReuse = proof.evidenceReuse;
+  if (
+    proof.rerunGroup !== "all" ||
+    !(
+      (directRoot === true && evidenceReuse === null) ||
+      (directRoot === false &&
+        evidenceReuse !== null &&
+        typeof evidenceReuse === "object" &&
+        !Array.isArray(evidenceReuse))
+    )
+  ) {
+    throw new Error(
+      "release evidence publication requires a complete direct validation or verified evidence reuse root",
+    );
+  }
+}
+
+function validateRunTuple(run, expected) {
+  const value = requireObject(run, "workflow run");
+  if (
+    requirePositiveInteger(value.id, "workflow run ID") !== expected.runId ||
+    requirePositiveInteger(value.run_attempt, "workflow run attempt") !== expected.runAttempt ||
+    value.name !== WORKFLOW_NAME ||
+    value.event !== "workflow_dispatch" ||
+    value.status !== "completed" ||
+    value.conclusion !== "success" ||
+    value.head_sha !== expected.headSha ||
+    workflowPath(value.path) !== WORKFLOW_PATH ||
+    value.repository?.full_name !== REPOSITORY ||
+    value.head_repository?.full_name !== REPOSITORY
+  ) {
+    throw new Error("workflow run does not match the exact completed/success publication tuple");
+  }
+  return value;
+}
+
+export function assessReleaseEvidencePublication({ event, evidence }) {
+  const workflowRun = requireObject(requireObject(event, "event").workflow_run, "workflow_run");
+  const runId = requirePositiveInteger(workflowRun.id, "workflow_run.id");
+  const runAttempt = requirePositiveInteger(workflowRun.run_attempt, "workflow_run.run_attempt");
+  const headSha = requireTrimmedString(workflowRun.head_sha, "workflow_run.head_sha");
+  const updatedAt = requireTrimmedString(workflowRun.updated_at, "workflow_run.updated_at");
+  if (Number.isNaN(Date.parse(updatedAt))) {
+    throw new Error("workflow_run.updated_at must be an ISO timestamp");
+  }
+  validateRunTuple(workflowRun, { headSha, runAttempt, runId });
+
+  const proof = requireObject(evidence, "release evidence");
+  if (proof.valid !== true) {
+    throw new Error("release evidence verifier did not return valid evidence");
+  }
+  const current = requireObject(proof.current, "release evidence current run");
+  if (
+    Number(current.runId) !== runId ||
+    Number(current.runAttempt) !== runAttempt ||
+    current.workflowSha !== headSha ||
+    current.status !== "completed" ||
+    current.conclusion !== "success"
+  ) {
+    throw new Error("release evidence verifier does not match the workflow_run event");
+  }
+  const publicationIntent = proof.releaseEvidencePublication;
+  if (publicationIntent == null) {
+    return { reason: "not-requested", shouldDispatch: false };
+  }
+  const publication = requireObject(publicationIntent, "release evidence publication intent");
+  if (
+    typeof publication.requested !== "boolean" ||
+    typeof publication.releaseRef !== "string" ||
+    typeof publication.packageSpec !== "string" ||
+    publication.releaseRef.trim() !== publication.releaseRef ||
+    publication.packageSpec.trim() !== publication.packageSpec ||
+    hasControlCharacter(publication.releaseRef) ||
+    hasControlCharacter(publication.packageSpec)
+  ) {
+    throw new Error("release evidence publication intent is invalid");
+  }
+  if (!publication.requested) {
+    return { reason: "not-requested", shouldDispatch: false };
+  }
+
+  validatePublicationSource(proof);
+  const releaseId = releaseIdFor(publication);
+  return {
+    fullValidationRunId: String(runId),
+    headSha,
+    notes: `Automatically requested after Full Release Validation ${runId}/${runAttempt} completed successfully.`,
+    packageSpec: publication.packageSpec,
+    publicationKey: `${runId}:${runAttempt}:${headSha}`,
+    reason: "requested",
+    releaseId,
+    releaseRef: publication.releaseRef,
+    runAttempt,
+    shouldDispatch: true,
+    updatedAt,
+  };
+}
+
+export function publishedReleaseEvidenceMatches(value, expected) {
+  const evidence = requireObject(value, "published release evidence");
+  const release = requireObject(evidence.release, "published release evidence release");
+  if (
+    release.id !== expected.releaseId ||
+    release.ref !== expected.releaseRef ||
+    release.packageSpec !== expected.packageSpec ||
+    !Array.isArray(evidence.runs)
+  ) {
+    return false;
+  }
+  return evidence.runs.some(
+    (run) =>
+      run?.label === "full-release-validation" &&
+      run.repo === REPOSITORY &&
+      String(run.runId) === expected.fullValidationRunId &&
+      Number(run.runAttempt) === expected.runAttempt &&
+      run.headSha === expected.headSha &&
+      run.status === "completed" &&
+      run.conclusion === "success" &&
+      run.updatedAt === expected.updatedAt &&
+      workflowPath(run.path) === WORKFLOW_PATH,
+  );
+}
+
+function requireToken() {
+  const token = process.env.RELEASES_DISPATCH_TOKEN?.trim();
+  if (!token) {
+    throw new Error("OPENCLAW_RELEASES_DISPATCH_TOKEN is required for release publication");
+  }
+  return token;
+}
+
+async function fetchPublishedReleaseEvidence(releaseId, token) {
+  const url = new URL(
+    `https://api.github.com/repos/${RELEASES_REPOSITORY}/contents/evidence/${encodeURIComponent(releaseId)}/release-evidence.json`,
+  );
+  url.searchParams.set("ref", "main");
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github.raw+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (response.status === 404) {
+    return undefined;
+  }
+  if (!response.ok) {
+    throw new Error(
+      `release evidence lookup failed with HTTP ${response.status}: ${await response.text()}`,
+    );
+  }
+  return JSON.parse(await response.text());
+}
+
+function writeOutputs(path, result) {
+  const lines = [
+    `should_dispatch=${result.shouldDispatch ? "true" : "false"}`,
+    `reason=${result.reason}`,
+  ];
+  if (result.shouldDispatch) {
+    lines.push(
+      `full_validation_run_id=${result.fullValidationRunId}`,
+      `head_sha=${result.headSha}`,
+      `run_attempt=${result.runAttempt}`,
+      `updated_at=${result.updatedAt}`,
+      `release_id=${result.releaseId}`,
+      `release_ref=${result.releaseRef}`,
+      `package_spec=${result.packageSpec}`,
+      `publication_key=${result.publicationKey}`,
+      `notes=${result.notes}`,
+    );
+  }
+  writeFileSync(path, `${lines.join("\n")}\n`, "utf8");
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  if (!["confirm", "prepare"].includes(command)) {
+    throw new Error("usage: release-evidence-publication.mjs <prepare|confirm> [options]");
+  }
+  const options = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const argument = rest[index];
+    if (
+      [
+        "--event",
+        "--evidence",
+        "--github-output",
+        "--head-sha",
+        "--package-spec",
+        "--release-id",
+        "--release-ref",
+        "--run-id",
+        "--run-attempt",
+        "--updated-at",
+      ].includes(argument)
+    ) {
+      options[argument.slice(2).replaceAll("-", "_")] = rest[++index];
+    } else {
+      throw new Error(`unknown or incomplete argument: ${argument}`);
+    }
+  }
+  const required =
+    command === "prepare"
+      ? ["event", "evidence", "github_output"]
+      : [
+          "head_sha",
+          "package_spec",
+          "release_id",
+          "release_ref",
+          "run_attempt",
+          "run_id",
+          "updated_at",
+        ];
+  for (const key of required) {
+    if (options[key] === undefined) {
+      throw new Error(`--${key.replaceAll("_", "-")} is required`);
+    }
+  }
+  return { command, options };
+}
+
+async function main(argv) {
+  const { command, options } = parseArgs(argv);
+  if (command === "confirm") {
+    const token = requireToken();
+    const expected = {
+      fullValidationRunId: requirePositiveInteger(options.run_id, "run ID").toString(),
+      headSha: requireTrimmedString(options.head_sha, "head SHA"),
+      packageSpec: requireTrimmedString(options.package_spec, "package spec"),
+      releaseId: requireTrimmedString(options.release_id, "release ID"),
+      releaseRef: requireTrimmedString(options.release_ref, "release ref"),
+      runAttempt: requirePositiveInteger(options.run_attempt, "run attempt"),
+      updatedAt: requireTrimmedString(options.updated_at, "updated at"),
+    };
+    for (let attempt = 1; attempt <= 30; attempt += 1) {
+      const published = await fetchPublishedReleaseEvidence(expected.releaseId, token);
+      if (published && publishedReleaseEvidenceMatches(published, expected)) {
+        return;
+      }
+      if (attempt < 30) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 20_000);
+        });
+      }
+    }
+    throw new Error("durable release evidence publication was not observed within 10 minutes");
+  }
+
+  const event = JSON.parse(readFileSync(options.event, "utf8"));
+  const evidence = JSON.parse(readFileSync(options.evidence, "utf8"));
+  const result = assessReleaseEvidencePublication({ event, evidence });
+  if (!result.shouldDispatch) {
+    writeOutputs(options.github_output, result);
+    return;
+  }
+  const published = await fetchPublishedReleaseEvidence(result.releaseId, requireToken());
+  writeOutputs(
+    options.github_output,
+    published && publishedReleaseEvidenceMatches(published, result)
+      ? { reason: "already-published", shouldDispatch: false }
+      : result,
+  );
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -90,6 +90,7 @@ interface NormalizedEvidence {
   current: ParentTuple;
   directRoot: boolean;
   evidenceReuse: Record<string, unknown> | null;
+  gatewayNodeCompatibility: Record<string, unknown> | null;
   manifest: Record<string, unknown>;
   releaseProfile: string;
   repository: string;
@@ -195,7 +196,70 @@ function getSharedRepo(): { clone: string; priorSha: string } {
   return sharedRepo;
 }
 
+function gatewayNodeCompatibility(targetSha: string, workflowSha: string) {
+  const baselineVersion = "2026.5.7";
+  const candidateVersion = "2026.7.1";
+  const rows = [
+    ["baseline-gateway-baseline-node", "passed"],
+    ["baseline-gateway-candidate-node", "passed"],
+    ["baseline-gateway-disjoint-node", "protocol-mismatch"],
+    ["candidate-gateway-baseline-node", "passed"],
+    ["candidate-gateway-candidate-node", "passed"],
+    ["candidate-gateway-disjoint-node", "protocol-mismatch"],
+  ] as const;
+  return {
+    architecture: "x64",
+    artifact: {
+      digest: `sha256:${"d".repeat(64)}`,
+      id: 7001,
+      name: "openclaw-gateway-node-linux-compat-x64-203-1",
+      producerJob: "cross_os_release_checks / Gateway/node packaged compatibility / Linux / x64",
+      repository: REPOSITORY,
+      runAttempt: 1,
+      runId: "203",
+      sizeBytes: 48_000,
+      workflowPath: ".github/workflows/openclaw-release-checks.yml",
+      workflowSha,
+    },
+    baselineVersion,
+    files: rows.map(([direction, outcome], index) => {
+      const candidateGateway = direction.startsWith("candidate-");
+      const candidateNode = !direction.includes("-baseline-node");
+      const mismatch = outcome === "protocol-mismatch";
+      const gatewayProtocolVersion = candidateGateway ? 4 : 3;
+      return {
+        caseId: `linux-x64-${direction}`,
+        direction,
+        gatewayAcceptedNodeMin: 3,
+        gatewayProtocolVersion,
+        gatewayVersion: candidateGateway ? candidateVersion : baselineVersion,
+        helloProtocol: mismatch ? null : gatewayProtocolVersion,
+        nodeVersion: candidateNode ? candidateVersion : baselineVersion,
+        outcome,
+        path: `linux-x64-${direction}.json`,
+        protocolClientAdvertisedMax: mismatch ? 2 : candidateNode ? 4 : 3,
+        protocolClientAdvertisedMin: mismatch ? 1 : 3,
+        sha256: (index + 1).toString(16).repeat(64),
+        sizeBytes: 4096 + index,
+      };
+    }),
+    platform: "linux",
+    producer: {
+      job: "gateway_node_linux_compat",
+      repository: REPOSITORY,
+      runAttempt: 1,
+      runId: "203",
+      workflowPath: ".github/workflows/openclaw-cross-os-release-checks-reusable.yml",
+      workflowSha,
+    },
+    schema: "openclaw.gateway-node-compat-release-evidence/v1",
+    targetSha,
+  };
+}
+
 function normalizedEvidence(options: {
+  compatibilityComplete?: boolean;
+  manifestVersion?: 2 | 3;
   producerSha?: string;
   releaseProfile?: string;
   runId?: string;
@@ -212,14 +276,19 @@ function normalizedEvidence(options: {
   const workflowRef = options.workflowRef ?? "main";
   const workflowFullRef = `refs/heads/${workflowRef}`;
   const shaPinned = workflowRef.startsWith("release-ci/");
+  const manifestVersion = options.manifestVersion ?? (shaPinned ? 3 : 2);
   const validationInputs =
     options.validationInputs === undefined ? DEFAULT_INPUTS : options.validationInputs;
   const npmTelegramRequired =
     validationInputs !== null &&
     (validationInputs.npmTelegramPackageSpec.length > 0 ||
       validationInputs.releasePackageSpec.length > 0);
+  const compatibility =
+    options.compatibilityComplete === false
+      ? null
+      : gatewayNodeCompatibility(options.targetSha, producerSha);
   const manifest = {
-    version: shaPinned ? 3 : 2,
+    version: manifestVersion,
     workflowName: "Full Release Validation",
     workflowRef,
     workflowSha: producerSha,
@@ -234,6 +303,7 @@ function normalizedEvidence(options: {
     runReleaseSoak: String(soak),
     validationInputs,
     controls: {
+      ...(compatibility ? { gatewayNodeCompatibility: "required" } : {}),
       performanceBlocking: true,
       performanceReportPublication: "artifact-only",
       stableSoakRequired: releaseProfile === "stable" || releaseProfile === "full",
@@ -249,6 +319,7 @@ function normalizedEvidence(options: {
         runId: "204",
       },
     },
+    ...(compatibility ? { gatewayNodeCompatibility: compatibility } : {}),
   };
   const root: ParentTuple = {
     artifact: {
@@ -260,7 +331,7 @@ function normalizedEvidence(options: {
     },
     conclusion: "success",
     manifest,
-    manifestVersion: shaPinned ? 3 : 2,
+    manifestVersion,
     runAttempt: 2,
     runId,
     status: "completed",
@@ -271,9 +342,12 @@ function normalizedEvidence(options: {
     workflowPath: ".github/workflows/full-release-validation.yml",
     workflowQualifiedPath: `.github/workflows/full-release-validation.yml@${workflowFullRef}`,
     workflowRef,
-    workflowRefProof: shaPinned
-      ? "manifest-v3-sha-pinned-main-ancestry"
-      : "legacy-v2-main-ancestry",
+    workflowRefProof:
+      manifestVersion === 2
+        ? "legacy-v2-main-ancestry"
+        : shaPinned
+          ? "manifest-v3-sha-pinned-main-ancestry"
+          : "manifest-v3-branch",
     workflowRefType: "branch",
     workflowRunPath: shaPinned
       ? `.github/workflows/full-release-validation.yml@${workflowFullRef}`
@@ -347,11 +421,13 @@ function normalizedEvidence(options: {
       root: "success",
     },
     controls: {
+      ...(compatibility ? { gatewayNodeCompatibility: "required" } : {}),
       performanceReportPublication: "artifact-only",
     },
     current: structuredClone(root),
     directRoot: true,
     evidenceReuse: null,
+    gatewayNodeCompatibility: compatibility,
     manifest,
     releaseProfile,
     repository: REPOSITORY,
@@ -574,6 +650,46 @@ describe("scripts/github/find-reusable-release-validation.sh", () => {
 
     expect(result.status).toBe(0);
     expect(parseOutput(result.stdout)).toMatchObject({
+      evidence_run_id: "111",
+      reuse: "true",
+    });
+  });
+
+  it("keeps historical v3 evidence readable but only reuses compatibility-complete roots", () => {
+    const { clone, priorSha } = getSharedRepo();
+    const historical = normalizedEvidence({
+      compatibilityComplete: false,
+      manifestVersion: 3,
+      runId: "222",
+      targetSha: priorSha,
+    });
+    expect(historical.valid).toBe(true);
+    expect(historical.manifest).not.toHaveProperty("gatewayNodeCompatibility");
+
+    const historicalFixtures = setUpFixtures([
+      { record: historical, runId: historical.root.runId },
+    ]);
+    const historicalResult = runResolver({
+      ...historicalFixtures,
+      repoDir: clone,
+      targetSha: priorSha,
+    });
+    expect(historicalResult.status).toBe(0);
+    expect(parseOutput(historicalResult.stdout)).toMatchObject({ reuse: "false" });
+
+    const complete = normalizedEvidence({
+      manifestVersion: 3,
+      runId: "111",
+      targetSha: priorSha,
+    });
+    const completeFixtures = setUpFixtures([{ record: complete, runId: complete.root.runId }]);
+    const completeResult = runResolver({
+      ...completeFixtures,
+      repoDir: clone,
+      targetSha: priorSha,
+    });
+    expect(completeResult.status).toBe(0);
+    expect(parseOutput(completeResult.stdout)).toMatchObject({
       evidence_run_id: "111",
       reuse: "true",
     });

--- a/test/scripts/gateway-node-compat-evidence.test.ts
+++ b/test/scripts/gateway-node-compat-evidence.test.ts
@@ -1438,7 +1438,7 @@ describe("gateway node compatibility evidence", () => {
     const declaration = readFileSync("scripts/gateway-node-compat-evidence.d.mts", "utf8");
     const declaredValueExports = Array.from(
       declaration.matchAll(/export (?:declare )?(?:const|function) ([A-Za-z0-9_]+)/gu),
-      (match) => match[1],
+      (match) => match[1] ?? "",
     ).toSorted(compareStrings);
 
     expect(Object.keys(evidenceModule).toSorted(compareStrings)).toEqual(declaredValueExports);

--- a/test/scripts/gateway-node-compat-release-evidence.test.ts
+++ b/test/scripts/gateway-node-compat-release-evidence.test.ts
@@ -1,0 +1,712 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  GATEWAY_NODE_COMPAT_SCHEMA,
+  canonicalizeGatewayNodeCompatEvidence,
+} from "../../scripts/gateway-node-compat-evidence.mjs";
+import {
+  GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY,
+  GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+  GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA,
+  GATEWAY_NODE_COMPAT_BASELINE_TAG,
+  GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+  GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW,
+  GATEWAY_NODE_COMPAT_PRODUCER_JOB,
+  GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW,
+  GATEWAY_NODE_COMPAT_RELEASE_SCHEMA,
+  collectGatewayNodeCompatReleaseEvidence,
+  renderGatewayNodeCompatSummary,
+  selectGatewayNodeCompatArtifact,
+  validateGatewayNodeCompatEvidenceSet,
+  validateGatewayNodeCompatManifestEvidence,
+} from "../../scripts/gateway-node-compat-release-evidence.mjs";
+
+const REPOSITORY = "openclaw/openclaw";
+const RUN_ID = "30710361061";
+const RUN_ATTEMPT = 3;
+const TARGET_SHA = "a".repeat(40);
+const WORKFLOW_SHA = "b".repeat(40);
+const CANDIDATE_PACKAGE_SHA256 = "f".repeat(64);
+const BASELINE_SHA = GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA;
+const ARTIFACT_IDENTITIES = {
+  baselinePackageSha256: GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+  candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+};
+const DIRECTIONS = [
+  "baseline-gateway-baseline-node",
+  "baseline-gateway-candidate-node",
+  "baseline-gateway-disjoint-node",
+  "candidate-gateway-baseline-node",
+  "candidate-gateway-candidate-node",
+  "candidate-gateway-disjoint-node",
+] as const;
+
+function actionsArtifact(seed: number, name: string) {
+  const digestSeed = seed === 11 ? "1" : "2";
+  return {
+    digest: `sha256:${digestSeed.repeat(64)}`,
+    id: seed,
+    name,
+    runAttempt: RUN_ATTEMPT,
+    runId: RUN_ID,
+    sizeBytes: 4096,
+  };
+}
+
+function runtimeBinding(role: "baseline" | "candidate") {
+  const candidate = role === "candidate";
+  const sourceSha = candidate ? TARGET_SHA : BASELINE_SHA;
+  const version = candidate ? "2026.8.6" : GATEWAY_NODE_COMPAT_BASELINE_VERSION;
+  return {
+    installedRuntime: {
+      identitySha256: candidate ? "d".repeat(64) : "e".repeat(64),
+      packageSha256: candidate ? CANDIDATE_PACKAGE_SHA256 : GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+      sourceSha,
+      version,
+    },
+    packagedArtifact: {
+      actionsArtifact: actionsArtifact(
+        candidate ? 11 : 22,
+        candidate ? "openclaw-candidate-input" : "openclaw-baseline-input",
+      ),
+      name: candidate ? "openclaw-candidate.tgz" : "openclaw-baseline.tgz",
+      sha256: candidate ? CANDIDATE_PACKAGE_SHA256 : GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+      sourceSha,
+      version,
+    },
+  };
+}
+
+function directionRoles(direction: (typeof DIRECTIONS)[number]) {
+  return {
+    gateway: direction.startsWith("candidate-") ? "candidate" : "baseline",
+    node: direction.includes("-baseline-node") ? "baseline" : "candidate",
+  } as const;
+}
+
+function evidence(direction: (typeof DIRECTIONS)[number]) {
+  const roles = directionRoles(direction);
+  const mismatch = direction.includes("-disjoint-node");
+  const candidateGateway = roles.gateway === "candidate";
+  const gatewayProtocol = candidateGateway ? 4 : 3;
+  return {
+    caseId: `linux-x64-${direction}`,
+    connection: {
+      mode: "node",
+      role: "node",
+      transport: "gateway-websocket",
+    },
+    direction,
+    gateway: runtimeBinding(roles.gateway),
+    node: {
+      architecture: "x64",
+      kind: "linux",
+      protocolClientId: "node-host",
+      ...runtimeBinding(roles.node),
+    },
+    operation: mismatch
+      ? null
+      : {
+          command: "system.which",
+          method: "node.invoke",
+          ok: true,
+          params: { bins: ["node"] },
+          result: { bins: { node: "/usr/bin/node" } },
+        },
+    producer: {
+      job: "gateway_node_linux_compat",
+      repository: REPOSITORY,
+      runAttempt: RUN_ATTEMPT,
+      runId: RUN_ID,
+      workflowPath: GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW,
+      workflowSha: WORKFLOW_SHA,
+    },
+    protocol: {
+      gatewayAcceptedNodeMin: 3,
+      gatewayProtocolVersion: gatewayProtocol,
+      helloProtocol: mismatch ? null : gatewayProtocol,
+      protocolClientAdvertisedMax: mismatch ? 2 : roles.node === "candidate" ? 4 : 3,
+      protocolClientAdvertisedMin: mismatch ? 1 : 3,
+    },
+    result: mismatch
+      ? {
+          completedAt: "2026-08-06T12:00:01.000Z",
+          failureCode: "PROTOCOL_MISMATCH",
+          failurePhase: "connect",
+          outcome: "protocol-mismatch",
+          startedAt: "2026-08-06T12:00:00.000Z",
+        }
+      : {
+          completedAt: "2026-08-06T12:00:05.000Z",
+          outcome: "passed",
+          startedAt: "2026-08-06T12:00:00.000Z",
+        },
+    schema: GATEWAY_NODE_COMPAT_SCHEMA,
+  };
+}
+
+function evidenceFiles() {
+  return new Map(
+    DIRECTIONS.map((direction) => [
+      `linux-x64-${direction}.json`,
+      Buffer.from(
+        canonicalizeGatewayNodeCompatEvidence(evidence(direction), ARTIFACT_IDENTITIES),
+        "utf8",
+      ),
+    ]),
+  );
+}
+
+function releaseRun(runAttempt = RUN_ATTEMPT, conclusion: "failure" | "success" = "success") {
+  return {
+    conclusion,
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_repository: { full_name: REPOSITORY },
+    head_sha: WORKFLOW_SHA,
+    id: Number(RUN_ID),
+    path: GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW,
+    repository: { full_name: REPOSITORY },
+    run_attempt: runAttempt,
+    status: "completed",
+  };
+}
+
+function producerJob(runAttempt: number, id = 1000 + runAttempt) {
+  return {
+    conclusion: "success",
+    head_sha: WORKFLOW_SHA,
+    id,
+    name: GATEWAY_NODE_COMPAT_PRODUCER_JOB,
+    run_attempt: runAttempt,
+    run_id: Number(RUN_ID),
+    status: "completed",
+  };
+}
+
+function artifact(runAttempt: number, id = 2000 + runAttempt) {
+  return {
+    digest: `sha256:${String(runAttempt).repeat(64)}`,
+    expired: false,
+    id,
+    name: `openclaw-gateway-node-linux-compat-x64-${RUN_ID}-${runAttempt}`,
+    size_in_bytes: 48_000,
+    workflow_run: {
+      head_sha: WORKFLOW_SHA,
+      id: Number(RUN_ID),
+    },
+  };
+}
+
+describe("Gateway/node compatibility release evidence", () => {
+  it("validates the exact canonical six-row Linux/x64 evidence set", () => {
+    const result = validateGatewayNodeCompatEvidenceSet(evidenceFiles(), {
+      candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+      repository: REPOSITORY,
+      runAttempt: RUN_ATTEMPT,
+      runId: RUN_ID,
+      targetSha: TARGET_SHA,
+      workflowSha: WORKFLOW_SHA,
+    });
+
+    expect(result.baselineVersion).toBe(GATEWAY_NODE_COMPAT_BASELINE_VERSION);
+    expect(result.baseline).toEqual({
+      npmIntegrity: GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY,
+      sha256: GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+      sourceSha: GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA,
+      tag: GATEWAY_NODE_COMPAT_BASELINE_TAG,
+      version: GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+    });
+    expect(result.targetSha).toBe(TARGET_SHA);
+    expect(result.files).toHaveLength(6);
+    expect(result.files.map((file) => [file.direction, file.outcome])).toEqual([
+      ["baseline-gateway-baseline-node", "passed"],
+      ["baseline-gateway-candidate-node", "passed"],
+      ["baseline-gateway-disjoint-node", "protocol-mismatch"],
+      ["candidate-gateway-baseline-node", "passed"],
+      ["candidate-gateway-candidate-node", "passed"],
+      ["candidate-gateway-disjoint-node", "protocol-mismatch"],
+    ]);
+    expect(result.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          caseId: "linux-x64-candidate-gateway-candidate-node",
+          gatewayAcceptedNodeMin: 3,
+          gatewayProtocolVersion: 4,
+          gatewayVersion: "2026.8.6",
+          helloProtocol: 4,
+          nodeVersion: "2026.8.6",
+          protocolClientAdvertisedMax: 4,
+          protocolClientAdvertisedMin: 3,
+        }),
+        expect.objectContaining({
+          caseId: "linux-x64-baseline-gateway-disjoint-node",
+          gatewayProtocolVersion: 3,
+          helloProtocol: null,
+          protocolClientAdvertisedMax: 2,
+          protocolClientAdvertisedMin: 1,
+        }),
+      ]),
+    );
+    expect(result.files.every((file) => /^[a-f0-9]{64}$/u.test(file.sha256))).toBe(true);
+  });
+
+  it("rejects incomplete, noncanonical, or cross-target evidence sets", () => {
+    const missing = evidenceFiles();
+    missing.delete("linux-x64-candidate-gateway-candidate-node.json");
+    expect(() =>
+      validateGatewayNodeCompatEvidenceSet(missing, {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        repository: REPOSITORY,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      }),
+    ).toThrow("exact six-row inventory");
+
+    const noncanonical = evidenceFiles();
+    const path = "linux-x64-candidate-gateway-candidate-node.json";
+    noncanonical.set(path, Buffer.from(JSON.stringify(JSON.parse(String(noncanonical.get(path))))));
+    expect(() =>
+      validateGatewayNodeCompatEvidenceSet(noncanonical, {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        repository: REPOSITORY,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      }),
+    ).toThrow("not canonical");
+
+    const wrongTarget = evidenceFiles();
+    expect(() =>
+      validateGatewayNodeCompatEvidenceSet(wrongTarget, {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        repository: REPOSITORY,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        targetSha: "9".repeat(40),
+        workflowSha: WORKFLOW_SHA,
+      }),
+    ).toThrow("candidate runtime source SHA");
+
+    expect(() =>
+      validateGatewayNodeCompatEvidenceSet(evidenceFiles(), {
+        candidatePackageSha256: "9".repeat(64),
+        repository: REPOSITORY,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      }),
+    ).toThrow("artifact identity must match the candidate package");
+  });
+
+  it("rejects baseline bindings that do not match the canonical source or tarball", () => {
+    const wrongSource = evidenceFiles();
+    const sourcePath = "linux-x64-baseline-gateway-baseline-node.json";
+    const sourceEvidence = JSON.parse(wrongSource.get(sourcePath)?.toString("utf8") ?? "{}");
+    sourceEvidence.gateway.packagedArtifact.sourceSha = "c".repeat(40);
+    sourceEvidence.gateway.installedRuntime.sourceSha = "c".repeat(40);
+    wrongSource.set(
+      sourcePath,
+      Buffer.from(
+        canonicalizeGatewayNodeCompatEvidence(sourceEvidence, ARTIFACT_IDENTITIES),
+        "utf8",
+      ),
+    );
+    expect(() =>
+      validateGatewayNodeCompatEvidenceSet(wrongSource, {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        repository: REPOSITORY,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      }),
+    ).toThrow("baseline runtime provenance is not canonical");
+
+    const wrongDigest = evidenceFiles();
+    const digestEvidence = JSON.parse(wrongDigest.get(sourcePath)?.toString("utf8") ?? "{}");
+    digestEvidence.gateway.packagedArtifact.sha256 = "2".repeat(64);
+    digestEvidence.gateway.installedRuntime.packageSha256 = "2".repeat(64);
+    digestEvidence.node.packagedArtifact.sha256 = "2".repeat(64);
+    digestEvidence.node.installedRuntime.packageSha256 = "2".repeat(64);
+    wrongDigest.set(
+      sourcePath,
+      Buffer.from(
+        canonicalizeGatewayNodeCompatEvidence(digestEvidence, {
+          ...ARTIFACT_IDENTITIES,
+          baselinePackageSha256: "2".repeat(64),
+        }),
+        "utf8",
+      ),
+    );
+    expect(() =>
+      validateGatewayNodeCompatEvidenceSet(wrongDigest, {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        repository: REPOSITORY,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      }),
+    ).toThrow("artifact identity must match the baseline package");
+
+    const wrongInstalledBinding = evidenceFiles();
+    const installedEvidence = JSON.parse(
+      wrongInstalledBinding.get(sourcePath)?.toString("utf8") ?? "{}",
+    );
+    installedEvidence.gateway.installedRuntime.packageSha256 = "2".repeat(64);
+    wrongInstalledBinding.set(
+      sourcePath,
+      Buffer.from(`${JSON.stringify(installedEvidence, null, 2)}\n`, "utf8"),
+    );
+    expect(() =>
+      validateGatewayNodeCompatEvidenceSet(wrongInstalledBinding, {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        repository: REPOSITORY,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      }),
+    ).toThrow("installedRuntime.packageSha256 must match packaged artifact sha256");
+  });
+
+  it("selects the highest eligible successful producer attempt", () => {
+    expect(
+      selectGatewayNodeCompatArtifact({
+        artifacts: [artifact(1), artifact(2)],
+        jobs: [producerJob(1), { ...producerJob(2), conclusion: "failure" }, producerJob(3)],
+        required: true,
+        run: releaseRun(3),
+      }),
+    ).toMatchObject({ runAttempt: 1 });
+
+    expect(() =>
+      selectGatewayNodeCompatArtifact({
+        artifacts: [artifact(2)],
+        jobs: [producerJob(2), producerJob(2, 9999)],
+        required: true,
+        run: releaseRun(2),
+      }),
+    ).toThrow("producer job is not unique");
+
+    expect(
+      selectGatewayNodeCompatArtifact({
+        artifacts: [],
+        jobs: [],
+        required: false,
+        run: releaseRun(),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("collects and binds the exact artifact, producer attempt, and six file hashes", async () => {
+    const readArtifact = vi.fn(async () => ({ files: evidenceFiles() }));
+    const result = await collectGatewayNodeCompatReleaseEvidence(
+      {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        mode: "required",
+        repository: REPOSITORY,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      },
+      {
+        getArtifacts: async () => [artifact(RUN_ATTEMPT)],
+        getJobs: async () => [producerJob(RUN_ATTEMPT)],
+        getRun: async () => releaseRun(),
+        readArtifact,
+      },
+    );
+
+    expect(readArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifactId: 2003,
+        producerJobName: GATEWAY_NODE_COMPAT_PRODUCER_JOB,
+        runAttempt: RUN_ATTEMPT,
+        runStatePolicy: "completed-producer-success",
+        workflowPath: GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW,
+      }),
+    );
+    expect(result).toMatchObject({
+      architecture: "x64",
+      artifact: {
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        workflowSha: WORKFLOW_SHA,
+      },
+      baselineVersion: GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+      baseline: {
+        npmIntegrity: GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY,
+        sha256: GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+        sourceSha: GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA,
+        tag: GATEWAY_NODE_COMPAT_BASELINE_TAG,
+        version: GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+      },
+      platform: "linux",
+      schema: GATEWAY_NODE_COMPAT_RELEASE_SCHEMA,
+      targetSha: TARGET_SHA,
+    });
+    if (!result) {
+      throw new Error("expected required Gateway/node compatibility evidence");
+    }
+    expect(validateGatewayNodeCompatManifestEvidence(result)).toBe(result);
+    const incompleteSummary = structuredClone(result);
+    delete (incompleteSummary.files[0] as Partial<(typeof result.files)[number]>).gatewayVersion;
+    expect(() => validateGatewayNodeCompatManifestEvidence(incompleteSummary)).toThrow(
+      "invalid shape",
+    );
+    expect(renderGatewayNodeCompatSummary(result)).toContain(
+      "| `candidate-gateway-disjoint-node` | `2026.8.6` | `2026.8.6` | `4` | `3` | `1-2` | `none` | `protocol-mismatch` |",
+    );
+  });
+
+  it("preserves advisory evidence from a successful producer when the child run failed", async () => {
+    const readArtifact = vi.fn(async () => ({ files: evidenceFiles() }));
+    const result = await collectGatewayNodeCompatReleaseEvidence(
+      {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        mode: "advisory",
+        repository: REPOSITORY,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      },
+      {
+        getArtifacts: async () => [artifact(RUN_ATTEMPT)],
+        getJobs: async () => [producerJob(RUN_ATTEMPT)],
+        getRun: async () => releaseRun(RUN_ATTEMPT, "failure"),
+        readArtifact,
+      },
+    );
+
+    expect(result).toMatchObject({
+      artifact: {
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+        workflowSha: WORKFLOW_SHA,
+      },
+      targetSha: TARGET_SHA,
+    });
+    expect(readArtifact).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a failed overall child run blocking in required mode", async () => {
+    await expect(
+      collectGatewayNodeCompatReleaseEvidence(
+        {
+          candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+          mode: "required",
+          repository: REPOSITORY,
+          runId: RUN_ID,
+          targetSha: TARGET_SHA,
+          workflowSha: WORKFLOW_SHA,
+        },
+        {
+          getArtifacts: async () => [artifact(RUN_ATTEMPT)],
+          getJobs: async () => [producerJob(RUN_ATTEMPT)],
+          getRun: async () => releaseRun(RUN_ATTEMPT, "failure"),
+          readArtifact: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("immutable compatibility tuple");
+  });
+
+  it("warns and returns null when advisory evidence collection fails", async () => {
+    const warnings: string[] = [];
+    const result = await collectGatewayNodeCompatReleaseEvidence(
+      {
+        candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+        mode: "advisory",
+        onWarning: (message) => warnings.push(message),
+        repository: REPOSITORY,
+        runId: RUN_ID,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      },
+      {
+        getArtifacts: async () => [artifact(RUN_ATTEMPT)],
+        getJobs: async () => [{ ...producerJob(RUN_ATTEMPT), conclusion: "failure" }],
+        getRun: async () => releaseRun(RUN_ATTEMPT, "failure"),
+        readArtifact: vi.fn(),
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(warnings).toEqual([
+      "Gateway/node compatibility evidence has no eligible successful producer",
+    ]);
+  });
+
+  it("warns and returns null when advisory evidence is malformed", async () => {
+    const warnings: string[] = [];
+    const files = evidenceFiles();
+    files.set(
+      "linux-x64-candidate-gateway-candidate-node.json",
+      Buffer.from('{"malformed":true}\n'),
+    );
+    await expect(
+      collectGatewayNodeCompatReleaseEvidence(
+        {
+          candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+          mode: "advisory",
+          onWarning: (message) => warnings.push(message),
+          repository: REPOSITORY,
+          runId: RUN_ID,
+          targetSha: TARGET_SHA,
+          workflowSha: WORKFLOW_SHA,
+        },
+        {
+          getArtifacts: async () => [artifact(RUN_ATTEMPT)],
+          getJobs: async () => [producerJob(RUN_ATTEMPT)],
+          getRun: async () => releaseRun(),
+          readArtifact: async () => ({ files }),
+        },
+      ),
+    ).resolves.toBeNull();
+    expect(warnings[0]).toContain("gateway-node compatibility evidence.schema is required");
+  });
+
+  it("keeps required evidence failures blocking", async () => {
+    await expect(
+      collectGatewayNodeCompatReleaseEvidence(
+        {
+          candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+          mode: "required",
+          repository: REPOSITORY,
+          runId: RUN_ID,
+          targetSha: TARGET_SHA,
+          workflowSha: WORKFLOW_SHA,
+        },
+        {
+          getArtifacts: async () => [],
+          getJobs: async () => [],
+          getRun: async () => releaseRun(),
+          readArtifact: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("no eligible successful producer");
+  });
+
+  it("does not call GitHub when compatibility evidence is not selected", async () => {
+    const getRun = vi.fn();
+    await expect(
+      collectGatewayNodeCompatReleaseEvidence(
+        {
+          mode: "not-selected",
+          repository: REPOSITORY,
+          runId: RUN_ID,
+          targetSha: TARGET_SHA,
+          workflowSha: WORKFLOW_SHA,
+        },
+        {
+          getArtifacts: vi.fn(),
+          getJobs: vi.fn(),
+          getRun,
+          readArtifact: vi.fn(),
+        },
+      ),
+    ).resolves.toBeNull();
+    expect(getRun).not.toHaveBeenCalled();
+
+    const workdir = mkdtempSync(join(tmpdir(), "gateway-node-compat-not-selected-"));
+    try {
+      const output = join(workdir, "evidence.json");
+      const result = spawnSync(
+        process.execPath,
+        [
+          "scripts/gateway-node-compat-release-evidence.mjs",
+          "collect",
+          "--repository",
+          REPOSITORY,
+          "--run-id",
+          RUN_ID,
+          "--workflow-sha",
+          WORKFLOW_SHA,
+          "--target-sha",
+          TARGET_SHA,
+          "--mode",
+          "not-selected",
+          "--output",
+          output,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(output, "utf8")).toBe("null\n");
+    } finally {
+      rmSync(workdir, { force: true, recursive: true });
+    }
+  });
+
+  it("stops transient collection retries at the explicit total deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const getRun = vi.fn(async () => {
+        throw new Error("GitHub API ETIMEDOUT");
+      });
+      const collection = collectGatewayNodeCompatReleaseEvidence(
+        {
+          candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+          mode: "required",
+          repository: REPOSITORY,
+          retryDeadlineMs: 1_000,
+          retryDelayMs: 250,
+          runId: RUN_ID,
+          targetSha: TARGET_SHA,
+          workflowSha: WORKFLOW_SHA,
+        },
+        {
+          getArtifacts: vi.fn(),
+          getJobs: vi.fn(),
+          getRun,
+          readArtifact: vi.fn(),
+        },
+      );
+      const rejection = expect(collection).rejects.toThrow(
+        "collection retry deadline was exhausted",
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await rejection;
+      expect(getRun).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry deterministic collection validation failures", async () => {
+    const getRun = vi.fn(async () => {
+      throw new Error("release-check run does not match the immutable compatibility tuple");
+    });
+    await expect(
+      collectGatewayNodeCompatReleaseEvidence(
+        {
+          candidatePackageSha256: CANDIDATE_PACKAGE_SHA256,
+          mode: "required",
+          repository: REPOSITORY,
+          retryDeadlineMs: 1_000,
+          retryDelayMs: 250,
+          runId: RUN_ID,
+          targetSha: TARGET_SHA,
+          workflowSha: WORKFLOW_SHA,
+        },
+        {
+          getArtifacts: vi.fn(),
+          getJobs: vi.fn(),
+          getRun,
+          readArtifact: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("immutable compatibility tuple");
+    expect(getRun).toHaveBeenCalledOnce();
+  });
+});

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -42,6 +42,7 @@ const ANDROID_RELEASE_WORKFLOW = ".github/workflows/android-release.yml";
 const STABLE_MAIN_CLOSEOUT_WORKFLOW = ".github/workflows/openclaw-stable-main-closeout.yml";
 const WINDOWS_NODE_RELEASE_WORKFLOW = ".github/workflows/windows-node-release.yml";
 const FULL_RELEASE_VALIDATION_WORKFLOW = ".github/workflows/full-release-validation.yml";
+const RELEASE_EVIDENCE_PUBLICATION_WORKFLOW = ".github/workflows/release-evidence-publication.yml";
 const FULL_RELEASE_CHILD_DISPATCHES = [
   {
     jobName: "normal_ci",
@@ -164,6 +165,10 @@ type Workflow = {
   on?: {
     workflow_call?: {
       inputs?: Record<string, unknown>;
+    };
+    workflow_run?: {
+      types?: string[];
+      workflows?: string[];
     };
   };
 };
@@ -430,6 +435,77 @@ if (args[0] === "workflow" && args[1] === "run") {
         },
     );
   return { calls, result };
+}
+
+function runGatewayNodeCompatSelection(params: {
+  selected: "false" | "true";
+  workflowRef?: string;
+}) {
+  const step = workflowStep(
+    workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary"),
+    "Select Gateway/node compatibility mode",
+  );
+  if (!step.run) {
+    throw new Error("Expected Gateway/node compatibility selection script");
+  }
+  const workdir = tempDirs.make("gateway-node-compat-selection-");
+  const nodePath = resolve(workdir, "node");
+  const outputPath = resolve(workdir, "github-output");
+  writeFileSync(nodePath, `#!/bin/sh\nprintf '%s\\n' "$MOCK_SELECTION"\n`);
+  chmodSync(nodePath, 0o755);
+  const result = spawnSync("bash", ["-c", step.run], {
+    cwd: workdir,
+    encoding: "utf8",
+    env: {
+      CROSS_OS_SUITE_FILTER: "",
+      GITHUB_OUTPUT: outputPath,
+      MOCK_SELECTION: params.selected,
+      PATH: `${workdir}:${process.env.PATH}`,
+      WORKFLOW_FULL_REF: params.workflowRef ?? "refs/heads/main",
+    },
+  });
+  return {
+    output: result.status === 0 ? readFileSync(outputPath, "utf8") : "",
+    result,
+  };
+}
+
+function runGatewayNodeCompatCollector(mode?: "advisory" | "required") {
+  const step = workflowStep(
+    workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary"),
+    "Collect Gateway/node compatibility evidence",
+  );
+  if (!step.run) {
+    throw new Error("Expected Gateway/node compatibility collector script");
+  }
+  const workdir = tempDirs.make("gateway-node-compat-collector-");
+  const nodePath = resolve(workdir, "node");
+  const callsPath = resolve(workdir, "node-calls");
+  writeFileSync(nodePath, '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$MOCK_NODE_CALLS"\n');
+  chmodSync(nodePath, 0o755);
+  const env: NodeJS.ProcessEnv = {
+    CANDIDATE_PACKAGE_SHA256: "c".repeat(64),
+    GH_TOKEN: "fixture-token",
+    GITHUB_REPOSITORY: "openclaw/openclaw",
+    GITHUB_SHA: "a".repeat(40),
+    MOCK_NODE_CALLS: callsPath,
+    PATH: `${workdir}:${process.env.PATH}`,
+    RELEASE_CHECKS_RUN_ID: "123",
+    RUNNER_TEMP: workdir,
+    TARGET_SHA: "b".repeat(40),
+  };
+  if (mode !== undefined) {
+    env.GATEWAY_NODE_COMPAT_MODE = mode;
+  }
+  const result = spawnSync("bash", ["-c", step.run], {
+    cwd: workdir,
+    encoding: "utf8",
+    env,
+  });
+  return {
+    calls: result.status === 0 ? readFileSync(callsPath, "utf8") : "",
+    result,
+  };
 }
 
 function runPackageAcceptanceSummary(params: {
@@ -2524,6 +2600,10 @@ describe("package artifact reuse", () => {
       workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_checks"),
       "Dispatch and monitor release checks",
     );
+    const releasePackageCandidate = workflowStep(
+      workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_checks"),
+      "Resolve release package candidate",
+    );
 
     expect(prepare.uses).toBe("./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
     expect(prepare.with).toMatchObject({
@@ -2537,11 +2617,26 @@ describe("package artifact reuse", () => {
     expect(prepare.with?.allow_frozen_target_scenario_omissions).toBe(
       "${{ inputs.target_context_ref != '' }}",
     );
+    expect(prepare.if).not.toContain("inputs.package_acceptance_package_spec == ''");
     expect(pluginDispatch.run).toContain(
       'args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")',
     );
     expect(releaseDispatch.run).toContain(
       'args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")',
+    );
+    expect(releaseDispatch.run).toContain(
+      '[[ -n "${CANDIDATE_ARTIFACT_JSON// }" && -z "${PACKAGE_ACCEPTANCE_PACKAGE_SPEC// }" ]]',
+    );
+    expect(releasePackageCandidate.run).toContain("resolve-openclaw-package-candidate.mjs");
+    expect(releasePackageCandidate.run).toContain('--package-spec "$RELEASE_PACKAGE_SPEC"');
+    expect(releaseDispatch.env?.RELEASE_PACKAGE_SPEC).toBe(
+      "${{ steps.release_package_candidate.outputs.package_version && format('openclaw@{0}', steps.release_package_candidate.outputs.package_version) || inputs.release_package_spec }}",
+    );
+    expect(
+      workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_checks").outputs
+        ?.candidate_package_sha256,
+    ).toBe(
+      "${{ steps.release_package_candidate.outputs.sha256 || needs.prepare_release_candidate.outputs.package_sha256 }}",
     );
     expect(workflow).toContain("Shared release candidate preparation ended with");
   });
@@ -4009,7 +4104,40 @@ describe("package artifact reuse", () => {
     const summaryJob = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary");
     const evidenceReuseStep = workflowStep(evidenceReuseJob, "Find reusable validation evidence");
     const dispatchStep = workflowStep(npmTelegramJob, "Dispatch and monitor npm Telegram E2E");
+    const modeStep = workflowStep(summaryJob, "Select Gateway/node compatibility mode");
+    const collectorCheckout = workflowStep(
+      summaryJob,
+      "Checkout Gateway/node compatibility selector and collector",
+    );
+    const collectorStep = workflowStep(summaryJob, "Collect Gateway/node compatibility evidence");
     const manifestStep = workflowStep(summaryJob, "Write release validation manifest");
+    const manifestUpload = workflowStep(summaryJob, "Upload release validation manifest");
+    const legacyManifestUpload = workflowStep(
+      summaryJob,
+      "Upload legacy release validation manifest alias",
+    );
+    const publicationWorkflow = readWorkflow(RELEASE_EVIDENCE_PUBLICATION_WORKFLOW);
+    const publicationJob = workflowJob(RELEASE_EVIDENCE_PUBLICATION_WORKFLOW, "publish");
+    const publicationCheckout = workflowStep(
+      publicationJob,
+      "Checkout trusted publication verifier",
+    );
+    const publicationVerify = workflowStep(
+      publicationJob,
+      "Verify exact completed release evidence",
+    );
+    const publicationDispatch = workflowStep(
+      publicationJob,
+      "Dispatch release evidence publication",
+    );
+    const publicationConfirm = workflowStep(
+      publicationJob,
+      "Confirm durable release evidence publication",
+    );
+    const manifestRun = manifestStep.run ?? "";
+    const manifestArtifactPath =
+      "${{ runner.temp }}/full-release-validation/full-release-validation-manifest.json";
+    const summaryStepNames = (summaryJob.steps ?? []).map((step) => step.name);
 
     expect(workflow).toContain("CHILD_WORKFLOW_REF: ${{ github.ref_name }}");
     expect(workflow).toContain('gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1');
@@ -4021,6 +4149,7 @@ describe("package artifact reuse", () => {
     expect(performanceJob["timeout-minutes"]).toBe(
       "${{ inputs.release_profile == 'full' && 360 || 120 }}",
     );
+    expect(summaryJob["timeout-minutes"]).toBe(20);
     expect(npmTelegramJob.if).toContain(
       'contains(fromJSON(\'["all","npm-telegram"]\'), inputs.rerun_group)',
     );
@@ -4049,14 +4178,140 @@ describe("package artifact reuse", () => {
       SCENARIO: "${{ inputs.npm_telegram_scenario }}",
       TARGET_SHA: "${{ needs.resolve_target.outputs.sha }}",
     });
+    expect(collectorCheckout.if).toContain("needs.release_checks.outputs.run_id != ''");
+    expect(collectorCheckout.if).toContain(
+      'contains(fromJSON(\'["all","release-checks","cross-os"]\'), inputs.rerun_group)',
+    );
+    expect(collectorCheckout.with).toMatchObject({
+      path: "workflow",
+      ref: "${{ github.sha }}",
+    });
+    expect(modeStep.id).toBe("gateway_node_compat_selection");
+    expect(modeStep.if).toContain("needs.release_checks.outputs.run_id != ''");
+    expect(modeStep.if).toContain(
+      'contains(fromJSON(\'["all","release-checks","cross-os"]\'), inputs.rerun_group)',
+    );
+    expect(collectorStep.env).toMatchObject({
+      CANDIDATE_PACKAGE_SHA256: "${{ needs.release_checks.outputs.candidate_package_sha256 }}",
+      GATEWAY_NODE_COMPAT_MODE: "${{ steps.gateway_node_compat_selection.outputs.mode }}",
+      GH_TOKEN: "${{ github.token }}",
+      RELEASE_CHECKS_RUN_ID: "${{ needs.release_checks.outputs.run_id }}",
+      TARGET_SHA: "${{ needs.resolve_target.outputs.sha }}",
+    });
+    expect(collectorStep.if).toBe(
+      "${{ success() && steps.gateway_node_compat_selection.outputs.selected == 'true' }}",
+    );
+    expectTextToIncludeAll(collectorStep.run, [
+      "gateway-node-compat-release-evidence.mjs collect",
+      '--candidate-package-sha256 "${CANDIDATE_PACKAGE_SHA256}"',
+      '--workflow-sha "${GITHUB_SHA}"',
+      '--target-sha "${TARGET_SHA}"',
+      '--mode "${GATEWAY_NODE_COMPAT_MODE}"',
+      '--retry-deadline-ms "900000"',
+    ]);
+    expect(modeStep.env).toEqual({
+      CROSS_OS_SUITE_FILTER: "${{ inputs.cross_os_suite_filter }}",
+      WORKFLOW_FULL_REF: "${{ github.ref }}",
+    });
+    expectTextToIncludeAll(modeStep.run, [
+      "openclaw-cross-os-release-checks.ts",
+      "--resolve-gateway-node-compat-selection true",
+      '--suite-filter "$CROSS_OS_SUITE_FILTER"',
+      "true)",
+      '[[ "$WORKFLOW_FULL_REF" == refs/heads/tideclaw/alpha/* ]]',
+      'mode="advisory"',
+      'mode="required"',
+      "false)",
+      'mode="not-selected"',
+      '"selected=$selected"',
+      '"mode=$mode"',
+    ]);
+    for (const mode of ["required", "advisory"] as const) {
+      const workflowRef =
+        mode === "advisory" ? "refs/heads/tideclaw/alpha/2026.8.7" : "refs/heads/main";
+      const selection = runGatewayNodeCompatSelection({ selected: "true", workflowRef });
+      expect(selection.result.status, selection.result.stderr).toBe(0);
+      expect(selection.output).toContain("selected=true");
+      expect(selection.output).toContain(`mode=${mode}`);
+
+      const collector = runGatewayNodeCompatCollector(mode);
+      expect(collector.result.status, collector.result.stderr).toBe(0);
+      expect(collector.calls).toContain(`--mode ${mode}`);
+    }
+    const skipped = runGatewayNodeCompatSelection({ selected: "false" });
+    expect(skipped.result.status, skipped.result.stderr).toBe(0);
+    expect(skipped.output).toContain("selected=false");
+    expect(skipped.output).toContain("mode=not-selected");
+
+    const unsetMode = runGatewayNodeCompatCollector();
+    expect(unsetMode.result.status).not.toBe(0);
+    expect(unsetMode.result.stderr).toContain("GATEWAY_NODE_COMPAT_MODE");
     expect(manifestStep.env).toMatchObject({
       ALLOW_UNRELEASED_CHANGELOG:
         "${{ inputs.allow_unreleased_changelog || (inputs.target_context_ref == '' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')) }}",
+      GATEWAY_NODE_COMPAT_MODE:
+        "${{ steps.gateway_node_compat_selection.outputs.mode || 'not-selected' }}",
       NPM_TELEGRAM_PACKAGE_SPEC: "${{ inputs.npm_telegram_package_spec }}",
       NPM_TELEGRAM_PROVIDER_MODE: "${{ inputs.npm_telegram_provider_mode }}",
       NPM_TELEGRAM_SCENARIO: "${{ inputs.npm_telegram_scenario }}",
     });
-    expectTextToIncludeAll(manifestStep.run, [
+    expectTextToIncludeAll(manifestRun, [
+      '--slurpfile gatewayNodeCompatibility "$GATEWAY_NODE_COMPAT_PATH"',
+      "gatewayNodeCompatibility: $gatewayNodeCompatibilityMode",
+      "{gatewayNodeCompatibility: $gatewayNodeCompatibility[0]}",
+      "releaseEvidencePublication:",
+      'requested: ($dispatchReleaseEvidence == "true")',
+      "releaseRef: $targetRef",
+      "packageSpec: $releaseEvidencePackageSpec",
+    ]);
+    const reuseManifestBranch = manifestRun.slice(
+      manifestRun.indexOf('if [[ "$EVIDENCE_REUSE" == "true" ]]'),
+      manifestRun.indexOf("exit 0"),
+    );
+    expect(reuseManifestBranch).not.toContain("gatewayNodeCompatibility");
+    expect(reuseManifestBranch).toContain(
+      '"${manifest_dir}/full-release-validation-manifest.json"',
+    );
+    for (const uploadStep of [manifestUpload, legacyManifestUpload]) {
+      expect(uploadStep.uses).toBe(UPLOAD_ARTIFACT_V7);
+      expect(uploadStep.with?.path).toBe(manifestArtifactPath);
+      expect(uploadStep.with?.path).not.toContain("gateway-node-compatibility.json");
+    }
+    expect(summaryStepNames).not.toContain("Request release evidence update");
+    expect(publicationWorkflow.on?.workflow_run).toMatchObject({
+      types: ["completed"],
+      workflows: ["Full Release Validation"],
+    });
+    expect(publicationJob.if).toContain("github.repository == 'openclaw/openclaw'");
+    expect(publicationJob.if).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(publicationCheckout.with?.ref).toBe("${{ github.sha }}");
+    expect(publicationVerify.run).toContain("node scripts/release-ci-summary.mjs");
+    expect(publicationVerify.run).toContain('--validate-run "$PARENT_RUN_ID"');
+    expect(publicationVerify.run).toContain(
+      "node scripts/release-evidence-publication.mjs prepare",
+    );
+    expect(publicationDispatch.if).toBe("steps.publication.outputs.should_dispatch == 'true'");
+    expectTextToIncludeAll(publicationDispatch.run, [
+      "OPENCLAW_RELEASES_DISPATCH_TOKEN is required",
+      "openclaw_full_release_validation_completed",
+      "full_validation_run_attempt",
+      "full_validation_head_sha",
+      "full_validation_updated_at",
+      "publication_key",
+      "https://api.github.com/repos/openclaw/releases/dispatches",
+    ]);
+    expect(publicationConfirm.if).toBe("steps.publication.outputs.should_dispatch == 'true'");
+    expectTextToIncludeAll(publicationConfirm.run, [
+      "release-evidence-publication.mjs confirm",
+      '--run-id "$FULL_VALIDATION_RUN_ID"',
+      '--run-attempt "$RUN_ATTEMPT"',
+      '--head-sha "$HEAD_SHA"',
+      '--updated-at "$UPDATED_AT"',
+      '--release-id "$RELEASE_ID"',
+      '--release-ref "$RELEASE_REF"',
+      '--package-spec "$PACKAGE_SPEC"',
+    ]);
+    expectTextToIncludeAll(manifestRun, [
       "npmTelegramPackageSpec: $npmTelegramPackageSpec",
       "npmTelegramProviderMode: $npmTelegramProviderMode",
       "npmTelegramScenario: $npmTelegramScenario",

--- a/test/scripts/plugin-publication-artifact.test.ts
+++ b/test/scripts/plugin-publication-artifact.test.ts
@@ -377,6 +377,7 @@ function createFixture(
       total_count: 1,
       jobs: [
         {
+          id: 9001,
           name: PRODUCER_JOB_NAME,
           run_id: RUN_ID,
           run_attempt: RUN_ATTEMPT,
@@ -717,6 +718,38 @@ describe("plugin publication artifact", () => {
     }
   });
 
+  it.each([
+    [WORKFLOW_PATH, "main"],
+    [`${WORKFLOW_PATH}@refs/heads/release/2026.7.1`, "release/2026.7.1"],
+    [`${WORKFLOW_PATH}@refs/tags/v2026.7.1`, "v2026.7.1"],
+  ])("accepts canonical workflow path variant %s", (workflowPath, workflowHeadBranch) => {
+    const fixture = createFixture();
+    const run = JSON.parse(readFileSync(fixture.workflowRunPath, "utf8"));
+    run.head_branch = workflowHeadBranch;
+    run.path = workflowPath;
+    writeFileSync(fixture.workflowRunPath, `${JSON.stringify(run)}\n`);
+
+    expect(verifyFixture(fixture, { workflowHeadBranch })).toMatchObject({
+      producerRunAttempt: RUN_ATTEMPT,
+      producerRunId: RUN_ID,
+    });
+  });
+
+  it.each([
+    ".github/workflows/other.yml",
+    ".github/workflows/other.yml@refs/heads/release/2026.7.1",
+    ".github/workflows/other.yml@refs/tags/v2026.7.1",
+  ])("rejects wrong workflow path variant %s", (workflowPath) => {
+    const fixture = createFixture();
+    const run = JSON.parse(readFileSync(fixture.workflowRunPath, "utf8"));
+    run.path = workflowPath;
+    writeFileSync(fixture.workflowRunPath, `${JSON.stringify(run)}\n`);
+
+    expect(() => verifyFixture(fixture)).toThrow(
+      /workflow run does not match the immutable publication tuple/u,
+    );
+  });
+
   it("accepts only the exact successful producer job for same-run publication", () => {
     const fixture = createFixture();
     const workflowRun = JSON.parse(readFileSync(fixture.workflowRunPath, "utf8"));
@@ -885,6 +918,7 @@ describe("plugin publication artifact", () => {
         total_count: 1,
         jobs: [
           {
+            id: 9000 + producerAttempt,
             name: producerJobName,
             run_id: RUN_ID,
             run_attempt: producerAttempt,
@@ -949,6 +983,113 @@ describe("plugin publication artifact", () => {
     );
     await expect(downloadForAttempts(3, 2)).rejects.toThrow(
       "Producer workflow run attempt must not be newer than the consumer attempt.",
+    );
+  });
+
+  it("paginates completed producer jobs and fails closed on incomplete or duplicate inventories", async () => {
+    const zip = createZip([{ bytes: Buffer.from("proof"), name: "proof.txt" }]);
+    const producerJobName = "Gateway/node packaged compatibility / Linux / x64";
+    const artifactMetadata = {
+      digest: `sha256:${sha256(zip)}`,
+      expired: false,
+      id: ARTIFACT_ID,
+      name: ARTIFACT_NAME,
+      size_in_bytes: zip.length,
+      workflow_run: { head_sha: WORKFLOW_SHA, id: RUN_ID },
+    };
+    const workflowRun = {
+      conclusion: "failure",
+      event: "workflow_dispatch",
+      head_branch: "main",
+      head_repository: { full_name: REPOSITORY },
+      head_sha: WORKFLOW_SHA,
+      id: RUN_ID,
+      path: WORKFLOW_PATH,
+      repository: { full_name: REPOSITORY },
+      run_attempt: RUN_ATTEMPT,
+      status: "completed",
+    };
+
+    async function downloadWithSecondPage(mode: "duplicate" | "incomplete" | "valid") {
+      const firstPage = Array.from({ length: 100 }, (_unused, index) => ({
+        conclusion: "success",
+        head_sha: WORKFLOW_SHA,
+        id: index + 1,
+        name: `decoy-${index}`,
+        run_attempt: RUN_ATTEMPT,
+        run_id: RUN_ID,
+        status: "completed",
+      }));
+      const secondPage =
+        mode === "incomplete"
+          ? []
+          : [
+              {
+                conclusion: "success",
+                head_sha: WORKFLOW_SHA,
+                id: mode === "duplicate" ? 1 : 101,
+                name: producerJobName,
+                run_attempt: RUN_ATTEMPT,
+                run_id: RUN_ID,
+                status: "completed",
+              },
+            ];
+      const fetchImpl = (async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith(`/actions/artifacts/${ARTIFACT_ID}`)) {
+          return Response.json(artifactMetadata);
+        }
+        if (url.endsWith(`/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}`)) {
+          return Response.json(workflowRun);
+        }
+        if (url.endsWith(`/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100`)) {
+          return Response.json({ jobs: firstPage, total_count: 101 });
+        }
+        if (
+          url.endsWith(`/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100&page=2`)
+        ) {
+          return Response.json({ jobs: secondPage, total_count: 101 });
+        }
+        if (url.endsWith(`/actions/artifacts/${ARTIFACT_ID}/zip`)) {
+          return new Response(zip as unknown as BodyInit, {
+            headers: { "content-length": String(zip.length) },
+            status: 200,
+          });
+        }
+        return new Response("unexpected", { status: 404 });
+      }) as typeof fetch;
+
+      return downloadActionsArtifactArchive({
+        expected: {
+          artifactDigest: artifactMetadata.digest,
+          artifactId: ARTIFACT_ID,
+          artifactName: ARTIFACT_NAME,
+          artifactSizeBytes: zip.length,
+          producerJobName,
+          repository: REPOSITORY,
+          runAttempt: RUN_ATTEMPT,
+          runId: RUN_ID,
+          runStatePolicy: "completed-producer-success",
+          workflowEvent: "workflow_dispatch",
+          workflowHeadBranch: "main",
+          workflowPath: WORKFLOW_PATH,
+          workflowSha: WORKFLOW_SHA,
+        },
+        fetchImpl,
+        maxArchiveBytes: 1024 * 1024,
+        retryAttempts: 1,
+        token: "test-token",
+      });
+    }
+
+    await expect(downloadWithSecondPage("valid")).resolves.toMatchObject({
+      workflowJobs: { total_count: 101 },
+    });
+    await expect(downloadWithSecondPage("incomplete")).rejects.toThrow(
+      "Actions workflow jobs inventory is incomplete.",
+    );
+    await expect(downloadWithSecondPage("duplicate")).rejects.toThrow(
+      "duplicate or invalid job IDs",
     );
   });
 

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -7,6 +7,17 @@ import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY,
+  GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+  GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA,
+  GATEWAY_NODE_COMPAT_BASELINE_TAG,
+  GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+  GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW,
+  GATEWAY_NODE_COMPAT_PRODUCER_JOB,
+  GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW,
+  GATEWAY_NODE_COMPAT_RELEASE_SCHEMA,
+} from "../../scripts/gateway-node-compat-release-evidence.mjs";
+import {
   artifactDownloadArgs,
   expectedChildDispatches,
   expectedSelectedChildDispatches,
@@ -180,26 +191,31 @@ function artifactDigest(bytes: Buffer): string {
 
 function rawManifest({
   evidenceReuse,
+  gatewayNodeCompatibility,
   rerunGroup = "all",
   runId = "29090000000",
   targetSha = "a".repeat(40),
   version = 2,
   workflowFullRef,
+  workflowRef = "main",
   workflowRefType,
   workflowSha,
 }: {
   evidenceReuse?: unknown;
+  gatewayNodeCompatibility?: unknown;
   rerunGroup?: string;
   runId?: string;
   targetSha?: string;
   version?: 2 | 3;
   workflowFullRef?: string;
+  workflowRef?: string;
   workflowRefType?: "branch" | "tag";
   workflowSha?: string;
 }): {
   childRuns: Record<string, string | { blocking: boolean; conclusion: string; runId: string }>;
   controls: Record<string, unknown>;
   evidenceReuse?: unknown;
+  gatewayNodeCompatibility?: unknown;
   releaseProfile: string;
   rerunGroup: string;
   runAttempt: string;
@@ -229,6 +245,7 @@ function rawManifest({
       stableSoakRequired: false,
     },
     evidenceReuse,
+    ...(gatewayNodeCompatibility ? { gatewayNodeCompatibility } : {}),
     releaseProfile: "beta",
     rerunGroup,
     runAttempt: "2",
@@ -251,14 +268,88 @@ function rawManifest({
     },
     version,
     workflowName: "Full Release Validation",
-    workflowRef: "main",
+    workflowRef,
     ...(workflowSha ? { workflowSha } : {}),
     ...(version === 3
       ? {
-          workflowFullRef: workflowFullRef ?? "refs/heads/main",
+          workflowFullRef: workflowFullRef ?? `refs/heads/${workflowRef}`,
           workflowRefType: workflowRefType ?? "branch",
         }
       : {}),
+  };
+}
+
+function gatewayNodeCompatibilityFixture({
+  runId = "404",
+  targetSha = "a".repeat(40),
+  workflowSha = "b".repeat(40),
+}: {
+  runId?: string;
+  targetSha?: string;
+  workflowSha?: string;
+} = {}) {
+  const rows = [
+    ["baseline-gateway-baseline-node", "passed"],
+    ["baseline-gateway-candidate-node", "passed"],
+    ["baseline-gateway-disjoint-node", "protocol-mismatch"],
+    ["candidate-gateway-baseline-node", "passed"],
+    ["candidate-gateway-candidate-node", "passed"],
+    ["candidate-gateway-disjoint-node", "protocol-mismatch"],
+  ] as const;
+  return {
+    architecture: "x64",
+    artifact: {
+      digest: `sha256:${"d".repeat(64)}`,
+      id: 7001,
+      name: `openclaw-gateway-node-linux-compat-x64-${runId}-1`,
+      producerJob: GATEWAY_NODE_COMPAT_PRODUCER_JOB,
+      repository: "openclaw/openclaw",
+      runAttempt: 1,
+      runId,
+      sizeBytes: 48000,
+      workflowPath: GATEWAY_NODE_COMPAT_RELEASE_CHECKS_WORKFLOW,
+      workflowSha,
+    },
+    baseline: {
+      npmIntegrity: GATEWAY_NODE_COMPAT_BASELINE_NPM_INTEGRITY,
+      sha256: GATEWAY_NODE_COMPAT_BASELINE_SHA256,
+      sourceSha: GATEWAY_NODE_COMPAT_BASELINE_SOURCE_SHA,
+      tag: GATEWAY_NODE_COMPAT_BASELINE_TAG,
+      version: GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+    },
+    baselineVersion: GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+    files: rows.map(([direction, outcome], index) => {
+      const candidateGateway = direction.startsWith("candidate-");
+      const candidateNode = !direction.includes("-baseline-node");
+      const mismatch = outcome === "protocol-mismatch";
+      const gatewayProtocolVersion = candidateGateway ? 4 : 3;
+      return {
+        caseId: `linux-x64-${direction}`,
+        direction,
+        gatewayAcceptedNodeMin: 3,
+        gatewayProtocolVersion,
+        gatewayVersion: candidateGateway ? "2026.8.6" : GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+        helloProtocol: mismatch ? null : gatewayProtocolVersion,
+        nodeVersion: candidateNode ? "2026.8.6" : GATEWAY_NODE_COMPAT_BASELINE_VERSION,
+        outcome,
+        path: `linux-x64-${direction}.json`,
+        protocolClientAdvertisedMax: mismatch ? 2 : candidateNode ? 4 : 3,
+        protocolClientAdvertisedMin: mismatch ? 1 : 3,
+        sha256: (index + 1).toString(16).repeat(64),
+        sizeBytes: 4096 + index,
+      };
+    }),
+    platform: "linux",
+    producer: {
+      job: "gateway_node_linux_compat",
+      repository: "openclaw/openclaw",
+      runAttempt: 1,
+      runId,
+      workflowPath: GATEWAY_NODE_COMPAT_EVIDENCE_WORKFLOW,
+      workflowSha,
+    },
+    schema: GATEWAY_NODE_COMPAT_RELEASE_SCHEMA,
+    targetSha,
   };
 }
 
@@ -744,6 +835,7 @@ describe("release CI summary child correlation", () => {
     expect(evidence).toMatchObject({
       directRoot: true,
       evidenceReuse: null,
+      releaseEvidencePublication: null,
       releaseProfile: "full",
       repository: "openclaw/openclaw",
       rerunGroup: "package",
@@ -838,6 +930,41 @@ describe("release CI summary child correlation", () => {
       workflowRefProof: "manifest-v3-branch",
       workflowRefType: "branch",
       workflowRunPath: ".github/workflows/full-release-validation.yml",
+    });
+  });
+
+  it("normalizes compact Gateway/node compatibility evidence without embedding row JSON", () => {
+    const fixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      workflowSha: "a".repeat(40),
+    });
+    fixture.manifest.gatewayNodeCompatibility = gatewayNodeCompatibilityFixture({
+      runId: String(fixture.childRun.id),
+      targetSha: fixture.targetSha,
+      workflowSha: fixture.workflowSha,
+    });
+
+    const evidence = validateReleaseRunEvidence(
+      {
+        repository: "openclaw/openclaw",
+        runId: fixture.runId,
+        verifierSourceContent: readFileSync(SCRIPT),
+        verifierSourceSha: "c".repeat(40),
+      },
+      fixture.client,
+    );
+
+    expect(evidence.gatewayNodeCompatibility).toEqual(fixture.manifest.gatewayNodeCompatibility);
+    expect(evidence.gatewayNodeCompatibility).not.toHaveProperty("rows");
+    expect(evidence.gatewayNodeCompatibility?.files).toHaveLength(6);
+    expect(evidence.gatewayNodeCompatibility?.files[4]).toMatchObject({
+      caseId: "linux-x64-candidate-gateway-candidate-node",
+      gatewayProtocolVersion: 4,
+      gatewayVersion: "2026.8.6",
+      helloProtocol: 4,
+      nodeVersion: "2026.8.6",
+      protocolClientAdvertisedMax: 4,
+      protocolClientAdvertisedMin: 3,
     });
   });
 
@@ -1374,6 +1501,42 @@ describe("release CI summary child correlation", () => {
     ).toThrow("release validation manifest workflow SHA mismatch");
   });
 
+  it("validates optional release evidence publication intent", () => {
+    const workflowSha = "b".repeat(40);
+    const raw = rawManifest({ version: 3, workflowSha });
+    Object.assign(raw, {
+      releaseEvidencePublication: {
+        packageSpec: "openclaw@2026.8.7",
+        releaseRef: "v2026.8.7",
+        requested: true,
+      },
+    });
+    expect(
+      validateParentManifest(raw, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }).releaseEvidencePublication,
+    ).toEqual({
+      packageSpec: "openclaw@2026.8.7",
+      releaseRef: "v2026.8.7",
+      requested: true,
+    });
+
+    (raw as Record<string, unknown>).releaseEvidencePublication = {
+      packageSpec: " openclaw@2026.8.7",
+      releaseRef: "v2026.8.7",
+      requested: true,
+    };
+    expect(() =>
+      validateParentManifest(raw, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }),
+    ).toThrow("release evidence publication is invalid");
+  });
+
   it("requires v3 manifests to record artifact-only performance publication", () => {
     const workflowSha = "b".repeat(40);
     const missing = rawManifest({ version: 3, workflowSha });
@@ -1399,6 +1562,158 @@ describe("release CI summary child correlation", () => {
         workflowSha,
       }),
     ).toThrow("release validation manifest performance report publication mode is invalid");
+  });
+
+  it("requires and validates Gateway/node compatibility evidence for selected release lanes", () => {
+    const workflowSha = "b".repeat(40);
+    const compatibility = gatewayNodeCompatibilityFixture({ workflowSha });
+    const raw = rawManifest({
+      gatewayNodeCompatibility: compatibility,
+      version: 3,
+      workflowSha,
+    });
+    raw.controls.gatewayNodeCompatibility = "required";
+    const manifest = validateParentManifest(raw, {
+      runAttempt: 2,
+      runId: "29090000000",
+      workflowSha,
+    });
+
+    expect(manifest.gatewayNodeCompatibility).toEqual(compatibility);
+
+    const missing = rawManifest({ version: 3, workflowSha });
+    missing.controls.gatewayNodeCompatibility = "required";
+    expect(() =>
+      validateParentManifest(missing, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }),
+    ).toThrow("requires Gateway/node compatibility evidence");
+  });
+
+  it("keeps historical v3 manifests readable and accepts missing Tideclaw advisory evidence", () => {
+    const workflowSha = "b".repeat(40);
+    expect(
+      validateParentManifest(rawManifest({ version: 3, workflowSha }), {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }).gatewayNodeCompatibility,
+    ).toBeUndefined();
+
+    const advisory = rawManifest({
+      version: 3,
+      workflowFullRef: "refs/heads/tideclaw/alpha/2026-08-06-1200Z",
+      workflowRef: "tideclaw/alpha/2026-08-06-1200Z",
+      workflowSha,
+    });
+    advisory.controls.gatewayNodeCompatibility = "advisory";
+    expect(
+      validateParentManifest(advisory, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }).gatewayNodeCompatibility,
+    ).toBeUndefined();
+
+    const compatibility = gatewayNodeCompatibilityFixture({ workflowSha });
+    advisory.gatewayNodeCompatibility = compatibility;
+    expect(
+      validateParentManifest(advisory, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }).gatewayNodeCompatibility,
+    ).toEqual(compatibility);
+    compatibility.targetSha = "c".repeat(40);
+    expect(() =>
+      validateParentManifest(advisory, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }),
+    ).toThrow("target SHA mismatch");
+  });
+
+  it("requires not-selected manifests to omit Gateway/node compatibility evidence", () => {
+    const workflowSha = "b".repeat(40);
+    const manifest = rawManifest({ rerunGroup: "package", version: 3, workflowSha });
+    manifest.controls.gatewayNodeCompatibility = "not-selected";
+    expect(
+      validateParentManifest(manifest, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }).gatewayNodeCompatibility,
+    ).toBeUndefined();
+
+    manifest.gatewayNodeCompatibility = gatewayNodeCompatibilityFixture({ workflowSha });
+    expect(() =>
+      validateParentManifest(manifest, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }),
+    ).toThrow("includes unselected Gateway/node compatibility evidence");
+  });
+
+  it("uses the canonical cross-OS filter to select Gateway/node compatibility evidence", () => {
+    const workflowSha = "b".repeat(40);
+    for (const crossOsSuiteFilter of ["", "gateway-node-compat"]) {
+      const compatibility = gatewayNodeCompatibilityFixture({ workflowSha });
+      const manifest = rawManifest({
+        gatewayNodeCompatibility: compatibility,
+        rerunGroup: "cross-os",
+        version: 3,
+        workflowSha,
+      });
+      manifest.validationInputs.crossOsSuiteFilter = crossOsSuiteFilter;
+      manifest.controls.gatewayNodeCompatibility = "required";
+      expect(
+        validateParentManifest(manifest, {
+          runAttempt: 2,
+          runId: "29090000000",
+          workflowSha,
+        }).gatewayNodeCompatibility,
+      ).toEqual(compatibility);
+    }
+
+    const windowsOnly = rawManifest({
+      rerunGroup: "cross-os",
+      version: 3,
+      workflowSha,
+    });
+    windowsOnly.validationInputs.crossOsSuiteFilter = "windows/packaged-upgrade";
+    windowsOnly.controls.gatewayNodeCompatibility = "not-selected";
+    expect(
+      validateParentManifest(windowsOnly, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }).gatewayNodeCompatibility,
+    ).toBeUndefined();
+  });
+
+  it("binds Gateway/node compatibility evidence to the release-check child run", () => {
+    const workflowSha = "b".repeat(40);
+    const compatibility = gatewayNodeCompatibilityFixture({
+      runId: "999",
+      workflowSha,
+    });
+    const manifest = rawManifest({
+      gatewayNodeCompatibility: compatibility,
+      version: 3,
+      workflowSha,
+    });
+    manifest.controls.gatewayNodeCompatibility = "required";
+    expect(() =>
+      validateParentManifest(manifest, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }),
+    ).toThrow("release-check run ID mismatch");
   });
 
   it("requires a successful artifact-only performance guard for the current attempt", () => {
@@ -1497,25 +1812,118 @@ describe("release CI summary child correlation", () => {
     expect(current.targetSha).toBe(root.targetSha);
   });
 
-  it("accepts a verified changelog-only release delta", () => {
-    const root = validateParentManifest(rawManifest({}), {
+  it("binds inherited compatibility evidence to the root across a newer wrapper SHA", () => {
+    const rootWorkflowSha = "b".repeat(40);
+    const currentWorkflowSha = "c".repeat(40);
+    const compatibility = gatewayNodeCompatibilityFixture({ workflowSha: rootWorkflowSha });
+    const rootValue = rawManifest({
+      gatewayNodeCompatibility: compatibility,
+      version: 3,
+      workflowSha: rootWorkflowSha,
+    });
+    rootValue.controls.gatewayNodeCompatibility = "required";
+    const root = validateParentManifest(rootValue, {
       runAttempt: 2,
       runId: "29090000000",
+      workflowSha: rootWorkflowSha,
     });
-    const changedPaths = validateParentManifest(
-      rawManifest({
-        evidenceReuse: {
-          changedPaths: ["CHANGELOG.md"],
-          evidenceSha: root.targetSha,
-          policy: "changelog-only-release-v1",
-          runId: root.runId,
-          selectedRunId: root.runId,
-        },
-        runId: "29090000001",
-        targetSha: "b".repeat(40),
-      }),
-      { runAttempt: 2, runId: "29090000001" },
+
+    const currentValue = rawManifest({
+      evidenceReuse: {
+        changedPaths: [],
+        evidenceSha: root.targetSha,
+        policy: "exact-target-full-validation-v1",
+        runId: root.runId,
+        selectedRunId: root.runId,
+      },
+      gatewayNodeCompatibility: structuredClone(compatibility),
+      runId: "29090000001",
+      targetSha: root.targetSha,
+      version: 3,
+      workflowSha: currentWorkflowSha,
+    });
+    currentValue.controls.gatewayNodeCompatibility = "required";
+    const current = validateParentManifest(currentValue, {
+      runAttempt: 2,
+      runId: "29090000001",
+      workflowSha: currentWorkflowSha,
+    });
+
+    expect(validateEvidenceReuseChain(current, root, root)).toBe(root.targetSha);
+    expect(current.workflowSha).toBe(currentWorkflowSha);
+    expect(current.gatewayNodeCompatibility).toEqual(root.gatewayNodeCompatibility);
+
+    const alteredValue = structuredClone(currentValue);
+    const alteredCompatibility = alteredValue.gatewayNodeCompatibility as ReturnType<
+      typeof gatewayNodeCompatibilityFixture
+    >;
+    expectDefined(
+      alteredCompatibility.files[0],
+      "first altered Gateway/node compatibility row",
+    ).sha256 = "f".repeat(64);
+    const altered = validateParentManifest(alteredValue, {
+      runAttempt: 2,
+      runId: "29090000001",
+      workflowSha: currentWorkflowSha,
+    });
+    expect(() => validateEvidenceReuseChain(altered, root, root)).toThrow(
+      "evidence reuse current manifest policy differs from the chain root",
     );
+
+    const invalidRootValue = structuredClone(rootValue);
+    const invalidRootCompatibility = invalidRootValue.gatewayNodeCompatibility as ReturnType<
+      typeof gatewayNodeCompatibilityFixture
+    >;
+    invalidRootCompatibility.artifact.workflowSha = currentWorkflowSha;
+    invalidRootCompatibility.producer.workflowSha = currentWorkflowSha;
+    expect(() =>
+      validateParentManifest(invalidRootValue, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha: rootWorkflowSha,
+      }),
+    ).toThrow("Gateway/node compatibility workflow SHA mismatch");
+  });
+
+  it("accepts a verified changelog-only release delta", () => {
+    const rootWorkflowSha = "b".repeat(40);
+    const currentWorkflowSha = "c".repeat(40);
+    const currentTargetSha = "d".repeat(40);
+    const compatibility = gatewayNodeCompatibilityFixture({
+      workflowSha: rootWorkflowSha,
+    });
+    const rootValue = rawManifest({
+      gatewayNodeCompatibility: compatibility,
+      version: 3,
+      workflowSha: rootWorkflowSha,
+    });
+    rootValue.controls.gatewayNodeCompatibility = "required";
+    const root = validateParentManifest(rootValue, {
+      runAttempt: 2,
+      runId: "29090000000",
+      workflowSha: rootWorkflowSha,
+    });
+
+    const changedPathsValue = rawManifest({
+      evidenceReuse: {
+        changedPaths: ["CHANGELOG.md"],
+        evidenceSha: root.targetSha,
+        policy: "changelog-only-release-v1",
+        runId: root.runId,
+        selectedRunId: root.runId,
+      },
+      gatewayNodeCompatibility: structuredClone(compatibility),
+      runId: "29090000001",
+      targetSha: currentTargetSha,
+      version: 3,
+      workflowSha: currentWorkflowSha,
+    });
+    changedPathsValue.controls.gatewayNodeCompatibility = "required";
+    const changedPaths = validateParentManifest(changedPathsValue, {
+      runAttempt: 2,
+      runId: "29090000001",
+      workflowSha: currentWorkflowSha,
+    });
     expect(
       validateEvidenceReuseChain(changedPaths, root, root, (base: string, head: string) => ({
         files: [{ filename: "CHANGELOG.md", status: "modified" }],
@@ -1523,6 +1931,30 @@ describe("release CI summary child correlation", () => {
         status: head === changedPaths.targetSha ? "ahead" : "diverged",
       })),
     ).toBe(root.targetSha);
+    expect(changedPaths.targetSha).toBe(currentTargetSha);
+    expect(changedPaths.workflowSha).toBe(currentWorkflowSha);
+    expect(changedPaths.gatewayNodeCompatibility).toEqual(root.gatewayNodeCompatibility);
+
+    const alteredValue = structuredClone(changedPathsValue);
+    const alteredCompatibility = alteredValue.gatewayNodeCompatibility as ReturnType<
+      typeof gatewayNodeCompatibilityFixture
+    >;
+    expectDefined(
+      alteredCompatibility.files[0],
+      "first altered Gateway/node compatibility row",
+    ).sha256 = "f".repeat(64);
+    const altered = validateParentManifest(alteredValue, {
+      runAttempt: 2,
+      runId: "29090000001",
+      workflowSha: currentWorkflowSha,
+    });
+    expect(() =>
+      validateEvidenceReuseChain(altered, root, root, (base: string, head: string) => ({
+        files: [{ filename: "CHANGELOG.md", status: "modified" }],
+        merge_base_commit: { sha: base },
+        status: head === altered.targetSha ? "ahead" : "diverged",
+      })),
+    ).toThrow("evidence reuse current manifest policy differs from the chain root");
   });
 
   it("rejects unverified changed paths and cross-SHA exact-target reuse", () => {

--- a/test/scripts/release-evidence-publication.test.ts
+++ b/test/scripts/release-evidence-publication.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessReleaseEvidencePublication,
+  publishedReleaseEvidenceMatches,
+} from "../../scripts/release-evidence-publication.mjs";
+
+const RUN_ID = 31144937783;
+const RUN_ATTEMPT = 2;
+const HEAD_SHA = "a".repeat(40);
+const UPDATED_AT = "2026-08-07T05:30:00Z";
+
+function run(overrides: Record<string, unknown> = {}) {
+  return {
+    conclusion: "success",
+    event: "workflow_dispatch",
+    head_repository: { full_name: "openclaw/openclaw" },
+    head_sha: HEAD_SHA,
+    id: RUN_ID,
+    name: "Full Release Validation",
+    path: ".github/workflows/full-release-validation.yml",
+    repository: { full_name: "openclaw/openclaw" },
+    run_attempt: RUN_ATTEMPT,
+    status: "completed",
+    updated_at: UPDATED_AT,
+    ...overrides,
+  };
+}
+
+function event(overrides: Record<string, unknown> = {}) {
+  return { workflow_run: run(overrides) };
+}
+
+function evidence(
+  publication: Record<string, unknown> = {
+    packageSpec: "openclaw@2026.8.7",
+    releaseRef: "v2026.8.7",
+    requested: true,
+  },
+  rootPublication: Record<string, unknown> = publication,
+) {
+  return {
+    current: {
+      conclusion: "success",
+      runAttempt: RUN_ATTEMPT,
+      runId: String(RUN_ID),
+      status: "completed",
+      workflowSha: HEAD_SHA,
+    },
+    directRoot: true,
+    evidenceReuse: null,
+    releaseEvidencePublication: publication,
+    manifest: {
+      releaseEvidencePublication: rootPublication,
+    },
+    rerunGroup: "all",
+    valid: true,
+  };
+}
+
+describe("release evidence publication", () => {
+  it("prepares one exact dispatch after a successful terminal run", () => {
+    expect(assessReleaseEvidencePublication({ event: event(), evidence: evidence() })).toEqual({
+      fullValidationRunId: String(RUN_ID),
+      headSha: HEAD_SHA,
+      notes: `Automatically requested after Full Release Validation ${RUN_ID}/${RUN_ATTEMPT} completed successfully.`,
+      packageSpec: "openclaw@2026.8.7",
+      publicationKey: `${RUN_ID}:${RUN_ATTEMPT}:${HEAD_SHA}`,
+      reason: "requested",
+      releaseId: "2026.8.7",
+      releaseRef: "v2026.8.7",
+      runAttempt: RUN_ATTEMPT,
+      shouldDispatch: true,
+      updatedAt: UPDATED_AT,
+    });
+  });
+
+  it("does not dispatch when the current wrapper did not request publication", () => {
+    expect(
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: evidence({ packageSpec: "", releaseRef: "main", requested: false }),
+      }),
+    ).toEqual({ reason: "not-requested", shouldDispatch: false });
+  });
+
+  it.each(["missing", "null"] as const)(
+    "keeps historical manifests with %s publication intent as a no-op",
+    (intent) => {
+      const historicalEvidence = evidence();
+      if (intent === "missing") {
+        delete (historicalEvidence as { releaseEvidencePublication?: unknown })
+          .releaseEvidencePublication;
+      } else {
+        (historicalEvidence as { releaseEvidencePublication: unknown }).releaseEvidencePublication =
+          null;
+      }
+
+      expect(
+        assessReleaseEvidencePublication({
+          event: event(),
+          evidence: historicalEvidence,
+        }),
+      ).toEqual({ reason: "not-requested", shouldDispatch: false });
+    },
+  );
+
+  it.each([false, [], "requested", { requested: true }])(
+    "rejects malformed present publication intent: %j",
+    (publication) => {
+      expect(() =>
+        assessReleaseEvidencePublication({
+          event: event(),
+          evidence: {
+            ...evidence(),
+            releaseEvidencePublication: publication,
+          },
+        }),
+      ).toThrow(/publication intent (?:must be an object|is invalid)/u);
+    },
+  );
+
+  it("uses current wrapper publication intent instead of stale reused root intent", () => {
+    expect(
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: evidence(
+          { packageSpec: "", releaseRef: "main", requested: false },
+          {
+            packageSpec: "openclaw@2026.7.31",
+            releaseRef: "v2026.7.31",
+            requested: true,
+          },
+        ),
+      }),
+    ).toEqual({ reason: "not-requested", shouldDispatch: false });
+  });
+
+  it("accepts publication from a verified full-validation reuse root", () => {
+    expect(
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: {
+          ...evidence(),
+          directRoot: false,
+          evidenceReuse: {
+            changedPaths: [],
+            evidenceSha: HEAD_SHA,
+            policy: "exact-target-full-validation-v1",
+            rootRunId: "30000000000",
+            selectedRunId: "30000000000",
+          },
+        },
+      }),
+    ).toMatchObject({
+      reason: "requested",
+      runAttempt: RUN_ATTEMPT,
+      shouldDispatch: true,
+    });
+  });
+
+  it("rejects successful partial reruns and inconsistent reuse claims", () => {
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: { ...evidence(), rerunGroup: "release-checks" },
+      }),
+    ).toThrow("complete direct validation or verified evidence reuse root");
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: { ...evidence(), directRoot: false },
+      }),
+    ).toThrow("complete direct validation or verified evidence reuse root");
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: { ...evidence(), evidenceReuse: { rootRunId: "30000000000" } },
+      }),
+    ).toThrow("complete direct validation or verified evidence reuse root");
+  });
+
+  it("keeps an unrequested partial rerun as a no-op", () => {
+    expect(
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: {
+          ...evidence({ packageSpec: "", releaseRef: "main", requested: false }),
+          rerunGroup: "release-checks",
+        },
+      }),
+    ).toEqual({ reason: "not-requested", shouldDispatch: false });
+  });
+
+  it.each([
+    { packageSpec: "openclaw@2026.8.7\nrelease_ref=forged", releaseRef: "v2026.8.7" },
+    { packageSpec: "openclaw@2026.8.7", releaseRef: "v2026.8.7\rpackage_spec=forged" },
+    { packageSpec: "openclaw@2026.8.7\u001b[2K", releaseRef: "v2026.8.7" },
+  ])("rejects control characters in publication outputs: $packageSpec", (publication) => {
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: evidence({ ...publication, requested: true }),
+      }),
+    ).toThrow("publication intent is invalid");
+  });
+
+  it.each(["failure", "cancelled"])("rejects a terminal %s run", (conclusion) => {
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event({ conclusion }),
+        evidence: evidence(),
+      }),
+    ).toThrow("exact completed/success publication tuple");
+  });
+
+  it("rejects stale or forged event and verifier tuples", () => {
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event({ run_attempt: 1 }),
+        evidence: evidence(),
+      }),
+    ).toThrow("does not match the workflow_run event");
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event({ head_sha: "b".repeat(40) }),
+        evidence: evidence(),
+      }),
+    ).toThrow("does not match the workflow_run event");
+  });
+
+  it("gives each successful attempt a distinct durable publication identity", () => {
+    const firstAttempt = assessReleaseEvidencePublication({
+      event: event({ run_attempt: 1 }),
+      evidence: {
+        ...evidence(),
+        current: { ...evidence().current, runAttempt: 1 },
+      },
+    });
+    const rerun = assessReleaseEvidencePublication({ event: event(), evidence: evidence() });
+
+    expect(firstAttempt.shouldDispatch).toBe(true);
+    expect(rerun.shouldDispatch).toBe(true);
+    if (!firstAttempt.shouldDispatch || !rerun.shouldDispatch) {
+      throw new Error("expected publication assessments");
+    }
+    expect(rerun.publicationKey).not.toBe(firstAttempt.publicationKey);
+    expect(rerun.releaseId).toBe(firstAttempt.releaseId);
+    expect(rerun.releaseRef).toBe(firstAttempt.releaseRef);
+    expect(rerun.runAttempt).toBe(2);
+    expect(firstAttempt.runAttempt).toBe(1);
+  });
+
+  it("recognizes only the exact durable publication binding", () => {
+    const expected = assessReleaseEvidencePublication({ event: event(), evidence: evidence() });
+    expect(expected.shouldDispatch).toBe(true);
+    if (!expected.shouldDispatch) {
+      throw new Error("expected a publication assessment");
+    }
+    const published = {
+      release: {
+        id: expected.releaseId,
+        packageSpec: expected.packageSpec,
+        ref: expected.releaseRef,
+      },
+      runs: [
+        {
+          conclusion: "success",
+          headSha: expected.headSha,
+          label: "full-release-validation",
+          path: ".github/workflows/full-release-validation.yml",
+          repo: "openclaw/openclaw",
+          runAttempt: expected.runAttempt,
+          runId: Number(expected.fullValidationRunId),
+          status: "completed",
+          updatedAt: expected.updatedAt,
+        },
+      ],
+    };
+    expect(publishedReleaseEvidenceMatches(published, expected)).toBe(true);
+    expect(publishedReleaseEvidenceMatches(published, expected)).toBe(true);
+    expect(
+      publishedReleaseEvidenceMatches(
+        {
+          ...published,
+          runs: [{ ...published.runs[0], headSha: "b".repeat(40) }],
+        },
+        expected,
+      ),
+    ).toBe(false);
+    expect(
+      publishedReleaseEvidenceMatches(
+        {
+          ...published,
+          runs: [{ ...published.runs[0], updatedAt: "2026-08-07T06:00:00Z" }],
+        },
+        expected,
+      ),
+    ).toBe(false);
+    expect(
+      publishedReleaseEvidenceMatches(
+        {
+          ...published,
+          runs: [{ ...published.runs[0], runAttempt: 1 }],
+        },
+        expected,
+      ),
+    ).toBe(false);
+    expect(
+      publishedReleaseEvidenceMatches(
+        {
+          ...published,
+          runs: [{ ...published.runs[0], conclusion: "failure" }],
+        },
+        expected,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects publication intent that cannot derive a safe release id", () => {
+    expect(() =>
+      assessReleaseEvidencePublication({
+        event: event(),
+        evidence: evidence({ packageSpec: "", releaseRef: "feature/bad", requested: true }),
+      }),
+    ).toThrow("safe release ID");
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/openclaw/openclaw/pull/120018.

## What Problem This Solves

Full Release Validation can report success after its release-check child completes without proving that the child produced the expected Gateway/node rolling-upgrade evidence. That leaves candidate/current, candidate/baseline, baseline/candidate, and incompatible-range behavior outside the release verdict.

## Why This Change Was Made

This change makes the Linux/x64 compatibility artifact from the release-check child part of the Full Release evidence contract.

- `required`: selected stable/beta/full release lanes fail closed unless the exact child run, attempt, producer job, artifact, target SHA, and six canonical rows validate.
- `advisory`: Tideclaw alpha retains valid producer evidence even when an unrelated advisory child job fails, but does not block when the producer itself is unavailable.
- `not-selected`: unrelated rerun groups do not collect or publish compatibility evidence.
- Evidence-reuse wrappers inherit the validated root evidence. Exact-target and changelog-only wrappers must remain identity-equivalent to the root while recording their own wrapper SHA/ref.
- Reusable release discovery now requires root manifests with the complete compatibility contract.

The existing Full Release manifest remains version 3. Gateway/node evidence has its own additive `openclaw.gateway-node-compat-release-evidence/v1` schema.

## User Impact

Release operators get a fail-closed verdict for the Linux packaged Gateway/node compatibility matrix instead of trusting child-workflow success alone. Release summaries also expose compact v3/v4 protocol, installed-version, outcome, and artifact provenance for each direction.

No runtime or end-user behavior changes.

## Evidence

Exact head: `e42d1c687824cfb11385d707b6b6de2f580232d2`

- `node scripts/run-vitest.mjs test/scripts/gateway-node-compat-release-evidence.test.ts test/scripts/gateway-node-compat-evidence.test.ts test/scripts/release-ci-summary.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/plugin-publication-artifact.test.ts test/scripts/find-reusable-release-validation.test.ts`
  - 6 files passed
  - 371 tests passed
- `actionlint` passed for `.github/workflows/full-release-validation.yml`.
- Targeted `oxfmt`, raw `oxlint`, script declarations, shell syntax, signature, and `git diff --check` passed.
- Independent exact-head review verified:
  - strict six-row evidence and child-run binding,
  - required/advisory/not-selected behavior,
  - root/current reuse identity across newer wrapper SHAs and changelog-only target deltas,
  - successful advisory producer recovery from an otherwise failed Tideclaw child,
  - single-file manifest artifact uploads.
- Exact whole-stack head `5444ab41b18fd0fe0ed5a21adf8c1d05b9ba1d58`: 606 focused tests passed, 1 intentional skip.
- Exact-head direct AWS Crabbox run `run_b766683b10a1`: the same matrix passed on `c7a.8xlarge`, including all release evidence aggregation tests; exit 0 and the lease stopped.
- Crabbox portal: https://crabbox.openclaw.ai/portal/runs/run_b766683b10a1
- This is exact-head remote code proof, not a live GitHub Full Release workflow dispatch.

Production delta: `+1077/-22`; tests: `+1153/-23`. The production growth implements the evidence collector, immutable GitHub Actions provenance checks, release/reuse policy binding, and summary contract; it does not add runtime product paths.

Punchcard: `frost-river-workshop-q5`
