### PR TITLE
fix(agents): resolve authoritative session keys for delegated compaction

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -486,6 +486,7 @@ export async function persistCliTurnTranscript(params: {
   const sessionTarget = await resolveAgentRunSessionTarget({
     agentId: params.sessionAgentId,
     config: params.config,
+    missingSessionKey: "resolve-existing",
     sessionFile: params.sessionFile,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -324,10 +324,10 @@ async function compactCliTranscript(params: {
       params.contextEngine,
       {
         sessionId: params.sessionId,
-        sessionKey: params.sessionKey || params.sessionId,
+        sessionKey: params.sessionKey,
         sessionTarget: {
           sessionId: params.sessionId,
-          sessionKey: params.sessionKey || params.sessionId,
+          sessionKey: params.sessionKey,
           ...(params.storePath ? { storePath: params.storePath } : {}),
         },
         tokenBudget: params.contextTokenBudget,

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -240,6 +240,7 @@ const resolveTestSessionTarget = async (params: {
 }) =>
   await resolveAgentRunSessionTarget({
     config: params.config,
+    missingSessionKey: "create",
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
   });

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -61,6 +61,14 @@ describe("classifyCompactionReason", () => {
     ).toBe("guard_blocked");
   });
 
+  it("classifies transcript persistence failures without losing them as unknown", () => {
+    expect(
+      classifyCompactionReason(
+        "Session transcript entry was not persisted: compaction-1: session-rebound",
+      ),
+    ).toBe("transcript_persistence_failed");
+  });
+
   it("keeps unclassified provider errors in the stable unknown bucket", () => {
     expect(classifyCompactionReason("No API provider registered for api: ollama")).toBe("unknown");
   });

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -48,6 +48,9 @@ export function classifyCompactionReason(reason?: string): string {
   if (text.includes("still exceeds target")) {
     return "live_context_still_exceeds_target";
   }
+  if (text.includes("session transcript") && text.includes("not persisted")) {
+    return "transcript_persistence_failed";
+  }
   if (text.includes("guard")) {
     return "guard_blocked";
   }

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -278,7 +278,7 @@ const sessionHook = (action: string): SessionHookEvent | undefined =>
     return event?.type === "session" && event.action === action;
   })?.[0] as SessionHookEvent | undefined;
 
-async function runCompactionHooks(params: { sessionKey?: string; messageProvider?: string }) {
+async function runCompactionHooks(params: { sessionKey: string; messageProvider?: string }) {
   // Build metrics through the production helper so hook payload assertions stay
   // aligned with compaction token accounting.
   const originalMessages = sessionMessages.slice(1) as AgentMessage[];
@@ -1903,26 +1903,6 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
-  it("uses sessionId as hook session key fallback when sessionKey is missing", async () => {
-    hookRunner.hasHooks.mockReturnValue(true);
-    await runCompactionHooks({});
-
-    expect(sessionHook("compact:before")?.sessionKey).toBe("session-1");
-    expect(sessionHook("compact:after")?.sessionKey).toBe("session-1");
-    expect(hookRunner.runBeforeCompaction).toHaveBeenCalledWith(
-      mockCallArg(hookRunner.runBeforeCompaction),
-      expectRecordFields(mockCallArg(hookRunner.runBeforeCompaction, 0, 1), {
-        sessionKey: "session-1",
-      }),
-    );
-    expect(hookRunner.runAfterCompaction).toHaveBeenCalledWith(
-      mockCallArg(hookRunner.runAfterCompaction),
-      expectRecordFields(mockCallArg(hookRunner.runAfterCompaction, 0, 1), {
-        sessionKey: "session-1",
-      }),
-    );
-  });
-
   it("applies validated transcript before hooks even when it becomes empty", async () => {
     hookRunner.hasHooks.mockReturnValue(true);
     const beforeMetrics = compactTesting.buildBeforeCompactionHookMetrics({
@@ -2452,6 +2432,46 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
     mockResolvedModel();
     mockQueuedRouteAwareModel();
+  });
+
+  it("resolves the durable session key before invoking an owning context engine", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-compaction-session-key-"));
+    const storePath = join(dir, "sessions.json");
+    const sessionId = "9d6c8436-7cb2-4bd5-a302-e33305bfc8c4";
+    const sessionKey = "agent:main:telegram:direct:reporter";
+    try {
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { sessionId, updatedAt: 1 },
+      );
+      hookRunner.hasHooks.mockReturnValue(true);
+
+      const result = await compactEmbeddedAgentSession(
+        wrappedCompactionArgs({
+          agentId: "main",
+          config: { session: { store: storePath } },
+          sessionFile: "",
+          sessionId,
+          sessionKey: undefined,
+          sessionTarget: undefined,
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+      expectRecordFields(mockCallArg(contextEngineCompactMock), {
+        sessionId,
+        sessionKey,
+      });
+      expectRecordFields(
+        (mockCallArg(contextEngineCompactMock) as { sessionTarget?: unknown }).sessionTarget,
+        { agentId: "main", sessionId, sessionKey, storePath },
+      );
+      expectRecordFields(mockCallArg(hookRunner.runBeforeCompaction, 0, 1), { sessionKey });
+      expectRecordFields(mockCallArg(hookRunner.runAfterCompaction, 0, 1), { sessionKey });
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      await rm(dir, { force: true, recursive: true });
+    }
   });
 
   it("uses the acquired gateway runtime generation for queued model resolution", async () => {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -129,7 +129,7 @@ function buildContextEngineCompactionSessionTarget(
   params: CompactEmbeddedAgentSessionParams,
 ): ContextEngineSessionTarget {
   const agentId = params.sessionTarget?.agentId ?? params.agentId;
-  const sessionKey = params.sessionTarget?.sessionKey ?? params.sessionKey ?? params.sessionId;
+  const sessionKey = params.sessionTarget?.sessionKey ?? params.sessionKey;
   const storePath = params.sessionTarget?.storePath;
   return {
     ...(agentId ? { agentId } : {}),
@@ -239,7 +239,10 @@ function mergeSecondaryNativeHarnessCompactionDetails(params: {
 export async function compactEmbeddedAgentSession(
   params: CompactEmbeddedAgentSessionParams,
 ): Promise<EmbeddedAgentCompactResult> {
-  const runtimeTarget = await resolveAgentRunSessionTarget(params);
+  const runtimeTarget = await resolveAgentRunSessionTarget({
+    ...params,
+    missingSessionKey: "resolve-existing",
+  });
   const resolvedParams = {
     ...params,
     agentId: runtimeTarget.agentId,
@@ -302,7 +305,10 @@ async function compactEmbeddedAgentSessionImpl(
   if (inputParams.abortSignal?.aborted) {
     return createCompactionAbortedResult();
   }
-  const runtimeTarget = await resolveAgentRunSessionTarget(inputParams);
+  const runtimeTarget = await resolveAgentRunSessionTarget({
+    ...inputParams,
+    missingSessionKey: "resolve-existing",
+  });
   const agentIds = resolveSessionAgentIds({
     sessionKey: runtimeTarget.sessionKey,
     config: inputParams.config,
@@ -387,7 +393,10 @@ async function compactResolvedContextEngine(
   preparedModelRuntime: PreparedModelRuntimeSnapshot,
   releaseContextEngineOwnership: () => void,
 ): Promise<EmbeddedAgentCompactResult> {
-  const runtimeTarget = await resolveAgentRunSessionTarget(params);
+  const runtimeTarget = await resolveAgentRunSessionTarget({
+    ...params,
+    missingSessionKey: "resolve-existing",
+  });
   const lockedHarnessRuntime =
     params.modelSelectionLocked === true
       ? normalizeOptionalAgentRuntimeId(params.agentHarnessId)
@@ -613,7 +622,7 @@ async function compactResolvedContextEngine(
         const hookRunner = engineOwnsCompaction
           ? asCompactionHookRunner(getGlobalHookRunner())
           : null;
-        const hookSessionKey = params.sessionKey?.trim() || params.sessionId;
+        const hookSessionKey = runtimeTarget.sessionKey;
         const { sessionAgentId } = resolveSessionAgentIds({
           sessionKey: params.sessionKey,
           config: params.config,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -130,7 +130,10 @@ export async function compactEmbeddedAgentSessionDirect(
       failure: { reason: "model_selection_locked" },
     };
   }
-  const runSessionTarget = await resolveAgentRunSessionTarget(paramsBase);
+  const runSessionTarget = await resolveAgentRunSessionTarget({
+    ...paramsBase,
+    missingSessionKey: "resolve-existing",
+  });
   const requestedParams: CompactEmbeddedAgentSessionParamsWithSessionFile = {
     ...paramsBase,
     agentId: runSessionTarget.agentId,

--- a/src/agents/embedded-agent-runner/compaction-hooks.ts
+++ b/src/agents/embedded-agent-runner/compaction-hooks.ts
@@ -209,7 +209,7 @@ export function buildBeforeCompactionHookMetrics(params: {
 export async function runBeforeCompactionHooks(params: {
   hookRunner?: CompactionHookRunner | null;
   sessionId: string;
-  sessionKey?: string;
+  sessionKey: string;
   sessionAgentId: string;
   workspaceDir: string;
   messageProvider?: string;
@@ -221,8 +221,8 @@ export async function runBeforeCompactionHooks(params: {
     sessionKey: string;
   }) => void | Promise<void>;
 }) {
-  const missingSessionKey = !params.sessionKey || !params.sessionKey.trim();
-  const hookSessionKey = params.sessionKey?.trim() || params.sessionId;
+  const missingSessionKey = false;
+  const hookSessionKey = params.sessionKey;
   try {
     const hookEvent = createInternalHookEvent("session", "compact:before", hookSessionKey, {
       sessionId: params.sessionId,

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -779,7 +779,7 @@ describe("buildContextEngineCompactionSessionTarget", () => {
     });
   });
 
-  it("uses the marker session id when its store has no mapped key yet", () => {
+  it("leaves the key absent when a marker store has no mapped row", () => {
     const storePath = path.join(compactionTempDirs.make("compaction-marker-"), "sessions.json");
     const sessionId = "legacy-unmapped-session";
 
@@ -788,6 +788,6 @@ describe("buildContextEngineCompactionSessionTarget", () => {
         sessionFile: formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath }),
         sessionId,
       }),
-    ).toMatchObject({ agentId: "main", sessionId, sessionKey: sessionId, storePath });
+    ).toEqual({ agentId: "main", sessionId, storePath });
   });
 });

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -113,6 +113,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
     const sessionTarget = await resolveAgentRunSessionTarget({
       agentId: sessionAgentId,
       config: params.config,
+      missingSessionKey: "resolve-existing",
       sessionFile: params.sessionFile,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
@@ -369,7 +370,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           const { hookSessionKey, missingSessionKey } = await runBeforeCompactionHooks({
             hookRunner,
             sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
+            sessionKey: sessionTarget.sessionKey,
             sessionAgentId,
             workspaceDir: effectiveWorkspace,
             messageProvider: resolvedMessageProvider,

--- a/src/agents/embedded-agent-runner/compaction-successor.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor.ts
@@ -32,6 +32,7 @@ export async function resolveContextEngineCompactionSuccessor(params: {
     const resolvedTarget = await resolveAgentRunSessionTarget({
       agentId: target.agentId ?? current.agentId,
       config: params.config,
+      missingSessionKey: "resolve-existing",
       sessionId: target.sessionId ?? successorId ?? current.sessionId,
       sessionFile: successorFile,
       sessionKey: target.sessionKey ?? current.sessionKey,
@@ -118,6 +119,7 @@ export async function resolveContextEngineCompactionSuccessor(params: {
     const resolvedTarget = await resolveAgentRunSessionTarget({
       agentId: legacyTarget.agentId,
       config: params.config,
+      missingSessionKey: "resolve-existing",
       sessionId: legacyTarget.sessionId,
       sessionKey: legacyTarget.sessionKey,
       sessionTarget: legacyTarget,

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -245,6 +245,12 @@ function buildContextEngineMaintenanceRuntimeContext(
     ...(params.allowDeferredCompactionExecution ? { allowDeferredCompactionExecution: true } : {}),
     rewriteTranscriptEntries: async (request) => {
       const runtimeAgentId = params.sessionTarget?.agentId ?? params.agentId;
+      const runtimeSessionKey = normalizeOptionalString(
+        params.sessionTarget?.sessionKey ?? params.sessionKey,
+      );
+      if (!runtimeSessionKey) {
+        throw new Error("Context-engine transcript rewrite requires a session key");
+      }
       const runtimeStorePath =
         params.sessionTarget?.storePath ??
         (runtimeAgentId
@@ -255,7 +261,7 @@ function buildContextEngineMaintenanceRuntimeContext(
       if (!sessionManager) {
         runtimeTarget = await resolveRuntimeTranscriptReadTarget({
           sessionId: params.sessionTarget?.sessionId ?? params.sessionId,
-          sessionKey: params.sessionTarget?.sessionKey ?? params.sessionKey ?? params.sessionId,
+          sessionKey: runtimeSessionKey,
           sessionFile: params.sessionFile,
           ...(runtimeAgentId ? { agentId: runtimeAgentId } : {}),
           ...(runtimeStorePath ? { storePath: runtimeStorePath } : {}),
@@ -549,10 +555,17 @@ export async function runContextEngineMaintenance(
 
   if (shouldDefer) {
     try {
+      const sessionKey = normalizeOptionalString(params.sessionKey);
+      if (!sessionKey) {
+        params.onDeferredMaintenanceFailure?.(
+          new Error("Deferred context-engine maintenance requires a session key"),
+        );
+        return undefined;
+      }
       const deferred = scheduleDeferredTurnMaintenance({
         ...params,
         contextEngine,
-        sessionKey: params.sessionKey ?? params.sessionId,
+        sessionKey,
         disposeContextEngineAfterMaintenance: params.disposeDeferredContextEngineAfterMaintenance,
         onScheduleFailure: params.onDeferredMaintenanceFailure,
       });

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -117,6 +117,7 @@ async function runEmbeddedAgentInternal(
   assertAgentHarnessRunAdmission({ ...paramsBase, sessionKey: effectiveSessionKey });
   const runSessionTarget = await resolveAgentRunSessionTarget({
     ...paramsBase,
+    missingSessionKey: "create",
     sessionKey: effectiveSessionKey,
   });
   let params: RunEmbeddedAgentParamsWithSessionFile = withExecutionPhaseDiagnostics({
@@ -341,8 +342,7 @@ async function runEmbeddedAgentInternal(
             sessionKey: normalizedSessionKey,
             modelFallbacksOverride: params.modelFallbacksOverride,
           });
-          const resolvedSessionKey =
-            normalizedSessionKey ?? params.sessionTarget?.sessionKey ?? params.sessionId;
+          const resolvedSessionKey = normalizedSessionKey ?? runSessionTarget.sessionKey;
           const hookRunner = getGlobalHookRunner();
           const hookCtx = {
             runId: params.runId,

--- a/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.ts
@@ -48,6 +48,7 @@ export async function prepareEmbeddedAttemptSessionLock(input: {
   const sessionTarget = await resolveAgentRunSessionTarget({
     agentId: attempt.sessionTarget?.agentId,
     config: attempt.config,
+    missingSessionKey: "resolve-existing",
     sessionFile: attempt.sessionFile,
     sessionId: attempt.sessionId,
     sessionKey: attempt.sessionKey,

--- a/src/agents/embedded-agent-runner/run/session-bootstrap.ts
+++ b/src/agents/embedded-agent-runner/run/session-bootstrap.ts
@@ -71,9 +71,9 @@ export function buildContextEngineCompactionSessionTarget(params: {
       ? candidateSessionKey
       : candidateSessionKey && !suppliedEntry
         ? candidateSessionKey
-        : (preferredMarkerSessionKey ?? (markerMatches.length === 0 ? marker.sessionId : undefined))
+        : preferredMarkerSessionKey
     : undefined;
-  if (marker && !markerSessionKey) {
+  if (marker && markerMatches.length > 0 && !markerSessionKey) {
     throw new Error("Legacy compaction transcript identity is ambiguous");
   }
   if (
@@ -90,7 +90,7 @@ export function buildContextEngineCompactionSessionTarget(params: {
     ? targetSessionKey
     : marker
       ? markerSessionKey
-      : (targetSessionKey ?? suppliedSessionKey ?? targetSessionId ?? params.sessionId);
+      : (targetSessionKey ?? suppliedSessionKey);
   const agentId =
     targetAgentId ??
     marker?.agentId ??

--- a/src/agents/embedded-agent-runner/run/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/run/session-prompt-state.ts
@@ -61,6 +61,7 @@ export function createEmbeddedRunSessionPromptState(input: {
     const resolvedTarget = await resolveAgentRunSessionTarget({
       agentId: nextSessionTarget.agentId ?? sessionAgentId,
       config: params.config,
+      missingSessionKey: "resolve-existing",
       sessionId: nextSessionTarget.sessionId ?? activeSessionId,
       sessionKey: nextSessionTarget.sessionKey ?? resolvedSessionKey,
       sessionTarget: nextSessionTarget,

--- a/src/agents/run-session-target.test.ts
+++ b/src/agents/run-session-target.test.ts
@@ -2,10 +2,23 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/io.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { upsertSessionEntry } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveAgentRunSessionTarget } from "./run-session-target.js";
+import { resolveAgentRunSessionTarget as resolveAgentRunSessionTargetImpl } from "./run-session-target.js";
+
+type ResolveTargetParams = Omit<
+  Parameters<typeof resolveAgentRunSessionTargetImpl>[0],
+  "missingSessionKey"
+>;
+
+function resolveAgentRunSessionTarget(
+  params: ResolveTargetParams,
+  missingSessionKey: "create" | "resolve-existing" = "resolve-existing",
+) {
+  return resolveAgentRunSessionTargetImpl({ ...params, missingSessionKey });
+}
 
 describe("agent run session target", () => {
   let tempDir: string;
@@ -60,10 +73,13 @@ describe("agent run session target", () => {
     const storePath = path.join(tempDir, "fallback", "sessions.json");
 
     await expect(
-      resolveAgentRunSessionTarget({
-        config: { session: { store: storePath } } as OpenClawConfig,
-        sessionId: "compat-session",
-      }),
+      resolveAgentRunSessionTarget(
+        {
+          config: { session: { store: storePath } } as OpenClawConfig,
+          sessionId: "compat-session",
+        },
+        "create",
+      ),
     ).resolves.toEqual({
       agentId: "main",
       sessionId: "compat-session",
@@ -72,15 +88,69 @@ describe("agent run session target", () => {
     });
   });
 
+  it("resolves an existing keyed row before creating a session-id compatibility key", async () => {
+    const storePath = path.join(tempDir, "existing", "sessions.json");
+    const sessionId = "2fb701ef-6425-4c48-9b6f-5a170aa2477e";
+    const sessionKey = "agent:main:telegram:direct:reporter";
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId, updatedAt: 1 },
+    );
+
+    await expect(
+      resolveAgentRunSessionTarget({
+        agentId: "main",
+        config: { session: { store: storePath } } as OpenClawConfig,
+        sessionId,
+      }),
+    ).resolves.toMatchObject({ sessionId, sessionKey, storePath });
+  });
+
+  it("uses the active runtime store when compatibility projection omits config", async () => {
+    const storePath = path.join(tempDir, "runtime-config", "sessions.json");
+    const sessionId = "7ef14ab2-4801-40e1-9c56-83f9250c1706";
+    const sessionKey = "agent:main:discord:direct:reporter";
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId, updatedAt: 1 },
+    );
+    setRuntimeConfigSnapshot({ session: { store: storePath } });
+    try {
+      await expect(
+        resolveAgentRunSessionTarget({ agentId: "main", sessionId }),
+      ).resolves.toMatchObject({ sessionId, sessionKey, storePath });
+    } finally {
+      clearRuntimeConfigSnapshot();
+    }
+  });
+
+  it("returns a typed failure when existing-transcript resolution has no keyed row", async () => {
+    const storePath = path.join(tempDir, "missing", "sessions.json");
+
+    await expect(
+      resolveAgentRunSessionTarget({
+        agentId: "main",
+        config: { session: { store: storePath } } as OpenClawConfig,
+        sessionId: "missing-session",
+      }),
+    ).rejects.toMatchObject({
+      code: "session-key-missing",
+      name: "AgentRunSessionTargetResolutionError",
+    });
+  });
+
   it("round-trips a plain compatibility key through sessionFile", async () => {
     const storePath = path.join(tempDir, "fallback", "sessions.json");
 
     await expect(
-      resolveAgentRunSessionTarget({
-        config: { session: { store: storePath } } as OpenClawConfig,
-        sessionId: "compat-session",
-        sessionFile: "compat-session",
-      }),
+      resolveAgentRunSessionTarget(
+        {
+          config: { session: { store: storePath } } as OpenClawConfig,
+          sessionId: "compat-session",
+          sessionFile: "compat-session",
+        },
+        "create",
+      ),
     ).resolves.toEqual({
       agentId: "main",
       sessionId: "compat-session",
@@ -176,15 +246,18 @@ describe("agent run session target", () => {
     const storePath = path.join(tempDir, "legacy-partial", "sessions.json");
 
     await expect(
-      resolveAgentRunSessionTarget({
-        sessionId: "legacy-session",
-        sessionFile: formatSqliteSessionFileMarker({
-          agentId: "main",
+      resolveAgentRunSessionTarget(
+        {
           sessionId: "legacy-session",
-          storePath,
-        }),
-        sessionTarget: { agentId: "main", sessionId: "legacy-session" },
-      }),
+          sessionFile: formatSqliteSessionFileMarker({
+            agentId: "main",
+            sessionId: "legacy-session",
+            storePath,
+          }),
+          sessionTarget: { agentId: "main", sessionId: "legacy-session" },
+        },
+        "create",
+      ),
     ).resolves.toMatchObject({ agentId: "main", sessionId: "legacy-session", storePath });
   });
 
@@ -227,11 +300,14 @@ describe("agent run session target", () => {
 
   it("uses a partial target session id as a plain compatibility key", async () => {
     await expect(
-      resolveAgentRunSessionTarget({
-        sessionId: "previous-session",
-        sessionFile: "current-session",
-        sessionTarget: { agentId: "main", sessionId: "current-session" },
-      }),
+      resolveAgentRunSessionTarget(
+        {
+          sessionId: "previous-session",
+          sessionFile: "current-session",
+          sessionTarget: { agentId: "main", sessionId: "current-session" },
+        },
+        "create",
+      ),
     ).resolves.toMatchObject({
       agentId: "main",
       sessionId: "current-session",
@@ -286,15 +362,18 @@ describe("agent run session target", () => {
 
   it("normalizes partial typed identity before comparing a legacy marker", async () => {
     await expect(
-      resolveAgentRunSessionTarget({
-        sessionId: "legacy-session",
-        sessionFile: formatSqliteSessionFileMarker({
-          agentId: "main",
+      resolveAgentRunSessionTarget(
+        {
           sessionId: "legacy-session",
-          storePath: path.join(tempDir, "legacy.json"),
-        }),
-        sessionTarget: { agentId: " main ", sessionId: " legacy-session " },
-      }),
+          sessionFile: formatSqliteSessionFileMarker({
+            agentId: "main",
+            sessionId: "legacy-session",
+            storePath: path.join(tempDir, "legacy.json"),
+          }),
+          sessionTarget: { agentId: " main ", sessionId: " legacy-session " },
+        },
+        "create",
+      ),
     ).resolves.toMatchObject({ agentId: "main", sessionId: "legacy-session" });
   });
 

--- a/src/agents/run-session-target.ts
+++ b/src/agents/run-session-target.ts
@@ -1,14 +1,20 @@
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getRuntimeConfig } from "../config/io.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import {
   listSessionEntries,
+  resolveTranscriptSessionKeyBySessionId,
   resolveSessionTranscriptRuntimeTarget,
   type SessionTranscriptRuntimeTarget,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import {
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+  toAgentStoreSessionKey,
+} from "../routing/session-key.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../sessions/session-id-resolution.js";
 import { resolveDefaultAgentId } from "./agent-scope.js";
 
@@ -24,15 +30,26 @@ export type AgentRunSessionTarget = {
 /** Canonical SQLite target resolved from the storage-neutral run identity. */
 type ResolvedAgentRunSessionTarget = SessionTranscriptRuntimeTarget;
 
+export class AgentRunSessionTargetResolutionError extends Error {
+  readonly code = "session-key-missing";
+
+  constructor(sessionId: string) {
+    super(`Cannot resolve a session key for existing session: ${sessionId}`);
+    this.name = "AgentRunSessionTargetResolutionError";
+  }
+}
+
 /** Resolves the active runtime target used by current run/session internals. */
 export async function resolveAgentRunSessionTarget(params: {
   agentId?: string;
   config?: OpenClawConfig;
+  missingSessionKey: "create" | "resolve-existing";
   sessionId: string;
   sessionFile?: string;
   sessionKey?: string;
   sessionTarget?: AgentRunSessionTarget;
 }): Promise<ResolvedAgentRunSessionTarget> {
+  const config = params.config ?? getRuntimeConfig();
   const sessionTarget = params.sessionTarget;
   const targetAgentId = normalizeOptionalString(sessionTarget?.agentId);
   const targetSessionId = normalizeOptionalString(sessionTarget?.sessionId);
@@ -75,12 +92,12 @@ export async function resolveAgentRunSessionTarget(params: {
   }
   const agentId = targetAgentId ?? legacyMarker?.agentId ?? params.agentId;
   const sessionId = targetSessionId ?? legacyMarker?.sessionId ?? params.sessionId;
+  const recognizedCompatibilitySessionKey = recognizedCompatibilityKey
+    ? legacySessionFile
+    : undefined;
   const compatibilitySessionKey =
-    plainCompatibilitySessionKey ||
-    legacySessionFile?.startsWith("agent:") ||
-    legacySessionFile?.startsWith("in-memory:")
-      ? legacySessionFile
-      : undefined;
+    recognizedCompatibilitySessionKey ??
+    (params.missingSessionKey === "create" ? plainCompatibilitySessionKey : undefined);
   const markerEntries =
     legacyMarker && !hasCompleteTypedTarget
       ? listSessionEntries({
@@ -108,12 +125,34 @@ export async function resolveAgentRunSessionTarget(params: {
   ) {
     throw new Error("Legacy SQLite transcript marker session key is ambiguous");
   }
+  const lookupAgentId = agentId ?? resolveDefaultAgentId(config);
+  const lookupStorePath =
+    targetStorePath ??
+    legacyMarker?.storePath ??
+    resolveStorePath(config.session?.store, { agentId: lookupAgentId });
+  const storedSessionKey =
+    params.missingSessionKey === "resolve-existing" &&
+    !targetSessionKey &&
+    !suppliedSessionKey &&
+    !compatibilitySessionKey &&
+    !markerSessionKey
+      ? resolveTranscriptSessionKeyBySessionId({
+          agentId: lookupAgentId,
+          sessionId,
+          storePath: lookupStorePath,
+        })
+      : undefined;
+  const createdSessionKey =
+    params.missingSessionKey === "create"
+      ? toAgentStoreSessionKey({ agentId: lookupAgentId, requestKey: sessionId })
+      : undefined;
   const sessionKey =
     targetSessionKey ??
     suppliedSessionKey ??
     compatibilitySessionKey ??
     markerSessionKey ??
-    normalizeOptionalString(sessionId);
+    storedSessionKey ??
+    createdSessionKey;
   const compatibilitySessionKeySelected =
     !targetSessionKey && !suppliedSessionKey && sessionKey === compatibilitySessionKey;
   const suppliedKeyAgentId = parseAgentSessionKey(suppliedSessionKey)?.agentId;
@@ -153,13 +192,16 @@ export async function resolveAgentRunSessionTarget(params: {
   ) {
     throw new Error("Compatibility session key conflicts with the supplied agent identity");
   }
+  if (!sessionKey) {
+    throw new AgentRunSessionTargetResolutionError(sessionId);
+  }
   const effectiveAgentId =
-    agentId ?? resolveAgentIdFromSessionKey(sessionKey, resolveDefaultAgentId(params.config ?? {}));
+    agentId ?? resolveAgentIdFromSessionKey(sessionKey, resolveDefaultAgentId(config));
   if (sessionTarget && sessionKey) {
     const storePath =
       targetStorePath ??
       legacyMarker?.storePath ??
-      resolveStorePath(params.config?.session?.store, { agentId: effectiveAgentId });
+      resolveStorePath(config.session?.store, { agentId: effectiveAgentId });
     return await resolveSessionTranscriptRuntimeTarget({
       ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
       sessionId,
@@ -178,10 +220,7 @@ export async function resolveAgentRunSessionTarget(params: {
     });
   }
 
-  if (!sessionKey) {
-    throw new Error(`Cannot resolve run session target without a session key: ${sessionId}`);
-  }
-  const storePath = resolveStorePath(params.config?.session?.store, { agentId: effectiveAgentId });
+  const storePath = resolveStorePath(config.session?.store, { agentId: effectiveAgentId });
   return await resolveSessionTranscriptRuntimeTarget({
     ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
     sessionId,

--- a/src/agents/run-session-target.ts
+++ b/src/agents/run-session-target.ts
@@ -30,7 +30,7 @@ export type AgentRunSessionTarget = {
 /** Canonical SQLite target resolved from the storage-neutral run identity. */
 type ResolvedAgentRunSessionTarget = SessionTranscriptRuntimeTarget;
 
-export class AgentRunSessionTargetResolutionError extends Error {
+class AgentRunSessionTargetResolutionError extends Error {
   readonly code = "session-key-missing";
 
   constructor(sessionId: string) {

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -20,6 +20,17 @@ import type {
 
 type PersistRecordResult = string | null | undefined | { adoptedMessageId: string };
 
+function requireTranscriptEventAppend(
+  result: ReturnType<typeof appendTranscriptEventSync>,
+  message: string,
+): void {
+  if (result.ok && result.value) {
+    return;
+  }
+  const cause = result.ok ? { code: "transcript-event-not-appended" as const } : result.error;
+  throw new Error(`${message}: ${cause.code}`, { cause });
+}
+
 export class SessionManagerPersistence extends SessionManagerCore {
   removeTrailingEntries(
     predicate: (entry: SessionEntry) => boolean,
@@ -160,33 +171,37 @@ export class SessionManagerPersistence extends SessionManagerCore {
         throw new Error("Session transcript header was not persisted");
       }
       const header = this.fileEntries[0];
-      if (!header || header.type !== "session" || !appendTranscriptEventSync(scope, header)) {
+      if (!header || header.type !== "session") {
         throw new Error("Session transcript header was not persisted");
       }
+      requireTranscriptEventAppend(
+        appendTranscriptEventSync(scope, header),
+        "Session transcript header was not persisted",
+      );
       this.persistenceHeaderPending = false;
     }
     const leafEntry = parseOpaqueLeafEntry(entry);
     if (leafEntry) {
-      if (!appendTranscriptEventSync(scope, entry)) {
-        throw new Error(`Session transcript leaf control was not persisted: ${leafEntry.id}`);
-      }
+      requireTranscriptEventAppend(
+        appendTranscriptEventSync(scope, entry),
+        `Session transcript leaf control was not persisted: ${leafEntry.id}`,
+      );
       return undefined;
     }
     if (!isIndexedSessionEntry(entry)) {
       return undefined;
     }
     if (entry.type !== "message") {
-      if (
-        !appendTranscriptEventSync(
+      requireTranscriptEventAppend(
+        appendTranscriptEventSync(
           scope,
           entry,
           options?.appendIntent === "active-branch"
             ? { appendIntent: options.appendIntent }
             : undefined,
-        )
-      ) {
-        throw new Error(`Session transcript entry was not persisted: ${entry.id}`);
-      }
+        ),
+        `Session transcript entry was not persisted: ${entry.id}`,
+      );
       return undefined;
     }
     const appendOptions = {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -869,6 +869,20 @@ describe("SessionManager.open", () => {
       { sessionId: "replacement-session", updatedAt: 20 },
     );
 
+    try {
+      sessionManager.appendCompaction("late summary", assistant.messageId, 42);
+      throw new Error("expected rebound compaction persistence to fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        cause: {
+          actualSessionId: "replacement-session",
+          code: "session-rebound",
+          expectedSessionId: sessionId,
+          sessionKey,
+        },
+      });
+    }
+
     expect(() =>
       sessionManager.mergePromptReleasedSessionEntries([sideEntry], { persistLeaf: true }),
     ).toThrow("leaf control was not persisted");

--- a/src/auto-reply/reply/conversation-turn-capture.ts
+++ b/src/auto-reply/reply/conversation-turn-capture.ts
@@ -212,7 +212,7 @@ async function capturePendingConversationTurnReplyUnsafe(params: {
     // without inserting a user row between an active tool call and its result.
     let persisted = false;
     try {
-      persisted = appendTranscriptEventSync(
+      const appendResult = appendTranscriptEventSync(
         { agentId, sessionId: sessionEntry.sessionId, sessionKey, storePath },
         {
           type: "custom",
@@ -230,6 +230,12 @@ async function capturePendingConversationTurnReplyUnsafe(params: {
           },
         },
       );
+      persisted = appendResult.ok && appendResult.value;
+      if (!appendResult.ok) {
+        logVerbose(
+          `captured conversation turn reply audit persistence failed: ${appendResult.error.code}`,
+        );
+      }
     } catch (error) {
       logVerbose(`captured conversation turn reply audit persistence failed: ${String(error)}`);
     }

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -80,6 +80,19 @@ export type TranscriptEventAppendOptions = {
   appendIntent?: "active-branch";
 };
 
+export type TranscriptEventAppendError =
+  | {
+      actualSessionId: string;
+      code: "session-rebound";
+      expectedSessionId: string;
+      sessionKey: string;
+    }
+  | {
+      code: "session-entry-missing";
+      expectedSessionId: string;
+      sessionKey: string;
+    };
+
 export type SessionTranscriptStats = {
   eventCount: number;
   lastMutationAtMs?: number;

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import {
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
@@ -13,6 +14,7 @@ import type {
   SessionTranscriptTurnWriteContext,
   SessionTranscriptWriteScope,
   TranscriptEvent,
+  TranscriptEventAppendError,
   TranscriptEventAppendOptions,
   TranscriptMessageAppendOptions,
   TranscriptMessageAppendResult,
@@ -270,22 +272,38 @@ export function appendSqliteTranscriptEventSync(
   scope: SessionTranscriptAccessScope,
   event: TranscriptEvent,
   options: TranscriptEventAppendOptions = {},
-): boolean {
+): Result<boolean, TranscriptEventAppendError> {
   assertNonMessageTranscriptEvent(event);
   const resolved = resolveSqliteTranscriptScope(scope);
-  let appended = false;
+  let result: Result<boolean, TranscriptEventAppendError> = ok(false);
   runOpenClawAgentWriteTransaction((database) => {
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
-    if (!fresh || fresh.entry.sessionId !== resolved.sessionId) {
+    if (!fresh) {
+      result = err({
+        code: "session-entry-missing",
+        expectedSessionId: resolved.sessionId,
+        sessionKey: resolved.sessionKey,
+      });
       return;
     }
-    appended = appendTranscriptEventInTransaction(
-      database,
-      resolved,
-      resolveTranscriptEventAppendParent(database, resolved.sessionId, event, options),
+    if (fresh.entry.sessionId !== resolved.sessionId) {
+      result = err({
+        actualSessionId: fresh.entry.sessionId,
+        code: "session-rebound",
+        expectedSessionId: resolved.sessionId,
+        sessionKey: resolved.sessionKey,
+      });
+      return;
+    }
+    result = ok(
+      appendTranscriptEventInTransaction(
+        database,
+        resolved,
+        resolveTranscriptEventAppendParent(database, resolved.sessionId, event, options),
+      ),
     );
   }, toDatabaseOptions(resolved));
-  return appended;
+  return result;
 }
 
 function resolveTranscriptEventAppendParent(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -139,6 +139,40 @@ describe("session accessor seam", () => {
     expect(deleteSessionEntryLifecycle).toBe(deleteSqliteSessionEntryLifecycle);
   });
 
+  it("returns typed sync event append outcomes for missing, rebound, and duplicate rows", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "expected-session",
+      sessionKey: "agent:main:typed-append",
+      storePath,
+    };
+    const event = { type: "custom", id: "typed-event", timestamp: 1 };
+
+    expect(appendSqliteTranscriptEventSync(scope, event)).toEqual({
+      ok: false,
+      error: {
+        code: "session-entry-missing",
+        expectedSessionId: scope.sessionId,
+        sessionKey: scope.sessionKey,
+      },
+    });
+
+    await upsertSessionEntry(scope, { sessionId: "replacement-session", updatedAt: 1 });
+    expect(appendSqliteTranscriptEventSync(scope, event)).toEqual({
+      ok: false,
+      error: {
+        actualSessionId: "replacement-session",
+        code: "session-rebound",
+        expectedSessionId: scope.sessionId,
+        sessionKey: scope.sessionKey,
+      },
+    });
+
+    await upsertSessionEntry(scope, { sessionId: scope.sessionId, updatedAt: 2 });
+    expect(appendSqliteTranscriptEventSync(scope, event)).toEqual({ ok: true, value: true });
+    expect(appendSqliteTranscriptEventSync(scope, event)).toEqual({ ok: true, value: false });
+  });
+
   it("loads, lists, and patches session entries without exposing the file store shape", async () => {
     const scope = {
       sessionKey: "agent:main:main",


### PR DESCRIPTION
## What Problem This Solves

When a plugin owns the `contextEngine` slot and delegates compaction back to the runtime, every LLM compaction fails as `outcome=failed reason=unknown`. Two independent defects: the sessionId UUID was silently substituted for a missing sessionKey (three layers deep), so the sqlite transcript write matched no row; and the failed append collapsed into a generic no-cause error, leaving the operator zero diagnostic signal.

Fixes https://github.com/openclaw/openclaw/issues/119018 (reported by @abacha).

## Why This Change Was Made

Provenance: `4273ca9dbd9b3` added the bare `sessionId` fallback in `run-session-target.ts`; `40dafc5c332d` added the compatibility projection that strips `sessionKey`/`sessionTarget` for undeclared engines — together they let a UUID masquerade as a session key.

The repair establishes two explicit ownership boundaries instead of patching the symptom:

1. `resolveAgentRunSessionTarget` now requires explicit intent — `missingSessionKey: "create" | "resolve-existing"`. Only new-run admission (`runEmbeddedAgent`, whose public input legitimately permits an omitted key) may mint a canonical agent-scoped key. Every keyed-store consumer (compaction, persistence, locks, successor paths) resolves the authoritative key through the session store or throws a typed `session-key-missing` error. All compaction-side `?? sessionId` sentinels were removed (queued/direct compaction, hooks, CLI compaction, recovery targets, transcript rewrites, deferred maintenance).
2. `appendSqliteTranscriptEventSync` returns `Result<boolean, TranscriptEventAppendError>`: missing-row and rebound-row outcomes carry typed codes and identity details; duplicate appends remain the load-bearing `ok(false)` no-op. SessionManager attaches the typed result as `Error.cause`, and compaction reports `reason=transcript_persistence_failed` instead of `unknown`.

Sibling surfaces checked: queued/manual, direct/delegated, overflow/timeout recovery, non-delegated engines (shared repaired seam), post-compaction maintenance, gateway manual compaction, Codex native compaction (separate keyed path, unaffected), Copilot (session-ID-owned lookup unaffected), ACPX (covered).

## User Impact

Delegated context-engine compaction works. When transcript persistence genuinely fails, operators see a typed reason with row-identity detail instead of `reason=unknown`.

## Evidence

- Reproduced on baseline `9fdae501` before implementation.
- Focused regression: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/run-session-target.test.ts src/config/sessions/session-accessor.test.ts src/agents/sessions/session-manager.test.ts src/agents/embedded-agent-runner/compact-reasons.test.ts src/agents/embedded-agent-runner/compaction-runtime-context.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts` — 5 shards, 319 tests passed (re-verified independently after review).
- Touched-module suites: 8 shards, 361 tests passed. Custom runtime-store regression 25/25; final compaction regression 124/124.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, targeted oxlint, plugin SDK API baseline: all passed.
- Codex autoreview (`gpt-5.6-sol`, high), run twice (worker closeout + independent coordinator pass on the frozen diff): clean both times, no accepted/actionable findings.
- Production +176/−51 (net +125: the two ownership boundaries above, justified per Repair Doctrine); tests +209/−53.
- Risk: medium — cross-cutting session identity and a sync accessor return-contract change (both production consumers updated). Reviewer attention: legacy host-parameter projection, custom-store lookup through runtime config, typed error propagation through delegated compaction.
