### PR TITLE
docs(google-vertex): add Google Vertex AI provider setup guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -604,6 +604,10 @@
     "target": "Google Chat"
   },
   {
+    "source": "Google (Vertex AI)",
+    "target": "Google（Vertex AI）"
+  },
+  {
     "source": "Matrix",
     "target": "Matrix"
   },

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -720,6 +720,14 @@
     "target": "Google Chat"
   },
   {
+    "source": "Google (Vertex AI)",
+    "target": "Google（Vertex AI）"
+  },
+  {
+    "source": "google-vertex",
+    "target": "google-vertex"
+  },
+  {
     "source": "Matrix",
     "target": "Matrix"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1534,6 +1534,7 @@
                   "providers/github-copilot",
                   "providers/gmi",
                   "providers/google",
+                  "providers/google-vertex",
                   "providers/gradium",
                   "providers/groq",
                   "providers/huggingface",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2215,6 +2215,7 @@
                       "providers/github-copilot",
                       "providers/gmi",
                       "providers/google",
+                      "providers/google-vertex",
                       "providers/groq",
                       "providers/huggingface",
                       "providers/longcat",

--- a/docs/plugins/reference/google.md
+++ b/docs/plugins/reference/google.md
@@ -25,3 +25,4 @@ Adds Google, Google Gemini CLI, Google Vertex model provider support to OpenClaw
 ## Related docs
 
 - [google](/providers/google)
+- [google-vertex](/providers/google-vertex)

--- a/docs/providers/google-vertex.md
+++ b/docs/providers/google-vertex.md
@@ -53,8 +53,8 @@ project and model, and confirm Gemini responds through Vertex AI.
         gcloud auth application-default login
         ```
 
-        This writes `~/.config/gcloud/application_default_credentials.json`, which
-        OpenClaw detects automatically.
+        Once you complete the authentication flow, gcloud writes the ADC file to
+        disk, which OpenClaw detects automatically.
       </Tab>
 
       <Tab title="Service account key">

--- a/docs/providers/google-vertex.md
+++ b/docs/providers/google-vertex.md
@@ -1,0 +1,231 @@
+---
+summary: "Google Vertex AI setup (ADC auth with gcloud user credentials or a service account key)"
+title: "Google (Vertex AI)"
+read_when:
+  - You want to use Gemini models through Google Cloud Vertex AI
+  - You have a GCP project and want to authenticate with Application Default Credentials
+  - You are running OpenClaw on a GCE VM or GKE
+---
+
+The `google-vertex` provider routes Gemini model requests through Google Cloud
+Vertex AI using Application Default Credentials (ADC). It is part of the bundled
+Google plugin, alongside the `google` (AI Studio) and `google-gemini-cli`
+providers.
+
+- Provider: `google-vertex`
+- Auth: Application Default Credentials from a credentials file (gcloud user ADC or a service account key)
+- Required env vars: `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`
+- Models: Gemini models accessed with the `google-vertex/` prefix
+
+<Note>
+  Vertex AI does not have an onboarding wizard, but you can configure it
+  manually using the steps below. A wizard flow exists only for the separate
+  [Google (Gemini)](/providers/google) provider, which uses the Gemini API
+  rather than Vertex AI.
+</Note>
+
+## Getting started
+
+Vertex AI uses ADC, which needs a credentials **file** on disk plus a project and
+location. Choose the authentication source that matches your environment:
+
+- **gcloud CLI**: uses your own Google account. Simplest to set up.
+- **Service account key**: uses a dedicated service identity. Best for an always-on gateway host.
+
+<Steps>
+  <Step title="Authenticate with ADC">
+    <Tabs>
+      <Tab title="gcloud CLI">
+        Log in with Application Default Credentials:
+
+        ```bash
+        gcloud auth application-default login
+        ```
+
+        This writes `~/.config/gcloud/application_default_credentials.json`, which
+        OpenClaw detects automatically.
+      </Tab>
+
+      <Tab title="Service account key">
+        Create a service account with the **Vertex AI User** role
+        (`roles/aiplatform.user`) and download a JSON key file:
+
+        ```bash
+        gcloud iam service-accounts create openclaw-vertex \
+          --display-name="OpenClaw Vertex AI"
+
+        gcloud projects add-iam-policy-binding your-project-id \
+          --member="serviceAccount:openclaw-vertex@your-project-id.iam.gserviceaccount.com" \
+          --role="roles/aiplatform.user"
+
+        gcloud iam service-accounts keys create ~/openclaw-vertex-key.json \
+          --iam-account="openclaw-vertex@your-project-id.iam.gserviceaccount.com"
+        ```
+
+        You will set `GOOGLE_APPLICATION_CREDENTIALS` in `~/.openclaw/.env` below.
+      </Tab>
+    </Tabs>
+
+  </Step>
+  <Step title="Enable the Vertex AI API">
+    ```bash
+    gcloud services enable aiplatform.googleapis.com
+    ```
+  </Step>
+  <Step title="Set your default model">
+    Set your agent's default model in `openclaw.json`:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          model: { primary: "google-vertex/gemini-3.5-flash" },
+        },
+      },
+    }
+    ```
+
+  </Step>
+  <Step title="Set your environment variables">
+    Set the required environment variables in `~/.openclaw/.env`:
+
+    ```bash
+    GOOGLE_CLOUD_PROJECT=your-project-id
+    GOOGLE_CLOUD_LOCATION=global
+
+    # If using a service account: uncomment and set the absolute key path
+    # GOOGLE_APPLICATION_CREDENTIALS=/home/username/openclaw-vertex-key.json
+    ```
+
+  </Step>
+  <Step title="Verify authentication">
+    Confirm OpenClaw resolves your Vertex AI credentials:
+
+    ```bash
+    openclaw models status
+    ```
+
+    If everything is configured correctly, `google-vertex` shows as the default
+    with resolved credentials (`source=gcloud adc`).
+
+    If the credentials file is missing or the project or location is unset, it is
+    flagged under Model route issues as `[indeterminate]` ("auth readiness could
+    not be confirmed").
+
+  </Step>
+  <Step title="Provision the gateway">
+    Running the agent requires a configured gateway. If you have not run
+    `openclaw onboard` on this host, run it once to provision gateway auth.
+    Passing `--auth-choice skip` sets up the gateway without changing your Vertex
+    AI config:
+
+    ```bash
+    openclaw onboard --auth-choice skip
+    ```
+
+    Onboarding ends by opening your agent (in the terminal, or the Control UI in a
+    browser). Send it a message to confirm Vertex AI responds end to end.
+
+  </Step>
+  <Step title="Use your agent">
+    Chat with your agent anytime from the terminal:
+
+    ```bash
+    openclaw tui
+    ```
+
+    You can also use the Control UI in a browser or any connected messaging
+    channel.
+
+  </Step>
+</Steps>
+
+## Configuration
+
+Set your default model in `openclaw.json` and your environment variables in
+`~/.openclaw/.env`. The Google plugin ships a bundled Vertex AI model catalog, so
+you do not need to declare `models.providers`, and you do not set an API key for
+the ADC path.
+
+<Note>
+  The managed gateway reads `~/.openclaw/.env`, not shell exports. Restart the
+  gateway after changing environment variables.
+</Note>
+
+## Environment variables
+
+| Variable                         | Required    | Description                                                                                                       |
+| :------------------------------- | :---------- | :---------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_CLOUD_PROJECT`           | Yes         | GCP project ID. `GCLOUD_PROJECT` is also accepted.                                                                |
+| `GOOGLE_CLOUD_LOCATION`          | Yes         | Vertex AI endpoint location: `global`, a multi-region (`us`, `eu`), or a region such as `us-central1`.            |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Conditional | Absolute path to a service-account key. Not needed for gcloud user ADC.                                           |
+| `GOOGLE_CLOUD_QUOTA_PROJECT`     | No          | Billing/quota project sent as the `x-goog-user-project` header. Takes precedence over the ADC `quota_project_id`. |
+| `CLOUDSDK_CONFIG`                | No          | Cloud SDK config directory. When set, it is the exclusive ADC directory override.                                 |
+| `GOOGLE_CLOUD_API_KEY`           | No          | Vertex AI Express API key, used as an alternative to ADC.                                                         |
+
+## Available models
+
+Use the `google-vertex/` prefix with any bundled Vertex AI model:
+
+| Model                  | ID                                     |
+| :--------------------- | :------------------------------------- |
+| Gemini 3.6 Flash       | `google-vertex/gemini-3.6-flash`       |
+| Gemini 3.5 Flash       | `google-vertex/gemini-3.5-flash`       |
+| Gemini 3.5 Flash-Lite  | `google-vertex/gemini-3.5-flash-lite`  |
+| Gemini 3.1 Pro Preview | `google-vertex/gemini-3.1-pro-preview` |
+| Gemini 3.1 Flash Lite  | `google-vertex/gemini-3.1-flash-lite`  |
+| Gemini 3 Flash Preview | `google-vertex/gemini-3-flash-preview` |
+| Gemini 2.5 Pro         | `google-vertex/gemini-2.5-pro`         |
+| Gemini 2.5 Flash       | `google-vertex/gemini-2.5-flash`       |
+| Gemini 2.5 Flash-Lite  | `google-vertex/gemini-2.5-flash-lite`  |
+
+Run `openclaw models list --provider google-vertex` to see the bundled catalog.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="No API key found for provider google-vertex">
+    OpenClaw could not resolve Vertex AI credentials. Confirm all three are present:
+
+    1. A credentials file exists (`gcloud auth application-default login` was run,
+       or `GOOGLE_APPLICATION_CREDENTIALS` points to a valid JSON key file).
+    2. `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) is set.
+    3. `GOOGLE_CLOUD_LOCATION` is set.
+
+    On GCE or GKE using only the metadata server, no credentials file exists, so
+    this error is expected until you create one with `gcloud auth
+    application-default login` or a service account key.
+
+  </Accordion>
+
+  <Accordion title="Vertex AI requires a location">
+    `GOOGLE_CLOUD_LOCATION` is not set. Add it to `~/.openclaw/.env` and restart
+    the gateway.
+
+  </Accordion>
+
+  <Accordion title="403 or PERMISSION_DENIED">
+    The service account or user lacks the required IAM role. Grant the **Vertex AI
+    User** role (`roles/aiplatform.user`) to the account making requests. On GCE,
+    also verify the VM has the **Cloud Platform** access scope.
+
+  </Accordion>
+
+  <Accordion title="404 or Model not found">
+    Some model aliases are only available on the `global` endpoint. If you set a
+    specific region and hit a 404, set `GOOGLE_CLOUD_LOCATION=global` in
+    `~/.openclaw/.env`.
+
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Google (Gemini)" href="/providers/google" icon="google">
+    Gemini models via an API key from Google AI Studio.
+  </Card>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layer-group">
+    Provider configuration reference.
+  </Card>
+</CardGroup>

--- a/docs/providers/google-vertex.md
+++ b/docs/providers/google-vertex.md
@@ -27,10 +27,8 @@ providers.
 ## Getting started
 
 Vertex AI uses ADC, which needs a credentials **file** on disk plus a project and
-location. Choose the authentication source that matches your environment:
-
-- **gcloud CLI**: uses your own Google account. Simplest to set up.
-- **Service account key**: uses a dedicated service identity. Best for an always-on gateway host.
+location. Follow the steps below to authenticate with Google Cloud, configure your
+project and model, and confirm Gemini responds through Vertex AI.
 
 <Steps>
   <Step title="Select your Google Cloud project">
@@ -43,6 +41,10 @@ location. Choose the authentication source that matches your environment:
 
   </Step>
   <Step title="Authenticate with ADC">
+    Choose the authentication source for your environment: **gcloud CLI** (your own
+    Google account, simplest to set up) or a **service account key** (a dedicated
+    identity, best for an always-on gateway host).
+
     <Tabs>
       <Tab title="gcloud CLI">
         Log in with Application Default Credentials:

--- a/docs/providers/google-vertex.md
+++ b/docs/providers/google-vertex.md
@@ -33,6 +33,15 @@ location. Choose the authentication source that matches your environment:
 - **Service account key**: uses a dedicated service identity. Best for an always-on gateway host.
 
 <Steps>
+  <Step title="Select your Google Cloud project">
+    Set your active project so the commands below create resources in the
+    correct project. Use this same project ID for `GOOGLE_CLOUD_PROJECT` later.
+
+    ```bash
+    gcloud config set project your-project-id
+    ```
+
+  </Step>
   <Step title="Authenticate with ADC">
     <Tabs>
       <Tab title="gcloud CLI">

--- a/docs/providers/google-vertex.md
+++ b/docs/providers/google-vertex.md
@@ -1,0 +1,245 @@
+---
+summary: "Google Vertex AI setup (ADC auth with gcloud user credentials or a service account key)"
+title: "Google (Vertex AI)"
+read_when:
+  - You want to use Gemini models through Google Cloud Vertex AI
+  - You have a GCP project and want to authenticate with Application Default Credentials
+  - You are running OpenClaw on a GCE VM or GKE
+---
+
+The `google-vertex` provider routes Gemini model requests through Google Cloud
+Vertex AI. It is part of the bundled Google plugin, alongside the `google`
+(AI Studio) and `google-gemini-cli` providers. This guide covers the
+Application Default Credentials (ADC) setup path.
+
+- Provider: `google-vertex`
+- Auth: Application Default Credentials from a credentials file (gcloud user ADC or a service account key)
+- Required env vars: `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`
+- Models: Gemini models accessed with the `google-vertex/` prefix
+
+<Note>
+  Vertex AI does not have an onboarding wizard, but you can configure it
+  manually using the steps below. A wizard flow exists only for the separate
+  [Google (Gemini)](/providers/google) provider, which uses the Gemini API
+  rather than Vertex AI.
+</Note>
+
+## Getting started
+
+Vertex AI uses ADC, which needs a credentials **file** on disk plus a project and
+location. Follow the steps below to authenticate with Google Cloud, configure your
+project and model, and confirm Gemini responds through Vertex AI.
+
+<Steps>
+  <Step title="Select your Google Cloud project">
+    Set your active project so the commands below create resources in the
+    correct project. Use this same project ID for `GOOGLE_CLOUD_PROJECT` later.
+
+    ```bash
+    gcloud config set project your-project-id
+    ```
+
+  </Step>
+  <Step title="Authenticate with ADC">
+    Choose the authentication source for your environment: **gcloud CLI** (your own
+    Google account, simplest to set up) or a **service account key** (a dedicated
+    identity, best for an always-on gateway host).
+
+    <Tabs>
+      <Tab title="gcloud CLI">
+        Log in with Application Default Credentials:
+
+        ```bash
+        gcloud auth application-default login
+        ```
+
+        Once you complete the authentication flow, gcloud writes the ADC file to
+        disk, which OpenClaw detects automatically.
+      </Tab>
+
+      <Tab title="Service account key">
+        Create a service account with the **Vertex AI User** role
+        (`roles/aiplatform.user`) and download a JSON key file:
+
+        ```bash
+        gcloud iam service-accounts create openclaw-vertex \
+          --display-name="OpenClaw Vertex AI"
+
+        gcloud projects add-iam-policy-binding your-project-id \
+          --member="serviceAccount:openclaw-vertex@your-project-id.iam.gserviceaccount.com" \
+          --role="roles/aiplatform.user"
+
+        gcloud iam service-accounts keys create /path/to/openclaw-vertex-key.json \
+          --iam-account="openclaw-vertex@your-project-id.iam.gserviceaccount.com"
+        ```
+
+        You will set `GOOGLE_APPLICATION_CREDENTIALS` in `~/.openclaw/.env` below.
+      </Tab>
+    </Tabs>
+
+  </Step>
+  <Step title="Enable the Vertex AI API">
+    ```bash
+    gcloud services enable aiplatform.googleapis.com
+    ```
+  </Step>
+  <Step title="Set your default model">
+    Set your agent's default model in `openclaw.json`:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          model: { primary: "google-vertex/gemini-3.5-flash" },
+        },
+      },
+    }
+    ```
+
+  </Step>
+  <Step title="Set your environment variables">
+    Set the required environment variables in `~/.openclaw/.env`:
+
+    ```bash
+    GOOGLE_CLOUD_PROJECT=your-project-id
+    GOOGLE_CLOUD_LOCATION=global
+
+    # If using a service account: uncomment and set the absolute key path
+    # GOOGLE_APPLICATION_CREDENTIALS=/path/to/openclaw-vertex-key.json
+    ```
+
+  </Step>
+  <Step title="Verify authentication">
+    Confirm OpenClaw resolves your Vertex AI credentials:
+
+    ```bash
+    openclaw models status
+    ```
+
+    If everything is configured correctly, `google-vertex` shows as the default
+    with resolved credentials (`source=gcloud adc`).
+
+    If the credentials file is missing or the project or location is unset, it is
+    flagged under Model route issues as `[indeterminate]` ("auth readiness could
+    not be confirmed").
+
+  </Step>
+  <Step title="Provision the gateway">
+    Running the agent requires a configured gateway. If you have not run
+    `openclaw onboard` on this host, run it once to provision gateway auth.
+    Passing `--auth-choice skip` sets up the gateway without changing your Vertex
+    AI config:
+
+    ```bash
+    openclaw onboard --auth-choice skip
+    ```
+
+    Onboarding ends by opening your agent (in the terminal, or the Control UI in a
+    browser). Send it a message to confirm Vertex AI responds end to end.
+
+  </Step>
+  <Step title="Use your agent">
+    Chat with your agent anytime from the terminal:
+
+    ```bash
+    openclaw tui
+    ```
+
+    You can also use the Control UI in a browser or any connected messaging
+    channel.
+
+  </Step>
+</Steps>
+
+## Configuration
+
+Set your default model in `openclaw.json` and your environment variables in
+`~/.openclaw/.env`. The Google plugin ships a bundled Vertex AI model catalog, so
+you do not need to declare `models.providers`, and you do not set an API key for
+the ADC path.
+
+<Note>
+  Variables exported only in an interactive shell are not visible to a
+  launchd/systemd Gateway daemon unless that environment is explicitly
+  imported. Set them in the service environment, `~/.openclaw/.env`, or via
+  `env.shellEnv`, in that order of precedence, then restart the gateway. See
+  [Environment variables](/help/environment) for the full precedence order.
+</Note>
+
+## Environment variables
+
+| Variable                         | Required    | Description                                                                                                       |
+| :------------------------------- | :---------- | :---------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_CLOUD_PROJECT`           | Yes         | GCP project ID. `GCLOUD_PROJECT` is also accepted.                                                                |
+| `GOOGLE_CLOUD_LOCATION`          | Yes         | Vertex AI endpoint location: `global`, a multi-region (`us`, `eu`), or a region such as `us-central1`.            |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Conditional | Absolute path to a service-account key. Not needed for gcloud user ADC.                                           |
+| `GOOGLE_CLOUD_QUOTA_PROJECT`     | No          | Billing/quota project sent as the `x-goog-user-project` header. Takes precedence over the ADC `quota_project_id`. |
+| `CLOUDSDK_CONFIG`                | No          | Cloud SDK config directory. When set, it is the exclusive ADC directory override.                                 |
+
+## Available models
+
+Use the `google-vertex/` prefix when selecting a model:
+
+| Model                  | ID                                     |
+| :--------------------- | :------------------------------------- |
+| Gemini 3.7 Flash       | `google-vertex/gemini-3.7-flash`       |
+| Gemini 3.6 Flash       | `google-vertex/gemini-3.6-flash`       |
+| Gemini 3.5 Flash       | `google-vertex/gemini-3.5-flash`       |
+| Gemini 3.5 Flash-Lite  | `google-vertex/gemini-3.5-flash-lite`  |
+| Gemini 3.1 Pro Preview | `google-vertex/gemini-3.1-pro-preview` |
+| Gemini 3.1 Flash Lite  | `google-vertex/gemini-3.1-flash-lite`  |
+| Gemini 3 Flash Preview | `google-vertex/gemini-3-flash-preview` |
+| Gemini 2.5 Pro         | `google-vertex/gemini-2.5-pro`         |
+| Gemini 2.5 Flash       | `google-vertex/gemini-2.5-flash`       |
+| Gemini 2.5 Flash-Lite  | `google-vertex/gemini-2.5-flash-lite`  |
+
+Run `openclaw models list --provider google-vertex` to see the bundled catalog.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="No API key found for provider google-vertex">
+    OpenClaw could not resolve Vertex AI credentials. Confirm all three are present:
+
+    1. A credentials file exists (`gcloud auth application-default login` was run,
+       or `GOOGLE_APPLICATION_CREDENTIALS` points to a valid JSON key file).
+    2. `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) is set.
+    3. `GOOGLE_CLOUD_LOCATION` is set.
+
+    On GCE or GKE using only the metadata server, no credentials file exists, so
+    this error is expected until you create one with `gcloud auth
+    application-default login` or a service account key.
+
+  </Accordion>
+
+  <Accordion title="Vertex AI requires a location">
+    `GOOGLE_CLOUD_LOCATION` is not set. Add it to `~/.openclaw/.env` and restart
+    the gateway.
+
+  </Accordion>
+
+  <Accordion title="403 or PERMISSION_DENIED">
+    The service account or user lacks the required IAM role. Grant the **Vertex AI
+    User** role (`roles/aiplatform.user`) to the account making requests. On GCE,
+    also verify the VM has the **Cloud Platform** access scope.
+
+  </Accordion>
+
+  <Accordion title="404 or Model not found">
+    Some model aliases are only available on the `global` endpoint. If you set a
+    specific region and hit a 404, set `GOOGLE_CLOUD_LOCATION=global` in
+    `~/.openclaw/.env`.
+
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Google (Gemini)" href="/providers/google" icon="google">
+    Gemini models via an API key from Google AI Studio.
+  </Card>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layer-group">
+    Provider configuration reference.
+  </Card>
+</CardGroup>

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -14,6 +14,11 @@ The Google plugin provides access to Gemini models through Google AI Studio, plu
 - Managed-cloud provider: `google-vertex` with Google Cloud Application Default Credentials
 - Optional runtime: `agentRuntime.id: "google-gemini-cli"` runs an explicitly configured model through the local Gemini CLI
 
+<Note>
+  To use Gemini models through Google Cloud Vertex AI with GCP project billing,
+  see the [Google Vertex AI](/providers/google-vertex) provider instead.
+</Note>
+
 ## Getting started
 
 For most installations, use a Google AI Studio API key. Use `google-vertex` when
@@ -502,5 +507,8 @@ roundtrip; pass `--openai-audio-cycles 3` for a short repeated lifecycle soak.
   </Card>
   <Card title="Music generation" href="/tools/music-generation" icon="music">
     Shared music tool parameters and provider selection.
+  </Card>
+  <Card title="Google (Vertex AI)" href="/providers/google-vertex" icon="cloud">
+    Gemini models via GCP project billing and ADC.
   </Card>
 </CardGroup>

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -14,6 +14,12 @@ The Google plugin provides access to Gemini models through Google AI Studio, plu
 - Managed-cloud provider: `google-vertex` with Google Cloud Application Default Credentials
 - Optional runtime: `agentRuntime.id: "google-gemini-cli"` runs an explicitly configured model through the local Gemini CLI
 
+<Note>
+  To use Gemini models through Google Cloud Vertex AI with GCP project billing,
+  see the [Google Vertex AI](/providers/google-vertex) guide, which covers the
+  ADC setup path.
+</Note>
+
 ## Getting started
 
 For most installations, use a Google AI Studio API key. Use `google-vertex` when
@@ -515,5 +521,8 @@ roundtrip; pass `--openai-audio-cycles 3` for a short repeated lifecycle soak.
   </Card>
   <Card title="Voice call plugin" href="/plugins/voice-call" icon="phone">
     Audio bridge that consumes the Gemini Live realtime voice provider.
+  </Card>
+  <Card title="Google (Vertex AI)" href="/providers/google-vertex" icon="cloud">
+    Gemini models via GCP project billing and ADC.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Related PRs: #118745, #87800, #83971

Related issues: #56253, #85864, #79595, #79837, #11413, #49191, #50053, #52476, #48910, #77643, #55572, #53566, #9729

## What Problem This Solves

OpenClaw has no documentation for the `google-vertex` provider. Users who want to run Gemini models through Google Cloud Vertex AI have no setup path to follow: the provider has no onboarding wizard entry, and the only mention was a couple of lines on the Google (Gemini) page. Anyone on Google Cloud hit trial-and-error to get authentication, environment variables, model selection, and the gateway working together.

## Why This Change Was Made

Vertex AI is a distinct provider in the bundled Google plugin that authenticates via Application Default Credentials, but it is setup-only (no wizard), so it needs a clear manual path. This adds a dedicated provider guide documenting the real, working flow on current `main`: authenticate with ADC (gcloud user credentials or a service-account key), set the model in `openclaw.json` and environment variables in `~/.openclaw/.env`, verify, provision the gateway, and use the agent. Every step was validated against live behavior rather than assumptions.

This PR documents the Vertex AI ADC behavior shipped in #118745, and ships the documentation portion of the earlier, broader #87800.

## User Impact

Users can now follow a single, accurate page to get Gemini models running through Vertex AI end to end. The guide covers both auth sources (gcloud ADC with auto-detected credentials, and service-account keys), where each environment variable must live (notably that `GOOGLE_APPLICATION_CREDENTIALS` must go in `~/.openclaw/.env`, not `openclaw.json`), the bundled model catalog, verification via `openclaw models status`, and troubleshooting. The Google (Gemini) page now cross-links to it, and it appears in the providers sidebar as "Google (Vertex AI)".

## Evidence

Verified end to end on a GCE VM against `main`:

- **gcloud ADC path:** `gcloud config set project` + `gcloud auth application-default login` + project/location in `~/.openclaw/.env` → `openclaw models status` shows `google-vertex ... source=gcloud adc` → `openclaw tui` responds via Vertex AI.
- **Service-account path:** key created via `gcloud iam service-accounts keys create`, `GOOGLE_APPLICATION_CREDENTIALS` set in `~/.openclaw/.env` → resolves and responds.
- **Detection is real:** `gcloud auth application-default revoke` flips `models status` to `[indeterminate]` ("auth readiness could not be confirmed").
- **Docs checks:** `pnpm check:docs` passes (format, markdownlint, MDX, i18n-glossary, link audit — 0 issues).

---

**Rendered provider page: `/providers/google-vertex`**

<img width="1477" height="1152" alt="openclaw vertex ai docs" src="https://github.com/user-attachments/assets/47c45e6b-68e7-40f2-ae20-59b3da166dc0" />

---

**Bundled model catalog: `openclaw models list --provider google-vertex`**

<img width="1025" height="312" alt="openclaw models list" src="https://github.com/user-attachments/assets/29b0a241-4383-49c8-b9bf-465accc7764e" />

---

**gcloud ADC configured: `openclaw models status` resolves (`source=gcloud adc`)**

<img width="949" height="438" alt="openclaw models status adc" src="https://github.com/user-attachments/assets/bd4f0761-8a87-4fc0-90c3-35e7a6ce7958" />

---

**Service-account key configured: `openclaw models status` resolves the same way**

<img width="941" height="439" alt="openclaw models status service account" src="https://github.com/user-attachments/assets/1b7ffb64-2042-4087-b8a9-bfad83f00c76" />

---

**Gateway provisioned without changing Vertex AI config: `openclaw onboard --auth-choice skip`**

<img width="965" height="312" alt="openclaw onboard" src="https://github.com/user-attachments/assets/a1d6868e-5b4e-4ed6-b54c-0051e03f7e57" />

---

**Agent responds end to end via Vertex AI**

<img width="811" height="315" alt="openclaw onboard tui" src="https://github.com/user-attachments/assets/ca984e5a-4761-4641-a07c-3fdf66652f24" />

## Metadata-server ADC: tested, not currently supported end to end

ClawSweeper flagged that the guide omits metadata-server / Workload Identity ADC. I tested this end to end on a GCE VM, and it does **not** currently work through the full agent request path, so the guide intentionally stays file-based.

**Repro (GCE VM):**
- Attached service account with Editor + the `cloud-platform` scope; `aiplatform.googleapis.com` enabled.
- No credential file (`gcloud auth application-default revoke`; `GOOGLE_APPLICATION_CREDENTIALS` unset).
- `~/.openclaw/.env` sets only `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`.
- `model.primary = google-vertex/gemini-3.5-flash`; gateway restarted (confirmed healthy and listening on 18789).

**Result:** `openclaw models status` shows `[indeterminate]` (expected), and sending a message in the TUI fails before any request reaches Vertex:

```
No API key found for provider "google-vertex". ... | missing-provider-auth
```

**Root cause:** the credential is resolved synchronously by `resolveGoogleVertexConfigApiKey` -> `hasGoogleVertexAuthorizedUserAdcSync` (`extensions/google/vertex-adc.ts`), which requires a credentials file. With metadata-only identity there is no file, so it returns undefined and the request is rejected with `missing-provider-auth` before the transport runs. The `google-auth-library` metadata fallback in the transport is real but is never reached on this path. The no-file metadata regression test drives the transport directly with a mocked `GoogleAuth`, so it passes without going through the auth gate and does not cover the end-to-end agent path.

**Conclusion:** this guide documents the file-based paths (gcloud user ADC, service-account key), which work today. Making attached-SA / Workload Identity usable without a file requires a runtime change to the auth gate (ambient env-marker evidence, as originally prototyped in #87800). We can track this as follow-up after the documentation in this PR is in place rather than documenting a path that currently returns `missing-provider-auth`.

## Vertex AI Express API key: intentionally out of scope

Review cycles have asked both to document and to remove `GOOGLE_CLOUD_API_KEY` on this page. It is deliberately not covered, because the transport cannot perform an express-mode request. `buildGoogleVertexRequestUrl` (`extensions/google/transport-stream.ts:434-446`) always emits a project- and location-scoped path and throws when either value is unset, while Vertex AI in express mode requires the global `aiplatform.googleapis.com` endpoint with no `projects` or `locations` segment. `model.baseUrl` overrides only the origin, so no config reaches that shape.

The route also has no test coverage for `google-vertex` (every Vertex transport test uses the ADC marker `gcp-vertex-credentials`) and was never verified live. Per the P1 note in the review, adding endpoint-specific operator instructions without that proof would be wrong, so the guide stays scoped to ADC, as its summary, intro, and auth bullet already state.