### PR TITLE
test(qa): define Gateway-node platform topologies

### DIFF
--- a/qa/contracts/gateway-node-platform-topologies.json
+++ b/qa/contracts/gateway-node-platform-topologies.json
@@ -1,0 +1,150 @@
+{
+  "kind": "openclaw.gateway-node-platform-topology-inventory",
+  "platforms": [
+    {
+      "platform": "macos",
+      "topology": {
+        "kind": "direct-ws",
+        "gatewayNegotiator": "macos",
+        "edges": [
+          {
+            "from": "macos",
+            "to": "gateway",
+            "transport": "websocket"
+          }
+        ]
+      },
+      "implementationOwners": [
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift"
+        },
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift"
+        }
+      ]
+    },
+    {
+      "platform": "ios",
+      "topology": {
+        "kind": "direct-ws",
+        "gatewayNegotiator": "ios",
+        "edges": [
+          {
+            "from": "ios",
+            "to": "gateway",
+            "transport": "websocket"
+          }
+        ]
+      },
+      "implementationOwners": [
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/ios/Sources/Model/NodeAppModel.swift"
+        },
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift"
+        }
+      ]
+    },
+    {
+      "platform": "watchos",
+      "topology": {
+        "kind": "watch-http",
+        "gatewayNegotiator": "watchos",
+        "edges": [
+          {
+            "from": "watchos",
+            "to": "gateway",
+            "transport": "bounded-https-challenge-connect-poll"
+          }
+        ]
+      },
+      "implementationOwners": [
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift"
+        },
+        {
+          "repository": "openclaw/openclaw",
+          "path": "src/gateway/watch-node-http.ts"
+        }
+      ]
+    },
+    {
+      "platform": "android",
+      "topology": {
+        "kind": "direct-ws",
+        "gatewayNegotiator": "android",
+        "edges": [
+          {
+            "from": "android",
+            "to": "gateway",
+            "transport": "websocket"
+          }
+        ]
+      },
+      "implementationOwners": [
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt"
+        }
+      ]
+    },
+    {
+      "platform": "wearos",
+      "topology": {
+        "kind": "wear-two-hop",
+        "gatewayNegotiator": "android-phone",
+        "edges": [
+          {
+            "from": "wearos",
+            "to": "android-phone",
+            "transport": "wear-message-api-data-layer"
+          },
+          {
+            "from": "android-phone",
+            "to": "gateway",
+            "transport": "websocket"
+          }
+        ]
+      },
+      "implementationOwners": [
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt"
+        },
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyBridge.kt"
+        },
+        {
+          "repository": "openclaw/openclaw",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt"
+        }
+      ]
+    },
+    {
+      "platform": "windows",
+      "topology": {
+        "kind": "direct-ws",
+        "gatewayNegotiator": "windows",
+        "edges": [
+          {
+            "from": "windows",
+            "to": "gateway",
+            "transport": "websocket"
+          }
+        ]
+      },
+      "implementationOwners": [
+        {
+          "repository": "openclaw/openclaw-windows-node",
+          "path": null
+        }
+      ]
+    }
+  ]
+}

--- a/qa/contracts/gateway-node-platform-topologies.json
+++ b/qa/contracts/gateway-node-platform-topologies.json
@@ -1,5 +1,8 @@
 {
-  "kind": "openclaw.gateway-node-platform-topology-inventory",
+  "kind": "openclaw.gateway-node-platform-topology-reference",
+  "scope": "advisory-source-topology",
+  "releaseEvidence": "none",
+  "consumers": [],
   "platforms": [
     {
       "platform": "macos",
@@ -14,14 +17,38 @@
           }
         ]
       },
-      "implementationOwners": [
+      "sourceAnchors": [
         {
+          "platform": "macos",
           "repository": "openclaw/openclaw",
-          "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift"
+          "verification": "tracked-source-markers",
+          "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift",
+          "symbols": [
+            "MacNodeModeCoordinator",
+            "GatewayNodeSession",
+            "self.session.connect("
+          ]
         },
         {
+          "platform": "macos",
           "repository": "openclaw/openclaw",
-          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift"
+          "verification": "tracked-source-markers",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift",
+          "symbols": [
+            "GatewayNodeSession",
+            "GatewayChannelActor(",
+            "try await channel.connect()"
+          ]
+        },
+        {
+          "platform": "macos",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
+          "symbols": [
+            "makeWebSocketTask",
+            "sendConnect("
+          ]
         }
       ]
     },
@@ -38,14 +65,38 @@
           }
         ]
       },
-      "implementationOwners": [
+      "sourceAnchors": [
         {
+          "platform": "ios",
           "repository": "openclaw/openclaw",
-          "path": "apps/ios/Sources/Model/NodeAppModel.swift"
+          "verification": "tracked-source-markers",
+          "path": "apps/ios/Sources/Model/NodeAppModel.swift",
+          "symbols": [
+            "NodeAppModel",
+            "GatewayNodeSession",
+            "self.nodeGateway.connect("
+          ]
         },
         {
+          "platform": "ios",
           "repository": "openclaw/openclaw",
-          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift"
+          "verification": "tracked-source-markers",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift",
+          "symbols": [
+            "GatewayNodeSession",
+            "GatewayChannelActor(",
+            "try await channel.connect()"
+          ]
+        },
+        {
+          "platform": "ios",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
+          "symbols": [
+            "makeWebSocketTask",
+            "sendConnect("
+          ]
         }
       ]
     },
@@ -62,14 +113,30 @@
           }
         ]
       },
-      "implementationOwners": [
+      "sourceAnchors": [
         {
+          "platform": "watchos",
           "repository": "openclaw/openclaw",
-          "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift"
+          "verification": "tracked-source-markers",
+          "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
+          "symbols": [
+            "WatchDirectNode",
+            "path: \"challenge\"",
+            "path: \"connect\"",
+            "path: \"poll\""
+          ]
         },
         {
+          "platform": "watchos",
           "repository": "openclaw/openclaw",
-          "path": "src/gateway/watch-node-http.ts"
+          "verification": "tracked-source-markers",
+          "path": "src/gateway/watch-node-http.ts",
+          "symbols": [
+            "createWatchNodeHttpRuntime",
+            "CHALLENGE_PATH",
+            "CONNECT_PATH",
+            "POLL_PATH"
+          ]
         }
       ]
     },
@@ -86,10 +153,17 @@
           }
         ]
       },
-      "implementationOwners": [
+      "sourceAnchors": [
         {
+          "platform": "android",
           "repository": "openclaw/openclaw",
-          "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt"
+          "verification": "tracked-source-markers",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
+          "symbols": [
+            "GatewaySession",
+            "client.newWebSocket(",
+            "sendConnect("
+          ]
         }
       ]
     },
@@ -105,24 +179,110 @@
             "transport": "wear-message-api-data-layer"
           },
           {
+            "from": "wearos",
+            "to": "android-phone",
+            "transport": "wear-channel-api-data-layer"
+          },
+          {
             "from": "android-phone",
             "to": "gateway",
             "transport": "websocket"
           }
         ]
       },
-      "implementationOwners": [
+      "sourceAnchors": [
         {
+          "platform": "wearos",
           "repository": "openclaw/openclaw",
-          "path": "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt"
+          "verification": "tracked-source-markers",
+          "path": "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt",
+          "symbols": [
+            "WearProxyClient",
+            "Wearable.getMessageClient",
+            "messageClient.sendMessage("
+          ]
         },
         {
+          "platform": "wearos",
           "repository": "openclaw/openclaw",
-          "path": "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyBridge.kt"
+          "verification": "tracked-source-markers",
+          "path": "apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt",
+          "symbols": [
+            "WearRealtimeTalkClient",
+            "Wearable.getChannelClient(",
+            ".openChannel("
+          ]
         },
         {
+          "platform": "wearos",
           "repository": "openclaw/openclaw",
-          "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt"
+          "verification": "tracked-source-markers",
+          "path": "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyListenerService.kt",
+          "symbols": [
+            "WearProxyListenerService",
+            "WearableListenerService",
+            "WearProtocol.RESPONSE_PATH",
+            "app.proxyClient.handleMessage("
+          ]
+        },
+        {
+          "platform": "wearos",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "apps/android/wear/src/main/AndroidManifest.xml",
+          "symbols": [
+            ".WearProxyListenerService",
+            "com.google.android.gms.wearable.MESSAGE_RECEIVED",
+            "com.google.android.gms.wearable.CAPABILITY_CHANGED"
+          ]
+        },
+        {
+          "platform": "wearos",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyBridge.kt",
+          "symbols": [
+            "WearProxyBridge",
+            "Wearable.getMessageClient",
+            "messageClient.sendMessage("
+          ]
+        },
+        {
+          "platform": "wearos",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyListenerService.kt",
+          "symbols": [
+            "WearProxyListenerService",
+            "WearableListenerService",
+            "WearProtocol.REQUEST_PATH",
+            "app.wearProxyBridge.handleMessage(",
+            "onChannelOpened(",
+            "app.wearRealtimeChannels.accept("
+          ]
+        },
+        {
+          "platform": "wearos",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "apps/android/app/src/main/AndroidManifest.xml",
+          "symbols": [
+            ".wear.WearProxyListenerService",
+            "com.google.android.gms.wearable.MESSAGE_RECEIVED",
+            "android:pathPrefix=\"/openclaw/wear/v1/request\"",
+            "com.google.android.gms.wearable.CHANNEL_EVENT",
+            "android:pathPrefix=\"/openclaw/wear/v1/realtime/audio/\""
+          ]
+        },
+        {
+          "platform": "wearos",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
+          "symbols": [
+            "GatewaySession",
+            "client.newWebSocket("
+          ]
         }
       ]
     },
@@ -139,10 +299,59 @@
           }
         ]
       },
-      "implementationOwners": [
+      "sourceAnchors": [
         {
+          "platform": "windows",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "src/node-host/runner.ts",
+          "symbols": [
+            "case \"win32\":",
+            "return \"windows\"",
+            "new GatewayClient({",
+            "role: \"node\""
+          ]
+        },
+        {
+          "platform": "windows",
           "repository": "openclaw/openclaw-windows-node",
-          "path": null
+          "verification": "unverified-external-reference",
+          "path": "src/OpenClaw.Shared/WebSocketClientBase.cs",
+          "revision": "9f9a8eda6340c7ec6f0acbc410de4f6b7d24a3ce",
+          "symbols": [
+            "WebSocketClientBase",
+            "ClientWebSocket",
+            "ConnectAsync("
+          ]
+        }
+      ]
+    },
+    {
+      "platform": "linux",
+      "topology": {
+        "kind": "direct-ws",
+        "gatewayNegotiator": "linux",
+        "edges": [
+          {
+            "from": "linux",
+            "to": "gateway",
+            "transport": "websocket"
+          }
+        ]
+      },
+      "sourceAnchors": [
+        {
+          "platform": "linux",
+          "repository": "openclaw/openclaw",
+          "verification": "tracked-source-markers",
+          "path": "src/node-host/runner.ts",
+          "symbols": [
+            "case \"linux\":",
+            "return \"linux\"",
+            "new GatewayClient({",
+            "role: \"node\"",
+            "startGatewayClientWhenEventLoopReady(client)"
+          ]
         }
       ]
     }

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -48,6 +48,10 @@ const IOS_BUILD_RE =
 const ANDROID_NATIVE_RE = /^(apps\/android\/|apps\/shared\/)/;
 const NODE_SCOPE_RE =
   /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
+// Native and QA owners need explicit Node activation; src owners such as
+// node-host/runner.ts already enter through NODE_SCOPE_RE.
+const GATEWAY_NODE_PLATFORM_TOPOLOGY_SOURCE_RE =
+  /^(?:qa\/contracts\/gateway-node-platform-topologies\.json|apps\/macos\/Sources\/OpenClaw\/NodeMode\/MacNodeModeCoordinator\.swift|apps\/shared\/OpenClawKit\/Sources\/OpenClawKit\/Gateway(?:Channel|NodeSession)\.swift|apps\/ios\/Sources\/Model\/NodeAppModel\.swift|apps\/ios\/WatchApp\/Sources\/WatchDirectNode\.swift|src\/gateway\/watch-node-http\.ts|apps\/android\/app\/src\/main\/(?:AndroidManifest\.xml|java\/ai\/openclaw\/app\/gateway\/GatewaySession\.kt|java\/ai\/openclaw\/app\/wear\/WearProxy(?:Bridge|ListenerService)\.kt)|apps\/android\/wear\/src\/main\/(?:AndroidManifest\.xml|java\/ai\/openclaw\/wear\/(?:WearProxy(?:Client|ListenerService)|WearRealtimeTalkClient)\.kt))$/;
 const WINDOWS_SQLITE_SCOPE_RE = /^src\/(?:state\/|.*sqlite.*\.ts$)/;
 const WINDOWS_SCOPE_RE =
   /^(extensions\/mxc\/|src\/agents\/(?:bash-tools\.exec-script-(?:preflight|target)|bash-tools\.exec\.script-preflight\.test)\.ts$|src\/config\/sessions\/(?:session-accessor\.sqlite-archive(?:\.worker(?:\.test)?)?|store\.session-lifecycle-mutation\.test)\.ts$|src\/process\/|src\/infra\/(?:(?:exec-allowlist-pattern|fs-safe-remove)(?:\.test)?|ssh-client(?:\.windows\.test)?|update-managed-service-handoff(?:\.test)?|windows-install-roots)\.ts$|src\/shared\/(?:import-specifier|runtime-import)(?:\.test)?\.ts$|src\/test-utils\/openclaw-test-state(?:\.test)?\.ts$|scripts\/(?:android-(?:app-i18n|pin-version)\.ts|ci-run-timings\.mjs|e2e\/lib\/package-compat\.mjs|generate-bundled-channel-config-metadata\.ts|install\.ps1|openclaw-cross-os-release-checks\.ts|plan-release-workflow-matrix\.mjs|run-additional-boundary-checks\.mjs|verify-docker-attestations\.mjs|github\/run-openclaw-cross-os-release-checks\.sh|(?:npm-runner|pnpm-runner|ui|vitest-process-group)\.(?:mjs|js)|lib\/(?:direct-run\.mjs|format-generated-module\.mjs|cross-os-release-checks\/[^/]+\.ts))$|test\/scripts\/(?:direct-run-entrypoints|format-generated-module|install-ps1|npm-runner|openclaw-cross-os-release-workflow|pnpm-runner|ui|vitest-process-group)\.test\.ts$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|\.github\/workflows\/(?:ci|openclaw-cross-os-release-checks-reusable)\.yml$|\.github\/actions\/setup-node-env\/action\.yml$|\.github\/actions\/setup-pnpm-store-cache\/action\.yml$)/;
@@ -151,7 +155,7 @@ export function detectChangedScope(changedPaths) {
       runAndroid = true;
     }
 
-    if (NODE_SCOPE_RE.test(path)) {
+    if (NODE_SCOPE_RE.test(path) || GATEWAY_NODE_PLATFORM_TOPOLOGY_SOURCE_RE.test(path)) {
       runNode = true;
     }
 

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -523,6 +523,33 @@ const CODEX_VERSION_CONTRACT_TEST_TARGETS = [
   "extensions/openai/openai-provider.test.ts",
   "test/scripts/codex-client-version-contract.test.ts",
 ];
+const GATEWAY_NODE_PLATFORM_TOPOLOGY_TEST_TARGETS = [
+  "test/scripts/gateway-node-platform-topologies.test.ts",
+];
+const GATEWAY_NODE_PLATFORM_TOPOLOGY_SOURCE_PATHS = [
+  "qa/contracts/gateway-node-platform-topologies.json",
+  "apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift",
+  "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
+  "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift",
+  "apps/ios/Sources/Model/NodeAppModel.swift",
+  "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
+  "src/gateway/watch-node-http.ts",
+  "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
+  "apps/android/app/src/main/AndroidManifest.xml",
+  "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt",
+  "apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt",
+  "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyListenerService.kt",
+  "apps/android/wear/src/main/AndroidManifest.xml",
+  "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyBridge.kt",
+  "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyListenerService.kt",
+  "src/node-host/runner.ts",
+];
+const ADDITIONAL_SOURCE_TEST_TARGETS = new Map(
+  GATEWAY_NODE_PLATFORM_TOPOLOGY_SOURCE_PATHS.map((sourcePath) => [
+    sourcePath,
+    GATEWAY_NODE_PLATFORM_TOPOLOGY_TEST_TARGETS,
+  ]),
+);
 const SOURCE_TEST_TARGETS = new Map([
   ...PRECISE_SOURCE_TEST_TARGETS,
   ["extensions/codex/package.json", CODEX_VERSION_CONTRACT_TEST_TARGETS],
@@ -2841,16 +2868,22 @@ function resolveAppcastTargets(changedPath) {
 
 function resolvePreciseChangedTestTargets(changedPath, options) {
   const cwd = options.cwd ?? process.cwd();
+  const withAdditionalTargets = (targets) => {
+    const additionalTargets = ADDITIONAL_SOURCE_TEST_TARGETS.get(changedPath) ?? [];
+    return targets || additionalTargets.length > 0
+      ? uniqueOrdered([...(targets ?? []), ...additionalTargets])
+      : null;
+  };
   const mappedTargets =
     SOURCE_TEST_TARGETS.get(changedPath) ??
     resolveToolingTestTargets(changedPath, cwd) ??
     resolveAppcastTargets(changedPath) ??
     resolvePromptSnapshotFixtureTargets(changedPath);
   if (mappedTargets) {
-    return mappedTargets;
+    return withAdditionalTargets(mappedTargets);
   }
   if (isRoutableChangedTarget(changedPath) && isTestFileTarget(changedPath)) {
-    return [changedPath];
+    return withAdditionalTargets([changedPath]);
   }
   const siblingTest = resolveSiblingTestTarget(changedPath, cwd);
   if (
@@ -2858,13 +2891,13 @@ function resolvePreciseChangedTestTargets(changedPath, options) {
     !shouldCombineSiblingTestWithImportGraph(changedPath) &&
     options.combineSiblingWithImportGraph !== true
   ) {
-    return [siblingTest];
+    return withAdditionalTargets([siblingTest]);
   }
   if (shouldRouteChangedTargetWithoutImportGraph(changedPath)) {
-    return changedPath.startsWith("ui/src/") ? [changedPath] : null;
+    return withAdditionalTargets(changedPath.startsWith("ui/src/") ? [changedPath] : null);
   }
   if (options.skipImportGraph === true) {
-    return null;
+    return withAdditionalTargets(null);
   }
   const facts = getChangedPathFacts(changedPath);
   if (
@@ -2879,10 +2912,12 @@ function resolvePreciseChangedTestTargets(changedPath, options) {
       forceFull: options.forceFullImportGraph === true,
     });
     if (affectedTests.length > 0) {
-      return siblingTest ? uniqueOrdered([siblingTest, ...affectedTests]) : affectedTests;
+      return withAdditionalTargets(
+        siblingTest ? uniqueOrdered([siblingTest, ...affectedTests]) : affectedTests,
+      );
     }
   }
-  return siblingTest ? [siblingTest] : null;
+  return withAdditionalTargets(siblingTest ? [siblingTest] : null);
 }
 
 function isDeletedChangedTestTarget(changedPath, cwd) {

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -54,6 +54,26 @@ function writeRepoFile(repoDir: string, filePath: string, contents: string): voi
   fs.writeFileSync(absolutePath, contents, "utf8");
 }
 
+function gatewayNodePlatformTopologySourcePaths(): string[] {
+  const inventory = JSON.parse(
+    fs.readFileSync("qa/contracts/gateway-node-platform-topologies.json", "utf8"),
+  ) as {
+    platforms: Array<{
+      sourceAnchors: Array<{ repository: string; path: string }>;
+    }>;
+  };
+  return [
+    "qa/contracts/gateway-node-platform-topologies.json",
+    ...new Set(
+      inventory.platforms.flatMap((row) =>
+        row.sourceAnchors
+          .filter((anchor) => anchor.repository === "openclaw/openclaw")
+          .map((anchor) => anchor.path),
+      ),
+    ),
+  ];
+}
+
 function createSyntheticMergeRepo(prefix: string): { repoDir: string; staleBase: string } {
   const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tempDirs.push(repoDir);
@@ -232,6 +252,22 @@ describe("detectChangedScope", () => {
       runControlUiI18n: false,
       runUiTests: false,
     });
+  });
+
+  it("runs the Node topology validator for its contract and local source owners", () => {
+    for (const changedPath of gatewayNodePlatformTopologySourcePaths()) {
+      const scope = detectChangedScope([changedPath]);
+      expect(scope.runNode, changedPath).toBe(true);
+      if (changedPath.startsWith("apps/android/")) {
+        expect(scope.runAndroid, changedPath).toBe(true);
+      }
+      if (changedPath.startsWith("apps/macos/")) {
+        expect(scope.runMacos, changedPath).toBe(true);
+      }
+      if (changedPath.startsWith("apps/ios/") || changedPath.startsWith("apps/shared/")) {
+        expect(scope.runIosBuild, changedPath).toBe(true);
+      }
+    }
   });
 
   it("runs both Apple lanes for shared Swift tooling changes", () => {

--- a/test/scripts/gateway-node-platform-topologies.test.ts
+++ b/test/scripts/gateway-node-platform-topologies.test.ts
@@ -1,0 +1,277 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const CONTRACT_PATH = "qa/contracts/gateway-node-platform-topologies.json";
+const PLATFORM_ORDER = ["macos", "ios", "watchos", "android", "wearos", "windows"] as const;
+const MAX_STRING_LENGTH = 180;
+
+type JsonRecord = Record<string, unknown>;
+type Platform = (typeof PLATFORM_ORDER)[number];
+type ImplementationOwner = {
+  repository: "openclaw/openclaw" | "openclaw/openclaw-windows-node";
+  path: string | null;
+};
+
+const EXPECTED_IMPLEMENTATION_OWNERS: Record<Platform, readonly ImplementationOwner[]> = {
+  macos: [
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift",
+    },
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
+    },
+  ],
+  ios: [
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/ios/Sources/Model/NodeAppModel.swift",
+    },
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
+    },
+  ],
+  watchos: [
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
+    },
+    {
+      repository: "openclaw/openclaw",
+      path: "src/gateway/watch-node-http.ts",
+    },
+  ],
+  android: [
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
+    },
+  ],
+  wearos: [
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt",
+    },
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyBridge.kt",
+    },
+    {
+      repository: "openclaw/openclaw",
+      path: "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
+    },
+  ],
+  windows: [{ repository: "openclaw/openclaw-windows-node", path: null }],
+};
+
+function asRecord(value: unknown, label: string): JsonRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as JsonRecord;
+}
+
+function assertExactKeys(value: JsonRecord, expected: readonly string[], label: string): void {
+  expect(Object.keys(value).toSorted(), `${label} keys`).toEqual([...expected].toSorted());
+}
+
+function assertBoundedString(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_STRING_LENGTH ||
+    value.trim() !== value
+  ) {
+    throw new Error(`${label} must be a bounded trimmed string.`);
+  }
+}
+
+function assertOwner(value: unknown, label: string): void {
+  const owner = asRecord(value, label);
+  assertExactKeys(owner, ["repository", "path"], label);
+  assertBoundedString(owner.repository, `${label}.repository`);
+  expect(["openclaw/openclaw", "openclaw/openclaw-windows-node"]).toContain(owner.repository);
+  if (owner.repository === "openclaw/openclaw-windows-node") {
+    expect(owner.path).toBeNull();
+    return;
+  }
+  assertBoundedString(owner.path, `${label}.path`);
+  expect(owner.path.startsWith("/")).toBe(false);
+  expect(owner.path.includes("\\")).toBe(false);
+  expect(owner.path.split("/")).not.toContain("");
+  expect(owner.path.split("/")).not.toContain(".");
+  expect(owner.path.split("/")).not.toContain("..");
+  expect(() => execFileSync("git", ["cat-file", "-e", `HEAD:${owner.path}`])).not.toThrow();
+}
+
+function expectedTopology(platform: string): JsonRecord {
+  if (platform === "watchos") {
+    return {
+      kind: "watch-http",
+      gatewayNegotiator: "watchos",
+      edges: [
+        {
+          from: "watchos",
+          to: "gateway",
+          transport: "bounded-https-challenge-connect-poll",
+        },
+      ],
+    };
+  }
+  if (platform === "wearos") {
+    return {
+      kind: "wear-two-hop",
+      gatewayNegotiator: "android-phone",
+      edges: [
+        {
+          from: "wearos",
+          to: "android-phone",
+          transport: "wear-message-api-data-layer",
+        },
+        {
+          from: "android-phone",
+          to: "gateway",
+          transport: "websocket",
+        },
+      ],
+    };
+  }
+  return {
+    kind: "direct-ws",
+    gatewayNegotiator: platform,
+    edges: [{ from: platform, to: "gateway", transport: "websocket" }],
+  };
+}
+
+function validateInventory(value: unknown): JsonRecord {
+  const inventory = asRecord(value, "platform topology inventory");
+  assertExactKeys(inventory, ["kind", "platforms"], "platform topology inventory");
+  expect(inventory.kind).toBe("openclaw.gateway-node-platform-topology-inventory");
+  expect(Array.isArray(inventory.platforms)).toBe(true);
+  const platforms = inventory.platforms as unknown[];
+  expect(platforms).toHaveLength(PLATFORM_ORDER.length);
+
+  const seenPlatforms = new Set<string>();
+  platforms.forEach((rowValue, index) => {
+    const row = asRecord(rowValue, `platforms[${index}]`);
+    assertExactKeys(row, ["platform", "topology", "implementationOwners"], `platforms[${index}]`);
+    const platform = PLATFORM_ORDER[index];
+    expect(row.platform).toBe(platform);
+    assertBoundedString(row.platform, `platforms[${index}].platform`);
+    expect(seenPlatforms.has(row.platform)).toBe(false);
+    seenPlatforms.add(row.platform);
+
+    const topology = asRecord(row.topology, `${row.platform}.topology`);
+    assertExactKeys(topology, ["kind", "gatewayNegotiator", "edges"], `${row.platform}.topology`);
+    expect(topology).toEqual(expectedTopology(platform));
+
+    expect(Array.isArray(row.implementationOwners)).toBe(true);
+    const owners = row.implementationOwners as unknown[];
+    owners.forEach((owner, ownerIndex) =>
+      assertOwner(owner, `${row.platform}.implementationOwners[${ownerIndex}]`),
+    );
+    expect(owners).toEqual(EXPECTED_IMPLEMENTATION_OWNERS[platform]);
+  });
+
+  return inventory;
+}
+
+function readInventory(): { raw: string; value: JsonRecord } {
+  const raw = readFileSync(CONTRACT_PATH, "utf8");
+  expect(Buffer.byteLength(raw, "utf8")).toBeLessThanOrEqual(32 * 1024);
+  return { raw, value: JSON.parse(raw) as JsonRecord };
+}
+
+function cloneInventory(): JsonRecord {
+  return structuredClone(readInventory().value);
+}
+
+describe("Gateway/node platform topology inventory", () => {
+  it("is canonical JSON with the exact six validated platform rows", () => {
+    const { raw, value } = readInventory();
+    expect(raw).toBe(`${JSON.stringify(value, null, 2)}\n`);
+    expect(validateInventory(value)).toBe(value);
+  });
+
+  it("encodes direct, watch HTTP, and Wear two-hop topology truth", () => {
+    const { platforms } = validateInventory(readInventory().value);
+    const rows = platforms as JsonRecord[];
+    expect(rows.map((row) => ({ platform: row.platform, topology: row.topology }))).toEqual(
+      PLATFORM_ORDER.map((platform) => ({ platform, topology: expectedTopology(platform) })),
+    );
+  });
+
+  it.each([
+    [
+      "unknown inventory field",
+      (value: JsonRecord) => {
+        value.proof = true;
+      },
+    ],
+    [
+      "missing platform",
+      (value: JsonRecord) => {
+        (value.platforms as unknown[]).pop();
+      },
+    ],
+    [
+      "duplicate platform",
+      (value: JsonRecord) => {
+        const rows = value.platforms as JsonRecord[];
+        rows[1] = structuredClone(rows[0]);
+      },
+    ],
+    [
+      "unknown row field",
+      (value: JsonRecord) => {
+        (value.platforms as JsonRecord[])[0].coverage = [];
+      },
+    ],
+    [
+      "core-owned Windows implementation",
+      (value: JsonRecord) => {
+        (value.platforms as JsonRecord[])[5].implementationOwners = [
+          { repository: "openclaw/openclaw", path: "src/node-host/runner.ts" },
+        ];
+      },
+    ],
+    [
+      "duplicate implementation owner",
+      (value: JsonRecord) => {
+        const owners = (value.platforms as JsonRecord[])[0].implementationOwners as JsonRecord[];
+        owners.push(structuredClone(owners[0]));
+      },
+    ],
+    [
+      "unrelated existing implementation owner",
+      (value: JsonRecord) => {
+        const owners = (value.platforms as JsonRecord[])[0].implementationOwners as JsonRecord[];
+        owners[0] = {
+          repository: "openclaw/openclaw",
+          path: "apps/ios/Sources/Model/NodeAppModel.swift",
+        };
+      },
+    ],
+    [
+      "reordered implementation owners",
+      (value: JsonRecord) => {
+        const owners = (value.platforms as JsonRecord[])[0].implementationOwners as JsonRecord[];
+        owners.reverse();
+      },
+    ],
+    [
+      "Wear negotiating directly with Gateway",
+      (value: JsonRecord) => {
+        const topology = (value.platforms as JsonRecord[])[4].topology as JsonRecord;
+        topology.gatewayNegotiator = "wearos";
+      },
+    ],
+  ])("rejects %s", (_name, mutate) => {
+    const value = cloneInventory();
+    mutate(value);
+    expect(() => validateInventory(value)).toThrow();
+  });
+});

--- a/test/scripts/gateway-node-platform-topologies.test.ts
+++ b/test/scripts/gateway-node-platform-topologies.test.ts
@@ -3,69 +3,19 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const CONTRACT_PATH = "qa/contracts/gateway-node-platform-topologies.json";
-const PLATFORM_ORDER = ["macos", "ios", "watchos", "android", "wearos", "windows"] as const;
+const PLATFORM_ORDER = [
+  "macos",
+  "ios",
+  "watchos",
+  "android",
+  "wearos",
+  "windows",
+  "linux",
+] as const;
 const MAX_STRING_LENGTH = 180;
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
 
 type JsonRecord = Record<string, unknown>;
-type Platform = (typeof PLATFORM_ORDER)[number];
-type ImplementationOwner = {
-  repository: "openclaw/openclaw" | "openclaw/openclaw-windows-node";
-  path: string | null;
-};
-
-const EXPECTED_IMPLEMENTATION_OWNERS: Record<Platform, readonly ImplementationOwner[]> = {
-  macos: [
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift",
-    },
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
-    },
-  ],
-  ios: [
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/ios/Sources/Model/NodeAppModel.swift",
-    },
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
-    },
-  ],
-  watchos: [
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
-    },
-    {
-      repository: "openclaw/openclaw",
-      path: "src/gateway/watch-node-http.ts",
-    },
-  ],
-  android: [
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
-    },
-  ],
-  wearos: [
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/android/wear/src/main/java/ai/openclaw/wear/WearProxyClient.kt",
-    },
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/android/app/src/main/java/ai/openclaw/app/wear/WearProxyBridge.kt",
-    },
-    {
-      repository: "openclaw/openclaw",
-      path: "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
-    },
-  ],
-  windows: [{ repository: "openclaw/openclaw-windows-node", path: null }],
-};
 
 function asRecord(value: unknown, label: string): JsonRecord {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -89,22 +39,49 @@ function assertBoundedString(value: unknown, label: string): asserts value is st
   }
 }
 
-function assertOwner(value: unknown, label: string): void {
-  const owner = asRecord(value, label);
-  assertExactKeys(owner, ["repository", "path"], label);
-  assertBoundedString(owner.repository, `${label}.repository`);
-  expect(["openclaw/openclaw", "openclaw/openclaw-windows-node"]).toContain(owner.repository);
-  if (owner.repository === "openclaw/openclaw-windows-node") {
-    expect(owner.path).toBeNull();
-    return;
+function assertRepositoryPath(value: unknown, label: string): asserts value is string {
+  assertBoundedString(value, label);
+  expect(value.startsWith("/")).toBe(false);
+  expect(value.includes("\\")).toBe(false);
+  expect(value.split("/")).not.toContain("");
+  expect(value.split("/")).not.toContain(".");
+  expect(value.split("/")).not.toContain("..");
+}
+
+function assertSourceAnchor(value: unknown, label: string, platform: string): string {
+  const anchor = asRecord(value, label);
+  expect(anchor.platform).toBe(platform);
+  assertBoundedString(anchor.repository, `${label}.repository`);
+  expect(["openclaw/openclaw", "openclaw/openclaw-windows-node"]).toContain(anchor.repository);
+  assertRepositoryPath(anchor.path, `${label}.path`);
+  expect(Array.isArray(anchor.symbols)).toBe(true);
+  const symbols = anchor.symbols as unknown[];
+  expect(symbols.length).toBeGreaterThan(0);
+  for (const [symbolIndex, symbol] of symbols.entries()) {
+    assertBoundedString(symbol, `${label}.symbols[${symbolIndex}]`);
   }
-  assertBoundedString(owner.path, `${label}.path`);
-  expect(owner.path.startsWith("/")).toBe(false);
-  expect(owner.path.includes("\\")).toBe(false);
-  expect(owner.path.split("/")).not.toContain("");
-  expect(owner.path.split("/")).not.toContain(".");
-  expect(owner.path.split("/")).not.toContain("..");
-  expect(() => execFileSync("git", ["cat-file", "-e", `HEAD:${owner.path}`])).not.toThrow();
+
+  if (anchor.repository === "openclaw/openclaw") {
+    assertExactKeys(anchor, ["platform", "repository", "verification", "path", "symbols"], label);
+    expect(anchor.verification).toBe("tracked-source-markers");
+    expect(() =>
+      execFileSync("git", ["ls-files", "--error-unmatch", "--", anchor.path], { stdio: "ignore" }),
+    ).not.toThrow();
+    const source = readFileSync(anchor.path, "utf8");
+    for (const symbol of symbols as string[]) {
+      expect(source, `${label} source anchor ${symbol}`).toContain(symbol);
+    }
+    return `${anchor.repository}:${anchor.path}`;
+  }
+
+  assertExactKeys(
+    anchor,
+    ["platform", "repository", "verification", "path", "revision", "symbols"],
+    label,
+  );
+  expect(anchor.verification).toBe("unverified-external-reference");
+  expect(anchor.revision).toMatch(SHA_PATTERN);
+  return `${anchor.repository}@${anchor.revision}:${anchor.path}`;
 }
 
 function expectedTopology(platform: string): JsonRecord {
@@ -132,6 +109,11 @@ function expectedTopology(platform: string): JsonRecord {
           transport: "wear-message-api-data-layer",
         },
         {
+          from: "wearos",
+          to: "android-phone",
+          transport: "wear-channel-api-data-layer",
+        },
+        {
           from: "android-phone",
           to: "gateway",
           transport: "websocket",
@@ -148,8 +130,15 @@ function expectedTopology(platform: string): JsonRecord {
 
 function validateInventory(value: unknown): JsonRecord {
   const inventory = asRecord(value, "platform topology inventory");
-  assertExactKeys(inventory, ["kind", "platforms"], "platform topology inventory");
-  expect(inventory.kind).toBe("openclaw.gateway-node-platform-topology-inventory");
+  assertExactKeys(
+    inventory,
+    ["kind", "scope", "releaseEvidence", "consumers", "platforms"],
+    "platform topology inventory",
+  );
+  expect(inventory.kind).toBe("openclaw.gateway-node-platform-topology-reference");
+  expect(inventory.scope).toBe("advisory-source-topology");
+  expect(inventory.releaseEvidence).toBe("none");
+  expect(inventory.consumers).toEqual([]);
   expect(Array.isArray(inventory.platforms)).toBe(true);
   const platforms = inventory.platforms as unknown[];
   expect(platforms).toHaveLength(PLATFORM_ORDER.length);
@@ -157,7 +146,7 @@ function validateInventory(value: unknown): JsonRecord {
   const seenPlatforms = new Set<string>();
   platforms.forEach((rowValue, index) => {
     const row = asRecord(rowValue, `platforms[${index}]`);
-    assertExactKeys(row, ["platform", "topology", "implementationOwners"], `platforms[${index}]`);
+    assertExactKeys(row, ["platform", "topology", "sourceAnchors"], `platforms[${index}]`);
     const platform = PLATFORM_ORDER[index];
     expect(row.platform).toBe(platform);
     assertBoundedString(row.platform, `platforms[${index}].platform`);
@@ -168,12 +157,13 @@ function validateInventory(value: unknown): JsonRecord {
     assertExactKeys(topology, ["kind", "gatewayNegotiator", "edges"], `${row.platform}.topology`);
     expect(topology).toEqual(expectedTopology(platform));
 
-    expect(Array.isArray(row.implementationOwners)).toBe(true);
-    const owners = row.implementationOwners as unknown[];
-    owners.forEach((owner, ownerIndex) =>
-      assertOwner(owner, `${row.platform}.implementationOwners[${ownerIndex}]`),
+    expect(Array.isArray(row.sourceAnchors)).toBe(true);
+    const anchors = row.sourceAnchors as unknown[];
+    expect(anchors.length).toBeGreaterThan(0);
+    const identities = anchors.map((anchor, anchorIndex) =>
+      assertSourceAnchor(anchor, `${row.platform}.sourceAnchors[${anchorIndex}]`, platform),
     );
-    expect(owners).toEqual(EXPECTED_IMPLEMENTATION_OWNERS[platform]);
+    expect(new Set(identities).size).toBe(identities.length);
   });
 
   return inventory;
@@ -189,14 +179,25 @@ function cloneInventory(): JsonRecord {
   return structuredClone(readInventory().value);
 }
 
+function windowsExternalAnchor(value: JsonRecord): JsonRecord {
+  const windows = (value.platforms as JsonRecord[]).find((row) => row.platform === "windows");
+  const anchor = (windows?.sourceAnchors as JsonRecord[] | undefined)?.find(
+    (candidate) => candidate.repository === "openclaw/openclaw-windows-node",
+  );
+  if (!anchor) {
+    throw new Error("Windows external source anchor is missing.");
+  }
+  return anchor;
+}
+
 describe("Gateway/node platform topology inventory", () => {
-  it("is canonical JSON with the exact six validated platform rows", () => {
+  it("is canonical advisory JSON with the exact seven validated platform rows", () => {
     const { raw, value } = readInventory();
     expect(raw).toBe(`${JSON.stringify(value, null, 2)}\n`);
     expect(validateInventory(value)).toBe(value);
   });
 
-  it("encodes direct, watch HTTP, and Wear two-hop topology truth", () => {
+  it("encodes direct, watch HTTP, and Wear two-hop source topology", () => {
     const { platforms } = validateInventory(readInventory().value);
     const rows = platforms as JsonRecord[];
     expect(rows.map((row) => ({ platform: row.platform, topology: row.topology }))).toEqual(
@@ -206,9 +207,15 @@ describe("Gateway/node platform topology inventory", () => {
 
   it.each([
     [
-      "unknown inventory field",
+      "release evidence field",
       (value: JsonRecord) => {
-        value.proof = true;
+        value.currentRunEvidence = [];
+      },
+    ],
+    [
+      "release evidence consumer",
+      (value: JsonRecord) => {
+        value.consumers = ["scripts/release-ci-summary.mjs"];
       },
     ],
     [
@@ -231,35 +238,49 @@ describe("Gateway/node platform topology inventory", () => {
       },
     ],
     [
-      "core-owned Windows implementation",
+      "unpinned external source",
       (value: JsonRecord) => {
-        (value.platforms as JsonRecord[])[5].implementationOwners = [
-          { repository: "openclaw/openclaw", path: "src/node-host/runner.ts" },
-        ];
+        delete windowsExternalAnchor(value).revision;
       },
     ],
     [
-      "duplicate implementation owner",
+      "external source claiming local verification",
       (value: JsonRecord) => {
-        const owners = (value.platforms as JsonRecord[])[0].implementationOwners as JsonRecord[];
-        owners.push(structuredClone(owners[0]));
+        windowsExternalAnchor(value).verification = "tracked-source-markers";
       },
     ],
     [
-      "unrelated existing implementation owner",
+      "local source claiming external verification",
       (value: JsonRecord) => {
-        const owners = (value.platforms as JsonRecord[])[0].implementationOwners as JsonRecord[];
-        owners[0] = {
-          repository: "openclaw/openclaw",
-          path: "apps/ios/Sources/Model/NodeAppModel.swift",
-        };
+        const anchor = ((value.platforms as JsonRecord[])[0].sourceAnchors as JsonRecord[])[0];
+        anchor.verification = "unverified-external-reference";
       },
     ],
     [
-      "reordered implementation owners",
+      "missing local source anchor",
       (value: JsonRecord) => {
-        const owners = (value.platforms as JsonRecord[])[0].implementationOwners as JsonRecord[];
-        owners.reverse();
+        const anchor = ((value.platforms as JsonRecord[])[0].sourceAnchors as JsonRecord[])[0];
+        anchor.path = "apps/macos/Sources/OpenClaw/NodeMode/DoesNotExist.swift";
+      },
+    ],
+    [
+      "stale local source symbol",
+      (value: JsonRecord) => {
+        const anchor = ((value.platforms as JsonRecord[])[0].sourceAnchors as JsonRecord[])[0];
+        anchor.symbols = ["RemovedMacNodeTransport"];
+      },
+    ],
+    [
+      "cross-platform source anchors",
+      (value: JsonRecord) => {
+        const rows = value.platforms as JsonRecord[];
+        rows[1].sourceAnchors = structuredClone(rows[0].sourceAnchors);
+      },
+    ],
+    [
+      "release coverage row field",
+      (value: JsonRecord) => {
+        (value.platforms as JsonRecord[])[0].coverage = [];
       },
     ],
     [

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -217,6 +217,26 @@ function expectChangedTargets(changedPaths: string[], targets: string[]): void {
   });
 }
 
+function gatewayNodePlatformTopologySourcePaths(): string[] {
+  const inventory = JSON.parse(
+    fs.readFileSync("qa/contracts/gateway-node-platform-topologies.json", "utf8"),
+  ) as {
+    platforms: Array<{
+      sourceAnchors: Array<{ repository: string; path: string }>;
+    }>;
+  };
+  return [
+    "qa/contracts/gateway-node-platform-topologies.json",
+    ...new Set(
+      inventory.platforms.flatMap((row) =>
+        row.sourceAnchors
+          .filter((anchor) => anchor.repository === "openclaw/openclaw")
+          .map((anchor) => anchor.path),
+      ),
+    ),
+  ];
+}
+
 function expectSingleVitestRunPlan(
   actual: ReturnType<typeof buildVitestRunPlans>,
   expected: {
@@ -1543,6 +1563,21 @@ describe("scripts/test-projects changed-target routing", () => {
       ["test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts"],
     );
   });
+
+  it.each(gatewayNodePlatformTopologySourcePaths())(
+    "routes Gateway/node topology owner path %s to its contract test",
+    (changedPath) => {
+      const behavioralTarget = new Map([
+        ["src/gateway/watch-node-http.ts", "src/gateway/watch-node-http.test.ts"],
+        ["src/node-host/runner.ts", "src/node-host/runner.test.ts"],
+      ]).get(changedPath);
+      const targets = [
+        ...(behavioralTarget ? [behavioralTarget] : []),
+        "test/scripts/gateway-node-platform-topologies.test.ts",
+      ];
+      expectChangedTargets([changedPath], targets);
+    },
+  );
 
   it("keeps extensionless helper script edits on owner tests", () => {
     const expectedTargets = Object.entries({


### PR DESCRIPTION
Depends on https://github.com/openclaw/openclaw/pull/120032.

## What Problem This Solves

Gateway-node release planning needs a canonical description of supported client transport topologies without presenting source structure as release evidence.

## Why This Change Was Made

Adds a machine-validated, advisory seven-platform topology reference:

- macOS, iOS, Android, Windows, and Linux connect directly to the Gateway over WebSocket
- watchOS uses bounded HTTPS challenge/connect/poll directly to the Gateway
- Wear OS uses both the Wear Message API and Channel API to reach the Android phone, then the phone connects to the Gateway over WebSocket
- all local source anchors are checked against tracked source markers
- the Windows external app pointer is immutable but explicitly marked `unverified-external-reference`
- contract and local owner-path changes activate Node CI and add the topology validator without replacing existing behavioral test targets

The reference explicitly declares `releaseEvidence: none` and `consumers: []`. It does not model selected, not-selected, or observed execution states and does not claim current-run, packaged, device, compatibility, or release proof. Those claims require an authoritative producer and manifest consumer owned by the release-validation stack.

## User Impact

No runtime, protocol, packaging, config, or release-policy behavior changes. QA and release maintainers get an advisory source-topology map for planning evidence lanes.

## Evidence

- Exact head: `75c05319178575c78af27418308a21ed3bd08693`
- Focused Vitest: 330/330 passed across topology validation, changed-test routing, and CI scope
- Targeted CI-scope rerun: 37/37 passed
- `git diff --check` and targeted formatting: passed
- Autoreview through P2: clean, confidence 0.88
- Local ClawSweeper exact range `14acd9e5..75c05319`: `nothing_found`, high confidence, success
- Full changed-gate delegation was unavailable because Crabbox had no ready `ci-fast` provider
- Targeted oxlint preflight was blocked before touched-file lint by the existing base error at `packages/terminal-core/src/ansi.ts:194` (`TS2554`)

Delta against the PR base: 359 QA reference lines, 47 routing/CI script additions with 8 deletions, and 369 test lines; zero production runtime LOC.

Punchcard-Session: cobalt-timber-orchard-d1
