### PR TITLE
refactor(plugins): adopt shared channel account config shape (no schema changes)

### DIFF
--- a/extensions/buzz/src/config-schema.ts
+++ b/extensions/buzz/src/config-schema.ts
@@ -1,7 +1,6 @@
 import {
   buildChannelConfigSchema,
-  GroupPolicySchema,
-  MarkdownConfigSchema,
+  buildCommonChannelAccountShape,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
@@ -14,12 +13,33 @@ const BuzzGroupConfigSchema = z
   })
   .strict();
 
+const BuzzCommonAccountShape = buildCommonChannelAccountShape({
+  groupPolicyDefault: true,
+  omit: [
+    "capabilities",
+    "dmPolicy",
+    "allowFrom",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const RawBuzzConfigSchema = z
   .object({
-    name: z.string().optional(),
-    enabled: z.boolean().optional(),
-    configWrites: z.boolean().optional(),
-    markdown: MarkdownConfigSchema,
+    name: BuzzCommonAccountShape.name,
+    enabled: BuzzCommonAccountShape.enabled,
+    configWrites: BuzzCommonAccountShape.configWrites,
+    markdown: BuzzCommonAccountShape.markdown,
     relayUrl: z
       .string()
       .url()
@@ -27,15 +47,15 @@ const RawBuzzConfigSchema = z
       .optional(),
     privateKey: buildSecretInputSchema().optional(),
     authTag: buildSecretInputSchema().optional(),
-    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
-    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupPolicy: BuzzCommonAccountShape.groupPolicy,
+    groupAllowFrom: BuzzCommonAccountShape.groupAllowFrom,
     groups: z
       .record(
         z.string().regex(BUZZ_CHANNEL_ID_PATTERN, "Buzz group key must be a channel UUID"),
         BuzzGroupConfigSchema,
       )
       .optional(),
-    defaultTo: z.string().optional(),
+    defaultTo: BuzzCommonAccountShape.defaultTo,
   })
   .strict();
 

--- a/extensions/clickclack/src/config-schema.ts
+++ b/extensions/clickclack/src/config-schema.ts
@@ -3,16 +3,40 @@
  */
 import {
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildMultiAccountChannelSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
 
+const ClickClackCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "markdown",
+    "dmPolicy",
+    "allowFrom",
+    "groupAllowFrom",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const ClickClackAccountConfigSchema = z
   .object({
-    name: z.string().optional(),
-    enabled: z.boolean().optional(),
-    configWrites: z.boolean().optional(),
+    name: ClickClackCommonAccountShape.name,
+    enabled: ClickClackCommonAccountShape.enabled,
+    configWrites: ClickClackCommonAccountShape.configWrites,
     baseUrl: z.string().url().optional(),
     apiBaseUrl: z.string().url().optional(),
     token: buildSecretInputSchema().optional(),
@@ -24,7 +48,7 @@ const ClickClackAccountConfigSchema = z
     model: z.string().optional(),
     systemPrompt: z.string().optional(),
     toolsAllow: z.array(z.string()).optional(),
-    defaultTo: z.string().optional(),
+    defaultTo: ClickClackCommonAccountShape.defaultTo,
     allowFrom: z.array(z.string()).optional(),
     reconnectMs: z.number().int().min(100).max(60_000).optional(),
     agentActivity: z.boolean().optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -4,6 +4,7 @@ import {
   DmPolicySchema,
   GroupPolicySchema,
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildGroupEntrySchema,
   buildMultiAccountChannelSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
@@ -198,24 +199,41 @@ const FeishuGroupSchema = buildGroupEntrySchema({
   replyInThread: ReplyInThreadSchema,
 }).omit({ toolsBySender: true });
 
+const FeishuCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "name",
+    "markdown",
+    "defaultTo",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "dms",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "replyToMode",
+  ],
+});
+
 const FeishuSharedConfigShape = {
   webhookHost: z.string().optional(),
   webhookPort: z.number().int().positive().optional(),
-  capabilities: z.array(z.string()).optional(),
+  capabilities: FeishuCommonAccountShape.capabilities,
   markdown: MarkdownConfigSchema,
-  configWrites: z.boolean().optional(),
-  dmPolicy: DmPolicySchema.optional(),
-  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  configWrites: FeishuCommonAccountShape.configWrites,
+  dmPolicy: FeishuCommonAccountShape.dmPolicy,
+  allowFrom: FeishuCommonAccountShape.allowFrom,
   groupPolicy: FeishuGroupPolicySchema.optional(),
-  groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  groupAllowFrom: FeishuCommonAccountShape.groupAllowFrom,
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
-  historyLimit: z.number().int().min(0).optional(),
-  dmHistoryLimit: z.number().int().min(0).optional(),
+  historyLimit: FeishuCommonAccountShape.historyLimit,
+  dmHistoryLimit: FeishuCommonAccountShape.dmHistoryLimit,
   dms: z.record(z.string(), DmConfigSchema).optional(),
-  textChunkLimit: z.number().int().positive().optional(),
-  mediaMaxMb: z.number().positive().optional(),
+  textChunkLimit: FeishuCommonAccountShape.textChunkLimit,
+  mediaMaxMb: FeishuCommonAccountShape.mediaMaxMb,
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeatVisibility: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
@@ -237,7 +255,7 @@ const FeishuSharedConfigShape = {
  */
 export const FeishuAccountConfigSchema = z
   .object({
-    enabled: z.boolean().optional(),
+    enabled: FeishuCommonAccountShape.enabled,
     name: z.string().optional(), // Display name for this account
     appId: z.string().optional(),
     appSecret: buildSecretInputSchema().optional(),
@@ -254,7 +272,7 @@ export const FeishuAccountConfigSchema = z
 
 const FeishuConfigSchemaBase = z
   .object({
-    enabled: z.boolean().optional(),
+    enabled: FeishuCommonAccountShape.enabled,
     defaultAccount: z.string().optional(),
     // Top-level credentials (backward compatible for single-account mode)
     appId: z.string().optional(),

--- a/extensions/irc/src/config-schema.ts
+++ b/extensions/irc/src/config-schema.ts
@@ -1,11 +1,8 @@
 // Irc helper module supports config schema behavior.
 import {
   ChannelGroupEntrySchema,
-  DmPolicySchema,
-  GroupPolicySchema,
-  MarkdownConfigSchema,
-  ReplyRuntimeConfigSchemaShape,
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildMultiAccountChannelSchema,
   requireOpenAllowFrom,
 } from "openclaw/plugin-sdk/channel-config-schema";
@@ -32,11 +29,23 @@ const IrcNickServSchema = z
     }
   });
 
+const IrcCommonAccountShape = buildCommonChannelAccountShape({
+  useDefaults: true,
+  omit: [
+    "capabilities",
+    "defaultTo",
+    "mentionPatterns",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "replyToMode",
+  ],
+});
+
 const IrcAccountSchemaBase = z
   .object({
-    name: z.string().optional(),
-    enabled: z.boolean().optional(),
-    configWrites: z.boolean().optional(),
+    name: IrcCommonAccountShape.name,
+    enabled: IrcCommonAccountShape.enabled,
+    configWrites: IrcCommonAccountShape.configWrites,
     dangerouslyAllowNameMatching: z.boolean().optional(),
     host: z.string().optional(),
     port: z.number().int().min(1).max(65535).optional(),
@@ -47,15 +56,22 @@ const IrcAccountSchemaBase = z
     password: z.string().optional(),
     passwordFile: z.string().optional(),
     nickserv: IrcNickServSchema.optional(),
-    dmPolicy: DmPolicySchema.optional().default("pairing"),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
-    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
-    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    dmPolicy: IrcCommonAccountShape.dmPolicy,
+    allowFrom: IrcCommonAccountShape.allowFrom,
+    groupPolicy: IrcCommonAccountShape.groupPolicy,
+    groupAllowFrom: IrcCommonAccountShape.groupAllowFrom,
     groups: z.record(z.string(), ChannelGroupEntrySchema.optional()).optional(),
     channels: z.array(z.string()).optional(),
     mentionPatterns: z.array(z.string()).optional(),
-    markdown: MarkdownConfigSchema,
-    ...ReplyRuntimeConfigSchemaShape,
+    markdown: IrcCommonAccountShape.markdown,
+    historyLimit: IrcCommonAccountShape.historyLimit,
+    dmHistoryLimit: IrcCommonAccountShape.dmHistoryLimit,
+    contextVisibility: IrcCommonAccountShape.contextVisibility,
+    dms: IrcCommonAccountShape.dms,
+    textChunkLimit: IrcCommonAccountShape.textChunkLimit,
+    streaming: IrcCommonAccountShape.streaming,
+    responsePrefix: IrcCommonAccountShape.responsePrefix,
+    mediaMaxMb: IrcCommonAccountShape.mediaMaxMb,
   })
   .strict();
 

--- a/extensions/line/src/config-schema.ts
+++ b/extensions/line/src/config-schema.ts
@@ -1,8 +1,7 @@
 // Line helper module supports config schema behavior.
 import {
-  DmPolicySchema,
-  GroupPolicySchema,
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildGroupEntrySchema,
   buildMultiAccountChannelSchema,
   requireOpenAllowFrom,
@@ -20,19 +19,39 @@ const ThreadBindingsSchema = z
   })
   .strict();
 
+const LineCommonAccountShape = buildCommonChannelAccountShape({
+  useDefaults: true,
+  omit: [
+    "capabilities",
+    "markdown",
+    "defaultTo",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const LineCommonConfigSchemaBase = z.object({
-  enabled: z.boolean().optional(),
-  configWrites: z.boolean().optional(),
+  enabled: LineCommonAccountShape.enabled,
+  configWrites: LineCommonAccountShape.configWrites,
   channelAccessToken: z.string().optional(),
   channelSecret: z.string().optional(),
   tokenFile: z.string().optional(),
   secretFile: z.string().optional(),
-  name: z.string().optional(),
-  allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
-  groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
-  dmPolicy: DmPolicySchema.optional().default("pairing"),
-  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
-  responsePrefix: z.string().optional(),
+  name: LineCommonAccountShape.name,
+  allowFrom: LineCommonAccountShape.allowFrom,
+  groupAllowFrom: LineCommonAccountShape.groupAllowFrom,
+  dmPolicy: LineCommonAccountShape.dmPolicy,
+  groupPolicy: LineCommonAccountShape.groupPolicy,
+  responsePrefix: LineCommonAccountShape.responsePrefix,
   mediaMaxMb: z.number().optional(),
   webhookPath: z.string().optional(),
   threadBindings: ThreadBindingsSchema.optional(),

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -3,12 +3,9 @@ import {
   AllowFromListSchema,
   BlockStreamingCoalesceSchema,
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildGroupEntrySchema,
   buildNestedDmConfigSchema,
-  ContextVisibilityModeSchema,
-  GroupPolicySchema,
-  MarkdownConfigSchema,
-  MentionPatternsPolicySchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
@@ -127,10 +124,27 @@ function hasCanonicalMatrixAccountStreaming(account: unknown): boolean {
   return typeof streaming === "object" && streaming !== null && !Array.isArray(streaming);
 }
 
+const MatrixCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "dmPolicy",
+    "allowFrom",
+    "defaultTo",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const MatrixConfigSchema = z.object({
-  name: z.string().optional(),
-  enabled: z.boolean().optional(),
-  configWrites: z.boolean().optional(),
+  name: MatrixCommonAccountShape.name,
+  enabled: MatrixCommonAccountShape.enabled,
+  configWrites: MatrixCommonAccountShape.configWrites,
   defaultAccount: z.string().optional(),
   // Accounts stay schema-open, but retired scalar streaming must fail loudly
   // instead of silently resolving to "off"; doctor migrates the old spelling.
@@ -143,7 +157,7 @@ const MatrixConfigSchema = z.object({
       }),
     )
     .optional(),
-  markdown: MarkdownConfigSchema,
+  markdown: MatrixCommonAccountShape.markdown,
   homeserver: z.string().optional(),
   network: matrixNetworkSchema,
   proxy: z.string().optional(),
@@ -159,14 +173,14 @@ const MatrixConfigSchema = z.object({
   dangerouslyAllowNameMatching: z.boolean().optional(),
   allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
   botLoopProtection: botLoopProtectionSchema,
-  groupPolicy: GroupPolicySchema.optional(),
-  mentionPatterns: MentionPatternsPolicySchema.optional(),
-  contextVisibility: ContextVisibilityModeSchema.optional(),
+  groupPolicy: MatrixCommonAccountShape.groupPolicy,
+  mentionPatterns: MatrixCommonAccountShape.mentionPatterns,
+  contextVisibility: MatrixCommonAccountShape.contextVisibility,
   streaming: matrixStreamingSchema.optional(),
   replyToMode: z.enum(["off", "first", "all", "batched"]).optional(),
   threadReplies: z.enum(["off", "inbound", "always"]).optional(),
   textChunkLimit: z.number().optional(),
-  responsePrefix: z.string().optional(),
+  responsePrefix: MatrixCommonAccountShape.responsePrefix,
   ackReaction: z.string().optional(),
   ackReactionScope: z
     .enum(["group-mentions", "group-all", "direct", "all", "none", "off"])
@@ -176,10 +190,10 @@ const MatrixConfigSchema = z.object({
   startupVerification: z.enum(["off", "if-unverified"]).optional(),
   startupVerificationCooldownHours: z.number().optional(),
   mediaMaxMb: z.number().optional(),
-  historyLimit: z.number().int().min(0).optional(),
+  historyLimit: MatrixCommonAccountShape.historyLimit,
   autoJoin: z.enum(["always", "allowlist", "off"]).optional(),
   autoJoinAllowlist: AllowFromListSchema,
-  groupAllowFrom: AllowFromListSchema,
+  groupAllowFrom: MatrixCommonAccountShape.groupAllowFrom,
   dm: buildNestedDmConfigSchema({
     sessionScope: z.enum(["per-user", "per-room"]).optional(),
     threadReplies: z.enum(["off", "inbound", "always"]).optional(),

--- a/extensions/nextcloud-talk/src/config-schema.ts
+++ b/extensions/nextcloud-talk/src/config-schema.ts
@@ -1,9 +1,6 @@
 // Nextcloud Talk helper module supports config schema behavior.
 import {
-  DmPolicySchema,
-  GroupPolicySchema,
-  MarkdownConfigSchema,
-  ReplyRuntimeConfigSchemaShape,
+  buildCommonChannelAccountShape,
   buildGroupEntrySchema,
   buildMultiAccountChannelSchema,
   requireOpenAllowFrom,
@@ -24,30 +21,51 @@ const NextcloudTalkNetworkSchema = z
   .strict()
   .optional();
 
+const NextcloudTalkCommonAccountShape = buildCommonChannelAccountShape({
+  useDefaults: true,
+  omit: [
+    "capabilities",
+    "allowFrom",
+    "defaultTo",
+    "groupAllowFrom",
+    "mentionPatterns",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "replyToMode",
+  ],
+});
+
 const NextcloudTalkAccountSchemaBase = z
   .object({
-    name: z.string().optional(),
-    enabled: z.boolean().optional(),
-    configWrites: z.boolean().optional(),
-    markdown: MarkdownConfigSchema,
+    name: NextcloudTalkCommonAccountShape.name,
+    enabled: NextcloudTalkCommonAccountShape.enabled,
+    configWrites: NextcloudTalkCommonAccountShape.configWrites,
+    markdown: NextcloudTalkCommonAccountShape.markdown,
     baseUrl: z.string().optional(),
     botSecret: buildSecretInputSchema().optional(),
     botSecretFile: z.string().optional(),
     apiUser: z.string().optional(),
     apiPassword: buildSecretInputSchema().optional(),
     apiPasswordFile: z.string().optional(),
-    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    dmPolicy: NextcloudTalkCommonAccountShape.dmPolicy,
     webhookPort: z.number().int().positive().optional(),
     webhookHost: z.string().optional(),
     webhookPath: z.string().optional(),
     webhookPublicUrl: z.string().optional(),
     allowFrom: z.array(z.string()).optional(),
     groupAllowFrom: z.array(z.string()).optional(),
-    groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    groupPolicy: NextcloudTalkCommonAccountShape.groupPolicy,
     rooms: z.record(z.string(), NextcloudTalkRoomSchema.optional()).optional(),
     /** Network policy overrides for self-hosted Nextcloud Talk on trusted private/internal hosts. */
     network: NextcloudTalkNetworkSchema,
-    ...ReplyRuntimeConfigSchemaShape,
+    historyLimit: NextcloudTalkCommonAccountShape.historyLimit,
+    dmHistoryLimit: NextcloudTalkCommonAccountShape.dmHistoryLimit,
+    contextVisibility: NextcloudTalkCommonAccountShape.contextVisibility,
+    dms: NextcloudTalkCommonAccountShape.dms,
+    textChunkLimit: NextcloudTalkCommonAccountShape.textChunkLimit,
+    streaming: NextcloudTalkCommonAccountShape.streaming,
+    responsePrefix: NextcloudTalkCommonAccountShape.responsePrefix,
+    mediaMaxMb: NextcloudTalkCommonAccountShape.mediaMaxMb,
   })
   .strict();
 

--- a/extensions/nostr/src/config-schema.ts
+++ b/extensions/nostr/src/config-schema.ts
@@ -1,9 +1,5 @@
 // Nostr helper module supports config schema behavior.
-import {
-  AllowFromListSchema,
-  DmPolicySchema,
-  MarkdownConfigSchema,
-} from "openclaw/plugin-sdk/channel-config-schema";
+import { buildCommonChannelAccountShape } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
 
@@ -69,19 +65,40 @@ export interface NostrProfile {
 /**
  * Zod schema for channels.nostr.* configuration
  */
+const NostrCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "defaultTo",
+    "groupAllowFrom",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 export const NostrConfigSchema = z.object({
   /** Account name (optional display name) */
-  name: z.string().optional(),
+  name: NostrCommonAccountShape.name,
 
   /** Optional default account id for routing/account selection. */
   defaultAccount: z.string().optional(),
 
   /** Whether this channel is enabled */
-  enabled: z.boolean().optional(),
-  configWrites: z.boolean().optional(),
+  enabled: NostrCommonAccountShape.enabled,
+  configWrites: NostrCommonAccountShape.configWrites,
 
   /** Markdown formatting overrides (tables). */
-  markdown: MarkdownConfigSchema,
+  markdown: NostrCommonAccountShape.markdown,
 
   /** Private key in hex or nsec bech32 format */
   privateKey: buildSecretInputSchema().optional(),
@@ -90,10 +107,10 @@ export const NostrConfigSchema = z.object({
   relays: z.array(z.string()).optional(),
 
   /** DM access policy: pairing, allowlist, open, or disabled */
-  dmPolicy: DmPolicySchema.optional(),
+  dmPolicy: NostrCommonAccountShape.dmPolicy,
 
   /** Allowed sender pubkeys (npub or hex format) */
-  allowFrom: AllowFromListSchema,
+  allowFrom: NostrCommonAccountShape.allowFrom,
 
   /** Profile metadata (NIP-01 kind:0 content) */
   profile: NostrProfileSchema.optional(),

--- a/extensions/qa-channel/src/config-schema.ts
+++ b/extensions/qa-channel/src/config-schema.ts
@@ -1,6 +1,7 @@
 // Qa Channel helper module supports config schema behavior.
 import {
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildGroupEntrySchema,
   buildMultiAccountChannelSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
@@ -22,20 +23,41 @@ const QaChannelGroupConfigSchema = buildGroupEntrySchema().omit({
   systemPrompt: true,
 });
 
+const QaChannelCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "markdown",
+    "dmPolicy",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const QaChannelAccountConfigSchema = z
   .object({
-    name: z.string().optional(),
-    enabled: z.boolean().optional(),
-    configWrites: z.boolean().optional(),
+    name: QaChannelCommonAccountShape.name,
+    enabled: QaChannelCommonAccountShape.enabled,
+    configWrites: QaChannelCommonAccountShape.configWrites,
     baseUrl: z.string().url().optional(),
     botUserId: z.string().optional(),
     botDisplayName: z.string().optional(),
     pollTimeoutMs: z.number().int().min(100).max(30_000).optional(),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: QaChannelCommonAccountShape.allowFrom,
     groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional(),
-    groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    groupAllowFrom: QaChannelCommonAccountShape.groupAllowFrom,
     groups: z.record(z.string(), QaChannelGroupConfigSchema).optional(),
-    defaultTo: z.string().optional(),
+    defaultTo: QaChannelCommonAccountShape.defaultTo,
     actions: QaChannelActionConfigSchema.optional(),
   })
   .strict();

--- a/extensions/qqbot/src/config-schema.ts
+++ b/extensions/qqbot/src/config-schema.ts
@@ -1,9 +1,7 @@
 // Qqbot helper module supports config schema behavior.
 import {
-  AllowFromListSchema,
-  ContextVisibilityModeSchema,
-  GroupPolicySchema,
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildGroupEntrySchema,
   buildMultiAccountChannelSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
@@ -53,7 +51,6 @@ const QQBotExecApprovalsSchema = z
   .optional();
 
 const QQBotDmPolicySchema = z.enum(["open", "allowlist", "disabled"]).optional();
-const QQBotGroupPolicySchema = GroupPolicySchema.optional();
 const QQBotGroupCommandLevelSchema = z.enum(["all", "safety", "strict"]).optional();
 
 const QQBotGroupSchema = buildGroupEntrySchema({
@@ -66,18 +63,39 @@ const QQBotGroupSchema = buildGroupEntrySchema({
 
 const QQBotGroupsSchema = z.record(z.string(), QQBotGroupSchema).optional();
 
+const QQBotCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "markdown",
+    "configWrites",
+    "dmPolicy",
+    "defaultTo",
+    "mentionPatterns",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const QQBotAccountSchema = z
   .object({
-    enabled: z.boolean().optional(),
-    name: z.string().optional(),
+    enabled: QQBotCommonAccountShape.enabled,
+    name: QQBotCommonAccountShape.name,
     appId: z.string().optional(),
     clientSecret: buildSecretInputSchema().optional(),
     clientSecretFile: z.string().optional(),
-    allowFrom: AllowFromListSchema,
-    groupAllowFrom: AllowFromListSchema,
+    allowFrom: QQBotCommonAccountShape.allowFrom,
+    groupAllowFrom: QQBotCommonAccountShape.groupAllowFrom,
     dmPolicy: QQBotDmPolicySchema,
-    groupPolicy: QQBotGroupPolicySchema,
-    contextVisibility: ContextVisibilityModeSchema.optional(),
+    groupPolicy: QQBotCommonAccountShape.groupPolicy,
+    contextVisibility: QQBotCommonAccountShape.contextVisibility,
     systemPrompt: z.string().optional(),
     markdownSupport: z.boolean().optional(),
     audioFormatPolicy: AudioFormatPolicySchema,

--- a/extensions/raft/src/config-schema.ts
+++ b/extensions/raft/src/config-schema.ts
@@ -1,15 +1,40 @@
 // Raft channel configuration schema.
 import {
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildMultiAccountChannelSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
 
+const RaftCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "markdown",
+    "dmPolicy",
+    "allowFrom",
+    "defaultTo",
+    "groupAllowFrom",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const RaftAccountSchema = z
   .object({
-    name: z.string().optional(),
-    enabled: z.boolean().optional(),
-    configWrites: z.boolean().optional(),
+    name: RaftCommonAccountShape.name,
+    enabled: RaftCommonAccountShape.enabled,
+    configWrites: RaftCommonAccountShape.configWrites,
     profile: z.string().min(1).optional(),
   })
   .strict();

--- a/extensions/sms/src/config-schema.ts
+++ b/extensions/sms/src/config-schema.ts
@@ -1,9 +1,8 @@
 // Sms helper module supports config schema behavior.
 import {
-  AllowFromListSchema,
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
   buildMultiAccountChannelSchema,
-  DmPolicySchema,
   requireOpenAllowFrom,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { requireChannelOpenAllowFrom } from "openclaw/plugin-sdk/extension-shared";
@@ -12,22 +11,43 @@ import { z } from "zod";
 
 const SecretInputSchema = buildSecretInputSchema();
 
+const SmsCommonAccountShape = buildCommonChannelAccountShape({
+  dmPolicyDefault: true,
+  omit: [
+    "capabilities",
+    "markdown",
+    "groupAllowFrom",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const SmsAccountConfigSchema = z
   .object({
-    name: z.string().optional(),
-    enabled: z.boolean().optional(),
-    configWrites: z.boolean().optional(),
+    name: SmsCommonAccountShape.name,
+    enabled: SmsCommonAccountShape.enabled,
+    configWrites: SmsCommonAccountShape.configWrites,
     accountSid: z.string().optional(),
     authToken: SecretInputSchema.optional(),
     fromNumber: z.string().optional(),
     messagingServiceSid: z.string().optional(),
-    defaultTo: z.string().optional(),
+    defaultTo: SmsCommonAccountShape.defaultTo,
     webhookPath: z.string().optional(),
     publicWebhookUrl: z.string().optional(),
     dangerouslyDisableSignatureValidation: z.boolean().optional(),
-    dmPolicy: DmPolicySchema.optional().default("pairing"),
-    allowFrom: AllowFromListSchema,
-    textChunkLimit: z.number().int().positive().optional(),
+    dmPolicy: SmsCommonAccountShape.dmPolicy,
+    allowFrom: SmsCommonAccountShape.allowFrom,
+    textChunkLimit: SmsCommonAccountShape.textChunkLimit,
   })
   .strict();
 

--- a/extensions/tlon/src/config-schema.ts
+++ b/extensions/tlon/src/config-schema.ts
@@ -2,6 +2,7 @@
 import {
   ChannelImplicitMentionsSchema,
   buildChannelConfigSchema,
+  buildCommonChannelAccountShape,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { createChannelConfigUiHints } from "openclaw/plugin-sdk/channel-core";
 import { z } from "zod";
@@ -25,10 +26,33 @@ const TlonNetworkSchema = z
   .strict()
   .optional();
 
+const TlonCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "markdown",
+    "dmPolicy",
+    "allowFrom",
+    "defaultTo",
+    "groupAllowFrom",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const tlonCommonConfigFields = {
-  name: z.string().optional(),
-  enabled: z.boolean().optional(),
-  configWrites: z.boolean().optional(),
+  name: TlonCommonAccountShape.name,
+  enabled: TlonCommonAccountShape.enabled,
+  configWrites: TlonCommonAccountShape.configWrites,
   ship: ShipSchema.optional(),
   url: z.string().optional(),
   code: z.string().optional(),
@@ -38,7 +62,7 @@ const tlonCommonConfigFields = {
   groupInviteAllowlist: z.array(ShipSchema).optional(),
   autoDiscoverChannels: z.boolean().optional(),
   showModelSignature: z.boolean().optional(),
-  responsePrefix: z.string().optional(),
+  responsePrefix: TlonCommonAccountShape.responsePrefix,
   implicitMentions: ChannelImplicitMentionsSchema.optional(),
   // Auto-accept settings
   autoAcceptDmInvites: z.boolean().optional(), // Auto-accept DMs from ships in dmAllowlist

--- a/extensions/twitch/src/config-schema.ts
+++ b/extensions/twitch/src/config-schema.ts
@@ -1,11 +1,35 @@
 // Twitch helper module supports config schema behavior.
-import { MarkdownConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import { buildCommonChannelAccountShape } from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
 
 /**
  * Twitch user roles that can be allowed to interact with the bot
  */
 const TwitchRoleSchema = z.enum(["moderator", "owner", "vip", "subscriber", "all"]);
+
+const TwitchCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "name",
+    "capabilities",
+    "markdown",
+    "dmPolicy",
+    "allowFrom",
+    "defaultTo",
+    "groupAllowFrom",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
 
 const TwitchAccountShape = {
   /** Twitch username */
@@ -17,9 +41,9 @@ const TwitchAccountShape = {
   /** Channel name to join */
   channel: z.string().min(1),
   /** Enable this account */
-  enabled: z.boolean().optional(),
+  enabled: TwitchCommonAccountShape.enabled,
   /** Allow channel-initiated configuration writes */
-  configWrites: z.boolean().optional(),
+  configWrites: TwitchCommonAccountShape.configWrites,
   /** Allowlist of Twitch user IDs who can interact with the bot (use IDs for safety, not usernames) */
   allowFrom: z.array(z.string()).optional(),
   /** Roles allowed to interact with the bot (e.g., ["moderator", "vip", "subscriber"]) */
@@ -27,7 +51,7 @@ const TwitchAccountShape = {
   /** Require @mention to trigger bot responses */
   requireMention: z.boolean().optional(),
   /** Outbound response prefix override for this channel/account. */
-  responsePrefix: z.string().optional(),
+  responsePrefix: TwitchCommonAccountShape.responsePrefix,
   /** Twitch client secret (required for token refresh via RefreshingAuthProvider) */
   clientSecret: z.string().optional(),
   /** Refresh token (required for automatic token refresh) */
@@ -46,11 +70,34 @@ const TwitchAccountSchema = z.object(TwitchAccountShape);
 /**
  * Base configuration properties shared by both single and multi-account modes
  */
+const TwitchCommonRootShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "dmPolicy",
+    "allowFrom",
+    "defaultTo",
+    "groupAllowFrom",
+    "groupPolicy",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "responsePrefix",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const TwitchConfigBaseShape = {
-  name: z.string().optional(),
-  enabled: z.boolean().optional(),
-  configWrites: z.boolean().optional(),
-  markdown: MarkdownConfigSchema.optional(),
+  name: TwitchCommonRootShape.name,
+  enabled: TwitchCommonRootShape.enabled,
+  configWrites: TwitchCommonRootShape.configWrites,
+  markdown: TwitchCommonRootShape.markdown,
   defaultAccount: z.string().optional(),
 };
 

--- a/extensions/zalo/src/config-schema.ts
+++ b/extensions/zalo/src/config-schema.ts
@@ -1,31 +1,46 @@
 // Zalo helper module supports config schema behavior.
 import {
-  AllowFromListSchema,
+  buildCommonChannelAccountShape,
   buildMultiAccountChannelSchema,
-  DmPolicySchema,
-  GroupPolicySchema,
-  MarkdownConfigSchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
 import { buildSecretInputSchema } from "./secret-input.js";
 
+const ZaloCommonAccountShape = buildCommonChannelAccountShape({
+  omit: [
+    "capabilities",
+    "defaultTo",
+    "mentionPatterns",
+    "contextVisibility",
+    "historyLimit",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const zaloAccountSchema = z.object({
-  name: z.string().optional(),
-  enabled: z.boolean().optional(),
-  configWrites: z.boolean().optional(),
-  markdown: MarkdownConfigSchema,
+  name: ZaloCommonAccountShape.name,
+  enabled: ZaloCommonAccountShape.enabled,
+  configWrites: ZaloCommonAccountShape.configWrites,
+  markdown: ZaloCommonAccountShape.markdown,
   botToken: buildSecretInputSchema().optional(),
   tokenFile: z.string().optional(),
   webhookUrl: z.string().optional(),
   webhookSecret: buildSecretInputSchema().optional(),
   webhookPath: z.string().optional(),
-  dmPolicy: DmPolicySchema.optional(),
-  allowFrom: AllowFromListSchema,
-  groupPolicy: GroupPolicySchema.optional(),
-  groupAllowFrom: AllowFromListSchema,
+  dmPolicy: ZaloCommonAccountShape.dmPolicy,
+  allowFrom: ZaloCommonAccountShape.allowFrom,
+  groupPolicy: ZaloCommonAccountShape.groupPolicy,
+  groupAllowFrom: ZaloCommonAccountShape.groupAllowFrom,
   mediaMaxMb: z.number().optional(),
   proxy: z.string().optional(),
-  responsePrefix: z.string().optional(),
+  responsePrefix: ZaloCommonAccountShape.responsePrefix,
 });
 
 export const ZaloConfigSchema = buildMultiAccountChannelSchema(zaloAccountSchema, {

--- a/extensions/zalouser/src/config-schema.ts
+++ b/extensions/zalouser/src/config-schema.ts
@@ -1,10 +1,7 @@
 // Zalouser helper module supports config schema behavior.
 import {
-  AllowFromListSchema,
+  buildCommonChannelAccountShape,
   buildMultiAccountChannelSchema,
-  DmPolicySchema,
-  GroupPolicySchema,
-  MarkdownConfigSchema,
   buildGroupEntrySchema,
 } from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
@@ -13,21 +10,39 @@ const groupConfigSchema = buildGroupEntrySchema()
   .omit({ toolsBySender: true, skills: true, allowFrom: true, systemPrompt: true })
   .strip();
 
+const ZalouserCommonAccountShape = buildCommonChannelAccountShape({
+  groupPolicyDefault: true,
+  omit: [
+    "capabilities",
+    "defaultTo",
+    "mentionPatterns",
+    "contextVisibility",
+    "dmHistoryLimit",
+    "dms",
+    "textChunkLimit",
+    "streaming",
+    "heartbeatVisibility",
+    "healthMonitor",
+    "mediaMaxMb",
+    "replyToMode",
+  ],
+});
+
 const zalouserAccountSchema = z.object({
-  name: z.string().optional(),
-  enabled: z.boolean().optional(),
-  configWrites: z.boolean().optional(),
-  markdown: MarkdownConfigSchema,
+  name: ZalouserCommonAccountShape.name,
+  enabled: ZalouserCommonAccountShape.enabled,
+  configWrites: ZalouserCommonAccountShape.configWrites,
+  markdown: ZalouserCommonAccountShape.markdown,
   profile: z.string().optional(),
   dangerouslyAllowNameMatching: z.boolean().optional(),
-  dmPolicy: DmPolicySchema.optional(),
-  allowFrom: AllowFromListSchema,
-  historyLimit: z.number().int().min(0).optional(),
-  groupAllowFrom: AllowFromListSchema,
-  groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+  dmPolicy: ZalouserCommonAccountShape.dmPolicy,
+  allowFrom: ZalouserCommonAccountShape.allowFrom,
+  historyLimit: ZalouserCommonAccountShape.historyLimit,
+  groupAllowFrom: ZalouserCommonAccountShape.groupAllowFrom,
+  groupPolicy: ZalouserCommonAccountShape.groupPolicy,
   groups: z.object({}).catchall(groupConfigSchema).optional(),
   messagePrefix: z.string().optional(),
-  responsePrefix: z.string().optional(),
+  responsePrefix: ZalouserCommonAccountShape.responsePrefix,
 });
 
 export const ZalouserConfigSchema = buildMultiAccountChannelSchema(zalouserAccountSchema, {


### PR DESCRIPTION
## What Problem This Solves

Sixteen bundled channel schemas duplicated shared channel-account leaves instead of sourcing them from `buildCommonChannelAccountShape`. That duplication can drift from the canonical account contract even when the fields initially look identical.

The requested Reef and ACPX migrations were skipped after premise checks: Reef now has only one identical common leaf (`configWrites`) while its `enabled` field has a plugin-specific `true` default, and ACPX is not a channel-account schema and has no matching top-level leaves.

## Why This Change Was Made

Each adopted field now comes from `openclaw/plugin-sdk/channel-config-schema`. Every absent common field is omitted, and every semantic or generated-schema divergence remains explicit. Helper-owned fields are placed back at their original object positions because bundled channel metadata records JSON-schema property order byte-for-byte.

| Plugin | Fields adopted | Kept explicit | Omitted from common shape |
| --- | --- | --- | --- |
| Feishu | `capabilities`, `configWrites`, `enabled`, `dmPolicy`, `allowFrom`, `groupAllowFrom`, `historyLimit`, `dmHistoryLimit`, `textChunkLimit`, `mediaMaxMb` | `name` (account-only), `markdown` (Feishu shape), `groupPolicy` (`allowall` transform/default split), `dms`, `streaming`, `heartbeatVisibility` (plugin shapes) | `name`, `markdown`, `defaultTo`, `groupPolicy`, `mentionPatterns`, `contextVisibility`, `dms`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `responsePrefix`, `replyToMode` |
| Matrix | `name`, `enabled`, `configWrites`, `markdown`, `groupPolicy`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `groupAllowFrom`, `responsePrefix` | `streaming` (Matrix modes), `textChunkLimit`/`mediaMaxMb` (unconstrained numbers), `replyToMode` (`z.enum` generated form) | `capabilities`, `dmPolicy`, `allowFrom`, `defaultTo`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `mediaMaxMb`, `replyToMode` |
| QQBot | `name`, `enabled`, `allowFrom`, `groupAllowFrom`, `groupPolicy`, `contextVisibility` | `dmPolicy` (no `pairing`), `streaming` (QQ shape/default) | `capabilities`, `markdown`, `configWrites`, `dmPolicy`, `defaultTo`, `mentionPatterns`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `responsePrefix`, `mediaMaxMb`, `replyToMode` |
| SMS | `name`, `enabled`, `configWrites`, `defaultTo`, `dmPolicy`, `allowFrom`, `textChunkLimit` | None | `capabilities`, `markdown`, `groupAllowFrom`, `groupPolicy`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `responsePrefix`, `mediaMaxMb`, `replyToMode` |
| IRC | `name`, `enabled`, `configWrites`, `markdown`, `dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `responsePrefix`, `mediaMaxMb` | `mentionPatterns` (shipped `string[]`) | `capabilities`, `defaultTo`, `mentionPatterns`, `heartbeatVisibility`, `healthMonitor`, `replyToMode` |
| LINE | `name`, `enabled`, `configWrites`, `dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`, `responsePrefix` | `mediaMaxMb` (unconstrained number) | `capabilities`, `markdown`, `defaultTo`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `mediaMaxMb`, `replyToMode` |
| Nextcloud Talk | `name`, `enabled`, `configWrites`, `markdown`, `dmPolicy`, `groupPolicy`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `responsePrefix`, `mediaMaxMb` | `allowFrom`, `groupAllowFrom` (`string[]` only) | `capabilities`, `allowFrom`, `defaultTo`, `groupAllowFrom`, `mentionPatterns`, `heartbeatVisibility`, `healthMonitor`, `replyToMode` |
| Zalo Personal | `name`, `enabled`, `configWrites`, `markdown`, `dmPolicy`, `allowFrom`, `historyLimit`, `groupAllowFrom`, `groupPolicy`, `responsePrefix` | None | `capabilities`, `defaultTo`, `mentionPatterns`, `contextVisibility`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `mediaMaxMb`, `replyToMode` |
| Zalo | `name`, `enabled`, `configWrites`, `markdown`, `dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`, `responsePrefix` | `mediaMaxMb` (unconstrained number) | `capabilities`, `defaultTo`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `mediaMaxMb`, `replyToMode` |
| QA channel | `name`, `enabled`, `configWrites`, `allowFrom`, `groupAllowFrom`, `defaultTo` | `groupPolicy` (enum order is generated metadata) | `capabilities`, `markdown`, `dmPolicy`, `groupPolicy`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `responsePrefix`, `mediaMaxMb`, `replyToMode` |
| Twitch | Root: `name`, `enabled`, `configWrites`, `markdown`; account: `enabled`, `configWrites`, `responsePrefix` | `allowFrom` (`string[]` only) | Root omits every other common leaf; account additionally omits `name` and `markdown` |
| ClickClack | `name`, `enabled`, `configWrites`, `defaultTo` | `allowFrom` (`string[]` only), `mentionPatterns` (`string[]`) | `capabilities`, `markdown`, `dmPolicy`, `allowFrom`, `groupAllowFrom`, `groupPolicy`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `responsePrefix`, `mediaMaxMb`, `replyToMode` |
| Buzz | `name`, `enabled`, `configWrites`, `markdown`, `groupPolicy`, `groupAllowFrom`, `defaultTo` | None | `capabilities`, `dmPolicy`, `allowFrom`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `responsePrefix`, `mediaMaxMb`, `replyToMode` |
| Nostr | `name`, `enabled`, `configWrites`, `markdown`, `dmPolicy`, `allowFrom` | None | `capabilities`, `defaultTo`, `groupAllowFrom`, `groupPolicy`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `responsePrefix`, `mediaMaxMb`, `replyToMode` |
| Tlon | `name`, `enabled`, `configWrites`, `responsePrefix` | None | `capabilities`, `markdown`, `dmPolicy`, `allowFrom`, `defaultTo`, `groupAllowFrom`, `groupPolicy`, `mentionPatterns`, `contextVisibility`, `historyLimit`, `dmHistoryLimit`, `dms`, `textChunkLimit`, `streaming`, `heartbeatVisibility`, `healthMonitor`, `mediaMaxMb`, `replyToMode` |
| Raft | `name`, `enabled`, `configWrites` | None | Every other common leaf |
| Reef | Skipped: only `configWrites` is identical | `enabled` defaults to `true` | No helper adoption; the stated four-field premise has drifted |
| ACPX | Skipped: no matching top-level account leaves | ACPX service/plugin config has unrelated custom errors/defaults | No helper adoption; structurally the wrong config surface |

Config-surface metric: **0 config surfaces added/removed/changed — pure declaration dedup**.

## User Impact

No operator-visible behavior or accepted configuration changes. Defaults, refinements, enum ordering, descriptions/help metadata, strictness, account inheritance, and generated schemas remain unchanged.

## Evidence

- `node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check` — passed unchanged.
- `node --import tsx scripts/generate-base-config-schema.ts --check` — passed unchanged.
- `node --import tsx scripts/generate-config-doc-baseline.ts --check` — passed unchanged.
- The exact focused test command passed 10 shards, 32 files, and 464 tests:

  ```bash
  OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs \
    extensions/feishu/src/config-schema.test.ts \
    extensions/matrix/src/config-schema.test.ts \
    extensions/matrix/src/matrix/client/config.test.ts \
    extensions/matrix/src/matrix/config-update.test.ts \
    extensions/matrix/src/matrix/monitor/ack-config.test.ts \
    extensions/matrix/src/matrix/monitor/config.test.ts \
    extensions/qqbot/src/config.test.ts \
    extensions/sms/src/accounts.test.ts \
    extensions/irc/src/config-schema.test.ts \
    extensions/line/src/config-schema.test.ts \
    extensions/line/src/config-adapter.test.ts \
    extensions/nextcloud-talk/src/channel.core.test.ts \
    extensions/nextcloud-talk/src/accounts.test.ts \
    extensions/nextcloud-talk/src/policy.test.ts \
    extensions/zalouser/src/accounts.test.ts \
    extensions/zalouser/src/setup-surface.test.ts \
    extensions/zalo/src/config-schema.test.ts \
    extensions/qa-channel/src/channel.test.ts \
    extensions/twitch/src/config-schema.test.ts \
    extensions/twitch/src/config.test.ts \
    extensions/clickclack/src/accounts.test.ts \
    extensions/clickclack/src/setup-core.test.ts \
    extensions/clickclack/src/doctor-contract.test.ts \
    extensions/buzz/src/config-schema.test.ts \
    extensions/nostr/src/channel.test.ts \
    extensions/nostr/src/channel.setup.test.ts \
    extensions/tlon/src/core.test.ts \
    extensions/raft/src/accounts.test.ts \
    src/channels/plugins/config-schema.test.ts \
    src/config/validation.channel-metadata.test.ts \
    src/config/bundled-channel-config-runtime.test.ts \
    src/config/load-channel-config-surface.test.ts
  ```
- `pnpm format extensions/{buzz,clickclack,feishu,irc,line,matrix,nextcloud-talk,nostr,qa-channel,qqbot,raft,sms,tlon,twitch,zalo,zalouser}/src/config-schema.ts` — passed.
- `node scripts/run-oxlint.mjs extensions/{buzz,clickclack,feishu,irc,line,matrix,nextcloud-talk,nostr,qa-channel,qqbot,raft,sms,tlon,twitch,zalo,zalouser}/src/config-schema.ts` — passed.
- `node scripts/check-changed.mjs` — remote delegation unavailable (Blacksmith CLI missing; other provider doctors timed out). Documented local fallback `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs` passed all selected extension production/test typecheck, lint, metadata, dead-code, boundary, and import-cycle lanes.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- `git diff --check` — passed.

Production LOC delta: **+482 / -150 (net +332)** across 16 schema files. Test LOC delta: **0 / 0**. The positive production delta is the compatibility cost of explicit omit lists plus retaining original property positions so the generated bundled metadata stays byte-identical; no runtime capability or config surface was added.
