### PR TITLE
fix(tui): avoid repeated runtime rebuilds in local sessions

### DIFF
--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -930,6 +930,43 @@ describe("EmbeddedTuiBackend", () => {
     expect(unregisterConfigWriteListenerMock).toHaveBeenCalledOnce();
   });
 
+  it("forwards overlapping config publications immediately for runtime latest-wins coalescing", async () => {
+    const initialConfig = { agents: { list: [{ id: "main" }] } };
+    const middleConfig = { agents: { defaults: { model: "openai/middle" } } };
+    const latestConfig = { agents: { defaults: { model: "openai/latest" } } };
+    getRuntimeConfigMock.mockReturnValue(initialConfig);
+    const initial = deferred<void>();
+    const middle = deferred<void>();
+    const latest = deferred<void>();
+    refreshPreparedModelRuntimeSnapshotsMock
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(middle.promise)
+      .mockReturnValueOnce(latest.promise);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await vi.waitFor(() => expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledOnce());
+
+    try {
+      configWriteListener?.({ runtimeConfig: middleConfig });
+      configWriteListener?.({ runtimeConfig: latestConfig });
+      await flushMicrotasks();
+
+      expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenNthCalledWith(2, middleConfig, {
+        catalogMode: "static",
+      });
+      expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenNthCalledWith(3, latestConfig, {
+        catalogMode: "static",
+      });
+    } finally {
+      initial.resolve();
+      middle.resolve();
+      latest.resolve();
+      await backend.stop();
+    }
+  });
+
   it("rechecks runtime publication when a queued turn reaches model admission", async () => {
     const first = deferred<{
       payloads: Array<{ text: string }>;

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -30,6 +30,9 @@ const loadAgentRuntimePluginRegistryHandleMock = vi.fn();
 const withPluginRuntimeRegistryScopeMock = vi.fn((_registry: unknown, run: () => unknown) => run());
 const ensureContextWindowCacheLoadedMock = vi.fn(async () => undefined);
 const runSessionStartupMigrationMock = vi.fn<() => Promise<void>>(async () => undefined);
+const refreshPreparedModelRuntimeSnapshotsMock = vi.fn(async () => undefined);
+const unregisterConfigWriteListenerMock = vi.fn();
+let configWriteListener: ((event: { runtimeConfig: Record<string, unknown> }) => void) | undefined;
 const createGatewaySessionMock = vi.fn();
 const listSessionsFromStoreAsyncMock = vi.fn(
   async (_options?: unknown): Promise<{ sessions: unknown[] }> => ({ sessions: [] }),
@@ -155,6 +158,11 @@ vi.mock("../agents/context.js", () => ({
   ensureContextWindowCacheLoaded: () => ensureContextWindowCacheLoadedMock(),
 }));
 
+vi.mock("../agents/prepared-model-runtime.js", () => ({
+  refreshPreparedModelRuntimeSnapshots: (...args: unknown[]) =>
+    refreshPreparedModelRuntimeSnapshotsMock(...args),
+}));
+
 vi.mock("../agents/defaults.js", () => ({
   DEFAULT_PROVIDER: "openai",
 }));
@@ -177,6 +185,12 @@ vi.mock("../agents/model-selection.js", () => ({
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => getRuntimeConfigMock(),
   loadConfig: () => getRuntimeConfigMock(),
+  registerConfigWriteListener: (
+    listener: (event: { runtimeConfig: Record<string, unknown> }) => void,
+  ) => {
+    configWriteListener = listener;
+    return unregisterConfigWriteListenerMock;
+  },
 }));
 
 vi.mock("../config/sessions/startup-migration.js", () => ({
@@ -326,6 +340,10 @@ describe("EmbeddedTuiBackend", () => {
     ensureContextWindowCacheLoadedMock.mockResolvedValue(undefined);
     runSessionStartupMigrationMock.mockReset();
     runSessionStartupMigrationMock.mockResolvedValue(undefined);
+    refreshPreparedModelRuntimeSnapshotsMock.mockReset();
+    refreshPreparedModelRuntimeSnapshotsMock.mockResolvedValue(undefined);
+    unregisterConfigWriteListenerMock.mockReset();
+    configWriteListener = undefined;
     createGatewaySessionMock.mockReset();
     createGatewaySessionMock.mockResolvedValue({
       ok: true,
@@ -848,6 +866,113 @@ describe("EmbeddedTuiBackend", () => {
       },
     });
     expect(listSessionsFromStoreAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes a static configured runtime before admitting the first local turn", async () => {
+    const initialConfig = { agents: { list: [{ id: "main" }] } };
+    getRuntimeConfigMock.mockReturnValue(initialConfig);
+    const publication = deferred<void>();
+    refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(publication.promise);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+
+    const send = backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "hello",
+      runId: "run-waits-for-static-runtime",
+    });
+    await flushMicrotasks();
+
+    expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledWith(initialConfig, {
+      catalogMode: "static",
+    });
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+
+    publication.resolve();
+    await send;
+    await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1));
+    await backend.stop();
+  });
+
+  it("queues config runtime publication ahead of later local turns and unregisters on stop", async () => {
+    const initialConfig = { agents: { list: [{ id: "main" }] } };
+    const nextConfig = { agents: { list: [{ id: "main" }], defaults: { model: "openai/next" } } };
+    getRuntimeConfigMock.mockReturnValue(initialConfig);
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await vi.waitFor(() => expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledOnce());
+
+    const replacement = deferred<void>();
+    refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(replacement.promise);
+    configWriteListener?.({ runtimeConfig: nextConfig });
+
+    const send = backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "after config write",
+      runId: "run-waits-for-config-runtime",
+    });
+    await flushMicrotasks();
+
+    expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenLastCalledWith(nextConfig, {
+      catalogMode: "static",
+    });
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+
+    replacement.resolve();
+    await send;
+    await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1));
+    await backend.stop();
+
+    expect(unregisterConfigWriteListenerMock).toHaveBeenCalledOnce();
+  });
+
+  it("rechecks runtime publication when a queued turn reaches model admission", async () => {
+    const first = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce({ payloads: [{ text: "second done" }], meta: {} });
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      cfg: { messages: { queue: { mode: "followup" } } },
+      canonicalKey: sessionKey,
+      storePath: "/tmp/openclaw-sessions.json",
+      store: {},
+      entry: { queueDebounceMs: 0 },
+    }));
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "first",
+      runId: "runtime-refresh-first",
+    });
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "queued second",
+      runId: "runtime-refresh-second",
+    });
+
+    const replacement = deferred<void>();
+    refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(replacement.promise);
+    configWriteListener?.({
+      runtimeConfig: { agents: { defaults: { model: "openai/next" } } },
+    });
+    first.resolve({ payloads: [{ text: "first done" }], meta: {} });
+    await flushMicrotasks();
+
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+    replacement.resolve();
+    await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2));
+    await backend.stop();
   });
 
   it("creates a local session entry before starting a goal", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -29,7 +29,6 @@ import {
   buildConfiguredModelCatalog,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
-import { refreshPreparedModelRuntimeSnapshots } from "../agents/prepared-model-runtime.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../agents/runtime-plugins.js";
 import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js";
 import { resolveTextCommand } from "../auto-reply/commands-registry.js";
@@ -101,6 +100,7 @@ import {
   previewQueueSummaryPrompt,
   waitForQueueDebounce,
 } from "../utils/queue-helpers.js";
+import { EmbeddedPreparedModelRuntimeHost } from "./embedded-prepared-runtime.js";
 import { resolveLocalRunShutdownGraceMs } from "./local-run-shutdown.js";
 import type {
   ChatSendOptions,
@@ -379,32 +379,11 @@ export class EmbeddedTuiBackend implements TuiBackend {
   private seq = 0;
   private readonly pendingLifecycleErrors = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly pluginApprovalBroker = new EmbeddedPluginApprovalBroker();
+  private readonly preparedModelRuntime = new EmbeddedPreparedModelRuntimeHost();
   private unsubscribePluginApprovals?: () => void;
   private unsubscribeConfigWrites?: () => void;
-  private preparedModelRuntimePublicationTail: Promise<void> = Promise.resolve();
-  private preparedModelRuntimeReady: Promise<void> = Promise.resolve();
   // Resolves once the one-time session-key migration has run; store methods await it.
   private ready: Promise<void> = Promise.resolve();
-
-  private publishPreparedModelRuntime(config: OpenClawConfig): void {
-    const publication = this.preparedModelRuntimePublicationTail.then(async () => {
-      await refreshPreparedModelRuntimeSnapshots(config, { catalogMode: "static" });
-    });
-    // Later config writes must still be able to replace a failed generation. Keep the admission
-    // promise rejected for callers while allowing the serialized publication tail to recover.
-    this.preparedModelRuntimeReady = publication;
-    this.preparedModelRuntimePublicationTail = publication.catch(() => undefined);
-  }
-
-  private async waitForPreparedModelRuntime(): Promise<void> {
-    for (;;) {
-      const ready = this.preparedModelRuntimeReady;
-      await ready;
-      if (ready === this.preparedModelRuntimeReady) {
-        return;
-      }
-    }
-  }
 
   start() {
     if (this.unsubscribe) {
@@ -426,9 +405,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
     const config = getRuntimeConfig();
     this.unsubscribeConfigWrites = registerConfigWriteListener((event) => {
-      this.publishPreparedModelRuntime(event.runtimeConfig);
+      this.preparedModelRuntime.publish(event.runtimeConfig);
     });
-    this.publishPreparedModelRuntime(config);
+    this.preparedModelRuntime.publish(config);
     // Local mode never runs gateway startup; canonicalize orphaned keys once here.
     this.ready = (async () => {
       const { runSessionStartupMigration } =
@@ -487,7 +466,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async sendChat(opts: ChatSendOptions): Promise<TuiChatSendResult> {
     await this.ready;
-    await this.waitForPreparedModelRuntime();
+    await this.preparedModelRuntime.waitUntilReady();
     const runId = opts.runId ?? randomUUID();
     const question = resolveBtwQuestion(opts.message);
     const isQueueCommand = resolveTextCommand(opts.message)?.command.key === "queue";
@@ -1409,7 +1388,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (recheckPreparedRuntimeAtAdmission) {
         // A turn may have queued behind another local run while a config write published a new
         // generation. Recheck at actual model admission so it cannot use stale facts.
-        await this.waitForPreparedModelRuntime();
+        await this.preparedModelRuntime.waitUntilReady();
         if (params.controller.signal.aborted) {
           if (activeRun) {
             this.emitChatTerminal(params.runId, activeRun, "aborted");

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -29,6 +29,7 @@ import {
   buildConfiguredModelCatalog,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
+import { refreshPreparedModelRuntimeSnapshots } from "../agents/prepared-model-runtime.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../agents/runtime-plugins.js";
 import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js";
 import { resolveTextCommand } from "../auto-reply/commands-registry.js";
@@ -41,7 +42,7 @@ import {
 } from "../auto-reply/reply/queue/state.js";
 import type { QueueSettings } from "../auto-reply/reply/queue/types.js";
 import { createDefaultDeps } from "../cli/deps.js";
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, registerConfigWriteListener } from "../config/config.js";
 import { applySessionPatchProjection } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
@@ -379,8 +380,31 @@ export class EmbeddedTuiBackend implements TuiBackend {
   private readonly pendingLifecycleErrors = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly pluginApprovalBroker = new EmbeddedPluginApprovalBroker();
   private unsubscribePluginApprovals?: () => void;
+  private unsubscribeConfigWrites?: () => void;
+  private preparedModelRuntimePublicationTail: Promise<void> = Promise.resolve();
+  private preparedModelRuntimeReady: Promise<void> = Promise.resolve();
   // Resolves once the one-time session-key migration has run; store methods await it.
   private ready: Promise<void> = Promise.resolve();
+
+  private publishPreparedModelRuntime(config: OpenClawConfig): void {
+    const publication = this.preparedModelRuntimePublicationTail.then(async () => {
+      await refreshPreparedModelRuntimeSnapshots(config, { catalogMode: "static" });
+    });
+    // Later config writes must still be able to replace a failed generation. Keep the admission
+    // promise rejected for callers while allowing the serialized publication tail to recover.
+    this.preparedModelRuntimeReady = publication;
+    this.preparedModelRuntimePublicationTail = publication.catch(() => undefined);
+  }
+
+  private async waitForPreparedModelRuntime(): Promise<void> {
+    for (;;) {
+      const ready = this.preparedModelRuntimeReady;
+      await ready;
+      if (ready === this.preparedModelRuntimeReady) {
+        return;
+      }
+    }
+  }
 
   start() {
     if (this.unsubscribe) {
@@ -400,12 +424,17 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.unsubscribePluginApprovals = this.pluginApprovalBroker.subscribe((event) => {
       this.emit(event.event, event.payload);
     });
+    const config = getRuntimeConfig();
+    this.unsubscribeConfigWrites = registerConfigWriteListener((event) => {
+      this.publishPreparedModelRuntime(event.runtimeConfig);
+    });
+    this.publishPreparedModelRuntime(config);
     // Local mode never runs gateway startup; canonicalize orphaned keys once here.
     this.ready = (async () => {
       const { runSessionStartupMigration } =
         await import("../config/sessions/startup-migration.js");
       await runSessionStartupMigration({
-        cfg: getRuntimeConfig(),
+        cfg: config,
         env: process.env,
         log: embeddedSessionStartupMigrationLog,
       });
@@ -416,6 +445,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async stop() {
+    this.unsubscribeConfigWrites?.();
+    this.unsubscribeConfigWrites = undefined;
     clearEmbeddedPluginApprovalBroker(this.pluginApprovalBroker);
     this.unsubscribePluginApprovals?.();
     this.unsubscribePluginApprovals = undefined;
@@ -456,6 +487,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async sendChat(opts: ChatSendOptions): Promise<TuiChatSendResult> {
     await this.ready;
+    await this.waitForPreparedModelRuntime();
     const runId = opts.runId ?? randomUUID();
     const question = resolveBtwQuestion(opts.message);
     const isQueueCommand = resolveTextCommand(opts.message)?.command.key === "queue";
@@ -1334,6 +1366,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     queuedAfter?: QueuedSessionRun;
   }) {
     try {
+      const recheckPreparedRuntimeAtAdmission = params.queuedAfter !== undefined;
       if (params.queuedAfter) {
         try {
           await Promise.race([
@@ -1372,6 +1405,17 @@ export class EmbeddedTuiBackend implements TuiBackend {
         }
         message = buildLocalQueuedPrompt(activeRun.pendingQueue);
         delete activeRun.pendingQueue;
+      }
+      if (recheckPreparedRuntimeAtAdmission) {
+        // A turn may have queued behind another local run while a config write published a new
+        // generation. Recheck at actual model admission so it cannot use stale facts.
+        await this.waitForPreparedModelRuntime();
+        if (params.controller.signal.aborted) {
+          if (activeRun) {
+            this.emitChatTerminal(params.runId, activeRun, "aborted");
+          }
+          return;
+        }
       }
       if (activeRun?.isBtw && activeRun.question) {
         const result = await this.runBtwTurn({

--- a/src/tui/embedded-prepared-runtime.test.ts
+++ b/src/tui/embedded-prepared-runtime.test.ts
@@ -1,0 +1,40 @@
+import "../agents/prepared-model-runtime.test-harness.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { acquireAgentRunPreparedModelRuntime } from "../agents/prepared-model-runtime.js";
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "../agents/prepared-model-runtime.test-harness.js";
+import { EmbeddedPreparedModelRuntimeHost } from "./embedded-prepared-runtime.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+
+describe("EmbeddedPreparedModelRuntimeHost", () => {
+  beforeEach(() => {
+    resetPreparedModelRuntimeHarness();
+  });
+
+  it("reuses its configured publication across two actual run admissions", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } };
+    const host = new EmbeddedPreparedModelRuntimeHost();
+    host.publish(config);
+    await host.waitUntilReady();
+
+    const input = {
+      agentId: "default",
+      config,
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/unused-workspace",
+      runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", agentId: "default" }],
+    };
+    const first = await acquireAgentRunPreparedModelRuntime(input);
+    first.release();
+    const second = await acquireAgentRunPreparedModelRuntime(input);
+    second.release();
+
+    expect(second.snapshot).toBe(first.snapshot);
+    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+  });
+});

--- a/src/tui/embedded-prepared-runtime.ts
+++ b/src/tui/embedded-prepared-runtime.ts
@@ -1,0 +1,23 @@
+// Owns prepared-model-runtime publication readiness for a long-lived embedded TUI host.
+import { refreshPreparedModelRuntimeSnapshots } from "../agents/prepared-model-runtime.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+export class EmbeddedPreparedModelRuntimeHost {
+  private ready: Promise<void> = Promise.resolve();
+
+  publish(config: OpenClawConfig): void {
+    // The runtime layer synchronously stales the prior generation and coalesces queued requests.
+    // Invoke it immediately so overlapping config writes retain those latest-wins semantics.
+    this.ready = refreshPreparedModelRuntimeSnapshots(config, { catalogMode: "static" });
+  }
+
+  async waitUntilReady(): Promise<void> {
+    for (;;) {
+      const ready = this.ready;
+      await ready;
+      if (ready === this.ready) {
+        return;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #119989

Reported by @Sedrak-Hovhannisyan.

## What Problem This Solves

Fixes an issue where users entering the embedded local TUI after onboarding could wait for an expensive prepared-model-runtime rebuild on each turn, eventually seeing `prepared model runtime publication timed out` and then repeating the same failure on retry.

The defect affects the configured `tui --local` host boundary. That host was long-lived, but it did not publish a long-lived configured runtime generation, so each explicit-config turn could create and release a live discovery owner instead of reusing host-owned static facts.

## Why This Change Was Made

`EmbeddedTuiBackend` now owns a configured static prepared-runtime publication for its lifetime, waits for the latest publication before admitting a turn, and republishes on config writes. Config publications are forwarded immediately so the prepared-runtime layer retains its existing synchronous stale marking, serialization, and latest-wins coalescing semantics.

The durable invariant is: a running configured local TUI publishes once at host activation, replaces that generation at config publication, and reuses the committed owner across run-admission leases without per-turn live generated-catalog work.

Alternatives considered and rejected:

- Increasing the 120-second timeout would hide the repeated owner transition and leave retries queued behind late work.
- Retaining explicit per-run owners would turn stale config into an implicit cache and duplicate the configured lifecycle contract.
- Routing onboarding away from local TUI would bypass a supported surface rather than repair its owner boundary.

## User Impact

Embedded local TUI turns reuse host-prepared model/runtime facts instead of rebuilding live discovery per turn. Config changes still replace the generation before later model admission, including turns that were queued behind another local run.

Production LOC: +48/-2 (net +46) | Tests: +202/-0.

The positive production delta is the small host-owned publication/readiness boundary that makes the lifecycle explicit and independently testable; the existing per-run and prepared-runtime serializers remain unchanged.

## Evidence

### Root-cause and behavior proof

- TDD red: overlapping config writes were trapped behind an outer backend tail, preventing the prepared-runtime API from seeing them synchronously.
- Green: overlapping writes now reach the runtime immediately, preserving latest-wins coalescing.
- Real owner-boundary integration: one configured static host snapshot was reused across two canonical run-admission leases with zero per-turn `ensureOpenClawModelsJson` writes.
- Real local PTY: 2 provider requests, dynamic second prompt, rendered completion, and second-prompt echo before first-response release; no publication timeout or overlapping-retry failure.

### Performance

Two warmups per ref and 12 alternating AB/BA pairs used fresh isolated local-TUI state, unique nonces, two completed prompts, and an identical loopback Responses mock. All 24 measured samples plus four warmups completed with zero failures/timeouts; every request/nonce/distinct-reply check passed.

| Metric | Base median | Fix median | Paired ratio | Paired median delta | Bootstrap 95% CI |
| --- | ---: | ---: | ---: | ---: | ---: |
| First completed turn | 8756.90 ms | 8089.33 ms | 0.9131 | -738.39 ms | -843.04 to -303.40 ms |
| Second completed turn | 6272.79 ms | 4850.46 ms | 0.7808 | -1390.81 ms | -1730.11 to -1266.32 ms |
| First prompt through second completion | 15032.34 ms | 13023.37 ms | 0.8566 | -2169.13 ms | -2439.62 to -1722.76 ms |

Launch-to-ready was inconclusive: paired median -98.09 ms, bootstrap 95% CI -1340.57 to +1483.12 ms.

The timing bundle was collected at base `9c2dbf6500f16cafc6c68edbc3144b9acf06fe56` and pre-rebase head `6e3065c4aa94c453e491e437b1fb88f79f483f35`. The required rebase to current `main` preserved both fix commit patch IDs and all four changed-file blobs. The three intervening commits touch Slack policy, Fish Audio release metadata/catalog tests, and Pi UI assets; no affected owner, caller, fixture, dependency, runtime config, package lock, or benchmark path changed. Exact rebased head `d80f9d0ac5045837c71ebe9e27753cea42df0a16` passed an independent source-blind PTY refresh. The table is carried forward under that code-aware non-impact determination and retains its original 9c2/6e collection identity; it is not relabeled as dcf/d80-collected data.

### Checks

- `node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts src/tui/embedded-prepared-runtime.test.ts` — 95/95 passed
- Selected prepared-runtime static/lazy/configless/timeout coverage — 16 passed across 6 shards
- Real local PTY behavior lane — passed
- `pnpm check` — passed
- Autoreview — clean, zero findings, confidence 0.98
- Independent source-aware audit — go
- Independent source-blind exact-head PTY refresh — `satisfies_contract`, confidence 0.99

### Private proof hashes

No proof asset was externally uploaded. Private artifacts are retained outside the repository:

- Historical red MP4 SHA-256: `8d9e14e3d22a55db1974f7998d92f29b31be28841e738bf65031f783b1eb56b9`
- Exact-head green MP4 SHA-256: `2b1d52cda758f4189ab947fc0a1eff85ccd3c8ceba49bc2c9ba6f07c867cd366`
- Exact-head source-blind refresh report SHA-256: `aeb1076c620cfdb6cbbf0f008d6e1bc79e0fb067f09d75bd5b1fd6c42347e945`
- Measured performance report SHA-256: `b37e0df6882bf42e1b8b43edbf6e93b14d4580a77bb73e2bbc0a5bca95a1c796`
- Measured performance raw JSON SHA-256: `ba5c0387d98f9d5f0b259b90f8960eb2068cdcd0178b1b2c32e6600a1eecad33`

### Limits

AWS Crabbox run `run_170c43efe07c` did not allocate a lease during the bounded attempt and was canceled, so the deterministic safe-local fallback was used. This evidence does not establish Ubuntu-specific behavior, live OAuth behavior, production-provider latency, CPU-percent improvement, or RSS improvement, and makes no such claims.
