### PR TITLE
perf(tool-call-repair): stop re-parsing the whole response for a bare bracket

### DIFF
--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -718,6 +718,45 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(textDeltas(events).join("")).toBe(visibleChunks.join(""));
   });
 
+  it("keeps protection work linear when streamed text is bracket-dense", async () => {
+    // Tokenizers emit "[" as its own token, so a bracket-dense answer ends many
+    // deltas exactly at "[". The empty tool name matches every prefix, so each of
+    // those used to re-parse the whole accumulated response.
+    const buildDeltas = (sections: number) => {
+      const deltas = ["```toml\n"];
+      for (let index = 0; index < sections; index += 1) {
+        deltas.push("[", `section-${index}`, "]\n", `key-${index} = "value ${index}"\n`);
+      }
+      deltas.push("```\n");
+      return deltas;
+    };
+    const measure = async (sections: number) => {
+      let charsResolved = 0;
+      const deltas = buildDeltas(sections);
+      const events = await collectNormalizedEvents(
+        deltas.map((delta) => streamTextDelta(delta)),
+        {
+          matcher,
+          createPromotedToolCallEvents: () => [],
+          normalizeTerminalMessage: () => undefined,
+          resolveProtectedRanges: (text) => {
+            charsResolved += text.length;
+            return [];
+          },
+        },
+      );
+      expect(textDeltas(events).join("")).toBe(deltas.join(""));
+      return charsResolved;
+    };
+
+    const small = await measure(150);
+    const large = await measure(600);
+    // Quadratic growth would multiply this by ~16 for a 4x longer response.
+    expect(large).toBeLessThan(small * 8);
+    // And the absolute cost stays proportional to the candidates, not the response.
+    expect(large).toBeLessThan(50_000);
+  });
+
   it("materializes accumulated Markdown only after a candidate-shaped delta", async () => {
     const resolvedLengths: number[] = [];
     const visibleChunks = Array.from({ length: 1_000 }, () => "ordinary prose\n");

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -445,6 +445,17 @@ export function projectScrubbedPlainTextToolCallMessage(params: {
     : undefined;
 }
 
+/**
+ * An opener with no name characters yet, at the very end of the delta. Every
+ * matcher accepts the empty name as a prefix, so `[` alone is not evidence of a
+ * call — and resolving protection for it costs a re-parse of the whole response.
+ * The next delta carries the name and settles it against the candidate buffer.
+ */
+function isNamelessCallOpener(text: string, start: number): boolean {
+  const opener = text[start];
+  return (opener === "[" || opener === "<") && start + 1 >= text.length;
+}
+
 function findPotentialCallStart(
   text: string,
   atLineStart: boolean,
@@ -1337,7 +1348,11 @@ export async function* normalizePlainTextToolCallStreamEvents(
               overCapSequenceOpen ||
               (lineStarts.get(key) ?? true);
             let callStart = findPotentialCallStart(incoming, atLineStart, options.matcher);
-            if (callStart !== null && options.resolveProtectedRanges) {
+            if (
+              callStart !== null &&
+              options.resolveProtectedRanges &&
+              !isNamelessCallOpener(incoming, skipLineIndentation(incoming, callStart))
+            ) {
               if (protectionContextOverflow) {
                 // Bounded live history no longer proves ownership. Preserve bytes and let the
                 // authoritative terminal snapshot decide instead of deleting literal content.


### PR DESCRIPTION
## What Problem This Solves

Closes #119478.

Streaming an answer that contains many `[` characters re-parses the entire accumulated response as Markdown once per bracket-shaped delta. The work is quadratic in response size and changes nothing — the emitted text is byte-identical with and without it.

Measured through `normalizePlainTextToolCallStreamEvents`, counting characters handed to `resolveProtectedRanges`:

```
response    re-parses    characters re-parsed
10.3 KB          450                 762,430
21.0 KB          900               3,107,155
42.3 KB        1,800              12,589,105
```

Response size doubles, characters re-parsed quadruple. The identical document with `(` instead of `[` costs **zero** re-parses.

This contradicts the expectations pinned in this file's own coverage: `stream-normalizer.test.ts` asserts `resolverCalls` is `0` for ordinary streamed text and `resolvedLengths.length <= 3` once a candidate-shaped delta appears.

## Why This Change Was Made

Tokenizers emit `[` as its own token, so a bracket-dense answer ends many deltas exactly at `[`. At `grammar.ts:203` a bracket opener with no name characters yet produces:

```ts
const firstName = text.slice(firstNameStart, cursor);   // ""
if (cursor === text.length && "tool".startsWith(firstName)) {
  return { kind: "prefix" };
}
```

`"tool".startsWith("")` is true, so a bare `[` is reported as a potential call start. `stream-normalizer.ts` then materializes the whole accumulated response and hands it to `resolveProtectedRanges`.

Tracing one bracket showed three resolutions, only one of them expensive:

```
resolve(len 74)   <- prefix + "["      the whole response, per bracket
resolve(len  1)   <- "["               candidate buffer only
resolve(len 10)   <- "[section-0"      candidate buffer only
```

A bare opener carries no evidence: the empty name matches every tool. The next delta brings the name and settles it against the candidate buffer, which is already cheap. So the fix skips protection resolution for an opener that has no name yet, and changes nothing else.

Protection is still resolved for every candidate that carries name characters, so a real `[read]` is unaffected. Scope is one guard plus a predicate — no change to the resolver contract, the matcher, or the candidate state machine.

## User Impact

Long bracket-dense answers — `[tool.poetry]`, `[Unit]`, pasted `[2026-08-04T…] INFO` log lines, i.e. routine coding-agent output — stop burning CPU proportional to the square of the response.

Protection work becomes linear:

```
response    characters re-parsed     before
10.3 KB                    1,840    762,430
21.0 KB                    3,790  3,107,155
42.3 KB                    7,690 12,589,105
```

Emitted text is byte-identical before and after, at every size.

Honest limits:

- This bounds the *number* of whole-response re-parses; it does not make the remaining ones incremental. A response that genuinely contains many named tool-call candidates still resolves once per candidate.
- Measured as characters handed to the resolver, not wall-clock, so the numbers are deterministic and machine-independent. The issue reports 3.2 s of CPU for the 35 KB case.

**Separate pre-existing defect found while verifying this, not fixed here and not caused by this change.** A fenced tool call whose opener arrives as its own delta has its body silently deleted:

```
input:   ```\n[read]\n{"path":"x.txt"}\n[/read]\n```
emitted: ```\n```
```

The same call in a single delta is preserved correctly. I confirmed this reproduces byte-identically on unmodified `main`, so it predates this patch — the pending-candidate classification resolves protected ranges against the candidate buffer without the accumulated fence prefix, so a fenced call reads as executable. That is user-visible content loss and deserves its own issue; I did not widen this PR to chase it.

## Evidence

Production diff is **+15 net LOC** in one file (tests counted separately):

```
16  1  packages/tool-call-repair/src/stream-normalizer.ts
--- tests ---
39  0  packages/tool-call-repair/src/stream-normalizer.test.ts
```

Proof command:

```
node scripts/run-vitest.mjs packages/tool-call-repair
```

The regression test sits directly beside the two pinned expectations it extends, and asserts the shape rather than a timing: a 4x longer response must not cost more than 8x the protection work, and the absolute cost must stay proportional to the candidates.

**Negative control.** With only `stream-normalizer.ts` restored to `origin/main` and the new test kept, it fails for the right reason:

```
FAIL  keeps protection work linear when streamed text is bracket-dense
AssertionError: expected 6299605 to be less than 2970440
```

With the patch, the same measurement is **7,690**.

**Blast radius**, found by symbol across the whole repo — every consumer of the normalizer:

```
packages/tool-call-repair/src/index.ts
src/agents/embedded-agent-runner/run/attempt-stream.ts
src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
src/plugin-sdk/provider-stream-shared.ts
```

```
node scripts/run-vitest.mjs packages/tool-call-repair \
  src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts \
  src/plugin-sdk/provider-stream-shared.test.ts \
  src/agents/embedded-agent-runner/stream-resolution.test.ts
-> all shards passed (155 package tests, including every fence-protection case)
```

Typecheck `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean; `oxfmt --check` and `oxlint` clean; `git diff --check` clean.

Reviewed with `codex review --base origin/main`. It raised one P1 — the fenced-split content loss above — attributing it to this patch. Running the same fixture against restored upstream sources produced byte-identical output, proving it pre-existing; it is reported above rather than folded into this diff.

No Crabbox/Testbox on this machine, so cross-OS breadth is CI's.

*AI-assisted: investigated, implemented and proved with Claude Code; the diff and evidence above are human-reviewed.*
