### PR TITLE
fix(ui): preserve structured login error codes

### DIFF
--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import type {
   GatewayBrowserClient,
   GatewayBrowserClientOptions,
@@ -152,6 +153,53 @@ describe("createApplicationGateway connection phase", () => {
 
     current().opts.onClose?.({ code: 4008, reason: "connect failed", willRetry: false });
     expect(gateway.snapshot.phase).toBe("offline");
+  });
+
+  it.each([
+    {
+      name: "missing-token auth detail",
+      outerCode: "INVALID_REQUEST",
+      detailCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+      message: "token missing",
+    },
+    {
+      name: "pairing-required detail",
+      outerCode: "NOT_PAIRED",
+      detailCode: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+      message: "device is not approved",
+    },
+  ])("preserves the structured $name in the login snapshot", (fixture) => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: fixture.outerCode,
+        message: fixture.message,
+        details: { code: fixture.detailCode },
+      },
+      willRetry: false,
+    });
+
+    expect(gateway.snapshot.lastError).toBe(fixture.message);
+    expect(gateway.snapshot.lastErrorCode).toBe(fixture.detailCode);
+  });
+
+  it("preserves an outer code when a transport failure has no structured detail", () => {
+    const { gateway, current } = createStore();
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 1006,
+      reason: "websocket error",
+      error: { code: "UNAVAILABLE", message: "WebSocket connection failed" },
+      willRetry: false,
+    });
+
+    expect(gateway.snapshot.lastError).toBe("WebSocket connection failed");
+    expect(gateway.snapshot.lastErrorCode).toBe("UNAVAILABLE");
   });
 
   it("does not invent an assistant agent id before the gateway advertises one", () => {

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -4,6 +4,7 @@ import type { ControlUiBootstrapProfileHint } from "../../../src/gateway/control
 import type { EventLogEntry } from "../api/event-log.ts";
 import {
   GatewayBrowserClient,
+  resolveGatewayErrorDetailCode,
   type GatewayBrowserClientOptions,
   type GatewayEventListener,
   type GatewayHelloOk,
@@ -412,7 +413,7 @@ export function createApplicationGateway(
           canvasPluginSurfaceUrl: null,
           selfUser: null,
           lastError: error?.message ?? `disconnected (${code}): ${reason || "no reason"}`,
-          lastErrorCode: error?.code ?? null,
+          lastErrorCode: resolveGatewayErrorDetailCode(error) ?? error?.code ?? null,
         });
       },
       onGap: ({ expected, received }) => {

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -86,6 +86,56 @@ suite.define(() => {
     }
   });
 
+  it.each([
+    {
+      name: "missing token",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "token missing",
+        details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
+      },
+      expectedKind: "auth-required",
+      expectedTitle: "Auth required",
+    },
+    {
+      name: "pairing approval",
+      error: {
+        code: "NOT_PAIRED",
+        message: "device is not approved",
+        details: { code: ConnectErrorDetailCodes.PAIRING_REQUIRED },
+      },
+      expectedKind: "pairing-required",
+      expectedTitle: "Device pairing required",
+    },
+    {
+      name: "generic transport",
+      error: {
+        code: "UNAVAILABLE",
+        message: "WebSocket connection failed",
+      },
+      expectedKind: "network",
+      expectedTitle: "Could not connect",
+    },
+  ])("renders $name guidance from the application gateway snapshot", async (fixture) => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    try {
+      await page.goto(suite.server.baseUrl);
+      await gateway.waitForRequest("connect");
+      await gateway.rejectDeferred("connect", fixture.error);
+
+      const failure = page.locator(`.login-gate__failure[data-kind="${fixture.expectedKind}"]`);
+      await failure.waitFor({ timeout: 10_000 });
+      expect(await failure.locator(".login-gate__failure-title").textContent()).toBe(
+        fixture.expectedTitle,
+      );
+    } finally {
+      await closeContext(context);
+    }
+  });
+
   it("keeps mobile controls compact, touchable, and keyboard-friendly", async () => {
     const context = await suite.browser.newContext({
       hasTouch: true,


### PR DESCRIPTION
## Summary

- preserve structured Gateway connect-error detail codes in the Control UI application snapshot
- retain the outer error code as the fallback when a failure has no structured detail
- cover missing-token, pairing-required, and generic transport behavior from the store through the rendered login gate

## Root cause

The browser client delivered both the outer protocol code and the more specific `details.code`, but the application store retained only the outer code. Login classification treats a present unknown outer code as authoritative, so `AUTH_TOKEN_MISSING` could be rendered as a generic transport failure.

## Verification

- focused UI/API suite: 4 files, 124 tests passed
- browser E2E: 7/7 passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31131013956)
- source-blind behavior validation: 7/7 passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31131715543)
- changed-file gate: passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/31131804442)
- dead-export scan: 0 findings on both untouched base and proposed head
- autoreview: clean, no accepted/actionable findings

## Screenshots

**Before**

<img width="1280" height="900" alt="final" src="https://github.com/user-attachments/assets/5382c1ab-54f5-4d24-89f6-bc8171e485e0" />

**After**

<img width="1280" height="900" alt="final" src="https://github.com/user-attachments/assets/0c954032-509d-48a7-863e-d4b51e092a5d" />
