### PR TITLE
fix(sessions): scope transcript byte stats to the active reset window

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -191,6 +191,45 @@ describe("SQLite active transcript event projection", () => {
     expect(afterReset.sizeBytes).toBeLessThan(1_000);
   });
 
+  it("excludes discarded tool results from the retained pre-reset window", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "old", parentId: null, message: { role: "user", content: "old" } },
+        {
+          eventId: "kept-user",
+          parentId: "old",
+          message: { role: "user", content: "kept question" },
+        },
+        {
+          eventId: "kept-tool",
+          parentId: "kept-user",
+          message: { role: "toolResult", content: `hidden tool ${"x".repeat(20_000)}` },
+        },
+        {
+          eventId: "kept-assistant",
+          parentId: "kept-tool",
+          message: { role: "assistant", content: "kept answer" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "kept-assistant",
+      timestamp: "2026-07-22T00:00:00.000Z",
+      reason: "new",
+      firstKeptEntryId: "kept-user",
+    });
+
+    // The reset retains kept-user and kept-assistant only; kept-tool is hidden from the
+    // next turn, so its bytes must not keep the byte fuse latched.
+    expect(readSessionTranscriptMessageEventById(scope, "kept-tool")).toBeUndefined();
+    const stats = readSessionTranscriptActiveStats(scope);
+    expect(stats.eventCount).toBe(2);
+    expect(stats.sizeBytes).toBeLessThan(1_000);
+  });
+
   it("defers mixed legacy and canonical rebuilds off request stacks", async () => {
     await persistSessionTranscriptTurn(scope, {
       messages: [

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -154,6 +154,43 @@ describe("SQLite active transcript event projection", () => {
     });
   });
 
+  it("stops counting pre-reset bytes once /new drops the earlier transcript", async () => {
+    const bulk = "x".repeat(20_000);
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "pre-reset", parentId: null, message: { role: "user", content: bulk } },
+      ],
+      touchSessionEntry: false,
+    });
+
+    const beforeReset = readSessionTranscriptActiveStats(scope);
+    expect(beforeReset.sizeBytes).toBeGreaterThan(20_000);
+
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "pre-reset",
+      timestamp: "2026-07-22T00:00:00.000Z",
+      reason: "new",
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "post-reset",
+          parentId: "reset-boundary",
+          message: { role: "user", content: "fresh start" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+
+    // The dropped turn is still stored, so a whole-projection sum would keep the
+    // byte fuse latched above its threshold forever after /new.
+    const afterReset = readSessionTranscriptActiveStats(scope);
+    expect(afterReset.eventCount).toBe(1);
+    expect(afterReset.sizeBytes).toBeLessThan(1_000);
+  });
+
   it("defers mixed legacy and canonical rebuilds off request stacks", async () => {
     await persistSessionTranscriptTurn(scope, {
       messages: [

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -18,6 +18,7 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import {
   readVisibleMessageRange,
+  readVisibleTranscriptByteStats,
   resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
@@ -265,35 +266,12 @@ export function readRecentSessionTranscriptActiveEvents(
   });
 }
 
-/** Reads active-path event count and JSONL byte size without materializing payloads. */
+/** Reads visible event count and JSONL byte size without materializing payloads. */
 export function readSessionTranscriptActiveStats(scope: SessionTranscriptReadScope): {
   eventCount: number;
   sizeBytes: number;
 } {
-  return withCurrentProjectionSnapshot(scope, (projection) => {
-    const db = getActiveTranscriptKysely(projection.database);
-    const row = executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events as active")
-        .innerJoin("transcript_events as event", (join) =>
-          join
-            .onRef("event.session_id", "=", "active.session_id")
-            .onRef("event.seq", "=", "active.event_seq"),
-        )
-        .select((eb) => [
-          eb.fn.count<number>("active.event_seq").as("event_count"),
-          /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
-          sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
-            + COUNT(*)`.as("size_bytes"),
-        ])
-        .where("active.session_id", "=", projection.resolved.sessionId),
-    );
-    return {
-      eventCount: row?.event_count ?? 0,
-      sizeBytes: row?.size_bytes ?? 0,
-    };
-  });
+  return withCurrentProjectionSnapshot(scope, readVisibleTranscriptByteStats);
 }
 
 /** Reads one append-stable forward page from the materialized active-message projection. */

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -1,4 +1,5 @@
 // Reset boundaries project a logical message window without rewriting raw cursor positions.
+import { sql } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -41,6 +42,10 @@ type ResetMessageWindow = {
   indexedSeq: number;
   keptMessagePositions: number[];
   postBoundaryMessagePosition: number;
+  /** Active position of the reset row; events at or before it are pre-boundary. */
+  boundaryActivePosition: number;
+  /** Start of the retained span before the boundary, when firstKeptEntryId applies. */
+  keptFromActivePosition: number | undefined;
 };
 
 type ResetMessageWindowCacheEntry = {
@@ -166,6 +171,7 @@ function findLatestResetMessageWindow(
         .limit(1),
     )?.message_position ?? projection.state.activeMessageCount;
   let keptMessagePositions: number[] = [];
+  let keptFromActivePosition: number | undefined;
   if (typeof reset.firstKeptEntryId === "string") {
     const firstKept = executeSqliteQueryTakeFirstSync(
       projection.database.db,
@@ -181,6 +187,7 @@ function findLatestResetMessageWindow(
         .where("identity.event_id", "=", reset.firstKeptEntryId),
     );
     if (firstKept && firstKept.active_position < resetRow.active_position) {
+      keptFromActivePosition = firstKept.active_position;
       keptMessagePositions = executeSqliteQuerySync(
         projection.database.db,
         db
@@ -215,6 +222,8 @@ function findLatestResetMessageWindow(
     indexedSeq: projection.state.indexedSeq,
     keptMessagePositions,
     postBoundaryMessagePosition,
+    boundaryActivePosition: resetRow.active_position,
+    keptFromActivePosition,
   };
 }
 
@@ -300,4 +309,56 @@ export function resolveVisibleMessagePositionRange(
     positions.push(visible.postStart + logical - visible.kept.length);
   }
   return positions;
+}
+
+/**
+ * JSONL byte size of the events a model still sees. When the latest boundary is a
+ * reset, pre-boundary events are excluded; otherwise the whole active projection
+ * counts. Without the reset window a `/new` leaves dropped bytes counted forever,
+ * so the byte fuse can never fall back below its threshold.
+ */
+export function readVisibleTranscriptByteStats(projection: ResetWindowProjection): {
+  eventCount: number;
+  sizeBytes: number;
+} {
+  const window = resolveResetMessageWindow(projection);
+  const db = getResetWindowKysely(projection.database);
+  const base = db
+    .selectFrom("session_transcript_active_events as active")
+    .innerJoin("transcript_events as event", (join) =>
+      join
+        .onRef("event.session_id", "=", "active.session_id")
+        .onRef("event.seq", "=", "active.event_seq"),
+    )
+    .select((eb) => [
+      eb.fn.count<number>("active.event_seq").as("event_count"),
+      /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
+      sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
+        + COUNT(*)`.as("size_bytes"),
+    ])
+    .where("active.session_id", "=", projection.resolved.sessionId);
+  const row = executeSqliteQueryTakeFirstSync(
+    projection.database.db,
+    window
+      ? base.where((eb) => {
+          const afterBoundary = eb("active.active_position", ">", window.boundaryActivePosition);
+          const keptFrom = window.keptFromActivePosition;
+          if (keptFrom === undefined) {
+            return afterBoundary;
+          }
+          // Retained pre-boundary span stays visible, so its bytes still count.
+          return eb.or([
+            afterBoundary,
+            eb.and([
+              eb("active.active_position", ">=", keptFrom),
+              eb("active.active_position", "<", window.boundaryActivePosition),
+            ]),
+          ]);
+        })
+      : base,
+  );
+  return {
+    eventCount: row?.event_count ?? 0,
+    sizeBytes: row?.size_bytes ?? 0,
+  };
 }

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -44,8 +44,6 @@ type ResetMessageWindow = {
   postBoundaryMessagePosition: number;
   /** Active position of the reset row; events at or before it are pre-boundary. */
   boundaryActivePosition: number;
-  /** Start of the retained span before the boundary, when firstKeptEntryId applies. */
-  keptFromActivePosition: number | undefined;
 };
 
 type ResetMessageWindowCacheEntry = {
@@ -171,7 +169,6 @@ function findLatestResetMessageWindow(
         .limit(1),
     )?.message_position ?? projection.state.activeMessageCount;
   let keptMessagePositions: number[] = [];
-  let keptFromActivePosition: number | undefined;
   if (typeof reset.firstKeptEntryId === "string") {
     const firstKept = executeSqliteQueryTakeFirstSync(
       projection.database.db,
@@ -187,7 +184,6 @@ function findLatestResetMessageWindow(
         .where("identity.event_id", "=", reset.firstKeptEntryId),
     );
     if (firstKept && firstKept.active_position < resetRow.active_position) {
-      keptFromActivePosition = firstKept.active_position;
       keptMessagePositions = executeSqliteQuerySync(
         projection.database.db,
         db
@@ -223,7 +219,6 @@ function findLatestResetMessageWindow(
     keptMessagePositions,
     postBoundaryMessagePosition,
     boundaryActivePosition: resetRow.active_position,
-    keptFromActivePosition,
   };
 }
 
@@ -342,16 +337,18 @@ export function readVisibleTranscriptByteStats(projection: ResetWindowProjection
     window
       ? base.where((eb) => {
           const afterBoundary = eb("active.active_position", ">", window.boundaryActivePosition);
-          const keptFrom = window.keptFromActivePosition;
-          if (keptFrom === undefined) {
+          const keptMessagePositions = window.keptMessagePositions;
+          if (keptMessagePositions.length === 0) {
             return afterBoundary;
           }
-          // Retained pre-boundary span stays visible, so its bytes still count.
+          // A reset retains only the user/assistant messages named by the window, so
+          // count those exact rows rather than the whole pre-boundary span. Including
+          // the span would keep discarded tool results on the byte fuse after `/new`.
           return eb.or([
             afterBoundary,
             eb.and([
-              eb("active.active_position", ">=", keptFrom),
               eb("active.active_position", "<", window.boundaryActivePosition),
+              eb("active.message_position", "in", keptMessagePositions),
             ]),
           ]);
         })


### PR DESCRIPTION
## What Problem This Solves

Fixes #119984.

After `/new`, a fresh session can fail on every single turn with:

```text
Context is too large and auto-compaction could not recover this turn. Try again, use /compact, or use /new to start a fresh session.
```

The advice in that message is the thing that does not work. `/new` is exactly what the user already did.

The cause is that `/new` does not shrink what the byte fuse measures. A reset writes a boundary event into the transcript, but it does not delete the events before it; the projection keeps them and readers are expected to apply the reset window at read time. That is how the message readers behave: `resolveVisibleMessagePositions` and `readVisibleMessageRange` in `src/config/sessions/session-accessor.sqlite-reset-window.ts` both honor the latest reset boundary.

`readSessionTranscriptActiveStats` was the one reader that skipped that step. It summed `LENGTH(event_json)` over every row in the active projection with no boundary filter, so the bytes dropped by `/new` kept counting. Everything downstream inherits that number: it is the only source of `snapshot.byteSize`, which becomes `transcriptByteSize`, which drives both `shouldCompactByTranscriptBytes` and the force flush check in `src/auto-reply/reply/agent-runner-memory.ts`. Once the total sits above `maxActiveTranscriptBytes` it stays there, so preflight compaction fires on a session that has nothing left to compact, fails, and prints the message above. Next turn, same thing.

## Why This Change Was Made

The fix belongs in the reader, not in the fuse. The fuse is asking a reasonable question, "how many bytes is this session carrying," and it was being handed the wrong answer. Guarding at the call site would have left the same wrong number available to the force flush path next to it.

Rather than add a second boundary-aware reader, I moved the aggregate into `session-accessor.sqlite-reset-window.ts`, which already owns boundary discovery and already caches the resolved window per generation. The consumer in `session-accessor.sqlite-active-events.ts` collapses to a single delegation and its duplicate copy of the query is deleted, so there is one byte-stats path instead of two.

The retained pre-boundary span is counted using the window's own `keptMessagePositions` rather than a contiguous active-position range. That matters because a reset retains only the user and assistant messages named by the window; an intervening `toolResult` is dropped from the next turn. Counting the whole span would have kept discarded tool-result bytes on the fuse, which is the exact latch this PR is trying to remove. Thanks to ClawSweeper for catching that on the first revision.

Scope is narrow by construction. Boundary discovery returns no window unless the latest boundary is a `reset`, so sessions with no reset, and sessions whose latest boundary is a `compaction`, sum the whole projection exactly as before. This only changes the case the issue is about.

I did not touch the projection writer. Keeping dropped events on disk and windowing at read time is the existing design, the message readers depend on it, and changing it would be a much larger change than this bug needs.

## User Impact

`/new` now actually clears the byte fuse. A fresh session starts from the bytes it really carries instead of inheriting the ones the reset dropped, so the "Context is too large" loop ends and the advice in that error message works.

No config, schema, or default surface changes. `readSessionTranscriptActiveStats` keeps its name, signature, and return shape.

## Evidence

Two regression tests in `src/config/sessions/session-accessor.sqlite-active-events.test.ts`:

1. a large turn, a `reset` with no retained history, then a short turn, asserting the reader reports one visible event and drops back under a kilobyte;
2. a reset carrying `firstKeptEntryId` with a 20 KB `toolResult` sitting between the retained user and assistant messages, asserting the reader reports two events and stays under a kilobyte. The test also asserts `readSessionTranscriptMessageEventById(scope, "kept-tool")` is `undefined`, so the fixture is pinned to the same visibility rule the message readers use.

Both were confirmed to pin the fix by breaking the code and rerunning against the final shape:

```
× stops counting pre-reset bytes once /new drops the earlier transcript
AssertionError: expected 3 to be 1

× excludes discarded tool results from the retained pre-reset window
AssertionError: expected 4 to be 2
```

then restored for 13/13.

Surrounding surfaces stay green on current `main`: `src/config/sessions` 57 files / 771 tests, and the fuse owner `src/auto-reply/reply/agent-runner-memory` 2 files / 67 tests. `tsgo -p tsconfig.core.json` and `tsgo -p test/tsconfig/tsconfig.core.test.json` are both clean, oxlint is clean on the changed files, and `git diff --check` is clean.

One gap stated plainly rather than buried: I proved this at the reader and through the suites above, not by driving a live provider into the compaction loop and watching a post-`/new` turn succeed. The reader is the single source of every byte number both fuses use, which is why I am confident in the mechanism, but I have not produced a runtime session trace. If that trace is required before merge, say so and I will set up a gateway and capture it rather than guess at what it would show.

AI-assisted: written with AI assistance. I read the reset-window module, the active-events reader, and the fuse call sites myself, traced every consumer of the byte number, and ran the tests and gates locally.
