### PR TITLE
refactor(test): compress repetitive fixtures in worst mega-tests with builders

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -174,17 +174,19 @@ function createSessionFile(params?: { history?: Array<{ role: "user"; content: s
   return { dir, sessionFile, storePath };
 }
 
-function buildPreparedContext(params?: {
-  sessionKey?: string;
-  cliSessionId?: string;
-  runId?: string;
-  lane?: string;
-  openClawHistoryPrompt?: string;
-  provider?: string;
-  model?: string;
-  executionMode?: PreparedCliRunContext["params"]["executionMode"];
-  allowEmptyAssistantReplyAsSilent?: boolean;
-}): PreparedCliRunContext {
+type PreparedContextOverrides = Partial<{
+  sessionKey: string;
+  cliSessionId: string;
+  runId: string;
+  lane: string;
+  openClawHistoryPrompt: string;
+  provider: string;
+  model: string;
+  executionMode: PreparedCliRunContext["params"]["executionMode"];
+  allowEmptyAssistantReplyAsSilent: boolean;
+}>;
+
+function buildPreparedContext(params: PreparedContextOverrides = {}): PreparedCliRunContext {
   // Common prepared context fixture for runPreparedCliAgent reliability branches.
   const provider = params?.provider ?? "codex-cli";
   const model = params?.model ?? "gpt-5.4";
@@ -244,6 +246,65 @@ function buildPreparedContext(params?: {
       ? { openClawHistoryPrompt: params.openClawHistoryPrompt }
       : {}),
     authEpochVersion: 2,
+  };
+}
+
+function makeClaudePreparedContext(
+  overrides: PreparedContextOverrides = {},
+): PreparedCliRunContext {
+  return buildPreparedContext({ provider: "claude-cli", model: "opus", ...overrides });
+}
+
+function makeRunExit(overrides: Partial<RunExit> = {}): RunExit {
+  return {
+    reason: "exit",
+    exitCode: 0,
+    exitSignal: null,
+    durationMs: 50,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    noOutputTimedOut: false,
+    ...overrides,
+  };
+}
+
+function makeManagedRun(overrides: Partial<RunExit> = {}) {
+  return createManagedRun(makeRunExit(overrides));
+}
+
+type CliBackend = PreparedCliRunContext["preparedBackend"]["backend"];
+
+type LiveClaudeBackend = CliBackend & {
+  reliability: {
+    watchdog: {
+      resume: { noOutputTimeoutMs: number; minMs: number; maxMs: number };
+      fresh: { noOutputTimeoutMs: number; minMs: number; maxMs: number };
+    };
+  };
+};
+
+function makeLiveClaudeBackend(overrides: Partial<LiveClaudeBackend> = {}): LiveClaudeBackend {
+  return {
+    command: "claude",
+    args: ["-p", "--output-format", "stream-json"],
+    resumeArgs: ["-p", "--resume", "{sessionId}", "--output-format", "stream-json"],
+    forkArg: "--fork-session",
+    resumeAtArg: "--resume-session-at",
+    output: "jsonl",
+    input: "stdin",
+    modelArg: "--model",
+    sessionArgs: ["--session-id", "{sessionId}"],
+    sessionMode: "always",
+    liveSession: "claude-stdio",
+    reliability: {
+      watchdog: {
+        resume: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
+        fresh: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
+      },
+    },
+    serialize: true,
+    ...overrides,
   };
 }
 
@@ -385,13 +446,11 @@ describe("runCliAgent reliability", () => {
 
   it("fails with timeout when no-output watchdog trips", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
@@ -407,13 +466,11 @@ describe("runCliAgent reliability", () => {
 
   it("adds request attribution to CLI watchdog failover errors", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
@@ -434,13 +491,11 @@ describe("runCliAgent reliability", () => {
 
   it("enqueues a system event and heartbeat wake on no-output watchdog timeout for session runs", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
@@ -474,13 +529,11 @@ describe("runCliAgent reliability", () => {
     enqueueSystemEventMock.mockClear();
     requestHeartbeatMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
@@ -504,15 +557,12 @@ describe("runCliAgent reliability", () => {
 
   it("fails with timeout when overall timeout trips", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "overall-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
-        noOutputTimedOut: false,
       }),
     );
 
@@ -527,13 +577,11 @@ describe("runCliAgent reliability", () => {
   it("does not retry recoverable failover when no reusable CLI session was used", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
@@ -541,11 +589,9 @@ describe("runCliAgent reliability", () => {
 
     await expect(
       runPreparedCliAgent(
-        buildPreparedContext({
+        makeClaudePreparedContext({
           sessionKey: "agent:main:fresh",
           runId: "run-fresh-timeout",
-          provider: "claude-cli",
-          model: "opus",
         }),
       ),
     ).rejects.toThrow("produced no output");
@@ -557,23 +603,18 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     const clearBeforeRetry = vi.fn(async () => false);
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "overall-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
-        noOutputTimedOut: false,
       }),
     );
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:overall-timeout",
       runId: "run-overall-timeout",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
     });
 
     await expect(
@@ -594,23 +635,19 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     const clearBeforeRetry = vi.fn(async () => false);
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
     );
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:no-reseed",
       runId: "run-no-reseed",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
     });
 
     await expect(
@@ -631,37 +668,22 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock
       .mockResolvedValueOnce(
-        createManagedRun({
+        makeManagedRun({
           reason: "no-output-timeout",
           exitCode: null,
           exitSignal: "SIGKILL",
           durationMs: 200,
-          stdout: "",
-          stderr: "",
           timedOut: true,
           noOutputTimedOut: true,
         }),
       )
-      .mockResolvedValueOnce(
-        createManagedRun({
-          reason: "exit",
-          exitCode: 0,
-          exitSignal: null,
-          durationMs: 50,
-          stdout: "fresh fallback",
-          stderr: "",
-          timedOut: false,
-          noOutputTimedOut: false,
-        }),
-      );
+      .mockResolvedValueOnce(makeManagedRun({ stdout: "fresh fallback" }));
     const prepareForkRetry = vi.fn(async () => true);
     const clearBeforeRetry = vi.fn(async () => true);
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:no-checkpoint",
       runId: "run-no-checkpoint",
       cliSessionId: "legacy-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.preparedBackend.backend = {
@@ -699,51 +721,31 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock
       .mockResolvedValueOnce(
-        createManagedRun({
+        makeManagedRun({
           reason: "no-output-timeout",
           exitCode: null,
           exitSignal: "SIGKILL",
           durationMs: 200,
-          stdout: "",
-          stderr: "",
           timedOut: true,
           noOutputTimedOut: true,
         }),
       )
       .mockResolvedValueOnce(
-        createManagedRun({
-          reason: "exit",
+        makeManagedRun({
           exitCode: 1,
-          exitSignal: null,
           durationMs: 25,
-          stdout: "",
           stderr: "error: unknown option '--resume-session-at'",
-          timedOut: false,
-          noOutputTimedOut: false,
         }),
       )
-      .mockResolvedValueOnce(
-        createManagedRun({
-          reason: "exit",
-          exitCode: 0,
-          exitSignal: null,
-          durationMs: 50,
-          stdout: "fresh fallback",
-          stderr: "",
-          timedOut: false,
-          noOutputTimedOut: false,
-        }),
-      );
+      .mockResolvedValueOnce(makeManagedRun({ stdout: "fresh fallback" }));
     const prepareForkRetry = vi.fn(async () => true);
     const claimFork = vi.fn(async () => true);
     const restoreFork = vi.fn(async () => {});
     const clearBeforeRetry = vi.fn(async () => true);
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:old-claude",
       runId: "run-old-claude",
       cliSessionId: "old-claude-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.preparedBackend.backend = {
@@ -785,38 +787,20 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock
       .mockResolvedValueOnce(
-        createManagedRun({
-          reason: "exit",
+        makeManagedRun({
           exitCode: 1,
-          exitSignal: null,
           durationMs: 25,
-          stdout: "",
           stderr: "error: unknown option '--resume-session-at'",
-          timedOut: false,
-          noOutputTimedOut: false,
         }),
       )
-      .mockResolvedValueOnce(
-        createManagedRun({
-          reason: "exit",
-          exitCode: 0,
-          exitSignal: null,
-          durationMs: 50,
-          stdout: "fresh fallback",
-          stderr: "",
-          timedOut: false,
-          noOutputTimedOut: false,
-        }),
-      );
+      .mockResolvedValueOnce(makeManagedRun({ stdout: "fresh fallback" }));
     const claimFork = vi.fn(async () => true);
     const restoreFork = vi.fn(async () => {});
     const clearBeforeRetry = vi.fn(async () => true);
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:downgraded-claude",
       runId: "run-downgraded-claude",
       cliSessionId: "downgraded-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.preparedBackend.backend = {
@@ -857,35 +841,17 @@ describe("runCliAgent reliability", () => {
   it("preserves fresh retry for direct CLI callers without a pre-clear hook", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
+      makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
         durationMs: 150,
-        stdout: "",
         stderr: "session expired",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from fresh cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
-    const context = buildPreparedContext({
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from fresh cli" }));
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:direct",
       runId: "run-direct-retry",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.preparedBackend.backend = {
@@ -986,23 +952,19 @@ describe("runCliAgent reliability", () => {
         });
         markMcpLoopbackToolCallFinished(captureHandle);
       }, 10);
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:delivered-timeout",
       runId: "run-delivered-timeout",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.mcpDeliveryCapture = true;
@@ -1052,23 +1014,16 @@ describe("runCliAgent reliability", () => {
         result: { status: "sent" },
       });
       markMcpLoopbackToolCallFinished(captureHandle);
-      return createManagedRun({
-        reason: "exit",
+      return makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
         durationMs: 150,
-        stdout: "",
         stderr: "failed after delivery",
-        timedOut: false,
-        noOutputTimedOut: false,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:soft-drift-delivered-failure",
       runId: "run-soft-drift-delivered-failure",
       cliSessionId: "soft-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.reusableCliSession = {
@@ -1117,23 +1072,16 @@ describe("runCliAgent reliability", () => {
         outcome: "completed",
       });
       markMcpLoopbackToolCallFinished(captureHandle);
-      return createManagedRun({
-        reason: "exit",
+      return makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
         durationMs: 150,
-        stdout: "",
         stderr: "Prompt is too long",
-        timedOut: false,
-        noOutputTimedOut: false,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:delivered-overflow",
       runId: "run-delivered-overflow",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.mcpDeliveryCapture = true;
@@ -1180,22 +1128,18 @@ describe("runCliAgent reliability", () => {
         outcome: "completed",
       });
       markMcpLoopbackToolCallFinished(captureHandle);
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:first-turn-delivered",
       runId: "run-first-turn-delivered",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.preparedBackend.backend.sessionMode = "none";
     context.backendResolved.config = context.preparedBackend.backend;
@@ -1226,18 +1170,7 @@ describe("runCliAgent reliability", () => {
 
   it("refreshes soft-resumed binding hashes without clearing the stored binding", async () => {
     supervisorSpawnMock.mockClear();
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "ok",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "ok" }));
     const context = buildPreparedContext({
       sessionKey: "agent:main:soft-drift-refresh",
       runId: "run-soft-drift-refresh",
@@ -1293,22 +1226,11 @@ describe("runCliAgent reliability", () => {
         outcome: "completed",
       });
       markMcpLoopbackToolCallFinished(captureHandle);
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "ordinary final should stay private",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      });
+      return makeManagedRun({ stdout: "ordinary final should stay private" });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:successful-source-reply",
       runId: "run-successful-source-reply",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.mcpDeliveryCapture = true;
     context.params.sourceReplyDeliveryMode = "message_tool_only";
@@ -1367,22 +1289,11 @@ describe("runCliAgent reliability", () => {
         outcome: "completed",
       });
       markMcpLoopbackToolCallFinished(captureHandle);
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "private terminal confirmation",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      });
+      return makeManagedRun({ stdout: "private terminal confirmation" });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:main",
       runId: "run-visible-source-reply",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.mcpDeliveryCapture = true;
     context.params.sourceReplyDeliveryMode = "message_tool_only";
@@ -1446,22 +1357,11 @@ describe("runCliAgent reliability", () => {
       input.onStdout?.(
         `${JSON.stringify({ type: "result", session_id: "claude-session", result: "" })}\n`,
       );
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      });
+      return makeManagedRun();
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:successful-empty-delivery",
       runId: "run-successful-empty-delivery",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.backendResolved.config.output = "jsonl";
     context.mcpDeliveryCapture = true;
@@ -1480,25 +1380,14 @@ describe("runCliAgent reliability", () => {
       input.onStdout?.(
         `${JSON.stringify({ type: "result", session_id: "stateless-cli-id", result: "ok" })}\n`,
       );
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      });
+      return makeManagedRun();
     });
     setCliRunnerTestDeps({
       claudeCliSessionTranscriptHasContent: async () => true,
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:stateless",
       runId: "run-stateless-session-id",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.preparedBackend.backend.output = "jsonl";
     context.preparedBackend.backend.input = "stdin";
@@ -1541,22 +1430,18 @@ describe("runCliAgent reliability", () => {
         },
       });
       captureStarted?.();
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:unresolved-internal-source-reply",
       runId: "run-unresolved-internal-source-reply",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.mcpDeliveryCapture = true;
     context.params.config = {};
@@ -1600,22 +1485,18 @@ describe("runCliAgent reliability", () => {
         },
       });
       captureStarted?.();
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:telegram:direct:123456789",
       runId: "run-unresolved-external-session-reply",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.mcpDeliveryCapture = true;
     context.params.config = {};
@@ -1632,18 +1513,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("surfaces prepared backend cleanup failures when nothing was delivered", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "ok",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "ok" }));
     const context = buildPreparedContext({
       sessionKey: "agent:main:cleanup-failure",
       runId: "run-cleanup-failure",
@@ -1686,23 +1556,19 @@ describe("runCliAgent reliability", () => {
         },
       });
       captureStarted?.();
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:unresolved-send",
       runId: "run-unresolved-send",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.mcpDeliveryCapture = true;
@@ -1733,23 +1599,19 @@ describe("runCliAgent reliability", () => {
         throw new Error("Expected request delivery capture");
       }
       captureStarted?.();
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:unresolved-request",
       runId: "run-unresolved-request",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.mcpDeliveryCapture = true;
@@ -1786,23 +1648,19 @@ describe("runCliAgent reliability", () => {
       });
       markMcpLoopbackRequestClassified(requestCaptureHandle);
       captureStarted?.();
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:unresolved-non-message-request",
       runId: "run-unresolved-non-message-request",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.mcpDeliveryCapture = true;
@@ -1846,23 +1704,19 @@ describe("runCliAgent reliability", () => {
         },
       });
       captureStarted?.();
-      return createManagedRun({
+      return makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 200,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       });
     });
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:unresolved-dry-run",
       runId: "run-unresolved-dry-run",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.mcpDeliveryCapture = true;
@@ -1880,23 +1734,16 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     const clearBeforeRetry = vi.fn(async () => true);
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
+      makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
         durationMs: 150,
-        stdout: "",
         stderr: "worker crashed without details",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:unknown-output",
       runId: "run-unknown-output",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
 
@@ -1918,23 +1765,19 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     const clearBeforeRetry = vi.fn(async () => true);
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 1_000,
-        stdout: "",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
     );
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:expired-budget",
       runId: "run-expired-budget",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     const expiredBudgetContext = {
@@ -1960,23 +1803,16 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     const clearBeforeRetry = vi.fn(async () => true);
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
+      makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
         durationMs: 150,
-        stdout: "",
         stderr: "Prompt is too long",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:expired-overflow-budget",
       runId: "run-expired-overflow-budget",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     const expiredBudgetContext = {
@@ -2068,16 +1904,13 @@ describe("runCliAgent reliability", () => {
           },
           wait: vi.fn(() => exited),
           cancel: vi.fn(() =>
-            resolveExit?.({
-              reason: "manual-cancel",
-              exitCode: null,
-              exitSignal: null,
-              durationMs: 1,
-              stdout: "",
-              stderr: "",
-              timedOut: false,
-              noOutputTimedOut: false,
-            }),
+            resolveExit?.(
+              makeRunExit({
+                reason: "manual-cancel",
+                exitCode: null,
+                durationMs: 1,
+              }),
+            ),
           ),
         };
       }
@@ -2115,8 +1948,7 @@ describe("runCliAgent reliability", () => {
       };
     });
 
-    const liveBackend = {
-      command: "claude",
+    const liveBackend = makeLiveClaudeBackend({
       args: [
         "-p",
         "--output-format",
@@ -2137,22 +1969,7 @@ describe("runCliAgent reliability", () => {
         "--skills-plugin-dir",
         skillsDir,
       ],
-      forkArg: "--fork-session",
-      resumeAtArg: "--resume-session-at",
-      output: "jsonl" as const,
-      input: "stdin" as const,
-      modelArg: "--model",
-      sessionArgs: ["--session-id", "{sessionId}"],
-      sessionMode: "always" as const,
-      liveSession: "claude-stdio" as const,
-      reliability: {
-        watchdog: {
-          resume: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
-          fresh: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
-        },
-      },
-      serialize: true,
-    };
+    });
     const cleanup = vi.fn(async () => {
       fs.rmSync(artifactDir, { recursive: true, force: true });
     });
@@ -2161,12 +1978,10 @@ describe("runCliAgent reliability", () => {
     const persistForkSuccessor = vi.fn(async () => {});
     const restoreFork = vi.fn(async () => {});
     const clearBeforeRetry = vi.fn(async () => true);
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:live-artifacts",
       runId: "run-live-artifact-retry",
       cliSessionId: "stale-live",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.preparedBackend.backend = liveBackend;
@@ -2285,46 +2100,22 @@ describe("runCliAgent reliability", () => {
         },
         wait: vi.fn(() => exited),
         cancel: vi.fn(() =>
-          resolveExit?.({
-            reason: "manual-cancel",
-            exitCode: null,
-            exitSignal: null,
-            durationMs: 1,
-            stdout: "",
-            stderr: "",
-            timedOut: false,
-            noOutputTimedOut: false,
-          }),
+          resolveExit?.(
+            makeRunExit({
+              reason: "manual-cancel",
+              exitCode: null,
+              durationMs: 1,
+            }),
+          ),
         ),
       };
     });
 
-    const backend = {
-      command: "claude",
-      args: ["-p", "--output-format", "stream-json"],
-      resumeArgs: ["-p", "--resume", "{sessionId}", "--output-format", "stream-json"],
-      forkArg: "--fork-session",
-      resumeAtArg: "--resume-session-at",
-      output: "jsonl" as const,
-      input: "stdin" as const,
-      modelArg: "--model",
-      sessionArgs: ["--session-id", "{sessionId}"],
-      sessionMode: "always" as const,
-      liveSession: "claude-stdio" as const,
-      reliability: {
-        watchdog: {
-          resume: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
-          fresh: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
-        },
-      },
-      serialize: true,
-    };
-    const context = buildPreparedContext({
+    const backend = makeLiveClaudeBackend();
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:fork-then-fresh",
       runId: "run-fork-then-fresh",
       cliSessionId: "stalled-source",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.preparedBackend.backend = backend;
@@ -2433,46 +2224,22 @@ describe("runCliAgent reliability", () => {
         },
         wait: vi.fn(() => exited),
         cancel: vi.fn(() =>
-          resolveExit?.({
-            reason: "manual-cancel",
-            exitCode: null,
-            exitSignal: null,
-            durationMs: 1,
-            stdout: "",
-            stderr: "",
-            timedOut: false,
-            noOutputTimedOut: false,
-          }),
+          resolveExit?.(
+            makeRunExit({
+              reason: "manual-cancel",
+              exitCode: null,
+              durationMs: 1,
+            }),
+          ),
         ),
       };
     });
 
-    const backend = {
-      command: "claude",
-      args: ["-p", "--output-format", "stream-json"],
-      resumeArgs: ["-p", "--resume", "{sessionId}", "--output-format", "stream-json"],
-      forkArg: "--fork-session",
-      resumeAtArg: "--resume-session-at",
-      output: "jsonl" as const,
-      input: "stdin" as const,
-      modelArg: "--model",
-      sessionArgs: ["--session-id", "{sessionId}"],
-      sessionMode: "always" as const,
-      liveSession: "claude-stdio" as const,
-      reliability: {
-        watchdog: {
-          resume: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
-          fresh: { noOutputTimeoutMs: 1_000, minMs: 1_000, maxMs: 1_000 },
-        },
-      },
-      serialize: true,
-    };
-    const context = buildPreparedContext({
+    const backend = makeLiveClaudeBackend();
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:initial-fork-fallback",
       runId: "run-initial-fork-fallback",
       cliSessionId: "initial-fork-parent",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
     context.preparedBackend.backend = backend;
@@ -2532,23 +2299,20 @@ describe("runCliAgent reliability", () => {
     enqueueSystemEventMock.mockClear();
     const clearBeforeRetry = vi.fn(async () => true);
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "no-output-timeout",
         exitCode: null,
         exitSignal: "SIGKILL",
         durationMs: 500,
         stdout: "partial progress before the stall",
-        stderr: "",
         timedOut: true,
         noOutputTimedOut: true,
       }),
     );
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:timeout-after-output",
       runId: "run-timeout-after-output",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
 
@@ -2571,23 +2335,15 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     const clearBeforeRetry = vi.fn(async () => true);
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
+      makeManagedRun({
         reason: "manual-cancel",
         exitCode: null,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey: "agent:main:manual-cancel",
       runId: "run-manual-cancel",
       cliSessionId: "stale-cli-session",
-      provider: "claude-cli",
-      model: "opus",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
 
@@ -2641,51 +2397,29 @@ describe("runCliAgent reliability", () => {
         spawnCount += 1;
         events.push(`spawn-${spawnCount}`);
         if (spawnCount === 1 && reason === "timeout") {
-          return createManagedRun({
+          return makeManagedRun({
             reason: "no-output-timeout",
             exitCode: null,
             exitSignal: "SIGKILL",
             durationMs: 200,
-            stdout: "",
-            stderr: "",
             timedOut: true,
             noOutputTimedOut: true,
           });
         }
         if (spawnCount === 1 && reason === "context_overflow") {
-          return createManagedRun({
-            reason: "exit",
+          return makeManagedRun({
             exitCode: 1,
-            exitSignal: null,
             durationMs: 150,
-            stdout: "",
             stderr: "Prompt is too long",
-            timedOut: false,
-            noOutputTimedOut: false,
           });
         }
         if (spawnCount === 1) {
-          return createManagedRun({
-            reason: "exit",
+          return makeManagedRun({
             exitCode: 1,
-            exitSignal: null,
             durationMs: 150,
-            stdout: "",
-            stderr: "",
-            timedOut: false,
-            noOutputTimedOut: false,
           });
         }
-        return createManagedRun({
-          reason: "exit",
-          exitCode: 0,
-          exitSignal: null,
-          durationMs: 50,
-          stdout: "hello from fresh cli",
-          stderr: "",
-          timedOut: false,
-          noOutputTimedOut: false,
-        });
+        return makeManagedRun({ stdout: "hello from fresh cli" });
       });
       const { dir, sessionFile } = createSessionFile({
         history: [{ role: "user", content: "earlier context" }],
@@ -2696,12 +2430,10 @@ describe("runCliAgent reliability", () => {
       });
 
       try {
-        const context = buildPreparedContext({
+        const context = makeClaudePreparedContext({
           sessionKey: "agent:main:subagent:retry",
           runId,
           cliSessionId: "stale-cli-session",
-          provider: "claude-cli",
-          model: "opus",
           openClawHistoryPrompt: CLI_RESEED_PROMPT,
         });
         const result = await runPreparedCliAgent({
@@ -2767,27 +2499,17 @@ describe("runCliAgent reliability", () => {
     setHookRunnerForTest(hookRunner);
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
+      makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
         durationMs: 150,
-        stdout: "",
         stderr: "session expired",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
+      makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
         durationMs: 150,
-        stdout: "",
         stderr: "rate limit exceeded",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
     const { dir, sessionFile } = createSessionFile({
@@ -2837,18 +2559,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("returns the assembled CLI prompt in meta for raw trace consumers", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     const result = await runPreparedCliAgent({
       ...buildPreparedContext(),
@@ -2876,21 +2587,10 @@ describe("runCliAgent reliability", () => {
   });
 
   it("reports the prepared context budget for successful claude-cli runs", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from claude",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from claude" }));
 
     const result = await runPreparedCliAgent(
-      buildPreparedContext({ provider: "claude-cli", model: "claude-opus-4-7" }),
+      makeClaudePreparedContext({ model: "claude-opus-4-7" }),
     );
 
     expect(result.meta.agentMeta?.contextTokens).toBe(150_000);
@@ -2903,16 +2603,7 @@ describe("runCliAgent reliability", () => {
       await resolveMcpLoopbackYieldContext(captureHandle)?.onYield("waiting on subagents");
       markMcpLoopbackRequestFinished(captureHandle);
       input.onStdout?.("yield acknowledged");
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      });
+      return makeManagedRun();
     });
     const context = buildPreparedContext();
     context.mcpDeliveryCapture = true;
@@ -2932,18 +2623,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("seeds fresh CLI sessions from the OpenClaw transcript", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     const result = await runPreparedCliAgent(
       buildPreparedContext({
@@ -2957,18 +2637,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("keeps resumed CLI sessions on native resume history", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     const result = await runPreparedCliAgent(
       buildPreparedContext({
@@ -2993,29 +2662,11 @@ describe("runCliAgent reliability", () => {
       Awaited<ReturnType<ReturnType<typeof createManagedRun>["wait"]>>
     >((resolve) => {
       finishRun = () => {
-        resolve({
-          reason: "exit",
-          exitCode: 0,
-          exitSignal: null,
-          durationMs: 50,
-          stdout: "hello from cli",
-          stderr: "",
-          timedOut: false,
-          noOutputTimedOut: false,
-        });
+        resolve(makeRunExit({ stdout: "hello from cli" }));
       };
     });
     supervisorSpawnMock.mockResolvedValueOnce({
-      ...createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "unused",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
+      ...makeManagedRun({ stdout: "unused" }),
       wait: vi.fn(() => waitForExit),
     });
 
@@ -3039,18 +2690,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("keeps raw assistant output separate from transformed visible CLI output", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     const result = await runPreparedCliAgent({
       ...buildPreparedContext(),
@@ -3079,18 +2719,7 @@ describe("runCliAgent reliability", () => {
     setHookRunnerForTest(hookRunner);
     const { dir, sessionFile } = createSessionFile();
 
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     try {
       await runPreparedCliAgent({
@@ -3216,18 +2845,7 @@ describe("runCliAgent reliability", () => {
     };
     setHookRunnerForTest(hookRunner);
 
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     let resolved = false;
     const run = runPreparedCliAgent(buildPreparedContext()).then((result) => {
@@ -3261,18 +2879,7 @@ describe("runCliAgent reliability", () => {
     };
     setHookRunnerForTest(hookRunner);
 
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     const context = buildPreparedContext();
     let resolved = false;
@@ -3306,18 +2913,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("persists approved CLI user turns and successful assistant output", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
     const { dir, sessionFile, storePath } = createSessionFile();
     const onUserMessagePersisted = vi.fn();
 
@@ -3410,18 +3006,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("honors CLI retry suppression before approved user-turn persistence", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from retry",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from retry" }));
     const { dir, sessionFile, storePath } = createSessionFile();
     const recorder = createUserTurnTranscriptRecorder({
       input: {
@@ -3475,18 +3060,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("honors a CLI user-turn recorder target that skips after session rebound", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello after rebound",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello after rebound" }));
     const { dir, sessionFile, storePath } = createSessionFile();
     const recorder = createUserTurnTranscriptRecorder({
       input: {
@@ -3529,18 +3103,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("records transformed fresh Claude reseed prompts with durable local proof", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from claude",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from claude" }));
     const { dir, sessionFile } = createSessionFile();
     const historyPrompt = [
       "Continue this conversation using the OpenClaw transcript below as prior session history.",
@@ -3559,8 +3122,7 @@ describe("runCliAgent reliability", () => {
       setCliRunnerTestDeps({
         claudeCliSessionTranscriptHasContent: async () => true,
       });
-      const context = buildPreparedContext({
-        provider: "claude-cli",
+      const context = makeClaudePreparedContext({
         model: "claude-opus-4-6",
         openClawHistoryPrompt: historyPrompt,
       });
@@ -3596,26 +3158,14 @@ describe("runCliAgent reliability", () => {
   });
 
   it("does not mint a reseed receipt without caller-owned durable proof", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from claude",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from claude" }));
     const { dir, sessionFile } = createSessionFile();
 
     try {
       setCliRunnerTestDeps({
         claudeCliSessionTranscriptHasContent: async () => true,
       });
-      const context = buildPreparedContext({
-        provider: "claude-cli",
+      const context = makeClaudePreparedContext({
         model: "claude-opus-4-6",
         openClawHistoryPrompt: CLI_RESEED_PROMPT,
       });
@@ -3641,18 +3191,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("mints an omission receipt for a trusted suppressed reseed turn", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from claude",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from claude" }));
     const { dir, sessionFile } = createSessionFile();
     const recorder = createUserTurnTranscriptRecorder({
       target: createTestUserTurnTranscriptTarget({
@@ -3669,8 +3208,7 @@ describe("runCliAgent reliability", () => {
       setCliRunnerTestDeps({
         claudeCliSessionTranscriptHasContent: async () => true,
       });
-      const context = buildPreparedContext({
-        provider: "claude-cli",
+      const context = makeClaudePreparedContext({
         model: "claude-opus-4-6",
         openClawHistoryPrompt: CLI_RESEED_PROMPT,
       });
@@ -3700,18 +3238,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("reuses durable local proof when a fallback suppresses duplicate persistence", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from claude",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from claude" }));
     const { dir, sessionFile } = createSessionFile();
     const recorder = createCliUserTurnRecorder({
       text: "current ask",
@@ -3725,8 +3252,7 @@ describe("runCliAgent reliability", () => {
       setCliRunnerTestDeps({
         claudeCliSessionTranscriptHasContent: async () => true,
       });
-      const context = buildPreparedContext({
-        provider: "claude-cli",
+      const context = makeClaudePreparedContext({
         model: "claude-opus-4-6",
         openClawHistoryPrompt: CLI_RESEED_PROMPT,
       });
@@ -3758,18 +3284,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("uses runtime-owned persistence proof", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from claude",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from claude" }));
     const { dir, sessionFile } = createSessionFile();
     const recorder = createCliUserTurnRecorder({
       text: "current ask",
@@ -3786,8 +3301,7 @@ describe("runCliAgent reliability", () => {
       setCliRunnerTestDeps({
         claudeCliSessionTranscriptHasContent: async () => true,
       });
-      const context = buildPreparedContext({
-        provider: "claude-cli",
+      const context = makeClaudePreparedContext({
         model: "claude-opus-4-6",
         openClawHistoryPrompt: CLI_RESEED_PROMPT,
       });
@@ -3816,26 +3330,14 @@ describe("runCliAgent reliability", () => {
   });
 
   it("preserves a reseed receipt when reusing the same Claude CLI session", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello again",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello again" }));
     const reseedReceipt = {
       version: 1 as const,
       promptHash: "a".repeat(64),
       localSessionId: "s1",
       userTurnDisposition: "persisted" as const,
     };
-    const context = buildPreparedContext({
-      provider: "claude-cli",
+    const context = makeClaudePreparedContext({
       model: "claude-opus-4-6",
       cliSessionId: "existing-cli-session",
     });
@@ -3860,18 +3362,7 @@ describe("runCliAgent reliability", () => {
       runBeforeMessageWrite: vi.fn(() => ({ block: true })),
     };
     setHookRunnerForTest(hookRunner);
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "secret CLI output",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "secret CLI output" }));
     const { dir, sessionFile, storePath } = createSessionFile();
 
     try {
@@ -3912,18 +3403,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("does not append late CLI output after the session key is rebound", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "late CLI output",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "late CLI output" }));
     const { dir, sessionFile, storePath } = createSessionFile();
     const replacementFile = path.join(path.dirname(sessionFile), "s2.jsonl");
     fs.writeFileSync(
@@ -3978,18 +3458,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("does not persist private room-event assistant output", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "private ambient output",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "private ambient output" }));
     const { dir, sessionFile, storePath } = createSessionFile();
 
     try {
@@ -4021,18 +3490,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("passes cwd to approved CLI user-turn persistence", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
     const { dir, sessionFile } = createSessionFile();
     const taskDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-persist-cwd-"));
     let capturedCwd: unknown;
@@ -4089,18 +3547,7 @@ describe("runCliAgent reliability", () => {
   });
 
   it("uses an existing user-turn recorder for approved CLI persistence", async () => {
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
     const { dir, sessionFile } = createSessionFile();
     const recorder = createUserTurnTranscriptRecorder({
       input: {
@@ -4162,18 +3609,7 @@ describe("runCliAgent reliability", () => {
       runBeforeMessageWrite: vi.fn(() => ({ block: true })),
     };
     setHookRunnerForTest(hookRunner);
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
     const { dir, sessionFile } = createSessionFile();
     const recorder = createUserTurnTranscriptRecorder({
       input: { text: "blocked user turn" },
@@ -4216,16 +3652,7 @@ describe("runCliAgent reliability", () => {
   it("does not fail CLI execution when persistence notification fails", async () => {
     supervisorSpawnMock.mockClear();
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello despite notification failure",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
+      makeManagedRun({ stdout: "hello despite notification failure" }),
     );
     const { dir, sessionFile } = createSessionFile();
 
@@ -4340,11 +3767,9 @@ describe("runCliAgent reliability", () => {
 
     try {
       let resolved = false;
-      const context = buildPreparedContext({
+      const context = makeClaudePreparedContext({
         sessionKey: "agent:main:main",
         runId: "run-blocked-cli",
-        provider: "claude-cli",
-        model: "opus",
       });
       context.preparedBackend.backend.sessionMode = "none";
       const run = runPreparedCliAgent({
@@ -4475,11 +3900,9 @@ describe("runCliAgent reliability", () => {
     supervisorSpawnMock.mockClear();
     const { dir, sessionFile, storePath } = createSessionFile();
     const sessionKey = "agent:main:main";
-    const context = buildPreparedContext({
+    const context = makeClaudePreparedContext({
       sessionKey,
       runId: "run-blocked-cli-rebound",
-      provider: "claude-cli",
-      model: "opus",
     });
     context.params.sessionEntry = { sessionId: "s1", updatedAt: 1 };
     const hookRunner = {
@@ -4696,18 +4119,7 @@ describe("runCliAgent reliability", () => {
     };
     setHookRunnerForTest(hookRunner);
 
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "   ",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "   " }));
 
     await expect(runPreparedCliAgent(buildPreparedContext())).rejects.toThrow(
       "CLI backend returned an empty response.",
@@ -4724,22 +4136,10 @@ describe("runCliAgent reliability", () => {
     };
     setHookRunnerForTest(hookRunner);
 
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "   ",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "   " }));
 
     const result = await runPreparedCliAgent(
-      buildPreparedContext({
-        provider: "claude-cli",
+      makeClaudePreparedContext({
         model: "claude-sonnet-4-6",
         allowEmptyAssistantReplyAsSilent: true,
       }),
@@ -4764,15 +4164,9 @@ describe("runCliAgent reliability", () => {
     setHookRunnerForTest(hookRunner);
 
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
+      makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "",
         stderr: "rate limit exceeded",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
 
@@ -4823,29 +4217,12 @@ describe("runCliAgent reliability", () => {
     });
 
     supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
+      makeManagedRun({
         exitCode: 1,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "",
         stderr: "session expired",
-        timedOut: false,
-        noOutputTimedOut: false,
       }),
     );
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "recovered output",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "recovered output" }));
 
     const context = buildPreparedContext({
       sessionKey: "agent:main:main",
@@ -4905,18 +4282,7 @@ describe("runCliAgent reliability", () => {
     setHookRunnerForTest(hookRunner);
     const historySpy = vi.spyOn(sessionHistoryModule, "loadCliSessionHistoryMessages");
 
-    supervisorSpawnMock.mockResolvedValueOnce(
-      createManagedRun({
-        reason: "exit",
-        exitCode: 0,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: "hello from cli",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      }),
-    );
+    supervisorSpawnMock.mockResolvedValueOnce(makeManagedRun({ stdout: "hello from cli" }));
 
     try {
       await runPreparedCliAgent(buildPreparedContext());

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -48,6 +48,24 @@ const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
 
 const runEmbeddedAgent = runIncompleteTurnOwnerHarness;
 
+type LastAssistant = NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+type LastAssistantFixture = Omit<LastAssistant, "content" | "stopReason" | "usage"> & {
+  content: Array<Record<string, unknown>>;
+  stopReason: LastAssistant["stopReason"] | "end_turn";
+  usage: Partial<LastAssistant["usage"]> & { total?: number };
+};
+
+function makeLastAssistant(overrides: Partial<LastAssistantFixture> = {}): LastAssistant {
+  return {
+    role: "assistant",
+    stopReason: "stop",
+    provider: "openai",
+    model: "gpt-5.5",
+    content: [],
+    ...overrides,
+  } as unknown as LastAssistant;
+}
+
 function resolveIncompleteTurnPayloadText(
   params: Omit<Parameters<typeof resolveIncompleteTurnPayloadTextCore>[0], "externalAbort"> & {
     externalAbort?: boolean;
@@ -196,13 +214,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         externalAbort: false,
         assistantTexts: [],
         toolMetas: [{ toolName: "web_search", meta: "query=next voice note" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
-          model: "gpt-5.5",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -225,14 +239,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const timeoutError = new Error("caller deadline elapsed");
     timeoutError.name = "TimeoutError";
     const setTerminalLifecycleMeta = vi.fn();
-    const interruptedAssistant = {
-      role: "assistant",
+    const interruptedAssistant = makeLastAssistant({
       stopReason: "error",
       errorMessage: "HTTP 429 Too Many Requests",
-      provider: "openai",
-      model: "gpt-5.5",
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedClassifyFailoverReason.mockReturnValue("rate_limit");
     mockedIsRateLimitAssistantError.mockReturnValue(true);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
@@ -271,13 +281,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const abortError = new Error("caller cancelled");
     abortError.name = "AbortError";
     const setTerminalLifecycleMeta = vi.fn();
-    const lateAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const lateAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Late answer" }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
       controller.abort(abortError);
       return makeAttemptResult({
@@ -308,13 +314,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("propagates canonical assistant aborts into terminal lifecycle metadata", async () => {
     const setTerminalLifecycleMeta = vi.fn();
-    const abortedAssistant = {
-      role: "assistant",
+    const abortedAssistant = makeLastAssistant({
       stopReason: "aborted",
-      provider: "openai",
-      model: "gpt-5.5",
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -353,13 +355,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             content: [{ type: "text", text: "NO_REPLY" }],
             details: { aggregated: "NO_REPLY" },
           } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-          {
-            role: "assistant",
-            stopReason: "stop",
-            provider: "openai",
+          makeLastAssistant({
             model: "gpt-5.4",
-            content: [],
-          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          }),
         ],
       }),
     });
@@ -385,13 +383,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             role: "user",
             content: [{ type: "text", text: "Current cron prompt" }],
           } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-          {
-            role: "assistant",
-            stopReason: "stop",
-            provider: "openai",
+          makeLastAssistant({
             model: "gpt-5.4",
-            content: [],
-          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          }),
         ],
       }),
     });
@@ -411,21 +405,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             content: [{ type: "text", text: "NO_REPLY" }],
             details: { aggregated: "NO_REPLY" },
           } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-          {
-            role: "assistant",
-            stopReason: "stop",
-            provider: "openai",
+          makeLastAssistant({
             model: "gpt-5.4",
-            content: [],
-          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          }),
         ],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -464,13 +450,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       return makeAttemptResult({
         assistantTexts: [],
         toolMetas: [{ toolName: "web_fetch" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
 
@@ -521,13 +504,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           hadPotentialSideEffects: false,
           replaySafe: true,
         },
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
 
@@ -571,25 +551,21 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       return makeAttemptResult({
         assistantTexts: [],
         toolMetas: [{ toolName: "web_fetch" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -641,13 +617,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       return makeAttemptResult({
         assistantTexts: [],
         toolMetas: [{ toolName: "web_fetch" }, { toolName: "exec" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
 
@@ -690,13 +663,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       return makeAttemptResult({
         assistantTexts: [],
         toolMetas: [{ toolName: "exec" }, { toolName: "web_fetch" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
 
@@ -716,13 +686,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     const finalText =
       "1. Verdict: the answer completed cleanly. 2. Evidence: the runner captured final text.";
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const finalAssistant = makeLastAssistant({
       content: [{ type: "text", text: finalText }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -756,13 +722,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("does not recover a stale prior assistant after the current prompt times out", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    const staleAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const staleAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Stale answer from the prior attempt." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -786,20 +748,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("does not resolve a successful run from a stale transcript assistant", async () => {
-    const staleAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const staleAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Prior transcript reply." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
-    const completedAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    });
+    const completedAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Current run reply." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptCompletedAssistant"]>;
+    });
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "Current run reply." }]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -829,20 +783,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("retains the yielded attempt assistant for paused-turn payload classification", async () => {
-    const completedAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const completedAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Earlier completed cycle." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptCompletedAssistant"]>;
-    const yieldedAssistant = {
-      role: "assistant",
+    });
+    const yieldedAssistant = makeLastAssistant({
       stopReason: "aborted",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", name: "sessions_yield", arguments: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -869,13 +816,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("recovers a completed prompt-timeout assistant without collected assistant text", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     const finalText = "Completed answer after the timeout race.";
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const finalAssistant = makeLastAssistant({
       content: [{ type: "text", text: finalText }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: undefined as unknown as string[],
@@ -899,13 +842,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     const partialText = "Partial answer before the timeout race.";
     const finalText = "Complete answer after the timeout race.";
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const finalAssistant = makeLastAssistant({
       content: [{ type: "text", text: finalText }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [partialText],
@@ -943,13 +882,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       { text: completedText },
       { text: partialText },
     ]);
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const finalAssistant = makeLastAssistant({
       content: [{ type: "text", text: finalText }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [completedText, partialText],
@@ -972,14 +907,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("records same-model rate-limit retries without a profile-rotation trace", async () => {
     const rateLimitMessage =
       "429 rate_limit_exceeded: requests per minute exceeded; Retry-After: 30";
-    const rateLimitAssistant = {
-      role: "assistant",
+    const rateLimitAssistant = makeLastAssistant({
       stopReason: "error",
-      provider: "openai",
-      model: "gpt-5.5",
       errorMessage: rateLimitMessage,
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedClassifyFailoverReason.mockImplementation((raw) =>
       raw.includes("429") ? "rate_limit" : null,
     );
@@ -996,13 +927,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         currentAttemptAssistant: rateLimitAssistant,
       }),
     );
-    const recoveredAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const recoveredAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Recovered after a short rate-limit wait." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Recovered after a short rate-limit wait."],
@@ -1044,10 +971,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       markUserMessagePersisted(attemptParams);
       return makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -1056,19 +981,17 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_reasoning_only", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible answer."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "Visible answer." }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -1091,11 +1014,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const acceptedSessionSpawns = [
       { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
     ];
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [
         { type: "toolCall", id: "tool_write", name: "write", arguments: { path: "note.txt" } },
         { type: "toolCall", id: "tool_cron", name: "cron", arguments: { action: "add" } },
@@ -1106,7 +1026,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           arguments: { task: "follow up" },
         },
       ],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const settledToolResults = [
       toolUseAssistant,
       { role: "toolResult", toolCallId: "tool_write", toolName: "write", isError: false },
@@ -1140,13 +1060,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         bridgeCalls: { search: 1, describe: 2, call: 3 },
       });
     });
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const finalAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Write completed. Here is the final answer." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Write completed. Here is the final answer."],
@@ -1198,13 +1114,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       terminalReplyExpectation: "required" as const,
     },
   ])("finalizes a settled failed tool once for a $label turn (#118274)", async (runPolicy) => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const failureText = "The exec tool failed: post-processing error.";
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
@@ -1254,13 +1167,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         },
       });
     });
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const finalAssistant = makeLastAssistant({
       content: [{ type: "text", text: failureText }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [failureText],
@@ -1305,13 +1214,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("preserves a structured visible failed-tool payload without finalizing (#118274)", async () => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const visibleError = {
       text: "Review the failed operation.",
       isError: true,
@@ -1347,13 +1253,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("keeps the original failed-tool warning if finalization fails (#118274)", async () => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const warning = { text: "⚠️ 🛠️ Exec failed", isError: true };
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt
@@ -1400,15 +1303,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       runAttempt: async (params) => await mockedRunEmbeddedAttempt(params),
     });
     try {
-      const toolUseAssistant = {
-        role: "assistant",
+      const toolUseAssistant = makeLastAssistant({
         stopReason: "toolUse",
-        provider: "openai",
-        model: "gpt-5.5",
         content: [
           { type: "toolCall", id: "tool_1", name: "write", arguments: { path: "note.txt" } },
         ],
-      } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+      });
       mockedClassifyFailoverReason.mockReturnValue(null);
       mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
         markUserMessagePersisted(attemptParams);
@@ -1445,13 +1345,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("continues from settled side-effecting tools after an empty stop without replaying them", async () => {
-    const emptyStopAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const emptyStopAssistant = makeLastAssistant();
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
       markUserMessagePersisted(attemptParams);
@@ -1463,13 +1357,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         currentAttemptAssistant: emptyStopAssistant,
       });
     });
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
+    const finalAssistant = makeLastAssistant({
       content: [{ type: "text", text: "Write completed. Here is the final answer." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Write completed. Here is the final answer."],
@@ -1511,13 +1401,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       terminalReplyExpectation: undefined,
     },
   ])("does not continue settled tools for $label", async (runPolicy) => {
-    const emptyStopAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const emptyStopAssistant = makeLastAssistant();
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
       markUserMessagePersisted(attemptParams);
@@ -1546,13 +1430,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("surfaces failure without cascading when the settled-tool continuation is also empty", async () => {
-    const emptyStopAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const emptyStopAssistant = makeLastAssistant();
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
       markUserMessagePersisted(attemptParams);
@@ -1618,13 +1496,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       },
     },
   ])("does not escape finalization through a $label", async ({ finalAttempt }) => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt
       .mockResolvedValueOnce(
@@ -1658,13 +1533,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("surfaces the existing incomplete-turn error after one tool-use continuation", async () => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: { path: "note.txt" } }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
@@ -1696,13 +1568,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("does not claim completion for a toolUse terminal whose tools never started", async () => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: { path: "note.txt" } }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
@@ -1730,13 +1599,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("ignores stale prior-turn tool results with colliding ids", async () => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: { path: "note.txt" } }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
@@ -1770,16 +1636,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("does not claim completion when only part of a multi-tool request dispatched", async () => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [
         { type: "toolCall", id: "tool_1", name: "write", arguments: { path: "a.txt" } },
         { type: "toolCall", id: "tool_2", name: "write", arguments: { path: "b.txt" } },
       ],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
@@ -1815,11 +1678,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
-          model: "gpt-5.5",
           content: [
             {
               type: "thinking",
@@ -1827,19 +1687,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_silent_group", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible answer."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
-          model: "gpt-5.5",
           content: [{ type: "text", text: "Visible answer." }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -1862,10 +1719,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       markUserMessagePersisted(attemptParams);
       return makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -1874,7 +1729,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_retry_boundary", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
@@ -1915,10 +1770,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered through the message tool."],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "gpt-5.4",
           content: [
             {
@@ -1927,7 +1779,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_after_send", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -1944,10 +1796,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("retries reasoning-only turns when the assistant ended in error", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    const errorAssistant = {
-      role: "assistant",
+    const errorAssistant = makeLastAssistant({
       stopReason: "error",
-      provider: "openai",
       model: "gpt-5.4",
       errorMessage: "provider failed after emitting reasoning",
       content: [
@@ -1957,7 +1807,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           thinkingSignature: JSON.stringify({ id: "rs_error_turn", type: "reasoning" }),
         },
       ],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -1968,13 +1818,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Recovered."],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "gpt-5.4",
           content: [{ type: "text", text: "Recovered." }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -1994,8 +1841,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "anthropic",
           model: "sonnet-4.6",
@@ -2009,7 +1855,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2043,10 +1889,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "anthropic-messages",
-          stopReason: "stop",
           provider: "kimi",
           model: "kimi-for-coding",
           content: [
@@ -2056,20 +1900,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: "",
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible Kimi answer."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "anthropic-messages",
-          stopReason: "stop",
           provider: "kimi",
           model: "kimi-for-coding",
           content: [{ type: "text", text: "Visible Kimi answer." }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2092,25 +1934,21 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       markUserMessagePersisted(attemptParams);
       return makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible answer."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "Visible answer." }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2131,13 +1969,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("retries replay-safe missing turns despite a stale aborted transcript assistant", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    const staleAssistant = {
-      role: "assistant",
+    const staleAssistant = makeLastAssistant({
       stopReason: "aborted",
-      provider: "openai",
-      model: "gpt-5.5",
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -2145,13 +1979,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         currentAttemptAssistant: undefined,
       }),
     );
-    const recoveredAssistant = {
-      role: "assistant",
+    const recoveredAssistant = makeLastAssistant({
       stopReason: "end_turn",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "text", text: "Recovered answer." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Recovered answer."],
@@ -2185,13 +2016,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         currentAttemptAssistant: undefined,
       });
     });
-    const recoveredAssistant = {
-      role: "assistant",
+    const recoveredAssistant = makeLastAssistant({
       stopReason: "end_turn",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "text", text: "Recovered answer." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Recovered answer."],
@@ -2303,13 +2131,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         currentAttemptAssistant: undefined,
       }),
     );
-    const recoveredAssistant = {
-      role: "assistant",
+    const recoveredAssistant = makeLastAssistant({
       stopReason: "end_turn",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "text", text: "Recovered answer." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Recovered answer."],
@@ -2334,12 +2159,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "anthropic",
           model: "claude-opus-4.7",
-          content: [],
           usage: {
             input: 0,
             output: 0,
@@ -2347,15 +2169,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             cacheWrite: 0,
             totalTokens: 0,
           },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible Claude answer."],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "anthropic",
           model: "claude-opus-4.7",
           content: [{ type: "text", text: "Visible Claude answer." }],
@@ -2366,7 +2186,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             cacheWrite: 0,
             totalTokens: 105,
           },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2401,13 +2221,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "openai-completions",
-          stopReason: "stop",
           provider: "llamacpp",
           model: "qwen3.6-27b",
-          content: [],
           usage: {
             input: 512,
             output: 103,
@@ -2415,16 +2232,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             cacheWrite: 0,
             totalTokens: 615,
           },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible local answer."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "openai-completions",
-          stopReason: "stop",
           provider: "llamacpp",
           model: "qwen3.6-27b",
           content: [{ type: "text", text: "Visible local answer." }],
@@ -2435,7 +2250,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             cacheWrite: 0,
             totalTokens: 645,
           },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2470,13 +2285,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "anthropic-messages",
-          stopReason: "stop",
           provider: "sub2api",
           model: "claude-opus-4-7",
-          content: [],
           usage: {
             input: 2048,
             output: 3100,
@@ -2484,16 +2296,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             cacheWrite: 0,
             totalTokens: 5148,
           },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible Anthropic-compatible answer."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "anthropic-messages",
-          stopReason: "stop",
           provider: "sub2api",
           model: "claude-opus-4-7",
           content: [{ type: "text", text: "Visible Anthropic-compatible answer." }],
@@ -2504,7 +2314,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             cacheWrite: 0,
             totalTokens: 2308,
           },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2526,13 +2336,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2554,10 +2362,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -2569,7 +2375,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -2592,10 +2398,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const reasoningOnlyAttempt = async () =>
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -2607,7 +2411,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       });
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
       (
@@ -2718,13 +2522,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     { label: "timed out", aborted: false, timedOut: true, promptError: null },
     { label: "prompt error", aborted: false, timedOut: false, promptError: new Error("closed") },
   ])("does not continue a $label tool-use terminal turn", ({ aborted, timedOut, promptError }) => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "tool_use", id: "tool_1", name: "bash", input: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const instruction = resolveSettledToolTerminalContinuationInstruction({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -2754,16 +2555,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   ])(
     "recognizes successful and failed current-batch tools with $label (#118274)",
     ({ lastToolError }) => {
-      const toolUseAssistant = {
-        role: "assistant",
+      const toolUseAssistant = makeLastAssistant({
         stopReason: "toolUse",
-        provider: "openai",
-        model: "gpt-5.5",
         content: [
           { type: "toolCall", id: "tool_ok", name: "read", arguments: {} },
           { type: "toolCall", id: "tool_failed", name: "exec", arguments: {} },
         ],
-      } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+      });
       const instruction = resolveSettledToolTerminalContinuationInstruction({
         provider: "openai",
         modelId: "gpt-5.5",
@@ -2805,13 +2603,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       lastErrorToolName: "exec",
     },
   ])("does not finalize $label (#118274)", ({ resultToolName, lastErrorToolName }) => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const instruction = resolveSettledToolTerminalContinuationInstruction({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -2842,16 +2637,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("does not settle same-name terminal calls from one failed result (#118274)", () => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [
         { type: "toolCall", id: "tool_1", name: "exec", arguments: {} },
         { type: "toolCall", id: "tool_2", name: "exec", arguments: {} },
       ],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const instruction = resolveSettledToolTerminalContinuationInstruction({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -2902,13 +2694,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attemptOverrides: { didSendDeterministicApprovalPrompt: true },
     },
   ])("does not finalize a failed terminal tool when $label (#118274)", ({ attemptOverrides }) => {
-    const toolUseAssistant = {
-      role: "assistant",
+    const toolUseAssistant = makeLastAssistant({
       stopReason: "toolUse",
-      provider: "openai",
-      model: "gpt-5.5",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     const instruction = resolveSettledToolTerminalContinuationInstruction({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -2960,13 +2749,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       asyncStarted,
       isError,
     }) => {
-      const emptyStopAssistant = {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "openai",
-        model: "gpt-5.5",
-        content: [],
-      } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+      const emptyStopAssistant = makeLastAssistant();
       const instruction = resolveSettledToolTerminalContinuationInstruction({
         provider: "openai",
         modelId: "gpt-5.5",
@@ -2989,13 +2772,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   );
 
   it("does not use a stale prior-turn empty stop to prove a settled continuation", () => {
-    const staleEmptyStopAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.5",
-      content: [],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const staleEmptyStopAssistant = makeLastAssistant();
     const instruction = resolveSettledToolTerminalContinuationInstruction({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -3024,23 +2801,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Analysis...", "Here is the final answer after update_plan."],
         toolMetas: [{ toolName: "update_plan" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
-          model: "gpt-5.5",
           content: [
             { type: "text", text: "Analysis..." },
             { type: "tool_use", id: "tool_1", name: "update_plan", input: {} },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        currentAttemptAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
+        }),
+        currentAttemptAssistant: makeLastAssistant({
           content: [{ type: "text", text: "Here is the final answer after update_plan." }],
-        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+        }),
       }),
     });
 
@@ -3055,16 +2825,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Let me update the file..."],
         toolMetas: [{ toolName: "write" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             { type: "text", text: "Let me update the file..." },
             { type: "tool_use", id: "tool_1", name: "write", input: {} },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
         currentAttemptAssistant: undefined,
       }),
     });
@@ -3181,8 +2949,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Initial analysis of the codebase..."],
         toolMetas: [{ toolName: "read", meta: "path=src/index.ts" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
           provider: "anthropic",
           model: "sonnet-4.6",
@@ -3190,7 +2957,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             { type: "text", text: "Initial analysis of the codebase..." },
             { type: "tool_use", id: "tool_1", name: "read", input: { path: "src/index.ts" } },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3211,10 +2978,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             asyncStarted: true,
           },
         ],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -3224,7 +2989,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               input: { action: "generate", prompt: "a portrait" },
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3239,16 +3004,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Let me update the file..."],
         toolMetas: [{ toolName: "write" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             { type: "text", text: "Let me update the file..." },
             { type: "tool_use", id: "tool_1", name: "write", input: {} },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3265,13 +3028,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Initial analysis...", "Here is the final answer."],
         toolMetas: [{ toolName: "read" }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "anthropic",
           model: "sonnet-4.6",
           content: [{ type: "text", text: "Here is the final answer." }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3288,10 +3050,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "qwen3.6-35b-a3b",
           content: [
             {
@@ -3300,7 +3059,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               // no signature — unsigned thinking block
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3316,10 +3075,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: ["Here is the answer to your question."],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "qwen3.6-35b-a3b",
           content: [
             {
@@ -3328,7 +3084,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             },
             { type: "text", text: "Here is the answer to your question." },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3374,22 +3130,15 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       makeAttemptResult({
         assistantTexts: [finalText],
         toolMetas: [{ toolName: "update_plan", replaySafe: true }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
-          model: "gpt-5.5",
           content: [{ type: "tool_use", id: "tool_1", name: "update_plan", input: {} }],
           usage: { input: 100, output: 5, total: 105 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        currentAttemptAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
+        }),
+        currentAttemptAssistant: makeLastAssistant({
           content: [{ type: "text", text: finalText }],
           usage: { input: 200, output: 20, total: 220 },
-        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+        }),
       }),
     );
 
@@ -3444,10 +3193,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -3456,7 +3203,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_helper", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3471,8 +3218,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "google",
           model: "gemini-2.5-pro",
@@ -3483,7 +3229,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "gemini_rs_helper", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3499,9 +3245,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "amazon-bedrock",
           model: "openai.gpt-oss-120b-1:0",
           content: [
@@ -3511,7 +3255,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: "bedrock-reasoning-signature",
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3526,8 +3270,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "ollama",
           model: "gemma4:31b",
@@ -3538,7 +3281,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "ollama_rs_helper", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3554,10 +3297,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "qwen3.6-35b-a3b",
           content: [
             {
@@ -3565,7 +3305,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinking: "let me plan the tool calls I need to make...",
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3580,8 +3320,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "ollama",
           model: "gemma4:31b",
@@ -3591,7 +3330,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinking: "internal reasoning",
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3607,8 +3346,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "ollama",
           model: "gemma4:31b",
@@ -3618,7 +3356,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinking: "internal reasoning",
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3634,13 +3372,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "ollama",
           model: "gemma4:31b",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3656,14 +3393,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "ollama",
           model: "minimax-m2.7:cloud",
-          content: [],
           usage: { input: 100, output: 6, totalTokens: 106 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3685,13 +3419,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             childSessionKey: "agent:claude:subagent:child",
           },
         ],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "ollama",
           model: "gemma4:31b",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3708,14 +3441,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
-          content: [],
+        lastAssistant: makeLastAssistant({
           usage: { input: 24794, output: 111, cacheRead: 4608, totalTokens: 29513 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3732,14 +3460,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
-          content: [],
+        lastAssistant: makeLastAssistant({
           usage: { input: 5000, output: 200, totalTokens: 5200 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3756,14 +3479,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "llama-cpp-local",
           model: "qwen3.6-27b",
-          content: [],
           usage: { input: 950, output: 103, totalTokens: 1053 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3779,14 +3499,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "ollama",
           model: "glm-5.1:cloud",
-          content: [],
           usage: { input: 100, output: 0, totalTokens: 100 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3800,10 +3517,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: ["NO_REPLY"],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "gpt-5.4",
           content: [
             {
@@ -3814,7 +3528,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             { type: "text", text: "" },
             { type: "text", text: "NO_REPLY" },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3830,13 +3544,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered through the message tool."],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "ollama",
           model: "kimi-k2.6:cloud",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3852,8 +3563,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered through the message tool."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "google",
           model: "gemini-2.5-pro",
@@ -3864,7 +3574,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_messaging_end_turn", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3880,13 +3590,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         didSendViaMessagingTool: false,
         messagingToolSentMediaUrls: ["file:///tmp/render.png"],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3902,14 +3609,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered before the provider error."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "error",
           provider: "ollama",
           model: "kimi-k2.6:cloud",
           errorMessage: "provider failed after delivery",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -3927,13 +3632,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           childSessionKey: "agent:claude:subagent:child",
         },
       ],
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
+      lastAssistant: makeLastAssistant({
         provider: "anthropic",
         model: "sonnet-4.6",
-        content: [],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     };
 
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
@@ -3959,13 +3661,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         acceptedSessionSpawns,
         timedOut: true,
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "toolUse",
-          provider: "openai",
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -3991,13 +3690,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     } = {
       assistantTexts: [],
       acceptedSessionSpawns: [],
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
+      lastAssistant: makeLastAssistant({
         provider: "anthropic",
         model: "sonnet-4.6",
-        content: [],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     };
 
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
@@ -4018,14 +3714,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: [],
         didSendViaMessagingTool: true,
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "error",
           provider: "ollama",
           model: "kimi-k2.6:cloud",
           errorMessage: "provider failed mid-turn",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4153,13 +3847,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           meta: "send",
           error: "delivery failed for second target",
         },
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "error",
-          provider: "openai",
           model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4175,10 +3866,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: [],
         didSendViaMessagingTool: true,
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -4187,7 +3876,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_side_effect", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4203,10 +3892,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "error",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -4215,7 +3902,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_helper_error", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4230,10 +3917,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: ["Visible answer."],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [
             {
@@ -4246,7 +3931,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             },
             { type: "text", text: "" },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4260,8 +3945,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "error",
           provider: "anthropic",
           model: "claude-opus-4-8",
@@ -4272,7 +3956,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               thinkingSignature: JSON.stringify({ id: "rs_error_payload", type: "reasoning" }),
             },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4286,13 +3970,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: ["Partial answer"],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "length",
           provider: "ollama",
           model: "qwen3.5",
           content: [{ type: "text", text: "Partial answer" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4306,13 +3989,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: ["Complete answer"],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "ollama",
           model: "qwen3.5",
           content: [{ type: "text", text: "Complete answer" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4327,13 +4008,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Partial answer"],
         toolMediaUrls: ["file:///tmp/render.png"],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "length",
           provider: "ollama",
           model: "qwen3.5",
           content: [{ type: "text", text: "Partial answer" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4348,13 +4028,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Partial answer"],
         hasToolMediaBlockReply: true,
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "length",
           provider: "ollama",
           model: "qwen3.5",
           content: [{ type: "text", text: "Partial answer" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4369,13 +4048,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: ["Partial answer"],
         successfulCronAdds: 1,
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "length",
           provider: "ollama",
           model: "qwen3.5",
           content: [{ type: "text", text: "Partial answer" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4411,8 +4089,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         attempt: makeAttemptResult({
           assistantTexts: [],
           ...attemptState,
-          lastAssistant: {
-            role: "assistant",
+          lastAssistant: makeLastAssistant({
             stopReason: "error",
             provider: "anthropic",
             model: "claude-opus-4-8",
@@ -4426,7 +4103,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
                 }),
               },
             ],
-          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+          }),
         }),
       });
 
@@ -4435,8 +4112,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   );
 
   it("retries replay-safe errored turns that only emitted thinking blocks", () => {
-    const assistant = {
-      role: "assistant",
+    const assistant = makeLastAssistant({
       stopReason: "error",
       provider: "anthropic",
       model: "claude-opus-4-8",
@@ -4450,7 +4126,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         { type: "text", text: " " },
       ],
       usage: { input: 100, output: 1120, totalTokens: 1220 },
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    });
     expect(
       shouldRetrySilentErrorAssistantTurn({
         attempt: makeAttemptResult({ assistantTexts: [], lastAssistant: assistant }),
@@ -4460,14 +4136,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("does not retry errored empty turns when non-zero output may indicate progress", () => {
-    const assistant = {
-      role: "assistant",
+    const assistant = makeLastAssistant({
       stopReason: "error",
       provider: "ollama",
       model: "glm-5.1:cloud",
-      content: [],
       usage: { input: 100, output: 12, totalTokens: 112 },
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    });
     expect(
       shouldRetrySilentErrorAssistantTurn({
         attempt: makeAttemptResult({ assistantTexts: [], lastAssistant: assistant }),
@@ -4496,14 +4170,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       content: [{ type: "provider_metadata", value: "opaque" }],
     },
   ])("does not retry errored turns containing $name", ({ content }) => {
-    const assistant = {
-      role: "assistant",
+    const assistant = makeLastAssistant({
       stopReason: "error",
       provider: "anthropic",
       model: "claude-opus-4-8",
       content,
       usage: { input: 100, output: 1120, totalTokens: 1220 },
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    });
     expect(
       shouldRetrySilentErrorAssistantTurn({
         attempt: makeAttemptResult({ assistantTexts: [], lastAssistant: assistant }),
@@ -4513,8 +4186,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("does not retry errored thinking-only turns after side effects", () => {
-    const assistant = {
-      role: "assistant",
+    const assistant = makeLastAssistant({
       stopReason: "error",
       provider: "anthropic",
       model: "claude-opus-4-8",
@@ -4525,7 +4197,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         },
       ],
       usage: { input: 100, output: 1120, totalTokens: 1220 },
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    });
     expect(
       shouldRetrySilentErrorAssistantTurn({
         attempt: makeAttemptResult({
@@ -4548,14 +4220,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   ] as const)(
     "uses current-attempt replay metadata when %s",
     (_label, cumulativeDirty, currentDirty, expected) => {
-      const assistant = {
-        role: "assistant",
+      const assistant = makeLastAssistant({
         stopReason: "error",
         provider: "openrouter",
         model: "test-model",
-        content: [],
         usage: { input: 100, output: 0, totalTokens: 100 },
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+      });
       expect(
         shouldRetrySilentErrorAssistantTurn({
           attempt: makeAttemptResult({
@@ -4586,14 +4256,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "llamacpp",
           model: "qwen3.6-27b",
-          content: [],
           usage: { input: 512, output: 103, totalTokens: 615 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4609,13 +4276,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4637,21 +4302,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             content: [{ type: "text", text: "" }],
             details: { aggregated: "" },
           } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-          {
-            role: "assistant",
-            stopReason: "stop",
-            provider: "openai",
-            model: "gpt-5.5",
+          makeLastAssistant({
             content: [{ type: "text", text: "" }],
-          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          }),
         ],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
+        lastAssistant: makeLastAssistant({
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4669,14 +4326,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
+        lastAssistant: makeLastAssistant({
           provider: "amazon-bedrock",
           model: "openai.gpt-oss-120b-1:0",
           content: [{ type: "text", text: "" }],
           usage: { input: 950, output: 103, totalTokens: 1053 },
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -4686,13 +4341,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("treats clean empty assistant turns as silent only for reply-optional runs", () => {
     const attempt = makeAttemptResult({
       assistantTexts: [],
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "openai",
-        model: "gpt-5.5",
+      lastAssistant: makeLastAssistant({
         content: [{ type: "text", text: "" }],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
 
     expect(
@@ -4728,11 +4379,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("treats reasoning-only assistant turns as silent only for reply-optional runs", () => {
     const attempt = makeAttemptResult({
       assistantTexts: [],
-      lastAssistant: {
-        role: "assistant",
+      lastAssistant: makeLastAssistant({
         stopReason: "end_turn",
-        provider: "openai",
-        model: "gpt-5.5",
         content: [
           {
             type: "thinking",
@@ -4740,7 +4388,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             thinkingSignature: JSON.stringify({ id: "rs_silent_helper", type: "reasoning" }),
           },
         ],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
 
     expect(
@@ -4776,13 +4424,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("treats exact NO_REPLY assistant turns as silent only when the caller allows it", () => {
     const attempt = makeAttemptResult({
       assistantTexts: ["NO_REPLY"],
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "openai",
-        model: "gpt-5.5",
+      lastAssistant: makeLastAssistant({
         content: [{ type: "text", text: "NO_REPLY" }],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
 
     expect(
@@ -4809,13 +4453,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const attempt = makeAttemptResult({
       assistantTexts: ["NO_REPLY"],
       toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "openai",
-        model: "gpt-5.5",
+      lastAssistant: makeLastAssistant({
         content: [{ type: "text", text: "NO_REPLY" }],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
 
     expect(
@@ -4832,47 +4472,33 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("does not treat error or side-effect empty turns as silent", () => {
     const errorAttempt = makeAttemptResult({
       assistantTexts: [],
-      lastAssistant: {
-        role: "assistant",
+      lastAssistant: makeLastAssistant({
         stopReason: "error",
-        provider: "openai",
-        model: "gpt-5.5",
-        content: [],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
     const silentErrorAttempt = makeAttemptResult({
       assistantTexts: ["NO_REPLY"],
-      lastAssistant: {
-        role: "assistant",
+      lastAssistant: makeLastAssistant({
         stopReason: "error",
-        provider: "openai",
-        model: "gpt-5.5",
         content: [{ type: "text", text: "NO_REPLY" }],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
     const sideEffectAttempt = makeAttemptResult({
       assistantTexts: [],
       didSendViaMessagingTool: true,
       messagingToolSentTexts: ["sent already"],
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "openai",
-        model: "gpt-5.5",
+      lastAssistant: makeLastAssistant({
         content: [{ type: "text", text: "" }],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
     const postToolEmptyAttempt = makeAttemptResult({
       assistantTexts: [],
       toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
-      lastAssistant: {
-        role: "assistant",
+      lastAssistant: makeLastAssistant({
         api: "openai-completions",
-        stopReason: "stop",
         provider: "stepfun",
         model: "step-router-v1",
-        content: [],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
 
     expect(
@@ -4918,25 +4544,17 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
+        lastAssistant: makeLastAssistant({
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible answer."],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
+        lastAssistant: makeLastAssistant({
           content: [{ type: "text", text: "Visible answer." }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -4958,11 +4576,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
         assistantTexts: ["NO_REPLY"],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
+        lastAssistant: makeLastAssistant({
           content: [
             {
               type: "thinking",
@@ -4971,7 +4585,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             },
             { type: "text", text: "NO_REPLY" },
           ],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -5014,32 +4628,24 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "openai-completions",
-          stopReason: "stop",
           provider: "stepfun",
           model: "step-router-v1",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        currentAttemptAssistant: {
-          role: "assistant",
+        }),
+        currentAttemptAssistant: makeLastAssistant({
           api: "openai-completions",
-          stopReason: "stop",
           provider: "stepfun",
           model: "step-router-v1",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+        }),
       }),
     );
-    const finalAssistant = {
-      role: "assistant",
+    const finalAssistant = makeLastAssistant({
       api: "openai-completions",
-      stopReason: "stop",
       provider: "stepfun",
       model: "step-router-v1",
       content: [{ type: "text", text: "Visible StepFun answer." }],
-    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible StepFun answer."],
@@ -5085,14 +4691,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       makeAttemptResult({
         assistantTexts: ["NO_REPLY"],
         toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           api: "openai-completions",
-          stopReason: "stop",
           provider: "stepfun",
           model: "step-router-v1",
           content: [{ type: "text", text: "NO_REPLY" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -5121,13 +4725,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const sideEffectToolAttempt = makeAttemptResult({
       assistantTexts: [],
       toolMetas: [{ toolName: "sessions", meta: "patch archived", replaySafe: false }],
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "openai",
-        model: "gpt-5.5",
+      lastAssistant: makeLastAssistant({
         content: [{ type: "text", text: "" }],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
 
     expect(
@@ -5167,24 +4767,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       assistantTexts: [],
       toolMetas: [{ toolName: "sessions", meta: "patch failed", replaySafe: false, isError: true }],
       lastToolError: { toolName: "sessions", error: "patch failed" },
-      lastAssistant: {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "openai",
-        model: "gpt-5.5",
+      lastAssistant: makeLastAssistant({
         content: [{ type: "text", text: "" }],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
     const errorStopAttempt = makeAttemptResult({
       assistantTexts: [],
       toolMetas: [{ toolName: "sessions", meta: "patch archived", replaySafe: false }],
-      lastAssistant: {
-        role: "assistant",
+      lastAssistant: makeLastAssistant({
         stopReason: "error",
-        provider: "openai",
-        model: "gpt-5.5",
-        content: [],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
     });
 
     expect(
@@ -5226,13 +4818,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         assistantTexts: [],
         toolMetas: [{ toolName: "sessions", meta: "patch archived", replaySafe: false }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.5",
+        lastAssistant: makeLastAssistant({
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -5258,13 +4846,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
+        lastAssistant: makeLastAssistant({
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     );
 
@@ -5289,13 +4874,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       timedOut: false,
       attempt: makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
           provider: "google-vertex",
           model: "gemini-3.1-flash",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 
@@ -5312,13 +4896,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: makeAttemptResult({
         assistantTexts: [],
         didSendViaMessagingTool: true,
-        lastAssistant: {
-          role: "assistant",
+        lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
-          provider: "openai",
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
       }),
     });
 

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -286,6 +286,99 @@ describe("subagent registry seam flow", () => {
     addSubagentRunForTests(entry: SubagentRunRecordOverrides): void;
     registerSubagentRun(params: SubagentRunParamsOverrides): void;
   };
+  type RunRecordFixtureOverrides = Pick<SubagentRunRecordOverrides, "runId"> &
+    Partial<Omit<SubagentRunRecordOverrides, "runId">>;
+  type KilledRunOverrides = Pick<SubagentRunRecordOverrides, "runId"> &
+    Required<Pick<SubagentRunRecord, "task" | "createdAt">> &
+    Partial<Omit<SubagentRunRecordOverrides, "runId" | "task" | "createdAt">>;
+  type RunningTaskParams = Parameters<typeof createRunningTaskRun>[0];
+  type RunningTaskParamsOverrides = Required<
+    Pick<RunningTaskParams, "runId" | "childSessionKey" | "startedAt">
+  > &
+    Pick<RunningTaskParams, "task"> &
+    Partial<Omit<RunningTaskParams, "runId" | "childSessionKey" | "startedAt" | "task">>;
+  type SuspendedDeliveryRunOverrides = Pick<SubagentRunRecordOverrides, "runId"> &
+    Required<
+      Pick<
+        SubagentRunRecord,
+        "childSessionKey" | "requesterSessionKey" | "requesterDisplayKey" | "task" | "createdAt"
+      >
+    > & {
+      endedAt: number;
+      delivery: Partial<NonNullable<SubagentRunRecord["delivery"]>>;
+    } & Partial<
+      Omit<
+        SubagentRunRecordOverrides,
+        | "runId"
+        | "childSessionKey"
+        | "requesterSessionKey"
+        | "requesterDisplayKey"
+        | "task"
+        | "createdAt"
+        | "startedAt"
+        | "endedAt"
+        | "outcome"
+        | "expectsCompletionMessage"
+        | "delivery"
+      >
+    >;
+
+  const makeKilledRun = (
+    killedAt: number,
+    overrides: KilledRunOverrides,
+  ): SubagentRunRecordOverrides => ({
+    endedAt: killedAt,
+    endedReason: SUBAGENT_ENDED_REASON_KILLED,
+    outcome: { status: "error", error: "manual kill" },
+    suppressAnnounceReason: "killed",
+    killReconciliation: { killedAt },
+    cleanupHandled: true,
+    cleanupCompletedAt: killedAt,
+    ...overrides,
+  });
+  const makeCompletedCollectorRun = (
+    overrides: RunRecordFixtureOverrides,
+  ): SubagentRunRecordOverrides => ({
+    collect: true,
+    collectorCompletion: { status: "done" },
+    ...overrides,
+  });
+  const makeRunningTaskParams = (overrides: RunningTaskParamsOverrides): RunningTaskParams => ({
+    runtime: "subagent",
+    sourceId: overrides.runId,
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    deliveryStatus: "pending",
+    lastEventAt: overrides.startedAt,
+    ...overrides,
+  });
+  const makeSuspendedDeliveryRun = ({
+    delivery: deliveryOverrides,
+    ...overrides
+  }: SuspendedDeliveryRunOverrides): SubagentRunRecordOverrides => ({
+    expectsCompletionMessage: true,
+    startedAt: overrides.createdAt,
+    outcome: { status: "ok" },
+    ...overrides,
+    delivery: {
+      status: "suspended",
+      createdAt: overrides.createdAt,
+      attemptCount: 3,
+      lastError: "gateway request timeout for agent",
+      payload: {
+        requesterSessionKey: overrides.requesterSessionKey,
+        requesterDisplayKey: overrides.requesterDisplayKey,
+        childSessionKey: overrides.childSessionKey,
+        childRunId: overrides.runId,
+        task: overrides.task,
+        endedAt: overrides.endedAt,
+        outcome: { status: "ok" },
+        expectsCompletionMessage: true,
+      },
+      suspendedReason: "expiry",
+      ...deliveryOverrides,
+    },
+  });
   let mod: RegistryHarness;
   const findRequesterRun = (runId: string) =>
     mod.listSubagentRunsForRequester("agent:main:main").find((entry) => entry.runId === runId);
@@ -494,19 +587,19 @@ describe("subagent registry seam flow", () => {
       ["one", now - 1],
       ["two", now + 1_000],
     ] as const) {
-      mod.addSubagentRunForTests({
-        runId: `run-collector-${suffix}`,
-        childSessionKey: `agent:main:subagent:collector-${suffix}`,
-        task: "retain lifetime group count",
-        cleanup: suffix === "one" ? "keep" : "delete",
-        createdAt: now - 10_000,
-        endedAt: now - 5_000,
-        cleanupCompletedAt: now - 4_000,
-        archiveAtMs,
-        collect: true,
-        groupId: "swarm:lifetime",
-        collectorCompletion: { status: "done" },
-      });
+      mod.addSubagentRunForTests(
+        makeCompletedCollectorRun({
+          runId: `run-collector-${suffix}`,
+          childSessionKey: `agent:main:subagent:collector-${suffix}`,
+          task: "retain lifetime group count",
+          cleanup: suffix === "one" ? "keep" : "delete",
+          createdAt: now - 10_000,
+          endedAt: now - 5_000,
+          cleanupCompletedAt: now - 4_000,
+          archiveAtMs,
+          groupId: "swarm:lifetime",
+        }),
+      );
     }
 
     await mod.testing.sweepOnceForTests();
@@ -532,20 +625,20 @@ describe("subagent registry seam flow", () => {
       ["agent:main:requester-one", now - 1],
       ["agent:main:requester-two", now + 1_000],
     ] as const) {
-      mod.addSubagentRunForTests({
-        runId: `run-${requesterSessionKey}`,
-        childSessionKey: `${requesterSessionKey}:subagent:collector`,
-        requesterSessionKey,
-        task: "retain requester-scoped collector groups",
-        cleanup: "delete",
-        createdAt: now - 10_000,
-        endedAt: now - 5_000,
-        cleanupCompletedAt: now - 4_000,
-        archiveAtMs,
-        collect: true,
-        groupId: "swarm:shared-group-id",
-        collectorCompletion: { status: "done" },
-      });
+      mod.addSubagentRunForTests(
+        makeCompletedCollectorRun({
+          runId: `run-${requesterSessionKey}`,
+          childSessionKey: `${requesterSessionKey}:subagent:collector`,
+          requesterSessionKey,
+          task: "retain requester-scoped collector groups",
+          cleanup: "delete",
+          createdAt: now - 10_000,
+          endedAt: now - 5_000,
+          cleanupCompletedAt: now - 4_000,
+          archiveAtMs,
+          groupId: "swarm:shared-group-id",
+        }),
+      );
     }
 
     await mod.testing.sweepOnceForTests();
@@ -556,17 +649,17 @@ describe("subagent registry seam flow", () => {
 
   it("keeps completed collectors while any group member is incomplete", async () => {
     const now = Date.now();
-    mod.addSubagentRunForTests({
-      runId: "run-collector-complete",
-      childSessionKey: "agent:main:subagent:collector-complete",
-      task: "completed collector",
-      createdAt: now - 10_000,
-      endedAt: now - 5_000,
-      archiveAtMs: now - 1,
-      collect: true,
-      groupId: "swarm:incomplete-member",
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-collector-complete",
+        childSessionKey: "agent:main:subagent:collector-complete",
+        task: "completed collector",
+        createdAt: now - 10_000,
+        endedAt: now - 5_000,
+        archiveAtMs: now - 1,
+        groupId: "swarm:incomplete-member",
+      }),
+    );
     mod.addSubagentRunForTests({
       runId: "run-collector-incomplete",
       childSessionKey: "agent:main:subagent:collector-incomplete",
@@ -616,17 +709,17 @@ describe("subagent registry seam flow", () => {
       cleanupCompletedAt: now - 4_000,
       archiveAtMs: now - 1,
     });
-    mod.addSubagentRunForTests({
-      runId: "run-collector-before-await",
-      childSessionKey: "agent:main:subagent:collector-before-await",
-      task: "completed collector present at sweep start",
-      createdAt: now - 10_000,
-      endedAt: now - 5_000,
-      archiveAtMs: now - 1,
-      collect: true,
-      groupId: "swarm:late-member",
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-collector-before-await",
+        childSessionKey: "agent:main:subagent:collector-before-await",
+        task: "completed collector present at sweep start",
+        createdAt: now - 10_000,
+        endedAt: now - 5_000,
+        archiveAtMs: now - 1,
+        groupId: "swarm:late-member",
+      }),
+    );
 
     const sweep = mod.testing.runSweeperTickForTests();
     await waitForFast(() => expect(releaseFirstDelete).toBeTypeOf("function"));
@@ -665,17 +758,17 @@ describe("subagent registry seam flow", () => {
         releaseCollectorDelete = () => resolve({});
       });
     });
-    mod.addSubagentRunForTests({
-      runId: "run-collector-cleanup-snapshot",
-      childSessionKey: "agent:main:subagent:collector-cleanup-snapshot",
-      task: "completed collector present before cleanup",
-      createdAt: now - 10_000,
-      endedAt: now - 5_000,
-      archiveAtMs: now - 1,
-      collect: true,
-      groupId: "swarm:cleanup-race",
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-collector-cleanup-snapshot",
+        childSessionKey: "agent:main:subagent:collector-cleanup-snapshot",
+        task: "completed collector present before cleanup",
+        createdAt: now - 10_000,
+        endedAt: now - 5_000,
+        archiveAtMs: now - 1,
+        groupId: "swarm:cleanup-race",
+      }),
+    );
 
     const sweep = mod.testing.runSweeperTickForTests();
     await waitForFast(() => expect(releaseCollectorDelete).toBeTypeOf("function"));
@@ -714,31 +807,31 @@ describe("subagent registry seam flow", () => {
         releaseCollectorDelete = () => resolve({});
       });
     });
-    mod.addSubagentRunForTests({
-      runId: "run-collector-replaced-during-cleanup",
-      childSessionKey: "agent:main:subagent:collector-before-replacement",
-      task: "collector before replacement",
-      createdAt: now - 10_000,
-      endedAt: now - 5_000,
-      archiveAtMs: now - 1,
-      collect: true,
-      groupId: "swarm:replacement-race",
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-collector-replaced-during-cleanup",
+        childSessionKey: "agent:main:subagent:collector-before-replacement",
+        task: "collector before replacement",
+        createdAt: now - 10_000,
+        endedAt: now - 5_000,
+        archiveAtMs: now - 1,
+        groupId: "swarm:replacement-race",
+      }),
+    );
 
     const sweep = mod.testing.runSweeperTickForTests();
     await waitForFast(() => expect(releaseCollectorDelete).toBeTypeOf("function"));
-    mod.addSubagentRunForTests({
-      runId: "run-collector-replaced-during-cleanup",
-      childSessionKey: "agent:main:subagent:collector-after-replacement",
-      task: "collector after replacement",
-      createdAt: now,
-      endedAt: now,
-      archiveAtMs: now - 1,
-      collect: true,
-      groupId: "swarm:replacement-race",
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-collector-replaced-during-cleanup",
+        childSessionKey: "agent:main:subagent:collector-after-replacement",
+        task: "collector after replacement",
+        createdAt: now,
+        endedAt: now,
+        archiveAtMs: now - 1,
+        groupId: "swarm:replacement-race",
+      }),
+    );
     releaseCollectorDelete?.();
     await sweep;
 
@@ -761,17 +854,17 @@ describe("subagent registry seam flow", () => {
         updatedAt: now,
       },
     });
-    mod.addSubagentRunForTests({
-      runId: "run-collector-clean",
-      childSessionKey: "agent:main:subagent:collector-clean",
-      task: "completed sibling",
-      createdAt: now - 10_000,
-      endedAt: now - 5_000,
-      archiveAtMs: now - 1,
-      collect: true,
-      groupId: "swarm:cleanup-pending",
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-collector-clean",
+        childSessionKey: "agent:main:subagent:collector-clean",
+        task: "completed sibling",
+        createdAt: now - 10_000,
+        endedAt: now - 5_000,
+        archiveAtMs: now - 1,
+        groupId: "swarm:cleanup-pending",
+      }),
+    );
     mod.addSubagentRunForTests({
       runId: "run-collector-cleanup-pending",
       childSessionKey: "agent:main:subagent:collector-cleanup-pending",
@@ -801,19 +894,19 @@ describe("subagent registry seam flow", () => {
     await fs.mkdir(attachmentsRootDir);
     await fs.mkdir(attachmentsDir);
     try {
-      mod.addSubagentRunForTests({
-        runId: "run-collector-unsafe-attachments",
-        childSessionKey: "agent:main:subagent:collector-unsafe-attachments",
-        task: "retain record until attachments are safely removed",
-        createdAt: Date.now() - 10_000,
-        endedAt: Date.now() - 5_000,
-        archiveAtMs: Date.now() - 1,
-        collect: true,
-        groupId: "swarm:unsafe-attachments",
-        attachmentsDir,
-        attachmentsRootDir,
-        collectorCompletion: { status: "done" },
-      });
+      mod.addSubagentRunForTests(
+        makeCompletedCollectorRun({
+          runId: "run-collector-unsafe-attachments",
+          childSessionKey: "agent:main:subagent:collector-unsafe-attachments",
+          task: "retain record until attachments are safely removed",
+          createdAt: Date.now() - 10_000,
+          endedAt: Date.now() - 5_000,
+          archiveAtMs: Date.now() - 1,
+          groupId: "swarm:unsafe-attachments",
+          attachmentsDir,
+          attachmentsRootDir,
+        }),
+      );
 
       await mod.testing.sweepOnceForTests();
 
@@ -1360,30 +1453,30 @@ describe("subagent registry seam flow", () => {
   });
 
   it("remaps a collector that completed before its acceptance response", () => {
-    mod.addSubagentRunForTests({
-      runId: "run-terminal-race",
-      childSessionKey: "agent:main:subagent:terminal-race",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "finish before acceptance",
-      cleanup: "keep",
-      collect: true,
-      swarmRunId: "run-terminal-race",
-      schedulerSlotId: "run-terminal-race",
-      swarmLaunchPending: false,
-      queuedLaunch: {
-        request: { sessionKey: "agent:main:subagent:terminal-race" },
-        timeoutMs: 1_000,
-        schedulerGroupKey: "terminal-race",
-        maxConcurrent: 1,
-      },
-      groupId: "terminal-race",
-      createdAt: 1_000,
-      endedAt: 2_000,
-      execution: { status: "terminal", endedAt: 2_000 },
-      completion: { required: false, resultText: "done", capturedAt: 2_000 },
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-terminal-race",
+        childSessionKey: "agent:main:subagent:terminal-race",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "finish before acceptance",
+        cleanup: "keep",
+        swarmRunId: "run-terminal-race",
+        schedulerSlotId: "run-terminal-race",
+        swarmLaunchPending: false,
+        queuedLaunch: {
+          request: { sessionKey: "agent:main:subagent:terminal-race" },
+          timeoutMs: 1_000,
+          schedulerGroupKey: "terminal-race",
+          maxConcurrent: 1,
+        },
+        groupId: "terminal-race",
+        createdAt: 1_000,
+        endedAt: 2_000,
+        execution: { status: "terminal", endedAt: 2_000 },
+        completion: { required: false, resultText: "done", capturedAt: 2_000 },
+      }),
+    );
 
     expect(mod.startQueuedSubagentRun("run-terminal-race", "gateway-terminal-race")).toBe(true);
     const remapped = mod.getSubagentRunByRunId("gateway-terminal-race");
@@ -1397,23 +1490,23 @@ describe("subagent registry seam flow", () => {
   });
 
   it("refuses to remap an unrelated terminal collector without a pending launch", () => {
-    mod.addSubagentRunForTests({
-      runId: "run-terminal-stale",
-      childSessionKey: "agent:main:subagent:terminal-stale",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "stale acceptance callback",
-      cleanup: "keep",
-      collect: true,
-      swarmRunId: "run-terminal-stale",
-      schedulerSlotId: "run-terminal-stale",
-      groupId: "terminal-stale",
-      createdAt: 1_000,
-      endedAt: 2_000,
-      execution: { status: "terminal", endedAt: 2_000 },
-      completion: { required: false, resultText: "done", capturedAt: 2_000 },
-      collectorCompletion: { status: "done" },
-    });
+    mod.addSubagentRunForTests(
+      makeCompletedCollectorRun({
+        runId: "run-terminal-stale",
+        childSessionKey: "agent:main:subagent:terminal-stale",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "stale acceptance callback",
+        cleanup: "keep",
+        swarmRunId: "run-terminal-stale",
+        schedulerSlotId: "run-terminal-stale",
+        groupId: "terminal-stale",
+        createdAt: 1_000,
+        endedAt: 2_000,
+        execution: { status: "terminal", endedAt: 2_000 },
+        completion: { required: false, resultText: "done", capturedAt: 2_000 },
+      }),
+    );
 
     expect(mod.startQueuedSubagentRun("run-terminal-stale", "gateway-terminal-stale")).toBe(false);
     expect(mod.getSubagentRunByRunId("run-terminal-stale")).toMatchObject({
@@ -3692,19 +3785,14 @@ describe("subagent registry seam flow", () => {
         endedAt,
       }),
     );
-    mod.addSubagentRunForTests({
-      runId: "run-killed-with-persisted-completion",
-      task: "recover persisted completion",
-      createdAt: startedAt,
-      startedAt,
-      endedAt: killedAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt },
-      cleanupHandled: true,
-      cleanupCompletedAt: killedAt,
-    });
+    mod.addSubagentRunForTests(
+      makeKilledRun(killedAt, {
+        runId: "run-killed-with-persisted-completion",
+        task: "recover persisted completion",
+        createdAt: startedAt,
+        startedAt,
+      }),
+    );
 
     await mod.testing.sweepOnceForTests();
 
@@ -3740,18 +3828,14 @@ describe("subagent registry seam flow", () => {
       const runId = `run-task-first-${taskStatus}`;
       const childSessionKey = `agent:main:subagent:task-first-${taskStatus}`;
       expect(
-        createRunningTaskRun({
-          runtime: "subagent",
-          sourceId: runId,
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          childSessionKey,
-          runId,
-          task: "repair task-first completion",
-          deliveryStatus: "pending",
-          startedAt,
-          lastEventAt: startedAt,
-        }),
+        createRunningTaskRun(
+          makeRunningTaskParams({
+            childSessionKey,
+            runId,
+            task: "repair task-first completion",
+            startedAt,
+          }),
+        ),
       ).not.toBeNull();
       expect(
         finalizeTaskRunByRunId({
@@ -3766,20 +3850,15 @@ describe("subagent registry seam flow", () => {
         }),
       ).toHaveLength(1);
       mocks.loadSessionStore.mockReturnValue({});
-      mod.addSubagentRunForTests({
-        runId,
-        childSessionKey,
-        task: "repair task-first completion",
-        createdAt: startedAt,
-        startedAt,
-        endedAt: killedAt,
-        endedReason: SUBAGENT_ENDED_REASON_KILLED,
-        outcome: { status: "error", error: "manual kill" },
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt },
-        cleanupHandled: true,
-        cleanupCompletedAt: killedAt,
-      });
+      mod.addSubagentRunForTests(
+        makeKilledRun(killedAt, {
+          runId,
+          childSessionKey,
+          task: "repair task-first completion",
+          createdAt: startedAt,
+          startedAt,
+        }),
+      );
 
       await mod.testing.sweepOnceForTests();
 
@@ -3814,18 +3893,15 @@ describe("subagent registry seam flow", () => {
       const runId = "run-task-first-replacement";
       const childSessionKey = "agent:main:subagent:task-first-steer";
       expect(
-        createRunningTaskRun({
-          runtime: "subagent",
-          sourceId: taskRunId,
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          childSessionKey,
-          runId: taskRunId,
-          task: "finish after steer",
-          deliveryStatus: "pending",
-          startedAt: originalStartedAt,
-          lastEventAt: originalStartedAt,
-        }),
+        createRunningTaskRun(
+          makeRunningTaskParams({
+            sourceId: taskRunId,
+            childSessionKey,
+            runId: taskRunId,
+            task: "finish after steer",
+            startedAt: originalStartedAt,
+          }),
+        ),
       ).not.toBeNull();
       expect(
         finalizeTaskRunByRunId({
@@ -3839,24 +3915,19 @@ describe("subagent registry seam flow", () => {
         }),
       ).toHaveLength(1);
       mocks.loadSessionStore.mockReturnValue({});
-      mod.addSubagentRunForTests({
-        runId,
-        taskRunId,
-        childSessionKey,
-        task: "finish after steer",
-        generation: 2,
-        createdAt: replacementStartedAt,
-        startedAt: replacementStartedAt,
-        sessionStartedAt: originalStartedAt,
-        runTimeoutSeconds: 10,
-        endedAt: killedAt,
-        endedReason: SUBAGENT_ENDED_REASON_KILLED,
-        outcome: { status: "error", error: "manual kill" },
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt },
-        cleanupHandled: true,
-        cleanupCompletedAt: killedAt,
-      });
+      mod.addSubagentRunForTests(
+        makeKilledRun(killedAt, {
+          runId,
+          taskRunId,
+          childSessionKey,
+          task: "finish after steer",
+          generation: 2,
+          createdAt: replacementStartedAt,
+          startedAt: replacementStartedAt,
+          sessionStartedAt: originalStartedAt,
+          runTimeoutSeconds: 10,
+        }),
+      );
 
       await mod.testing.sweepOnceForTests();
 
@@ -3886,18 +3957,14 @@ describe("subagent registry seam flow", () => {
       const killedAt = Date.parse("2026-03-24T11:55:00Z");
       const runId = "run-killed-projection-retry";
       const childSessionKey = "agent:main:subagent:projection-retry";
-      const task = createRunningTaskRun({
-        runtime: "subagent",
-        sourceId: runId,
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey,
-        runId,
-        task: "retry completion projection",
-        deliveryStatus: "pending",
-        startedAt,
-        lastEventAt: startedAt,
-      });
+      const task = createRunningTaskRun(
+        makeRunningTaskParams({
+          childSessionKey,
+          runId,
+          task: "retry completion projection",
+          startedAt,
+        }),
+      );
       expect(task).not.toBeNull();
       finalizeTaskRunByRunId({
         runId,
@@ -3924,20 +3991,15 @@ describe("subagent registry seam flow", () => {
           endedAt: completedAt,
         },
       });
-      mod.addSubagentRunForTests({
-        runId,
-        childSessionKey,
-        task: "retry completion projection",
-        createdAt: startedAt,
-        startedAt,
-        endedAt: killedAt,
-        endedReason: SUBAGENT_ENDED_REASON_KILLED,
-        outcome: { status: "error", error: "manual kill" },
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt },
-        cleanupHandled: true,
-        cleanupCompletedAt: killedAt,
-      });
+      mod.addSubagentRunForTests(
+        makeKilledRun(killedAt, {
+          runId,
+          childSessionKey,
+          task: "retry completion projection",
+          createdAt: startedAt,
+          startedAt,
+        }),
+      );
 
       await mod.testing.sweepOnceForTests();
 
@@ -3978,20 +4040,15 @@ describe("subagent registry seam flow", () => {
         endedAt,
       },
     });
-    mod.addSubagentRunForTests({
-      runId: "run-opaque-killed-with-persisted-completion",
-      childSessionKey: "agent:main:subagent:opaque-child",
-      task: "recover opaque persisted completion",
-      createdAt: startedAt,
-      startedAt,
-      endedAt: killedAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt },
-      cleanupHandled: true,
-      cleanupCompletedAt: killedAt,
-    });
+    mod.addSubagentRunForTests(
+      makeKilledRun(killedAt, {
+        runId: "run-opaque-killed-with-persisted-completion",
+        childSessionKey: "agent:main:subagent:opaque-child",
+        task: "recover opaque persisted completion",
+        createdAt: startedAt,
+        startedAt,
+      }),
+    );
 
     await mod.testing.sweepOnceForTests();
 
@@ -4032,21 +4089,16 @@ describe("subagent registry seam flow", () => {
         endedAt: completedAt,
       },
     });
-    mod.addSubagentRunForTests({
-      runId: "run-opaque-finalizer-miss",
-      childSessionKey,
-      task: "bound opaque finalizer failure",
-      expectsCompletionMessage: false,
-      createdAt: startedAt,
-      startedAt,
-      endedAt: killedAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt },
-      cleanupHandled: true,
-      cleanupCompletedAt: killedAt,
-    });
+    mod.addSubagentRunForTests(
+      makeKilledRun(killedAt, {
+        runId: "run-opaque-finalizer-miss",
+        childSessionKey,
+        task: "bound opaque finalizer failure",
+        expectsCompletionMessage: false,
+        createdAt: startedAt,
+        startedAt,
+      }),
+    );
 
     await mod.testing.sweepOnceForTests();
 
@@ -4077,18 +4129,14 @@ describe("subagent registry seam flow", () => {
         },
       });
       expect(
-        createRunningTaskRun({
-          runtime: "subagent",
-          sourceId: runId,
-          ownerKey: "agent:main:main",
-          scopeKind: "session",
-          childSessionKey,
-          runId,
-          task: "preserve operator cancellation",
-          deliveryStatus: "pending",
-          startedAt,
-          lastEventAt: startedAt,
-        }),
+        createRunningTaskRun(
+          makeRunningTaskParams({
+            childSessionKey,
+            runId,
+            task: "preserve operator cancellation",
+            startedAt,
+          }),
+        ),
       ).not.toBeNull();
       expect(
         finalizeTaskRunByRunId({
@@ -4101,23 +4149,18 @@ describe("subagent registry seam flow", () => {
           error: "Cancelled by operator.",
         }),
       ).toHaveLength(1);
-      mod.addSubagentRunForTests({
-        runId,
-        childSessionKey,
-        task: "preserve operator cancellation",
-        cleanup: "delete",
-        expectsCompletionMessage: true,
-        createdAt: startedAt,
-        startedAt,
-        endedAt: killedAt,
-        endedReason: "subagent-killed",
-        outcome: { status: "error", error: "manual kill" },
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt },
-        cleanupHandled: true,
-        cleanupCompletedAt: killedAt,
-        archiveAtMs: Date.now(),
-      });
+      mod.addSubagentRunForTests(
+        makeKilledRun(killedAt, {
+          runId,
+          childSessionKey,
+          task: "preserve operator cancellation",
+          cleanup: "delete",
+          expectsCompletionMessage: true,
+          createdAt: startedAt,
+          startedAt,
+          archiveAtMs: Date.now(),
+        }),
+      );
 
       expect(killedAt + 5 * 60_000).toBeGreaterThan(Date.now());
       vi.setSystemTime(killedAt + 5 * 60_000);
@@ -4169,18 +4212,14 @@ describe("subagent registry seam flow", () => {
           endedAt: completedAt,
         },
       });
-      createRunningTaskRun({
-        runtime: "subagent",
-        sourceId: runId,
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey,
-        runId,
-        task: "preserve earlier completion",
-        deliveryStatus: "pending",
-        startedAt,
-        lastEventAt: startedAt,
-      });
+      createRunningTaskRun(
+        makeRunningTaskParams({
+          childSessionKey,
+          runId,
+          task: "preserve earlier completion",
+          startedAt,
+        }),
+      );
       finalizeTaskRunByRunId({
         runId,
         runtime: "subagent",
@@ -4191,22 +4230,17 @@ describe("subagent registry seam flow", () => {
         error: "Cancelled by operator.",
         suppressDelivery: true,
       });
-      mod.addSubagentRunForTests({
-        runId,
-        childSessionKey,
-        task: "preserve earlier completion",
-        expectsCompletionMessage: false,
-        createdAt: startedAt,
-        startedAt,
-        runTimeoutSeconds: 8,
-        endedAt: killedAt,
-        endedReason: "subagent-killed",
-        outcome: { status: "error", error: "manual kill" },
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt },
-        cleanupHandled: true,
-        cleanupCompletedAt: killedAt,
-      });
+      mod.addSubagentRunForTests(
+        makeKilledRun(killedAt, {
+          runId,
+          childSessionKey,
+          task: "preserve earlier completion",
+          expectsCompletionMessage: false,
+          createdAt: startedAt,
+          startedAt,
+          runTimeoutSeconds: 8,
+        }),
+      );
 
       vi.setSystemTime(killedAt + 5 * 60_000);
       await mod.testing.sweepOnceForTests();
@@ -4254,18 +4288,14 @@ describe("subagent registry seam flow", () => {
         },
       });
       vi.setSystemTime(startedAt);
-      createRunningTaskRun({
-        runtime: "subagent",
-        sourceId: runId,
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey,
-        runId,
-        task: "cancel during result capture",
-        deliveryStatus: "pending",
-        startedAt,
-        lastEventAt: startedAt,
-      });
+      createRunningTaskRun(
+        makeRunningTaskParams({
+          childSessionKey,
+          runId,
+          task: "cancel during result capture",
+          startedAt,
+        }),
+      );
       vi.setSystemTime(now);
       finalizeTaskRunByRunId({
         runId,
@@ -4283,21 +4313,16 @@ describe("subagent registry seam flow", () => {
             finishCapture = resolve;
           }),
       );
-      mod.addSubagentRunForTests({
-        runId,
-        childSessionKey,
-        task: "cancel during result capture",
-        expectsCompletionMessage: true,
-        createdAt: startedAt,
-        startedAt,
-        endedAt: killedAt,
-        endedReason: "subagent-killed",
-        outcome: { status: "error", error: "manual kill" },
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt },
-        cleanupHandled: true,
-        cleanupCompletedAt: killedAt,
-      });
+      mod.addSubagentRunForTests(
+        makeKilledRun(killedAt, {
+          runId,
+          childSessionKey,
+          task: "cancel during result capture",
+          expectsCompletionMessage: true,
+          createdAt: startedAt,
+          startedAt,
+        }),
+      );
 
       const sweep = mod.testing.sweepOnceForTests();
       await vi.waitFor(() => expect(mocks.captureSubagentCompletionReply).toHaveBeenCalled());
@@ -4359,18 +4384,14 @@ describe("subagent registry seam flow", () => {
           endedAt: completedAt,
         },
       });
-      createRunningTaskRun({
-        runtime: "subagent",
-        sourceId: runId,
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey,
-        runId,
-        task: "complete between yield and kill",
-        deliveryStatus: "pending",
-        startedAt,
-        lastEventAt: startedAt,
-      });
+      createRunningTaskRun(
+        makeRunningTaskParams({
+          childSessionKey,
+          runId,
+          task: "complete between yield and kill",
+          startedAt,
+        }),
+      );
       mod.addSubagentRunForTests({
         runId,
         childSessionKey,
@@ -4431,20 +4452,15 @@ describe("subagent registry seam flow", () => {
         endedAt,
       }),
     );
-    mod.addSubagentRunForTests({
-      runId: "run-killed-with-persisted-kill",
-      task: "expire persisted kill",
-      expectsCompletionMessage: false,
-      createdAt: startedAt,
-      startedAt,
-      endedAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: endedAt },
-      cleanupHandled: true,
-      cleanupCompletedAt: endedAt,
-    });
+    mod.addSubagentRunForTests(
+      makeKilledRun(endedAt, {
+        runId: "run-killed-with-persisted-kill",
+        task: "expire persisted kill",
+        expectsCompletionMessage: false,
+        createdAt: startedAt,
+        startedAt,
+      }),
+    );
 
     await mod.testing.sweepOnceForTests();
 
@@ -4459,20 +4475,16 @@ describe("subagent registry seam flow", () => {
 
   it("keeps requester stop delivery suppressed after kill reconciliation", async () => {
     const killedAt = Date.now() - 5 * 60_000;
-    mod.addSubagentRunForTests({
-      runId: "run-requester-stop-suppressed",
-      childSessionKey: "agent:main:subagent:requester-stop-suppressed",
-      task: "do not re-inject after stop",
-      expectsCompletionMessage: true,
-      createdAt: killedAt - 60_000,
-      endedAt: killedAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt, suppressTaskDelivery: true },
-      cleanupHandled: true,
-      cleanupCompletedAt: killedAt,
-    });
+    mod.addSubagentRunForTests(
+      makeKilledRun(killedAt, {
+        runId: "run-requester-stop-suppressed",
+        childSessionKey: "agent:main:subagent:requester-stop-suppressed",
+        task: "do not re-inject after stop",
+        expectsCompletionMessage: true,
+        createdAt: killedAt - 60_000,
+        killReconciliation: { killedAt, suppressTaskDelivery: true },
+      }),
+    );
 
     await mod.testing.sweepOnceForTests();
     await waitForFast(() => {
@@ -4492,20 +4504,15 @@ describe("subagent registry seam flow", () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
       request.method === "agent.wait" ? { status: "pending" } : {},
     );
-    mod.addSubagentRunForTests({
-      runId: "run-released-successor-old",
-      childSessionKey,
-      task: "retire only old ownership",
-      cleanup: "delete",
-      createdAt: killedAt - 60_000,
-      endedAt: killedAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt },
-      cleanupHandled: true,
-      cleanupCompletedAt: killedAt,
-    });
+    mod.addSubagentRunForTests(
+      makeKilledRun(killedAt, {
+        runId: "run-released-successor-old",
+        childSessionKey,
+        task: "retire only old ownership",
+        cleanup: "delete",
+        createdAt: killedAt - 60_000,
+      }),
+    );
     mod.registerSubagentRun({
       runId: "run-released-successor-new",
       childSessionKey,
@@ -4563,32 +4570,27 @@ describe("subagent registry seam flow", () => {
       sessionKey: "agent:main:internal-session-effects:run-old-tombstone",
       storePath: "/tmp/test-store",
     };
-    mod.addSubagentRunForTests({
-      runId: "run-old-tombstone",
-      childSessionKey: "agent:main:subagent:reused",
-      task: "old generation",
-      cleanup: "delete",
-      createdAt: oldStartedAt,
-      startedAt: oldStartedAt,
-      sessionStartedAt: oldStartedAt,
-      endedAt: oldEndedAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: oldEndedAt },
-      cleanupHandled: true,
-      cleanupCompletedAt: oldEndedAt,
-      archiveAtMs: Date.now(),
-      retainAttachmentsOnKeep: true,
-      attachmentsDir,
-      attachmentsRootDir,
-      execution: {
-        status: "terminal",
+    mod.addSubagentRunForTests(
+      makeKilledRun(oldEndedAt, {
+        runId: "run-old-tombstone",
+        childSessionKey: "agent:main:subagent:reused",
+        task: "old generation",
+        cleanup: "delete",
+        createdAt: oldStartedAt,
         startedAt: oldStartedAt,
-        endedAt: oldEndedAt,
-        transcriptTarget: oldTranscriptTarget,
-      },
-    });
+        sessionStartedAt: oldStartedAt,
+        archiveAtMs: Date.now(),
+        retainAttachmentsOnKeep: true,
+        attachmentsDir,
+        attachmentsRootDir,
+        execution: {
+          status: "terminal",
+          startedAt: oldStartedAt,
+          endedAt: oldEndedAt,
+          transcriptTarget: oldTranscriptTarget,
+        },
+      }),
+    );
     mod.addSubagentRunForTests({
       runId: "run-new-generation",
       childSessionKey: "agent:main:subagent:reused",
@@ -4638,18 +4640,15 @@ describe("subagent registry seam flow", () => {
           endedAt: newEndedAt,
         },
       });
-      createRunningTaskRun({
-        runtime: "subagent",
-        sourceId: "run-old-no-start",
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey,
-        runId: "run-old-no-start",
-        task: "keep old cancellation canonical",
-        deliveryStatus: "pending",
-        startedAt: oldStartedAt,
-        lastEventAt: oldStartedAt,
-      });
+      createRunningTaskRun(
+        makeRunningTaskParams({
+          sourceId: "run-old-no-start",
+          childSessionKey,
+          runId: "run-old-no-start",
+          task: "keep old cancellation canonical",
+          startedAt: oldStartedAt,
+        }),
+      );
       finalizeTaskRunByRunId({
         runId: "run-old-no-start",
         runtime: "subagent",
@@ -4659,21 +4658,16 @@ describe("subagent registry seam flow", () => {
         lastEventAt: oldKilledAt,
         error: SUBAGENT_KILL_TASK_ERROR,
       });
-      mod.addSubagentRunForTests({
-        runId: "run-old-no-start",
-        childSessionKey,
-        task: "keep old cancellation canonical",
-        createdAt: oldStartedAt,
-        startedAt: oldStartedAt,
-        endedAt: oldKilledAt,
-        endedReason: "subagent-killed",
-        outcome: { status: "error", error: "manual kill" },
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt: oldKilledAt },
-        cleanupHandled: true,
-        cleanupCompletedAt: oldKilledAt,
-        runTimeoutSeconds: 60,
-      });
+      mod.addSubagentRunForTests(
+        makeKilledRun(oldKilledAt, {
+          runId: "run-old-no-start",
+          childSessionKey,
+          task: "keep old cancellation canonical",
+          createdAt: oldStartedAt,
+          startedAt: oldStartedAt,
+          runTimeoutSeconds: 60,
+        }),
+      );
       mod.addSubagentRunForTests({
         runId: "run-new-no-start",
         childSessionKey,
@@ -4785,22 +4779,17 @@ describe("subagent registry seam flow", () => {
       hasHooks: (hookName: string) => hookName === "subagent_ended",
       runSubagentEnded: mocks.runSubagentEnded,
     } as never);
-    mod.addSubagentRunForTests({
-      runId: "run-old-completed-tombstone",
-      childSessionKey,
-      task: "old completed generation",
-      cleanup: "delete",
-      createdAt: oldStartedAt,
-      startedAt: oldStartedAt,
-      sessionStartedAt: oldStartedAt,
-      endedAt: oldKilledAt,
-      endedReason: "subagent-killed",
-      outcome: { status: "error", error: "manual kill" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: oldKilledAt },
-      cleanupHandled: true,
-      cleanupCompletedAt: oldKilledAt,
-    });
+    mod.addSubagentRunForTests(
+      makeKilledRun(oldKilledAt, {
+        runId: "run-old-completed-tombstone",
+        childSessionKey,
+        task: "old completed generation",
+        cleanup: "delete",
+        createdAt: oldStartedAt,
+        startedAt: oldStartedAt,
+        sessionStartedAt: oldStartedAt,
+      }),
+    );
     mod.addSubagentRunForTests({
       runId: "run-new-generation-after-completion",
       childSessionKey,
@@ -6124,18 +6113,14 @@ describe("subagent registry seam flow", () => {
     try {
       const runId = "run-interrupted-persist-failure";
       const childSessionKey = "agent:main:subagent:interrupted-persist-failure";
-      createRunningTaskRun({
-        runtime: "subagent",
-        sourceId: runId,
-        ownerKey: "agent:main:main",
-        scopeKind: "session",
-        childSessionKey,
-        runId,
-        task: "preserve interrupted task",
-        deliveryStatus: "pending",
-        startedAt: 1,
-        lastEventAt: 1,
-      });
+      createRunningTaskRun(
+        makeRunningTaskParams({
+          childSessionKey,
+          runId,
+          task: "preserve interrupted task",
+          startedAt: 1,
+        }),
+      );
       const entry = createSubagentRunRecord({
         runId,
         childSessionKey,
@@ -6450,40 +6435,24 @@ describe("subagent registry seam flow", () => {
   it("expires suspended cron final deliveries after seven days", async () => {
     const now = Date.parse("2026-03-24T12:00:00Z");
     const runId = "run-suspended-cron-expired";
-    mod.addSubagentRunForTests({
-      runId,
-      childSessionKey: "agent:main:subagent:suspended-cron",
-      controllerSessionKey: "agent:main:cron:cron-1:run:parent",
-      requesterSessionKey: "agent:main:cron:cron-1:run:parent",
-      requesterDisplayKey: "cron",
-      task: "cron suspended delivery",
-      expectsCompletionMessage: true,
-      spawnMode: "session",
-      createdAt: now - 8 * 24 * 60 * 60_000,
-      startedAt: now - 8 * 24 * 60 * 60_000,
-      endedAt: now - 8 * 24 * 60 * 60_000,
-      outcome: { status: "ok" },
-      completion: { required: true, resultText: "large final payload" },
-      delivery: {
-        status: "suspended",
+    mod.addSubagentRunForTests(
+      makeSuspendedDeliveryRun({
+        runId,
+        childSessionKey: "agent:main:subagent:suspended-cron",
+        controllerSessionKey: "agent:main:cron:cron-1:run:parent",
+        requesterSessionKey: "agent:main:cron:cron-1:run:parent",
+        requesterDisplayKey: "cron",
+        task: "cron suspended delivery",
+        spawnMode: "session",
         createdAt: now - 8 * 24 * 60 * 60_000,
-        lastAttemptAt: now - 7 * 24 * 60 * 60_000 - 1,
-        attemptCount: 3,
-        lastError: "gateway request timeout for agent",
-        payload: {
-          requesterSessionKey: "agent:main:cron:cron-1:run:parent",
-          requesterDisplayKey: "cron",
-          childSessionKey: "agent:main:subagent:suspended-cron",
-          childRunId: runId,
-          task: "cron suspended delivery",
-          endedAt: now - 8 * 24 * 60 * 60_000,
-          outcome: { status: "ok" },
-          expectsCompletionMessage: true,
+        endedAt: now - 8 * 24 * 60 * 60_000,
+        completion: { required: true, resultText: "large final payload" },
+        delivery: {
+          lastAttemptAt: now - 7 * 24 * 60 * 60_000 - 1,
+          suspendedAt: now - 7 * 24 * 60 * 60_000 - 1,
         },
-        suspendedAt: now - 7 * 24 * 60 * 60_000 - 1,
-        suspendedReason: "expiry",
-      },
-    });
+      }),
+    );
 
     await mod.testing.sweepOnceForTests();
 
@@ -6530,40 +6499,24 @@ describe("subagent registry seam flow", () => {
     mocks.persistSubagentRunsToDiskOrThrow.mockImplementationOnce(() => {
       throw new Error("registry deletion failed");
     });
-    mod.addSubagentRunForTests({
-      runId,
-      childSessionKey,
-      controllerSessionKey: "agent:main:main",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "discard suspended delete delivery",
-      cleanup: "delete",
-      expectsCompletionMessage: true,
-      spawnMode: "run",
-      createdAt: now - 8 * 24 * 60 * 60_000,
-      startedAt: now - 8 * 24 * 60 * 60_000,
-      endedAt: now - 8 * 24 * 60 * 60_000,
-      outcome: { status: "ok" },
-      delivery: {
-        status: "suspended",
+    mod.addSubagentRunForTests(
+      makeSuspendedDeliveryRun({
+        runId,
+        childSessionKey,
+        controllerSessionKey: "agent:main:main",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "discard suspended delete delivery",
+        cleanup: "delete",
+        spawnMode: "run",
         createdAt: now - 8 * 24 * 60 * 60_000,
-        lastAttemptAt: now - 7 * 24 * 60 * 60_000 - 1,
-        attemptCount: 3,
-        lastError: "gateway request timeout for agent",
-        payload: {
-          requesterSessionKey: "agent:main:main",
-          requesterDisplayKey: "main",
-          childSessionKey,
-          childRunId: runId,
-          task: "discard suspended delete delivery",
-          endedAt: now - 8 * 24 * 60 * 60_000,
-          outcome: { status: "ok" },
-          expectsCompletionMessage: true,
+        endedAt: now - 8 * 24 * 60 * 60_000,
+        delivery: {
+          lastAttemptAt: now - 7 * 24 * 60 * 60_000 - 1,
+          suspendedAt: now - 7 * 24 * 60 * 60_000 - 1,
         },
-        suspendedAt: now - 7 * 24 * 60 * 60_000 - 1,
-        suspendedReason: "expiry",
-      },
-    });
+      }),
+    );
     const original = structuredClone(mod.getSubagentRunByChildSessionKey(childSessionKey));
 
     await expect(mod.testing.sweepOnceForTests()).rejects.toThrow("registry deletion failed");
@@ -6586,39 +6539,23 @@ describe("subagent registry seam flow", () => {
     const now = Date.parse("2026-03-24T12:00:00Z");
     for (let i = 0; i < 51; i += 1) {
       const runId = `run-suspended-pressure-${i}`;
-      mod.addSubagentRunForTests({
-        runId,
-        childSessionKey: `agent:main:subagent:suspended-pressure-${i}`,
-        controllerSessionKey: "agent:main:main",
-        requesterSessionKey: "agent:main:telegram:direct:418181497",
-        requesterDisplayKey: "telegram",
-        task: "interactive suspended delivery",
-        expectsCompletionMessage: true,
-        spawnMode: "session",
-        createdAt: now - 60_000,
-        startedAt: now - 60_000,
-        endedAt: now - 60_000,
-        outcome: { status: "ok" },
-        delivery: {
-          status: "suspended",
+      mod.addSubagentRunForTests(
+        makeSuspendedDeliveryRun({
+          runId,
+          childSessionKey: `agent:main:subagent:suspended-pressure-${i}`,
+          controllerSessionKey: "agent:main:main",
+          requesterSessionKey: "agent:main:telegram:direct:418181497",
+          requesterDisplayKey: "telegram",
+          task: "interactive suspended delivery",
+          spawnMode: "session",
           createdAt: now - 60_000,
-          lastAttemptAt: now - 60_000 + i,
-          attemptCount: 3,
-          lastError: "gateway request timeout for agent",
-          payload: {
-            requesterSessionKey: "agent:main:telegram:direct:418181497",
-            requesterDisplayKey: "telegram",
-            childSessionKey: `agent:main:subagent:suspended-pressure-${i}`,
-            childRunId: runId,
-            task: "interactive suspended delivery",
-            endedAt: now - 60_000,
-            outcome: { status: "ok" },
-            expectsCompletionMessage: true,
+          endedAt: now - 60_000,
+          delivery: {
+            lastAttemptAt: now - 60_000 + i,
+            suspendedAt: now - 60_000 + i,
           },
-          suspendedAt: now - 60_000 + i,
-          suspendedReason: "expiry",
-        },
-      });
+        }),
+      );
     }
 
     await mod.testing.sweepOnceForTests();

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -42,6 +42,22 @@ import { cleanupTalkConnection } from "./talk-session-registry.js";
 const activeRelaySessions = new Map<string, string>();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function makeRelayTransport<Overrides extends Partial<RealtimeVoiceBridge> = Record<never, never>>(
+  overrides: Overrides = {} as Overrides,
+) {
+  return {
+    connect: vi.fn(async () => undefined),
+    sendAudio: vi.fn(),
+    setMediaTimestamp: vi.fn(),
+    handleBargeIn: vi.fn(),
+    submitToolResult: vi.fn(),
+    acknowledgeMark: vi.fn(),
+    close: vi.fn(),
+    isConnected: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
 function createTalkRealtimeRelaySession(
   params: Parameters<typeof createTalkRealtimeRelaySessionRaw>[0],
 ): ReturnType<typeof createTalkRealtimeRelaySessionRaw> {
@@ -87,16 +103,7 @@ describe("talk realtime gateway relay", () => {
       id: "relay-test",
       label: "Relay Test",
       isConfigured: () => true,
-      createBridge: () => ({
-        connect: vi.fn(async () => undefined),
-        sendAudio: vi.fn(),
-        setMediaTimestamp: vi.fn(),
-        handleBargeIn: vi.fn(),
-        submitToolResult: vi.fn(),
-        acknowledgeMark: vi.fn(),
-        close: vi.fn(),
-        isConnected: vi.fn(() => true),
-      }),
+      createBridge: () => makeRelayTransport(),
     };
   }
 
@@ -118,20 +125,16 @@ describe("talk realtime gateway relay", () => {
       bridgeCloses.push(close);
       bridgeAudioSends.push(sendAudio);
       bridgeToolResults.push(submitToolResult);
-      return {
+      return makeRelayTransport({
         connect: vi.fn(async () => {
           if (bridgeIndex === 1) {
             throw new Error("late connect failure");
           }
         }),
         sendAudio,
-        setMediaTimestamp: vi.fn(),
-        handleBargeIn: vi.fn(),
         submitToolResult,
-        acknowledgeMark: vi.fn(),
         close,
-        isConnected: vi.fn(() => true),
-      };
+      });
     };
     try {
       const logGateway = { warn: vi.fn() };
@@ -314,12 +317,11 @@ describe("talk realtime gateway relay", () => {
       const connect = vi.fn(async () => undefined);
       const sendAudio = vi.fn();
       const close = vi.fn();
-      const bridge = {
-        ...createIdleRelayProvider().createBridge({} as never),
+      const bridge = makeRelayTransport({
         connect,
         sendAudio,
         close,
-      };
+      });
       const provider = createIdleRelayProvider();
       provider.createBridge = (request) => {
         terminate(request);
@@ -444,10 +446,9 @@ describe("talk realtime gateway relay", () => {
       const provider = createIdleRelayProvider();
       provider.createBridge = (request) => {
         bridgeRequest = request;
-        return {
-          ...createIdleRelayProvider().createBridge(request),
+        return makeRelayTransport({
           close: bridgeClose,
-        } as RealtimeVoiceBridge;
+        });
       };
       const session = createTalkRealtimeRelaySession({
         context: {
@@ -789,19 +790,12 @@ describe("talk realtime gateway relay", () => {
       submitToolResult.mockReturnValueOnce(options.firstSubmission);
     }
     const sendUserMessage = vi.fn();
-    const bridge = {
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: options.supportsToolResultContinuation ?? false,
       supportsToolResultSuppression: false,
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
       sendUserMessage,
-      handleBargeIn: vi.fn(),
       submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -948,10 +942,9 @@ describe("talk realtime gateway relay", () => {
     const provider = createIdleRelayProvider();
     provider.createBridge = (request) => {
       bridgeRequest = request;
-      return {
-        ...createIdleRelayProvider().createBridge?.(request),
+      return makeRelayTransport({
         submitToolResult,
-      } as RealtimeVoiceBridge;
+      });
     };
     const fixture = createAbortableRelayRunFixture(provider);
     await Promise.resolve();
@@ -1051,10 +1044,9 @@ describe("talk realtime gateway relay", () => {
     const provider = createIdleRelayProvider();
     provider.createBridge = (request) => {
       bridgeRequest = request;
-      return {
-        ...createIdleRelayProvider().createBridge?.(request),
+      return makeRelayTransport({
         submitToolResult,
-      } as RealtimeVoiceBridge;
+      });
     };
     const fixture = createAbortableRelayRunFixture(provider, { register: false });
     const relay = relaySessions.get(fixture.session.relaySessionId);
@@ -1119,10 +1111,9 @@ describe("talk realtime gateway relay", () => {
     const provider = createIdleRelayProvider();
     provider.createBridge = (request) => {
       bridgeRequest = request;
-      return {
-        ...createIdleRelayProvider().createBridge?.(request),
+      return makeRelayTransport({
         submitToolResult,
-      } as RealtimeVoiceBridge;
+      });
     };
     const fixture = createAbortableRelayRunFixture(provider);
     await Promise.resolve();
@@ -1227,18 +1218,12 @@ describe("talk realtime gateway relay", () => {
     const submitToolResult = vi
       .fn<RealtimeVoiceBridge["submitToolResult"]>()
       .mockReturnValueOnce(pendingWorking.promise);
-    const bridge = {
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: true,
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
       sendUserMessage: vi.fn(),
       handleBargeIn,
       submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -1381,7 +1366,7 @@ describe("talk realtime gateway relay", () => {
 
   it("bridges browser audio, transcripts, and tool results through a backend provider", async () => {
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    const bridge = {
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: true,
       connect: vi.fn(async () => {
         bridgeRequest?.onReady?.();
@@ -1397,16 +1382,9 @@ describe("talk realtime gateway relay", () => {
           args: { question: "hello" },
         });
       }),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
       sendUserMessage: vi.fn(),
       triggerGreeting: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -1713,18 +1691,13 @@ describe("talk realtime gateway relay", () => {
       id: "openai",
       label: "OpenAI Realtime",
       isConfigured: () => true,
-      createBridge: () => ({
-        connect: vi.fn(async () => {
-          throw new Error("OpenAI API key rejected with 401");
+      createBridge: () =>
+        makeRelayTransport({
+          connect: vi.fn(async () => {
+            throw new Error("OpenAI API key rejected with 401");
+          }),
+          isConnected: vi.fn(() => false),
         }),
-        sendAudio: vi.fn(),
-        setMediaTimestamp: vi.fn(),
-        handleBargeIn: vi.fn(),
-        submitToolResult: vi.fn(),
-        acknowledgeMark: vi.fn(),
-        close: vi.fn(),
-        isConnected: vi.fn(() => false),
-      }),
     };
     const events: Array<{
       event: string;
@@ -1789,16 +1762,7 @@ describe("talk realtime gateway relay", () => {
       isConfigured: () => true,
       createBridge: (req) => {
         bridgeRequest = req;
-        return {
-          connect: vi.fn(async () => undefined),
-          sendAudio: vi.fn(),
-          setMediaTimestamp: vi.fn(),
-          handleBargeIn: vi.fn(),
-          submitToolResult: vi.fn(),
-          acknowledgeMark: vi.fn(),
-          close: vi.fn(),
-          isConnected: vi.fn(() => true),
-        };
+        return makeRelayTransport();
       },
     };
     const events: Array<{ event: string; payload: unknown; connIds: string[] }> = [];
@@ -1845,16 +1809,7 @@ describe("talk realtime gateway relay", () => {
       isConfigured: () => true,
       createBridge: (req) => {
         bridgeRequest = req;
-        return {
-          connect: vi.fn(async () => undefined),
-          sendAudio: vi.fn(),
-          setMediaTimestamp: vi.fn(),
-          handleBargeIn: vi.fn(),
-          submitToolResult: vi.fn(),
-          acknowledgeMark: vi.fn(),
-          close: vi.fn(),
-          isConnected: vi.fn(() => true),
-        };
+        return makeRelayTransport();
       },
     };
     const events: Array<{ event: string; payload: unknown; connIds: string[] }> = [];
@@ -1897,17 +1852,9 @@ describe("talk realtime gateway relay", () => {
 
   it("does not route assistant echo transcripts back into the realtime model", async () => {
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    const bridge = {
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
+    const bridge = makeRelayTransport({
       sendUserMessage: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -1957,19 +1904,11 @@ describe("talk realtime gateway relay", () => {
     vi.useFakeTimers();
 
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    const bridge = {
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: true,
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
       sendUserMessage: vi.fn(),
       triggerGreeting: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -2017,19 +1956,14 @@ describe("talk realtime gateway relay", () => {
     vi.useFakeTimers();
 
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    const bridge = {
+    const sendUserMessage = vi.fn();
+    const submitToolResult = vi.fn();
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: true,
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      sendUserMessage: vi.fn(),
+      sendUserMessage,
       triggerGreeting: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+      submitToolResult,
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -2117,7 +2051,7 @@ describe("talk realtime gateway relay", () => {
     );
 
     const forcedAcceptance = createDeferredVoid();
-    bridge.submitToolResult.mockImplementationOnce(() => forcedAcceptance.promise);
+    submitToolResult.mockImplementationOnce(() => forcedAcceptance.promise);
     const forcedSubmission = submitTalkRealtimeRelayToolResult({
       relaySessionId: session.relaySessionId,
       connId: "conn-1",
@@ -2146,12 +2080,12 @@ describe("talk realtime gateway relay", () => {
       ].join("\n"),
     );
     expect(
-      bridge.submitToolResult.mock.invocationCallOrder[
-        bridge.submitToolResult.mock.invocationCallOrder.length - 1
+      submitToolResult.mock.invocationCallOrder[
+        submitToolResult.mock.invocationCallOrder.length - 1
       ],
     ).toBeLessThan(
-      bridge.sendUserMessage.mock.invocationCallOrder[
-        bridge.sendUserMessage.mock.invocationCallOrder.length - 1
+      sendUserMessage.mock.invocationCallOrder[
+        sendUserMessage.mock.invocationCallOrder.length - 1
       ] ?? 0,
     );
     expect(
@@ -2459,19 +2393,11 @@ describe("talk realtime gateway relay", () => {
     vi.useFakeTimers();
 
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    const bridge = {
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: true,
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
       sendUserMessage: vi.fn(),
       triggerGreeting: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -2596,16 +2522,7 @@ describe("talk realtime gateway relay", () => {
       id: "relay-test",
       label: "Relay Test",
       isConfigured: () => true,
-      createBridge: () => ({
-        connect: vi.fn(async () => undefined),
-        sendAudio: vi.fn(),
-        setMediaTimestamp: vi.fn(),
-        handleBargeIn: vi.fn(),
-        submitToolResult: vi.fn(),
-        acknowledgeMark: vi.fn(),
-        close: vi.fn(),
-        isConnected: vi.fn(() => true),
-      }),
+      createBridge: () => makeRelayTransport(),
     };
     const session = createTalkRealtimeRelaySession({
       context: { broadcastToConnIds: vi.fn() } as never,
@@ -2633,16 +2550,7 @@ describe("talk realtime gateway relay", () => {
       isConfigured: () => true,
       createBridge: (req) => {
         bridgeRequest = req;
-        return {
-          connect: vi.fn(async () => undefined),
-          sendAudio: vi.fn(),
-          setMediaTimestamp: vi.fn(),
-          handleBargeIn: vi.fn(),
-          submitToolResult: vi.fn(),
-          acknowledgeMark: vi.fn(),
-          close: vi.fn(),
-          isConnected: vi.fn(() => true),
-        };
+        return makeRelayTransport();
       },
     };
     const events: Array<{
@@ -2701,16 +2609,10 @@ describe("talk realtime gateway relay", () => {
   it("terminally satisfies a late normal result after turn cancellation without a new turn", async () => {
     const submitToolResult = vi.fn<RealtimeVoiceBridge["submitToolResult"]>();
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+      });
     const { broadcastToConnIds, session } = createAbortableRelayRunFixture(provider);
     cancelTalkRealtimeRelayTurn({
       relaySessionId: session.relaySessionId,
@@ -2784,17 +2686,10 @@ describe("talk realtime gateway relay", () => {
       isConfigured: () => true,
       createBridge: (request) => {
         bridgeRequest = request;
-        return {
+        return makeRelayTransport({
           supportsToolResultContinuation: true,
-          connect: vi.fn(async () => undefined),
-          sendAudio: vi.fn(),
-          setMediaTimestamp: vi.fn(),
-          handleBargeIn: vi.fn(),
           submitToolResult,
-          acknowledgeMark: vi.fn(),
-          close: vi.fn(),
-          isConnected: vi.fn(() => true),
-        };
+        });
       },
     };
     const events: Array<{ payload: Record<string, unknown> }> = [];
@@ -2853,16 +2748,10 @@ describe("talk realtime gateway relay", () => {
       .mockReturnValueOnce(secondAccepted.promise)
       .mockReturnValueOnce(undefined);
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+      });
     const session = createTalkRealtimeRelaySession({
       context: { broadcastToConnIds: vi.fn() } as never,
       connId: "conn-1",
@@ -2917,16 +2806,10 @@ describe("talk realtime gateway relay", () => {
       .mockReturnValueOnce(rejectedInterim)
       .mockReturnValueOnce(undefined);
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+      });
     const session = createTalkRealtimeRelaySession({
       context: { broadcastToConnIds: vi.fn() } as never,
       connId: "conn-1",
@@ -2965,16 +2848,10 @@ describe("talk realtime gateway relay", () => {
       .mockReturnValueOnce(interimAccepted.promise)
       .mockReturnValueOnce(undefined);
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+      });
     const { broadcastToConnIds, session } = createAbortableRelayRunFixture(provider);
     const firstInterim = submitTalkRealtimeRelayToolResult({
       relaySessionId: session.relaySessionId,
@@ -3034,17 +2911,11 @@ describe("talk realtime gateway relay", () => {
       .mockReturnValueOnce(workingAccepted.promise)
       .mockReturnValueOnce(undefined);
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      supportsToolResultSuppression: false,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+        supportsToolResultSuppression: false,
+      });
     const { broadcastToConnIds, session } = createAbortableRelayRunFixture(provider);
     const working = submitTalkRealtimeRelayToolResult({
       relaySessionId: session.relaySessionId,
@@ -3103,16 +2974,10 @@ describe("talk realtime gateway relay", () => {
       .mockReturnValueOnce(rejectedFinal)
       .mockReturnValueOnce(undefined);
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+      });
     const { session } = createAbortableRelayRunFixture(provider);
     const staleFinal = submitTalkRealtimeRelayToolResult({
       relaySessionId: session.relaySessionId,
@@ -3146,16 +3011,9 @@ describe("talk realtime gateway relay", () => {
 
   it("waits for provider acceptance before broadcasting and clearing a final tool result", async () => {
     const deferred = createDeferredVoid();
-    const bridge = {
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
+    const bridge = makeRelayTransport({
       submitToolResult: vi.fn(() => deferred.promise),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -3229,16 +3087,9 @@ describe("talk realtime gateway relay", () => {
   });
 
   it("keeps linked run state and omits success events when provider submission rejects", async () => {
-    const bridge = {
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
+    const bridge = makeRelayTransport({
       submitToolResult: vi.fn(() => Promise.reject(new Error("provider rejected tool result"))),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -3274,19 +3125,12 @@ describe("talk realtime gateway relay", () => {
 
   it("allows a final tool result to retry after provider rejection", async () => {
     let attempt = 0;
-    const bridge = {
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
+    const bridge = makeRelayTransport({
       submitToolResult: vi.fn(() => {
         attempt += 1;
         return attempt === 1 ? Promise.reject(new Error("temporary rejection")) : undefined;
       }),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -3393,17 +3237,9 @@ describe("talk realtime gateway relay", () => {
         },
         "main",
       );
-      const bridge = {
+      const bridge = makeRelayTransport({
         supportsToolResultSuppression: supportsSuppression,
-        connect: vi.fn(async () => undefined),
-        sendAudio: vi.fn(),
-        setMediaTimestamp: vi.fn(),
-        handleBargeIn: vi.fn(),
-        submitToolResult: vi.fn(),
-        acknowledgeMark: vi.fn(),
-        close: vi.fn(),
-        isConnected: vi.fn(() => true),
-      };
+      });
       const provider: RealtimeVoiceProviderPlugin = {
         id: "relay-test",
         label: "Relay Test",
@@ -3475,16 +3311,10 @@ describe("talk realtime gateway relay", () => {
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error("second cancel rejected"));
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+      });
     const { broadcastToConnIds, session } = createAbortableRelayRunFixture(provider);
     registerTalkRealtimeRelayAgentRun({
       relaySessionId: session.relaySessionId,
@@ -3547,16 +3377,10 @@ describe("talk realtime gateway relay", () => {
     const accepted = createDeferredVoid();
     const submitToolResult = vi.fn(() => accepted.promise);
     const provider = createIdleRelayProvider();
-    provider.createBridge = () => ({
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult,
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    });
+    provider.createBridge = () =>
+      makeRelayTransport({
+        submitToolResult,
+      });
     const { broadcastToConnIds, session } = createAbortableRelayRunFixture(provider);
 
     const steering = steerTalkRealtimeRelayAgentRun({
@@ -3596,19 +3420,11 @@ describe("talk realtime gateway relay", () => {
     );
 
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    const bridge = {
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: true,
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
       sendUserMessage: vi.fn(),
       triggerGreeting: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -3833,14 +3649,10 @@ describe("talk realtime gateway relay", () => {
 
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
     let rejectNextSubmission = false;
-    const bridge = {
+    const bridge = makeRelayTransport({
       supportsToolResultContinuation: true,
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
       sendUserMessage: vi.fn(),
       triggerGreeting: vi.fn(),
-      handleBargeIn: vi.fn(),
       submitToolResult: vi.fn(() => {
         if (!rejectNextSubmission) {
           return undefined;
@@ -3848,10 +3660,7 @@ describe("talk realtime gateway relay", () => {
         rejectNextSubmission = false;
         return Promise.reject(new Error("provider cancellation rejected"));
       }),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -3929,17 +3738,9 @@ describe("talk realtime gateway relay", () => {
 
   it("does not duplicate control-like transcripts when the linked relay run is already gone", async () => {
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    const bridge = {
-      connect: vi.fn(async () => undefined),
-      sendAudio: vi.fn(),
-      setMediaTimestamp: vi.fn(),
+    const bridge = makeRelayTransport({
       sendUserMessage: vi.fn(),
-      handleBargeIn: vi.fn(),
-      submitToolResult: vi.fn(),
-      acknowledgeMark: vi.fn(),
-      close: vi.fn(),
-      isConnected: vi.fn(() => true),
-    };
+    });
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -4016,16 +3817,7 @@ describe("talk realtime gateway relay", () => {
       isConfigured: () => true,
       createBridge: (req) => {
         bridgeRequest = req;
-        return {
-          connect: vi.fn(async () => undefined),
-          sendAudio: vi.fn(),
-          setMediaTimestamp: vi.fn(),
-          handleBargeIn: vi.fn(),
-          submitToolResult: vi.fn(),
-          acknowledgeMark: vi.fn(),
-          close: vi.fn(),
-          isConnected: vi.fn(() => true),
-        };
+        return makeRelayTransport();
       },
     };
     const context = {
@@ -4081,16 +3873,10 @@ describe("talk realtime gateway relay", () => {
       isConfigured: () => true,
       createBridge: (request) => {
         bridgeRequest = request;
-        return {
-          connect: vi.fn(async () => undefined),
-          sendAudio: vi.fn(),
-          setMediaTimestamp: vi.fn(),
-          handleBargeIn: vi.fn(),
+        return makeRelayTransport({
           submitToolResult,
-          acknowledgeMark: vi.fn(),
           close,
-          isConnected: vi.fn(() => true),
-        };
+        });
       },
     };
     const broadcastToConnIds = vi.fn();
@@ -4177,16 +3963,9 @@ describe("talk realtime gateway relay", () => {
       isConfigured: () => true,
       createBridge: (request) => {
         bridgeRequest = request;
-        return {
-          connect: vi.fn(async () => undefined),
-          sendAudio: vi.fn(),
-          setMediaTimestamp: vi.fn(),
-          handleBargeIn: vi.fn(),
-          submitToolResult: vi.fn(),
-          acknowledgeMark: vi.fn(),
+        return makeRelayTransport({
           close,
-          isConnected: vi.fn(() => true),
-        };
+        });
       },
     };
     const broadcastToConnIds = vi.fn();
@@ -4229,16 +4008,7 @@ describe("talk realtime gateway relay", () => {
       id: "relay-test",
       label: "Relay Test",
       isConfigured: () => true,
-      createBridge: () => ({
-        connect: vi.fn(async () => undefined),
-        sendAudio: vi.fn(),
-        setMediaTimestamp: vi.fn(),
-        handleBargeIn: vi.fn(),
-        submitToolResult: vi.fn(),
-        acknowledgeMark: vi.fn(),
-        close: vi.fn(),
-        isConnected: vi.fn(() => true),
-      }),
+      createBridge: () => makeRelayTransport(),
     };
     const createSession = (connId: string) =>
       createTalkRealtimeRelaySession({

--- a/ui/src/pages/chat/chat-host.test-fixture.ts
+++ b/ui/src/pages/chat/chat-host.test-fixture.ts
@@ -1,0 +1,195 @@
+import { vi } from "vitest";
+import type { UiSettings } from "../../app/settings.ts";
+import { createSessionCapability } from "../../lib/sessions/index.ts";
+import type { ChatHost } from "./chat-send-contract.ts";
+import { patchChatSessionSettings } from "./chat-settings-patches.ts";
+import type { ChatComposerMemoryFallback } from "./chat-state-host.ts";
+import type { RenderLifecycle } from "./render-lifecycle.ts";
+
+type RequestHandlers = Record<string, unknown>;
+
+export function makeRequestMock(handlers: RequestHandlers = {}) {
+  return vi.fn((method: string, params?: unknown) => {
+    if (!Object.hasOwn(handlers, method)) {
+      // Keep unrelated Gateway traffic inert so each test declares only the responses it observes.
+      return Promise.resolve({});
+    }
+    try {
+      const handler = handlers[method];
+      const response = typeof handler === "function" ? handler(params) : handler;
+      return Promise.resolve(response);
+    } catch (error) {
+      return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}
+
+type RequestMock = ReturnType<typeof makeRequestMock>;
+
+function clientWithRequest(request: unknown): ChatHost["client"] {
+  return { request } as unknown as ChatHost["client"];
+}
+
+type TestChatHost = Omit<ChatHost, "settings"> & {
+  applySettings: (patch: Partial<UiSettings>) => void;
+  basePath: string;
+  chatAvatarUrl: string | null;
+  chatAvatarSource?: string | null;
+  chatAvatarStatus?: "none" | "local" | "remote" | "data" | null;
+  chatAvatarReason?: string | null;
+  chatComposerFallbackByScope: Record<string, ChatComposerMemoryFallback>;
+  sessionsError?: string | null;
+  sessionsResultAgentId?: string | null;
+  sessionsArchivedFilter?: "active" | "archived" | "all";
+  password?: string;
+  pendingSettingsPatches?: Record<string, Promise<boolean>>;
+  settings?: Partial<UiSettings>;
+};
+
+function createPendingSettingsSessionCapability(
+  sessions: ChatHost["sessions"],
+  pendingSettingsPatches: Record<string, Promise<boolean>>,
+): ChatHost["sessions"] {
+  const pendingBySession = new Map(Object.entries(pendingSettingsPatches));
+  const wrapped = Object.create(sessions) as ChatHost["sessions"];
+  wrapped.patch = async (sessionKey, patch, options) => {
+    const pendingPatch = pendingBySession.get(sessionKey);
+    if (!pendingPatch) {
+      return sessions.patch(sessionKey, patch, options);
+    }
+    pendingBySession.delete(sessionKey);
+    if (!(await pendingPatch)) {
+      return null;
+    }
+    return {
+      ok: true,
+      path: "",
+      key: sessionKey,
+      entry: { sessionId: "pending-settings-test" },
+    };
+  };
+  return wrapped;
+}
+
+type TestChatHostWithRequest = TestChatHost & { request: RequestMock };
+type MakeHostOverrides = Partial<TestChatHost> & { requestHandlers?: RequestHandlers };
+
+export function makeChatHost(
+  overrides: MakeHostOverrides & { requestHandlers: RequestHandlers },
+): TestChatHostWithRequest;
+export function makeChatHost(overrides?: Partial<TestChatHost>): TestChatHost;
+export function makeChatHost(
+  overrides?: MakeHostOverrides,
+): TestChatHost | TestChatHostWithRequest {
+  const { requestHandlers, ...hostOverrides } = overrides ?? {};
+  const request = requestHandlers ? makeRequestMock(requestHandlers) : undefined;
+  const settings = { lastActiveSessionKey: "", ...hostOverrides.settings };
+  const renderLifecycle: RenderLifecycle = {
+    invalidate: vi.fn(),
+    afterCommit: (effect) => {
+      let active = true;
+      renderLifecycle.invalidate();
+      queueMicrotask(() => {
+        if (active) {
+          effect(() => undefined);
+        }
+      });
+      return () => {
+        active = false;
+      };
+    },
+  };
+  const host = {
+    client: request ? clientWithRequest(request) : null,
+    chatMessages: [],
+    chatDisplayedLeafEntryId: undefined,
+    chatStream: null,
+    chatStreamSegments: [],
+    chatToolMessages: [],
+    connected: true,
+    chatLoading: false,
+    chatMessage: "",
+    chatLocalInputHistoryBySession: {},
+    chatInputHistorySessionKey: null,
+    chatInputHistoryItems: null,
+    chatInputHistoryIndex: -1,
+    chatDraftBeforeHistory: null,
+    chatAttachments: [],
+    chatComposerFallbackByScope: {},
+    chatQueue: [],
+    chatRunId: null,
+    chatSending: false,
+    lastError: null,
+    sessionKey: "agent:main",
+    basePath: "",
+    hello: null,
+    chatAvatarUrl: null,
+    chatAvatarSource: null,
+    chatAvatarStatus: null,
+    chatAvatarReason: null,
+    sessionsLoading: false,
+    sessionsResult: null,
+    sessionsResultAgentId: null,
+    sessionsError: null,
+    sessionsArchivedFilter: "active" as const,
+    chatModelsLoading: false,
+    chatMetadataRequestVersion: 0,
+    chatModelCatalog: [],
+    refreshSessionsAfterChat: new Map(),
+    toolStreamById: new Map(),
+    toolStreamOrder: [],
+    toolStreamSyncTimer: null,
+    renderLifecycle,
+    querySelector: () => null,
+    chatScrollCommitCleanup: null,
+    chatScrollFrame: null,
+    chatScrollGuardFrame: null,
+    chatScrollGeneration: 0,
+    chatLastScrollTop: 0,
+    chatLastScrollHeight: 0,
+    chatHasAutoScrolled: false,
+    chatUserNearBottom: true,
+    chatFollowLocked: false,
+    chatNewMessagesBelow: false,
+    chatIsProgrammaticScroll: false,
+    chatProgrammaticScrollTarget: 0,
+    applySettings: vi.fn((patch: Partial<UiSettings>) => {
+      // Chat pages own display/layout settings; active-session persistence belongs to pane bindings.
+      const next = { ...settings, ...patch };
+      Object.assign(settings, {
+        chatShowThinking: next.chatShowThinking,
+        chatShowToolCalls: next.chatShowToolCalls,
+        chatPersistCommentary: next.chatPersistCommentary,
+        chatSendShortcut: next.chatSendShortcut,
+      });
+    }),
+    ...hostOverrides,
+    settings,
+  };
+  const sessions =
+    hostOverrides.sessions ??
+    createSessionCapability({
+      snapshot: {
+        client: host.client,
+        phase: host.connected ? "connected" : "reconnecting",
+        hello: host.hello,
+      },
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    });
+  for (const session of host.sessionsResult?.sessions ?? []) {
+    sessions.reconcile(session, host.sessionsResult?.defaults, {
+      selectedGlobalAgentId: host.assistantAgentId,
+      archivedFilter: host.sessionsArchivedFilter,
+    });
+  }
+  const pendingSettingsPatches = hostOverrides.pendingSettingsPatches;
+  const resolvedSessions = pendingSettingsPatches
+    ? createPendingSettingsSessionCapability(sessions, pendingSettingsPatches)
+    : sessions;
+  const resolvedHost = { ...host, sessions: resolvedSessions } as TestChatHost;
+  for (const sessionKey of Object.keys(pendingSettingsPatches ?? {})) {
+    void patchChatSessionSettings(resolvedHost, sessionKey, {}).catch(() => undefined);
+  }
+  return request ? Object.assign(resolvedHost, { request }) : resolvedHost;
+}

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6,9 +6,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
-import type { UiSettings } from "../../app/settings.ts";
 import { SLASH_COMMANDS } from "../../lib/chat/commands.ts";
-import { createSessionCapability } from "../../lib/sessions/index.ts";
 import { createResolvedModelPatch } from "../../test-helpers/chat-model.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
@@ -21,6 +19,7 @@ import {
 import { refreshChatAvatar } from "./chat-avatar.ts";
 import * as chatCommandExecutor from "./chat-command-executor.ts";
 import type { executeSlashCommand } from "./chat-command-executor.ts";
+import { makeChatHost, makeRequestMock } from "./chat-host.test-fixture.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import {
   getPendingChatPickerPatch,
@@ -28,7 +27,7 @@ import {
   switchChatThinkingLevel,
 } from "./chat-session.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
-import type { ChatComposerMemoryFallback, ChatPageHost } from "./chat-state-host.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
 import {
   admitStoredChatComposerQueueItem,
   listStoredChatOutboxes,
@@ -39,7 +38,6 @@ import {
 } from "./composer-persistence.ts";
 import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
 import { handleChatInputHistoryKey } from "./input-history.ts";
-import type { RenderLifecycle } from "./render-lifecycle.ts";
 import {
   cacheChatSessionSnapshot,
   readChatMessagesFromCache,
@@ -47,45 +45,11 @@ import {
 } from "./session-message-cache.ts";
 
 type ExecuteSlashCommand = typeof executeSlashCommand;
-type RequestHandlers = Record<string, unknown>;
-
-function makeRequestMock(handlers: RequestHandlers = {}) {
-  return vi.fn((method: string, params?: unknown) => {
-    if (!Object.hasOwn(handlers, method)) {
-      // Keep unrelated Gateway traffic inert so each test declares only the responses it observes.
-      return Promise.resolve({});
-    }
-    try {
-      const handler = handlers[method];
-      const response = typeof handler === "function" ? handler(params) : handler;
-      return Promise.resolve(response);
-    } catch (error) {
-      return Promise.reject(error instanceof Error ? error : new Error(String(error)));
-    }
-  });
-}
-
-type RequestMock = ReturnType<typeof makeRequestMock>;
+type TestChatHost = ReturnType<typeof makeChatHost>;
 
 function clientWithRequest(request: unknown): ChatHost["client"] {
   return { request } as unknown as ChatHost["client"];
 }
-
-type TestChatHost = Omit<ChatHost, "settings"> & {
-  applySettings: (patch: Partial<UiSettings>) => void;
-  basePath: string;
-  chatAvatarUrl: string | null;
-  chatAvatarSource?: string | null;
-  chatAvatarStatus?: "none" | "local" | "remote" | "data" | null;
-  chatAvatarReason?: string | null;
-  chatComposerFallbackByScope: Record<string, ChatComposerMemoryFallback>;
-  sessionsError?: string | null;
-  sessionsResultAgentId?: string | null;
-  sessionsArchivedFilter?: "active" | "archived" | "all";
-  password?: string;
-  pendingSettingsPatches?: Record<string, Promise<boolean>>;
-  settings?: Partial<UiSettings>;
-};
 
 function asChatPageHost(host: TestChatHost): ChatPageHost {
   return host as unknown as ChatPageHost;
@@ -300,152 +264,6 @@ function fetchUrl(source: MockCallSource, callIndex: number) {
   throw new Error(`expected fetch input ${callIndex}`);
 }
 
-function createPendingSettingsSessionCapability(
-  sessions: ChatHost["sessions"],
-  pendingSettingsPatches: Record<string, Promise<boolean>>,
-): ChatHost["sessions"] {
-  const pendingBySession = new Map(Object.entries(pendingSettingsPatches));
-  const wrapped = Object.create(sessions) as ChatHost["sessions"];
-  wrapped.patch = async (sessionKey, patch, options) => {
-    const pendingPatch = pendingBySession.get(sessionKey);
-    if (!pendingPatch) {
-      return sessions.patch(sessionKey, patch, options);
-    }
-    pendingBySession.delete(sessionKey);
-    if (!(await pendingPatch)) {
-      return null;
-    }
-    return {
-      ok: true,
-      path: "",
-      key: sessionKey,
-      entry: { sessionId: "pending-settings-test" },
-    };
-  };
-  return wrapped;
-}
-
-type TestChatHostWithRequest = TestChatHost & { request: RequestMock };
-type MakeHostOverrides = Partial<TestChatHost> & { requestHandlers?: RequestHandlers };
-
-function makeHost(
-  overrides: MakeHostOverrides & { requestHandlers: RequestHandlers },
-): TestChatHostWithRequest;
-function makeHost(overrides?: Partial<TestChatHost>): TestChatHost;
-function makeHost(overrides?: MakeHostOverrides): TestChatHost | TestChatHostWithRequest {
-  const { requestHandlers, ...hostOverrides } = overrides ?? {};
-  const request = requestHandlers ? makeRequestMock(requestHandlers) : undefined;
-  const settings = { lastActiveSessionKey: "", ...hostOverrides.settings };
-  const renderLifecycle: RenderLifecycle = {
-    invalidate: vi.fn(),
-    afterCommit: (effect) => {
-      let active = true;
-      renderLifecycle.invalidate();
-      queueMicrotask(() => {
-        if (active) {
-          effect(() => undefined);
-        }
-      });
-      return () => {
-        active = false;
-      };
-    },
-  };
-  const host = {
-    client: request ? clientWithRequest(request) : null,
-    chatMessages: [],
-    chatDisplayedLeafEntryId: undefined,
-    chatStream: null,
-    chatStreamSegments: [],
-    chatToolMessages: [],
-    connected: true,
-    chatLoading: false,
-    chatMessage: "",
-    chatLocalInputHistoryBySession: {},
-    chatInputHistorySessionKey: null,
-    chatInputHistoryItems: null,
-    chatInputHistoryIndex: -1,
-    chatDraftBeforeHistory: null,
-    chatAttachments: [],
-    chatComposerFallbackByScope: {},
-    chatQueue: [],
-    chatRunId: null,
-    chatSending: false,
-    lastError: null,
-    sessionKey: "agent:main",
-    basePath: "",
-    hello: null,
-    chatAvatarUrl: null,
-    chatAvatarSource: null,
-    chatAvatarStatus: null,
-    chatAvatarReason: null,
-    sessionsLoading: false,
-    sessionsResult: null,
-    sessionsResultAgentId: null,
-    sessionsError: null,
-    sessionsArchivedFilter: "active" as const,
-    chatModelsLoading: false,
-    chatMetadataRequestVersion: 0,
-    chatModelCatalog: [],
-    refreshSessionsAfterChat: new Map(),
-    toolStreamById: new Map(),
-    toolStreamOrder: [],
-    toolStreamSyncTimer: null,
-    renderLifecycle,
-    querySelector: () => null,
-    chatScrollCommitCleanup: null,
-    chatScrollFrame: null,
-    chatScrollGuardFrame: null,
-    chatScrollGeneration: 0,
-    chatLastScrollTop: 0,
-    chatLastScrollHeight: 0,
-    chatHasAutoScrolled: false,
-    chatUserNearBottom: true,
-    chatFollowLocked: false,
-    chatNewMessagesBelow: false,
-    chatIsProgrammaticScroll: false,
-    chatProgrammaticScrollTarget: 0,
-    applySettings: vi.fn((patch: Partial<UiSettings>) => {
-      // Chat pages own display/layout settings; active-session persistence belongs to pane bindings.
-      const next = { ...settings, ...patch };
-      Object.assign(settings, {
-        chatShowThinking: next.chatShowThinking,
-        chatShowToolCalls: next.chatShowToolCalls,
-        chatPersistCommentary: next.chatPersistCommentary,
-        chatSendShortcut: next.chatSendShortcut,
-      });
-    }),
-    ...hostOverrides,
-    settings,
-  };
-  const sessions =
-    hostOverrides.sessions ??
-    createSessionCapability({
-      snapshot: {
-        client: host.client,
-        phase: host.connected ? "connected" : "reconnecting",
-        hello: host.hello,
-      },
-      subscribe: () => () => undefined,
-      subscribeEvents: () => () => undefined,
-    });
-  for (const session of host.sessionsResult?.sessions ?? []) {
-    sessions.reconcile(session, host.sessionsResult?.defaults, {
-      selectedGlobalAgentId: host.assistantAgentId,
-      archivedFilter: host.sessionsArchivedFilter,
-    });
-  }
-  const pendingSettingsPatches = hostOverrides.pendingSettingsPatches;
-  const resolvedSessions = pendingSettingsPatches
-    ? createPendingSettingsSessionCapability(sessions, pendingSettingsPatches)
-    : sessions;
-  const resolvedHost = { ...host, sessions: resolvedSessions } as TestChatHost;
-  for (const sessionKey of Object.keys(pendingSettingsPatches ?? {})) {
-    void patchChatSessionSettings(resolvedHost, sessionKey, {}).catch(() => undefined);
-  }
-  return request ? Object.assign(resolvedHost, { request }) : resolvedHost;
-}
-
 function createSessionsResult(sessions: GatewaySessionRow[]): SessionsListResult {
   return {
     ts: 0,
@@ -532,7 +350,7 @@ describe("refreshChat", () => {
 
   it("dispatches chat refresh work without waiting for slow history RPCs", async () => {
     const requestUpdate = vi.fn();
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.branches.list": () => pendingPromise(),
         "chat.history": () => pendingPromise(),
@@ -552,7 +370,7 @@ describe("refreshChat", () => {
 
   it("uses startup-shipped metadata without requesting chat.metadata", async () => {
     const startup = createDeferred<unknown>();
-    const host = makeHost({
+    const host = makeChatHost({
       hello: {
         features: { methods: ["chat.metadata", "chat.startup"] },
       } as TestChatHost["hello"],
@@ -602,7 +420,7 @@ describe("refreshChat", () => {
 
   it("fills omitted startup metadata immediately and populates models and commands", async () => {
     const startup = createDeferred<unknown>();
-    const host = makeHost({
+    const host = makeChatHost({
       hello: {
         features: { methods: ["chat.metadata", "chat.startup"] },
       } as TestChatHost["hello"],
@@ -702,7 +520,7 @@ describe("refreshChat", () => {
       { sessionKey: "unknown", limit: 100 },
     ],
   ])("scopes history for %s", async (_name, overrides, expected) => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => pendingPromise(),
       },
@@ -718,7 +536,7 @@ describe("refreshChat", () => {
     const history = createDeferred<unknown>();
     const requestUpdate = vi.fn();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => history.promise,
       },
@@ -743,7 +561,7 @@ describe("refreshChat", () => {
 
   it("keeps an active run adopted from history over newer stale catalog metadata", async () => {
     const runId = "run-restored";
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -830,7 +648,7 @@ describe("refreshChat", () => {
     },
   ])("$name", async ({ history, overrides, message, expectedSend, preservesSessionsResult }) => {
     const previousSessionsResult = overrides.sessionsResult;
-    const host = makeHost({
+    const host = makeChatHost({
       ...overrides,
       requestHandlers: {
         "chat.history": history,
@@ -895,7 +713,7 @@ describe("refreshChat", () => {
     },
   ])("$name", async ({ history, text, sessionsResult, expectedSession }) => {
     const restoredQueue = [{ id: "queued-1", text, createdAt: 1 }];
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: { "chat.history": history },
       sessionKey: "agent:main:dashboard",
       chatQueue: restoredQueue,
@@ -969,7 +787,7 @@ describe("refreshChatAvatar", () => {
       throw new Error(`Unexpected avatar URL: ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const host = makeHost({ basePath, sessionKey: "agent:main", ...overrides });
+    const host = makeChatHost({ basePath, sessionKey: "agent:main", ...overrides });
 
     await refreshChatAvatar(host);
 
@@ -994,7 +812,7 @@ describe("refreshChatAvatar", () => {
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    const host = makeHost({ basePath: "/openclaw/", sessionKey: "agent:ops:main" });
+    const host = makeChatHost({ basePath: "/openclaw/", sessionKey: "agent:ops:main" });
     await refreshChatAvatar(host);
 
     expect(fetchUrl(fetchMock as unknown as MockCallSource, 0)).toBe("/openclaw/avatar/ops?meta=1");
@@ -1014,7 +832,7 @@ describe("refreshChatAvatar", () => {
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
+    const host = makeChatHost({ basePath: "", sessionKey: "agent:main" });
     await refreshChatAvatar(host);
 
     expect(host.chatAvatarUrl).toBeNull();
@@ -1034,7 +852,7 @@ describe("refreshChatAvatar", () => {
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
+    const host = makeChatHost({ basePath: "", sessionKey: "agent:main" });
     await refreshChatAvatar(host);
 
     expect(host.chatAvatarUrl).toBeNull();
@@ -1092,7 +910,7 @@ describe("refreshChatAvatar", () => {
       throw new Error(`Unexpected avatar URL: ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const host = makeHost({ basePath: "", ...overrides });
+    const host = makeChatHost({ basePath: "", ...overrides });
 
     const firstRefresh = refreshChatAvatar(host);
     fixture.switchAgent(host);
@@ -1123,7 +941,7 @@ describe("handleSendChat", () => {
   });
 
   it("preserves the visible bare main route for an immediate send", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { runId: "bare-main-run", status: "started" },
       },
@@ -1144,7 +962,7 @@ describe("handleSendChat", () => {
   });
 
   it("preserves user-authored bang commands through the normal composer send", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { runId: "bang-command-run", status: "started" },
       },
@@ -1164,7 +982,7 @@ describe("handleSendChat", () => {
   it.each(["stop", "esc", "abort", "wait", "exit"])(
     "sends the idle conversational word %s as a normal message",
     async (message) => {
-      const host = makeHost({
+      const host = makeChatHost({
         requestHandlers: {
           "chat.send": { runId: `idle-${message}`, status: "started" },
         },
@@ -1190,7 +1008,7 @@ describe("handleSendChat", () => {
 
   it("routes typed /new through the fresh-session action without confirmation", async () => {
     const createChatSession = vi.fn(async () => true);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "/new",
       sessionKey: "agent:main",
@@ -1206,7 +1024,7 @@ describe("handleSendChat", () => {
 
   it("restores typed /new when session creation is cancelled", async () => {
     const createChatSession = vi.fn(async () => false);
-    const host = makeHost({
+    const host = makeChatHost({
       chatMessage: "/new",
       sessionKey: "agent:main",
       createChatSession,
@@ -1220,7 +1038,7 @@ describe("handleSendChat", () => {
 
   it("does not queue typed /new behind an active run", async () => {
     const createChatSession = vi.fn(async () => true);
-    const host = makeHost({
+    const host = makeChatHost({
       chatMessage: "/new",
       chatRunId: "run-main",
       chatStream: "Working...",
@@ -1237,7 +1055,7 @@ describe("handleSendChat", () => {
   });
 
   it("preserves typed /reset command dispatch without confirmation", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -1260,7 +1078,7 @@ describe("handleSendChat", () => {
   it("parks a settings-delayed reset when the user changes sessions", async () => {
     const settingsPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -1292,7 +1110,7 @@ describe("handleSendChat", () => {
   it("coalesces settings-delayed redirects and preserves a newer draft", async () => {
     const settingsPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.steer": {
           status: "started",
@@ -1334,7 +1152,7 @@ describe("handleSendChat", () => {
       fileName: "notes.txt",
     };
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatAttachments: [attachment],
       chatMessage: "/redirect start over",
@@ -1373,7 +1191,7 @@ describe("handleSendChat", () => {
       expected: "/reset soft please reload system prompt",
     },
   ])("preserves $input args and skips confirmation dialog", async ({ input, expected }) => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -1394,7 +1212,7 @@ describe("handleSendChat", () => {
   });
 
   it("does not seed refreshSessionsAfterChat for a terminal timeout ack on a refreshing send", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "timeout" },
       },
@@ -1430,7 +1248,7 @@ describe("handleSendChat", () => {
     const archivedSessions = createSessionsResult([
       row("agent:main:archived", { archived: true, status: "done" }),
     ]);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "chat send payload");
@@ -1464,7 +1282,7 @@ describe("handleSendChat", () => {
   });
 
   it("marks terminal error ACK sends failed instead of accepting the queued message", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "chat send payload");
@@ -1498,7 +1316,7 @@ describe("handleSendChat", () => {
         __openclaw: { id: "peer-user", seq: 1, idempotencyKey: "peer-run:user" },
       };
       let rejectedRunId = "";
-      const host = makeHost({
+      const host = makeChatHost({
         requestHandlers: {
           "chat.send": (params: unknown) => {
             const payload = requireRecord(params, "terminal chat send payload");
@@ -1544,7 +1362,7 @@ describe("handleSendChat", () => {
   );
 
   it("records visible send timing phases for a normal chat send", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": {
           status: "started",
@@ -1581,7 +1399,7 @@ describe("handleSendChat", () => {
   });
 
   it("records Gateway post-ACK server timing milestones for a chat send", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -1633,7 +1451,7 @@ describe("handleSendChat", () => {
     });
     const chatSend = createDeferred<{ status: "started" }>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => chatSend.promise,
       },
@@ -1661,7 +1479,7 @@ describe("handleSendChat", () => {
   it("waits for an in-flight model picker update before sending chat", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -1702,7 +1520,7 @@ describe("handleSendChat", () => {
         thinkingLevel: "low",
       }),
     ]);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.patch": (params: unknown) => {
           const patch = requireRecord(params, "session settings patch");
@@ -1773,7 +1591,7 @@ describe("handleSendChat", () => {
     });
     vi.stubGlobal("sessionStorage", storage);
     let patchCount = 0;
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.patch": () => (++patchCount === 1 ? firstUpdate.promise : secondUpdate.promise),
         "chat.send": { status: "started" },
@@ -1805,7 +1623,7 @@ describe("handleSendChat", () => {
   it("keeps a resolved model reconciliation inside the canonical settings queue", async () => {
     const reconcile = createDeferred<void>();
     let patchCount = 0;
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.patch": () => {
           patchCount += 1;
@@ -1835,7 +1653,7 @@ describe("handleSendChat", () => {
   it("rolls a failed queued picker back to the preceding slash model value", async () => {
     const firstPatch = createDeferred<unknown>();
     let patchCount = 0;
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.patch": () => {
           patchCount += 1;
@@ -1890,7 +1708,7 @@ describe("handleSendChat", () => {
       write(key, value);
     });
     vi.stubGlobal("sessionStorage", storage);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => history.promise,
         "chat.send": { status: "started" },
@@ -1937,7 +1755,7 @@ describe("handleSendChat", () => {
   it("does not gate a queued local command on an unrelated picker update", async () => {
     const settingsUpdate = createDeferred<boolean>();
     executeSlashCommandMock.mockResolvedValue({ content: "Compaction complete." });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "/compact",
       pendingSettingsPatches: { "agent:main": settingsUpdate.promise },
@@ -1953,7 +1771,7 @@ describe("handleSendChat", () => {
 
   it("wakes a picker-delayed durable send after reconnect already tried its drain", async () => {
     const settingsUpdate = createDeferred<boolean>();
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -1990,7 +1808,7 @@ describe("handleSendChat", () => {
       text: "reply context",
       senderLabel: "User",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -2054,13 +1872,13 @@ describe("handleSendChat", () => {
     });
     const client = clientWithRequest(request);
     const agentsList = { defaultId: "main", mainKey: "home" };
-    const settingsPane = makeHost({
+    const settingsPane = makeChatHost({
       agentsList,
       client,
       sessionKey: "agent:work:main",
       sessionsResult,
     });
-    const sendPane = makeHost({
+    const sendPane = makeChatHost({
       agentsList,
       client,
       chatMessage: "wait for the other pane",
@@ -2104,12 +1922,12 @@ describe("handleSendChat", () => {
       scope: "per-sender",
       agents: [{ id: "ops" }],
     };
-    const settingsPane = makeHost({
+    const settingsPane = makeChatHost({
       agentsList,
       pendingSettingsPatches: { [patchKey]: settingsPatch.promise },
       sessionKey: patchKey,
     });
-    const sendPane = makeHost({
+    const sendPane = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2139,12 +1957,12 @@ describe("handleSendChat", () => {
       scope: "per-sender",
       agents: [{ id: "ops" }, { id: "main" }],
     };
-    const mainPane = makeHost({
+    const mainPane = makeChatHost({
       agentsList,
       pendingSettingsPatches: { "agent:main:main": settingsPatch.promise },
       sessionKey: "agent:main:main",
     });
-    const sendPane = makeHost({
+    const sendPane = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2165,7 +1983,7 @@ describe("handleSendChat", () => {
   it("does not gate an agent main send on a distinct per-sender global patch", async () => {
     const globalPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2201,7 +2019,7 @@ describe("handleSendChat", () => {
   it("gates global-scope agent main aliases on the global patch", async () => {
     const globalPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2225,7 +2043,7 @@ describe("handleSendChat", () => {
   it("parks a delayed global send after navigating to an agent main alias", async () => {
     const globalPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       agentsList: { defaultId: "main", mainKey: "main", scope: "per-sender" },
       assistantAgentId: "work",
@@ -2256,7 +2074,7 @@ describe("handleSendChat", () => {
         thinkingLevel: "low",
       }),
     ]);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatFollowLocked: true,
       chatMessage: "do not send after reconnect",
@@ -2291,7 +2109,7 @@ describe("handleSendChat", () => {
   it("preserves draft edits made while waiting for a model picker update", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2330,7 +2148,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:application/pdf;base64,JVBERi0xLjQK",
       file,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2388,7 +2206,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:application/pdf;base64,ZWRpdGVk",
       file: editedFile,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2436,7 +2254,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:application/pdf;base64,b3JpZ2luYWw=",
       file,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2483,7 +2301,7 @@ describe("handleSendChat", () => {
       dataUrl: `data:text/plain;base64,${btoa(text)}`,
       file,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2512,7 +2330,7 @@ describe("handleSendChat", () => {
   it("does not cross-gate case-distinct opaque Matrix sessions", async () => {
     const otherSessionSwitch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2543,7 +2361,7 @@ describe("handleSendChat", () => {
       senderLabel: "User",
     };
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "do not send on rollback",
       chatReplyTarget: replyTarget,
@@ -2571,7 +2389,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:text/plain;base64,bmV3ZXI=",
       file: new File(["newer"], "newer.txt", { type: "text/plain" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "keep this send separate",
       pendingSettingsPatches: { "agent:main": switchUpdate.promise },
@@ -2598,7 +2416,7 @@ describe("handleSendChat", () => {
   it("preserves every send when a shared picker patch fails", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "first blocked message",
       pendingSettingsPatches: { "agent:main": switchUpdate.promise },
@@ -2639,7 +2457,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:text/plain;base64,cHJpdmF0ZQ==",
       file,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatAttachments: [attachment],
       chatMessage: "send this attachment",
@@ -2668,7 +2486,7 @@ describe("handleSendChat", () => {
   it("does not restore a manually removed model-wait send after model update failure", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "remove this pending send",
       pendingSettingsPatches: { "agent:main": switchUpdate.promise },
@@ -2691,7 +2509,7 @@ describe("handleSendChat", () => {
   it("keeps resolved model-wait sends queued under the submitted session after switching", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -2727,7 +2545,7 @@ describe("handleSendChat", () => {
   it("continues a resolved model-wait send in its submitted session after switching", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -2773,7 +2591,7 @@ describe("handleSendChat", () => {
   it("keeps failed model-wait sends retryable under the submitted session after switching", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "send from session a",
       pendingSettingsPatches: { "agent:main": switchUpdate.promise },
@@ -2803,7 +2621,7 @@ describe("handleSendChat", () => {
   it("does not flush model-wait sends before the model picker update finishes", async () => {
     const switchUpdate = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -2845,7 +2663,7 @@ describe("handleSendChat", () => {
   it("waits for pending settings before retrying a failed queued send", async () => {
     const settingsPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
         "chat.send": { runId: "retry-run", status: "started" },
@@ -2892,7 +2710,7 @@ describe("handleSendChat", () => {
   it("keeps a queued retry failed when its pending settings patch fails", async () => {
     const settingsPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
       },
@@ -2940,7 +2758,7 @@ describe("handleSendChat", () => {
       sendState: "failed" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatQueue: [original],
     });
@@ -2969,7 +2787,7 @@ describe("handleSendChat", () => {
       sendState: "unconfirmed" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatQueue: [original],
     });
@@ -2998,7 +2816,7 @@ describe("handleSendChat", () => {
       sendState: "failed" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatQueue: [original],
     });
@@ -3027,7 +2845,7 @@ describe("handleSendChat", () => {
       sendState: "failed" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => Promise.resolve(idleChatHistory()),
         "chat.send": (params: unknown) => {
@@ -3069,7 +2887,7 @@ describe("handleSendChat", () => {
     const settingsPatch = createDeferred<boolean>();
     const foregroundAck = createDeferred<{ runId: string; status: "started" }>();
     const sendPayloads: Array<Record<string, unknown>> = [];
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": (params: unknown) => {
           const payload = requireRecord(params, "chat.history payload");
@@ -3137,7 +2955,7 @@ describe("handleSendChat", () => {
     );
 
     const refreshCurrentSessionTools = vi.fn();
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.patch": {
           ok: true,
@@ -3175,7 +2993,7 @@ describe("handleSendChat", () => {
   });
 
   it("queues local slash commands while the gateway client is unavailable", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       chatMessage: "/think",
       connected: true,
@@ -3197,7 +3015,7 @@ describe("handleSendChat", () => {
   it("shows local slash-command feedback when dispatch fails unexpectedly", async () => {
     executeSlashCommandMock.mockRejectedValue(new Error("dispatch failed"));
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "/think",
       connected: true,
@@ -3226,7 +3044,7 @@ describe("handleSendChat", () => {
 
   it("routes /btw to the session companion while a main run is active", async () => {
     const openSessionCompanion = vi.fn();
-    const host = makeHost({
+    const host = makeChatHost({
       chatRunId: "run-main",
       chatStream: "Working...",
       chatMessage: "/btw what changed?",
@@ -3246,7 +3064,7 @@ describe("handleSendChat", () => {
   });
 
   it("sends /approve immediately while a main run is waiting without queueing it", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started" },
       },
@@ -3286,7 +3104,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:text/plain;base64,YXBwcm92YWw=",
       file: new File(["approval"], "approval.txt", { type: "text/plain" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => ack.promise,
       },
@@ -3322,7 +3140,7 @@ describe("handleSendChat", () => {
   it("fences a detached transport rejection when the composer and session changed", async () => {
     const settingsPatch = createDeferred<boolean>();
     const request = createDeferred<never>();
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => request.promise,
       },
@@ -3361,7 +3179,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:text/plain;base64,c3VjY2Vzcw==",
       file: new File(["success"], "success.txt", { type: "text/plain" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => ack.promise,
       },
@@ -3406,7 +3224,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:text/plain;base64,cmVkaXJlY3Q=",
       file: new File(["redirect"], "redirect.txt", { type: "text/plain" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       chatAttachments: [attachment],
       chatMessage: "/redirect start over",
       client: clientWithRequest(vi.fn()),
@@ -3448,7 +3266,7 @@ describe("handleSendChat", () => {
       file: new File(["stale"], "stale.txt", { type: "text/plain" }),
     });
     const originalClient = clientWithRequest(vi.fn());
-    const host = makeHost({
+    const host = makeChatHost({
       chatAttachments: [attachment],
       chatMessage: "/redirect start over",
       client: originalClient,
@@ -3473,7 +3291,7 @@ describe("handleSendChat", () => {
   it("does not overwrite newer same-session input after a delayed command failure", async () => {
     const command = createDeferred<Awaited<ReturnType<ExecuteSlashCommand>>>();
     executeSlashCommandMock.mockImplementationOnce(() => command.promise);
-    const host = makeHost({
+    const host = makeChatHost({
       chatMessage: "/redirect start over",
       client: clientWithRequest(vi.fn()),
       connectionEpoch: 1,
@@ -3510,7 +3328,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:text/plain;base64,bmV3ZXI=",
       file: new File(["newer"], "newer.txt", { type: "text/plain" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       chatAttachments: [submittedAttachment],
       chatMessage: "/redirect start over",
       client: clientWithRequest(vi.fn()),
@@ -3542,7 +3360,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:text/plain;base64,c3VjY2Vzcw==",
       file: new File(["success"], "success.txt", { type: "text/plain" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       chatAttachments: [attachment],
       chatMessage: "/redirect start over",
       client: clientWithRequest(vi.fn()),
@@ -3568,7 +3386,7 @@ describe("handleSendChat", () => {
 
   it("routes /side through the same session companion path", async () => {
     const openSessionCompanion = vi.fn();
-    const host = makeHost({
+    const host = makeChatHost({
       chatRunId: "run-main",
       chatStream: "Working...",
       chatMessage: "/side what changed?",
@@ -3584,7 +3402,7 @@ describe("handleSendChat", () => {
 
   it("routes /btw without adopting a main chat run when idle", async () => {
     const openSessionCompanion = vi.fn();
-    const host = makeHost({
+    const host = makeChatHost({
       chatMessage: "/btw summarize this",
       openSessionCompanion,
     });
@@ -3600,7 +3418,7 @@ describe("handleSendChat", () => {
   });
 
   it("keeps queued normal messages recallable before transcript history catches up", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "queued while busy",
       chatRunId: "run-1",
@@ -3637,7 +3455,7 @@ describe("handleSendChat", () => {
       text: "keep this reply target",
       senderLabel: "User",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatMessage: "queue behind the active run",
       chatReplyTarget: replyTarget,
@@ -3656,7 +3474,7 @@ describe("handleSendChat", () => {
   });
 
   it("auto-steers messages sent during an active run with the default steer setting", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started", runId: "steer-run" },
       },
@@ -3694,7 +3512,7 @@ describe("handleSendChat", () => {
       text: "reply context",
       senderLabel: "User",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => {
           historyRequests += 1;
@@ -3749,7 +3567,7 @@ describe("handleSendChat", () => {
   });
 
   it("leaves active-run resolution to the Gateway while its effective mode is loading", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started", runId: "gateway-resolved-run" },
       },
@@ -3774,7 +3592,7 @@ describe("handleSendChat", () => {
   it.each(["followup", "collect", "interrupt"] as const)(
     "preserves the inherited %s mode for active-run sends",
     async (queueMode) => {
-      const host = makeHost({
+      const host = makeChatHost({
         requestHandlers: {
           "chat.send": { status: "started", runId: `${queueMode}-run` },
         },
@@ -3802,7 +3620,7 @@ describe("handleSendChat", () => {
   );
 
   it("honors the selected mode when only the session row reports an active run", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started", runId: "interrupt-run" },
       },
@@ -3832,7 +3650,7 @@ describe("handleSendChat", () => {
   it("keeps a steered message visible when only the session row reports an active run", async () => {
     let wireRunId: unknown;
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           wireRunId = requireRecord(params, "steered chat send payload").idempotencyKey;
@@ -3861,7 +3679,7 @@ describe("handleSendChat", () => {
   });
 
   it("keeps busy sends queued in steer mode while disconnected", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatMessage: "queued while offline",
@@ -3889,7 +3707,7 @@ describe("handleSendChat", () => {
       fileName: "offline.png",
       dataUrl: "data:image/png;base64,AAA",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       chatAttachments: [attachment],
       chatMessage: "queue after the active run",
       chatRunId: "run-1",
@@ -3914,7 +3732,7 @@ describe("handleSendChat", () => {
           sessionInfo: row("agent:main", { hasActiveRun: true, status: "running" }),
         }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       chatMessage: "wait for the active run",
       chatRunId: "run-1",
       connected: false,
@@ -3963,8 +3781,8 @@ describe("handleSendChat", () => {
       },
     });
     const client = clientWithRequest(request);
-    const firstHost = makeHost({ client });
-    const secondHost = makeHost({ client });
+    const firstHost = makeChatHost({ client });
+    const secondHost = makeChatHost({ client });
 
     const firstSend = handleSendChat(firstHost, "first pane turn");
     await waitForFast(() => expect(sendPayloads).toHaveLength(1));
@@ -4001,7 +3819,7 @@ describe("handleSendChat", () => {
       sendState: "waiting-reconnect" as const,
       sessionKey: "agent:main:ready",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": (params: unknown) => {
           const payload = requireRecord(params, "chat.history payload");
@@ -4048,7 +3866,7 @@ describe("handleSendChat", () => {
     const sentSessions: string[] = [];
     const visibleSessionKey = "agent:main:visible";
     const inactiveSessionKey = "agent:main:inactive";
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": (params: unknown) => {
           const payload = requireRecord(params, "chat.history payload");
@@ -4099,7 +3917,7 @@ describe("handleSendChat", () => {
 
   it("keeps global outboxes for different agents isolated", async () => {
     const sends: Array<Record<string, unknown>> = [];
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -4149,7 +3967,7 @@ describe("handleSendChat", () => {
 
   it("reconciles a restored undefined-state command before destructive execution", async () => {
     const item = createQueuedLocalCommand("restored-undefined-clear", "/clear");
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -4183,7 +4001,7 @@ describe("handleSendChat", () => {
       sendState: "waiting-idle" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -4211,8 +4029,8 @@ describe("handleSendChat", () => {
     });
     const client = clientWithRequest(request);
     const item = createQueuedLocalCommand("shared-local-command", "/think high");
-    const firstHost = makeHost({ client, chatQueue: [item] });
-    const secondHost = makeHost({ client, chatQueue: [{ ...item }] });
+    const firstHost = makeChatHost({ client, chatQueue: [item] });
+    const secondHost = makeChatHost({ client, chatQueue: [{ ...item }] });
     expect(admitQueuedMessageForSession(firstHost, firstHost.sessionKey, item)).toBe(true);
 
     await Promise.all([
@@ -4243,8 +4061,8 @@ describe("handleSendChat", () => {
         sessionKey,
       }),
     ];
-    const visibleHost = makeHost({ client, chatQueue: items, sessionKey });
-    const inactiveHost = makeHost({ client, chatQueue: [], sessionKey: "agent:main:inactive" });
+    const visibleHost = makeChatHost({ client, chatQueue: items, sessionKey });
+    const inactiveHost = makeChatHost({ client, chatQueue: [], sessionKey: "agent:main:inactive" });
     admitHostQueueItems(visibleHost);
 
     const visibleDrain = retryReconnectableQueuedChatSends(visibleHost);
@@ -4265,11 +4083,11 @@ describe("handleSendChat", () => {
     });
     const item = createQueuedLocalCommand("slow-local-command", "/compact");
     const client = clientWithRequest(request);
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       chatQueue: [item],
     });
-    const peer = makeHost({ client, chatQueue: [] });
+    const peer = makeChatHost({ client, chatQueue: [] });
     const stopHost = subscribeChatOutboxProjection(host);
     let stopPeer = () => {};
     expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
@@ -4315,7 +4133,7 @@ describe("handleSendChat", () => {
     const confirmation = createDeferred<boolean>();
 
     const item = createQueuedLocalCommand("clear-confirmation-race", "/clear");
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
       },
@@ -4338,7 +4156,7 @@ describe("handleSendChat", () => {
   it("cancels a queued reset when dashboard reset confirmation is rejected", async () => {
     const item = createQueuedLocalCommand("queued-reset-cancelled", "/reset");
     const confirmConversationReset = vi.fn(async () => false);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
       },
@@ -4360,7 +4178,7 @@ describe("handleSendChat", () => {
 
     const item = createQueuedLocalCommand("queued-reset-approved-before-run", "/reset");
     const confirmConversationReset = vi.fn(async () => await confirmation.promise);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => Promise.resolve(idleChatHistory()),
         "chat.send": (params: unknown) => {
@@ -4405,7 +4223,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:first",
     });
     const confirmConversationReset = vi.fn(async () => await confirmation.promise);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory("agent:main:first"),
       },
@@ -4436,7 +4254,7 @@ describe("handleSendChat", () => {
       "chat.send": () => ({ status: "ok" }),
     });
     const item = createQueuedLocalCommand("queued-reset-reconnect", "/reset");
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
         "chat.send": () => ({ status: "ok" }),
@@ -4475,7 +4293,7 @@ describe("handleSendChat", () => {
     const ack = createDeferred<{ runId: string; status: "ok" }>();
     const replacementRequest = makeRequestMock();
     const item = createQueuedLocalCommand("queued-reset-ack-reconnect", "/reset");
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
         "chat.send": () => ack.promise,
@@ -4548,7 +4366,7 @@ describe("handleSendChat", () => {
       sendRunId: runId,
       sendState: "unconfirmed" as const,
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "retried reset payload");
@@ -4588,7 +4406,7 @@ describe("handleSendChat", () => {
     });
     const refreshCurrentSessionTools = vi.fn(async () => undefined);
     const refreshCurrentChat = vi.fn(async () => undefined);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory("agent:main:first"),
       },
@@ -4636,7 +4454,7 @@ describe("handleSendChat", () => {
     const item = createQueuedLocalCommand("reconnected-model-command", "/model gpt-5-mini", {
       sessionKey: "agent:main:first",
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(item.sessionKey),
       },
@@ -4678,7 +4496,7 @@ describe("handleSendChat", () => {
       const item = createQueuedLocalCommand("switched-global-model-command", "/model gpt-5-mini", {
         sessionKey,
       });
-      const host = makeHost({
+      const host = makeChatHost({
         requestHandlers: {
           "chat.history": () => idleChatHistory(item.sessionKey),
         },
@@ -4719,7 +4537,7 @@ describe("handleSendChat", () => {
     const item = createQueuedLocalCommand("reconnected-local-command", "/model unavailable", {
       sessionKey: "agent:main:first",
     });
-    const host = makeHost({
+    const host = makeChatHost({
       client: firstClient,
       connectionEpoch: 1,
       chatQueue: [item],
@@ -4758,7 +4576,7 @@ describe("handleSendChat", () => {
       sendState: "sending" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({ chatQueue: [item] });
+    const host = makeChatHost({ chatQueue: [item] });
     expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
 
     expect(removeDeliveredQueuedChatSendForRun(host, item.sendRunId)).toMatchObject({
@@ -4779,8 +4597,8 @@ describe("handleSendChat", () => {
       sendState: "sending" as const,
       sessionKey: "agent:main:closed-pane",
     };
-    const sender = makeHost({ chatQueue: [item], sessionKey: item.sessionKey });
-    const replacement = makeHost({ chatQueue: [], sessionKey: "agent:main:replacement" });
+    const sender = makeChatHost({ chatQueue: [item], sessionKey: item.sessionKey });
+    const replacement = makeChatHost({ chatQueue: [], sessionKey: "agent:main:replacement" });
     expect(admitQueuedMessageForSession(sender, item.sessionKey, item)).toBe(true);
 
     expect(removeDeliveredQueuedChatSendForRun(replacement, item.sendRunId)).toMatchObject({
@@ -4802,13 +4620,13 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:visible",
     };
     const client = clientWithRequest(vi.fn());
-    const visible = makeHost({
+    const visible = makeChatHost({
       chatQueue: [item],
       chatRunId: item.sendRunId,
       client,
       sessionKey: item.sessionKey,
     });
-    const inactive = makeHost({
+    const inactive = makeChatHost({
       chatQueue: [],
       client,
       sessionKey: "agent:main:inactive",
@@ -4899,13 +4717,13 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:visible",
     };
     const client = clientWithRequest(vi.fn());
-    const visible = makeHost({
+    const visible = makeChatHost({
       chatQueue: [item],
       chatRunId: item.sendRunId,
       client,
       sessionKey: item.sessionKey,
     });
-    const inactive = makeHost({
+    const inactive = makeChatHost({
       chatQueue: [],
       client,
       sessionKey: "agent:main:inactive",
@@ -4969,7 +4787,7 @@ describe("handleSendChat", () => {
         sessionKey: "agent:main",
       },
     ];
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => Promise.resolve(idleChatHistory()),
         "chat.send": (params: unknown) => {
@@ -5005,7 +4823,7 @@ describe("handleSendChat", () => {
       sendState: "waiting-reconnect" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -5037,7 +4855,7 @@ describe("handleSendChat", () => {
     executeSlashCommandMock.mockResolvedValue({ content: "Thinking level set." });
 
     const item = createQueuedLocalCommand("local-command-claim-failure", "/think high");
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
       },
@@ -5082,7 +4900,7 @@ describe("handleSendChat", () => {
       createdAt: 2,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
         "chat.send": () => {
@@ -5129,7 +4947,7 @@ describe("handleSendChat", () => {
       createdAt: 2,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": () => {
           throw new Error("post-commit lifecycle failed");
@@ -5176,7 +4994,7 @@ describe("handleSendChat", () => {
   });
 
   it("fails closed when history refresh rejects after an uncertain clear", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": () => {
           throw new Error("post-commit lifecycle failed");
@@ -5211,7 +5029,7 @@ describe("handleSendChat", () => {
       createdAt: 2,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": () => {
           resetIssued = true;
@@ -5265,8 +5083,8 @@ describe("handleSendChat", () => {
       "chat.send": () => ack.promise,
     });
     const client = clientWithRequest(request);
-    const sendingHost = makeHost({ client });
-    const staleHost = makeHost({ client });
+    const sendingHost = makeChatHost({ client });
+    const staleHost = makeChatHost({ client });
     const send = handleSendChat(sendingHost, "delete before ack");
     await waitForFast(() => expect(sendingHost.chatQueue[0]?.sendState).toBe("sending"));
     const id = sendingHost.chatQueue[0]?.id ?? "missing";
@@ -5289,7 +5107,7 @@ describe("handleSendChat", () => {
       createdAt: 1,
       sessionKey: queuedSessionKey,
     };
-    const host = makeHost({ sessionKey: "agent:main:new-route" });
+    const host = makeChatHost({ sessionKey: "agent:main:new-route" });
     writeChatQueueForScope(host, queuedSessionKey, [item]);
     expect(admitQueuedMessageForSession(host, queuedSessionKey, item)).toBe(true);
 
@@ -5302,10 +5120,10 @@ describe("handleSendChat", () => {
   });
 
   it("does not project an outbox across gateways", () => {
-    const source = makeHost({
+    const source = makeChatHost({
       settings: { gatewayUrl: "ws://gateway-a.test/control" },
     });
-    const otherGateway = makeHost({
+    const otherGateway = makeChatHost({
       settings: { gatewayUrl: "ws://gateway-b.test/control" },
     });
     const stopSource = subscribeChatOutboxProjection(source);
@@ -5327,8 +5145,8 @@ describe("handleSendChat", () => {
   });
 
   it("projects direct canonical store mutations into an open pane", () => {
-    const source = makeHost();
-    const peer = makeHost();
+    const source = makeChatHost();
+    const peer = makeChatHost();
     const item = {
       id: "direct-store-projection",
       text: "refresh the already-open pane",
@@ -5357,8 +5175,8 @@ describe("handleSendChat", () => {
       createdAt: 1,
       sessionKey,
     };
-    const source = makeHost({ chatQueue: [item], sessionKey });
-    const cachedPane = makeHost({ sessionKey: "agent:main:other-session" });
+    const source = makeChatHost({ chatQueue: [item], sessionKey });
+    const cachedPane = makeChatHost({ sessionKey: "agent:main:other-session" });
     writeChatQueueForScope(cachedPane, sessionKey, [{ ...item }]);
     const stopSource = subscribeChatOutboxProjection(source);
     const stopCachedPane = subscribeChatOutboxProjection(cachedPane);
@@ -5387,8 +5205,8 @@ describe("handleSendChat", () => {
       sendState: "failed" as const,
       sessionKey: "agent:main",
     };
-    const source = makeHost({ chatQueue: [item], sessionKey: item.sessionKey });
-    const peer = makeHost({
+    const source = makeChatHost({ chatQueue: [item], sessionKey: item.sessionKey });
+    const peer = makeChatHost({
       requestHandlers: {},
       chatQueue: [{ ...item }],
       sessionKey: item.sessionKey,
@@ -5413,7 +5231,7 @@ describe("handleSendChat", () => {
   it("coalesces duplicate in-flight chat submits before the gateway acknowledges them", async () => {
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => sent.promise,
       },
@@ -5445,7 +5263,7 @@ describe("handleSendChat", () => {
   it("coalesces duplicate queued local commands while the first command is running", async () => {
     const command = createDeferred<{ content: string }>();
     executeSlashCommandMock.mockImplementation(() => command.promise);
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
       },
@@ -5469,7 +5287,7 @@ describe("handleSendChat", () => {
   it("keeps normal prompt text visible as pending until chat.send is acknowledged", async () => {
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => sent.promise,
       },
@@ -5516,11 +5334,11 @@ describe("handleSendChat", () => {
       createdAt: 1,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       chatQueue: [item],
     });
-    const stalePeer = makeHost({ client, chatQueue: [{ ...item }] });
+    const stalePeer = makeChatHost({ client, chatQueue: [{ ...item }] });
     expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
 
     const send = retryReconnectableQueuedChatSends(host);
@@ -5533,7 +5351,7 @@ describe("handleSendChat", () => {
       "waiting-reconnect",
     );
 
-    const latePeer = makeHost({ client, chatQueue: [] });
+    const latePeer = makeChatHost({ client, chatQueue: [] });
     const stopLatePeer = subscribeChatOutboxProjection(latePeer);
     try {
       expect(latePeer.chatQueue).toEqual([
@@ -5565,7 +5383,7 @@ describe("handleSendChat", () => {
   it("escapes reply sender labels and clears reply state after chat.send is acknowledged", async () => {
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => sent.promise,
       },
@@ -5592,7 +5410,7 @@ describe("handleSendChat", () => {
   it("sends replyToId instead of an inline quote when the reply target has a transcript id", async () => {
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => sent.promise,
       },
@@ -5620,7 +5438,7 @@ describe("handleSendChat", () => {
   });
 
   it("keeps reply state when chat.send fails before acceptance", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => Promise.resolve({ runId: "run-failed", status: "error" }),
       },
@@ -5641,7 +5459,7 @@ describe("handleSendChat", () => {
   it("routes queued Skill Workshop revisions through the proposal request RPC", async () => {
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
       },
@@ -5689,7 +5507,7 @@ describe("handleSendChat", () => {
 
   it("fails an in-flight Skill Workshop revision after connection replacement", async () => {
     const sent = createDeferred<unknown>();
-    const host = makeHost({
+    const host = makeChatHost({
       connectionEpoch: 1,
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
@@ -5721,7 +5539,7 @@ describe("handleSendChat", () => {
 
   it("fails a rejected in-flight Skill Workshop revision after connection replacement", async () => {
     const sent = createDeferred<unknown>();
-    const host = makeHost({
+    const host = makeChatHost({
       connectionEpoch: 1,
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
@@ -5749,7 +5567,7 @@ describe("handleSendChat", () => {
   });
 
   it("does not send queued Skill Workshop revisions with read-only operator access", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "skills.proposals.requestRevision": {},
       },
@@ -5772,7 +5590,7 @@ describe("handleSendChat", () => {
   it("treats slash-like Skill Workshop revision drafts as revision instructions", async () => {
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "skills.proposals.requestRevision": () => sent.promise,
       },
@@ -5815,7 +5633,7 @@ describe("handleSendChat", () => {
   it("keeps delayed chat.send ACK effects scoped to the submitted session", async () => {
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => sent.promise,
       },
@@ -5850,7 +5668,7 @@ describe("handleSendChat", () => {
   });
 
   it("keeps a pre-ack socket close recoverable with the same run id", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => {
           throw new Error("gateway closed (1006): network lost");
@@ -5889,7 +5707,7 @@ describe("handleSendChat", () => {
     });
     vi.stubGlobal("sessionStorage", storage);
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           rejectWrites = true;
@@ -5935,7 +5753,7 @@ describe("handleSendChat", () => {
       text: "quoted body",
       senderLabel: "User",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "chat send payload");
@@ -5997,7 +5815,7 @@ describe("handleSendChat", () => {
     });
     vi.stubGlobal("sessionStorage", storage);
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => {
           throw new Error("gateway not connected");
@@ -6027,7 +5845,7 @@ describe("handleSendChat", () => {
       mimeType: "application/pdf",
       sizeBytes: 20 * 1024 * 1024,
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "volatile connected send payload");
@@ -6074,7 +5892,7 @@ describe("handleSendChat", () => {
     vi.stubGlobal("sessionStorage", storage);
     const runIds: unknown[] = [];
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "volatile retry payload");
@@ -6118,7 +5936,7 @@ describe("handleSendChat", () => {
     const firstAttempt = createDeferred<unknown>();
     const runIds: unknown[] = [];
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "failed volatile retry payload");
@@ -6162,7 +5980,7 @@ describe("handleSendChat", () => {
     vi.stubGlobal("sessionStorage", storage);
     const volatileSend = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => volatileSend.promise,
       },
@@ -6208,7 +6026,7 @@ describe("handleSendChat", () => {
     });
     vi.stubGlobal("sessionStorage", storage);
     const request = makeRequestMock({});
-    const host = makeHost({
+    const host = makeChatHost({
       connected: false,
       chatMessage: "durable first",
     });
@@ -6243,7 +6061,7 @@ describe("handleSendChat", () => {
     vi.stubGlobal("sessionStorage", storage);
     const sent = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => {
           rejectWrites = true;
@@ -6273,7 +6091,7 @@ describe("handleSendChat", () => {
   });
 
   it("queues normal sends made while disconnected", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatMessage: "send after reconnect",
@@ -6305,7 +6123,7 @@ describe("handleSendChat", () => {
     const sendRunIds: string[] = [];
     let sendAttempts = 0;
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -6339,7 +6157,7 @@ describe("handleSendChat", () => {
   });
 
   it("retries reconnect history after a retryable response without a socket close", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatMessage: "retry history while connected",
@@ -6395,7 +6213,7 @@ describe("handleSendChat", () => {
       fileName: "notes.txt",
       mimeType: "text/plain",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatAttachments: [attachment],
@@ -6447,7 +6265,7 @@ describe("handleSendChat", () => {
         });
       },
     });
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatMessage: "/think high",
@@ -6483,7 +6301,7 @@ describe("handleSendChat", () => {
       throw new DOMException("quota exceeded", "QuotaExceededError");
     });
     vi.stubGlobal("sessionStorage", storage);
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatMessage: "/think high",
@@ -6511,7 +6329,7 @@ describe("handleSendChat", () => {
       sizeBytes: 3,
       dataUrl: "data:image/png;base64,AAA",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatAttachments: [attachment],
@@ -6527,7 +6345,7 @@ describe("handleSendChat", () => {
   });
 
   it("consumes a reply target after queueing its turn offline", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatMessage: "continue offline",
@@ -6560,7 +6378,7 @@ describe("handleSendChat", () => {
         }),
       "chat.send": () => Promise.resolve({ runId: "run-work", status: "started" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       sessionKey: "global",
@@ -6610,7 +6428,7 @@ describe("handleSendChat", () => {
         return Promise.resolve({ runId: payload.idempotencyKey, status: "started" });
       },
     });
-    const host = makeHost({
+    const host = makeChatHost({
       assistantAgentId: "work",
       chatMessage: "survive alias canonicalization",
       client: null,
@@ -6644,7 +6462,7 @@ describe("handleSendChat", () => {
   it("abandons stale reconnect history after the connection epoch changes", async () => {
     const history = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => history.promise,
       },
@@ -6685,7 +6503,7 @@ describe("handleSendChat", () => {
     const staleHistory = createDeferred<unknown>();
     let historyRequests = 0;
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => {
           historyRequests += 1;
@@ -6736,7 +6554,7 @@ describe("handleSendChat", () => {
     const activeHistory = createDeferred<unknown>();
     let historyRequests = 0;
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => {
           historyRequests += 1;
@@ -6785,7 +6603,7 @@ describe("handleSendChat", () => {
     const storage = createStorageMock();
     vi.stubGlobal("sessionStorage", storage);
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -6825,7 +6643,7 @@ describe("handleSendChat", () => {
   });
 
   it("removes a reconnect send with history proof before stale local busy state blocks it", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -6862,7 +6680,7 @@ describe("handleSendChat", () => {
   it("rechecks an idle history snapshot before parking a delivered send", async () => {
     let historyRequests = 0;
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => {
           historyRequests += 1;
@@ -6905,7 +6723,7 @@ describe("handleSendChat", () => {
   it("keeps a settings-blocked Skill Workshop revision retryable", async () => {
     const settingsPatch = createDeferred<boolean>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () => idleChatHistory(),
         "skills.proposals.requestRevision": { runId: "revision-retry", status: "started" },
@@ -6966,7 +6784,7 @@ describe("handleSendChat", () => {
       sendState: "waiting-reconnect" as const,
       sessionKey: "agent:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -7000,7 +6818,7 @@ describe("handleSendChat", () => {
   });
 
   it("parks an ambiguous reconnect send when idle history cannot prove delivery", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -7044,7 +6862,7 @@ describe("handleSendChat", () => {
   });
 
   it("does not replay while fresh history reports an active run", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -7073,7 +6891,7 @@ describe("handleSendChat", () => {
   });
 
   it("skips a manually failed head when replaying a later reconnect send", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
@@ -7117,7 +6935,7 @@ describe("handleSendChat", () => {
   it("keeps the sole failed queue item when an offline manual retry cannot persist", async () => {
     const storage = createStorageMock();
     vi.stubGlobal("sessionStorage", storage);
-    const host = makeHost({
+    const host = makeChatHost({
       connected: false,
       chatQueue: [
         {
@@ -7156,7 +6974,7 @@ describe("handleSendChat", () => {
         }),
       "chat.send": () => Promise.resolve({ runId: "run-work", status: "started" }),
     });
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       sessionKey: "global",
@@ -7191,7 +7009,7 @@ describe("handleSendChat", () => {
   });
 
   it("marks saved session queued sends waiting after a disconnect", () => {
-    const host = makeHost({ chatQueue: [] });
+    const host = makeChatHost({ chatQueue: [] });
     writeChatQueueForScope(host, "agent:a", [
       {
         id: "pending-send-a",
@@ -7212,7 +7030,7 @@ describe("handleSendChat", () => {
   });
 
   it("keeps the rendered-history leaf after a background branch refresh", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.branches.list": {
           branches: [
@@ -7251,7 +7069,7 @@ describe("handleSendChat", () => {
   });
 
   it("attaches an authoritative empty displayed leaf to a foreground send", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "empty-leaf send payload");
@@ -7270,7 +7088,7 @@ describe("handleSendChat", () => {
   });
 
   it("omits the active leaf when draining a restored outbox", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: null,
       connected: false,
       chatDisplayedLeafEntryId: "leaf-current",
@@ -7301,7 +7119,7 @@ describe("handleSendChat", () => {
 
   it("preserves a foreground leaf past an earlier outbox row", async () => {
     const sends: Record<string, unknown>[] = [];
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": idleChatHistory(),
         "chat.send": (params: unknown) => {
@@ -7338,7 +7156,7 @@ describe("handleSendChat", () => {
   });
 
   it("parks an active-leaf rejection, restores the draft, and refreshes branch state", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => {
           throw new GatewayRequestError({
@@ -7380,7 +7198,7 @@ describe("handleSendChat", () => {
   });
 
   it("marks validation failures visible and restores the composer", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () => {
           throw new Error("send blocked by session policy");
@@ -7402,7 +7220,7 @@ describe("handleSendChat", () => {
   });
 
   it("clears chat state when /clear resets chat history", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": { ok: true },
         "chat.history": {
@@ -7443,7 +7261,7 @@ describe("handleSendChat", () => {
     const history = createDeferred<unknown>();
     const sourceSessionKey = "agent:main:source";
     const replacementSessionKey = "agent:main:replacement";
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": { ok: true },
         "chat.history": () => history.promise,
@@ -7475,7 +7293,7 @@ describe("handleSendChat", () => {
 
   it("preserves the replacement connection leaf when post-clear history resolves late", async () => {
     const history = createDeferred<unknown>();
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": { ok: true },
         "chat.history": () => history.promise,
@@ -7507,7 +7325,7 @@ describe("handleSendChat", () => {
   });
 
   it("keeps the prior branch precondition when post-clear history cannot verify reset state", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": { ok: true },
         "chat.history": () => {
@@ -7526,7 +7344,7 @@ describe("handleSendChat", () => {
   });
 
   it("scopes /clear resets for selected-agent global sessions", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": { ok: true },
         "chat.history": { messages: [], thinkingLevel: null },
@@ -7567,7 +7385,7 @@ describe("handleSendChat", () => {
 
     const sourceSessionKey = "agent:main:source";
     const visibleSessionKey = "agent:main:visible";
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": () => reset.promise,
       },
@@ -7614,7 +7432,7 @@ describe("handleSendChat", () => {
 
     const sourceSessionKey = "agent:main:source";
     const visibleSessionKey = "agent:main:visible";
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": () => reset.promise,
       },
@@ -7659,7 +7477,7 @@ describe("handleSendChat", () => {
   it("retires an uncertain clear and refreshes replacement history without retrying", async () => {
     const reset = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": () => reset.promise,
       },
@@ -7714,7 +7532,7 @@ describe("handleSendChat", () => {
       const replacementRequest = makeRequestMock({
         "chat.history": () => history.promise,
       });
-      const host = makeHost({
+      const host = makeChatHost({
         requestHandlers: {
           "sessions.reset": () => reset.promise,
         },
@@ -7759,7 +7577,7 @@ describe("handleSendChat", () => {
   it("clears a canonically equivalent alias that becomes visible while reset is pending", async () => {
     const reset = createDeferred<unknown>();
 
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "sessions.reset": () => reset.promise,
         "chat.history": () =>
@@ -7799,7 +7617,7 @@ describe("handleSendChat", () => {
   });
 
   it("shows a visible pending item for /steer on the active run", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: clientWithRequest(
         makeRequestMock({
           "chat.send": { status: "started", runId: "run-1", messageSeq: 2 },
@@ -7821,7 +7639,7 @@ describe("handleSendChat", () => {
 
   it("steers a queued message into the active run without replacing run tracking", async () => {
     const original = { id: "queued-1", text: "tighten the plan", createdAt: 1 };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started", runId: "steer-run" },
       },
@@ -7861,7 +7679,7 @@ describe("handleSendChat", () => {
 
   it("steers a queued message when only the session row reports an active run", async () => {
     const original = { id: "queued-1", text: "tighten the plan", createdAt: 1 };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started", runId: "steer-run" },
       },
@@ -7907,7 +7725,7 @@ describe("handleSendChat", () => {
       sendState: "waiting-idle" as const,
       sessionKey: "agent:main:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "ok", runId: "completed-steer-run" },
         "chat.history": () => idleChatHistory("agent:main:main"),
@@ -7951,7 +7769,7 @@ describe("handleSendChat", () => {
       content: [{ type: "text", text: "history-owned steer" }],
       __openclaw: { idempotencyKey: "history-steer:user", seq: 1 },
     };
-    const host = makeHost({
+    const host = makeChatHost({
       client: clientWithRequest(
         makeRequestMock({
           "chat.history": { messages: [historyUser] },
@@ -7978,7 +7796,7 @@ describe("handleSendChat", () => {
   });
 
   it("retires a lingering steer chip for a different run from a top-level history key", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       client: clientWithRequest(
         makeRequestMock({
           "chat.history": {
@@ -8022,7 +7840,7 @@ describe("handleSendChat", () => {
       sendRunId: "inflight-steer",
       sendState: "steering" as const,
     };
-    const host = makeHost({
+    const host = makeChatHost({
       client: clientWithRequest(
         makeRequestMock({
           "chat.history": {
@@ -8046,7 +7864,7 @@ describe("handleSendChat", () => {
 
   it("does not steer a queued message without a durable claim", async () => {
     const original = { id: "memory-only-steer", text: "do not lose this", createdAt: 1 };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatRunId: "run-1",
       chatQueue: [original],
@@ -8073,7 +7891,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:main",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "started", runId: "steer-run" },
       },
@@ -8118,7 +7936,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:main",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () =>
           new Promise<{ status: "started"; runId: string }>((resolve) => {
@@ -8165,7 +7983,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:main",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () =>
           new Promise<{ status: "error"; runId: string }>((resolve) => {
@@ -8209,7 +8027,7 @@ describe("handleSendChat", () => {
   });
 
   it("materializes a steered user turn before a terminal event clears its chip", () => {
-    const host = makeHost({
+    const host = makeChatHost({
       chatRunId: "active-run",
       chatQueue: [
         {
@@ -8255,7 +8073,7 @@ describe("handleSendChat", () => {
       timestamp: 1,
       __openclaw: { idempotencyKey: "steer-send-run" },
     };
-    const host = makeHost({
+    const host = makeChatHost({
       chatRunId: "active-run",
       chatMessages: [assistantWithRunKey],
       chatQueue: [
@@ -8310,7 +8128,7 @@ describe("handleSendChat", () => {
       dataUrl,
       file,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       chatRunId: "active-run",
       chatQueue: [
         {
@@ -8363,7 +8181,7 @@ describe("handleSendChat", () => {
       sendState: "sending" as const,
       sessionKey: "agent:main:main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       chatRunId: "active-run",
       chatQueue: [
         original,
@@ -8420,7 +8238,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:main",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -8469,7 +8287,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:original",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -8544,7 +8362,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:main",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.history": {
           messages: [],
@@ -8597,7 +8415,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:original",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": () =>
           new Promise<{ status: "started"; runId: string }>((resolve) => {
@@ -8640,7 +8458,7 @@ describe("handleSendChat", () => {
         sessionKey: "agent:main:original",
         agentId: "main",
       };
-      const host = makeHost({
+      const host = makeChatHost({
         requestHandlers: {
           "chat.send": () =>
             new Promise<{ status: "error"; runId: string }>((resolve, reject) => {
@@ -8701,19 +8519,19 @@ describe("handleSendChat", () => {
       agentId: "main",
     };
     const client = clientWithRequest(request);
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       chatRunId: "active-run",
       chatQueue: [original],
       sessionKey: "agent:main:main",
     });
-    const peer = makeHost({
+    const peer = makeChatHost({
       client,
       chatRunId: "active-run",
       chatQueue: [{ ...original }],
       sessionKey: host.sessionKey,
     });
-    const latePeer = makeHost({ client, chatQueue: [], sessionKey: host.sessionKey });
+    const latePeer = makeChatHost({ client, chatQueue: [], sessionKey: host.sessionKey });
     const stopHost = subscribeChatOutboxProjection(host);
     const stopPeer = subscribeChatOutboxProjection(peer);
     let stopLatePeer = () => {};
@@ -8787,7 +8605,7 @@ describe("handleSendChat", () => {
 
   it("removes queued steer indicators when chat.send returns terminal ok", async () => {
     const original = { id: "queued-1", text: "tighten the plan", createdAt: 1 };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "ok", runId: "steer-ok" },
       },
@@ -8811,7 +8629,7 @@ describe("handleSendChat", () => {
 
   it("restores queued steer items when chat.send returns terminal error", async () => {
     const original = { id: "queued-1", text: "tighten the plan", createdAt: 1 };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "error", runId: "steer-error" },
       },
@@ -8832,7 +8650,7 @@ describe("handleSendChat", () => {
   });
 
   it("removes pending steer indicators when the run finishes", () => {
-    const host = makeHost({
+    const host = makeChatHost({
       chatQueue: [
         {
           id: "pending",
@@ -8875,7 +8693,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:application/pdf;base64,JVBERi0xLjQK",
       file,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": { status: "ok", runId: "run-1" },
       },
@@ -8928,7 +8746,7 @@ describe("handleSendChat", () => {
       dataUrl: "data:application/pdf;base64,JVBERi0xLjQK",
       file,
     });
-    const host = makeHost({
+    const host = makeChatHost({
       chatQueue: [{ id: "queued", text: "later", createdAt: 1, attachments: [attachment] }],
     });
 
@@ -8946,7 +8764,7 @@ describe("handleAbortChat", () => {
   });
 
   it("preserves the draft for connected toolbar aborts", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.abort": { aborted: true },
       },
@@ -8968,7 +8786,7 @@ describe("handleAbortChat", () => {
   it("aborts the exact selected session when no browser run id exists", async () => {
     const request = vi.fn(async () => ({ abortedRunId: null, status: "aborted" }));
     const sessionKey = "agent:main:openclaw-weixin:direct:wechat-user";
-    const host = makeHost({
+    const host = makeChatHost({
       client: { request } as unknown as ChatHost["client"],
       chatRunId: null,
       chatMessage: "/stop",
@@ -8990,7 +8808,7 @@ describe("handleAbortChat", () => {
 
   it("keeps selected global aborts on the compatible key-only request", async () => {
     const request = vi.fn(async () => ({ abortedRunId: null, status: "aborted" }));
-    const host = makeHost({
+    const host = makeChatHost({
       client: { request } as unknown as ChatHost["client"],
       chatRunId: null,
       chatMessage: "/stop",
@@ -9031,7 +8849,7 @@ describe("handleAbortChat", () => {
   ])("$name", async ({ scope, expected }) => {
     const request = vi.fn(async () => ({ abortedRunId: null, status: "aborted" }));
     const sessionKey = "agent:work:main";
-    const host = makeHost({
+    const host = makeChatHost({
       client: { request } as unknown as ChatHost["client"],
       chatRunId: null,
       sessionKey,
@@ -9049,7 +8867,7 @@ describe("handleAbortChat", () => {
   it.each(["/stop", "stop", "esc", "abort", "wait", "exit"])(
     "clears the typed stop command %s after aborting the active run",
     async (message) => {
-      const host = makeHost({
+      const host = makeChatHost({
         requestHandlers: {
           "chat.abort": { aborted: true },
         },
@@ -9069,7 +8887,7 @@ describe("handleAbortChat", () => {
   );
 
   it("blocks a typed stop before aborting when the operator lacks write scope", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {},
       chatRunId: "run-main",
       chatMessage: "/stop",
@@ -9095,7 +8913,7 @@ describe("handleAbortChat", () => {
   it("queues a typed exact-run stop while disconnected", async () => {
     const request = vi.fn();
     const client = { request } as unknown as NonNullable<ChatHost["client"]>;
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       connected: false,
       chatRunId: "run-main",
@@ -9116,7 +8934,7 @@ describe("handleAbortChat", () => {
 
   it("queues the active run abort while disconnected", async () => {
     const client = { request: vi.fn() } as unknown as NonNullable<ChatHost["client"]>;
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       connected: false,
       chatRunId: "run-main",
@@ -9137,7 +8955,7 @@ describe("handleAbortChat", () => {
 
   it("preserves the draft when queueing a toolbar abort while disconnected", async () => {
     const client = { request: vi.fn() } as unknown as NonNullable<ChatHost["client"]>;
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       connected: false,
       chatRunId: "run-main",
@@ -9160,7 +8978,7 @@ describe("handleAbortChat", () => {
     const request = vi.fn();
     const client = { request } as unknown as NonNullable<ChatHost["client"]>;
     const sessionKey = "agent:main:telegram:direct:queued-user";
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       connected: false,
       chatRunId: null,
@@ -9182,7 +9000,7 @@ describe("handleAbortChat", () => {
   it("does not queue an unversioned global stop while disconnected", async () => {
     const request = vi.fn();
     const client = { request } as unknown as NonNullable<ChatHost["client"]>;
-    const host = makeHost({
+    const host = makeChatHost({
       client,
       connected: false,
       chatRunId: null,
@@ -9212,7 +9030,7 @@ describe("handleAbortChat", () => {
       selected: { hasActiveRun: false, status: "running" as const },
     },
   ])("$name", ({ selected }) => {
-    const host = makeHost({
+    const host = makeChatHost({
       chatRunId: null,
       sessionKey: "agent:main",
       sessionsResult: createSessionsResult([
@@ -9225,7 +9043,7 @@ describe("handleAbortChat", () => {
   });
 
   it("keeps the draft when disconnected without an active run", async () => {
-    const host = makeHost({
+    const host = makeChatHost({
       connected: false,
       chatRunId: null,
       chatMessage: "draft",


### PR DESCRIPTION
## What Problem This Solves

Five of the largest test files repeated dominant arrange objects dozens of times, obscuring the scenario-specific inputs and making fixture-wide updates risky. This refactor gives each scope one domain-named builder with Partial-based overrides, while preserving every test title, assertion, and runtime input.

## Why This Change Was Made

- `run.incomplete-turn.test.ts`: adds `makeLastAssistant`; the canonical `makeAttemptResult` was already present on this base and remains unchanged.
- `talk-realtime-relay.test.ts`: adds `makeRelayTransport` while retaining the one deliberately method-absent fixture and preserving Vitest mock metadata.
- `subagent-registry.test.ts`: keeps the already-landed shared run builders and compresses the remaining killed-run, running-task, completed-collector, and suspended-delivery clusters.
- `cli-runner.reliability.test.ts`: adds builders for run exits, managed runs, Claude prepared contexts, and live Claude backends.
- `chat-send.test.ts`: extracts its existing mature host/request fixture into `chat-host.test-fixture.ts`; adoption is intentionally limited to this test file.

Per-file physical LOC before → after:

- `src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`: 5,375 → 4,957
- `src/gateway/talk-realtime-relay.test.ts`: 4,269 → 4,039
- `src/agents/subagent-registry.test.ts`: 6,655 → 6,592
- `src/agents/cli-runner.reliability.test.ts`: 5,060 → 4,426
- `ui/src/pages/chat/chat-send.test.ts`: 9,240 → 9,058
- `ui/src/pages/chat/chat-host.test-fixture.ts`: 0 → 195

## User Impact

None. This is test-only fixture compression: no production code, behavior, public API, configuration, snapshots, inventories, or generated baselines changed.

## Evidence

Focused Vitest counts are unchanged before → after:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`: 171 → 171 passed
- `node scripts/run-vitest.mjs src/gateway/talk-realtime-relay.test.ts`: 63 → 63 passed
- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts`: 143 → 143 passed
- `node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts`: 83 → 83 passed
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts`: 268 → 268 passed

Checks:

- `pnpm format <six changed paths>`: passed
- `node scripts/run-oxlint.mjs <six changed paths>`: passed
- `git diff --check`: passed
- `pnpm tsgo:ui`: passed
- `pnpm tsgo:core:test`: changed fixture errors cleared; blocked only by three untouched `browser`/`server` global errors in `ui/src/e2e/appearance-settings-defaults.e2e.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings

`node scripts/check-changed.mjs` delegated as required but the provider chain failed before running: Blacksmith doctor failed, Daytona timed out, and Azure rejected the configured image selector with `admin_required`. Its local fallback plan was run constituent-by-constituent; all guards, format, UI i18n, dead-code, dependency, boundary, and UI type lanes passed, with only the unrelated core-test diagnostics noted above.

Production vs test LOC from `git diff origin/main...HEAD --numstat`:

- Production: +0 / -0 (net 0)
- Tests and test fixtures: +1,618 / -2,950 (net -1,332)
