### PR TITLE
[AI-assisted] fix(android): request phone state for SMS

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
@@ -470,6 +470,7 @@ class PermissionRequester internal constructor(
       Manifest.permission.RECORD_AUDIO -> nativeString("Microphone")
       Manifest.permission.SEND_SMS -> nativeString("Send SMS")
       Manifest.permission.READ_SMS -> nativeString("Read SMS")
+      Manifest.permission.READ_PHONE_STATE -> nativeString("Read phone state")
       Manifest.permission.READ_CONTACTS -> nativeString("Read Contacts")
       Manifest.permission.WRITE_CONTACTS -> nativeString("Write Contacts")
       Manifest.permission.READ_CALENDAR -> nativeString("Read Calendar")

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -3173,7 +3173,8 @@ private fun rememberPermissionState(
     !smsAvailable ||
       (
         hasPermission(context, Manifest.permission.SEND_SMS) &&
-          hasPermission(context, Manifest.permission.READ_SMS)
+          hasPermission(context, Manifest.permission.READ_SMS) &&
+          hasPermission(context, Manifest.permission.READ_PHONE_STATE)
       )
   val callLogAvailable = SensitiveFeatureConfig.callLogEnabled
   var motionGranted by rememberSaveable { mutableStateOf(!motionAvailable || hasPermission(context, Manifest.permission.ACTIVITY_RECOGNITION)) }
@@ -3223,7 +3224,12 @@ private fun rememberPermissionState(
       smsGranted =
         mergedRequiredPermissionGrantState(
           permissions = permissions,
-          requiredPermissions = listOf(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS),
+          requiredPermissions =
+            listOf(
+              Manifest.permission.SEND_SMS,
+              Manifest.permission.READ_SMS,
+              Manifest.permission.READ_PHONE_STATE,
+            ),
           currentlyGranted = { permission -> hasPermission(context, permission) },
         )
       callLogGranted = permissions[Manifest.permission.READ_CALL_LOG] ?: callLogGranted
@@ -3294,7 +3300,11 @@ private fun rememberPermissionState(
       },
       if (smsAvailable) {
         PermissionRowModel(PermissionRowId.Sms, nativeText("SMS"), nativeText("Device access; Gateway opt-in still required"), Icons.Default.Notifications, smsGranted) {
-          request(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS)
+          request(
+            Manifest.permission.SEND_SMS,
+            Manifest.permission.READ_SMS,
+            Manifest.permission.READ_PHONE_STATE,
+          )
         }
       } else {
         null

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -323,7 +323,12 @@ class OnboardingFlowLogicTest {
 
   @Test
   fun splitSmsPermissionCallbacksMergePerPermissionGrantState() {
-    val requiredPermissions = listOf(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS)
+    val requiredPermissions =
+      listOf(
+        Manifest.permission.SEND_SMS,
+        Manifest.permission.READ_SMS,
+        Manifest.permission.READ_PHONE_STATE,
+      )
     val afterSendOnly =
       mergedRequiredPermissionGrantState(
         permissions = mapOf(Manifest.permission.SEND_SMS to true),
@@ -338,7 +343,15 @@ class OnboardingFlowLogicTest {
         requiredPermissions = requiredPermissions,
         currentlyGranted = { permission -> permission == Manifest.permission.SEND_SMS },
       )
-    assertTrue(afterReadOnly)
+    assertFalse(afterReadOnly)
+
+    val afterPhoneState =
+      mergedRequiredPermissionGrantState(
+        permissions = mapOf(Manifest.permission.READ_PHONE_STATE to true),
+        requiredPermissions = requiredPermissions,
+        currentlyGranted = { permission -> permission != Manifest.permission.READ_PHONE_STATE },
+      )
+    assertTrue(afterPhoneState)
 
     val deniedRead =
       mergedRequiredPermissionGrantState(

--- a/apps/android/app/src/thirdParty/AndroidManifest.xml
+++ b/apps/android/app/src/thirdParty/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-feature
         android:name="android.hardware.telephony"

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/node/SmsManager.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/node/SmsManager.kt
@@ -560,6 +560,12 @@ class SmsManager(
       Manifest.permission.SEND_SMS,
     ) == PackageManager.PERMISSION_GRANTED
 
+  private fun hasReadPhoneStatePermission(): Boolean =
+    ContextCompat.checkSelfPermission(
+      context,
+      Manifest.permission.READ_PHONE_STATE,
+    ) == PackageManager.PERMISSION_GRANTED
+
   fun hasReadSmsPermission(): Boolean =
     ContextCompat.checkSelfPermission(
       context,
@@ -736,10 +742,17 @@ class SmsManager(
     }
 
   private suspend fun ensureSmsPermission(): Boolean {
-    if (hasSmsPermission()) return true
+    if (hasSmsPermission() && hasReadPhoneStatePermission()) return true
     val requester = permissionRequester ?: return false
-    val results = requester.requestIfMissing(listOf(Manifest.permission.SEND_SMS))
-    return results[Manifest.permission.SEND_SMS] == true
+    val results =
+      requester.requestIfMissing(
+        listOf(
+          Manifest.permission.SEND_SMS,
+          Manifest.permission.READ_PHONE_STATE,
+        ),
+      )
+    return results[Manifest.permission.SEND_SMS] == true &&
+      results[Manifest.permission.READ_PHONE_STATE] == true
   }
 
   private suspend fun ensureReadSmsPermission(): Boolean {


### PR DESCRIPTION
Closes #120038

## What Problem This Solves

On affected Android devices, `sms.send` can fail after `SEND_SMS` and `READ_SMS` are granted because the framework SMS path reads SIM group information and enforces `READ_PHONE_STATE`. The third-party manifest did not declare that permission, so the app could not request it.

## Why This Change Was Made

The sideload-only `thirdParty` flavor now declares `READ_PHONE_STATE`. SMS onboarding includes it in its completion state and prompt, and the runtime SMS path requests it together with `SEND_SMS` when it is missing. This keeps `sms.send` advertised for already-installed clients so the app can still request the newly required permission on demand.

The Play flavor is unchanged.

## User Impact

Users of the third-party Android build may see Android’s “Read phone state” prompt as part of SMS setup. Once granted, the SMS send path works on devices that require the extra framework permission.

## Evidence

- Reproduced on a ThinkPhone by motorola running Android 16: `sms.send` returned `SMS_PERMISSION_REQUIRED: getGroupIdLevel1` before the manifest permission was available.
- `:app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest` passed in a clean Cloud Build environment.
- `git diff --check` passed.
- A local Codex review was attempted, but the host sandbox cannot create its loopback interface (`bwrap` permission error); the patch was manually reviewed before opening this PR.

## AI-assisted

This PR was prepared with Codex. I have reviewed the code and understand the change.