### PR TITLE
refactor(test): adopt codex app-server test harness in worst-preamble suites

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -14,6 +14,7 @@ import {
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
+import { codexTestTurnIds } from "./codex-app-server.test-fixtures.js";
 import {
   requestPluginApproval,
   waitForPluginApprovalDecision,
@@ -142,14 +143,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-yolo",
         command: "/bin/bash -lc 'node -v'",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       autoApprove: true,
     });
 
@@ -173,14 +172,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/fileChange/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "patch-yolo",
         reason: "needs write access",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       autoApprove: true,
     });
 
@@ -208,14 +205,12 @@ describe("Codex app-server approval bridge", () => {
       const result = await handleCodexAppServerApprovalRequest({
         method,
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId,
           ...requestFields,
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         autoApproveOpenClawToolPolicy: true,
       });
 
@@ -242,13 +237,11 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/fileChange/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "patch-owner-policy",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       autoApproveOpenClawToolPolicy: true,
     });
 
@@ -285,8 +278,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "permission-policy-allow",
         permissions: {
           network: { enabled: true },
@@ -294,8 +286,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       ...policy,
     });
 
@@ -324,14 +315,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-1",
         command: "pnpm test extensions/codex/src/app-server",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -353,8 +342,7 @@ describe("Codex app-server approval bridge", () => {
       params: {
         command: "pnpm test extensions/codex/src/app-server",
         approval: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-1",
           command: "pnpm test extensions/codex/src/app-server",
         },
@@ -406,14 +394,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review",
         command: "node --version",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "decline" });
@@ -441,14 +427,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-missing",
         command: "node --version",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -483,8 +467,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-network",
         command: "curl https://example.test",
         networkApprovalContext: {
@@ -494,8 +477,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -532,14 +514,12 @@ describe("Codex app-server approval bridge", () => {
       const result = await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-auto-review-local",
           command: "node --version",
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
       });
 
       expect(result).toEqual({ decision: "accept" });
@@ -639,14 +619,12 @@ describe("Codex app-server approval bridge", () => {
       const result = await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-auto-review-custom-openai",
           command: "node --version",
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
       });
 
       expect(result).toEqual({ decision: "accept" });
@@ -691,14 +669,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-aliased-openai",
         command: "node --version",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -745,14 +721,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-agent-alias",
         command: "node --version",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -788,14 +762,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-env-openai",
         command: "node --version",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -838,14 +810,12 @@ describe("Codex app-server approval bridge", () => {
       const result = await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-auto-review-native-openai",
           command: "node --version",
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
       });
 
       expect(result).toEqual({ decision: "accept" });
@@ -883,8 +853,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-amendment",
         command: "node --version",
         additionalPermissions: {
@@ -894,8 +863,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -931,8 +899,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-execpolicy-object",
         command: "node --version",
         proposedExecpolicyAmendment: {
@@ -940,8 +907,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "acceptForSession" });
@@ -976,14 +942,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-unbound",
         command: "node --version && echo ok",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -1023,14 +987,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-control-command",
         command,
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -1068,14 +1030,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-security-suppression",
         command: "openclaw config set security.audit.suppressions '[]'",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -1110,8 +1070,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-amendment-only",
         command: "node --version",
         availableDecisions: [
@@ -1123,8 +1082,7 @@ describe("Codex app-server approval bridge", () => {
         ],
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -1165,14 +1123,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-auto-review-ask",
         command: "git status",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -1195,14 +1151,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-prefixed",
         command: "pnpm test extensions/codex/src/app-server",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(mockRunBeforeToolCallHook).toHaveBeenCalledWith(
@@ -1227,14 +1181,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-blocked",
         command: "cat /tmp/private_key",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "decline" });
@@ -1259,15 +1211,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay",
         command: "cat /tmp/private_key",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       autoApprove: true,
       nativeHookRelay: {
         relayId: "relay-1",
@@ -1295,8 +1245,7 @@ describe("Codex app-server approval bridge", () => {
           command: "cat /tmp/private_key",
           cwd: "/workspace",
           approval: {
-            threadId: "thread-1",
-            turnId: "turn-1",
+            ...codexTestTurnIds(),
             itemId: "cmd-native-relay",
             command: "cat /tmp/private_key",
             cwd: "/workspace",
@@ -1343,16 +1292,14 @@ describe("Codex app-server approval bridge", () => {
       await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "parent-command-item",
           approvalId,
           command,
           cwd: "/workspace",
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         nativeHookRelay,
       });
     }
@@ -1389,15 +1336,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-noop",
         command: "pnpm test extensions/codex/src/app-server",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay: {
         relayId: "relay-1",
         generation: "generation-1",
@@ -1437,15 +1382,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-observed",
         command: "pnpm test extensions/codex/src/app-server",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay: {
         relayId: "relay-1",
         generation: "generation-1",
@@ -1482,15 +1425,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-deferred",
         command: "pnpm test extensions/codex/src/app-server",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay: {
         relayId: "relay-1",
         allowedEvents: ["pre_tool_use"],
@@ -1521,15 +1462,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-deferred-failure",
         command: "pnpm test extensions/codex/src/app-server",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay: {
         relayId: "relay-1",
         allowedEvents: ["pre_tool_use"],
@@ -1555,15 +1494,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-unreadable",
         command: "pnpm test extensions/codex/src/app-server",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       autoApprove: true,
       nativeHookRelay: {
         relayId: "relay-1",
@@ -1600,15 +1537,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-allow",
         command: "pnpm test extensions/codex/src/app-server",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay: {
         relayId: "relay-1",
         generation: "generation-1",
@@ -1637,15 +1572,13 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-exit",
         command: "pnpm test extensions/codex/src/app-server",
         cwd: "/workspace",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay: {
         relayId: "relay-1",
         generation: "generation-1",
@@ -1670,14 +1603,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-missing",
         command: "cat /tmp/private_key",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay: {
         relayId: "relay-missing",
         generation: "generation-1",
@@ -1703,14 +1634,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-full-auto-missing",
         command: "pwd",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       autoApprove: true,
       nativeHookRelay: {
         relayId: "relay-missing",
@@ -1737,14 +1666,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-native-relay-handler-failure",
         command: "pwd",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       autoApprove: true,
       nativeHookRelay: {
         relayId: "relay-1",
@@ -1779,29 +1706,25 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/fileChange/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "patch-native-relay-registered",
         reason: "needs write access",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay,
     });
     await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "permission-native-relay-registered",
         permissions: {
           network: { allowHosts: ["example.com"] },
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       nativeHookRelay,
     });
 
@@ -1820,8 +1743,7 @@ describe("Codex app-server approval bridge", () => {
       params: {
         command: "echo rewritten",
         approval: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-rewritten",
           command: "echo rewritten",
         },
@@ -1831,14 +1753,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-rewritten",
         command: "cat /tmp/private_key",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "decline" });
@@ -1857,8 +1777,7 @@ describe("Codex app-server approval bridge", () => {
       params: {
         command: "pnpm test",
         approval: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-needs-approval",
           command: "pnpm test",
         },
@@ -1869,14 +1788,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-needs-approval",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -1899,14 +1816,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-needs-approval",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "decline" });
@@ -1933,14 +1848,12 @@ describe("Codex app-server approval bridge", () => {
       const result = await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-policy-failure",
           command: "pnpm test",
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         onNativeToolFailureDisposition,
       });
 
@@ -1975,14 +1888,12 @@ describe("Codex app-server approval bridge", () => {
       await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-aborted-policy",
           command: "pnpm test",
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         signal: controller.signal,
         onNativeToolFailureDisposition,
       });
@@ -2003,15 +1914,13 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-actions",
         command: "bash -lc 'pnpm test extensions/codex'",
         commandActions: [{ command: "pnpm test extensions/codex" }],
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const requestPayload = gatewayRequestPayload();
@@ -2038,8 +1947,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-permissions",
         command: "npm install",
         additionalPermissions: {
@@ -2052,8 +1960,7 @@ describe("Codex app-server approval bridge", () => {
         proposedNetworkPolicyAmendments: [{ host: "registry.npmjs.org", action: "allow" }],
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "acceptForSession" });
@@ -2079,8 +1986,7 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-long-permissions",
         command: `${"npm install ".repeat(500)} --unsafe-perm`,
         additionalPermissions: {
@@ -2091,8 +1997,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const description = String(gatewayRequestPayload().description);
@@ -2110,14 +2015,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-sanitized",
         command: ["pnpm", "test\n--watch", "\u001b[31mextensions/codex/src/app-server\u001b[0m"],
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(gatewayRequestPayload().description).toBe(
@@ -2138,14 +2041,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-escaped",
         command: "printf '<@U123> [trusted](https://evil) @here'",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const description = String(gatewayRequestPayload().description);
@@ -2170,14 +2071,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-osc",
         command: `prefix ${esc}]8;;https://example.com${esc}\\VISIBLE${esc}]8;;${esc}\\ suffix`,
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(gatewayRequestPayload().description).toBe(
@@ -2195,14 +2094,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-bidi",
         command: "echo safe\u202e cod.exe\u2066 hidden\u2069 \ufeffdone\u{e0100}",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(gatewayRequestPayload().description).toBe(
@@ -2222,14 +2119,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-omitted",
         command: [oversizedPrefix, "TAIL"],
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(gatewayRequestPayload().description).toBe(
@@ -2248,14 +2143,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-clipped",
         command: `${"a".repeat(5000)} tail`,
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const description = String(gatewayRequestPayload().description);
@@ -2277,14 +2170,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-untrusted",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "decline" });
@@ -2311,14 +2202,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-inherited",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -2344,14 +2233,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-accessor",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -2377,14 +2264,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-proxy",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -2401,14 +2286,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/fileChange/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "patch-1",
         reason: "needs write access",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       onNativeToolFailureDisposition,
     });
 
@@ -2427,14 +2310,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/fileChange/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "patch-stale",
         reason: "needs write access",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ decision: "decline" });
@@ -2474,14 +2355,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-expired",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       onNativeToolFailureDisposition,
     });
 
@@ -2503,14 +2382,12 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-mismatch",
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       onNativeToolFailureDisposition,
     });
 
@@ -2533,14 +2410,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/fileChange/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "patch-sanitized",
         reason: "needs write access\nfor \u001b[31m/tmp\u001b[0m\tplease",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(gatewayRequestPayload().description).toBe(
@@ -2561,13 +2436,11 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "future/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "future-1",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -2593,8 +2466,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "perm-1",
         permissions: {
           network: { allowHosts: ["example.com", "*.internal"] },
@@ -2602,8 +2474,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -2638,8 +2509,7 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "perm-2",
         permissions: {
           network: {
@@ -2658,8 +2528,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const description = String(gatewayRequestPayload().description);
@@ -2682,8 +2551,7 @@ describe("Codex app-server approval bridge", () => {
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "perm-current",
         permissions: {
           network: { enabled: true },
@@ -2699,8 +2567,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -2734,8 +2601,7 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "perm-windows-home",
         permissions: {
           fileSystem: {
@@ -2745,8 +2611,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const description = String(gatewayRequestPayload().description);
@@ -2763,8 +2628,7 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/permissions/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "perm-controls",
         permissions: {
           network: { allowHosts: ["exa\u009b31mmple.com", "safe\u202e.example.com"] },
@@ -2772,8 +2636,7 @@ describe("Codex app-server approval bridge", () => {
         },
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const description = String(gatewayRequestPayload().description);
@@ -2795,8 +2658,7 @@ describe("Codex app-server approval bridge", () => {
         command: "pnpm test",
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toBeUndefined();
@@ -2818,14 +2680,12 @@ describe("Codex app-server approval bridge", () => {
     await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         itemId: "cmd-utf16",
         command,
       },
       paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const event = findApprovalEvent(params, { status: "pending" });
@@ -2856,14 +2716,12 @@ describe("Codex app-server approval bridge", () => {
       await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
         requestParams: {
-          threadId: "thread-1",
-          turnId: "turn-1",
+          ...codexTestTurnIds(),
           itemId: "cmd-utf16-scan",
           ...input,
         },
         paramsForRun: params,
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
       });
 
       const event = findApprovalEvent(params, { status: "pending" });

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startCodexAttemptThread } from "./attempt-startup.js";
 import { isCodexAppServerStartupError } from "./attempt-timeouts.js";
 import { CodexAppServerClient, isCodexAppServerRequestTimeoutError } from "./client.js";
+import { threadStartResult as createThreadStartResult } from "./codex-app-server.test-fixtures.js";
 import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   type CodexPluginConfig,
@@ -212,38 +213,7 @@ async function waitForThreadStart(harness: ClientHarness): Promise<{ id?: number
 }
 
 function threadStartResult(threadId = "thread-1") {
-  return {
-    thread: {
-      id: threadId,
-      sessionId: "session-1",
-      forkedFromId: null,
-      preview: "",
-      ephemeral: false,
-      modelProvider: "openai",
-      createdAt: 1,
-      updatedAt: 1,
-      status: { type: "idle" },
-      path: null,
-      cwd: "/repo",
-      cliVersion: "0.146.1",
-      source: "unknown",
-      agentNickname: null,
-      agentRole: null,
-      gitInfo: null,
-      name: null,
-      turns: [],
-    },
-    model: "gpt-5.4-codex",
-    modelProvider: "openai",
-    serviceTier: null,
-    cwd: "/repo",
-    instructionSources: [],
-    approvalPolicy: "never",
-    approvalsReviewer: "user",
-    sandbox: { type: "dangerFullAccess" },
-    permissionProfile: null,
-    reasoningEffort: null,
-  };
+  return createThreadStartResult(threadId, "/repo");
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -1,43 +1,23 @@
 // Codex tests cover auth profile runtime contract plugin behavior.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import {
-  abortAndDrainAgentHarnessRun,
-  type EmbeddedRunAttemptParams,
-} from "openclaw/plugin-sdk/agent-harness";
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
 import { AUTH_PROFILE_RUNTIME_CONTRACT } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createCodexRuntimePlanFixture } from "./run-attempt-test-harness.js";
-import { runCodexAppServerAttempt as runCodexAppServerAttemptImpl } from "./run-attempt.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createAppServerHarness,
+  createCodexRuntimePlanFixture,
+  createParams as createSharedParams,
+  runCodexAppServerAttempt as runSharedCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+  turnStartResult,
+} from "./run-attempt-test-harness.js";
 import {
   readCodexAppServerBinding,
-  registerCodexTestSessionIdentity,
-  resetCodexTestBindingStore,
-  testCodexAppServerBindingStore,
   writeCodexAppServerBinding as writeRawCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
-import {
-  adaptCodexTestClientFactory,
-  createCodexTestModel,
-  type CodexTestAppServerClientFactory,
-} from "./test-support.js";
-import { CODEX_APP_SERVER_VERSION } from "./version.js";
-
-let codexAppServerClientFactoryForTest: CodexTestAppServerClientFactory | undefined;
-
-type RunCodexAppServerAttemptOptions = Omit<
-  NonNullable<Parameters<typeof runCodexAppServerAttemptImpl>[1]>,
-  "bindingStore"
->;
-
-function setCodexAppServerClientFactoryForTest(factory: CodexTestAppServerClientFactory): void {
-  codexAppServerClientFactoryForTest = factory;
-}
-
-function resetCodexAppServerClientFactoryForTest(): void {
-  codexAppServerClientFactoryForTest = undefined;
-}
+import type { CodexAppServerClientOptions } from "./shared-client.js";
 
 /** Keeps native Codex bindings reusable while omitting OpenClaw tools and search. */
 function withPersistentCodexTestToolPolicy(
@@ -71,42 +51,23 @@ function withPersistentCodexTestToolPolicy(
 
 function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
-  options: RunCodexAppServerAttemptOptions = {},
+  options: Parameters<typeof runSharedCodexAppServerAttempt>[1] = {},
 ) {
-  const clientFactory =
-    options.clientFactory ??
-    (codexAppServerClientFactoryForTest
-      ? adaptCodexTestClientFactory(codexAppServerClientFactoryForTest)
-      : undefined);
-  return runCodexAppServerAttemptImpl(withPersistentCodexTestToolPolicy(params), {
-    ...options,
-    bindingStore: testCodexAppServerBindingStore,
-    ...(clientFactory ? { clientFactory } : {}),
-  });
+  return runSharedCodexAppServerAttempt(withPersistentCodexTestToolPolicy(params), options);
 }
 
 function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
-  registerCodexTestSessionIdentity(
-    sessionFile,
-    AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
-    AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey,
-  );
-  return {
+  const params = createSharedParams(sessionFile, workspaceDir, {
     prompt: AUTH_PROFILE_RUNTIME_CONTRACT.workspacePrompt,
     sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
     sessionKey: AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey,
-    sessionFile,
-    workspaceDir,
     runId: AUTH_PROFILE_RUNTIME_CONTRACT.runId,
     provider: AUTH_PROFILE_RUNTIME_CONTRACT.codexHarnessProvider,
-    modelId: "gpt-5.4-codex",
-    model: createCodexTestModel(AUTH_PROFILE_RUNTIME_CONTRACT.codexHarnessProvider),
-    thinkLevel: "medium",
-    timeoutMs: 5_000,
-    authStorage: {} as never,
-    authProfileStore: { version: 1, profiles: {} },
-    modelRegistry: {} as never,
-  } as EmbeddedRunAttemptParams;
+  });
+  delete params.contextTokenBudget;
+  delete params.contextWindowInfo;
+  delete params.observeToolTerminal;
+  return params;
 }
 
 function setPreparedOpenAIRoute(
@@ -156,121 +117,37 @@ function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppS
   );
 }
 
-function threadStartResult(threadId = "thread-auth-contract") {
-  return {
-    thread: {
-      id: threadId,
-      sessionId: "session-1",
-      forkedFromId: null,
-      preview: "",
-      ephemeral: false,
-      modelProvider: "openai",
-      createdAt: 1,
-      updatedAt: 1,
-      status: { type: "idle" },
-      path: null,
-      cwd: "",
-      cliVersion: "0.146.1",
-      source: "unknown",
-      agentNickname: null,
-      agentRole: null,
-      gitInfo: null,
-      name: null,
-      turns: [],
-    },
-    model: "gpt-5.4-codex",
-    modelProvider: "openai",
-    serviceTier: null,
-    cwd: "",
-    instructionSources: [],
-    approvalPolicy: "never",
-    approvalsReviewer: "user",
-    sandbox: { type: "dangerFullAccess" },
-    permissionProfile: null,
-    reasoningEffort: null,
-  };
-}
-
-function turnStartResult(turnId = "turn-auth-contract") {
-  return {
-    turn: {
-      id: turnId,
-      status: "inProgress",
-      items: [],
-      error: null,
-      startedAt: null,
-      completedAt: null,
-      durationMs: null,
-    },
-  };
-}
-
-function getMockServerVersion() {
-  return CODEX_APP_SERVER_VERSION;
-}
-
-function getMockRuntimeIdentity() {
-  return { serverVersion: getMockServerVersion() };
-}
-
-function mockClientRuntimeMethods() {
-  return {
-    getInstanceId: () => "test-client-1",
-    getRuntimeIdentity: getMockRuntimeIdentity,
-    getServerVersion: getMockServerVersion,
-  };
-}
-
 function createCodexAuthProfileHarness(params: { startMethod: "thread/start" | "thread/resume" }) {
   const seenAuthProfileIds: Array<string | undefined> = [];
   const seenAgentDirs: Array<string | undefined> = [];
-  const seenClientOptions: Array<NonNullable<Parameters<CodexTestAppServerClientFactory>[4]>> = [];
-  const requests: Array<{ method: string; params: unknown }> = [];
-  const notificationHandlers = new Set<(notification: unknown) => Promise<void> | void>();
-  const notify = async (notification: unknown) => {
-    await Promise.all(
-      [...notificationHandlers].map((handler) => Promise.resolve(handler(notification))),
-    );
-  };
-  setCodexAppServerClientFactoryForTest(
-    async (_startOptions, authProfileId, agentDir, _config, options) => {
-      seenAuthProfileIds.push(authProfileId);
-      seenAgentDirs.push(agentDir);
-      if (options) {
-        seenClientOptions.push(options);
+  const seenClientOptions: CodexAppServerClientOptions[] = [];
+  const harness = createAppServerHarness(
+    async (method) => {
+      if (method === params.startMethod) {
+        return threadStartResult("thread-auth-contract", { cwd: "" });
       }
-      return {
-        ...mockClientRuntimeMethods(),
-        request: vi.fn(async (method: string, requestParams?: unknown) => {
-          requests.push({ method, params: requestParams });
-          if (method === params.startMethod) {
-            return threadStartResult();
-          }
-          if (method === "turn/start") {
-            return turnStartResult();
-          }
-          throw new Error(`unexpected method: ${method}`);
-        }),
-        addNotificationHandler: (handler: (notification: unknown) => Promise<void> | void) => {
-          notificationHandlers.add(handler);
-          return () => notificationHandlers.delete(handler);
-        },
-        addRequestHandler: () => () => undefined,
-        addCloseHandler: () => () => undefined,
-      } as never;
+      if (method === "turn/start") {
+        return turnStartResult("turn-auth-contract");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    },
+    {
+      onStart(authProfileId, agentDir, options) {
+        seenAuthProfileIds.push(authProfileId);
+        seenAgentDirs.push(agentDir);
+        if (options) {
+          seenClientOptions.push(options);
+        }
+      },
     },
   );
   return {
+    ...harness,
     seenAuthProfileIds,
     seenAgentDirs,
     seenClientOptions,
-    async waitForMethod(method: string) {
-      await vi.waitFor(() => expect(requests.map((entry) => entry.method)).toContain(method), {
-        ...APP_SERVER_START_WAIT,
-      });
-    },
     async completeTurn() {
-      await notify({
+      await harness.notify({
         method: "turn/completed",
         params: {
           threadId: "thread-auth-contract",
@@ -282,26 +159,13 @@ function createCodexAuthProfileHarness(params: { startMethod: "thread/start" | "
   };
 }
 
+setupRunAttemptTestHooks();
+
 describe("Auth profile runtime contract - Codex app-server adapter", () => {
   let tmpDir: string;
 
-  beforeEach(async () => {
-    resetCodexTestBindingStore();
-    vi.useRealTimers();
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-auth-contract-"));
-  });
-
-  afterEach(async () => {
-    vi.useRealTimers();
-    await abortAndDrainAgentHarnessRun({
-      sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
-      sessionKey: AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey,
-      settleMs: 1_000,
-      forceClear: true,
-      reason: "test_cleanup",
-    });
-    resetCodexAppServerClientFactoryForTest();
-    await fs.rm(tmpDir, { recursive: true, force: true });
+  beforeEach(() => {
+    tmpDir = tempDir;
   });
 
   it("passes the exact OpenAI Codex auth profile into app-server startup", async () => {

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { runBoundedCodexAppServerTurn } from "./bounded-turn.js";
-import type { CodexAppServerClient } from "./client.js";
-import type { CodexServerNotification, JsonValue } from "./protocol.js";
+import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
+import type { JsonValue } from "./protocol.js";
 import type { CodexAppServerClientFactory } from "./shared-client.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
@@ -108,8 +108,7 @@ function createClientFactory(
   } = {},
 ) {
   const methods: string[] = [];
-  const notificationHandlers: Array<(notification: CodexServerNotification) => void> = [];
-  const request = vi.fn(async (method: string, _params?: unknown) => {
+  const fixture = createFakeCodexAppServerClient(async (method: string, _params?: unknown) => {
     methods.push(method);
     if (method === "model/list") {
       return modelList();
@@ -134,8 +133,8 @@ function createClientFactory(
     }
     if (method === "turn/interrupt") {
       queueMicrotask(() => {
-        for (const handler of notificationHandlers) {
-          handler({
+        for (const handler of fixture.notifications) {
+          void handler({
             method: "turn/completed",
             params: {
               threadId: "thread-finalizer",
@@ -151,9 +150,9 @@ function createClientFactory(
         return inProgressTurnResult();
       }
       queueMicrotask(() => {
-        for (const handler of notificationHandlers) {
+        for (const handler of fixture.notifications) {
           if (options.errorBeforeCompletion) {
-            handler({
+            void handler({
               method: "error",
               params: {
                 threadId: "thread-finalizer",
@@ -164,7 +163,7 @@ function createClientFactory(
             });
           }
           if (options.assistantDelta) {
-            handler({
+            void handler({
               method: "item/agentMessage/delta",
               params: {
                 threadId: "thread-finalizer",
@@ -174,7 +173,7 @@ function createClientFactory(
               },
             });
           }
-          handler({
+          void handler({
             method: "rawResponse/completed",
             params: {
               threadId: "thread-finalizer",
@@ -190,7 +189,7 @@ function createClientFactory(
               },
             },
           });
-          handler({
+          void handler({
             method: "turn/completed",
             params: {
               threadId: "thread-finalizer",
@@ -208,21 +207,8 @@ function createClientFactory(
     }
     throw new Error(`unexpected request: ${method}`);
   });
-  const client = {
-    request,
-    addNotificationHandler: vi.fn((handler) => {
-      notificationHandlers.push(handler);
-      return () => {
-        const index = notificationHandlers.indexOf(handler);
-        if (index >= 0) {
-          notificationHandlers.splice(index, 1);
-        }
-      };
-    }),
-    addRequestHandler: vi.fn(() => () => undefined),
-    addCloseHandler: vi.fn(() => () => undefined),
-    close: vi.fn(),
-  } as unknown as CodexAppServerClient;
+  const request = fixture.request;
+  const client = Object.assign(fixture.client, { close: vi.fn() });
   const factory = vi.fn(async () => client) as unknown as CodexAppServerClientFactory;
   return { factory, methods, request };
 }

--- a/extensions/codex/src/app-server/codex-app-server.test-fixtures.ts
+++ b/extensions/codex/src/app-server/codex-app-server.test-fixtures.ts
@@ -1,0 +1,134 @@
+import { vi } from "vitest";
+import type { CodexAppServerClient } from "./client.js";
+import type { CodexServerNotification, RpcRequest } from "./protocol.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+type ServerRequestHandler = (request: RpcRequest) => unknown;
+type NotificationHandler = (notification: CodexServerNotification) => Promise<void> | void;
+
+export function codexTestTurnIds(threadId = "thread-1", turnId = "turn-1") {
+  return { threadId, turnId };
+}
+
+export function mockClientRuntimeMethods() {
+  const getServerVersion = () => CODEX_APP_SERVER_VERSION;
+  return {
+    getInstanceId: () => "test-client-1",
+    getRuntimeIdentity: () => ({ serverVersion: getServerVersion() }),
+    getServerVersion,
+  };
+}
+
+export function threadStartResult(threadId = "thread-1", cwd = "/tmp/openclaw-codex-test") {
+  return {
+    thread: {
+      id: threadId,
+      sessionId: "session-1",
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd,
+      cliVersion: "0.146.1",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: "gpt-5.4-codex",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd,
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    permissionProfile: null,
+    reasoningEffort: null,
+  };
+}
+
+export function turnStartResult(turnId = "turn-1", status = "inProgress") {
+  return {
+    turn: {
+      id: turnId,
+      status,
+      items: [],
+      error: null,
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+    },
+  };
+}
+
+export function createFakeCodexAppServerClient(
+  requestImpl: (method: string, params?: unknown, options?: unknown) => unknown = async () =>
+    undefined,
+) {
+  const notificationHandlers: NotificationHandler[] = [];
+  const requestHandlers: ServerRequestHandler[] = [];
+  const closeHandlers = new Set<(client: CodexAppServerClient) => void>();
+  let closeError: Error | undefined;
+  const request = vi.fn(requestImpl);
+  const client = {
+    ...mockClientRuntimeMethods(),
+    request,
+    addNotificationHandler(handler: NotificationHandler) {
+      notificationHandlers.push(handler);
+      return () => {
+        const index = notificationHandlers.indexOf(handler);
+        if (index >= 0) {
+          notificationHandlers.splice(index, 1);
+        }
+      };
+    },
+    addRequestHandler(handler: ServerRequestHandler) {
+      requestHandlers.push(handler);
+      return () => {
+        const index = requestHandlers.indexOf(handler);
+        if (index >= 0) {
+          requestHandlers.splice(index, 1);
+        }
+      };
+    },
+    addCloseHandler(handler: (client: CodexAppServerClient) => void) {
+      closeHandlers.add(handler);
+      return () => closeHandlers.delete(handler);
+    },
+    getCloseError: () => closeError,
+  } as unknown as CodexAppServerClient;
+
+  return {
+    client,
+    notifications: notificationHandlers,
+    request,
+    requests: requestHandlers,
+    async notify(notification: CodexServerNotification) {
+      await Promise.all(
+        [...notificationHandlers].map((handler) => Promise.resolve(handler(notification))),
+      );
+    },
+    async handleServerRequest(serverRequest: RpcRequest) {
+      for (const handler of requestHandlers) {
+        const result = await handler(serverRequest);
+        if (result !== undefined) {
+          return result;
+        }
+      }
+      return undefined;
+    },
+    close(error?: Error) {
+      closeError = error;
+      for (const handler of closeHandlers) {
+        handler(client);
+      }
+    },
+  };
+}

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -5,6 +5,7 @@ import {
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { codexTestTurnIds } from "./codex-app-server.test-fixtures.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
 
 vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => ({
@@ -43,8 +44,7 @@ function createParams(): EmbeddedRunAttemptParams {
 
 function buildApprovalElicitation() {
   return {
-    threadId: "thread-1",
-    turnId: "turn-1",
+    ...codexTestTurnIds(),
     serverName: "codex_apps__github",
     mode: "form",
     message: "Approve app tool call?",
@@ -92,8 +92,7 @@ function buildCurrentCodexApprovalElicitation() {
 
 function buildComputerUseApprovalElicitation(overrides: Record<string, unknown> = {}) {
   return {
-    threadId: "thread-1",
-    turnId: "turn-1",
+    ...codexTestTurnIds(),
     serverName: "computer-use",
     mode: "form",
     message: "Allow Codex to use Notes?",
@@ -110,8 +109,7 @@ function buildComputerUseApprovalElicitation(overrides: Record<string, unknown> 
 
 function buildPluginApprovalElicitation(overrides: Record<string, unknown> = {}) {
   return {
-    threadId: "thread-1",
-    turnId: "turn-1",
+    ...codexTestTurnIds(),
     serverName: "google-calendar-mcp",
     mode: "form",
     message: "Approve app action?",
@@ -134,8 +132,7 @@ function buildPluginApprovalElicitation(overrides: Record<string, unknown> = {})
 
 function buildConnectorPluginApprovalElicitation(overrides: Record<string, unknown> = {}) {
   return {
-    threadId: "thread-1",
-    turnId: "turn-1",
+    ...codexTestTurnIds(),
     serverName: "codex_apps",
     mode: "form",
     message: "Allow Google Calendar to create an event?",
@@ -238,8 +235,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -267,8 +263,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ action: "decline", content: null, _meta: null });
@@ -290,8 +285,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -315,8 +309,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildCurrentCodexApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -344,8 +337,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildComputerUseApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use",
     });
@@ -372,8 +364,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildComputerUseApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use",
     });
@@ -391,8 +382,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildComputerUseApprovalElicitation({ serverName: "desktop-control" }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use",
     });
@@ -412,8 +402,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildComputerUseApprovalElicitation({ serverName: "desktop-control" }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "desktop-control",
     });
@@ -447,8 +436,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use",
     });
@@ -480,8 +468,7 @@ describe("Codex app-server elicitation bridge", () => {
         requestedSchema: "not-a-schema",
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use",
     });
@@ -499,8 +486,7 @@ describe("Codex app-server elicitation bridge", () => {
         mode: "notification",
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use",
     });
@@ -521,8 +507,7 @@ describe("Codex app-server elicitation bridge", () => {
         _meta: null,
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use\u009b31m",
     });
@@ -577,8 +562,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const approvalRequest = gatewayToolArg(0, 2) as {
@@ -632,8 +616,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const approvalRequest = gatewayToolArg(0, 2) as {
@@ -690,8 +673,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const approvalRequest = gatewayToolArg(0, 2) as {
@@ -734,8 +716,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const approvalRequest = gatewayToolArg(0, 2) as {
@@ -767,8 +748,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const approvalRequest = gatewayToolArg(0, 2) as {
@@ -791,8 +771,7 @@ describe("Codex app-server elicitation bridge", () => {
         turnId: null,
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -806,8 +785,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: false }),
     });
 
@@ -819,8 +797,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: true }),
     });
 
@@ -836,8 +813,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildConnectorPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         apps: [
@@ -875,8 +851,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createAccountAppPolicyContext({
         appId: "chatgpt_meetings",
         appName: "ChatGPT Meetings",
@@ -899,8 +874,7 @@ describe("Codex app-server elicitation bridge", () => {
         _meta: { app_id: "chatgpt_meetings" },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createAccountAppPolicyContext({
         appId: "chatgpt_meetings",
         appName: "ChatGPT Meetings",
@@ -927,8 +901,7 @@ describe("Codex app-server elicitation bridge", () => {
       const result = await handleCodexAppServerElicitationRequest({
         requestParams: buildConnectorPluginApprovalElicitation({ requestedSchema }),
         paramsForRun: createParams(),
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         pluginAppPolicyContext: createPluginAppPolicyContext({
           allowDestructiveActions: true,
           apps: [
@@ -954,8 +927,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildConnectorPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "auto",
@@ -1006,8 +978,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "auto",
@@ -1068,8 +1039,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "auto",
@@ -1115,8 +1085,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "ask",
@@ -1163,8 +1132,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "ask",
@@ -1193,8 +1161,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildConnectorPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "auto",
@@ -1220,8 +1187,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildConnectorPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "auto",
@@ -1253,8 +1219,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildConnectorPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         destructiveApprovalMode: "auto",
@@ -1276,8 +1241,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildConnectorPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: false,
         apps: [
@@ -1305,8 +1269,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         apps: [
@@ -1336,8 +1299,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         apps: [
@@ -1358,8 +1320,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildPluginApprovalElicitation({ turnId: null }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: true }),
     });
 
@@ -1371,8 +1332,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildPluginApprovalElicitation({ turnId: "turn-2" }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: true }),
     });
 
@@ -1387,8 +1347,7 @@ describe("Codex app-server elicitation bridge", () => {
         _meta: {},
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({
         allowDestructiveActions: true,
         apps: [
@@ -1419,8 +1378,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: true }),
     });
 
@@ -1432,8 +1390,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildPluginApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({ action: "decline", content: null, _meta: null });
@@ -1455,8 +1412,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       }),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: true }),
     });
 
@@ -1472,8 +1428,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildCurrentCodexApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: true }),
     });
 
@@ -1494,8 +1449,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: { turnId, serverName, mode, message, _meta, requestedSchema },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toBeUndefined();
@@ -1510,8 +1464,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -1534,8 +1487,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildCurrentCodexApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -1573,8 +1525,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -1608,8 +1559,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -1639,8 +1589,7 @@ describe("Codex app-server elicitation bridge", () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildApprovalElicitation(),
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -1653,8 +1602,7 @@ describe("Codex app-server elicitation bridge", () => {
   it("ignores non-approval elicitation requests", async () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
+        ...codexTestTurnIds(),
         serverName: "codex_apps__github",
         mode: "form",
         message: "Choose a template",
@@ -1671,8 +1619,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toBeUndefined();
@@ -1701,8 +1648,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     expect(result).toEqual({
@@ -1740,8 +1686,7 @@ describe("Codex app-server elicitation bridge", () => {
         },
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const approvalCallParams = gatewayToolArg(0, 2) as { title?: string; description?: string };
@@ -1760,8 +1705,7 @@ describe("Codex app-server elicitation bridge", () => {
         message: `${"\u0000".repeat(4095)}😀tail`,
       },
       paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
+      ...codexTestTurnIds(),
     });
 
     const approvalCallParams = gatewayToolArg(0, 2) as { title?: string; description?: string };

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -5,6 +5,7 @@ import type {
   AgentHarnessTaskRuntimeScope,
 } from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
 import type {
   CodexAppServerRequestResult,
@@ -21,9 +22,6 @@ type CodexNativeSubagentMonitorInstance = InstanceType<typeof CodexNativeSubagen
 function createClient() {
   type ThreadReadParams = { threadId?: string; includeTurns?: boolean };
   type ThreadTurnsParams = { threadId?: string };
-  type NotificationHandler = (notification: CodexServerNotification) => Promise<void> | void;
-  const notificationHandlers = new Set<NotificationHandler>();
-  const closeHandlers = new Set<() => void>();
   const threadReads = new Map<
     string,
     | CodexThreadReadResponse
@@ -31,7 +29,7 @@ function createClient() {
     | ((params: ThreadReadParams) => CodexThreadReadResponse | Promise<CodexThreadReadResponse>)
   >();
   const threadTurns = new Map<string, JsonValue | Error>();
-  const request = vi.fn(async (method: string, params?: unknown) => {
+  const fixture = createFakeCodexAppServerClient(async (method: string, params?: unknown) => {
     if (method === "thread/turns/list") {
       const childThreadId = ((params as ThreadTurnsParams | undefined) ?? {}).threadId ?? "";
       const response = threadTurns.get(childThreadId);
@@ -58,7 +56,7 @@ function createClient() {
     return typeof response === "function" ? await response(readParams) : response;
   });
   return {
-    request,
+    request: fixture.request,
     setThreadRead(childThreadId: string, response: CodexThreadReadResponse | Error) {
       threadReads.set(childThreadId, response);
     },
@@ -73,25 +71,10 @@ function createClient() {
     setThreadTurns(childThreadId: string, response: JsonValue | Error) {
       threadTurns.set(childThreadId, response);
     },
-    addNotificationHandler(handler: NotificationHandler) {
-      notificationHandlers.add(handler);
-      return () => notificationHandlers.delete(handler);
-    },
-    addCloseHandler(handler: (client: never) => void) {
-      const closeHandler = () => handler(undefined as never);
-      closeHandlers.add(closeHandler);
-      return () => closeHandlers.delete(closeHandler);
-    },
-    async notify(notification: CodexServerNotification) {
-      await Promise.all(
-        [...notificationHandlers].map(async (handler) => await handler(notification)),
-      );
-    },
-    close() {
-      for (const handler of closeHandlers) {
-        handler();
-      }
-    },
+    addNotificationHandler: fixture.client.addNotificationHandler.bind(fixture.client),
+    addCloseHandler: fixture.client.addCloseHandler.bind(fixture.client),
+    notify: (notification: CodexServerNotification) => fixture.notify(notification),
+    close: () => fixture.close(),
   };
 }
 

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -18,6 +18,11 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, beforeEach, expect, vi } from "vitest";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import type { CodexAppServerClient } from "./client.js";
+import {
+  mockClientRuntimeMethods as createMockClientRuntimeMethods,
+  threadStartResult as createThreadStartResult,
+  turnStartResult as createTurnStartResult,
+} from "./codex-app-server.test-fixtures.js";
 import * as codexRequirements from "./config-requirements.js";
 import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
@@ -90,14 +95,14 @@ export function setCodexAppServerClientFactoryForTest(
     // Narrow test doubles still need the client lifecycle hook installed by
     // the keyed router, even when the test never simulates transport closure.
     testClient.addCloseHandler ??= () => () => undefined;
-    multiplexTestClientHandlers(client);
+    multiplexCodexTestClientHandlers(client);
     return client;
   });
 }
 
 // The keyed router, client runtime, and subagent monitor each register their
 // own handlers; single-slot test doubles would silently drop all but the last.
-function multiplexTestClientHandlers(client: CodexAppServerClient): void {
+export function multiplexCodexTestClientHandlers(client: CodexAppServerClient): void {
   if (multiplexedTestClients.has(client)) {
     return;
   }
@@ -203,16 +208,29 @@ async function drainActiveAppServerAttemptsForTest(): Promise<void> {
   }
 }
 
-export function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
-  const model = createCodexTestModel("codex");
+export function createParams(
+  sessionFile: string,
+  workspaceDir: string,
+  identity: {
+    prompt?: string;
+    provider?: string;
+    runId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+  } = {},
+): EmbeddedRunAttemptParams {
+  const sessionId = identity.sessionId ?? "session-1";
+  const sessionKey = identity.sessionKey ?? "agent:main:session-1";
+  const provider = identity.provider ?? "codex";
+  const model = createCodexTestModel(provider);
   return {
-    prompt: "hello",
-    sessionId: "session-1",
-    sessionKey: "agent:main:session-1",
+    prompt: identity.prompt ?? "hello",
+    sessionId,
+    sessionKey,
     sessionFile,
     workspaceDir,
-    runId: "run-1",
-    provider: "codex",
+    runId: identity.runId ?? "run-1",
+    provider,
     modelId: "gpt-5.4-codex",
     model: {
       ...model,
@@ -315,60 +333,16 @@ export function getMockRuntimeIdentity() {
 }
 
 export function mockClientRuntimeMethods() {
-  return {
-    getInstanceId: () => "test-client-1",
-    getRuntimeIdentity: getMockRuntimeIdentity,
-    getServerVersion: getMockServerVersion,
-  };
-}
-
-export function threadStartResult(threadId = "thread-1") {
-  return {
-    thread: {
-      id: threadId,
-      sessionId: "session-1",
-      forkedFromId: null,
-      preview: "",
-      ephemeral: false,
-      modelProvider: "openai",
-      createdAt: 1,
-      updatedAt: 1,
-      status: { type: "idle" },
-      path: null,
-      cwd: tempDir || "/tmp/openclaw-codex-test",
-      cliVersion: "0.146.1",
-      source: "unknown",
-      agentNickname: null,
-      agentRole: null,
-      gitInfo: null,
-      name: null,
-      turns: [],
-    },
-    model: "gpt-5.4-codex",
-    modelProvider: "openai",
-    serviceTier: null,
-    cwd: tempDir || "/tmp/openclaw-codex-test",
-    instructionSources: [],
-    approvalPolicy: "never",
-    approvalsReviewer: "user",
-    sandbox: { type: "dangerFullAccess" },
-    permissionProfile: null,
-    reasoningEffort: null,
-  };
+  return createMockClientRuntimeMethods();
 }
 
 export function turnStartResult(turnId = "turn-1", status = "inProgress") {
-  return {
-    turn: {
-      id: turnId,
-      status,
-      items: [],
-      error: null,
-      startedAt: null,
-      completedAt: null,
-      durationMs: null,
-    },
-  };
+  return createTurnStartResult(turnId, status);
+}
+
+export function threadStartResult(threadId = "thread-1", options: { cwd?: string } = {}) {
+  const cwd = options.cwd ?? tempDir ?? "/tmp/openclaw-codex-test";
+  return createThreadStartResult(threadId, cwd);
 }
 
 export function rateLimitsUpdated(resetsAt: number): CodexServerNotification {

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -1,20 +1,22 @@
 // Codex tests cover run attempt thread cleanup plugin behavior.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import {
-  resetAgentEventsForTest,
-  type EmbeddedRunAttemptParams,
-} from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import { CodexAppServerClient } from "./client.js";
 import type { CodexServerNotification } from "./protocol.js";
-import { runCodexAppServerAttempt } from "./run-attempt.js";
+import {
+  createParams as createSharedParams,
+  mockClientRuntimeMethods,
+  multiplexCodexTestClientHandlers,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+  turnStartResult,
+} from "./run-attempt-test-harness.js";
 import {
   readCodexAppServerBinding,
-  registerCodexTestSessionIdentity,
-  resetCodexTestBindingStore,
   testCodexAppServerBindingStore,
 } from "./session-binding.test-helpers.js";
 import {
@@ -25,7 +27,6 @@ import {
 import {
   adaptCodexTestClientFactory,
   createClientHarness,
-  createCodexTestModel,
   type CodexTestAppServerClientFactory,
 } from "./test-support.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
@@ -37,108 +38,23 @@ function multiplexedClientFactory(
 ): CodexAppServerClientFactory {
   return adaptCodexTestClientFactory(async (...args) => {
     const client = await factory(...args);
-    const notificationHandlers = new Set<Parameters<typeof client.addNotificationHandler>[0]>();
-    const requestHandlers = new Set<Parameters<typeof client.addRequestHandler>[0]>();
-    client.addNotificationHandler((notification) =>
-      Promise.all(
-        [...notificationHandlers].map((handler) => Promise.resolve(handler(notification))),
-      ).then(() => undefined),
-    );
-    client.addRequestHandler(async (request) => {
-      for (const handler of requestHandlers) {
-        const result = await handler(request);
-        if (result !== undefined) {
-          return result;
-        }
-      }
-      return undefined;
-    });
-    client.addNotificationHandler = (handler) => {
-      notificationHandlers.add(handler);
-      return () => notificationHandlers.delete(handler);
-    };
-    client.addRequestHandler = (handler) => {
-      requestHandlers.add(handler);
-      return () => requestHandlers.delete(handler);
-    };
+    multiplexCodexTestClientHandlers(client);
     return client;
   });
 }
-
-let tempDir: string;
 
 function createParams(
   sessionFile: string,
   workspaceDir: string,
   sessionKey = "agent:main:session-1",
 ): EmbeddedRunAttemptParams {
-  registerCodexTestSessionIdentity(sessionFile, "session-1", sessionKey);
-  return {
-    prompt: "hello",
-    sessionId: "session-1",
-    sessionKey,
-    sessionFile,
-    workspaceDir,
-    runId: "run-1",
-    provider: "codex",
-    modelId: "gpt-5.4-codex",
-    model: createCodexTestModel("codex"),
-    thinkLevel: "medium",
-    disableTools: true,
-    timeoutMs: 5_000,
-    authStorage: {} as never,
-    authProfileStore: { version: 1, profiles: {} },
-    modelRegistry: {} as never,
-  } as EmbeddedRunAttemptParams;
-}
-
-function threadStartResult(threadId = "thread-1") {
-  return {
-    thread: {
-      id: threadId,
-      sessionId: "session-1",
-      forkedFromId: null,
-      preview: "",
-      ephemeral: false,
-      modelProvider: "openai",
-      createdAt: 1,
-      updatedAt: 1,
-      status: { type: "idle" },
-      path: null,
-      cwd: tempDir || "/tmp/openclaw-codex-test",
-      cliVersion: "0.146.1",
-      source: "unknown",
-      agentNickname: null,
-      agentRole: null,
-      gitInfo: null,
-      name: null,
-      turns: [],
-    },
-    model: "gpt-5.4-codex",
-    modelProvider: "openai",
-    serviceTier: null,
-    cwd: tempDir || "/tmp/openclaw-codex-test",
-    instructionSources: [],
-    approvalPolicy: "never",
-    approvalsReviewer: "user",
-    sandbox: { type: "dangerFullAccess" },
-    permissionProfile: null,
-    reasoningEffort: null,
-  };
-}
-
-function turnStartResult(turnId = "turn-1") {
-  return {
-    turn: {
-      id: turnId,
-      status: "inProgress",
-      items: [],
-      error: null,
-      startedAt: null,
-      completedAt: null,
-      durationMs: null,
-    },
-  };
+  const params = createSharedParams(sessionFile, workspaceDir, { sessionKey });
+  params.disableTools = true;
+  params.config = undefined;
+  delete params.contextTokenBudget;
+  delete params.contextWindowInfo;
+  delete params.observeToolTerminal;
+  return params;
 }
 
 async function waitForHarnessRequest(
@@ -161,41 +77,15 @@ async function waitForHarnessRequest(
   return { id: request.id };
 }
 
-function getMockServerVersion() {
-  return CODEX_APP_SERVER_VERSION;
-}
-
-function getMockRuntimeIdentity() {
-  return { serverVersion: getMockServerVersion() };
-}
-
-function mockClientRuntimeMethods() {
-  return {
-    getInstanceId: () => "test-client-1",
-    getRuntimeIdentity: getMockRuntimeIdentity,
-    getServerVersion: getMockServerVersion,
-  };
-}
+setupRunAttemptTestHooks();
 
 describe("Codex app-server main thread cleanup", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     resetSharedCodexAppServerClientForTests();
-    resetCodexTestBindingStore();
-    vi.useRealTimers();
-    resetAgentEventsForTest();
-    vi.stubEnv("OPENCLAW_TRAJECTORY", "0");
-    vi.stubEnv("CODEX_API_KEY", "");
-    vi.stubEnv("OPENAI_API_KEY", "");
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-run-cleanup-"));
   });
 
-  afterEach(async () => {
-    vi.useRealTimers();
+  afterEach(() => {
     resetSharedCodexAppServerClientForTests();
-    resetAgentEventsForTest();
-    vi.restoreAllMocks();
-    vi.unstubAllEnvs();
-    await fs.rm(tempDir, { recursive: true, force: true });
   });
 
   it.each([

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
@@ -10,10 +9,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { openFileBackedSessionManagerForTest } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
-import {
-  initializeGlobalHookRunner,
-  resetGlobalHookRunner,
-} from "openclaw/plugin-sdk/hook-runtime";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "openclaw/plugin-sdk/message-tool-delivery-hints";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { registerSandboxBackend } from "openclaw/plugin-sdk/sandbox";
@@ -21,41 +17,33 @@ import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 // Codex tests cover run attempt.context engine plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import { shouldEnableCodexAppServerNativeToolSurface } from "./dynamic-tool-build.js";
-import type { CodexServerNotification } from "./protocol.js";
-import { runCodexAppServerAttempt as runCodexAppServerAttemptImpl } from "./run-attempt.js";
+import {
+  assistantMessage,
+  createParams as createSharedParams,
+  createStartedThreadHarness as createSharedStartedThreadHarness,
+  runCodexAppServerAttempt as runSharedCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+  turnStartResult,
+  userMessage,
+} from "./run-attempt-test-harness.js";
 import {
   readCodexAppServerBinding,
-  registerCodexTestSessionIdentity,
-  resetCodexTestBindingStore,
-  testCodexAppServerBindingStore,
   writeCodexAppServerBinding as writeRawCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
-import {
-  adaptCodexTestClientFactory,
-  createCodexTestModel,
-  type CodexTestAppServerClientFactory,
-} from "./test-support.js";
-import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
 const CODEX_TURN_START_TEXT_INPUT_MAX_CHARS = 1 << 20;
 
-let tempDir: string;
-let codexAppServerClientFactoryForTest: CodexTestAppServerClientFactory | undefined;
-
-type RunCodexAppServerAttemptOptions = Omit<
-  NonNullable<Parameters<typeof runCodexAppServerAttemptImpl>[1]>,
-  "bindingStore"
->;
-
-function setCodexAppServerClientFactoryForTest(factory: CodexTestAppServerClientFactory): void {
-  codexAppServerClientFactoryForTest = factory;
-}
-
-function resetCodexAppServerClientFactoryForTest(): void {
-  codexAppServerClientFactoryForTest = undefined;
+function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
+  const params = createSharedParams(sessionFile, workspaceDir);
+  delete params.contextTokenBudget;
+  delete params.contextWindowInfo;
+  delete params.observeToolTerminal;
+  return params;
 }
 
 /** Keeps native Codex bindings reusable while omitting OpenClaw tools and search. */
@@ -90,38 +78,9 @@ function withPersistentCodexTestToolPolicy(
 
 function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
-  options: RunCodexAppServerAttemptOptions = {},
+  options: Parameters<typeof runSharedCodexAppServerAttempt>[1] = {},
 ) {
-  const clientFactory =
-    options.clientFactory ??
-    (codexAppServerClientFactoryForTest
-      ? adaptCodexTestClientFactory(codexAppServerClientFactoryForTest)
-      : undefined);
-  return runCodexAppServerAttemptImpl(withPersistentCodexTestToolPolicy(params), {
-    ...options,
-    bindingStore: testCodexAppServerBindingStore,
-    ...(clientFactory ? { clientFactory } : {}),
-  });
-}
-
-function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
-  registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
-  return {
-    prompt: "hello",
-    sessionId: "session-1",
-    sessionKey: "agent:main:session-1",
-    sessionFile,
-    workspaceDir,
-    runId: "run-1",
-    provider: "codex",
-    modelId: "gpt-5.4-codex",
-    model: createCodexTestModel("codex"),
-    thinkLevel: "medium",
-    timeoutMs: 5_000,
-    authStorage: {} as never,
-    authProfileStore: { version: 1, profiles: {} },
-    modelRegistry: {} as never,
-  } as EmbeddedRunAttemptParams;
+  return runSharedCodexAppServerAttempt(withPersistentCodexTestToolPolicy(params), options);
 }
 
 async function createSqliteParams(
@@ -175,34 +134,6 @@ function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppS
   );
 }
 
-function assistantMessage(text: string, timestamp: number): AgentMessage {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text }],
-    api: "openai-chatgpt-responses",
-    provider: "openai",
-    model: "gpt-5.4-codex",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: "stop",
-    timestamp,
-  };
-}
-
-function userMessage(text: string, timestamp: number): AgentMessage {
-  return {
-    role: "user",
-    content: [{ type: "text", text }],
-    timestamp,
-  } as AgentMessage;
-}
-
 function toolResultMessage(payload: unknown, timestamp: number): AgentMessage {
   return {
     role: "toolResult",
@@ -220,126 +151,14 @@ function toolResultMessage(payload: unknown, timestamp: number): AgentMessage {
   } as unknown as AgentMessage;
 }
 
-function threadStartResult(threadId = "thread-1") {
-  return {
-    thread: {
-      id: threadId,
-      sessionId: "session-1",
-      forkedFromId: null,
-      preview: "",
-      ephemeral: false,
-      modelProvider: "openai",
-      createdAt: 1,
-      updatedAt: 1,
-      status: { type: "idle" },
-      path: null,
-      cwd: tempDir || "/tmp/openclaw-codex-test",
-      cliVersion: "0.146.1",
-      source: "unknown",
-      agentNickname: null,
-      agentRole: null,
-      gitInfo: null,
-      name: null,
-      turns: [],
-    },
-    model: "gpt-5.4-codex",
-    modelProvider: "openai",
-    serviceTier: null,
-    cwd: tempDir || "/tmp/openclaw-codex-test",
-    instructionSources: [],
-    approvalPolicy: "never",
-    approvalsReviewer: "user",
-    sandbox: { type: "dangerFullAccess" },
-    permissionProfile: null,
-    reasoningEffort: null,
-  };
-}
-
-function turnStartResult(turnId = "turn-1", status = "inProgress") {
-  return {
-    turn: {
-      id: turnId,
-      status,
-      items: [],
-      error: null,
-      startedAt: null,
-      completedAt: null,
-      durationMs: null,
-    },
-  };
-}
-
-function getMockServerVersion() {
-  return CODEX_APP_SERVER_VERSION;
-}
-
-function getMockRuntimeIdentity() {
-  return { serverVersion: getMockServerVersion() };
-}
-
-function mockClientRuntimeMethods() {
-  return {
-    getInstanceId: () => "test-client-1",
-    getRuntimeIdentity: getMockRuntimeIdentity,
-    getServerVersion: getMockServerVersion,
-  };
-}
-
 function createStartedThreadHarness(
-  requestImpl: (method: string, params: unknown) => Promise<unknown> = async () => undefined,
+  requestImpl?: Parameters<typeof createSharedStartedThreadHarness>[0],
 ) {
-  const requests: Array<{ method: string; params: unknown }> = [];
-  const notificationHandlers = new Set<
-    (notification: CodexServerNotification) => Promise<void> | void
-  >();
-  const notify = async (notification: CodexServerNotification) => {
-    await Promise.all(
-      [...notificationHandlers].map((handler) => Promise.resolve(handler(notification))),
-    );
-  };
-  const request = vi.fn(async (method: string, params?: unknown) => {
-    requests.push({ method, params });
-    const override = await requestImpl(method, params);
-    if (override !== undefined) {
-      return override;
-    }
-    if (method === "thread/start") {
-      return threadStartResult();
-    }
-    if (method === "turn/start") {
-      return turnStartResult();
-    }
-    return {};
-  });
-
-  setCodexAppServerClientFactoryForTest(
-    async () =>
-      ({
-        ...mockClientRuntimeMethods(),
-        request,
-        addNotificationHandler: (
-          handler: (notification: CodexServerNotification) => Promise<void> | void,
-        ) => {
-          notificationHandlers.add(handler);
-          return () => notificationHandlers.delete(handler);
-        },
-        addRequestHandler: () => () => undefined,
-        addCloseHandler: () => () => undefined,
-      }) as never,
-  );
-
+  const harness = createSharedStartedThreadHarness(requestImpl);
   return {
-    requests,
-    async waitForMethod(method: string) {
-      await vi.waitFor(() => expect(requests.map((entry) => entry.method)).toContain(method), {
-        interval: 1,
-      });
-    },
-    async notify(notification: CodexServerNotification) {
-      await notify(notification);
-    },
+    ...harness,
     async completeTurn(status: "completed" | "failed" = "completed", threadId = "thread-1") {
-      await notify({
+      await harness.notify({
         method: "turn/completed",
         params: {
           threadId,
@@ -438,19 +257,9 @@ function getRequestInputTextAt(
     .join("\n");
 }
 
+setupRunAttemptTestHooks();
+
 describe("runCodexAppServerAttempt context-engine lifecycle", () => {
-  beforeEach(async () => {
-    resetCodexTestBindingStore();
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-context-engine-"));
-  });
-
-  afterEach(async () => {
-    resetCodexAppServerClientFactoryForTest();
-    resetGlobalHookRunner();
-    vi.restoreAllMocks();
-    await fs.rm(tempDir, { recursive: true, force: true });
-  });
-
   it("keeps the fixture thread persistent while denying web search", () => {
     const params = withPersistentCodexTestToolPolicy(
       createParams(path.join(tempDir, "policy.jsonl"), path.join(tempDir, "workspace")),

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -14,9 +14,13 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  codexTestTurnIds,
+  createFakeCodexAppServerClient,
+} from "./codex-app-server.test-fixtures.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
-import type { CodexServerNotification, JsonObject, JsonValue, RpcRequest } from "./protocol.js";
+import type { CodexServerNotification, JsonObject, JsonValue } from "./protocol.js";
 import {
   createCodexTestBindingStore,
   type CodexAppServerBindingStore,
@@ -110,65 +114,18 @@ function runCodexAppServerSideQuestion(
   return runCodexAppServerSideQuestionImpl(params, { ...options, bindingStore });
 }
 
-type ServerRequest = Required<Pick<RpcRequest, "id" | "method">> & {
-  params?: RpcRequest["params"];
-};
-type ClientRequest = (
-  method: string,
-  requestParams?: unknown,
-  options?: unknown,
-) => Promise<unknown>;
-
-type FakeClient = {
-  request: ReturnType<typeof vi.fn<ClientRequest>>;
-  addNotificationHandler: ReturnType<typeof vi.fn>;
-  addRequestHandler: ReturnType<typeof vi.fn>;
-  notifications: Array<(notification: CodexServerNotification) => void>;
-  requests: Array<(request: ServerRequest) => unknown>;
-  emit: (notification: CodexServerNotification) => void;
-  handleRequest: (request: ServerRequest) => Promise<unknown>;
-};
-
-function createFakeClient(): FakeClient {
-  const notifications: FakeClient["notifications"] = [];
-  const requests: FakeClient["requests"] = [];
-  const client: FakeClient = {
-    notifications,
-    requests,
-    request: vi.fn<ClientRequest>(),
-    addNotificationHandler: vi.fn((handler: (notification: CodexServerNotification) => void) => {
-      notifications.push(handler);
-      return () => {
-        const index = notifications.indexOf(handler);
-        if (index >= 0) {
-          notifications.splice(index, 1);
-        }
-      };
-    }),
-    addRequestHandler: vi.fn((handler: FakeClient["requests"][number]) => {
-      requests.push(handler);
-      return () => {
-        const index = requests.indexOf(handler);
-        if (index >= 0) {
-          requests.splice(index, 1);
-        }
-      };
-    }),
-    emit: (notification) => {
-      for (const handler of notifications) {
-        handler(notification);
-      }
+function createFakeClient() {
+  const fixture = createFakeCodexAppServerClient();
+  const client = Object.assign(fixture.client, {
+    notifications: fixture.notifications,
+    request: fixture.request,
+    requests: fixture.requests,
+    emit: (notification: CodexServerNotification) => {
+      void fixture.notify(notification);
     },
-    handleRequest: async (request) => {
-      for (const handler of requests) {
-        const result = await handler(request);
-        if (result !== undefined) {
-          return result;
-        }
-      }
-      return undefined;
-    },
-  };
+    handleRequest: (request: Parameters<typeof fixture.handleServerRequest>[0]) =>
+      fixture.handleServerRequest(request),
+  });
   client.request.mockImplementation(async (method: string) => {
     if (method === "thread/fork") {
       return threadResult("side-thread");
@@ -485,8 +442,7 @@ async function runSideQuestionWithManagedWebSearchCall(
             id: 42,
             method: "item/tool/call",
             params: {
-              threadId: "side-thread",
-              turnId: "turn-1",
+              ...codexTestTurnIds("side-thread"),
               callId: "tool-1",
               tool: "web_search",
               arguments: { query: "service providers" },
@@ -1483,8 +1439,7 @@ describe("runCodexAppServerSideQuestion", () => {
               id: 42,
               method: "item/commandExecution/requestApproval",
               params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
+                ...codexTestTurnIds("side-thread"),
                 itemId: "cmd-side",
                 command: "/bin/bash -lc 'node -v'",
                 cwd: "/tmp/workspace",
@@ -1529,14 +1484,12 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(approvalArgs).toMatchObject({
       method: "item/commandExecution/requestApproval",
       requestParams: {
-        threadId: "side-thread",
-        turnId: "turn-1",
+        ...codexTestTurnIds("side-thread"),
         itemId: "cmd-side",
         command: "/bin/bash -lc 'node -v'",
         cwd: "/tmp/workspace",
       },
-      threadId: "side-thread",
-      turnId: "turn-1",
+      ...codexTestTurnIds("side-thread"),
       autoApprove: false,
       paramsForRun: {
         messageChannel: "discord",
@@ -2170,8 +2123,7 @@ describe("runCodexAppServerSideQuestion", () => {
           client.emit({
             method: "item/started",
             params: {
-              threadId: "side-thread",
-              turnId: "turn-1",
+              ...codexTestTurnIds("side-thread"),
               item: nativeCommandItem("side-cleanup-failure-tool", "inProgress", null),
             },
           });
@@ -2245,8 +2197,7 @@ describe("runCodexAppServerSideQuestion", () => {
               id: 42,
               method: "item/tool/call",
               params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
+                ...codexTestTurnIds("side-thread"),
                 callId: "tool-1",
                 tool: "wiki_status",
                 arguments: { topic: "AGENTS.md" },
@@ -2306,8 +2257,7 @@ describe("runCodexAppServerSideQuestion", () => {
               id: 43,
               method: "item/tool/call",
               params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
+                ...codexTestTurnIds("side-thread"),
                 callId: "computer-1",
                 tool: "computer",
                 arguments: { action: "screenshot" },
@@ -2375,8 +2325,7 @@ describe("runCodexAppServerSideQuestion", () => {
               id: 42,
               method: "item/tool/call",
               params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
+                ...codexTestTurnIds("side-thread"),
                 callId: "tool-1",
                 tool: "wiki_status",
                 arguments: {},
@@ -2427,8 +2376,7 @@ describe("runCodexAppServerSideQuestion", () => {
               id: 42,
               method: "item/tool/call",
               params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
+                ...codexTestTurnIds("side-thread"),
                 callId: "tool-1",
                 tool: "wiki_status",
                 arguments: { topic: "AGENTS.md" },
@@ -2502,16 +2450,14 @@ describe("runCodexAppServerSideQuestion", () => {
           client.emit({
             method: "item/started",
             params: {
-              threadId: "side-thread",
-              turnId: "turn-1",
+              ...codexTestTurnIds("side-thread"),
               item: nativeCommandItem("native-tool-1", "inProgress", null),
             },
           });
           client.emit({
             method: "item/completed",
             params: {
-              threadId: "side-thread",
-              turnId: "turn-1",
+              ...codexTestTurnIds("side-thread"),
               item: nativeCommandItem("native-tool-1", "completed", 12),
             },
           });
@@ -2634,8 +2580,7 @@ describe("runCodexAppServerSideQuestion", () => {
           client.emit({
             method: "item/started",
             params: {
-              threadId: "side-thread",
-              turnId: "turn-1",
+              ...codexTestTurnIds("side-thread"),
               item: nativeCommandItem("native-tool-unfinished", "inProgress", null),
             },
           });
@@ -2772,8 +2717,7 @@ describe("runCodexAppServerSideQuestion", () => {
           client.emit({
             method: "item/started",
             params: {
-              threadId: "side-thread",
-              turnId: "turn-1",
+              ...codexTestTurnIds("side-thread"),
               item: nativeCommandItem("native-tool-timeout", "inProgress", null),
             },
           });
@@ -2844,8 +2788,7 @@ describe("runCodexAppServerSideQuestion", () => {
             id: 42,
             method: "item/tool/call",
             params: {
-              threadId: "side-thread",
-              turnId: "turn-1",
+              ...codexTestTurnIds("side-thread"),
               callId: "tool-timeout",
               tool: "wiki_status",
               arguments: {},
@@ -2912,8 +2855,7 @@ describe("runCodexAppServerSideQuestion", () => {
               id: 42,
               method: "item/tool/call",
               params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
+                ...codexTestTurnIds("side-thread"),
                 callId: "tool-1",
                 tool: "wiki_status",
                 arguments: { topic: "AGENTS.md" },
@@ -2977,8 +2919,7 @@ describe("runCodexAppServerSideQuestion", () => {
               id: 43,
               method: "item/tool/requestUserInput",
               params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
+                ...codexTestTurnIds("side-thread"),
                 itemId: "input-1",
                 questions: [
                   {


### PR DESCRIPTION
## What Problem This Solves

The 126 Codex app-server test files contain 9,712 lines before their first suite declaration. The 12 measured target files alone contained 4,111 preamble lines, much of it repeated client-handler plumbing, standard thread/turn results, runtime identity methods, and thread/turn identifiers.

## Why This Change Was Made

This adds one dependency-light test fixture for the repeated fake client, standard thread/turn builders, runtime identity methods, and current-turn identifiers. The existing run-attempt harness now delegates to that fixture, and the target suites reuse it without changing test titles or assertions.

The N-way comparison also showed that the remaining 1,038-line run-attempt preamble and 277-line thread-lifecycle binding preamble are already harness adopters and mostly contain suite-specific setup. Auth bridge is likewise auth-specific. Those paths were left local instead of moving one-off fixtures into a shared file.

## User Impact

No runtime behavior changes. This is test-scaffolding-only cleanup. Across the branch, test code changes by +516/-1,163 lines for a net reduction of 647 lines; production runtime code changes by +0/-0.

The selected files' measured preambles fall from 4,111 to 3,606 lines. The reduction is smaller than the initial 2,500-4,000 estimate because the two largest files had already adopted the harness and their remaining setup was not repeated across three target suites.

## Evidence

- Focused Vitest: 13 files, 552 tests passed.
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/side-question.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/native-subagent-monitor.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/bounded-turn.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/approval-bridge.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/elicitation-bridge.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-startup.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.binding.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.usage-limits.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.hooks.test.ts`
- `pnpm format <11 changed paths>` passed.
- `node scripts/run-oxlint.mjs <11 changed paths>` passed.
- `node scripts/check-changed.mjs` could not provision the routed remote backend because Azure rejected its configured image selector with `admin_required`; Blacksmith and Daytona were unavailable first.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed` passed all extension production/test type checks, lint partitions, formatting, boundary checks, ratchets, dead-export scan, storage guards, and import-cycle checks locally.
- `git diff origin/main...HEAD --numstat`: production runtime +0/-0; test scaffolding +516/-1,163 (net -647).
