### PR TITLE
refactor(test): replace logic-bearing vi.mock factories with real modules and boundary fakes

### DIFF
--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -1,3 +1,7 @@
+import type {
+  ChatCommandDefinition,
+  NativeCommandSpec,
+} from "openclaw/plugin-sdk/command-auth-native";
 // Slack tests cover slash plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -6,10 +10,6 @@ import {
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSlackSlashMocks, resetSlackSlashMocks } from "./slash.test-harness.js";
-
-const slashCommandMenuMocks = vi.hoisted(() => ({
-  resolveCommandArgMenu: vi.fn(),
-}));
 
 vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/agent-runtime")>(
@@ -21,298 +21,127 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
   };
 });
 
-vi.mock("./slash-commands.runtime.js", () => {
-  const loginCommand = { key: "login", nativeName: "login" };
-  const usageCommand = { key: "usage", nativeName: "usage" };
-  const reportCommand = { key: "report", nativeName: "report" };
-  const reportCompactCommand = { key: "reportcompact", nativeName: "reportcompact" };
-  const reportExternalCommand = { key: "reportexternal", nativeName: "reportexternal" };
-  const reportLongCommand = { key: "reportlong", nativeName: "reportlong" };
-  const reportLongButtonCommand = { key: "reportlongbutton", nativeName: "reportlongbutton" };
-  const reportHugeButtonCommand = { key: "reporthugebutton", nativeName: "reporthugebutton" };
-  const reportHugeValueCommand = { key: "reporthugevalue", nativeName: "reporthugevalue" };
-  const unsafeConfirmCommand = { key: "unsafeconfirm", nativeName: "unsafeconfirm" };
-  const longConfirmCommand = { key: "longconfirm", nativeName: "longconfirm" };
-  const statusAliasCommand = { key: "status", nativeName: "status" };
-  const thinkCommand = {
-    key: "think",
-    nativeName: "think",
+type StaticCommandChoice = string | { value: string; label: string };
+
+const slashCommandFixtures = vi.hoisted(() => {
+  const defineMenuCommand = (params: {
+    name: string;
+    choices: StaticCommandChoice[];
+    argName?: string;
+  }): ChatCommandDefinition => ({
+    key: params.name,
+    nativeName: params.name,
+    description: `Slack ${params.name} test command`,
+    textAliases: [],
+    acceptsArgs: true,
+    argsParsing: "positional",
     argsMenu: "auto",
     args: [
       {
-        name: "level",
-        description: "Thinking level",
+        name: params.argName ?? "period",
+        description: params.argName ?? "period",
         type: "string",
-        choices: () => ["max"],
+        choices: params.choices,
       },
     ],
-  };
-  const periodArg = { name: "period", description: "period" };
-  const baseReportPeriodChoices = [
-    { value: "day", label: "day" },
-    { value: "week", label: "week" },
-    { value: "month", label: "month" },
-    { value: "quarter", label: "quarter" },
+    scope: "native",
+  });
+  const commands: ChatCommandDefinition[] = [
+    {
+      key: "login",
+      nativeName: "login",
+      description: "Login",
+      textAliases: [],
+      acceptsArgs: true,
+      argsParsing: "none",
+      scope: "native",
+    },
+    defineMenuCommand({
+      name: "reportlong",
+      choices: ["day", "week", "month", "quarter", "year", "x".repeat(100)],
+    }),
+    defineMenuCommand({
+      name: "reportlongbutton",
+      choices: [{ value: "x".repeat(170), label: "Long button label ".repeat(8) }],
+    }),
+    defineMenuCommand({
+      name: "reporthugebutton",
+      choices: Array.from({ length: 250 }, (_value, index) => ({
+        value: `${String(index + 1)}-${"x".repeat(170)}`,
+        label: `Long button label ${index + 1}`,
+      })),
+    }),
+    defineMenuCommand({
+      name: "reporthugevalue",
+      choices: [
+        { value: "valid", label: "Valid" },
+        { value: "x".repeat(2500), label: "Overlong" },
+      ],
+    }),
+    defineMenuCommand({
+      name: "reportexternal",
+      choices: [
+        ...Array.from({ length: 140 }, (_value, index) => ({
+          value: `period-${index + 1}`,
+          label: `Period ${index + 1}`,
+        })),
+        // The emoji straddles Slack's 75-character plain-text limit.
+        { value: "emoji-overflow", label: `${"a".repeat(74)}😀 emojioverflow` },
+      ],
+    }),
+    defineMenuCommand({
+      name: "unsafeconfirm",
+      argName: "mode_*`~<&>",
+      choices: ["on", "off"],
+    }),
+    defineMenuCommand({
+      name: "longconfirm",
+      argName: `mode_${"x".repeat(320)}`,
+      choices: ["on", "off"],
+    }),
   ];
-  const fullReportPeriodChoices = [...baseReportPeriodChoices, { value: "year", label: "year" }];
-  const hasNonEmptyArgValue = (values: unknown, key: string) => {
-    const raw =
-      typeof values === "object" && values !== null
-        ? (values as Record<string, unknown>)[key]
-        : undefined;
-    return typeof raw === "string" && raw.trim().length > 0;
-  };
-  const resolvePeriodMenu = (
-    params: { args?: { values?: unknown } },
-    choices: Array<{
-      value: string;
-      label: string;
-    }>,
-  ) => {
-    if (hasNonEmptyArgValue(params.args?.values, "period")) {
-      return null;
-    }
-    return { arg: periodArg, choices };
-  };
-
+  const specs = commands.map(
+    (command): NativeCommandSpec => ({
+      name: command.nativeName!,
+      description: command.description,
+      acceptsArgs: true,
+      args: command.args,
+    }),
+  );
   return {
-    buildCommandTextFromArgs: (
-      cmd: { nativeName?: string; key: string },
-      args?: { values?: Record<string, unknown> },
-    ) => {
-      const name = cmd.nativeName ?? cmd.key;
-      const values = args?.values ?? {};
-      const mode = values.mode;
-      const period = values.period;
-      const selected =
-        typeof mode === "string" && mode.trim()
-          ? mode.trim()
-          : typeof period === "string" && period.trim()
-            ? period.trim()
-            : "";
-      return selected ? `/${name} ${selected}` : `/${name}`;
-    },
-    findCommandByNativeName: (name: string) => {
-      const normalized = name.trim().toLowerCase();
-      if (normalized === "login") {
-        return loginCommand;
-      }
-      if (normalized === "usage") {
-        return usageCommand;
-      }
-      if (normalized === "report") {
-        return reportCommand;
-      }
-      if (normalized === "reportcompact") {
-        return reportCompactCommand;
-      }
-      if (normalized === "reportexternal") {
-        return reportExternalCommand;
-      }
-      if (normalized === "reportlong") {
-        return reportLongCommand;
-      }
-      if (normalized === "reportlongbutton") {
-        return reportLongButtonCommand;
-      }
-      if (normalized === "reporthugebutton") {
-        return reportHugeButtonCommand;
-      }
-      if (normalized === "reporthugevalue") {
-        return reportHugeValueCommand;
-      }
-      if (normalized === "unsafeconfirm") {
-        return unsafeConfirmCommand;
-      }
-      if (normalized === "longconfirm") {
-        return longConfirmCommand;
-      }
-      if (normalized === "agentstatus") {
-        return statusAliasCommand;
-      }
-      if (normalized === "think") {
-        return thinkCommand;
-      }
-      return undefined;
-    },
-    listNativeCommandSpecsForConfig: () => [
-      {
-        name: "login",
-        description: "Login",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "usage",
-        description: "Usage",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "report",
-        description: "Report",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "reportcompact",
-        description: "ReportCompact",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "reportexternal",
-        description: "ReportExternal",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "reportlong",
-        description: "ReportLong",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "reportlongbutton",
-        description: "ReportLongButton",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "reporthugebutton",
-        description: "ReportHugeButton",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "reporthugevalue",
-        description: "ReportHugeValue",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "unsafeconfirm",
-        description: "UnsafeConfirm",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "longconfirm",
-        description: "LongConfirm",
-        acceptsArgs: true,
-        args: [],
-      },
-      {
-        name: "agentstatus",
-        description: "Status",
-        acceptsArgs: false,
-        args: [],
-      },
-      {
-        name: "think",
-        description: "Thinking",
-        acceptsArgs: true,
-        args: thinkCommand.args,
-      },
+    commandsByName: new Map(commands.map((command) => [command.nativeName!, command])),
+    specs: [
+      ...specs,
+      { name: "agentstatus", description: "Status", acceptsArgs: false },
+    ] satisfies NativeCommandSpec[],
+  };
+});
+
+vi.mock("./slash-commands.runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("./slash-commands.runtime.js")>(
+    "./slash-commands.runtime.js",
+  );
+  return {
+    ...actual,
+    findCommandByNativeName: (
+      ...args: Parameters<typeof actual.findCommandByNativeName>
+    ): ReturnType<typeof actual.findCommandByNativeName> =>
+      slashCommandFixtures.commandsByName.get(args[0]) ??
+      (args[0] === "agentstatus"
+        ? actual.findCommandByNativeName("status", undefined, args[2])
+        : undefined) ??
+      // Plugin discovery can recursively load Slack while this test is importing
+      // its monitor. The built-in command definitions are the behavior under test.
+      actual.findCommandByNativeName(args[0], undefined, args[2]),
+    listNativeCommandSpecsForConfig: (
+      ...args: Parameters<typeof actual.listNativeCommandSpecsForConfig>
+    ): ReturnType<typeof actual.listNativeCommandSpecsForConfig> => [
+      ...actual.listNativeCommandSpecsForConfig(args[0], {
+        ...args[1],
+        provider: undefined,
+      }),
+      ...slashCommandFixtures.specs,
     ],
-    parseCommandArgs: () => ({ values: {} }),
-    resolveCommandArgMenu: (params: {
-      command?: { key?: string };
-      args?: { values?: unknown };
-      agentRuntime?: string;
-    }) => {
-      slashCommandMenuMocks.resolveCommandArgMenu(params);
-      if (params.command?.key === "think") {
-        return {
-          arg: thinkCommand.args[0]!,
-          choices: [{ value: "max", label: "max" }],
-        };
-      }
-      if (params.command?.key === "report") {
-        return resolvePeriodMenu(params, [
-          ...fullReportPeriodChoices,
-          { value: "all", label: "all" },
-        ]);
-      }
-      if (params.command?.key === "reportlong") {
-        return resolvePeriodMenu(params, [
-          ...fullReportPeriodChoices,
-          { value: "x".repeat(100), label: "long" },
-        ]);
-      }
-      if (params.command?.key === "reportlongbutton") {
-        return resolvePeriodMenu(params, [
-          {
-            value: "x".repeat(170),
-            label: "Long button label ".repeat(8),
-          },
-        ]);
-      }
-      if (params.command?.key === "reporthugebutton") {
-        return resolvePeriodMenu(
-          params,
-          Array.from({ length: 250 }, (_v, i) => ({
-            value: `${String(i + 1)}-${"x".repeat(170)}`,
-            label: `Long button label ${i + 1}`,
-          })),
-        );
-      }
-      if (params.command?.key === "reporthugevalue") {
-        return resolvePeriodMenu(params, [
-          { value: "valid", label: "Valid" },
-          { value: "x".repeat(2500), label: "Overlong" },
-        ]);
-      }
-      if (params.command?.key === "reportcompact") {
-        return resolvePeriodMenu(params, baseReportPeriodChoices);
-      }
-      if (params.command?.key === "reportexternal") {
-        return {
-          arg: { name: "period", description: "period" },
-          choices: [
-            ...Array.from({ length: 140 }, (_v, i) => ({
-              value: `period-${i + 1}`,
-              label: `Period ${i + 1}`,
-            })),
-            // Label whose emoji surrogate pair straddles the 75-char plain_text
-            // limit, to cover surrogate-safe truncation in served options.
-            { value: "emoji-overflow", label: `${"a".repeat(74)}😀 emojioverflow` },
-          ],
-        };
-      }
-      if (params.command?.key === "unsafeconfirm") {
-        return {
-          arg: { name: "mode_*`~<&>", description: "mode" },
-          choices: [
-            { value: "on", label: "on" },
-            { value: "off", label: "off" },
-          ],
-        };
-      }
-      if (params.command?.key === "longconfirm") {
-        return {
-          arg: { name: `mode_${"x".repeat(320)}`, description: "mode" },
-          choices: [
-            { value: "on", label: "on" },
-            { value: "off", label: "off" },
-          ],
-        };
-      }
-      if (params.command?.key !== "usage") {
-        return null;
-      }
-      const values = (params.args?.values ?? {}) as Record<string, unknown>;
-      if (typeof values.mode === "string" && values.mode.trim()) {
-        return null;
-      }
-      return {
-        arg: { name: "mode", description: "mode" },
-        choices: [
-          { value: "tokens", label: "tokens" },
-          { value: "cost", label: "cost" },
-        ],
-      };
-    },
   };
 });
 
@@ -329,7 +158,6 @@ const { dispatchMock } = getSlackSlashMocks();
 beforeEach(() => {
   clearRuntimeConfigSnapshot();
   resetSlackSlashMocks();
-  slashCommandMenuMocks.resolveCommandArgMenu.mockClear();
 });
 
 afterEach(() => {
@@ -530,6 +358,28 @@ async function getFirstActionElementFromCommand(handler: (args: unknown) => Prom
   return element;
 }
 
+async function getCommandArgMenuValues(handler: (args: unknown) => Promise<void>) {
+  const { respond } = await runCommandHandler(handler);
+  const payload = firstCallPayload(respond, "response") as {
+    blocks?: Array<{
+      type: string;
+      elements?: Array<{ value?: string; options?: Array<{ value?: string }> }>;
+    }>;
+  };
+  const encodedValues = (payload.blocks ?? [])
+    .filter((block) => block.type === "actions")
+    .flatMap((block) =>
+      (block.elements ?? []).flatMap((element) => [
+        ...(element.value ? [element.value] : []),
+        ...(element.options ?? []).flatMap((option) => (option.value ? [option.value] : [])),
+      ]),
+    );
+  return encodedValues.flatMap((value) => {
+    const encodedChoice = value.split("|")[3];
+    return encodedChoice ? [decodeURIComponent(encodedChoice)] : [];
+  });
+}
+
 async function runArgMenuAction(
   handler: (args: unknown) => Promise<void>,
   params: {
@@ -626,9 +476,9 @@ function mockSixDispatchedReplies() {
 describe("Slack native command argument menus", () => {
   let harness: ReturnType<typeof createArgMenusHarness>;
   let loginHandler: (args: unknown) => Promise<void>;
+  let toolsHandler: (args: unknown) => Promise<void>;
+  let ttsHandler: (args: unknown) => Promise<void>;
   let usageHandler: (args: unknown) => Promise<void>;
-  let reportHandler: (args: unknown) => Promise<void>;
-  let reportCompactHandler: (args: unknown) => Promise<void>;
   let reportExternalHandler: (args: unknown) => Promise<void>;
   let reportLongHandler: (args: unknown) => Promise<void>;
   let reportLongButtonHandler: (args: unknown) => Promise<void>;
@@ -644,9 +494,9 @@ describe("Slack native command argument menus", () => {
     harness = createArgMenusHarness();
     await registerCommands(harness.ctx, harness.account);
     loginHandler = requireHandler(harness.commands, "/login", "/login");
+    toolsHandler = requireHandler(harness.commands, "/tools", "/tools");
+    ttsHandler = requireHandler(harness.commands, "/tts", "/tts");
     usageHandler = requireHandler(harness.commands, "/usage", "/usage");
-    reportHandler = requireHandler(harness.commands, "/report", "/report");
-    reportCompactHandler = requireHandler(harness.commands, "/reportcompact", "/reportcompact");
     reportExternalHandler = requireHandler(harness.commands, "/reportexternal", "/reportexternal");
     reportLongHandler = requireHandler(harness.commands, "/reportlong", "/reportlong");
     reportLongButtonHandler = requireHandler(
@@ -881,9 +731,12 @@ describe("Slack native command argument menus", () => {
     expect(testHarness.optionsReceiverContexts[0]).toBe(testHarness.app);
   });
 
-  it.each(["codex", "openclaw"] as const)(
-    "passes the configured %s runtime to dynamic /think choices",
-    async (agentRuntime) => {
+  it.each([
+    { agentRuntime: "codex", includesUltra: false },
+    { agentRuntime: "openclaw", includesUltra: true },
+  ] as const)(
+    "renders runtime-specific /think choices for $agentRuntime",
+    async ({ agentRuntime, includesUltra }) => {
       const testHarness = createArgMenusHarness({
         commands: { native: true, nativeSkills: false },
         agents: {
@@ -898,12 +751,10 @@ describe("Slack native command argument menus", () => {
       await registerCommands(testHarness.ctx, testHarness.account);
       const handler = requireHandler(testHarness.commands, "/think", "/think");
 
-      await runCommandHandler(handler);
+      const values = await getCommandArgMenuValues(handler);
 
-      const menuCall = slashCommandMenuMocks.resolveCommandArgMenu.mock.calls.find(
-        ([params]) => (params as { command?: { key?: string } }).command?.key === "think",
-      )?.[0] as { agentRuntime?: string } | undefined;
-      expect(menuCall?.agentRuntime).toBe(agentRuntime);
+      expect(values.length).toBeGreaterThan(0);
+      expect(values.includes("ultra")).toBe(includesUltra);
     },
   );
 
@@ -950,7 +801,7 @@ describe("Slack native command argument menus", () => {
   });
 
   it("shows a button menu when required args are omitted", async () => {
-    const { respond } = await runCommandHandler(usageHandler);
+    const { respond } = await runCommandHandler(toolsHandler);
     const actions = expectArgMenuLayout(respond);
     const elementType = actions?.elements?.[0]?.type;
     expect(elementType).toBe("button");
@@ -960,7 +811,7 @@ describe("Slack native command argument menus", () => {
   });
 
   it("shows a static_select menu when choices exceed button row size", async () => {
-    const { respond } = await runCommandHandler(reportHandler);
+    const { respond } = await runCommandHandler(ttsHandler);
     const actions = expectArgMenuLayout(respond);
     const element = actions?.elements?.[0];
     expect(element?.type).toBe("static_select");
@@ -1024,7 +875,7 @@ describe("Slack native command argument menus", () => {
   });
 
   it("shows an overflow menu when choices fit compact range", async () => {
-    const element = await getFirstActionElementFromCommand(reportCompactHandler);
+    const element = await getFirstActionElementFromCommand(usageHandler);
     expect(element?.type).toBe("overflow");
     expect(element?.action_id).toBe("openclaw_cmdarg");
     expect(element).toHaveProperty("confirm");
@@ -1052,13 +903,13 @@ describe("Slack native command argument menus", () => {
   it("dispatches the command when a menu button is clicked", async () => {
     await runArgMenuAction(argMenuHandler, {
       action: {
-        value: encodeValue({ command: "usage", arg: "mode", value: "tokens", userId: "U1" }),
+        value: encodeValue({ command: "tools", arg: "mode", value: "compact", userId: "U1" }),
       },
     });
 
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     const call = firstDispatchArg() as { ctx?: { Body?: string } };
-    expect(call.ctx?.Body).toBe("/usage tokens");
+    expect(call.ctx?.Body).toBe("/tools compact");
   });
 
   it("does not apply the response_url call cap to Web API action replies", async () => {
@@ -1152,12 +1003,12 @@ describe("Slack native command argument menus", () => {
     await runArgMenuAction(argMenuHandler, {
       action: {
         selected_option: {
-          value: encodeValue({ command: "report", arg: "period", value: "month", userId: "U1" }),
+          value: encodeValue({ command: "tts", arg: "action", value: "status", userId: "U1" }),
         },
       },
     });
 
-    expectSingleDispatchedSlashBody("/report month");
+    expectSingleDispatchedSlashBody("/tts status");
   });
 
   it("dispatches the command when an overflow option is chosen", async () => {
@@ -1165,16 +1016,16 @@ describe("Slack native command argument menus", () => {
       action: {
         selected_option: {
           value: encodeValue({
-            command: "reportcompact",
-            arg: "period",
-            value: "quarter",
+            command: "usage",
+            arg: "mode",
+            value: "cost",
             userId: "U1",
           }),
         },
       },
     });
 
-    expectSingleDispatchedSlashBody("/reportcompact quarter");
+    expectSingleDispatchedSlashBody("/usage cost");
   });
 
   it("shows an external_select menu when choices exceed static_select options max", async () => {

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -369,10 +369,15 @@ async function getCommandArgMenuValues(handler: (args: unknown) => Promise<void>
   const encodedValues = (payload.blocks ?? [])
     .filter((block) => block.type === "actions")
     .flatMap((block) =>
-      (block.elements ?? []).flatMap((element) => [
-        ...(element.value ? [element.value] : []),
-        ...(element.options ?? []).flatMap((option) => (option.value ? [option.value] : [])),
-      ]),
+      (block.elements ?? []).flatMap((element) => {
+        const values = (element.options ?? []).flatMap((option) =>
+          option.value ? [option.value] : [],
+        );
+        if (element.value) {
+          values.unshift(element.value);
+        }
+        return values;
+      }),
     );
   return encodedValues.flatMap((value) => {
     const encodedChoice = value.split("|")[3];

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -16,80 +16,6 @@ vi.mock("../plugins/provider-hook-runtime.js", () => ({
   wrapProviderStreamFn: (params: { context: { streamFn?: StreamFn } }) => params.context.streamFn,
 }));
 
-vi.mock("./codex-native-web-search.js", () => ({
-  patchCodexNativeWebSearchPayload: (params: {
-    payload: unknown;
-    config?: {
-      tools?: {
-        web?: {
-          search?: {
-            openaiCodex?: {
-              mode?: string;
-              allowedDomains?: string[];
-            };
-          };
-        };
-      };
-    };
-  }) => {
-    if (!params.payload || typeof params.payload !== "object") {
-      return { status: "payload_not_object" };
-    }
-    const payload = params.payload as { tools?: Array<Record<string, unknown>> };
-    if (payload.tools?.some((tool) => tool.type === "web_search")) {
-      return { status: "native_tool_already_present" };
-    }
-    const nativeConfig = params.config?.tools?.web?.search?.openaiCodex;
-    payload.tools = [
-      ...(payload.tools ?? []),
-      {
-        type: "web_search",
-        external_web_access: nativeConfig?.mode === "live",
-        ...(nativeConfig?.allowedDomains
-          ? { filters: { allowed_domains: nativeConfig.allowedDomains } }
-          : {}),
-      },
-    ];
-    return { status: "injected" };
-  },
-  resolveCodexNativeSearchActivation: (params: {
-    config?: {
-      auth?: { profiles?: Record<string, { provider?: string }> };
-      tools?: {
-        web?: {
-          search?: {
-            enabled?: boolean;
-            openaiCodex?: { enabled?: boolean; mode?: string };
-          };
-        };
-      };
-    };
-    modelProvider?: string;
-    modelApi?: string;
-  }) => {
-    const search = params.config?.tools?.web?.search;
-    const codex = search?.openaiCodex;
-    const nativeEligible =
-      params.modelProvider === "openai" || params.modelApi === "openai-chatgpt-responses";
-    const hasRequiredAuth =
-      params.modelProvider !== "openai" ||
-      Object.values(params.config?.auth?.profiles ?? {}).some(
-        (profile) => profile.provider === "openai",
-      );
-    const active =
-      search?.enabled !== false && codex?.enabled === true && nativeEligible && hasRequiredAuth;
-    return {
-      globalWebSearchEnabled: search?.enabled !== false,
-      codexNativeEnabled: codex?.enabled === true,
-      codexMode: codex?.mode === "live" ? "live" : "cached",
-      nativeEligible,
-      hasRequiredAuth,
-      state: active ? "native_active" : "managed_only",
-      ...(active ? {} : { inactiveReason: "test_inactive" }),
-    };
-  },
-}));
-
 const ANTHROPIC_DEFAULT_BETAS = [
   "fine-grained-tool-streaming-2025-05-14",
   "interleaved-thinking-2025-05-14",
@@ -2406,9 +2332,17 @@ describe("applyExtraParamsToAgent", () => {
 
   it("does not inject duplicate native Codex web_search tools", () => {
     const payload = runResponsesPayloadMutationCase({
-      applyProvider: "gateway",
+      applyProvider: "openai",
       applyModelId: "gpt-5.4",
       cfg: {
+        auth: {
+          profiles: {
+            "openai:default": {
+              provider: "openai",
+              mode: "oauth",
+            },
+          },
+        },
         tools: {
           web: {
             search: {
@@ -2423,7 +2357,7 @@ describe("applyExtraParamsToAgent", () => {
       },
       model: {
         api: "openai-chatgpt-responses",
-        provider: "gateway",
+        provider: "openai",
         id: "gpt-5.4",
       } as Model<"openai-chatgpt-responses">,
       payload: { tools: [{ type: "web_search" }] },


### PR DESCRIPTION
## What Problem This Solves

Two test suites carried logic-bearing module factories that either copied production policy or let assertions pass without reaching the real implementation. The embedded-agent suite duplicated Codex native-search activation and payload injection, while the Slack slash suite duplicated command lookup, parsing, formatting, menu eligibility, and choice resolution.

## Why This Change Was Made

The embedded-agent suite now uses the real Codex native-search module. Its duplicate-tool case was also corrected to route through the real OpenAI wrapper with a valid OAuth profile; the previous gateway route bypassed the behavior under test.

The Slack slash suite now imports the real command runtime and keeps only a narrow, data-only adapter for synthetic Slack-limit cases that no production command can express. Real built-ins cover login, tools, TTS, usage, think, and status behavior. The former internal mock-call assertion for dynamic think choices is now an observable assertion over encoded Block Kit menu values.

Per-file results:

- `src/agents/embedded-agent-runner-extraparams.test.ts`: 139 -> 139 tests. Boundary: provider stream request/payload handoff. Deleted tests/assertions: none.
- `extensions/slack/src/monitor/slash.test.ts`: 56 -> 56 tests. Boundaries: Bolt/Slack response transport, model catalog loading, and plugin command discovery. Deleted tests: none. Deleted assertion: the `resolveCommandArgMenu` mock-call inspection, replaced by observable runtime-specific menu values.

Three requested files were intentionally not changed:

- Browser hot-reload: premise mismatch. The current file already imports the real refresh/lifecycle modules and contains only narrow config-source, process, MCP, and Playwright boundary fakes; the claimed 567-line logic factory is not present.
- Doctor config flow: skipped after two honest attempts. The real preflight/plugin path exceeded 180 seconds for the full file and a single-test probe hit the bounded 300-second no-output limit while compiling/discovering plugins. The attempted rewrite was reverted cleanly.
- Slack dispatch preview fallback: skipped after two honest attempts. The full real-kernel attempt took 225 seconds and failed broadly; after correcting the missing real reply-payload exports, a single ordinary preview test still timed out. The attempted rewrite was reverted cleanly.

## User Impact

No production behavior changes. The retained tests now cover production Codex search and Slack command/menu behavior instead of local reimplementations, while preserving all successful test cases.

## Evidence

Passed:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner-extraparams.test.ts` — 139 passed
- `node scripts/run-vitest.mjs src/agents/codex-native-web-search.test.ts` — 21 passed
- `node scripts/run-vitest.mjs src/llm/providers/stream-wrappers/openai.test.ts` — 32 passed
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/slash.test.ts` — 56 passed
- `node scripts/run-vitest.mjs src/auto-reply/commands-registry.test.ts` — 37 passed
- `node scripts/run-vitest.mjs src/agents/thinking-runtime.test.ts` — 12 passed
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/external-arg-menu-store.test.ts` — 4 passed
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner-extraparams.test.ts extensions/slack/src/monitor/slash.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings

Changed-gate note: `node scripts/check-changed.mjs` could not acquire any remote provider. The trusted local fallback passed all guards, formatting, and lint before core-test typechecking stopped on pre-existing Control UI E2E errors in `ui/src/e2e/appearance-settings-defaults.e2e.test.ts` (`browser`/`server` are undefined). The independent extension-test typecheck passed.

Production LOC delta: +0 / -0.

Test LOC delta from `git diff origin/main...HEAD --numstat`: +175 / -385 (net -210) across two test files.
