### PR TITLE
fix(cron): preserve tool failures after silent replies

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -29,6 +29,33 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.summary).toContain("Exec failed");
   });
 
+  it.each([
+    ["token", "NO_REPLY"],
+    ["JSON string", '"NO_REPLY"'],
+    ["envelope", '{"action":"NO_REPLY"}'],
+    ["reasoning-prefixed", "<think>internal reasoning</think>\nNO_REPLY"],
+  ])("keeps tool warnings fatal when terminal output is a silent %s", (_label, text) => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "⚠️ 🛠️ Bash failed: mount unavailable", isError: true }],
+      finalAssistantVisibleText: text,
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toContain("Bash failed");
+  });
+
+  it("keeps genuine visible terminal output as recovery proof", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "⚠️ 🛠️ Bash failed: mount unavailable", isError: true }],
+      finalAssistantVisibleText: "Mount restored; report written.",
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.outputText).toBe("Mount restored; report written.");
+  });
+
   it("lets preferred final assistant text recover a plain tool warning", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -293,9 +293,9 @@ export function resolveCronPayloadOutcome(params: {
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
     ?.text?.trim();
   const errorPayloads = params.payloads.filter((payload) => payload?.isError === true);
-  const normalizedFinalAssistantVisibleText = normalizeOptionalString(
-    params.finalAssistantVisibleText,
-  );
+  const finalText = normalizeOptionalString(params.finalAssistantVisibleText);
+  const normalizedFinalAssistantVisibleText =
+    finalText && !isSilentReplyPayloadText(finalText) ? finalText : undefined;
   const hasSuccessfulPayloadAfterLastError =
     !params.runLevelError &&
     lastErrorPayloadIndex >= 0 &&
@@ -310,8 +310,8 @@ export function resolveCronPayloadOutcome(params: {
     normalizedFinalAssistantVisibleText !== undefined ||
     hasSuccessfulPayloadAfterLastError ||
     hasSuccessfulPayloadBeforeLastError;
-  // Some tools emit warning/error payloads before a final answer. Treat those
-  // as non-terminal only when later visible output proves the run recovered.
+  // Only genuinely visible terminal text can recover preceding tool warnings;
+  // silent control replies must leave the error fatal for scheduler alerting.
   const hasNonTerminalToolErrorWarning =
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&
@@ -333,7 +333,7 @@ export function resolveCronPayloadOutcome(params: {
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
     errorPayloads.every((payload) => isCronToolWarning(payload?.text));
-  // Structured error payloads are fatal unless later successful output or a
+  // Structured error payloads stay fatal unless later successful output or a
   // known non-terminal warning proves the agent recovered.
   const hasFatalStructuredErrorPayload =
     hasErrorPayload &&

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -1,5 +1,5 @@
 // Run meta error tests cover status reporting when cron run metadata fails.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
@@ -173,6 +173,9 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
   });
 
   it("keeps explicit silent replies as successful cron completions", async () => {
+    const { resolveCronPayloadOutcome } =
+      await vi.importActual<typeof import("./helpers.js")>("./helpers.js");
+    resolveCronPayloadOutcomeMock.mockImplementation(resolveCronPayloadOutcome);
     mockAgentRun({
       usage: { input: 10, output: 1 },
       meta: {
@@ -180,13 +183,27 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
         finalAssistantVisibleText: "NO_REPLY",
       },
     });
-    mockAnnounceOutcome();
 
     const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
 
     expect(dispatchCronDeliveryMock).toHaveBeenCalled();
     expect(result.status).toBe("ok");
     expect(result.error).toBeUndefined();
+  });
+
+  it("records a real tool error when the terminal assistant reply is silent", async () => {
+    const { resolveCronPayloadOutcome } =
+      await vi.importActual<typeof import("./helpers.js")>("./helpers.js");
+    resolveCronPayloadOutcomeMock.mockImplementation(resolveCronPayloadOutcome);
+    mockAgentRun({
+      payloads: [{ text: "⚠️ 🛠️ Bash failed: mount unavailable", isError: true }],
+      meta: { finalAssistantVisibleText: "NO_REPLY" },
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("Bash failed");
   });
 
   it("keeps committed message-tool deliveries as successful cron completions", async () => {

--- a/src/cron/service.failure-alert-silent-reply.test.ts
+++ b/src/cron/service.failure-alert-silent-reply.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  resetRunCronIsolatedAgentTurnHarness,
+  resolveConfiguredModelRefMock,
+  resolveCronPayloadOutcomeMock,
+  runEmbeddedAgentMock,
+} from "./isolated-agent/run.test-harness.js";
+import { CronService } from "./service.js";
+import { createNoopLogger } from "./service.test-harness.js";
+import { loadCronStore } from "./store.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+type CronServiceParams = ConstructorParameters<typeof CronService>[0];
+type SendCronFailureAlertParams = Parameters<
+  NonNullable<CronServiceParams["sendCronFailureAlert"]>
+>[0];
+
+describe.sequential("CronService silent failure alerts", () => {
+  beforeEach(() => {
+    resetRunCronIsolatedAgentTurnHarness();
+  });
+
+  it("persists a tool failure and emits the configured operator alert", async () => {
+    const { resolveCronPayloadOutcome } = await vi.importActual<
+      typeof import("./isolated-agent/helpers.js")
+    >("./isolated-agent/helpers.js");
+    resolveCronPayloadOutcomeMock.mockImplementation(resolveCronPayloadOutcome);
+    const modelRef = { provider: "openai", model: "gpt-5.4" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "⚠️ 🛠️ Bash failed: mount unavailable", isError: true }],
+      meta: { agentMeta: {}, finalAssistantVisibleText: "NO_REPLY" },
+    });
+
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-cron-silent-failure-" },
+      async (state) => {
+        resetTaskRegistryForTests();
+        const sendCronFailureAlert = vi.fn(
+          async (_params: SendCronFailureAlertParams) => undefined,
+        );
+        const storePath = state.path("cron", "jobs.json");
+        const cron = new CronService({
+          storePath,
+          cronEnabled: true,
+          cronConfig: {
+            triggers: { enabled: true },
+            failureAlert: { enabled: true, after: 1, cooldownMs: 0 },
+          },
+          log: createNoopLogger(),
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          sendCronFailureAlert,
+          runIsolatedAgentJob: async (runParams) =>
+            await runCronIsolatedAgentTurn({
+              ...runParams,
+              cfg: { agents: { defaults: { model: `${modelRef.provider}/${modelRef.model}` } } },
+              deps: {},
+              sessionKey: `cron:${runParams.job.id}`,
+            }),
+        });
+        try {
+          await cron.start();
+          const job = await cron.add({
+            name: "mount check",
+            enabled: true,
+            schedule: { kind: "every", everyMs: 60_000 },
+            sessionTarget: "isolated",
+            wakeMode: "next-heartbeat",
+            payload: {
+              kind: "agentTurn",
+              message: "check mount",
+              model: `${modelRef.provider}/${modelRef.model}`,
+            },
+            delivery: { mode: "none" },
+          });
+
+          await expect(cron.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+
+          const persisted = (await loadCronStore(storePath)).jobs.find(
+            (candidate) => candidate.id === job.id,
+          );
+          expect(persisted?.state.lastRunStatus).toBe("error");
+          expect(persisted?.state.lastError).toContain("Bash failed");
+          expect(persisted?.state.consecutiveErrors).toBe(1);
+          expect(persisted?.state.lastFailureAlertAtMs).toBeDefined();
+          expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+          expect(sendCronFailureAlert.mock.calls[0]?.[0].payload.text).toContain(
+            'Automation "mount check" failed 1 times',
+          );
+        } finally {
+          cron.stop();
+          resetTaskRegistryForTests({ persist: false });
+        }
+      },
+    );
+  });
+});


### PR DESCRIPTION
Closes #116731

## What Problem This Solves

Fixes an issue where cron jobs with a real tool failure could be recorded as successful when the terminal assistant reply was a silent control payload such as `NO_REPLY`. That reset the error streak and prevented the configured failure alert from reaching the operator.

## Why This Change Was Made

The shared `resolveCronPayloadOutcome` classifier now removes terminal text recognized by the existing silent-reply contract before deciding whether a preceding tool warning recovered. Genuine visible terminal output still recovers tool warnings, and pure silent runs without an error remain successful.

This stays inside the classifier owner boundary. It does not change scheduler lifecycle, persistence policy or schema, configuration, provider behavior, WSL detection, or error-text matching.

Production LOC: +6/-6 (net 0) | Tests: +150/-2

## User Impact

Recurring cron tool failures followed only by a silent reply now persist as errors, increment `consecutiveErrors`, and trigger `failureAlert` at the configured threshold. Operators see the existing alert text and retained tool error instead of a false successful run.

Release-note context: cron failure alerts now remain active when a tool error is followed by a silent assistant reply.

## Evidence

- Current-main red on `8578b8f55cf77ddb161891b662a02f8c8c2a80ba`: 6 expected failures reproduced the bug across the classifier, real run finalization, and SQLite-backed CronService path.
- Rewritten-head green: 148 assertions passed across `src/auto-reply/tokens.test.ts` and the three focused cron files.
- Silent forms covered: canonical token, JSON string, action envelope, and reasoning-prefixed token.
- Controls covered: genuine visible recovery remains successful; a pure silent run without an error remains successful.
- CronService proof reads the persisted SQLite-backed store and verifies `lastRunStatus: error`, the original Bash error, `consecutiveErrors: 1`, a failure-alert timestamp, and `Automation "mount check" failed 1 times`.
- Exact-head hosted CI on `c6cb9436241d9b559e76d26fc11b7a5782ab7ff3`: 211 successful checks, 44 skipped, one neutral, zero pending, and zero failures.
- Exact-head Blacksmith Testbox changed gate passed before the conflict-free rebase: `tbx_01m0qmfzsj51qf7ere72176b00` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/32649302144)).
- Real isolated cron proof passed before the conflict-free rebase on `3beafccff71605825974b0d9f0faf415f03fe396`: `tbx_01m0qnzgabxs04m3wqs25g4evn` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/32650655456)).
  - Started the real gateway and CronService with an isolated cron job.
  - The agent performed a real `read` tool call against a missing fixture, received the tool failure, and then emitted terminal `NO_REPLY`.
  - Run history recorded `status: error` and retained the tool-error summary.
  - SQLite-backed state recorded `lastRunStatus: error`, the retained tool error, `consecutiveErrors: 1`, and `lastFailureAlertAtMs`.
  - The configured webhook received `Automation "mount check" failed 1 times` with the retained read failure.
- Rebasing onto current `main` produced head `c6cb9436241d9b559e76d26fc11b7a5782ab7ff3` with no conflicts and the same stable patch ID, `7d7aa5a7fdc1f1b66d4cf04b8ea4d4d048221003`. No commits between the old base and the rebase target touched the changed cron/token surfaces.
- Fresh exact-head max-P1 autoreview: no actionable findings; patch correct with 0.94 confidence.
- `git diff --check` and targeted formatting passed.

Punchcard-Session: brisk-valley-timber-85
