### PR TITLE
fix(install): Windows installer no longer reports failed doctor migration as complete

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -882,6 +882,10 @@ function Invoke-OpenClawCommand {
     }
 
     & $commandPath @Arguments
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "openclaw $($Arguments -join ' ') failed with exit code $exitCode."
+    }
 }
 
 function Invoke-InteractiveOpenClawCommand {
@@ -1608,10 +1612,10 @@ function Run-Doctor {
     Write-Host "[*] Running doctor to migrate settings..." -ForegroundColor Yellow
     try {
         Invoke-OpenClawCommand doctor --non-interactive
+        Write-Host "[OK] Migration complete" -ForegroundColor Green
     } catch {
-        # Ignore errors from doctor
+        Write-Host "[!] Migration failed; continuing. Run: openclaw doctor --non-interactive" -ForegroundColor Yellow
     }
-    Write-Host "[OK] Migration complete" -ForegroundColor Green
 }
 
 function Test-GatewayServiceLoaded {

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -105,6 +105,36 @@ describe("install.ps1 failure handling", () => {
     const scriptWithoutEntryPoint = source.replace(ENTRYPOINT_RE, "");
     const cases = [
       {
+        name: "openclaw-native-command-exit",
+        source: [
+          scriptWithoutEntryPoint,
+          "",
+          "function Get-OpenClawCommandPath { return (Get-Process -Id $PID).Path }",
+          "$caught = $false",
+          "try {",
+          "  Invoke-OpenClawCommand -NoLogo -NoProfile -Command 'exit 17'",
+          "} catch {",
+          "  if ($_.Exception.Message -notmatch 'failed with exit code 17') { throw }",
+          "  $caught = $true",
+          "}",
+          "if (-not $caught) { throw 'nonzero native exit was accepted' }",
+          "",
+        ].join("\n"),
+      },
+      {
+        name: "doctor-failure-output",
+        source: [
+          scriptWithoutEntryPoint,
+          "",
+          "function Invoke-OpenClawCommand { throw 'doctor failed' }",
+          "$output = @(Run-Doctor *>&1 | ForEach-Object { $_.ToString() })",
+          '$text = $output -join "`n"',
+          "if ($text -match 'Migration complete') { throw 'doctor failure reported success' }",
+          "if ($text -notmatch 'Migration failed') { throw \"missing warning: $text\" }",
+          "",
+        ].join("\n"),
+      },
+      {
         name: "node-versions",
         source: [
           scriptWithoutEntryPoint,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Windows installer printed `[OK] Migration complete` even when `openclaw doctor --non-interactive` failed. `Invoke-OpenClawCommand` invoked the CLI with `&` and never checked `$LASTEXITCODE` — PowerShell does not throw on nonzero child exit — so the `try/catch` around the doctor run could never catch a failure, and every other installer step using the wrapper had the same blind spot.

## Why This Change Was Made

The wrapper is the owner of the child-process contract, so it now throws on any nonzero exit code (`openclaw <args> failed with exit code N`). `Run-Doctor` keeps migration failures non-fatal for the install as intended, but reports honestly: success prints `[OK] Migration complete` only inside the success path, and failure prints a warning naming the exact command to rerun.

## User Impact

Windows operators whose config migration fails during install now see it immediately with a recovery command, instead of discovering a stale config later.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/install-ps1.test.ts` — passes, with new regression tests asserting the wrapper throws on nonzero exit and that Run-Doctor emits the failure branch text (and no false `[OK]`).
- Codex autoreview (gpt-5.6-sol, high) over the change bundle: clean, no actionable findings.
