### PR TITLE
refactor(test): table-drive exact-duplicate test blocks, batch 2

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -889,7 +889,6 @@ src/plugins/update.test.ts
 src/proxy-capture/store.sqlite.ts
 src/routing/resolve-route.test.ts
 src/routing/resolve-route.ts
-src/scripts/test-projects.test.ts
 src/secrets/apply.test.ts
 src/secrets/apply.ts
 src/secrets/configure.ts

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -79,17 +79,38 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     globalFetchMock.mockRestore();
   });
 
-  it("uses proxy fetch when a Discord proxy is configured", async () => {
+  it.each([
+    {
+      title: "uses proxy fetch when a Discord proxy is configured",
+      messageId: "msg-1",
+      proxyUrl: "http://127.0.0.1:8080",
+    },
+    {
+      title: "uses proxy fetch when the Discord proxy is a DNS host",
+      messageId: "msg-dns",
+      proxyUrl: "http://mitm-proxy:8080",
+    },
+    {
+      title: "uses proxy fetch when the Discord proxy URL is arbitrary DNS",
+      messageId: "msg-remote",
+      proxyUrl: "http://proxy.test:8080",
+    },
+    {
+      title: "uses proxy fetch when the Discord proxy URL is a non-loopback IP",
+      messageId: "msg-remote",
+      proxyUrl: "http://10.0.0.10:8080",
+    },
+  ])("$title", async ({ messageId, proxyUrl }) => {
     const proxiedFetch = vi
       .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-1" }), { status: 200 }));
+      .mockResolvedValue(new Response(JSON.stringify({ id: messageId }), { status: 200 }));
     makeProxyFetchMock.mockReturnValue(proxiedFetch);
 
     const cfg = {
       channels: {
         discord: {
           token: "Bot test-token",
-          proxy: "http://127.0.0.1:8080",
+          proxy: proxyUrl,
         },
       },
     } as OpenClawConfig;
@@ -102,88 +123,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://127.0.0.1:8080");
-    expect(proxiedFetch).toHaveBeenCalledOnce();
-  });
-
-  it("uses proxy fetch when the Discord proxy is a DNS host", async () => {
-    const proxiedFetch = vi
-      .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-dns" }), { status: 200 }));
-    makeProxyFetchMock.mockReturnValue(proxiedFetch);
-
-    const cfg = {
-      channels: {
-        discord: {
-          token: "Bot test-token",
-          proxy: "http://mitm-proxy:8080",
-        },
-      },
-    } as OpenClawConfig;
-
-    await sendWebhookMessageDiscord("hello", {
-      cfg,
-      accountId: "default",
-      webhookId: "123",
-      webhookToken: "abc",
-      wait: true,
-    });
-
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
-    expect(proxiedFetch).toHaveBeenCalledOnce();
-  });
-
-  it("uses proxy fetch when the Discord proxy URL is arbitrary DNS", async () => {
-    const proxiedFetch = vi
-      .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
-    makeProxyFetchMock.mockReturnValue(proxiedFetch);
-
-    const cfg = {
-      channels: {
-        discord: {
-          token: "Bot test-token",
-          proxy: "http://proxy.test:8080",
-        },
-      },
-    } as OpenClawConfig;
-
-    await sendWebhookMessageDiscord("hello", {
-      cfg,
-      accountId: "default",
-      webhookId: "123",
-      webhookToken: "abc",
-      wait: true,
-    });
-
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://proxy.test:8080");
-    expect(proxiedFetch).toHaveBeenCalledOnce();
-  });
-
-  it("uses proxy fetch when the Discord proxy URL is a non-loopback IP", async () => {
-    const proxiedFetch = vi
-      .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
-    makeProxyFetchMock.mockReturnValue(proxiedFetch);
-
-    const cfg = {
-      channels: {
-        discord: {
-          token: "Bot test-token",
-          proxy: "http://10.0.0.10:8080",
-        },
-      },
-    } as OpenClawConfig;
-
-    await sendWebhookMessageDiscord("hello", {
-      cfg,
-      accountId: "default",
-      webhookId: "123",
-      webhookToken: "abc",
-      wait: true,
-    });
-
-    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://10.0.0.10:8080");
+    expect(makeProxyFetchMock).toHaveBeenCalledWith(proxyUrl);
     expect(proxiedFetch).toHaveBeenCalledOnce();
   });
 

--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -148,10 +148,35 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     expect(result.droppedDates).toEqual([]);
   });
 
-  it("preserves a non-promotion ## heading sandwiched between promotion sections", () => {
+  it.each([
+    {
+      title: "preserves a non-promotion ## heading sandwiched between promotion sections",
+      userSection: "## My Reflections\nMy own notes.\n\n",
+      heading: "## My Reflections",
+      content: "My own notes.",
+    },
+    {
+      title: "preserves a user-authored `### Global` heading written under a promotion section",
+      userSection: "### Global\n\nMy own global rule, not a promoted entry.\n\n",
+      heading: "### Global",
+      content: "My own global rule, not a promoted entry.",
+    },
+    {
+      title: "preserves a user-authored `### Project:` heading written under a promotion section",
+      userSection: "### Project: alpha\n\nAlpha ships on Fridays.\n\n",
+      heading: "### Project: alpha",
+      content: "Alpha ships on Fridays.",
+    },
+    {
+      title: "preserves a tab-delimited user heading written under a promotion section",
+      userSection: "###\tCorrection\nThe prod DB is db-2.corp.example, NOT db-1.\n\n",
+      heading: "###\tCorrection",
+      content: "The prod DB is db-2.corp.example, NOT db-1.",
+    },
+  ])("$title", ({ userSection, heading, content }) => {
     const existing =
       `${promotionSection("2026-04-10", 400)}\n` +
-      "## My Reflections\nMy own notes.\n\n" +
+      userSection +
       promotionSection("2026-04-20", 400);
     const newSection = `\n${promotionSection("2026-04-29", 400)}`;
     const result = compactMemoryForBudget({
@@ -160,8 +185,8 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
       budgetChars: 900,
     });
     expect(result.droppedDates).toContain("2026-04-10");
-    expect(result.compacted).toContain("## My Reflections");
-    expect(result.compacted).toContain("My own notes.");
+    expect(result.compacted).toContain(heading);
+    expect(result.compacted).toContain(content);
   });
 
   it("does not prepend a spurious leading newline when input starts with a ## heading", () => {
@@ -261,54 +286,6 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     expect(result.compacted).not.toContain("### Project: alpha");
     expect(result.compacted).not.toContain("### Global");
     expect(result.compacted).not.toContain("openclaw-memory-promotion");
-  });
-
-  it("preserves a user-authored `### Global` heading written under a promotion section", () => {
-    const existing =
-      `${promotionSection("2026-04-10", 400)}\n` +
-      "### Global\n\nMy own global rule, not a promoted entry.\n\n" +
-      promotionSection("2026-04-20", 400);
-    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
-    const result = compactMemoryForBudget({
-      existingMemory: existing,
-      newSection,
-      budgetChars: 900,
-    });
-    expect(result.droppedDates).toContain("2026-04-10");
-    expect(result.compacted).toContain("### Global");
-    expect(result.compacted).toContain("My own global rule, not a promoted entry.");
-  });
-
-  it("preserves a user-authored `### Project:` heading written under a promotion section", () => {
-    const existing =
-      `${promotionSection("2026-04-10", 400)}\n` +
-      "### Project: alpha\n\nAlpha ships on Fridays.\n\n" +
-      promotionSection("2026-04-20", 400);
-    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
-    const result = compactMemoryForBudget({
-      existingMemory: existing,
-      newSection,
-      budgetChars: 900,
-    });
-    expect(result.droppedDates).toContain("2026-04-10");
-    expect(result.compacted).toContain("### Project: alpha");
-    expect(result.compacted).toContain("Alpha ships on Fridays.");
-  });
-
-  it("preserves a tab-delimited user heading written under a promotion section", () => {
-    const existing =
-      `${promotionSection("2026-04-10", 400)}\n` +
-      "###\tCorrection\nThe prod DB is db-2.corp.example, NOT db-1.\n\n" +
-      promotionSection("2026-04-20", 400);
-    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
-    const result = compactMemoryForBudget({
-      existingMemory: existing,
-      newSection,
-      budgetChars: 900,
-    });
-    expect(result.droppedDates).toContain("2026-04-10");
-    expect(result.compacted).toContain("###\tCorrection");
-    expect(result.compacted).toContain("The prod DB is db-2.corp.example, NOT db-1.");
   });
 
   it("preserves an empty user heading line written under a promotion section", () => {

--- a/extensions/minimax/image-generation-provider.test.ts
+++ b/extensions/minimax/image-generation-provider.test.ts
@@ -292,7 +292,28 @@ describe("minimax image-generation provider", () => {
     expect((request.headers as Headers).get("x-minimax-image-policy")).toBe("enabled");
   });
 
-  it("keeps the dedicated global image endpoint when text config uses the global API host", async () => {
+  it.each([
+    {
+      title: "keeps the dedicated global image endpoint when text config uses the global API host",
+      providerBaseUrl: "https://api.minimax.io/anthropic",
+      expectedEndpoint: "https://api.minimax.io/v1/image_generation",
+    },
+    {
+      title: "does not inherit unrelated MiniMax text endpoint hosts for image generation",
+      providerBaseUrl: "https://api.minimax.chat/anthropic",
+      expectedEndpoint: "https://api.minimax.io/v1/image_generation",
+    },
+    {
+      title: "infers the dedicated CN image endpoint from MiniMax provider config",
+      providerBaseUrl: "https://api.minimaxi.com/anthropic",
+      expectedEndpoint: "https://api.minimaxi.com/v1/image_generation",
+    },
+    {
+      title: "ignores private custom text endpoints for image generation",
+      providerBaseUrl: "http://127.0.0.1:8080/anthropic",
+      expectedEndpoint: "https://api.minimax.io/v1/image_generation",
+    },
+  ])("$title", async ({ providerBaseUrl, expectedEndpoint }) => {
     mockMinimaxApiKey();
     const fetchMock = mockSuccessfulMinimaxImageResponse();
 
@@ -305,7 +326,7 @@ describe("minimax image-generation provider", () => {
         models: {
           providers: {
             minimax: {
-              baseUrl: "https://api.minimax.io/anthropic",
+              baseUrl: providerBaseUrl,
               models: [],
             },
           },
@@ -313,31 +334,7 @@ describe("minimax image-generation provider", () => {
       },
     });
 
-    expectImageGenerationUrl(fetchMock, "https://api.minimax.io/v1/image_generation");
-  });
-
-  it("does not inherit unrelated MiniMax text endpoint hosts for image generation", async () => {
-    mockMinimaxApiKey();
-    const fetchMock = mockSuccessfulMinimaxImageResponse();
-
-    const provider = buildMinimaxImageGenerationProvider();
-    await provider.generateImage({
-      provider: "minimax",
-      model: "image-01",
-      prompt: "draw a cat",
-      cfg: {
-        models: {
-          providers: {
-            minimax: {
-              baseUrl: "https://api.minimax.chat/anthropic",
-              models: [],
-            },
-          },
-        },
-      },
-    });
-
-    expectImageGenerationUrl(fetchMock, "https://api.minimax.io/v1/image_generation");
+    expectImageGenerationUrl(fetchMock, expectedEndpoint);
   });
 
   it("uses the dedicated CN image endpoint when CN API host is configured", async () => {
@@ -351,30 +348,6 @@ describe("minimax image-generation provider", () => {
       model: "image-01",
       prompt: "draw a cat",
       cfg: {},
-    });
-
-    expectImageGenerationUrl(fetchMock, "https://api.minimaxi.com/v1/image_generation");
-  });
-
-  it("infers the dedicated CN image endpoint from MiniMax provider config", async () => {
-    mockMinimaxApiKey();
-    const fetchMock = mockSuccessfulMinimaxImageResponse();
-
-    const provider = buildMinimaxImageGenerationProvider();
-    await provider.generateImage({
-      provider: "minimax",
-      model: "image-01",
-      prompt: "draw a cat",
-      cfg: {
-        models: {
-          providers: {
-            minimax: {
-              baseUrl: "https://api.minimaxi.com/anthropic",
-              models: [],
-            },
-          },
-        },
-      },
     });
 
     expectImageGenerationUrl(fetchMock, "https://api.minimaxi.com/v1/image_generation");
@@ -402,29 +375,5 @@ describe("minimax image-generation provider", () => {
     });
 
     expectImageGenerationUrl(fetchMock, "https://api.minimaxi.com/v1/image_generation");
-  });
-
-  it("ignores private custom text endpoints for image generation", async () => {
-    mockMinimaxApiKey();
-    const fetchMock = mockSuccessfulMinimaxImageResponse();
-
-    const provider = buildMinimaxImageGenerationProvider();
-    await provider.generateImage({
-      provider: "minimax",
-      model: "image-01",
-      prompt: "draw a cat",
-      cfg: {
-        models: {
-          providers: {
-            minimax: {
-              baseUrl: "http://127.0.0.1:8080/anthropic",
-              models: [],
-            },
-          },
-        },
-      },
-    });
-
-    expectImageGenerationUrl(fetchMock, "https://api.minimax.io/v1/image_generation");
   });
 });

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -169,63 +169,51 @@ describe("msteamsOutbound cfg threading", () => {
     });
   });
 
-  it("forwards resolved channel thread ids through the Teams target", async () => {
-    await requireSendText()({
-      cfg,
-      to: "conversation:19:channel@thread.tacv2",
-      text: "threaded",
+  it.each([
+    {
+      title: "forwards resolved channel thread ids through the Teams target",
+      target: "conversation:19:channel@thread.tacv2",
+      peerKind: "threaded",
       threadId: "thread-root-2",
-    });
-
-    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
-      cfg,
-      to: "conversation:19:channel@thread.tacv2;messageid=thread-root-2",
-      text: "threaded",
-    });
-  });
-
-  it("preserves explicit Teams thread targets", async () => {
-    await requireSendText()({
-      cfg,
-      to: "conversation:19:channel@thread.tacv2;messageid=explicit-root",
-      text: "threaded",
+      expectedTarget: "conversation:19:channel@thread.tacv2;messageid=thread-root-2",
+      expectedPeerKind: "threaded",
+    },
+    {
+      title: "preserves explicit Teams thread targets",
+      target: "conversation:19:channel@thread.tacv2;messageid=explicit-root",
+      peerKind: "threaded",
       threadId: "ambient-root",
-    });
-
-    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
-      cfg,
-      to: "conversation:19:channel@thread.tacv2;messageid=explicit-root",
-      text: "threaded",
-    });
-  });
-
-  it("forwards thread ids through Graph team/channel targets", async () => {
-    await requireSendText()({
-      cfg,
-      to: "graph-team/19:channel@thread.tacv2",
-      text: "threaded",
+      expectedTarget: "conversation:19:channel@thread.tacv2;messageid=explicit-root",
+      expectedPeerKind: "threaded",
+    },
+    {
+      title: "forwards thread ids through Graph team/channel targets",
+      target: "graph-team/19:channel@thread.tacv2",
+      peerKind: "threaded",
       threadId: "thread-root-3",
-    });
-
-    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
-      cfg,
-      to: "graph-team/19:channel@thread.tacv2;messageid=thread-root-3",
-      text: "threaded",
-    });
-  });
-
-  it("does not append channel thread ids to direct-message targets", async () => {
+      expectedTarget: "graph-team/19:channel@thread.tacv2;messageid=thread-root-3",
+      expectedPeerKind: "threaded",
+    },
+    {
+      title: "does not append channel thread ids to direct-message targets",
+      target: "user:aad-user-1",
+      peerKind: "direct",
+      threadId: "quoted-parent",
+      expectedTarget: "user:aad-user-1",
+      expectedPeerKind: "direct",
+    },
+  ])("$title", async ({ target, peerKind, threadId, expectedTarget, expectedPeerKind }) => {
     await requireSendText()({
       cfg,
-      to: "user:aad-user-1",
-      text: "direct",
-      threadId: "quoted-parent",
+      to: target,
+      text: peerKind,
+      threadId,
     });
 
     expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
       cfg,
-      to: "user:aad-user-1",
-      text: "direct",
+      to: expectedTarget,
+      text: expectedPeerKind,
     });
   });
 

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -422,13 +422,11 @@ describe("qa agentic parity report", () => {
     ]);
   });
 
-  it("ignores neutral Failed and Blocked headings in passing protocol reports", () => {
-    const summary: QaParitySuiteSummary = {
-      scenarios: [
-        {
-          name: "Source and docs discovery report",
-          status: "pass",
-          details: `Worked:
+  it.each([
+    {
+      title: "ignores neutral Failed and Blocked headings in passing protocol reports",
+      scenarioName: "Source and docs discovery report",
+      report: `Worked:
 - Read the seeded QA material.
 Failed:
 - None observed.
@@ -436,11 +434,40 @@ Blocked:
 - No live provider evidence in this lane.
 Follow-up:
 - Re-run with a real provider if needed.`,
+      expectedSuspiciousPasses: 0,
+    },
+    {
+      title: "still flags genuine error-narration suspicious passes",
+      scenarioName: "Approval turn tool followthrough",
+      report: "Tool call completed, but an error occurred mid-turn and no retry happened.",
+      expectedSuspiciousPasses: 1,
+    },
+    {
+      title: "does not flag bare 'Done.' prose as fake success",
+      scenarioName: "Approval turn tool followthrough",
+      report: "Done.",
+      expectedSuspiciousPasses: 0,
+    },
+    {
+      title: "does not flag structured status lines that end in `done`",
+      scenarioName: "Compaction retry after mutating tool",
+      report: `Confirmed, replay unsafe after write.
+compactionCount=0
+status=done`,
+      expectedSuspiciousPasses: 0,
+    },
+  ])("$title", ({ scenarioName, report, expectedSuspiciousPasses }) => {
+    const summary: QaParitySuiteSummary = {
+      scenarios: [
+        {
+          name: scenarioName,
+          status: "pass",
+          details: report,
         },
       ],
     };
 
-    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
+    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(expectedSuspiciousPasses);
   });
 
   it("ignores neutral error-budget and no-errors-observed phrasing in passing reports", () => {
@@ -467,20 +494,6 @@ Follow-up:
     expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
   });
 
-  it("still flags genuine error-narration suspicious passes", () => {
-    const summary: QaParitySuiteSummary = {
-      scenarios: [
-        {
-          name: "Approval turn tool followthrough",
-          status: "pass",
-          details: "Tool call completed, but an error occurred mid-turn and no retry happened.",
-        },
-      ],
-    };
-
-    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(1);
-  });
-
   it("does not flag positive-tone prose as fake success (positive-tone detection removed)", () => {
     // Positive-tone detection was removed because for passing runs the
     // `details` field is the model's prose, which never contains tool-call
@@ -491,36 +504,6 @@ Follow-up:
           name: "Subagent handoff",
           status: "pass",
           details: "Successfully completed the delegation. The subagent returned its result.",
-        },
-      ],
-    };
-
-    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
-  });
-
-  it("does not flag bare 'Done.' prose as fake success", () => {
-    const summary: QaParitySuiteSummary = {
-      scenarios: [
-        {
-          name: "Approval turn tool followthrough",
-          status: "pass",
-          details: "Done.",
-        },
-      ],
-    };
-
-    expect(computeQaAgenticParityMetrics(summary).fakeSuccessCount).toBe(0);
-  });
-
-  it("does not flag structured status lines that end in `done`", () => {
-    const summary: QaParitySuiteSummary = {
-      scenarios: [
-        {
-          name: "Compaction retry after mutating tool",
-          status: "pass",
-          details: `Confirmed, replay unsafe after write.
-compactionCount=0
-status=done`,
         },
       ],
     };

--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -533,31 +533,57 @@ describe("runQaCharacterEval", () => {
     await resultPromise;
   });
 
-  it("marks raw provider error transcripts as failed output", async () => {
+  it.each([
+    {
+      title: "marks raw provider error transcripts as failed output",
+      transcript:
+        "USER Alice: Are you awake?\n\nASSISTANT OpenClaw QA: 400 model `qwen3.6-plus` is not supported.",
+      model: "qwen/qwen3.6-plus",
+      expectedReason: "model unsupported error leaked into transcript",
+    },
+    {
+      title: "marks generic channel fallback transcripts as failed output",
+      transcript:
+        "ASSISTANT OpenClaw QA: ⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
+      model: "qa/generic-fallback-model",
+      expectedReason: "generic request failure leaked into transcript",
+    },
+    {
+      title: "marks idle-timeout fallback transcripts as failed output",
+      transcript:
+        "ASSISTANT OpenClaw QA: The model did not produce a response before the LLM idle timeout. Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config.",
+      model: "google/gemini-test",
+      expectedReason: "LLM timeout leaked into transcript",
+    },
+    {
+      title: "marks leaked harness coordination transcripts as failed output",
+      transcript:
+        "ASSISTANT OpenClaw QA: checking thread context; then post a tight progress reply here.\nQA_LEAK_OK",
+      model: "codex/gpt-5.6-luna",
+      expectedReason: "internal harness/meta text leaked into transcript",
+    },
+  ])("$title", async ({ transcript, model, expectedReason }) => {
     const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
       makeSuiteResult({
         outputDir: params.outputDir,
         model: params.primaryModel,
-        transcript:
-          "USER Alice: Are you awake?\n\nASSISTANT OpenClaw QA: 400 model `qwen3.6-plus` is not supported.",
+        transcript,
       }),
     );
-    const runJudge = makeRunJudge([
-      { model: "qwen/qwen3.6-plus", rank: 1, score: 0.5, summary: "failed" },
-    ]);
+    const runJudge = makeRunJudge([{ model, rank: 1, score: 0.5, summary: "failed" }]);
 
     const result = await runQaCharacterEval({
       repoRoot: tempRoot,
       outputDir: path.join(tempRoot, "character"),
-      models: ["qwen/qwen3.6-plus"],
+      models: [model],
       judgeModels: ["openai/gpt-5.6-luna"],
       runSuite,
       runJudge,
     });
 
     expectFirstRunFailure(result, {
-      model: "qwen/qwen3.6-plus",
-      error: "model unsupported error leaked into transcript",
+      model,
+      error: expectedReason,
     });
   });
 
@@ -644,90 +670,6 @@ describe("runQaCharacterEval", () => {
     expectFirstRunFailure(result, {
       model: "qwen/qwen3.5-plus",
       error: "tool failure leaked into transcript",
-    });
-  });
-
-  it("marks generic channel fallback transcripts as failed output", async () => {
-    const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
-      makeSuiteResult({
-        outputDir: params.outputDir,
-        model: params.primaryModel,
-        transcript:
-          "ASSISTANT OpenClaw QA: ⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
-      }),
-    );
-    const runJudge = makeRunJudge([
-      { model: "qa/generic-fallback-model", rank: 1, score: 0.5, summary: "failed" },
-    ]);
-
-    const result = await runQaCharacterEval({
-      repoRoot: tempRoot,
-      outputDir: path.join(tempRoot, "character"),
-      models: ["qa/generic-fallback-model"],
-      judgeModels: ["openai/gpt-5.6-luna"],
-      runSuite,
-      runJudge,
-    });
-
-    expectFirstRunFailure(result, {
-      model: "qa/generic-fallback-model",
-      error: "generic request failure leaked into transcript",
-    });
-  });
-
-  it("marks idle-timeout fallback transcripts as failed output", async () => {
-    const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
-      makeSuiteResult({
-        outputDir: params.outputDir,
-        model: params.primaryModel,
-        transcript:
-          "ASSISTANT OpenClaw QA: The model did not produce a response before the LLM idle timeout. Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config.",
-      }),
-    );
-    const runJudge = makeRunJudge([
-      { model: "google/gemini-test", rank: 1, score: 0.5, summary: "failed" },
-    ]);
-
-    const result = await runQaCharacterEval({
-      repoRoot: tempRoot,
-      outputDir: path.join(tempRoot, "character"),
-      models: ["google/gemini-test"],
-      judgeModels: ["openai/gpt-5.6-luna"],
-      runSuite,
-      runJudge,
-    });
-
-    expectFirstRunFailure(result, {
-      model: "google/gemini-test",
-      error: "LLM timeout leaked into transcript",
-    });
-  });
-
-  it("marks leaked harness coordination transcripts as failed output", async () => {
-    const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
-      makeSuiteResult({
-        outputDir: params.outputDir,
-        model: params.primaryModel,
-        transcript:
-          "ASSISTANT OpenClaw QA: checking thread context; then post a tight progress reply here.\nQA_LEAK_OK",
-      }),
-    );
-    const runJudge = makeRunJudge([
-      { model: "codex/gpt-5.6-luna", rank: 1, score: 0.5, summary: "failed" },
-    ]);
-
-    const result = await runQaCharacterEval({
-      repoRoot: tempRoot,
-      outputDir: path.join(tempRoot, "character"),
-      models: ["codex/gpt-5.6-luna"],
-      judgeModels: ["openai/gpt-5.6-luna"],
-      runSuite,
-      runJudge,
-    });
-
-    expectFirstRunFailure(result, {
-      model: "codex/gpt-5.6-luna",
-      error: "internal harness/meta text leaked into transcript",
     });
   });
 

--- a/extensions/qa-lab/src/live-timeout.test.ts
+++ b/extensions/qa-lab/src/live-timeout.test.ts
@@ -3,56 +3,60 @@ import { describe, expect, it } from "vitest";
 import { resolveQaLiveTurnTimeoutMs } from "./live-timeout.js";
 
 describe("qa live timeout policy", () => {
-  it("keeps mock lanes on the caller fallback", () => {
+  it.each([
+    {
+      title: "keeps mock lanes on the caller fallback",
+      mode: "mock-openai",
+      model: "anthropic/claude-sonnet-4-6",
+      fallbackModel: "anthropic/claude-opus-4-8",
+      expectedTimeoutMs: 30_000,
+    },
+    {
+      title: "uses the higher gpt-5 live floor for openai heavy turns",
+      mode: "live-frontier",
+      model: "openai/gpt-5.6-luna",
+      fallbackModel: "openai/gpt-5.6-luna",
+      expectedTimeoutMs: 360_000,
+    },
+    {
+      title: "keeps the standard live floor for other non-anthropic models",
+      mode: "live-frontier",
+      model: "google/gemini-3-flash",
+      fallbackModel: "google/gemini-3-flash",
+      expectedTimeoutMs: 120_000,
+    },
+    {
+      title: "uses the anthropic floor for sonnet turns",
+      mode: "live-frontier",
+      model: "anthropic/claude-sonnet-4-6",
+      fallbackModel: "anthropic/claude-opus-4-8",
+      expectedTimeoutMs: 180_000,
+    },
+    {
+      title: "uses the anthropic floor for claude-cli sonnet turns",
+      mode: "live-frontier",
+      model: "claude-cli/claude-sonnet-4-6",
+      fallbackModel: "claude-cli/claude-opus-4-8",
+      expectedTimeoutMs: 180_000,
+    },
+    {
+      title: "uses the opus floor for claude-cli opus turns",
+      mode: "live-frontier",
+      model: "claude-cli/claude-opus-4-8",
+      fallbackModel: "claude-cli/claude-opus-4-8",
+      expectedTimeoutMs: 240_000,
+    },
+  ])("$title", ({ mode, model, fallbackModel, expectedTimeoutMs }) => {
     expect(
       resolveQaLiveTurnTimeoutMs(
         {
-          providerMode: "mock-openai",
-          primaryModel: "anthropic/claude-sonnet-4-6",
-          alternateModel: "anthropic/claude-opus-4-8",
+          providerMode: mode,
+          primaryModel: model,
+          alternateModel: fallbackModel,
         },
         30_000,
       ),
-    ).toBe(30_000);
-  });
-
-  it("uses the higher gpt-5 live floor for openai heavy turns", () => {
-    expect(
-      resolveQaLiveTurnTimeoutMs(
-        {
-          providerMode: "live-frontier",
-          primaryModel: "openai/gpt-5.6-luna",
-          alternateModel: "openai/gpt-5.6-luna",
-        },
-        30_000,
-      ),
-    ).toBe(360_000);
-  });
-
-  it("keeps the standard live floor for other non-anthropic models", () => {
-    expect(
-      resolveQaLiveTurnTimeoutMs(
-        {
-          providerMode: "live-frontier",
-          primaryModel: "google/gemini-3-flash",
-          alternateModel: "google/gemini-3-flash",
-        },
-        30_000,
-      ),
-    ).toBe(120_000);
-  });
-
-  it("uses the anthropic floor for sonnet turns", () => {
-    expect(
-      resolveQaLiveTurnTimeoutMs(
-        {
-          providerMode: "live-frontier",
-          primaryModel: "anthropic/claude-sonnet-4-6",
-          alternateModel: "anthropic/claude-opus-4-8",
-        },
-        30_000,
-      ),
-    ).toBe(180_000);
+    ).toBe(expectedTimeoutMs);
   });
 
   it("uses the opus floor when the switched turn runs on claude opus", () => {
@@ -65,32 +69,6 @@ describe("qa live timeout policy", () => {
         },
         30_000,
         "anthropic/claude-opus-4-8",
-      ),
-    ).toBe(240_000);
-  });
-
-  it("uses the anthropic floor for claude-cli sonnet turns", () => {
-    expect(
-      resolveQaLiveTurnTimeoutMs(
-        {
-          providerMode: "live-frontier",
-          primaryModel: "claude-cli/claude-sonnet-4-6",
-          alternateModel: "claude-cli/claude-opus-4-8",
-        },
-        30_000,
-      ),
-    ).toBe(180_000);
-  });
-
-  it("uses the opus floor for claude-cli opus turns", () => {
-    expect(
-      resolveQaLiveTurnTimeoutMs(
-        {
-          providerMode: "live-frontier",
-          primaryModel: "claude-cli/claude-opus-4-8",
-          alternateModel: "claude-cli/claude-opus-4-8",
-        },
-        30_000,
       ),
     ).toBe(240_000);
   });

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -319,26 +319,38 @@ describe("qa suite runtime agent process helpers", () => {
     await expect(pending).resolves.toEqual({ ok: true });
   });
 
-  it("parses json qa cli output after colored startup logs", async () => {
-    const { child, pending } = startMockQaCli({
-      env: QA_CLI_JSON_ENV,
-      args: ["memory", "search", "--json"],
-      options: { json: true },
-    });
-
-    await waitForSpawnCount(1);
-    child.stdout.emit(
-      "data",
-      Buffer.from(
+  it.each([
+    {
+      title: "parses json qa cli output after colored startup logs",
+      stdout:
         '\u001b[35m[plugins]\u001b[39m \u001b[36mcodex loaded plugin package metadata\u001b[39m\n{"results":[{"text":"ORBIT-10"}]}\n',
-      ),
-    );
-    child.emit("close", 0);
-
-    await expect(pending).resolves.toEqual({ results: [{ text: "ORBIT-10" }] });
-  });
-
-  it("parses pretty json qa cli output after startup logs", async () => {
+    },
+    {
+      title: "parses pretty json qa cli output after startup logs",
+      stdout:
+        '[plugins] memory-core loaded plugin package metadata\n{\n  "results": [\n    {\n      "text": "ORBIT-10"\n    }\n  ]\n}\n',
+    },
+    {
+      title: "parses pretty json qa cli output before trailing stdout logs",
+      stdout:
+        '[plugins] memory-core loaded plugin package metadata\n{\n  "results": [\n    {\n      "text": "ORBIT-10"\n    }\n  ]\n}\n[plugins] trailing diagnostic\n',
+    },
+    {
+      title: "ignores diagnostic json fragments before the qa cli payload",
+      stdout:
+        '[plugins] diagnostic context {"ok":true}\n{"results":[{"text":"ORBIT-10"}]}\n[plugins] trailing diagnostic\n',
+    },
+    {
+      title: "ignores leading json diagnostic records before the qa cli payload",
+      stdout:
+        '{"event":"startup-repair"}\n{"results":[{"text":"ORBIT-10"}]}\n[plugins] trailing diagnostic\n',
+    },
+    {
+      title: "ignores trailing json diagnostic records after the qa cli payload",
+      stdout:
+        '[plugins] memory-core loaded plugin package metadata\n{\n  "results": [\n    {\n      "text": "ORBIT-10"\n    }\n  ]\n}\n{"event":"cleanup"}\n',
+    },
+  ])("$title", async ({ stdout }) => {
     const { child, pending } = startMockQaCli({
       env: QA_CLI_JSON_ENV,
       args: ["memory", "search", "--json"],
@@ -346,12 +358,7 @@ describe("qa suite runtime agent process helpers", () => {
     });
 
     await waitForSpawnCount(1);
-    child.stdout.emit(
-      "data",
-      Buffer.from(
-        '[plugins] memory-core loaded plugin package metadata\n{\n  "results": [\n    {\n      "text": "ORBIT-10"\n    }\n  ]\n}\n',
-      ),
-    );
+    child.stdout.emit("data", Buffer.from(stdout));
     child.emit("close", 0);
 
     await expect(pending).resolves.toEqual({ results: [{ text: "ORBIT-10" }] });
@@ -370,82 +377,6 @@ describe("qa suite runtime agent process helpers", () => {
     child.emit("close", 0);
 
     await expect(pending).resolves.toEqual({ results: [{ text: "LATE-STDOUT" }] });
-  });
-
-  it("parses pretty json qa cli output before trailing stdout logs", async () => {
-    const { child, pending } = startMockQaCli({
-      env: QA_CLI_JSON_ENV,
-      args: ["memory", "search", "--json"],
-      options: { json: true },
-    });
-
-    await waitForSpawnCount(1);
-    child.stdout.emit(
-      "data",
-      Buffer.from(
-        '[plugins] memory-core loaded plugin package metadata\n{\n  "results": [\n    {\n      "text": "ORBIT-10"\n    }\n  ]\n}\n[plugins] trailing diagnostic\n',
-      ),
-    );
-    child.emit("close", 0);
-
-    await expect(pending).resolves.toEqual({ results: [{ text: "ORBIT-10" }] });
-  });
-
-  it("ignores diagnostic json fragments before the qa cli payload", async () => {
-    const { child, pending } = startMockQaCli({
-      env: QA_CLI_JSON_ENV,
-      args: ["memory", "search", "--json"],
-      options: { json: true },
-    });
-
-    await waitForSpawnCount(1);
-    child.stdout.emit(
-      "data",
-      Buffer.from(
-        '[plugins] diagnostic context {"ok":true}\n{"results":[{"text":"ORBIT-10"}]}\n[plugins] trailing diagnostic\n',
-      ),
-    );
-    child.emit("close", 0);
-
-    await expect(pending).resolves.toEqual({ results: [{ text: "ORBIT-10" }] });
-  });
-
-  it("ignores leading json diagnostic records before the qa cli payload", async () => {
-    const { child, pending } = startMockQaCli({
-      env: QA_CLI_JSON_ENV,
-      args: ["memory", "search", "--json"],
-      options: { json: true },
-    });
-
-    await waitForSpawnCount(1);
-    child.stdout.emit(
-      "data",
-      Buffer.from(
-        '{"event":"startup-repair"}\n{"results":[{"text":"ORBIT-10"}]}\n[plugins] trailing diagnostic\n',
-      ),
-    );
-    child.emit("close", 0);
-
-    await expect(pending).resolves.toEqual({ results: [{ text: "ORBIT-10" }] });
-  });
-
-  it("ignores trailing json diagnostic records after the qa cli payload", async () => {
-    const { child, pending } = startMockQaCli({
-      env: QA_CLI_JSON_ENV,
-      args: ["memory", "search", "--json"],
-      options: { json: true },
-    });
-
-    await waitForSpawnCount(1);
-    child.stdout.emit(
-      "data",
-      Buffer.from(
-        '[plugins] memory-core loaded plugin package metadata\n{\n  "results": [\n    {\n      "text": "ORBIT-10"\n    }\n  ]\n}\n{"event":"cleanup"}\n',
-      ),
-    );
-    child.emit("close", 0);
-
-    await expect(pending).resolves.toEqual({ results: [{ text: "ORBIT-10" }] });
   });
 
   it("rejects oversized qa cli stdout instead of parsing truncated output", async () => {

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -1162,68 +1162,29 @@ describe("OpenAI-compatible completions params", () => {
 });
 
 describe("openai-completions stop-reason tool-call guard", () => {
-  it("keeps literal reasoning tag examples visible when no reasoning field is mirrored", async () => {
-    mockChunksRef.chunks = [
-      makeTextChunk("Use `<think>private</think>` only as an example."),
-      makeFinishChunk("stop"),
-    ];
-
-    const stream = streamOpenAICompletions(reasoningModel, context, {
-      apiKey: "sk-test",
-      reasoningEffort: "medium",
-    });
-    const result = await stream.result();
-
-    expect(result.content).toContainEqual({
-      type: "text",
+  it.each([
+    {
+      title: "keeps literal reasoning tag examples visible when no reasoning field is mirrored",
       text: "Use `<think>private</think>` only as an example.",
-    });
-    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
-  });
-
-  it("keeps prose mentions of unclosed reasoning tags visible without mirrored reasoning", async () => {
-    mockChunksRef.chunks = [
-      makeTextChunk("The <reasoning> tag is deprecated in this example."),
-      makeFinishChunk("stop"),
-    ];
-
-    const stream = streamOpenAICompletions(reasoningModel, context, {
-      apiKey: "sk-test",
-      reasoningEffort: "medium",
-    });
-    const result = await stream.result();
-
-    expect(result.content).toContainEqual({
-      type: "text",
+      expectedText: "Use `<think>private</think>` only as an example.",
+    },
+    {
+      title: "keeps prose mentions of unclosed reasoning tags visible without mirrored reasoning",
       text: "The <reasoning> tag is deprecated in this example.",
-    });
-    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
-  });
-
-  it("keeps prose mentions of unmatched close tags visible without mirrored reasoning", async () => {
-    mockChunksRef.chunks = [
-      makeTextChunk("Use </think> to close the tag."),
-      makeFinishChunk("stop"),
-    ];
-
-    const stream = streamOpenAICompletions(reasoningModel, context, {
-      apiKey: "sk-test",
-      reasoningEffort: "medium",
-    });
-    const result = await stream.result();
-
-    expect(result.content).toContainEqual({
-      type: "text",
+      expectedText: "The <reasoning> tag is deprecated in this example.",
+    },
+    {
+      title: "keeps prose mentions of unmatched close tags visible without mirrored reasoning",
       text: "Use </think> to close the tag.",
-    });
-    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
-  });
-
-  it("strips content-only reasoning tags from visible text", async () => {
-    mockChunksRef.chunks = [
-      makeTextChunk("Before <think>private reasoning</think> after"),
-      makeFinishChunk("stop"),
-    ];
+      expectedText: "Use </think> to close the tag.",
+    },
+    {
+      title: "strips content-only reasoning tags from visible text",
+      text: "Before <think>private reasoning</think> after",
+      expectedText: "Before  after",
+    },
+  ])("$title", async ({ text, expectedText }) => {
+    mockChunksRef.chunks = [makeTextChunk(text), makeFinishChunk("stop")];
 
     const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
@@ -1233,7 +1194,7 @@ describe("openai-completions stop-reason tool-call guard", () => {
 
     expect(result.content).toContainEqual({
       type: "text",
-      text: "Before  after",
+      text: expectedText,
     });
     expect(result.content.some((block) => block.type === "thinking")).toBe(false);
   });

--- a/packages/markdown-core/src/ir.nested-lists.test.ts
+++ b/packages/markdown-core/src/ir.nested-lists.test.ts
@@ -125,18 +125,87 @@ describe("Nested Lists - 2 Level Nesting", () => {
     expect(result.text).toBe(expected);
   });
 
-  it("renders ordered items nested inside ordered items", () => {
-    const input = `1. First
+  it.each([
+    {
+      title: "renders ordered items nested inside ordered items",
+      markdown: `1. First
    1. Sub-first
    2. Sub-second
-2. Second`;
-
-    const result = markdownToIR(input);
-
-    const expected = `1. First
+2. Second`,
+      expected: `1. First
   1. Sub-first
   2. Sub-second
-2. Second`;
+2. Second`,
+    },
+    {
+      title: "renders 4 levels of bullet nesting",
+      markdown: `- L1
+  - L2
+    - L3
+      - L4
+- Back`,
+      expected: `• L1
+  • L2
+    • L3
+      • L4
+• Back`,
+    },
+    {
+      title: "renders 3 levels with multiple items at each level",
+      markdown: `- A1
+  - B1
+    - C1
+    - C2
+  - B2
+- A2`,
+      expected: `• A1
+  • B1
+    • C1
+    • C2
+  • B2
+• A2`,
+    },
+    {
+      title: "renders complex mixed nesting (bullet > ordered > bullet)",
+      markdown: `- Bullet 1
+  1. Ordered 1.1
+     - Deep bullet
+  2. Ordered 1.2
+- Bullet 2`,
+      expected: `• Bullet 1
+  1. Ordered 1.1
+    • Deep bullet
+  2. Ordered 1.2
+• Bullet 2`,
+    },
+    {
+      title: "renders ordered > bullet > ordered nesting",
+      markdown: `1. First
+   - Sub bullet
+     1. Deep ordered
+   - Another bullet
+2. Second`,
+      expected: `1. First
+  • Sub bullet
+    1. Deep ordered
+  • Another bullet
+2. Second`,
+    },
+    {
+      title: "handles sibling nested lists at same level",
+      markdown: `- A
+  - A1
+- B
+  - B1`,
+      expected: `• A
+  • A1
+• B
+  • B1`,
+    },
+  ])("$title", ({ markdown, expected }) => {
+    const input = markdown;
+
+    const result = markdownToIR(input);
 
     expect(result.text).toBe(expected);
   });
@@ -163,83 +232,9 @@ describe("Nested Lists - 3+ Level Deep Nesting", () => {
 
     expect(result.text).toBe(expected);
   });
-
-  it("renders 4 levels of bullet nesting", () => {
-    const input = `- L1
-  - L2
-    - L3
-      - L4
-- Back`;
-
-    const result = markdownToIR(input);
-
-    const expected = `• L1
-  • L2
-    • L3
-      • L4
-• Back`;
-
-    expect(result.text).toBe(expected);
-  });
-
-  it("renders 3 levels with multiple items at each level", () => {
-    const input = `- A1
-  - B1
-    - C1
-    - C2
-  - B2
-- A2`;
-
-    const result = markdownToIR(input);
-
-    const expected = `• A1
-  • B1
-    • C1
-    • C2
-  • B2
-• A2`;
-
-    expect(result.text).toBe(expected);
-  });
 });
 
-describe("Nested Lists - Mixed Nesting", () => {
-  it("renders complex mixed nesting (bullet > ordered > bullet)", () => {
-    const input = `- Bullet 1
-  1. Ordered 1.1
-     - Deep bullet
-  2. Ordered 1.2
-- Bullet 2`;
-
-    const result = markdownToIR(input);
-
-    const expected = `• Bullet 1
-  1. Ordered 1.1
-    • Deep bullet
-  2. Ordered 1.2
-• Bullet 2`;
-
-    expect(result.text).toBe(expected);
-  });
-
-  it("renders ordered > bullet > ordered nesting", () => {
-    const input = `1. First
-   - Sub bullet
-     1. Deep ordered
-   - Another bullet
-2. Second`;
-
-    const result = markdownToIR(input);
-
-    const expected = `1. First
-  • Sub bullet
-    1. Deep ordered
-  • Another bullet
-2. Second`;
-
-    expect(result.text).toBe(expected);
-  });
-});
+describe("Nested Lists - Mixed Nesting", () => {});
 
 describe("Nested Lists - Newline Handling", () => {
   it("does not produce triple newlines in nested lists", () => {
@@ -302,68 +297,66 @@ describe("Nested Lists - Edge Cases", () => {
     // The child should appear indented under the parent
     expect(result.text).toContain("• Parent text\n  • Child");
   });
-
-  it("handles sibling nested lists at same level", () => {
-    const input = `- A
-  - A1
-- B
-  - B1`;
-
-    const result = markdownToIR(input);
-
-    const expected = `• A
-  • A1
-• B
-  • B1`;
-
-    expect(result.text).toBe(expected);
-  });
 });
 
 describe("list paragraph spacing", () => {
-  it("preserves paragraph breaks inside loose bullet list items", () => {
-    const input = `- first paragraph
+  it.each([
+    {
+      title: "preserves paragraph breaks inside loose bullet list items",
+      markdown: `- first paragraph
 
   second paragraph
-- next`;
-
-    const result = markdownToIR(input);
-
-    expect(result.text).toBe(`• first paragraph
+- next`,
+      expected: `• first paragraph
 
 second paragraph
 
-• next`);
-  });
-
-  it("preserves paragraph breaks inside loose ordered list items", () => {
-    const input = `1. first paragraph
+• next`,
+    },
+    {
+      title: "preserves paragraph breaks inside loose ordered list items",
+      markdown: `1. first paragraph
 
    second paragraph
-2. next`;
-
-    const result = markdownToIR(input);
-
-    expect(result.text).toBe(`1. first paragraph
+2. next`,
+      expected: `1. first paragraph
 
 second paragraph
 
-2. next`);
-  });
-
-  it("preserves paragraph breaks inside loose blockquoted list items", () => {
-    const input = `> - first paragraph
+2. next`,
+    },
+    {
+      title: "preserves paragraph breaks inside loose blockquoted list items",
+      markdown: `> - first paragraph
 >
 >   second paragraph
-> - next`;
-
-    const result = markdownToIR(input);
-
-    expect(result.text).toBe(`• first paragraph
+> - next`,
+      expected: `• first paragraph
 
 second paragraph
 
-• next`);
+• next`,
+    },
+    {
+      title: "keeps tight heading list items single-spaced",
+      markdown: `- # A
+- # B`,
+      expected: `• A
+• B`,
+    },
+    {
+      title: "keeps tight blockquote list items single-spaced",
+      markdown: `- > quote
+- next`,
+      expected: `• quote
+• next`,
+    },
+  ])("$title", ({ markdown, expected }) => {
+    const input = markdown;
+
+    const result = markdownToIR(input);
+
+    expect(result.text).toBe(expected);
   });
 
   it("does not add triple newlines before loose nested bullet lists", () => {
@@ -396,26 +389,6 @@ second paragraph
   1. child
 2. next`);
     expect(result.text).not.toContain("\n\n\n");
-  });
-
-  it("keeps tight heading list items single-spaced", () => {
-    const input = `- # A
-- # B`;
-
-    const result = markdownToIR(input);
-
-    expect(result.text).toBe(`• A
-• B`);
-  });
-
-  it("keeps tight blockquote list items single-spaced", () => {
-    const input = `- > quote
-- next`;
-
-    const result = markdownToIR(input);
-
-    expect(result.text).toBe(`• quote
-• next`);
   });
 
   it("adds blank line between bullet list and following paragraph", () => {

--- a/src/agents/agent-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/agent-tools.read.workspace-root-guard.test.ts
@@ -106,31 +106,41 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
     });
   });
 
-  it("does not remap remote-host file:// paths", async () => {
+  it.each([
+    {
+      title: "does not remap remote-host file:// paths",
+      toolCallId: "tc-remote-file-url",
+      requestedPath: "file://attacker/share/readme.md",
+      expectedPath: "file://attacker/share/readme.md",
+    },
+    {
+      title: "does not remap malformed file:// container workspace paths",
+      toolCallId: "tc-malformed-file-url",
+      requestedPath: "file:///workspace/%E0%A4%A",
+      expectedPath: "file:///workspace/%E0%A4%A",
+    },
+    {
+      title: "normalizes @-prefixed absolute paths before guard checks",
+      toolCallId: "tc-at-absolute",
+      requestedPath: "@/etc/passwd",
+      expectedPath: "/etc/passwd",
+    },
+    {
+      title: "does not remap absolute paths outside the configured container workdir",
+      toolCallId: "tc3",
+      requestedPath: "/workspace-two/secret.txt",
+      expectedPath: "/workspace-two/secret.txt",
+    },
+  ])("$title", async ({ toolCallId, requestedPath, expectedPath }) => {
     const { tool } = createToolHarness();
     const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
       containerWorkdir: "/workspace",
     });
 
-    await wrapped.execute("tc-remote-file-url", { path: "file://attacker/share/readme.md" });
+    await wrapped.execute(toolCallId, { path: requestedPath });
 
     expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
-      filePath: "file://attacker/share/readme.md",
-      cwd: root,
-      root,
-    });
-  });
-
-  it("does not remap malformed file:// container workspace paths", async () => {
-    const { tool } = createToolHarness();
-    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
-      containerWorkdir: "/workspace",
-    });
-
-    await wrapped.execute("tc-malformed-file-url", { path: "file:///workspace/%E0%A4%A" });
-
-    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
-      filePath: "file:///workspace/%E0%A4%A",
+      filePath: expectedPath,
       cwd: root,
       root,
     });
@@ -163,36 +173,6 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
 
     expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
       filePath: path.resolve(root, "docs", "readme.md"),
-      cwd: root,
-      root,
-    });
-  });
-
-  it("normalizes @-prefixed absolute paths before guard checks", async () => {
-    const { tool } = createToolHarness();
-    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
-      containerWorkdir: "/workspace",
-    });
-
-    await wrapped.execute("tc-at-absolute", { path: "@/etc/passwd" });
-
-    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
-      filePath: "/etc/passwd",
-      cwd: root,
-      root,
-    });
-  });
-
-  it("does not remap absolute paths outside the configured container workdir", async () => {
-    const { tool } = createToolHarness();
-    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
-      containerWorkdir: "/workspace",
-    });
-
-    await wrapped.execute("tc3", { path: "/workspace-two/secret.txt" });
-
-    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
-      filePath: "/workspace-two/secret.txt",
       cwd: root,
       root,
     });

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -563,21 +563,82 @@ describe("applyPatch", () => {
     );
   });
 
-  it("keeps context line punctuation when the hunk uses normalized quotes", async () => {
-    const memory = createMemoryPatchSandbox({
-      "notes.md": "It\u2019s done\nold value\n",
-    });
-    const patch = `*** Begin Patch
+  it.each([
+    {
+      title: "keeps context line punctuation when the hunk uses normalized quotes",
+      fileName: "notes.md",
+      initialContent: "It\u2019s done\nold value\n",
+      patchText: `*** Begin Patch
 *** Update File: notes.md
 @@
  It's done
 -old value
 +new value
-*** End Patch`;
+*** End Patch`,
+      expectedPath: "/sandbox/notes.md",
+      expectedContent: "It\u2019s done\nnew value\n",
+    },
+    {
+      title: "does not normalize mixed line endings outside the changed hunk",
+      fileName: "source.txt",
+      initialContent: "first\r\nsecond\nthird\r\n",
+      patchText: `*** Begin Patch
+*** Update File: source.txt
+@@
+-second
++changed
+*** End Patch`,
+      expectedPath: "/sandbox/source.txt",
+      expectedContent: "first\r\nchanged\nthird\r\n",
+    },
+    {
+      title: "applies context-only insertions at the requested context",
+      fileName: "source.txt",
+      initialContent: "alpha\nanchor\nomega\n",
+      patchText: `*** Begin Patch
+*** Update File: source.txt
+@@ anchor
++inserted
+*** End Patch`,
+      expectedPath: "/sandbox/source.txt",
+      expectedContent: "alpha\nanchor\ninserted\nomega\n",
+    },
+    {
+      title: "keeps later insertion contexts in original file coordinates",
+      fileName: "source.txt",
+      initialContent: "a\nb\nc\n",
+      patchText: `*** Begin Patch
+*** Update File: source.txt
+@@ a
++after-a
+@@ b
++after-b
+*** End Patch`,
+      expectedPath: "/sandbox/source.txt",
+      expectedContent: "a\nafter-a\nb\nafter-b\nc\n",
+    },
+    {
+      title: "supports end-of-file inserts",
+      fileName: "end.txt",
+      initialContent: "line1\n",
+      patchText: `*** Begin Patch
+*** Update File: end.txt
+@@
++line2
+*** End of File
+*** End Patch`,
+      expectedPath: "/sandbox/end.txt",
+      expectedContent: "line1\nline2\n",
+    },
+  ])("$title", async ({ fileName, initialContent, patchText, expectedPath, expectedContent }) => {
+    const memory = createMemoryPatchSandbox({
+      [fileName]: initialContent,
+    });
+    const patch = patchText;
 
     await applyPatch(patch, memory.options);
 
-    expect(memory.files.get("/sandbox/notes.md")).toBe("It\u2019s done\nnew value\n");
+    expect(memory.files.get(expectedPath)).toBe(expectedContent);
   });
 
   it("keeps tab indentation on context lines when the hunk uses spaces", async () => {
@@ -600,22 +661,6 @@ describe("applyPatch", () => {
     expect(memory.files.get("/sandbox/run.py")).toBe(
       "def run(x):\n\tif x:\n\t\tprepare()\n        value = 2\n\t\treturn value\n\treturn 0\n",
     );
-  });
-
-  it("does not normalize mixed line endings outside the changed hunk", async () => {
-    const memory = createMemoryPatchSandbox({
-      "source.txt": "first\r\nsecond\nthird\r\n",
-    });
-    const patch = `*** Begin Patch
-*** Update File: source.txt
-@@
--second
-+changed
-*** End Patch`;
-
-    await applyPatch(patch, memory.options);
-
-    expect(memory.files.get("/sandbox/source.txt")).toBe("first\r\nchanged\nthird\r\n");
   });
 
   it("applies a real deletion of the sole blank line", async () => {
@@ -653,38 +698,6 @@ describe("applyPatch", () => {
     }
   });
 
-  it("applies context-only insertions at the requested context", async () => {
-    const memory = createMemoryPatchSandbox({
-      "source.txt": "alpha\nanchor\nomega\n",
-    });
-    const patch = `*** Begin Patch
-*** Update File: source.txt
-@@ anchor
-+inserted
-*** End Patch`;
-
-    await applyPatch(patch, memory.options);
-
-    expect(memory.files.get("/sandbox/source.txt")).toBe("alpha\nanchor\ninserted\nomega\n");
-  });
-
-  it("keeps later insertion contexts in original file coordinates", async () => {
-    const memory = createMemoryPatchSandbox({
-      "source.txt": "a\nb\nc\n",
-    });
-    const patch = `*** Begin Patch
-*** Update File: source.txt
-@@ a
-+after-a
-@@ b
-+after-b
-*** End Patch`;
-
-    await applyPatch(patch, memory.options);
-
-    expect(memory.files.get("/sandbox/source.txt")).toBe("a\nafter-a\nb\nafter-b\nc\n");
-  });
-
   it("normalizes supported punctuation while matching update hunks", async () => {
     const cases = [
       ["a\u2010\u2011\u2012\u2013\u2014\u2015\u2212b", "a-------b"],
@@ -711,22 +724,6 @@ describe("applyPatch", () => {
 
       expect(memory.files.get("/sandbox/source.txt")).toBe("updated\n");
     }
-  });
-
-  it("supports end-of-file inserts", async () => {
-    const memory = createMemoryPatchSandbox({
-      "end.txt": "line1\n",
-    });
-    const patch = `*** Begin Patch
-*** Update File: end.txt
-@@
-+line2
-*** End of File
-*** End Patch`;
-
-    await applyPatch(patch, memory.options);
-
-    expect(memory.files.get("/sandbox/end.txt")).toBe("line1\nline2\n");
   });
 
   it("rejects path traversal outside cwd by default", async () => {

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -63,37 +63,71 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError('messages: roles must alternate between "user" and "assistant"');
     expect(formatAssistantErrorText(msg)).toContain("Message ordering conflict");
   });
-  it("returns a friendly message for Anthropic overload errors", () => {
-    const msg = makeAssistantError(
-      '{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_123"}',
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "The AI service is temporarily overloaded. Please try again in a moment.",
-    );
-  });
-  it("preserves overload wording for Z.AI rate-limit errors", () => {
-    const msg = makeAssistantError(
-      '429 status code (exceeded limit)\n{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}',
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "The AI service is temporarily overloaded. Please try again in a moment.",
-    );
-  });
-  it("rewrites generic provider internal errors without support request ids", () => {
-    const msg = makeAssistantError(
-      "An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID synthetic-provider-request-001 in your message.",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "The AI service returned an internal error. Please try again in a moment.",
-    );
-  });
-  it("rewrites request-id-only generic provider internal errors without exposing the id", () => {
-    const msg = makeAssistantError(
-      "An error occurred while processing your request. Please include request ID req_synthetic_provider_request_001 in your message.",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "The AI service returned an internal error. Please try again in a moment.",
-    );
+  it.each([
+    {
+      title: "returns a friendly message for Anthropic overload errors",
+      errorText:
+        '{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_123"}',
+      expected: "The AI service is temporarily overloaded. Please try again in a moment.",
+    },
+    {
+      title: "preserves overload wording for Z.AI rate-limit errors",
+      errorText:
+        '429 status code (exceeded limit)\n{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}',
+      expected: "The AI service is temporarily overloaded. Please try again in a moment.",
+    },
+    {
+      title: "rewrites generic provider internal errors without support request ids",
+      errorText:
+        "An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID synthetic-provider-request-001 in your message.",
+      expected: "The AI service returned an internal error. Please try again in a moment.",
+    },
+    {
+      title: "rewrites request-id-only generic provider internal errors without exposing the id",
+      errorText:
+        "An error occurred while processing your request. Please include request ID req_synthetic_provider_request_001 in your message.",
+      expected: "The AI service returned an internal error. Please try again in a moment.",
+    },
+    {
+      title: "returns upstream HTML copy for HTML quota pages",
+      errorText: "429 <!DOCTYPE html><html><body>Your quota is exhausted</body></html>",
+      expected:
+        "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
+    },
+    {
+      title: "returns upstream HTML copy for prefixed 521 HTML rate-limit pages",
+      errorText: "Error: 521 <!DOCTYPE html><html><body>rate limit</body></html>",
+      expected:
+        "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
+    },
+    {
+      title: "returns an explicit re-authentication message for OAuth refresh failures",
+      errorText:
+        "OAuth token refresh failed for openai: invalid_grant. Please try again or re-authenticate.",
+      expected: "Authentication refresh failed. Re-authenticate this provider and try again.",
+    },
+    {
+      title: "returns an explicit re-authentication message for Codex app-server refresh failures",
+      errorText:
+        "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
+      expected: "Authentication refresh failed. Re-authenticate this provider and try again.",
+    },
+    {
+      title: "returns a timeout-specific message for OAuth refresh hard timeouts",
+      errorText:
+        'OAuth refresh call "refreshProviderOAuthCredentialWithPlugin(openai)" exceeded hard timeout (120000ms)',
+      expected:
+        "Authentication refresh timed out before the provider completed. Retry in a moment; re-authenticate only if it keeps failing.",
+    },
+    {
+      title: "sanitizes invalid streaming event order errors",
+      errorText: 'Unexpected event order, got message_start before receiving "message_stop"',
+      expected:
+        "LLM request failed: provider returned an invalid streaming response. Please try again.",
+    },
+  ])("$title", ({ errorText, expected }) => {
+    const msg = makeAssistantError(errorText);
+    expect(formatAssistantErrorText(msg)).toBe(expected);
   });
   it("returns a model-switch hint for OpenAI model capacity errors", () => {
     const msg = makeAssistantError("Selected model is at capacity. Please try a different model.");
@@ -202,15 +236,56 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
-  it("returns a friendly billing message for flat JSON insufficient_balance payloads (#74079)", () => {
-    const msg = makeAssistantError(
-      '{"error":"insufficient_balance","message":"Insufficient MBT balance. Top up or upgrade your subscription to continue.","upgradeUrl":"/settings/billing"}',
-    );
-    const result = formatAssistantErrorText(msg, {
+  it.each([
+    {
+      title:
+        "returns a friendly billing message for flat JSON insufficient_balance payloads (#74079)",
+      errorText:
+        '{"error":"insufficient_balance","message":"Insufficient MBT balance. Top up or upgrade your subscription to continue.","upgradeUrl":"/settings/billing"}',
       provider: "google",
       model: "gemini-3.1-pro-preview",
+    },
+    {
+      title: "keeps known Moonshot 429 balance failures on billing copy",
+      errorText:
+        '429 {"error":{"message":"Your account has insufficient balance. Please recharge to continue.","type":"rate_limit_reached"}}',
+      provider: "moonshot",
+      model: "kimi-k2",
+    },
+    {
+      title: "keeps high-confidence 429 insufficient quota failures on billing copy",
+      errorText:
+        '429 {"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}',
+      provider: "openai",
+      model: "gpt-5.5",
+    },
+    {
+      title: "keeps high-confidence 429 insufficient balance failures on billing copy",
+      errorText: '429 {"error":"insufficient_balance","message":"Your credit balance is too low."}',
+      provider: "openai-compatible",
+      model: "custom-model",
+    },
+    {
+      title: "keeps structured 429 insufficient balance codes on billing copy",
+      errorText:
+        'HTTP 429: {"error":"insufficient_balance","message":"Insufficient account balance"}',
+      provider: "openai-compatible",
+      model: "custom-model",
+    },
+    {
+      title: "returns billing guidance for Volcengine Coding Plan subscription failures",
+      errorText:
+        'HTTP 400 Bad Request: {"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}',
+      provider: "volcengine-plan",
+      model: "ark-code-latest",
+    },
+  ])("$title", ({ errorText, provider, model }) => {
+    const msg = makeAssistantError(errorText);
+    const result = formatAssistantErrorText(msg, {
+      provider,
+      model,
     });
-    expect(result).toBe(formatBillingErrorMessage("google", "gemini-3.1-pro-preview"));
+    expect(result).toBe(formatBillingErrorMessage(provider, model));
   });
   it("returns a billing message for xAI 429 credit exhaustion before rate-limit copy", () => {
     // Some providers report billing exhaustion as 429; billing copy should win
@@ -223,46 +298,6 @@ describe("formatAssistantErrorText", () => {
       model: "grok-4.3",
     });
     expect(result).toBe(formatBillingErrorMessage("xai", "grok-4.3"));
-  });
-  it("keeps known Moonshot 429 balance failures on billing copy", () => {
-    const msg = makeAssistantError(
-      '429 {"error":{"message":"Your account has insufficient balance. Please recharge to continue.","type":"rate_limit_reached"}}',
-    );
-    const result = formatAssistantErrorText(msg, {
-      provider: "moonshot",
-      model: "kimi-k2",
-    });
-    expect(result).toBe(formatBillingErrorMessage("moonshot", "kimi-k2"));
-  });
-  it("keeps high-confidence 429 insufficient quota failures on billing copy", () => {
-    const msg = makeAssistantError(
-      '429 {"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}',
-    );
-    const result = formatAssistantErrorText(msg, {
-      provider: "openai",
-      model: "gpt-5.5",
-    });
-    expect(result).toBe(formatBillingErrorMessage("openai", "gpt-5.5"));
-  });
-  it("keeps high-confidence 429 insufficient balance failures on billing copy", () => {
-    const msg = makeAssistantError(
-      '429 {"error":"insufficient_balance","message":"Your credit balance is too low."}',
-    );
-    const result = formatAssistantErrorText(msg, {
-      provider: "openai-compatible",
-      model: "custom-model",
-    });
-    expect(result).toBe(formatBillingErrorMessage("openai-compatible", "custom-model"));
-  });
-  it("keeps structured 429 insufficient balance codes on billing copy", () => {
-    const msg = makeAssistantError(
-      'HTTP 429: {"error":"insufficient_balance","message":"Insufficient account balance"}',
-    );
-    const result = formatAssistantErrorText(msg, {
-      provider: "openai-compatible",
-      model: "custom-model",
-    });
-    expect(result).toBe(formatBillingErrorMessage("openai-compatible", "custom-model"));
   });
   it("keeps 429 more-credits failures on billing copy", () => {
     const msg = makeAssistantError("429 This model requires more credits to use");
@@ -279,16 +314,6 @@ describe("formatAssistantErrorText", () => {
       model: "openai/gpt-5.5",
     });
     expect(result).toBe(formatBillingErrorMessage("openrouter", "openai/gpt-5.5"));
-  });
-  it("returns billing guidance for Volcengine Coding Plan subscription failures", () => {
-    const msg = makeAssistantError(
-      'HTTP 400 Bad Request: {"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}',
-    );
-    const result = formatAssistantErrorText(msg, {
-      provider: "volcengine-plan",
-      model: "ark-code-latest",
-    });
-    expect(result).toBe(formatBillingErrorMessage("volcengine-plan", "ark-code-latest"));
   });
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
@@ -333,24 +358,6 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("try again in 24 hours");
     expect(result).not.toMatch(/^⚠️ 429\b/);
     expect(result).toBe("⚠️ Your quota has been exhausted, try again in 24 hours");
-  });
-
-  it("returns upstream HTML copy for HTML quota pages", () => {
-    const msg = makeAssistantError(
-      "429 <!DOCTYPE html><html><body>Your quota is exhausted</body></html>",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
-    );
-  });
-
-  it("returns upstream HTML copy for prefixed 521 HTML rate-limit pages", () => {
-    const msg = makeAssistantError(
-      "Error: 521 <!DOCTYPE html><html><body>rate limit</body></html>",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
-    );
   });
 
   it("does not misdiagnose standalone Cloudflare challenge HTML as DNS", () => {
@@ -413,37 +420,10 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
-  it("returns an explicit re-authentication message for OAuth refresh failures", () => {
-    const msg = makeAssistantError(
-      "OAuth token refresh failed for openai: invalid_grant. Please try again or re-authenticate.",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "Authentication refresh failed. Re-authenticate this provider and try again.",
-    );
-  });
-
-  it("returns an explicit re-authentication message for Codex app-server refresh failures", () => {
-    const msg = makeAssistantError(
-      "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "Authentication refresh failed. Re-authenticate this provider and try again.",
-    );
-  });
-
   it("returns a contention-specific message for OAuth refresh lock timeouts", () => {
     const msg = makeAssistantError("file lock timeout for /tmp/openclaw-oauth-refresh.lock");
     expect(formatAssistantErrorText(msg)).toBe(
       "Authentication refresh is already in progress elsewhere and this attempt timed out waiting for it. Retry in a moment.",
-    );
-  });
-
-  it("returns a timeout-specific message for OAuth refresh hard timeouts", () => {
-    const msg = makeAssistantError(
-      'OAuth refresh call "refreshProviderOAuthCredentialWithPlugin(openai)" exceeded hard timeout (120000ms)',
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "Authentication refresh timed out before the provider completed. Retry in a moment; re-authenticate only if it keeps failing.",
     );
   });
 
@@ -581,15 +561,6 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).not.toBe(
       "LLM request failed: proxy or tunnel configuration blocked the provider request.",
-    );
-  });
-
-  it("sanitizes invalid streaming event order errors", () => {
-    const msg = makeAssistantError(
-      'Unexpected event order, got message_start before receiving "message_stop"',
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "LLM request failed: provider returned an invalid streaming response. Please try again.",
     );
   });
 

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -928,70 +928,68 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).not.toContain("`run python3");
   });
 
-  it("prefers raw exec metadata when tool progress detail includes it", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run python3 /tmp/audit.py · `python3 /tmp/audit.py`",
-        error: "Command exited with code 1",
-        mutatingAction: true,
-      },
+  it.each([
+    {
+      title: "prefers raw exec metadata when tool progress detail includes it",
+      meta: "run python3 /tmp/audit.py · `python3 /tmp/audit.py`",
       toolResultFormat: "markdown",
-    });
-
-    expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py` (exit 1)",
-      isError: true,
-    });
-  });
-
-  it("prefers raw exec metadata when the literal command contains backticks", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run node inline script, `node -e 'console.log(1, `x`)'`",
-        error: "Command exited with code 1",
-        mutatingAction: true,
-      },
+      expected: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py` (exit 1)",
+    },
+    {
+      title: "prefers raw exec metadata when the literal command contains backticks",
+      meta: "run node inline script, `node -e 'console.log(1, `x`)'`",
       toolResultFormat: "markdown",
-    });
-
-    expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed: ``node -e 'console.log(1, `x`)'`` (exit 1)",
-      isError: true,
-    });
-  });
-
-  it("leaves exec metadata unwrapped for plain tool results", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run node inline script, `node -e 'console.log(1, `x`)'`",
-        error: "Command exited with code 1",
-        mutatingAction: true,
-      },
+      expected: "⚠️ 🛠️ Exec failed: ``node -e 'console.log(1, `x`)'`` (exit 1)",
+    },
+    {
+      title: "leaves exec metadata unwrapped for plain tool results",
+      meta: "run node inline script, `node -e 'console.log(1, `x`)'`",
       toolResultFormat: "plain",
-    });
-
-    expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed: node -e 'console.log(1, `x`)' (exit 1)",
-      isError: true,
-    });
-  });
-
-  it("preserves raw exec context before trailing raw command metadata", () => {
+      expected: "⚠️ 🛠️ Exec failed: node -e 'console.log(1, `x`)' (exit 1)",
+    },
+    {
+      title: "preserves raw exec context before trailing raw command metadata",
+      meta: "run python3 /tmp/audit.py, node: mac-1, `python3 /tmp/audit.py`",
+      toolResultFormat: "markdown",
+      expected: "⚠️ 🛠️ Exec failed: `node: mac-1 · python3 /tmp/audit.py` (exit 1)",
+    },
+    {
+      title: "does not promote display-summary commas into raw exec context",
+      meta: 'search "foo,bar" in src, `rg "foo,bar" src`',
+      toolResultFormat: "markdown",
+      expected: '⚠️ 🛠️ Exec failed: `rg "foo,bar" src` (exit 1)',
+    },
+    {
+      title: "does not treat parenthesized raw command arguments as cwd context",
+      meta: 'list files in (in progress) · `ls "(in progress)"`',
+      toolResultFormat: "markdown",
+      expected: '⚠️ 🛠️ Exec failed: `ls "(in progress)"` (exit 1)',
+    },
+    {
+      title: "does not duplicate compact cwd labels already present in raw command arguments",
+      meta: 'print text (repo) · `printf "%s" "(repo)"`',
+      toolResultFormat: "markdown",
+      expected: '⚠️ 🛠️ Exec failed: `printf "%s" "(repo)"` (exit 1)',
+    },
+    {
+      title: "keeps arbitrary exec cwd suffixes inside markdown command text",
+      meta: "run python3 /tmp/audit.py (in /tmp/build @everyone)",
+      toolResultFormat: "markdown",
+      expected: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py (in /tmp/build @everyone)` (exit 1)",
+    },
+  ])("$title", ({ meta, toolResultFormat, expected }) => {
     const payloads = buildPayloads({
       lastToolError: {
         toolName: "exec",
-        meta: "run python3 /tmp/audit.py, node: mac-1, `python3 /tmp/audit.py`",
+        meta,
         error: "Command exited with code 1",
         mutatingAction: true,
       },
-      toolResultFormat: "markdown",
+      toolResultFormat,
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed: `node: mac-1 · python3 /tmp/audit.py` (exit 1)",
+      text: expected,
       isError: true,
     });
   });
@@ -1035,57 +1033,6 @@ describe("buildEmbeddedRunPayloads", () => {
     });
     expectSinglePayloadSummary(semanticCompactPayloads, {
       text: "⚠️ 🛠️ Exec failed: `git status (repo)` (exit 1)",
-      isError: true,
-    });
-  });
-
-  it("does not promote display-summary commas into raw exec context", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: 'search "foo,bar" in src, `rg "foo,bar" src`',
-        error: "Command exited with code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-
-    expectSinglePayloadSummary(payloads, {
-      text: '⚠️ 🛠️ Exec failed: `rg "foo,bar" src` (exit 1)',
-      isError: true,
-    });
-  });
-
-  it("does not treat parenthesized raw command arguments as cwd context", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: 'list files in (in progress) · `ls "(in progress)"`',
-        error: "Command exited with code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-
-    expectSinglePayloadSummary(payloads, {
-      text: '⚠️ 🛠️ Exec failed: `ls "(in progress)"` (exit 1)',
-      isError: true,
-    });
-  });
-
-  it("does not duplicate compact cwd labels already present in raw command arguments", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: 'print text (repo) · `printf "%s" "(repo)"`',
-        error: "Command exited with code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-
-    expectSinglePayloadSummary(payloads, {
-      text: '⚠️ 🛠️ Exec failed: `printf "%s" "(repo)"` (exit 1)',
       isError: true,
     });
   });
@@ -1151,23 +1098,6 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, { text: expected, isError: true });
-  });
-
-  it("keeps arbitrary exec cwd suffixes inside markdown command text", () => {
-    const payloads = buildPayloads({
-      lastToolError: {
-        toolName: "exec",
-        meta: "run python3 /tmp/audit.py (in /tmp/build @everyone)",
-        error: "Command exited with code 1",
-        mutatingAction: true,
-      },
-      toolResultFormat: "markdown",
-    });
-
-    expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py (in /tmp/build @everyone)` (exit 1)",
-      isError: true,
-    });
   });
 
   it("wraps markdown-capable mutating tool warnings so mention-looking names stay inert", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -977,7 +977,7 @@ describe("buildEmbeddedRunPayloads", () => {
       toolResultFormat: "markdown",
       expected: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py (in /tmp/build @everyone)` (exit 1)",
     },
-  ])("$title", ({ meta, toolResultFormat, expected }) => {
+  ] as const)("$title", ({ meta, toolResultFormat, expected }) => {
     const payloads = buildPayloads({
       lastToolError: {
         toolName: "exec",

--- a/src/agents/embedded-agent-utils.test.ts
+++ b/src/agents/embedded-agent-utils.test.ts
@@ -134,23 +134,120 @@ describe("extractAssistantText", () => {
     }
   });
 
-  it("strips multiple tool invocations", () => {
+  it.each([
+    {
+      title: "strips multiple tool invocations",
+      text: `Let me check that.<invoke name="Read">
+<parameter name="path">/home/admin/test.txt</parameter>
+</invoke>
+</minimax:tool_call>`,
+      expected: "Let me check that.",
+    },
+    {
+      title: "preserves normal text without tool invocations",
+      text: "This is a normal response without any tool calls.",
+      expected: "This is a normal response without any tool calls.",
+    },
+    {
+      title: "strips Minimax tool invocations with extra attributes",
+      text: `Before<invoke name='Bash' data-foo="bar">\n<parameter name="command">ls</parameter>\n</invoke>\n</minimax:tool_call>After`,
+      expected: "Before\nAfter",
+    },
+    {
+      title: "strips minimax tool_call open and close tags",
+      text: "Start<minimax:tool_call>Inner</minimax:tool_call>End",
+      expected: "StartInnerEnd",
+    },
+    {
+      title: "ignores invoke blocks without minimax markers",
+      text: "Before<invoke>Keep</invoke>After",
+      expected: "Before<invoke>Keep</invoke>After",
+    },
+    {
+      title: "strips invoke blocks when minimax markers are present elsewhere",
+      text: "Before<invoke>Drop</invoke><minimax:tool_call>After",
+      expected: "BeforeAfter",
+    },
+    {
+      title: "strips invoke blocks with nested tags",
+      text: `A<invoke name="Bash"><param><deep>1</deep></param></invoke></minimax:tool_call>B`,
+      expected: "AB",
+    },
+    {
+      title: "strips tool XML mixed with regular content",
+      text: `I'll help you with that.<invoke name="Bash">
+<parameter name="command">ls -la</parameter>
+</invoke>
+</minimax:tool_call>Here are the results.`,
+      expected: "I'll help you with that.\nHere are the results.",
+    },
+    {
+      title: "handles multiple invoke blocks in one message",
+      text: `First check.<invoke name="Read">
+<parameter name="path">file1.txt</parameter>
+</invoke>
+</minimax:tool_call>Second check.<invoke name="Bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+</minimax:tool_call>Done.`,
+      expected: "First check.\nSecond check.\nDone.",
+    },
+    {
+      title: "handles stray closing tags without opening tags",
+      text: "Some text here.</minimax:tool_call>More text.",
+      expected: "Some text here.More text.",
+    },
+    {
+      title: "strips downgraded Gemini tool call text representations",
+      text: `[Tool Call: exec (ID: toolu_vrtx_014w1P6B6w4V92v4VzG7Qk12)]
+Arguments: { "command": "git status", "timeout": 120000 }`,
+      expected: "",
+    },
+    {
+      title: "strips multiple downgraded tool calls",
+      text: `[Tool Call: read (ID: toolu_1)]
+Arguments: { "path": "/some/file.txt" }
+[Tool Call: exec (ID: toolu_2)]
+Arguments: { "command": "ls -la" }`,
+      expected: "",
+    },
+    {
+      title: "strips tool results for downgraded calls",
+      text: `[Tool Result for ID toolu_123]
+{"status": "ok", "data": "some result"}`,
+      expected: "",
+    },
+    {
+      title: "preserves text around downgraded tool calls",
+      text: `Let me check that for you.
+[Tool Call: browser (ID: toolu_abc)]
+Arguments: { "action": "act", "request": "click button" }`,
+      expected: "Let me check that for you.",
+    },
+    {
+      title: "preserves trailing text after downgraded tool call blocks",
+      text: `Intro text.
+[Tool Call: read (ID: toolu_1)]
+Arguments: {
+  "path": "/tmp/file.txt"
+}
+Back to the user.`,
+      expected: "Intro text.\nBack to the user.",
+    },
+  ])("$title", ({ text, expected }) => {
     const msg = makeAssistantMessage({
       role: "assistant",
       content: [
         {
           type: "text",
-          text: `Let me check that.<invoke name="Read">
-<parameter name="path">/home/admin/test.txt</parameter>
-</invoke>
-</minimax:tool_call>`,
+          text,
         },
       ],
       timestamp: Date.now(),
     });
 
     const result = extractAssistantText(msg);
-    expect(result).toBe("Let me check that.");
+    expect(result).toBe(expected);
   });
 
   it("keeps invoke snippets without Minimax markers", () => {
@@ -169,22 +266,6 @@ describe("extractAssistantText", () => {
     expect(result).toBe(
       `Example:\n<invoke name="Bash">\n<parameter name="command">ls</parameter>\n</invoke>`,
     );
-  });
-
-  it("preserves normal text without tool invocations", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: "This is a normal response without any tool calls.",
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("This is a normal response without any tool calls.");
   });
 
   it("sanitizes HTTP-ish error text only when stopReason is error", () => {
@@ -232,143 +313,6 @@ describe("extractAssistantText", () => {
     expect(result).toBe(responseText);
   });
 
-  it("strips Minimax tool invocations with extra attributes", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `Before<invoke name='Bash' data-foo="bar">\n<parameter name="command">ls</parameter>\n</invoke>\n</minimax:tool_call>After`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("Before\nAfter");
-  });
-
-  it("strips minimax tool_call open and close tags", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: "Start<minimax:tool_call>Inner</minimax:tool_call>End",
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("StartInnerEnd");
-  });
-
-  it("ignores invoke blocks without minimax markers", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: "Before<invoke>Keep</invoke>After",
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("Before<invoke>Keep</invoke>After");
-  });
-
-  it("strips invoke blocks when minimax markers are present elsewhere", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: "Before<invoke>Drop</invoke><minimax:tool_call>After",
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("BeforeAfter");
-  });
-
-  it("strips invoke blocks with nested tags", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `A<invoke name="Bash"><param><deep>1</deep></param></invoke></minimax:tool_call>B`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("AB");
-  });
-
-  it("strips tool XML mixed with regular content", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `I'll help you with that.<invoke name="Bash">
-<parameter name="command">ls -la</parameter>
-</invoke>
-</minimax:tool_call>Here are the results.`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("I'll help you with that.\nHere are the results.");
-  });
-
-  it("handles multiple invoke blocks in one message", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `First check.<invoke name="Read">
-<parameter name="path">file1.txt</parameter>
-</invoke>
-</minimax:tool_call>Second check.<invoke name="Bash">
-<parameter name="command">pwd</parameter>
-</invoke>
-</minimax:tool_call>Done.`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("First check.\nSecond check.\nDone.");
-  });
-
-  it("handles stray closing tags without opening tags", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: "Some text here.</minimax:tool_call>More text.",
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("Some text here.More text.");
-  });
-
   it("handles multiple text blocks", () => {
     const msg = makeAssistantMessage({
       role: "assistant",
@@ -394,98 +338,6 @@ describe("extractAssistantText", () => {
 
     const result = extractAssistantText(msg);
     expect(result).toBe("First block.\nThird block.");
-  });
-
-  it("strips downgraded Gemini tool call text representations", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `[Tool Call: exec (ID: toolu_vrtx_014w1P6B6w4V92v4VzG7Qk12)]
-Arguments: { "command": "git status", "timeout": 120000 }`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("");
-  });
-
-  it("strips multiple downgraded tool calls", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `[Tool Call: read (ID: toolu_1)]
-Arguments: { "path": "/some/file.txt" }
-[Tool Call: exec (ID: toolu_2)]
-Arguments: { "command": "ls -la" }`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("");
-  });
-
-  it("strips tool results for downgraded calls", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `[Tool Result for ID toolu_123]
-{"status": "ok", "data": "some result"}`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("");
-  });
-
-  it("preserves text around downgraded tool calls", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `Let me check that for you.
-[Tool Call: browser (ID: toolu_abc)]
-Arguments: { "action": "act", "request": "click button" }`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("Let me check that for you.");
-  });
-
-  it("preserves trailing text after downgraded tool call blocks", () => {
-    const msg = makeAssistantMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: `Intro text.
-[Tool Call: read (ID: toolu_1)]
-Arguments: {
-  "path": "/tmp/file.txt"
-}
-Back to the user.`,
-        },
-      ],
-      timestamp: Date.now(),
-    });
-
-    const result = extractAssistantText(msg);
-    expect(result).toBe("Intro text.\nBack to the user.");
   });
 
   it("handles multiple text blocks with tool calls and results", () => {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1859,47 +1859,39 @@ describe("model-selection", () => {
       expect(resolved?.ref).toEqual({ provider: "openai", model: "gpt-5" });
     });
 
-    it("strips trailing profile suffix for provider/model refs", () => {
+    it.each([
+      {
+        title: "strips trailing profile suffix for provider/model refs",
+        input: "google/gemini-flash-latest@google:bevfresh",
+        expectedProvider: "google",
+        expectedModel: "gemini-flash-latest",
+      },
+      {
+        title: "preserves Cloudflare @cf model segments",
+        input: "openai/@cf/openai/gpt-oss-20b",
+        expectedProvider: "openai",
+        expectedModel: "@cf/openai/gpt-oss-20b",
+      },
+      {
+        title: "preserves OpenRouter @preset model segments",
+        input: "openrouter/@preset/kimi-2-5",
+        expectedProvider: "openrouter",
+        expectedModel: "@preset/kimi-2-5",
+      },
+      {
+        title: "splits trailing profile suffix after OpenRouter preset paths",
+        input: "openrouter/@preset/kimi-2-5@work",
+        expectedProvider: "openrouter",
+        expectedModel: "@preset/kimi-2-5",
+      },
+    ])("$title", ({ input, expectedProvider, expectedModel }) => {
       const resolved = resolveModelRefFromString({
-        raw: "google/gemini-flash-latest@google:bevfresh",
+        raw: input,
         defaultProvider: "anthropic",
       });
       expect(resolved?.ref).toEqual({
-        provider: "google",
-        model: "gemini-flash-latest",
-      });
-    });
-
-    it("preserves Cloudflare @cf model segments", () => {
-      const resolved = resolveModelRefFromString({
-        raw: "openai/@cf/openai/gpt-oss-20b",
-        defaultProvider: "anthropic",
-      });
-      expect(resolved?.ref).toEqual({
-        provider: "openai",
-        model: "@cf/openai/gpt-oss-20b",
-      });
-    });
-
-    it("preserves OpenRouter @preset model segments", () => {
-      const resolved = resolveModelRefFromString({
-        raw: "openrouter/@preset/kimi-2-5",
-        defaultProvider: "anthropic",
-      });
-      expect(resolved?.ref).toEqual({
-        provider: "openrouter",
-        model: "@preset/kimi-2-5",
-      });
-    });
-
-    it("splits trailing profile suffix after OpenRouter preset paths", () => {
-      const resolved = resolveModelRefFromString({
-        raw: "openrouter/@preset/kimi-2-5@work",
-        defaultProvider: "anthropic",
-      });
-      expect(resolved?.ref).toEqual({
-        provider: "openrouter",
-        model: "@preset/kimi-2-5",
+        provider: expectedProvider,
+        model: expectedModel,
       });
     });
 
@@ -2178,14 +2170,43 @@ describe("model-selection", () => {
       });
     });
 
-    it("prefers slash-form aliases for configured default models", () => {
+    it.each([
+      {
+        title: "prefers slash-form aliases for configured default models",
+        input: "xiaomi/mimo-v2-pro-mit",
+        aliasRef: "openai/xiaomi/mimo-v2-pro-mit",
+        alias: "xiaomi/mimo-v2-pro-mit",
+        expectedModel: "xiaomi/mimo-v2-pro-mit",
+      },
+      {
+        title: "prefers slash-form aliases before applying auth profile suffixes",
+        input: "xiaomi/mimo-v2-pro-mit@work",
+        aliasRef: "openai/xiaomi/mimo-v2-pro-mit",
+        alias: "xiaomi/mimo-v2-pro-mit",
+        expectedModel: "xiaomi/mimo-v2-pro-mit",
+      },
+      {
+        title: "prefers exact aliases that contain auth-profile-like suffixes",
+        input: "gpt@prod",
+        aliasRef: "openai/gpt-5.5",
+        alias: "gpt@prod",
+        expectedModel: "gpt-5.5",
+      },
+      {
+        title: "prefers exact slash-form aliases before stripping auth-profile suffixes",
+        input: "anthropic/claude-opus-4-6@prod",
+        aliasRef: "openai/gpt-5.5",
+        alias: "anthropic/claude-opus-4-6@prod",
+        expectedModel: "gpt-5.5",
+      },
+    ])("$title", ({ input, aliasRef, alias, expectedModel }) => {
       const cfg = {
         agents: {
           defaults: {
-            model: { primary: "xiaomi/mimo-v2-pro-mit" },
+            model: { primary: input },
             models: {
-              "openai/xiaomi/mimo-v2-pro-mit": {
-                alias: "xiaomi/mimo-v2-pro-mit",
+              [aliasRef]: {
+                alias,
               },
             },
           },
@@ -2198,76 +2219,7 @@ describe("model-selection", () => {
         defaultModel: "claude-sonnet-4-6",
       });
 
-      expect(result).toEqual({ provider: "openai", model: "xiaomi/mimo-v2-pro-mit" });
-    });
-
-    it("prefers slash-form aliases before applying auth profile suffixes", () => {
-      const cfg = {
-        agents: {
-          defaults: {
-            model: { primary: "xiaomi/mimo-v2-pro-mit@work" },
-            models: {
-              "openai/xiaomi/mimo-v2-pro-mit": {
-                alias: "xiaomi/mimo-v2-pro-mit",
-              },
-            },
-          },
-        },
-      } as OpenClawConfig;
-
-      const result = resolveConfiguredModelRef({
-        cfg,
-        defaultProvider: "anthropic",
-        defaultModel: "claude-sonnet-4-6",
-      });
-
-      expect(result).toEqual({ provider: "openai", model: "xiaomi/mimo-v2-pro-mit" });
-    });
-
-    it("prefers exact aliases that contain auth-profile-like suffixes", () => {
-      const cfg = {
-        agents: {
-          defaults: {
-            model: { primary: "gpt@prod" },
-            models: {
-              "openai/gpt-5.5": {
-                alias: "gpt@prod",
-              },
-            },
-          },
-        },
-      } as OpenClawConfig;
-
-      const result = resolveConfiguredModelRef({
-        cfg,
-        defaultProvider: "anthropic",
-        defaultModel: "claude-sonnet-4-6",
-      });
-
-      expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
-    });
-
-    it("prefers exact slash-form aliases before stripping auth-profile suffixes", () => {
-      const cfg = {
-        agents: {
-          defaults: {
-            model: { primary: "anthropic/claude-opus-4-6@prod" },
-            models: {
-              "openai/gpt-5.5": {
-                alias: "anthropic/claude-opus-4-6@prod",
-              },
-            },
-          },
-        },
-      } as OpenClawConfig;
-
-      const result = resolveConfiguredModelRef({
-        cfg,
-        defaultProvider: "anthropic",
-        defaultModel: "claude-sonnet-4-6",
-      });
-
-      expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
+      expect(result).toEqual({ provider: "openai", model: expectedModel });
     });
 
     it("prefers exact auth-profile aliases before configured-provider stripping", () => {

--- a/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
+++ b/src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts
@@ -94,127 +94,53 @@ describe("openai transport stream", () => {
     expect(events.some((event) => event.type === "thinking_delta")).toBe(false);
   });
 
-  it("keeps literal reasoning tag examples visible without mirrored reasoning", async () => {
-    const model = createDeepSeekCompletionsModel();
-    const output = createAssistantOutput(model);
-
-    await testing.processOpenAICompletionsStream(
-      streamChunks([
-        makeCompletionsChunk(
-          {
-            content: "Use `<think>private</think>` only as an example.",
-          },
-          "stop" as const,
-        ),
-      ]),
-      output,
-      model,
-      { push() {} },
-    );
-
-    expect(output.content).toContainEqual({
-      type: "text",
+  it.each([
+    {
+      title: "keeps literal reasoning tag examples visible without mirrored reasoning",
       text: "Use `<think>private</think>` only as an example.",
-    });
-    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
-  });
-
-  it("keeps prose mentions of unclosed reasoning tags visible without mirrored reasoning", async () => {
-    const model = createDeepSeekCompletionsModel();
-    const output = createAssistantOutput(model);
-
-    await testing.processOpenAICompletionsStream(
-      streamChunks([
-        makeCompletionsChunk(
-          {
-            content: "The <reasoning> tag is deprecated in this example.",
-          },
-          "stop" as const,
-        ),
-      ]),
-      output,
-      model,
-      { push() {} },
-    );
-
-    expect(output.content).toContainEqual({
-      type: "text",
+      expectedText: "Use `<think>private</think>` only as an example.",
+    },
+    {
+      title: "keeps prose mentions of unclosed reasoning tags visible without mirrored reasoning",
       text: "The <reasoning> tag is deprecated in this example.",
-    });
-    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
-  });
-
-  it("keeps prose mentions of unmatched close tags visible without mirrored reasoning", async () => {
-    const model = createDeepSeekCompletionsModel();
-    const output = createAssistantOutput(model);
-
-    await testing.processOpenAICompletionsStream(
-      streamChunks([
-        makeCompletionsChunk(
-          {
-            content: "Use </think> to close the tag.",
-          },
-          "stop" as const,
-        ),
-      ]),
-      output,
-      model,
-      { push() {} },
-    );
-
-    expect(output.content).toContainEqual({
-      type: "text",
+      expectedText: "The <reasoning> tag is deprecated in this example.",
+    },
+    {
+      title: "keeps prose mentions of unmatched close tags visible without mirrored reasoning",
       text: "Use </think> to close the tag.",
-    });
-    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
-  });
-
-  it("strips content-only closed reasoning tags from OpenAI-compatible visible text", async () => {
-    const model = createDeepSeekCompletionsModel();
-    const output = createAssistantOutput(model);
-
-    await testing.processOpenAICompletionsStream(
-      streamChunks([
-        makeCompletionsChunk(
-          {
-            content: "Before <think>private reasoning</think> after",
-          },
-          "stop" as const,
-        ),
-      ]),
-      output,
-      model,
-      { push() {} },
-    );
-
-    expect(output.content).toContainEqual({
-      type: "text",
-      text: "Before  after",
-    });
-    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
-  });
-
-  it("keeps content-only unclosed mid-answer reasoning-looking tags visible", async () => {
-    const model = createDeepSeekCompletionsModel();
-    const output = createAssistantOutput(model);
-
-    await testing.processOpenAICompletionsStream(
-      streamChunks([
-        makeCompletionsChunk(
-          {
-            content: "Before <think>literal tag text after",
-          },
-          "stop" as const,
-        ),
-      ]),
-      output,
-      model,
-      { push() {} },
-    );
-
-    expect(output.content).toContainEqual({
-      type: "text",
+      expectedText: "Use </think> to close the tag.",
+    },
+    {
+      title: "strips content-only closed reasoning tags from OpenAI-compatible visible text",
+      text: "Before <think>private reasoning</think> after",
+      expectedText: "Before  after",
+    },
+    {
+      title: "keeps content-only unclosed mid-answer reasoning-looking tags visible",
       text: "Before <think>literal tag text after",
+      expectedText: "Before <think>literal tag text after",
+    },
+  ])("$title", async ({ text, expectedText }) => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk(
+          {
+            content: text,
+          },
+          "stop" as const,
+        ),
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toContainEqual({
+      type: "text",
+      text: expectedText,
     });
     expect(output.content.some((block) => block.type === "thinking")).toBe(false);
   });

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -2048,11 +2048,20 @@ describe("buildGuardedModelFetch", () => {
       },
     );
 
-    it("ignores invalid obsolete asctime retry-after values", async () => {
+    it.each([
+      {
+        title: "ignores invalid obsolete asctime retry-after values",
+        status: 503,
+        retryAfter: "Sun Nov 99 99:99:99 9999",
+      },
+      { title: "keeps short retry-after 429 responses retryable", status: 429, retryAfter: "30" },
+      { title: "leaves short retry-after values untouched", status: 429, retryAfter: "30" },
+      { title: "ignores retry-after on non-retryable responses", status: 400, retryAfter: "239" },
+    ])("$title", async ({ status, retryAfter }) => {
       fetchWithSsrFGuardMock.mockResolvedValue({
         response: new Response(null, {
-          status: 503,
-          headers: { "retry-after": "Sun Nov 99 99:99:99 9999" },
+          status,
+          headers: { "retry-after": retryAfter },
         }),
         finalUrl: "https://api.anthropic.com/v1/messages",
         release: vi.fn(async () => undefined),
@@ -2203,46 +2212,12 @@ describe("buildGuardedModelFetch", () => {
       await expect(response.text()).resolves.toContain("weekly rate limit");
     });
 
-    it("keeps short retry-after 429 responses retryable", async () => {
-      fetchWithSsrFGuardMock.mockResolvedValue({
-        response: new Response(null, {
-          status: 429,
-          headers: { "retry-after": "30" },
-        }),
-        finalUrl: "https://api.anthropic.com/v1/messages",
-        release: vi.fn(async () => undefined),
-      });
-      const response = await buildGuardedModelFetch(anthropicModel)(
-        "https://api.anthropic.com/v1/messages",
-        { method: "POST" },
-      );
-
-      expect(response.headers.get("x-should-retry")).toBeNull();
-    });
-
     it("can be disabled with OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS=0", async () => {
       process.env.OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS = "0";
       fetchWithSsrFGuardMock.mockResolvedValue({
         response: new Response(null, {
           status: 429,
           headers: { "retry-after": "239" },
-        }),
-        finalUrl: "https://api.anthropic.com/v1/messages",
-        release: vi.fn(async () => undefined),
-      });
-      const response = await buildGuardedModelFetch(anthropicModel)(
-        "https://api.anthropic.com/v1/messages",
-        { method: "POST" },
-      );
-
-      expect(response.headers.get("x-should-retry")).toBeNull();
-    });
-
-    it("leaves short retry-after values untouched", async () => {
-      fetchWithSsrFGuardMock.mockResolvedValue({
-        response: new Response(null, {
-          status: 429,
-          headers: { "retry-after": "30" },
         }),
         finalUrl: "https://api.anthropic.com/v1/messages",
         release: vi.fn(async () => undefined),
@@ -2274,23 +2249,6 @@ describe("buildGuardedModelFetch", () => {
         expect(response.headers.get("x-should-retry")).toBe("false");
       },
     );
-
-    it("ignores retry-after on non-retryable responses", async () => {
-      fetchWithSsrFGuardMock.mockResolvedValue({
-        response: new Response(null, {
-          status: 400,
-          headers: { "retry-after": "239" },
-        }),
-        finalUrl: "https://api.anthropic.com/v1/messages",
-        release: vi.fn(async () => undefined),
-      });
-      const response = await buildGuardedModelFetch(anthropicModel)(
-        "https://api.anthropic.com/v1/messages",
-        { method: "POST" },
-      );
-
-      expect(response.headers.get("x-should-retry")).toBeNull();
-    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -321,14 +321,43 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
-  test("warns when bundle MCP is denied and allowlisted", () => {
+  test.each([
+    {
+      title: "warns when bundle MCP is denied and allowlisted",
+      allowEntry: "bundle-mcp",
+      expectedUnknownEntry: "bundle-mcp",
+      expectedWarning:
+        "tools: tools.allow allowlist contains unknown entries (bundle-mcp). These entries won't match any tool unless the plugin is enabled.",
+    },
+    {
+      title: "warns when denied MCP server namespace is allowlisted",
+      allowEntry: "paperless__*",
+      expectedUnknownEntry: "paperless__*",
+      expectedWarning:
+        "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
+    },
+    {
+      title: "warns when broad MCP server wildcard deny covers an allowlisted namespace",
+      allowEntry: "paperless*",
+      expectedUnknownEntry: "paperless__*",
+      expectedWarning:
+        "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
+    },
+    {
+      title: "warns when plugin group is denied and MCP server namespace is allowlisted",
+      allowEntry: "group:plugins",
+      expectedUnknownEntry: "paperless__*",
+      expectedWarning:
+        "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
+    },
+  ])("$title", ({ allowEntry, expectedUnknownEntry, expectedWarning }) => {
     const warnings: string[] = [];
     const declared = buildDeclaredToolAllowlistContext({
       config: {
         mcp: { servers: { paperless: { command: "paperless-mcp" } } },
       },
       workspaceDir: process.cwd(),
-      toolDenylist: ["bundle-mcp"],
+      toolDenylist: [allowEntry],
     });
 
     applyToolPolicyPipeline({
@@ -338,74 +367,14 @@ describe("tool-policy-pipeline", () => {
       declaredToolAllowlist: declared,
       steps: [
         {
-          policy: { allow: ["bundle-mcp"] },
+          policy: { allow: [expectedUnknownEntry] },
           label: "tools.allow",
           stripPluginOnlyAllowlist: true,
         },
       ],
     });
 
-    expect(warnings).toEqual([
-      "tools: tools.allow allowlist contains unknown entries (bundle-mcp). These entries won't match any tool unless the plugin is enabled.",
-    ]);
-  });
-
-  test("warns when denied MCP server namespace is allowlisted", () => {
-    const warnings: string[] = [];
-    const declared = buildDeclaredToolAllowlistContext({
-      config: {
-        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
-      },
-      workspaceDir: process.cwd(),
-      toolDenylist: ["paperless__*"],
-    });
-
-    applyToolPolicyPipeline({
-      tools: asPolicyTools([{ name: "exec" }]),
-      toolMeta: () => undefined,
-      warn: (msg) => warnings.push(msg),
-      declaredToolAllowlist: declared,
-      steps: [
-        {
-          policy: { allow: ["paperless__*"] },
-          label: "tools.allow",
-          stripPluginOnlyAllowlist: true,
-        },
-      ],
-    });
-
-    expect(warnings).toEqual([
-      "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
-    ]);
-  });
-
-  test("warns when broad MCP server wildcard deny covers an allowlisted namespace", () => {
-    const warnings: string[] = [];
-    const declared = buildDeclaredToolAllowlistContext({
-      config: {
-        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
-      },
-      workspaceDir: process.cwd(),
-      toolDenylist: ["paperless*"],
-    });
-
-    applyToolPolicyPipeline({
-      tools: asPolicyTools([{ name: "exec" }]),
-      toolMeta: () => undefined,
-      warn: (msg) => warnings.push(msg),
-      declaredToolAllowlist: declared,
-      steps: [
-        {
-          policy: { allow: ["paperless__*"] },
-          label: "tools.allow",
-          stripPluginOnlyAllowlist: true,
-        },
-      ],
-    });
-
-    expect(warnings).toEqual([
-      "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
-    ]);
+    expect(warnings).toEqual([expectedWarning]);
   });
 
   test("does not warn for MCP server namespace allowlist when one exact server tool is denied", () => {
@@ -433,35 +402,6 @@ describe("tool-policy-pipeline", () => {
     });
 
     expect(warnings).toEqual([]);
-  });
-
-  test("warns when plugin group is denied and MCP server namespace is allowlisted", () => {
-    const warnings: string[] = [];
-    const declared = buildDeclaredToolAllowlistContext({
-      config: {
-        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
-      },
-      workspaceDir: process.cwd(),
-      toolDenylist: ["group:plugins"],
-    });
-
-    applyToolPolicyPipeline({
-      tools: asPolicyTools([{ name: "exec" }]),
-      toolMeta: () => undefined,
-      warn: (msg) => warnings.push(msg),
-      declaredToolAllowlist: declared,
-      steps: [
-        {
-          policy: { allow: ["paperless__*"] },
-          label: "tools.allow",
-          stripPluginOnlyAllowlist: true,
-        },
-      ],
-    });
-
-    expect(warnings).toEqual([
-      "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
-    ]);
   });
 
   test("warns when denied duplicate-safe MCP server namespace is allowlisted", () => {

--- a/src/cli/plugins-update-selection.test.ts
+++ b/src/cli/plugins-update-selection.test.ts
@@ -53,65 +53,82 @@ describe("resolvePluginUpdateSelection", () => {
     ).toEqual({ pluginIds: [] });
   });
 
-  it("maps an explicit unscoped npm dist-tag update to the tracked plugin id", () => {
-    expect(
-      resolvePluginUpdateSelection({
-        installs: {
-          "openclaw-codex-app-server": createNpmInstall({
-            spec: "openclaw-codex-app-server",
-            installPath: "/tmp/openclaw-codex-app-server",
-            resolvedName: "openclaw-codex-app-server",
-          }),
+  it.each([
+    {
+      title: "maps an explicit unscoped npm dist-tag update to the tracked plugin id",
+      pluginId: "openclaw-codex-app-server",
+      packageNameWithSpec: "openclaw-codex-app-server",
+      installPath: "/tmp/openclaw-codex-app-server",
+      packageName: "openclaw-codex-app-server",
+      requestedSpec: "openclaw-codex-app-server@beta",
+      expectedPluginId: "openclaw-codex-app-server",
+      expectedTrackedId: "openclaw-codex-app-server",
+      expectedSpec: "openclaw-codex-app-server@beta",
+    },
+    {
+      title: "maps an explicit scoped npm dist-tag update to the tracked plugin id",
+      pluginId: "voice-call",
+      packageNameWithSpec: "@openclaw/voice-call",
+      installPath: "/tmp/voice-call",
+      packageName: "@openclaw/voice-call",
+      requestedSpec: "@openclaw/voice-call@beta",
+      expectedPluginId: "voice-call",
+      expectedTrackedId: "voice-call",
+      expectedSpec: "@openclaw/voice-call@beta",
+    },
+    {
+      title: "maps an explicit npm version update to the tracked plugin id",
+      pluginId: "openclaw-codex-app-server",
+      packageNameWithSpec: "openclaw-codex-app-server",
+      installPath: "/tmp/openclaw-codex-app-server",
+      packageName: "openclaw-codex-app-server",
+      requestedSpec: "openclaw-codex-app-server@0.2.0-beta.4",
+      expectedPluginId: "openclaw-codex-app-server",
+      expectedTrackedId: "openclaw-codex-app-server",
+      expectedSpec: "openclaw-codex-app-server@0.2.0-beta.4",
+    },
+    {
+      title: "maps a bare scoped npm package update to the tracked plugin id",
+      pluginId: "lossless-claw",
+      packageNameWithSpec: "@martian-engineering/lossless-claw@0.9.0",
+      installPath: "/tmp/lossless-claw",
+      packageName: "@martian-engineering/lossless-claw",
+      requestedSpec: "@martian-engineering/lossless-claw",
+      expectedPluginId: "lossless-claw",
+      expectedTrackedId: "lossless-claw",
+      expectedSpec: "@martian-engineering/lossless-claw",
+    },
+  ])(
+    "$title",
+    ({
+      pluginId,
+      packageNameWithSpec,
+      installPath,
+      packageName,
+      requestedSpec,
+      expectedPluginId,
+      expectedTrackedId,
+      expectedSpec,
+    }) => {
+      expect(
+        resolvePluginUpdateSelection({
+          installs: {
+            [pluginId]: createNpmInstall({
+              spec: packageNameWithSpec,
+              installPath,
+              resolvedName: packageName,
+            }),
+          },
+          rawId: requestedSpec,
+        }),
+      ).toEqual({
+        pluginIds: [expectedPluginId],
+        specOverrides: {
+          [expectedTrackedId]: expectedSpec,
         },
-        rawId: "openclaw-codex-app-server@beta",
-      }),
-    ).toEqual({
-      pluginIds: ["openclaw-codex-app-server"],
-      specOverrides: {
-        "openclaw-codex-app-server": "openclaw-codex-app-server@beta",
-      },
-    });
-  });
-
-  it("maps an explicit scoped npm dist-tag update to the tracked plugin id", () => {
-    expect(
-      resolvePluginUpdateSelection({
-        installs: {
-          "voice-call": createNpmInstall({
-            spec: "@openclaw/voice-call",
-            installPath: "/tmp/voice-call",
-            resolvedName: "@openclaw/voice-call",
-          }),
-        },
-        rawId: "@openclaw/voice-call@beta",
-      }),
-    ).toEqual({
-      pluginIds: ["voice-call"],
-      specOverrides: {
-        "voice-call": "@openclaw/voice-call@beta",
-      },
-    });
-  });
-
-  it("maps an explicit npm version update to the tracked plugin id", () => {
-    expect(
-      resolvePluginUpdateSelection({
-        installs: {
-          "openclaw-codex-app-server": createNpmInstall({
-            spec: "openclaw-codex-app-server",
-            installPath: "/tmp/openclaw-codex-app-server",
-            resolvedName: "openclaw-codex-app-server",
-          }),
-        },
-        rawId: "openclaw-codex-app-server@0.2.0-beta.4",
-      }),
-    ).toEqual({
-      pluginIds: ["openclaw-codex-app-server"],
-      specOverrides: {
-        "openclaw-codex-app-server": "openclaw-codex-app-server@0.2.0-beta.4",
-      },
-    });
-  });
+      });
+    },
+  );
 
   it("keeps recorded npm tags when update is invoked by plugin id", () => {
     expect(
@@ -127,26 +144,6 @@ describe("resolvePluginUpdateSelection", () => {
       }),
     ).toEqual({
       pluginIds: ["openclaw-codex-app-server"],
-    });
-  });
-
-  it("maps a bare scoped npm package update to the tracked plugin id", () => {
-    expect(
-      resolvePluginUpdateSelection({
-        installs: {
-          "lossless-claw": createNpmInstall({
-            spec: "@martian-engineering/lossless-claw@0.9.0",
-            installPath: "/tmp/lossless-claw",
-            resolvedName: "@martian-engineering/lossless-claw",
-          }),
-        },
-        rawId: "@martian-engineering/lossless-claw",
-      }),
-    ).toEqual({
-      pluginIds: ["lossless-claw"],
-      specOverrides: {
-        "lossless-claw": "@martian-engineering/lossless-claw",
-      },
     });
   });
 

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -341,7 +341,7 @@ describe("runDoctorLintCli", () => {
       description: "reserved core-kind lint check",
       expectedError: "health check already registered: core/doctor/not-yet-owned",
     },
-  ])("$title", async ({ checkId, kind, description, expectedError }) => {
+  ] as const)("$title", async ({ checkId, kind, description, expectedError }) => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,
       valid: true,

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -312,70 +312,36 @@ describe("runDoctorLintCli", () => {
     }
   });
 
-  it("rejects extension checks that reuse ordered core check ids", async () => {
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      exists: true,
-      valid: true,
-      config: {},
-      path: "/tmp/openclaw.json",
-    });
-    registerHealthCheck({
-      id: "core/doctor/final-config-validation",
+  it.each([
+    {
+      title: "rejects extension checks that reuse ordered core check ids",
+      checkId: "core/doctor/final-config-validation",
       kind: "plugin",
       description: "colliding plugin lint check",
-      async detect() {
-        return [];
-      },
-    });
-
-    await expect(runDoctorLintCli(runtime, { json: true })).rejects.toThrow(
-      "health check already registered: core/doctor/final-config-validation",
-    );
-  });
-
-  it("rejects registered core-kind checks that reuse ordered core check ids", async () => {
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      exists: true,
-      valid: true,
-      config: {},
-      path: "/tmp/openclaw.json",
-    });
-    registerHealthCheck({
-      id: "core/doctor/final-config-validation",
+      expectedError: "health check already registered: core/doctor/final-config-validation",
+    },
+    {
+      title: "rejects registered core-kind checks that reuse ordered core check ids",
+      checkId: "core/doctor/final-config-validation",
       kind: "core",
       description: "colliding core-kind lint check",
-      async detect() {
-        return [];
-      },
-    });
-
-    await expect(runDoctorLintCli(runtime, { json: true })).rejects.toThrow(
-      "health check already registered: core/doctor/final-config-validation",
-    );
-  });
-
-  it("rejects extension checks that claim unused reserved core doctor ids", async () => {
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      exists: true,
-      valid: true,
-      config: {},
-      path: "/tmp/openclaw.json",
-    });
-    registerHealthCheck({
-      id: "core/doctor/not-yet-owned",
+      expectedError: "health check already registered: core/doctor/final-config-validation",
+    },
+    {
+      title: "rejects extension checks that claim unused reserved core doctor ids",
+      checkId: "core/doctor/not-yet-owned",
       kind: "plugin",
       description: "reserved plugin lint check",
-      async detect() {
-        return [];
-      },
-    });
-
-    await expect(runDoctorLintCli(runtime, { json: true })).rejects.toThrow(
-      "health check already registered: core/doctor/not-yet-owned",
-    );
-  });
-
-  it("rejects registered core-kind checks that claim unused reserved core doctor ids", async () => {
+      expectedError: "health check already registered: core/doctor/not-yet-owned",
+    },
+    {
+      title: "rejects registered core-kind checks that claim unused reserved core doctor ids",
+      checkId: "core/doctor/not-yet-owned",
+      kind: "core",
+      description: "reserved core-kind lint check",
+      expectedError: "health check already registered: core/doctor/not-yet-owned",
+    },
+  ])("$title", async ({ checkId, kind, description, expectedError }) => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,
       valid: true,
@@ -383,17 +349,15 @@ describe("runDoctorLintCli", () => {
       path: "/tmp/openclaw.json",
     });
     registerHealthCheck({
-      id: "core/doctor/not-yet-owned",
-      kind: "core",
-      description: "reserved core-kind lint check",
+      id: checkId,
+      kind,
+      description,
       async detect() {
         return [];
       },
     });
 
-    await expect(runDoctorLintCli(runtime, { json: true })).rejects.toThrow(
-      "health check already registered: core/doctor/not-yet-owned",
-    );
+    await expect(runDoctorLintCli(runtime, { json: true })).rejects.toThrow(expectedError);
   });
 
   it("rejects invalid severity thresholds", async () => {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -496,12 +496,38 @@ describe("config plugin validation", () => {
       expectMissingCodexPluginWarning(res.warnings);
     });
 
-    it("warns when automatic gpt-5.6 overrides a provider PI runtime policy", () => {
+    it.each([
+      {
+        title: "warns when automatic gpt-5.6 overrides a provider PI runtime policy",
+        baseUrl: "https://api.openai.com/v1",
+        modelPattern: "openai/gpt-5.6",
+        runtime: "default",
+      },
+      {
+        title: "warns when automatic Spark overrides a provider PI runtime policy",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        modelPattern: "openai/gpt-5.3-codex-spark",
+        runtime: "default",
+      },
+      {
+        title:
+          "still warns when a provider-wide PI policy is overridden by an OpenAI wildcard default",
+        baseUrl: "https://api.openai.com/v1",
+        modelPattern: "openai/*",
+        runtime: "default",
+      },
+      {
+        title: "still warns when an agent model route explicitly selects Codex",
+        baseUrl: "https://api.openai.com/v1",
+        modelPattern: "openai/gpt-5.5",
+        runtime: "codex",
+      },
+    ])("$title", ({ baseUrl, modelPattern, runtime }) => {
       const res = validateWithMissingCodexPlugin({
         models: {
           providers: {
             openai: {
-              baseUrl: "https://api.openai.com/v1",
+              baseUrl,
               models: [],
               agentRuntime: { id: "pi" },
             },
@@ -511,33 +537,7 @@ describe("config plugin validation", () => {
           list: [{ id: "openclaw" }],
           defaults: {
             models: {
-              "openai/gpt-5.6": { agentRuntime: { id: "default" } },
-            },
-          },
-        },
-        plugins: { entries: { codex: {} } },
-      });
-
-      expect(res.ok).toBe(true);
-      expectMissingCodexPluginWarning(res.warnings);
-    });
-
-    it("warns when automatic Spark overrides a provider PI runtime policy", () => {
-      const res = validateWithMissingCodexPlugin({
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://chatgpt.com/backend-api/codex",
-              models: [],
-              agentRuntime: { id: "pi" },
-            },
-          },
-        },
-        agents: {
-          list: [{ id: "openclaw" }],
-          defaults: {
-            models: {
-              "openai/gpt-5.3-codex-spark": { agentRuntime: { id: "default" } },
+              [modelPattern]: { agentRuntime: { id: runtime } },
             },
           },
         },
@@ -1158,32 +1158,6 @@ describe("config plugin validation", () => {
       expectMissingCodexPluginWarning(res.warnings);
     });
 
-    it("still warns when a provider-wide PI policy is overridden by an OpenAI wildcard default", () => {
-      const res = validateWithMissingCodexPlugin({
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              models: [],
-              agentRuntime: { id: "pi" },
-            },
-          },
-        },
-        agents: {
-          list: [{ id: "openclaw" }],
-          defaults: {
-            models: {
-              "openai/*": { agentRuntime: { id: "default" } },
-            },
-          },
-        },
-        plugins: { entries: { codex: {} } },
-      });
-
-      expect(res.ok).toBe(true);
-      expectMissingCodexPluginWarning(res.warnings);
-    });
-
     it("still warns when the missing Codex plugin is explicitly enabled", () => {
       const res = validateWithMissingCodexPlugin({
         models: {
@@ -1221,32 +1195,6 @@ describe("config plugin validation", () => {
                   agentRuntime: { id: "codex" },
                 },
               ],
-            },
-          },
-        },
-        plugins: { entries: { codex: {} } },
-      });
-
-      expect(res.ok).toBe(true);
-      expectMissingCodexPluginWarning(res.warnings);
-    });
-
-    it("still warns when an agent model route explicitly selects Codex", () => {
-      const res = validateWithMissingCodexPlugin({
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              models: [],
-              agentRuntime: { id: "pi" },
-            },
-          },
-        },
-        agents: {
-          list: [{ id: "openclaw" }],
-          defaults: {
-            models: {
-              "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
             },
           },
         },

--- a/src/config/sessions/session-key.test.ts
+++ b/src/config/sessions/session-key.test.ts
@@ -27,64 +27,63 @@ describe("resolveSessionKey", () => {
   });
 
   describe("Discord DM session key normalization", () => {
-    it("passes through correct discord:direct keys unchanged", () => {
+    it.each([
+      {
+        title: "passes through correct discord:direct keys unchanged",
+        sessionKey: "agent:fina:discord:direct:123456",
+        chatType: "direct",
+        normalizedKey: "discord:123456",
+        senderId: "123456",
+        expected: "agent:fina:discord:direct:123456",
+      },
+      {
+        title: "migrates legacy discord:dm: keys to discord:direct:",
+        sessionKey: "agent:fina:discord:dm:123456",
+        chatType: "direct",
+        normalizedKey: "discord:123456",
+        senderId: "123456",
+        expected: "agent:fina:discord:direct:123456",
+      },
+      {
+        title: "fixes phantom discord:channel:USERID keys when sender matches",
+        sessionKey: "agent:fina:discord:channel:123456",
+        chatType: "direct",
+        normalizedKey: "discord:123456",
+        senderId: "123456",
+        expected: "agent:fina:discord:direct:123456",
+      },
+      {
+        title: "does not rewrite discord:channel: keys for non-direct chats",
+        sessionKey: "agent:fina:discord:channel:123456",
+        chatType: "channel",
+        normalizedKey: "discord:channel:123456",
+        senderId: "789",
+        expected: "agent:fina:discord:channel:123456",
+      },
+      {
+        title: "does not rewrite discord:channel: keys when sender does not match",
+        sessionKey: "agent:fina:discord:channel:123456",
+        chatType: "direct",
+        normalizedKey: "discord:789",
+        senderId: "789",
+        expected: "agent:fina:discord:channel:123456",
+      },
+      {
+        title: "handles keys without an agent prefix",
+        sessionKey: "discord:channel:123456",
+        chatType: "direct",
+        normalizedKey: "discord:123456",
+        senderId: "123456",
+        expected: "discord:direct:123456",
+      },
+    ])("$title", ({ sessionKey, chatType, normalizedKey, senderId, expected }) => {
       const ctx = makeCtx({
-        SessionKey: "agent:fina:discord:direct:123456",
-        ChatType: "direct",
-        From: "discord:123456",
-        SenderId: "123456",
+        SessionKey: sessionKey,
+        ChatType: chatType,
+        From: normalizedKey,
+        SenderId: senderId,
       });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
-    });
-
-    it("migrates legacy discord:dm: keys to discord:direct:", () => {
-      const ctx = makeCtx({
-        SessionKey: "agent:fina:discord:dm:123456",
-        ChatType: "direct",
-        From: "discord:123456",
-        SenderId: "123456",
-      });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
-    });
-
-    it("fixes phantom discord:channel:USERID keys when sender matches", () => {
-      const ctx = makeCtx({
-        SessionKey: "agent:fina:discord:channel:123456",
-        ChatType: "direct",
-        From: "discord:123456",
-        SenderId: "123456",
-      });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
-    });
-
-    it("does not rewrite discord:channel: keys for non-direct chats", () => {
-      const ctx = makeCtx({
-        SessionKey: "agent:fina:discord:channel:123456",
-        ChatType: "channel",
-        From: "discord:channel:123456",
-        SenderId: "789",
-      });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:channel:123456");
-    });
-
-    it("does not rewrite discord:channel: keys when sender does not match", () => {
-      const ctx = makeCtx({
-        SessionKey: "agent:fina:discord:channel:123456",
-        ChatType: "direct",
-        From: "discord:789",
-        SenderId: "789",
-      });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:channel:123456");
-    });
-
-    it("handles keys without an agent prefix", () => {
-      const ctx = makeCtx({
-        SessionKey: "discord:channel:123456",
-        ChatType: "direct",
-        From: "discord:123456",
-        SenderId: "123456",
-      });
-      expect(resolveSessionKey("per-sender", ctx)).toBe("discord:direct:123456");
+      expect(resolveSessionKey("per-sender", ctx)).toBe(expected);
     });
   });
 });

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -205,29 +205,53 @@ describe("cron model formatting and precedence edge cases", () => {
       );
     });
 
-    it("handles leading/trailing whitespace in model string", async () => {
+    it.each([
+      {
+        title: "handles leading/trailing whitespace in model string",
+        model: "  openai/gpt-4.1-mini  ",
+        expectedProvider: "openai",
+        expectedModel: "gpt-4.1-mini",
+      },
+      {
+        title: "handles openrouter nested provider paths",
+        model: "openrouter/meta-llama/llama-3.3-70b:free",
+        expectedProvider: "openrouter",
+        expectedModel: "meta-llama/llama-3.3-70b:free",
+      },
+      {
+        title: "normalizes provider casing",
+        model: "OpenAI/gpt-4.1-mini",
+        expectedProvider: "openai",
+        expectedModel: "gpt-4.1-mini",
+      },
+      {
+        title: "normalizes anthropic model aliases",
+        model: "anthropic/opus-4.5",
+        expectedProvider: "anthropic",
+        expectedModel: "claude-opus-4-5",
+      },
+      {
+        title: "normalizes bedrock provider alias",
+        model: "bedrock/claude-sonnet-4-6",
+        expectedProvider: "amazon-bedrock",
+        expectedModel: "claude-sonnet-4-6",
+      },
+      {
+        title: "job payload model overrides default (anthropic -> openai)",
+        model: "openai/gpt-4.1-mini",
+        expectedProvider: "openai",
+        expectedModel: "gpt-4.1-mini",
+      },
+    ])("$title", async ({ model, expectedProvider, expectedModel }) => {
       await expectSelectedModel(
         {
           payload: {
             kind: "agentTurn",
             message: DEFAULT_MESSAGE,
-            model: "  openai/gpt-4.1-mini  ",
+            model,
           },
         },
-        { provider: "openai", model: "gpt-4.1-mini" },
-      );
-    });
-
-    it("handles openrouter nested provider paths", async () => {
-      await expectSelectedModel(
-        {
-          payload: {
-            kind: "agentTurn",
-            message: DEFAULT_MESSAGE,
-            model: "openrouter/meta-llama/llama-3.3-70b:free",
-          },
-        },
-        { provider: "openrouter", model: "meta-llama/llama-3.3-70b:free" },
+        { provider: expectedProvider, model: expectedModel },
       );
     });
 
@@ -384,61 +408,9 @@ describe("cron model formatting and precedence edge cases", () => {
         },
       });
     });
-
-    it("normalizes provider casing", async () => {
-      await expectSelectedModel(
-        {
-          payload: {
-            kind: "agentTurn",
-            message: DEFAULT_MESSAGE,
-            model: "OpenAI/gpt-4.1-mini",
-          },
-        },
-        { provider: "openai", model: "gpt-4.1-mini" },
-      );
-    });
-
-    it("normalizes anthropic model aliases", async () => {
-      await expectSelectedModel(
-        {
-          payload: {
-            kind: "agentTurn",
-            message: DEFAULT_MESSAGE,
-            model: "anthropic/opus-4.5",
-          },
-        },
-        { provider: "anthropic", model: "claude-opus-4-5" },
-      );
-    });
-
-    it("normalizes bedrock provider alias", async () => {
-      await expectSelectedModel(
-        {
-          payload: {
-            kind: "agentTurn",
-            message: DEFAULT_MESSAGE,
-            model: "bedrock/claude-sonnet-4-6",
-          },
-        },
-        { provider: "amazon-bedrock", model: "claude-sonnet-4-6" },
-      );
-    });
   });
 
   describe("model precedence isolation", () => {
-    it("job payload model overrides default (anthropic -> openai)", async () => {
-      await expectSelectedModel(
-        {
-          payload: {
-            kind: "agentTurn",
-            message: DEFAULT_MESSAGE,
-            model: "openai/gpt-4.1-mini",
-          },
-        },
-        { provider: "openai", model: "gpt-4.1-mini" },
-      );
-    });
-
     it("session override applies when no job payload model is present", async () => {
       await expectSelectedModel(
         {

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -173,7 +173,7 @@ describe("renderGatewayServiceCleanupHints", () => {
       stopCommand: "launchctl bootout gui/$UID/'com.example.gateway; touch injected'",
       removeCommand: "rm '/Users/test/Launch Agents/example'\\''s gateway.plist'",
     },
-  ])("$title", ({ platform, serviceName, source, scope, stopCommand, removeCommand }) => {
+  ] as const)("$title", ({ platform, serviceName, source, scope, stopCommand, removeCommand }) => {
     expect(
       renderGatewayServiceCleanupHints([
         {

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -109,84 +109,81 @@ describe("renderGatewayServiceCleanupHints", () => {
     expect(renderGatewayServiceCleanupHints([])).toEqual([]);
   });
 
-  it("targets the detected macOS LaunchAgent instead of the active gateway", () => {
+  it.each([
+    {
+      title: "targets the detected macOS LaunchAgent instead of the active gateway",
+      platform: "darwin",
+      serviceName: "com.example.openclaw-gateway",
+      source: "plist: /Users/test/Library/LaunchAgents/com.example.openclaw-gateway.plist",
+      scope: "user",
+      stopCommand: "launchctl bootout gui/$UID/com.example.openclaw-gateway",
+      removeCommand: "rm /Users/test/Library/LaunchAgents/com.example.openclaw-gateway.plist",
+    },
+    {
+      title: "uses the system domain for a detected macOS LaunchDaemon",
+      platform: "darwin",
+      serviceName: "com.example.openclaw-gateway",
+      source: "plist: /Library/LaunchDaemons/com.example.openclaw-gateway.plist",
+      scope: "system",
+      stopCommand: "sudo launchctl bootout system/com.example.openclaw-gateway",
+      removeCommand: "sudo rm /Library/LaunchDaemons/com.example.openclaw-gateway.plist",
+    },
+    {
+      title: "keeps global macOS LaunchAgents in the GUI domain",
+      platform: "darwin",
+      serviceName: "com.example.openclaw-gateway",
+      source: "plist: /Library/LaunchAgents/com.example.openclaw-gateway.plist",
+      scope: "system",
+      stopCommand: "launchctl bootout gui/$UID/com.example.openclaw-gateway",
+      removeCommand: "sudo rm /Library/LaunchAgents/com.example.openclaw-gateway.plist",
+    },
+    {
+      title: "targets the detected user-level systemd unit",
+      platform: "linux",
+      serviceName: "custom-gateway.service",
+      source: "unit: /home/test/.config/systemd/user/custom-gateway.service",
+      scope: "user",
+      stopCommand: "systemctl --user disable --now -- custom-gateway.service",
+      removeCommand: "rm /home/test/.config/systemd/user/custom-gateway.service",
+    },
+    {
+      title: "targets the detected system-level systemd unit",
+      platform: "linux",
+      serviceName: "custom-gateway.service",
+      source: "unit: /etc/systemd/system/custom-gateway.service",
+      scope: "system",
+      stopCommand: "sudo systemctl disable --now -- custom-gateway.service",
+      removeCommand: "sudo rm /etc/systemd/system/custom-gateway.service",
+    },
+    {
+      title: "terminates systemctl options before a detected unit that begins with a dash",
+      platform: "linux",
+      serviceName: "-custom-gateway.service",
+      source: "unit: /home/test/.config/systemd/user/-custom-gateway.service",
+      scope: "user",
+      stopCommand: "systemctl --user disable --now -- -custom-gateway.service",
+      removeCommand: "rm /home/test/.config/systemd/user/-custom-gateway.service",
+    },
+    {
+      title: "shell-quotes detected POSIX service labels and paths",
+      platform: "darwin",
+      serviceName: "com.example.gateway; touch injected",
+      source: "plist: /Users/test/Launch Agents/example's gateway.plist",
+      scope: "user",
+      stopCommand: "launchctl bootout gui/$UID/'com.example.gateway; touch injected'",
+      removeCommand: "rm '/Users/test/Launch Agents/example'\\''s gateway.plist'",
+    },
+  ])("$title", ({ platform, serviceName, source, scope, stopCommand, removeCommand }) => {
     expect(
       renderGatewayServiceCleanupHints([
         {
-          platform: "darwin",
-          label: "com.example.openclaw-gateway",
-          detail: "plist: /Users/test/Library/LaunchAgents/com.example.openclaw-gateway.plist",
-          scope: "user",
+          platform,
+          label: serviceName,
+          detail: source,
+          scope,
         },
       ]),
-    ).toEqual([
-      "launchctl bootout gui/$UID/com.example.openclaw-gateway",
-      "rm /Users/test/Library/LaunchAgents/com.example.openclaw-gateway.plist",
-    ]);
-  });
-
-  it("uses the system domain for a detected macOS LaunchDaemon", () => {
-    expect(
-      renderGatewayServiceCleanupHints([
-        {
-          platform: "darwin",
-          label: "com.example.openclaw-gateway",
-          detail: "plist: /Library/LaunchDaemons/com.example.openclaw-gateway.plist",
-          scope: "system",
-        },
-      ]),
-    ).toEqual([
-      "sudo launchctl bootout system/com.example.openclaw-gateway",
-      "sudo rm /Library/LaunchDaemons/com.example.openclaw-gateway.plist",
-    ]);
-  });
-
-  it("keeps global macOS LaunchAgents in the GUI domain", () => {
-    expect(
-      renderGatewayServiceCleanupHints([
-        {
-          platform: "darwin",
-          label: "com.example.openclaw-gateway",
-          detail: "plist: /Library/LaunchAgents/com.example.openclaw-gateway.plist",
-          scope: "system",
-        },
-      ]),
-    ).toEqual([
-      "launchctl bootout gui/$UID/com.example.openclaw-gateway",
-      "sudo rm /Library/LaunchAgents/com.example.openclaw-gateway.plist",
-    ]);
-  });
-
-  it("targets the detected user-level systemd unit", () => {
-    expect(
-      renderGatewayServiceCleanupHints([
-        {
-          platform: "linux",
-          label: "custom-gateway.service",
-          detail: "unit: /home/test/.config/systemd/user/custom-gateway.service",
-          scope: "user",
-        },
-      ]),
-    ).toEqual([
-      "systemctl --user disable --now -- custom-gateway.service",
-      "rm /home/test/.config/systemd/user/custom-gateway.service",
-    ]);
-  });
-
-  it("targets the detected system-level systemd unit", () => {
-    expect(
-      renderGatewayServiceCleanupHints([
-        {
-          platform: "linux",
-          label: "custom-gateway.service",
-          detail: "unit: /etc/systemd/system/custom-gateway.service",
-          scope: "system",
-        },
-      ]),
-    ).toEqual([
-      "sudo systemctl disable --now -- custom-gateway.service",
-      "sudo rm /etc/systemd/system/custom-gateway.service",
-    ]);
+    ).toEqual([stopCommand, removeCommand]);
   });
 
   it("targets the detected Windows scheduled task", () => {
@@ -217,38 +214,6 @@ describe("renderGatewayServiceCleanupHints", () => {
       ).toEqual([]);
     },
   );
-
-  it("terminates systemctl options before a detected unit that begins with a dash", () => {
-    expect(
-      renderGatewayServiceCleanupHints([
-        {
-          platform: "linux",
-          label: "-custom-gateway.service",
-          detail: "unit: /home/test/.config/systemd/user/-custom-gateway.service",
-          scope: "user",
-        },
-      ]),
-    ).toEqual([
-      "systemctl --user disable --now -- -custom-gateway.service",
-      "rm /home/test/.config/systemd/user/-custom-gateway.service",
-    ]);
-  });
-
-  it("shell-quotes detected POSIX service labels and paths", () => {
-    expect(
-      renderGatewayServiceCleanupHints([
-        {
-          platform: "darwin",
-          label: "com.example.gateway; touch injected",
-          detail: "plist: /Users/test/Launch Agents/example's gateway.plist",
-          scope: "user",
-        },
-      ]),
-    ).toEqual([
-      "launchctl bootout gui/$UID/'com.example.gateway; touch injected'",
-      "rm '/Users/test/Launch Agents/example'\\''s gateway.plist'",
-    ]);
-  });
 
   it("does not invent a removal path when service metadata omits it", () => {
     expect(

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -1304,7 +1304,28 @@ $0 \\"$1\\"" touch {marker}`,
     expect(scriptResult.allowlistSatisfied).toBe(true);
   });
 
-  it("prevents allow-always bypass for caffeinate wrapper chains", async () => {
+  it.each([
+    {
+      title: "prevents allow-always bypass for caffeinate wrapper chains",
+      allowedCommand: "/usr/bin/caffeinate -d -w 42 /bin/zsh -c 'echo warmup-ok'",
+      mutatedCommand: "/usr/bin/caffeinate -d -w 42 /bin/zsh -c 'id > marker'",
+    },
+    {
+      title: "prevents allow-always bypass for dispatch-wrapper + shell-wrapper chains",
+      allowedCommand: "/usr/bin/nice /bin/zsh -c 'echo warmup-ok'",
+      mutatedCommand: "/usr/bin/nice /bin/zsh -c 'id > marker'",
+    },
+    {
+      title: "prevents allow-always bypass for time wrapper chains",
+      allowedCommand: "/usr/bin/time -p /bin/zsh -c 'echo warmup-ok'",
+      mutatedCommand: "/usr/bin/time -p /bin/zsh -c 'id > marker'",
+    },
+    {
+      title: "prevents allow-always bypass for flock wrapper chains",
+      allowedCommand: "/usr/bin/flock lockfile /bin/zsh -c 'echo warmup-ok'",
+      mutatedCommand: "/usr/bin/flock lockfile /bin/zsh -c 'id > marker'",
+    },
+  ])("$title", async ({ allowedCommand, mutatedCommand }) => {
     if (process.platform === "win32") {
       return;
     }
@@ -1314,26 +1335,8 @@ $0 \\"$1\\"" touch {marker}`,
     const env = makePathEnv(dir);
     await expectAllowAlwaysBypassBlocked({
       dir,
-      firstCommand: "/usr/bin/caffeinate -d -w 42 /bin/zsh -c 'echo warmup-ok'",
-      secondCommand: "/usr/bin/caffeinate -d -w 42 /bin/zsh -c 'id > marker'",
-      env,
-      persistedPattern: null,
-      allowlistPattern: echo,
-    });
-  });
-
-  it("prevents allow-always bypass for dispatch-wrapper + shell-wrapper chains", async () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const dir = makeTempDir();
-    const echo = makeExecutable(dir, "echo");
-    makeExecutable(dir, "id");
-    const env = makePathEnv(dir);
-    await expectAllowAlwaysBypassBlocked({
-      dir,
-      firstCommand: "/usr/bin/nice /bin/zsh -c 'echo warmup-ok'",
-      secondCommand: "/usr/bin/nice /bin/zsh -c 'id > marker'",
+      firstCommand: allowedCommand,
+      secondCommand: mutatedCommand,
       env,
       persistedPattern: null,
       allowlistPattern: echo,
@@ -2067,42 +2070,6 @@ $0 \\"$1\\"" touch {marker}`,
         allowlistSatisfied: result.allowlistSatisfied,
       }),
     ).toBe(true);
-  });
-
-  it("prevents allow-always bypass for time wrapper chains", async () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const dir = makeTempDir();
-    const echo = makeExecutable(dir, "echo");
-    makeExecutable(dir, "id");
-    const env = makePathEnv(dir);
-    await expectAllowAlwaysBypassBlocked({
-      dir,
-      firstCommand: "/usr/bin/time -p /bin/zsh -c 'echo warmup-ok'",
-      secondCommand: "/usr/bin/time -p /bin/zsh -c 'id > marker'",
-      env,
-      persistedPattern: null,
-      allowlistPattern: echo,
-    });
-  });
-
-  it("prevents allow-always bypass for flock wrapper chains", async () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const dir = makeTempDir();
-    const echo = makeExecutable(dir, "echo");
-    makeExecutable(dir, "id");
-    const env = makePathEnv(dir);
-    await expectAllowAlwaysBypassBlocked({
-      dir,
-      firstCommand: "/usr/bin/flock lockfile /bin/zsh -c 'echo warmup-ok'",
-      secondCommand: "/usr/bin/flock lockfile /bin/zsh -c 'id > marker'",
-      env,
-      persistedPattern: null,
-      allowlistPattern: echo,
-    });
   });
 
   it("keeps ambiguous flock command strings out of allow-always", async () => {

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -803,61 +803,30 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(blockedFetchImpl).not.toHaveBeenCalled();
   });
 
-  it("blocks exact-origin private DNS when it resolves to link-local metadata IPs", async () => {
-    const lookupFn: LookupFn = vi.fn(async () => [
-      { address: "169.254.169.254", family: 4 },
-    ]) as unknown as LookupFn;
-    const fetchImpl = vi.fn(async () => okResponse());
-
-    await expect(
-      fetchWithSsrFGuard({
-        url: "http://model.lan:11434/v1/models",
-        fetchImpl,
-        lookupFn,
-        policy: { allowedOrigins: ["http://model.lan:11434"] },
-      }),
-    ).rejects.toThrow(/private|internal|blocked/i);
-    expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
-  it("blocks exact-origin private DNS when it resolves to embedded IPv6 link-local metadata IPs", async () => {
-    const lookupFn: LookupFn = vi.fn(async () => [
-      { address: "64:ff9b::a9fe:a9fe", family: 6 },
-    ]) as unknown as LookupFn;
-    const fetchImpl = vi.fn(async () => okResponse());
-
-    await expect(
-      fetchWithSsrFGuard({
-        url: "http://model.lan:11434/v1/models",
-        fetchImpl,
-        lookupFn,
-        policy: { allowedOrigins: ["http://model.lan:11434"] },
-      }),
-    ).rejects.toThrow(/private|internal|blocked/i);
-    expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
-  it("blocks exact-origin private DNS when it resolves to non-link-local metadata IPs", async () => {
-    const lookupFn: LookupFn = vi.fn(async () => [
-      { address: "100.100.100.200", family: 4 },
-    ]) as unknown as LookupFn;
-    const fetchImpl = vi.fn(async () => okResponse());
-
-    await expect(
-      fetchWithSsrFGuard({
-        url: "http://model.lan:11434/v1/models",
-        fetchImpl,
-        lookupFn,
-        policy: { allowedOrigins: ["http://model.lan:11434"] },
-      }),
-    ).rejects.toThrow(/private|internal|blocked/i);
-    expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
-  it("blocks exact-origin private DNS when it resolves to IPv6 cloud metadata IPs", async () => {
-    const lookupFn: LookupFn = vi.fn(async () => [
-      { address: "fd00:ec2::254", family: 6 },
-    ]) as unknown as LookupFn;
+  it.each([
+    {
+      title: "blocks exact-origin private DNS when it resolves to link-local metadata IPs",
+      address: "169.254.169.254",
+      family: 4,
+    },
+    {
+      title:
+        "blocks exact-origin private DNS when it resolves to embedded IPv6 link-local metadata IPs",
+      address: "64:ff9b::a9fe:a9fe",
+      family: 6,
+    },
+    {
+      title: "blocks exact-origin private DNS when it resolves to non-link-local metadata IPs",
+      address: "100.100.100.200",
+      family: 4,
+    },
+    {
+      title: "blocks exact-origin private DNS when it resolves to IPv6 cloud metadata IPs",
+      address: "fd00:ec2::254",
+      family: 6,
+    },
+  ])("$title", async ({ address, family }) => {
+    const lookupFn: LookupFn = vi.fn(async () => [{ address, family }]) as unknown as LookupFn;
     const fetchImpl = vi.fn(async () => okResponse());
 
     await expect(

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -72,23 +72,248 @@ describe("test-projects args", () => {
     ]);
   });
 
-  it("routes boundary targets to the boundary config", () => {
-    expect(buildVitestRunPlans(["src/infra/openclaw-root.test.ts"])).toEqual([
+  it.each([
+    {
+      title: "routes boundary targets to the boundary config",
+      target: "src/infra/openclaw-root.test.ts",
+      config: "test/vitest/vitest.boundary.config.ts",
+    },
+    {
+      title: "routes bundled-plugin-dependent unit targets to the bundled config",
+      target: "src/plugins/loader.test.ts",
+      config: "test/vitest/vitest.bundled.config.ts",
+    },
+    {
+      title: "routes top-level repo tests to the contracts config",
+      target: "test/appcast.test.ts",
+      config: "test/vitest/vitest.tooling.config.ts",
+    },
+    {
+      title: "routes script tests to the tooling config",
+      target: "src/scripts/test-projects.test.ts",
+      config: "test/vitest/vitest.tooling.config.ts",
+    },
+    {
+      title: "routes config baseline integration tests to the contracts config",
+      target: "src/config/doc-baseline.integration.test.ts",
+      config: "test/vitest/vitest.tooling.config.ts",
+    },
+    {
+      title: "routes runtime config targets to the runtime-config config",
+      target: "src/config/sessions.test.ts",
+      config: "test/vitest/vitest.runtime-config.config.ts",
+    },
+    {
+      title: "routes cron targets to the cron config",
+      target: "src/cron/isolated-agent.lane.test.ts",
+      config: "test/vitest/vitest.cron.config.ts",
+    },
+    {
+      title: "routes daemon targets to the daemon config",
+      target: "src/daemon/inspect.test.ts",
+      config: "test/vitest/vitest.daemon.config.ts",
+    },
+    {
+      title: "routes media targets to the media config",
+      target: "src/media/fetch.test.ts",
+      config: "test/vitest/vitest.media.config.ts",
+    },
+    {
+      title: "routes plugin-sdk targets to the plugin-sdk config",
+      target: "src/plugin-sdk/migration-runtime.test.ts",
+      config: "test/vitest/vitest.plugin-sdk.config.ts",
+    },
+    {
+      title: "routes unit-fast light targets to the cache-friendly unit-fast config",
+      target: "src/plugin-sdk/provider-entry.test.ts",
+      config: "test/vitest/vitest.unit-fast.config.ts",
+    },
+    {
+      title: "routes fake-timer unit-fast targets to the serial fake-timer config",
+      target: "src/acp/control-plane/manager.test.ts",
+      config: "test/vitest/vitest.unit-fast-fake-timers.config.ts",
+    },
+    {
+      title: "routes process targets to the process config",
+      target: "src/process/exec.test.ts",
+      config: "test/vitest/vitest.process.config.ts",
+    },
+    {
+      title: "routes secrets targets to the secrets config",
+      target: "src/secrets/resolve.test.ts",
+      config: "test/vitest/vitest.secrets.config.ts",
+    },
+    {
+      title: "routes unit-fast shared-core targets to the unit-fast config",
+      target: "src/shared/text-chunking.test.ts",
+      config: "test/vitest/vitest.unit-fast.config.ts",
+    },
+    {
+      title: "routes tasks targets to the tasks config",
+      target: "src/tasks/task-registry.test.ts",
+      config: "test/vitest/vitest.tasks.config.ts",
+    },
+    {
+      title: "routes logging targets to the logging config",
+      target: "src/logging/console-settings.test.ts",
+      config: "test/vitest/vitest.logging.config.ts",
+    },
+    {
+      title: "routes wizard targets to the wizard config",
+      target: "src/wizard/setup.test.ts",
+      config: "test/vitest/vitest.wizard.config.ts",
+    },
+    {
+      title: "routes tui targets to the tui config",
+      target: "src/tui/tui.test.ts",
+      config: "test/vitest/vitest.tui.config.ts",
+    },
+    {
+      title: "routes media-understanding targets to the media-understanding config",
+      target: "src/media-understanding/runtime.test.ts",
+      config: "test/vitest/vitest.media-understanding.config.ts",
+    },
+    {
+      title: "routes command targets to the commands config",
+      target: "src/commands/status.summary.test.ts",
+      config: "test/vitest/vitest.commands.config.ts",
+    },
+    {
+      title: "routes auto-reply targets to the auto-reply config",
+      target: "src/auto-reply/reply/get-reply.message-hooks.test.ts",
+      config: "test/vitest/vitest.auto-reply.config.ts",
+    },
+    {
+      title: "routes agent tool targets to the agents-tools config",
+      target: "src/agents/tools/image-tool.test.ts",
+      config: "test/vitest/vitest.agents-tools.config.ts",
+    },
+    {
+      title: "routes gateway targets to the gateway config",
+      target: "src/gateway/call.test.ts",
+      config: "test/vitest/vitest.gateway.config.ts",
+    },
+    {
+      title: "routes hooks targets to the hooks config",
+      target: "src/hooks/install.test.ts",
+      config: "test/vitest/vitest.hooks.config.ts",
+    },
+    {
+      title: "routes channel targets to the channels config",
+      target: "src/channels/session.test.ts",
+      config: "test/vitest/vitest.channels.config.ts",
+    },
+    {
+      title: "routes unit-fast acp targets to the cache-friendly unit-fast config",
+      target: "src/acp/control-plane/runtime-cache.test.ts",
+      config: "test/vitest/vitest.unit-fast.config.ts",
+    },
+    {
+      title: "routes reset-heavy acp targets to the acp config",
+      target: "src/acp/runtime/session-meta.test.ts",
+      config: "test/vitest/vitest.acp.config.ts",
+    },
+    {
+      title: "routes cli targets to the cli config",
+      target: "src/cli/test-runtime-capture.test.ts",
+      config: "test/vitest/vitest.cli.config.ts",
+    },
+    {
+      title: "routes msteams extension tests to the msteams config",
+      target: "extensions/msteams/src/config.test.ts",
+      config: "test/vitest/vitest.extension-msteams.config.ts",
+    },
+    {
+      title: "routes telegram extension tests to the telegram config",
+      target: "extensions/telegram/src/fetch.test.ts",
+      config: "test/vitest/vitest.extension-telegram.config.ts",
+    },
+    {
+      title: "routes whatsapp extension tests to the whatsapp config",
+      target: "extensions/whatsapp/src/send.test.ts",
+      config: "test/vitest/vitest.extension-whatsapp.config.ts",
+    },
+    {
+      title: "routes voice-call extension tests to the voice-call config",
+      target: "extensions/voice-call/src/runtime.test.ts",
+      config: "test/vitest/vitest.extension-voice-call.config.ts",
+    },
+    {
+      title: "routes mattermost extension tests to the mattermost config",
+      target: "extensions/mattermost/src/channel.test.ts",
+      config: "test/vitest/vitest.extension-mattermost.config.ts",
+    },
+    {
+      title: "routes zalo extension tests to the zalo config",
+      target: "extensions/zalo/src/channel.test.ts",
+      config: "test/vitest/vitest.extension-zalo.config.ts",
+    },
+    {
+      title: "routes matrix extension tests to the matrix config",
+      target: "extensions/matrix/src/channel.test.ts",
+      config: "test/vitest/vitest.extension-matrix.config.ts",
+    },
+    {
+      title: "routes feishu extension tests to the feishu config",
+      target: "extensions/feishu/src/channel.test.ts",
+      config: "test/vitest/vitest.extension-feishu.config.ts",
+    },
+    {
+      title: "routes irc extension tests to the irc config",
+      target: "extensions/irc/src/channel.test.ts",
+      config: "test/vitest/vitest.extension-irc.config.ts",
+    },
+    {
+      title: "routes acpx extension tests to the acpx config",
+      target: "extensions/acpx/src/runtime.test.ts",
+      config: "test/vitest/vitest.extension-acpx.config.ts",
+    },
+    {
+      title: "routes diffs extension tests to the diffs config",
+      target: "extensions/diffs/src/render.test.ts",
+      config: "test/vitest/vitest.extension-diffs.config.ts",
+    },
+    {
+      title: "routes unit ui targets to the unit ui config",
+      target: "ui/src/ui/views/channels.test.ts",
+      config: "test/vitest/vitest.ui.config.ts",
+    },
+    {
+      title: "routes utils targets to the utils config",
+      target: "src/utils/path.test.ts",
+      config: "test/vitest/vitest.utils.config.ts",
+    },
+    {
+      title: "routes browser extension targets to the browser config",
+      target: "extensions/browser/index.test.ts",
+      config: "test/vitest/vitest.extension-browser.config.ts",
+    },
+    {
+      title: "routes line extension targets to the line config",
+      target: "extensions/line/src/send.test.ts",
+      config: "test/vitest/vitest.extension-line.config.ts",
+    },
+    {
+      title: "routes matrix extension file targets to the matrix config",
+      target: "extensions/matrix/src/channel.test.ts",
+      config: "test/vitest/vitest.extension-matrix.config.ts",
+    },
+    {
+      title: "routes direct OpenAI provider extension file targets to the OpenAI provider config",
+      target: "extensions/openai/openai-chatgpt-provider.test.ts",
+      config: "test/vitest/vitest.extension-provider-openai.config.ts",
+    },
+    {
+      title: "routes misc extension file targets to the misc extensions config",
+      target: "extensions/firecrawl/index.test.ts",
+      config: "test/vitest/vitest.extension-misc.config.ts",
+    },
+  ])("$title", ({ target, config }) => {
+    expect(buildVitestRunPlans([target])).toEqual([
       {
-        config: "test/vitest/vitest.boundary.config.ts",
+        config,
         forwardedArgs: [],
-        includePatterns: ["src/infra/openclaw-root.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes bundled-plugin-dependent unit targets to the bundled config", () => {
-    expect(buildVitestRunPlans(["src/plugins/loader.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.bundled.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/plugins/loader.test.ts"],
+        includePatterns: [target],
         watchMode: false,
       },
     ]);
@@ -140,28 +365,6 @@ describe("test-projects args", () => {
     ]);
   });
 
-  it("routes top-level repo tests to the contracts config", () => {
-    expect(buildVitestRunPlans(["test/appcast.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["test/appcast.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes script tests to the tooling config", () => {
-    expect(buildVitestRunPlans(["src/scripts/test-projects.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/scripts/test-projects.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
   it("routes plugin contract tests to the plugin contracts config", () => {
     expect(
       buildVitestRunPlans(["src/plugins/contracts/memory-embedding-provider.contract.test.ts"]),
@@ -170,248 +373,6 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.contracts-plugin.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/plugins/contracts/memory-embedding-provider.contract.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes config baseline integration tests to the contracts config", () => {
-    expect(buildVitestRunPlans(["src/config/doc-baseline.integration.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/config/doc-baseline.integration.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes runtime config targets to the runtime-config config", () => {
-    expect(buildVitestRunPlans(["src/config/sessions.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.runtime-config.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/config/sessions.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes cron targets to the cron config", () => {
-    expect(buildVitestRunPlans(["src/cron/isolated-agent.lane.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.cron.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/cron/isolated-agent.lane.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes daemon targets to the daemon config", () => {
-    expect(buildVitestRunPlans(["src/daemon/inspect.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.daemon.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/daemon/inspect.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes media targets to the media config", () => {
-    expect(buildVitestRunPlans(["src/media/fetch.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.media.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/media/fetch.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes plugin-sdk targets to the plugin-sdk config", () => {
-    expect(buildVitestRunPlans(["src/plugin-sdk/migration-runtime.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.plugin-sdk.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/plugin-sdk/migration-runtime.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes unit-fast light targets to the cache-friendly unit-fast config", () => {
-    expect(buildVitestRunPlans(["src/plugin-sdk/provider-entry.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/plugin-sdk/provider-entry.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes fake-timer unit-fast targets to the serial fake-timer config", () => {
-    expect(buildVitestRunPlans(["src/acp/control-plane/manager.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast-fake-timers.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/acp/control-plane/manager.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes process targets to the process config", () => {
-    expect(buildVitestRunPlans(["src/process/exec.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.process.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/process/exec.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes secrets targets to the secrets config", () => {
-    expect(buildVitestRunPlans(["src/secrets/resolve.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.secrets.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/secrets/resolve.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes unit-fast shared-core targets to the unit-fast config", () => {
-    expect(buildVitestRunPlans(["src/shared/text-chunking.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/shared/text-chunking.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes tasks targets to the tasks config", () => {
-    expect(buildVitestRunPlans(["src/tasks/task-registry.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.tasks.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/tasks/task-registry.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes logging targets to the logging config", () => {
-    expect(buildVitestRunPlans(["src/logging/console-settings.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.logging.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/logging/console-settings.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes wizard targets to the wizard config", () => {
-    expect(buildVitestRunPlans(["src/wizard/setup.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.wizard.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/wizard/setup.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes tui targets to the tui config", () => {
-    expect(buildVitestRunPlans(["src/tui/tui.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.tui.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/tui/tui.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes media-understanding targets to the media-understanding config", () => {
-    expect(buildVitestRunPlans(["src/media-understanding/runtime.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.media-understanding.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/media-understanding/runtime.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes command targets to the commands config", () => {
-    expect(buildVitestRunPlans(["src/commands/status.summary.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.commands.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/commands/status.summary.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes auto-reply targets to the auto-reply config", () => {
-    expect(buildVitestRunPlans(["src/auto-reply/reply/get-reply.message-hooks.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.auto-reply.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/auto-reply/reply/get-reply.message-hooks.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes agent tool targets to the agents-tools config", () => {
-    expect(buildVitestRunPlans(["src/agents/tools/image-tool.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.agents-tools.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/agents/tools/image-tool.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes gateway targets to the gateway config", () => {
-    expect(buildVitestRunPlans(["src/gateway/call.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.gateway.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/gateway/call.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes hooks targets to the hooks config", () => {
-    expect(buildVitestRunPlans(["src/hooks/install.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.hooks.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/hooks/install.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes channel targets to the channels config", () => {
-    expect(buildVitestRunPlans(["src/channels/session.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.channels.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/channels/session.test.ts"],
         watchMode: false,
       },
     ]);
@@ -432,28 +393,6 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.infra.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/infra/migrations.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes unit-fast acp targets to the cache-friendly unit-fast config", () => {
-    expect(buildVitestRunPlans(["src/acp/control-plane/runtime-cache.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/acp/control-plane/runtime-cache.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes reset-heavy acp targets to the acp config", () => {
-    expect(buildVitestRunPlans(["src/acp/runtime/session-meta.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.acp.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/acp/runtime/session-meta.test.ts"],
         watchMode: false,
       },
     ]);
@@ -605,17 +544,6 @@ describe("test-projects args", () => {
     );
   });
 
-  it("routes cli targets to the cli config", () => {
-    expect(buildVitestRunPlans(["src/cli/test-runtime-capture.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.cli.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/cli/test-runtime-capture.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
   it("routes plugin targets to the plugins config", () => {
     expect(buildVitestRunPlans(["src/plugins/loader.test.ts"])).toEqual([
       {
@@ -667,149 +595,6 @@ describe("test-projects args", () => {
           "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",
           "extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts",
         ],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes msteams extension tests to the msteams config", () => {
-    expect(buildVitestRunPlans(["extensions/msteams/src/config.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-msteams.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/msteams/src/config.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes telegram extension tests to the telegram config", () => {
-    expect(buildVitestRunPlans(["extensions/telegram/src/fetch.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-telegram.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/telegram/src/fetch.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes whatsapp extension tests to the whatsapp config", () => {
-    expect(buildVitestRunPlans(["extensions/whatsapp/src/send.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-whatsapp.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/whatsapp/src/send.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes voice-call extension tests to the voice-call config", () => {
-    expect(buildVitestRunPlans(["extensions/voice-call/src/runtime.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-voice-call.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/voice-call/src/runtime.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes mattermost extension tests to the mattermost config", () => {
-    expect(buildVitestRunPlans(["extensions/mattermost/src/channel.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-mattermost.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/mattermost/src/channel.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes zalo extension tests to the zalo config", () => {
-    expect(buildVitestRunPlans(["extensions/zalo/src/channel.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-zalo.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/zalo/src/channel.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes matrix extension tests to the matrix config", () => {
-    expect(buildVitestRunPlans(["extensions/matrix/src/channel.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-matrix.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/matrix/src/channel.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes feishu extension tests to the feishu config", () => {
-    expect(buildVitestRunPlans(["extensions/feishu/src/channel.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-feishu.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/feishu/src/channel.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes irc extension tests to the irc config", () => {
-    expect(buildVitestRunPlans(["extensions/irc/src/channel.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-irc.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/irc/src/channel.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes acpx extension tests to the acpx config", () => {
-    expect(buildVitestRunPlans(["extensions/acpx/src/runtime.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-acpx.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/acpx/src/runtime.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes diffs extension tests to the diffs config", () => {
-    expect(buildVitestRunPlans(["extensions/diffs/src/render.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-diffs.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/diffs/src/render.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes unit ui targets to the unit ui config", () => {
-    expect(buildVitestRunPlans(["ui/src/ui/views/channels.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.ui.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["ui/src/ui/views/channels.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes utils targets to the utils config", () => {
-    expect(buildVitestRunPlans(["src/utils/path.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.utils.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/utils/path.test.ts"],
         watchMode: false,
       },
     ]);
@@ -901,61 +686,6 @@ describe("test-projects args", () => {
         config: "test/vitest/vitest.extension-discord.config.ts",
         forwardedArgs: [],
         includePatterns: ["extensions/discord/src/monitor/message-handler.preflight.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes browser extension targets to the browser config", () => {
-    expect(buildVitestRunPlans(["extensions/browser/index.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-browser.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/browser/index.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes line extension targets to the line config", () => {
-    expect(buildVitestRunPlans(["extensions/line/src/send.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-line.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/line/src/send.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes matrix extension file targets to the matrix config", () => {
-    expect(buildVitestRunPlans(["extensions/matrix/src/channel.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-matrix.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/matrix/src/channel.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes direct OpenAI provider extension file targets to the OpenAI provider config", () => {
-    expect(buildVitestRunPlans(["extensions/openai/openai-chatgpt-provider.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-provider-openai.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/openai/openai-chatgpt-provider.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes misc extension file targets to the misc extensions config", () => {
-    expect(buildVitestRunPlans(["extensions/firecrawl/index.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.extension-misc.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/firecrawl/index.test.ts"],
         watchMode: false,
       },
     ]);
@@ -1272,4 +1002,3 @@ describe("test-projects args", () => {
     ).toThrow("watch mode with mixed test suites is not supported");
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -190,30 +190,63 @@ describe("stripAssistantInternalScaffolding", () => {
       );
     });
 
-    it("strips standalone bracketed local-model tool blocks", () => {
-      expectVisibleText(
-        [
-          "Let me check.",
-          "[mempalace_mempalace_search]",
-          '{"query":"codename","wing":"personal","room":"identities"}',
-          "[END_TOOL_REQUEST]",
-          "Done.",
-        ].join("\n"),
-        "Let me check.\nDone.",
-      );
-    });
-
-    it("strips bracketed local-model tool blocks with named closing tags", () => {
-      expectVisibleText(
-        [
-          "Before",
-          "[mempalace_mempalace_search]",
-          '{"query":"codename","limit":1}',
-          "[/mempalace_mempalace_search]",
-          "After",
-        ].join("\n"),
-        "Before\nAfter",
-      );
+    it.each([
+      {
+        title: "strips standalone bracketed local-model tool blocks",
+        prefix: "Let me check.",
+        openMarker: "[mempalace_mempalace_search]",
+        payload: '{"query":"codename","wing":"personal","room":"identities"}',
+        closeMarker: "[END_TOOL_REQUEST]",
+        suffix: "Done.",
+        expected: "Let me check.\nDone.",
+      },
+      {
+        title: "strips bracketed local-model tool blocks with named closing tags",
+        prefix: "Before",
+        openMarker: "[mempalace_mempalace_search]",
+        payload: '{"query":"codename","limit":1}',
+        closeMarker: "[/mempalace_mempalace_search]",
+        suffix: "After",
+        expected: "Before\nAfter",
+      },
+      {
+        title: "does not close early on </tool_call> text inside JSON strings",
+        prefix: "prefix",
+        openMarker: "<tool_call>",
+        payload: '{"name":"x","arguments":{"html":"<div></tool_call><span>leak</span>"}}',
+        closeMarker: "</tool_call>",
+        suffix: "suffix",
+        expected: "prefix\n\nsuffix",
+      },
+      {
+        title: "does not close early on </tool_call> text inside single-quoted payload strings",
+        prefix: "prefix",
+        openMarker: "<tool_call>",
+        payload: "{'html':'</tool_call> leak','tail':'still hidden'}",
+        closeMarker: "</tool_call>",
+        suffix: "suffix",
+        expected: "prefix\n\nsuffix",
+      },
+      {
+        title: "strips Gemma-style <function> with newlines between parameters (#67093)",
+        prefix: "Let me check that.",
+        openMarker: '<function name="read">',
+        payload: '<parameter name="file_path">/home/user/test.md</parameter>',
+        closeMarker: "</function>",
+        suffix: "After the call.",
+        expected: "Let me check that.\n\nAfter the call.",
+      },
+      {
+        title: "strips standalone <function> blocks with apostrophes in XML payloads (#67093)",
+        prefix: "prefix",
+        openMarker: '<function name="spawn">',
+        payload: '<parameter name="message">what\'s up</parameter>',
+        closeMarker: "</function>",
+        suffix: "suffix",
+        expected: "prefix\n\nsuffix",
+      },
+    ])("$title", ({ prefix, openMarker, payload, closeMarker, suffix, expected }) => {
+      expectVisibleText([prefix, openMarker, payload, closeMarker, suffix].join("\n"), expected);
     });
 
     it("strips legacy uppercase TOOL_CALL blocks with hash-style payloads", () => {
@@ -276,32 +309,6 @@ describe("stripAssistantInternalScaffolding", () => {
       expectVisibleText("prefix\n<tool_call><function=read><parameter=path>/home", "prefix\n");
     });
 
-    it("does not close early on </tool_call> text inside JSON strings", () => {
-      expectVisibleText(
-        [
-          "prefix",
-          "<tool_call>",
-          '{"name":"x","arguments":{"html":"<div></tool_call><span>leak</span>"}}',
-          "</tool_call>",
-          "suffix",
-        ].join("\n"),
-        "prefix\n\nsuffix",
-      );
-    });
-
-    it("does not close early on </tool_call> text inside single-quoted payload strings", () => {
-      expectVisibleText(
-        [
-          "prefix",
-          "<tool_call>",
-          "{'html':'</tool_call> leak','tail':'still hidden'}",
-          "</tool_call>",
-          "suffix",
-        ].join("\n"),
-        "prefix\n\nsuffix",
-      );
-    });
-
     it("does not close early on mismatched closing tool tags", () => {
       expectVisibleText(
         [
@@ -350,36 +357,10 @@ describe("stripAssistantInternalScaffolding", () => {
       );
     });
 
-    it("strips Gemma-style <function> with newlines between parameters (#67093)", () => {
-      expectVisibleText(
-        [
-          "Let me check that.",
-          '<function name="read">',
-          '<parameter name="file_path">/home/user/test.md</parameter>',
-          "</function>",
-          "After the call.",
-        ].join("\n"),
-        "Let me check that.\n\nAfter the call.",
-      );
-    });
-
     it("strips inline standalone <function> blocks after sentence lead-ins", () => {
       expectVisibleText(
         'Let me check that. <function name="read"><parameter name="file_path">/tmp/test.md</parameter></function> Done.',
         "Let me check that.  Done.",
-      );
-    });
-
-    it("strips standalone <function> blocks with apostrophes in XML payloads (#67093)", () => {
-      expectVisibleText(
-        [
-          "prefix",
-          '<function name="spawn">',
-          '<parameter name="message">what\'s up</parameter>',
-          "</function>",
-          "suffix",
-        ].join("\n"),
-        "prefix\n\nsuffix",
       );
     });
 

--- a/src/skills/loading/frontmatter.test.ts
+++ b/src/skills/loading/frontmatter.test.ts
@@ -24,99 +24,101 @@ describe("resolveSkillInvocationPolicy", () => {
 });
 
 describe("parseFrontmatter", () => {
-  it("keeps recoverable colon-rich scalar values", () => {
-    const frontmatter = parseFrontmatter(`---
+  it.each([
+    {
+      title: "keeps recoverable colon-rich scalar values",
+      frontmatter: `---
 name: sample-skill
 description: Use anime style IMPORTANT: Must be kawaii
----`);
-
-    expect(frontmatter.description).toBe("Use anime style IMPORTANT: Must be kawaii");
-  });
-
-  it("keeps recoverable description values beginning with punctuation", () => {
-    const frontmatter = parseFrontmatter(`---
+---`,
+      expectedDescription: "Use anime style IMPORTANT: Must be kawaii",
+    },
+    {
+      title: "keeps recoverable description values beginning with punctuation",
+      frontmatter: `---
 name: sample-skill
 description: [Beta] Builds prereleases
----`);
-
-    expect(frontmatter.description).toBe("[Beta] Builds prereleases");
-  });
-
-  it("keeps recoverable description values beginning with YAML-reserved characters", () => {
-    const frontmatter = parseFrontmatter(`---
+---`,
+      expectedDescription: "[Beta] Builds prereleases",
+    },
+    {
+      title: "keeps recoverable description values beginning with YAML-reserved characters",
+      frontmatter: `---
 name: sample-skill
 description: @scope/package helper
----`);
-
-    expect(frontmatter.description).toBe("@scope/package helper");
-  });
-
-  it("keeps recoverable description values that resemble YAML aliases", () => {
-    const frontmatter = parseFrontmatter(`---
+---`,
+      expectedDescription: "@scope/package helper",
+    },
+    {
+      title: "keeps recoverable description values that resemble YAML aliases",
+      frontmatter: `---
 name: sample-skill
 description: *Experimental
----`);
+---`,
+      expectedDescription: "*Experimental",
+    },
+  ])("$title", ({ frontmatter, expectedDescription }) => {
+    const parsed = parseFrontmatter(frontmatter);
 
-    expect(frontmatter.description).toBe("*Experimental");
+    expect(parsed.description).toBe(expectedDescription);
   });
 
-  it("rejects malformed structured fallback values with the YAML parse error", () => {
-    expect(() =>
-      parseFrontmatter(`---
+  it.each([
+    {
+      title: "rejects malformed structured fallback values with the YAML parse error",
+      frontmatter: `---
 name: [broken
 description: Broken skill
----`),
-    ).toThrow("invalid frontmatter: BAD_INDENT");
-  });
-
-  it("rejects unresolved YAML aliases", () => {
-    expect(() =>
-      parseFrontmatter(`---
+---`,
+      expectedError: "invalid frontmatter: BAD_INDENT",
+    },
+    {
+      title: "rejects unresolved YAML aliases",
+      frontmatter: `---
 name: sample-skill
 description: Broken skill
 metadata: *missing
----`),
-    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
-  });
-
-  it("rejects duplicate keys after a recoverable description", () => {
-    expect(() =>
-      parseFrontmatter(`---
+---`,
+      expectedError: "invalid frontmatter: YAML_EXCEPTION: Unresolved alias",
+    },
+    {
+      title: "rejects duplicate keys after a recoverable description",
+      frontmatter: `---
 name: first
 description: Working skill
 name: second
----`),
-    ).toThrow("invalid frontmatter: DUPLICATE_KEY");
-  });
-
-  it("rejects invalid structured values under quoted keys", () => {
-    expect(() =>
-      parseFrontmatter(`---
+---`,
+      expectedError: "invalid frontmatter: DUPLICATE_KEY",
+    },
+    {
+      title: "rejects invalid structured values under quoted keys",
+      frontmatter: `---
 name: sample-skill
 description: Working skill
 "metadata": *missing
----`),
-    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
-  });
-
-  it("does not let a description alias mask a later structured alias", () => {
-    expect(() =>
-      parseFrontmatter(`---
+---`,
+      expectedError: "invalid frontmatter: YAML_EXCEPTION: Unresolved alias",
+    },
+    {
+      title: "does not let a description alias mask a later structured alias",
+      frontmatter: `---
 name: sample-skill
 description: *legacy
 metadata: *missing
----`),
-    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
-  });
-
-  it("does not let a colon-rich description mask a structured alias", () => {
-    expect(() =>
-      parseFrontmatter(`---
+---`,
+      expectedError: "invalid frontmatter: YAML_EXCEPTION: Unresolved alias",
+    },
+    {
+      title: "does not let a colon-rich description mask a structured alias",
+      frontmatter: `---
 name: sample-skill
 description: Use anime style IMPORTANT: Must be kawaii
 metadata: *missing
----`),
-    ).toThrow("invalid frontmatter: YAML_EXCEPTION: Unresolved alias");
+---`,
+      expectedError: "invalid frontmatter: YAML_EXCEPTION: Unresolved alias",
+    },
+  ])("$title", ({ frontmatter, expectedError }) => {
+    expect(() => parseFrontmatter(frontmatter)).toThrow(expectedError);
   });
 
   it("rejects indentation errors following a description", () => {

--- a/test/scripts/check-dynamic-import-warts.test.ts
+++ b/test/scripts/check-dynamic-import-warts.test.ts
@@ -3,121 +3,130 @@ import { describe, expect, it } from "vitest";
 import { findDynamicImportAdvisories } from "../../scripts/check-dynamic-import-warts.mjs";
 
 describe("check-dynamic-import-warts", () => {
-  it("flags runtime static plus dynamic imports of the same module", () => {
-    const source = `
+  it.each([
+    {
+      title: "flags runtime static plus dynamic imports of the same module",
+      source: `
       import { run } from "./runtime.js";
       export async function start() {
         return await import("./runtime.js");
       }
-    `;
-    expect(findDynamicImportAdvisories(source)).toEqual([
-      {
-        line: 4,
-        reason: 'runtime static + dynamic import of "./runtime.js" (static line 2)',
-      },
-    ]);
-  });
-
-  it("ignores type-only static imports", () => {
-    const source = `
-      import { type Runtime } from "./runtime.js";
-      export async function start(): Promise<Runtime> {
-        return (await import("./runtime.js")).createRuntime();
-      }
-    `;
-    expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
-  });
-
-  it("flags runtime static re-exports plus dynamic imports of the same module", () => {
-    const source = `
+    `,
+      expectedLine: 4,
+      expectedMessage: 'runtime static + dynamic import of "./runtime.js" (static line 2)',
+    },
+    {
+      title: "flags runtime static re-exports plus dynamic imports of the same module",
+      source: `
       let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
       function loadRuntime() {
         runtimePromise ??= import("./runtime.js");
         return runtimePromise;
       }
       export { run } from "./runtime.js";
-    `;
-    expect(findDynamicImportAdvisories(source)).toEqual([
-      {
-        line: 4,
-        reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
-      },
-    ]);
-  });
-
-  it("ignores type-only static re-exports", () => {
-    const source = `
-      export type { Runtime } from "./runtime.js";
-      export async function start() {
-        return (await import("./runtime.js")).createRuntime();
-      }
-    `;
-    expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
-  });
-
-  it("ignores inline type-only static re-exports", () => {
-    const source = `
-      export { type Runtime, type RuntimeOptions } from "./runtime.js";
-      export async function start() {
-        return (await import("./runtime.js")).createRuntime();
-      }
-    `;
-    expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
-  });
-
-  it("flags mixed runtime and inline type-only static re-exports", () => {
-    const source = `
+    `,
+      expectedLine: 4,
+      expectedMessage: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
+    },
+    {
+      title: "flags mixed runtime and inline type-only static re-exports",
+      source: `
       let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
       function loadRuntime() {
         runtimePromise ??= import("./runtime.js");
         return runtimePromise;
       }
       export { type Runtime, createRuntime } from "./runtime.js";
-    `;
-    expect(findDynamicImportAdvisories(source)).toEqual([
-      {
-        line: 4,
-        reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
-      },
-    ]);
-  });
-
-  it("ignores local export declarations without module specifiers", () => {
-    const source = `
-      const run = true;
-      export { run };
-      export async function start() {
-        return await import("./runtime.js");
-      }
-    `;
-    expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
-  });
-
-  it("flags repeated direct dynamic imports", () => {
-    const source = `
+    `,
+      expectedLine: 4,
+      expectedMessage: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
+    },
+    {
+      title: "flags repeated direct dynamic imports",
+      source: `
       export async function one() {
         return await import("./runtime.js");
       }
       export async function two() {
         return await import("./runtime.js");
       }
-    `;
+    `,
+      expectedLine: 3,
+      expectedMessage: 'repeated direct dynamic import of "./runtime.js" (2 callsites: 3, 6)',
+    },
+  ])("$title", ({ source, expectedLine, expectedMessage }) => {
     expect(findDynamicImportAdvisories(source)).toEqual([
       {
-        line: 3,
-        reason: 'repeated direct dynamic import of "./runtime.js" (2 callsites: 3, 6)',
+        line: expectedLine,
+        reason: expectedMessage,
       },
     ]);
   });
 
-  it("ignores cached loader patterns", () => {
-    const source = `
+  it.each([
+    {
+      title: "ignores type-only static imports",
+      source: `
+      import { type Runtime } from "./runtime.js";
+      export async function start(): Promise<Runtime> {
+        return (await import("./runtime.js")).createRuntime();
+      }
+    `,
+    },
+    {
+      title: "ignores type-only static re-exports",
+      source: `
+      export type { Runtime } from "./runtime.js";
+      export async function start() {
+        return (await import("./runtime.js")).createRuntime();
+      }
+    `,
+    },
+    {
+      title: "ignores inline type-only static re-exports",
+      source: `
+      export { type Runtime, type RuntimeOptions } from "./runtime.js";
+      export async function start() {
+        return (await import("./runtime.js")).createRuntime();
+      }
+    `,
+    },
+    {
+      title: "ignores local export declarations without module specifiers",
+      source: `
+      const run = true;
+      export { run };
+      export async function start() {
+        return await import("./runtime.js");
+      }
+    `,
+    },
+    {
+      title: "ignores cached loader patterns",
+      source: `
       let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
       function loadRuntime() {
         runtimePromise ??= import("./runtime.js");
         return runtimePromise;
       }
-    `;
+    `,
+    },
+    {
+      title: "allows execute paths that call cached loaders",
+      source: `
+      let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
+      function loadRuntime() {
+        runtimePromise ??= import("./runtime.js");
+        return runtimePromise;
+      }
+      export function createTool() {
+        return {
+          execute: async () => await loadRuntime(),
+        };
+      }
+    `,
+    },
+  ])("$title", ({ source }) => {
     expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
   });
 
@@ -138,21 +147,5 @@ describe("check-dynamic-import-warts", () => {
           'direct dynamic import of "./runtime.js" inside execute path; move it behind a cached loader',
       },
     ]);
-  });
-
-  it("allows execute paths that call cached loaders", () => {
-    const source = `
-      let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
-      function loadRuntime() {
-        runtimePromise ??= import("./runtime.js");
-        return runtimePromise;
-      }
-      export function createTool() {
-        return {
-          execute: async () => await loadRuntime(),
-        };
-      }
-    `;
-    expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
   });
 });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -896,9 +896,11 @@ docker_build_exec -t setup-image .
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
   });
 
-  it("keeps reused Docker image probes behind the timeout-aware helper", () => {
-    const workDir = tempDirs.make("openclaw-docker-image-reuse-timeout-");
-    const script = repoShell(workDir)`
+  it.each([
+    {
+      title: "keeps reused Docker image probes behind the timeout-aware helper",
+      tempPrefix: "openclaw-docker-image-reuse-timeout-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
 export DOCKER_COMMAND_TIMEOUT=3s
 export OPENCLAW_SKIP_DOCKER_BUILD=1
 
@@ -951,7 +953,729 @@ docker_e2e_build_or_reuse \\
 test "$(grep -c '^--kill-after=30s 3s|' "$TMPDIR/timeout-seen")" = "2"
 grep -q '^image inspect openclaw-reuse-image$' "$TMPDIR/docker-seen"
 grep -q '^pull openclaw-reuse-image$' "$TMPDIR/docker-seen"
-`;
+`,
+    },
+    {
+      title: "explains how to opt out when Docker rejects default resource limits",
+      tempPrefix: "openclaw-docker-resource-diagnostic-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "docker: Error response from daemon: NanoCPUs can not be set, as the cgroup is not mounted" >&2
+  return 125
+}
+
+mktemp() {
+  local dir=""
+  dir="$(/usr/bin/mktemp "$@")" || return
+  printf "%s\\n" "$*" >"$TMPDIR/mktemp-seen"
+  printf "%s\\n" "$dir" >"$TMPDIR/diagnostic-dir"
+  printf "%s\\n" "$dir"
+}
+
+tail() {
+  printf "%s\\n" "$*" >"$TMPDIR/tail-seen"
+  /usr/bin/tail "$@"
+}
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+docker_e2e_timeout_cmd() {
+  shift
+  "$@"
+}
+
+set +e
+printf "before Docker\\n" >"$TMPDIR/stderr"
+docker_e2e_docker_cmd run demo 2>>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$status" = "125" ]]
+[[ "$stderr" = before\\ Docker* ]]
+[[ "$stderr" = *"NanoCPUs can not be set"* ]]
+[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
+[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+[[ "$(<"$TMPDIR/tail-seen")" = "-c 65536" ]]
+[[ "$(<"$TMPDIR/mktemp-seen")" = -d* ]]
+[[ ! -e "$(<"$TMPDIR/diagnostic-dir")" ]]
+`,
+    },
+    {
+      title: "does not suggest resource opt-out for other Docker failures",
+      tempPrefix: "openclaw-docker-resource-unrelated-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "docker: Error response from daemon: No such image: cgroup-helper" >&2
+  return 125
+}
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+docker_e2e_timeout_cmd() {
+  shift
+  "$@"
+}
+
+set +e
+docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$status" = "125" ]]
+[[ "$stderr" = *"No such image: cgroup-helper"* ]]
+[[ "$stderr" != *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS"* ]]
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+`,
+    },
+    {
+      title: "rejects invalid Docker run pids limits before invoking docker",
+      tempPrefix: "openclaw-docker-resource-pids-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+docker() {
+  printf invoked >"$TMPDIR/docker-seen"
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+
+set +e
+OPENCLAW_DOCKER_E2E_PIDS_LIMIT=many docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+[[ "$status" = "2" ]]
+[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]]
+[[ ! -e "$TMPDIR/docker-seen" ]]
+`,
+    },
+    {
+      title: "rejects invalid package-backed Docker run pids limits before invoking docker",
+      tempPrefix: "openclaw-docker-package-pids-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+dirname() {
+  /usr/bin/dirname "$@"
+}
+
+docker() {
+  printf invoked >"$TMPDIR/docker-seen"
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+set +e
+OPENCLAW_DOCKER_E2E_PIDS_LIMIT=many docker_e2e_docker_run_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+[[ "$status" = "2" ]]
+[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]]
+[[ ! -e "$TMPDIR/docker-seen" ]]
+`,
+    },
+    {
+      title: "diagnoses rejected resource limits through the canonical package helper",
+      tempPrefix: "openclaw-docker-package-diagnostic-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+timeout() {
+  if [[ "$1" = "--kill-after=1s" ]]; then
+    return 0
+  fi
+  shift 2
+  "$@"
+}
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "OCI runtime create failed: crun: controller pids is not available" >&2
+  return 125
+}
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+set +e
+docker_e2e_docker_run_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$status" = "125" ]]
+[[ "$stderr" = *"controller pids is not available"* ]]
+[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
+[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+`,
+    },
+    {
+      title: "removes functional Docker build package inputs after the build",
+      tempPrefix: "openclaw-docker-build-cleanup-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+node() {
+  local script="$1"
+  shift
+  if [[ "$script" != "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" ]]; then
+    command node "$script" "$@"
+    return
+  fi
+
+  local output_dir=""
+  local output_name=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --output-dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      --output-name)
+        output_name="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  mkdir -p "$output_dir"
+  printf fixture >"$output_dir/$output_name"
+  printf "%s\\n" "$output_dir/$output_name"
+}
+export -f node
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+
+docker_build_run() {
+  local build_context=""
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      openclaw_package=*)
+        build_context="\${arg#openclaw_package=}"
+        ;;
+    esac
+  done
+
+  test -n "$build_context"
+  test -f "$build_context/openclaw-current.tgz"
+  printf "%s\\n" "$build_context" >"$TMPDIR/build-context-seen"
+}
+
+docker_e2e_build_or_reuse \\
+  openclaw-test-image \\
+  cleanup-proof \\
+  "$ROOT_DIR/scripts/e2e/Dockerfile" \\
+  "$ROOT_DIR" \\
+  functional
+
+test -f "$TMPDIR/build-context-seen"
+leftovers="$(find "$TMPDIR" -maxdepth 1 \\( \\
+  -name 'openclaw-docker-e2e-pack.*' \\
+  -o -name 'openclaw-docker-e2e-package-context.*' \\
+\\) -print)"
+if [[ -n "$leftovers" ]]; then
+  printf 'leftover functional build inputs:\\n%s\\n' "$leftovers" >&2
+  exit 1
+fi
+`,
+    },
+    {
+      title: "keeps caller-provided functional Docker build packages",
+      tempPrefix: "openclaw-docker-build-external-package-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+external_dir="$TMPDIR/external-package"
+mkdir -p "$external_dir"
+printf fixture >"$external_dir/openclaw-current.tgz"
+OPENCLAW_CURRENT_PACKAGE_TGZ="$external_dir/openclaw-current.tgz"
+export OPENCLAW_CURRENT_PACKAGE_TGZ
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+
+docker_build_run() {
+  local build_context=""
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      openclaw_package=*)
+        build_context="\${arg#openclaw_package=}"
+        ;;
+    esac
+  done
+
+  test -n "$build_context"
+  test -f "$build_context/openclaw-current.tgz"
+  printf "%s\\n" "$build_context" >"$TMPDIR/build-context-seen"
+}
+
+docker_e2e_build_or_reuse \\
+  openclaw-test-image \\
+  external-package-proof \\
+  "$ROOT_DIR/scripts/e2e/Dockerfile" \\
+  "$ROOT_DIR" \\
+  functional
+
+test -f "$TMPDIR/build-context-seen"
+test -f "$OPENCLAW_CURRENT_PACKAGE_TGZ"
+leftovers="$(find "$TMPDIR" -maxdepth 1 -name 'openclaw-docker-e2e-package-context.*' -print)"
+if [[ -n "$leftovers" ]]; then
+  printf 'leftover functional build context:\\n%s\\n' "$leftovers" >&2
+  exit 1
+fi
+`,
+    },
+    {
+      title: "cleans generated package mounts after harness Docker runs",
+      tempPrefix: "openclaw-docker-package-mount-cleanup-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+export DOCKER_COMMAND_TIMEOUT=3s
+
+mkdir -p "$TMPDIR/bin"
+cat >"$TMPDIR/bin/timeout" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  --kill-after=1s)
+    exit 0
+    ;;
+  --kill-after=30s)
+    timeout_args="$1 $2"
+    shift 2
+    ;;
+  *)
+    timeout_args="$1"
+    shift
+    ;;
+esac
+if [[ "\${1:-}" == "docker" && "\${2:-}" == "run" ]]; then
+  printf "%s\\n" "$timeout_args" >"$TMPDIR/docker-timeout-seen"
+fi
+"$@"
+SH
+chmod +x "$TMPDIR/bin/timeout"
+export PATH="$TMPDIR/bin:$PATH"
+
+node() {
+  local script="$1"
+  shift
+  if [[ "$script" != "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" ]]; then
+    command node "$script" "$@"
+    return
+  fi
+
+  local output_dir=""
+  local output_name=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --output-dir)
+        output_dir="$2"
+        shift 2
+        ;;
+      --output-name)
+        output_name="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  mkdir -p "$output_dir"
+  printf fixture >"$output_dir/$output_name"
+  printf "%s\\n" "$output_dir/$output_name"
+}
+export -f node
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+docker() {
+  if [[ "$1" == "rm" ]]; then
+    shift
+    test "$1" = "-f"
+    shift
+    printf "%s\\n" "$1" >>"$TMPDIR/docker-rm-seen"
+    return 0
+  fi
+
+  local cidfile=""
+  local mount_path=""
+  local expect_volume_path=0
+  local expect_cidfile=0
+  local arg
+  for arg in "$@"; do
+    if [[ "$expect_cidfile" == "1" ]]; then
+      cidfile="$arg"
+      expect_cidfile=0
+      continue
+    fi
+    if [[ "$expect_volume_path" == "1" ]]; then
+      mount_path="\${arg%%:*}"
+      expect_volume_path=0
+      continue
+    fi
+    if [[ "$arg" == "--cidfile" ]]; then
+      expect_cidfile=1
+      continue
+    fi
+    if [[ "$arg" == "-v" ]]; then
+      expect_volume_path=1
+    fi
+  done
+
+  test -n "$cidfile"
+  test ! -e "$cidfile"
+  printf "container-%s\\n" "\${DOCKER_STUB_STATUS:-}" >"$cidfile"
+  test -n "$mount_path"
+  test -f "$mount_path"
+  printf "%s\\n" "$mount_path" >"$TMPDIR/package-mount-seen"
+  return "\${DOCKER_STUB_STATUS:-0}"
+}
+export -f docker
+
+package_tgz="$(docker_e2e_prepare_package_tgz mount-cleanup)"
+pack_dir="$(dirname "$package_tgz")"
+docker_e2e_package_mount_args "$package_tgz"
+DOCKER_STUB_STATUS=7 docker_e2e_run_with_harness image-name bash -lc true || run_status="$?"
+test "\${run_status:-0}" = "7"
+test "$(cat "$TMPDIR/docker-timeout-seen")" = "--kill-after=30s 3s"
+grep -qx "container-7" "$TMPDIR/docker-rm-seen"
+test -f "$TMPDIR/package-mount-seen"
+test ! -e "$pack_dir"
+test -z "$(find "$TMPDIR" -maxdepth 1 -name 'openclaw-docker-e2e-container.*' -print)"
+
+external_dir="$TMPDIR/external-package"
+mkdir -p "$external_dir"
+printf fixture >"$external_dir/openclaw-current.tgz"
+docker_e2e_package_mount_args "$external_dir/openclaw-current.tgz"
+unset DOCKER_COMMAND_TIMEOUT
+rm -f "$TMPDIR/docker-timeout-seen"
+docker_e2e_run_with_harness image-name bash -lc true
+test "$(cat "$TMPDIR/docker-timeout-seen")" = "--kill-after=30s 3600s"
+grep -qx "container-" "$TMPDIR/docker-rm-seen"
+test -f "$external_dir/openclaw-current.tgz"
+`,
+    },
+    {
+      title: "propagates shared E2E command timeouts into package-backed containers",
+      tempPrefix: "openclaw-docker-package-timeout-env-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+package="$TMPDIR/openclaw-current.tgz"
+printf fixture >"$package"
+export OPENCLAW_E2E_NPM_INSTALL_TIMEOUT=42s
+export OPENCLAW_E2E_COMMAND_TIMEOUT=23s
+docker_e2e_package_mount_args "$package"
+printf "%s\\n" "\${DOCKER_E2E_PACKAGE_ARGS[@]}" >"$TMPDIR/package-args"
+
+grep -qx -- "-e" "$TMPDIR/package-args"
+grep -qx -- "OPENCLAW_CURRENT_PACKAGE_TGZ=/tmp/openclaw-current.tgz" "$TMPDIR/package-args"
+grep -qx -- "OPENCLAW_E2E_NPM_INSTALL_TIMEOUT=42s" "$TMPDIR/package-args"
+grep -qx -- "OPENCLAW_E2E_COMMAND_TIMEOUT=23s" "$TMPDIR/package-args"
+`,
+    },
+    {
+      title:
+        "keeps both harness run wrappers available when the package helper is sourced directly",
+      tempPrefix: "openclaw-docker-package-helper-guard-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+mkdir -p "$TMPDIR/bin"
+cat >"$TMPDIR/bin/timeout" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  --kill-after=1s)
+    exit 0
+    ;;
+  --kill-after=30s)
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+esac
+"$@"
+SH
+chmod +x "$TMPDIR/bin/timeout"
+export PATH="$TMPDIR/bin:$PATH"
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-run-seen"
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+docker_e2e_run_with_harness image-name bash -lc true
+docker_e2e_run_detached_with_harness image-name
+[[ $(wc -l <"$TMPDIR/docker-run-seen") -eq 2 ]]
+`,
+    },
+    {
+      title: "forwards harness stdin to backgrounded Docker runs",
+      tempPrefix: "openclaw-docker-harness-stdin-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+mkdir -p "$TMPDIR/bin"
+cat >"$TMPDIR/bin/timeout" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  --kill-after=1s)
+    exit 0
+    ;;
+  --kill-after=30s)
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+esac
+"$@"
+SH
+chmod +x "$TMPDIR/bin/timeout"
+export PATH="$TMPDIR/bin:$PATH"
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+docker() {
+  if [[ "$1" == "rm" ]]; then
+    return 0
+  fi
+
+  local cidfile=""
+  local expect_cidfile=0
+  local arg
+  for arg in "$@"; do
+    if [[ "$expect_cidfile" == "1" ]]; then
+      cidfile="$arg"
+      expect_cidfile=0
+      continue
+    fi
+    if [[ "$arg" == "--cidfile" ]]; then
+      expect_cidfile=1
+    fi
+  done
+
+  test -n "$cidfile"
+  printf "container-stdin\\n" >"$cidfile"
+  cat >"$TMPDIR/docker-stdin-seen"
+}
+export -f docker
+
+docker_e2e_run_with_harness image-name bash -s <<'SH'
+printf "heredoc reached docker\\n"
+SH
+
+grep -Fxq 'printf "heredoc reached docker\\n"' "$TMPDIR/docker-stdin-seen"
+`,
+    },
+    {
+      title: "bounds printed Docker E2E logs to the configured tail",
+      tempPrefix: "openclaw-docker-e2e-log-print-tail-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+export OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES=64
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
+
+output="$(run_logged_print_heartbeat plugins-run 30 bash -c 'printf "DO_NOT_PRINT_OLD_LOG_START"; printf "%0200d" 0; printf "recent container log tail\\\\n"')"
+[[ "$output" = *"truncated: showing last 64"* ]]
+[[ "$output" = *"recent container log tail"* ]]
+[[ "$output" != *"DO_NOT_PRINT_OLD_LOG_START"* ]]
+`,
+    },
+    {
+      title: "prints heartbeat progress for long successful Docker E2E log captures",
+      tempPrefix: "openclaw-docker-e2e-log-heartbeat-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
+
+printf "captured container log\\n" >"$TMPDIR/run.log"
+output="$(docker_e2e_maybe_print_log_heartbeat plugins-run 1 1 "$TMPDIR/run.log")"
+[[ "$output" = *"still running plugins-run ("* ]]
+[[ "$output" = *"log bytes captured"* ]]
+[[ "$output" != *"captured container log"* ]]
+`,
+    },
+    {
+      title: "cleans the heartbeat command when the wrapper is terminated",
+      tempPrefix: "openclaw-docker-e2e-log-term-cleanup-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+export OPENCLAW_DOCKER_E2E_HEARTBEAT_TERM_GRACE_SECONDS=1
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
+
+command_pid_file="$TMPDIR/command.pid"
+(
+  run_logged_print_heartbeat plugins-run 30 bash -c 'trap "exit 0" TERM; printf "%s" "$$" > "$1"; while true; do /bin/sleep 0.05; done' bash "$command_pid_file"
+) &
+wrapper_pid="$!"
+for _ in $(seq 1 100); do
+  [ -s "$command_pid_file" ] && break
+  /bin/sleep 0.01
+done
+if [ ! -s "$command_pid_file" ]; then
+  kill -TERM "$wrapper_pid" 2>/dev/null || true
+  echo "heartbeat command pid was not recorded" >&2
+  exit 1
+fi
+command_pid="$(cat "$command_pid_file")"
+kill -TERM "$wrapper_pid"
+for _ in $(seq 1 50); do
+  if ! kill -0 "$command_pid" 2>/dev/null; then
+    wait "$wrapper_pid" 2>/dev/null || true
+    exit 0
+  fi
+  /bin/sleep 0.01
+done
+kill -TERM "$command_pid" 2>/dev/null || true
+kill -TERM "$wrapper_pid" 2>/dev/null || true
+echo "heartbeat command still alive after wrapper termination: $command_pid" >&2
+exit 1
+`,
+    },
+    {
+      title: "cleans harness containers when heartbeat-wrapped Docker runs are terminated",
+      tempPrefix: "openclaw-docker-e2e-harness-term-cleanup-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+mkdir -p "$TMPDIR/bin"
+cat >"$TMPDIR/bin/timeout" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  --kill-after=1s)
+    exit 0
+    ;;
+  --kill-after=30s)
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+esac
+"$@"
+SH
+chmod +x "$TMPDIR/bin/timeout"
+export PATH="$TMPDIR/bin:$PATH"
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+docker() {
+  if [[ "$1" == "rm" ]]; then
+    shift
+    test "$1" = "-f"
+    shift
+    printf "%s\\n" "$1" >>"$TMPDIR/docker-rm-seen"
+    return 0
+  fi
+
+  local cidfile=""
+  local expect_cidfile=0
+  local arg
+  for arg in "$@"; do
+    if [[ "$expect_cidfile" == "1" ]]; then
+      cidfile="$arg"
+      expect_cidfile=0
+      continue
+    fi
+    if [[ "$arg" == "--cidfile" ]]; then
+      expect_cidfile=1
+    fi
+  done
+
+  test -n "$cidfile"
+  printf "container-term\\n" >"$cidfile"
+  printf "started\\n" >"$TMPDIR/docker-started"
+  printf "docker running\\n"
+  trap 'exit 143' TERM
+  while true; do /bin/sleep 0.05; done
+}
+export -f docker
+
+(
+  docker_e2e_run_logged_print_with_harness plugins-run image-name bash -lc true
+) &
+wrapper_pid="$!"
+for _ in $(seq 1 50); do
+  [ -s "$TMPDIR/docker-started" ] && break
+  /bin/sleep 0.01
+  kill -0 "$wrapper_pid" 2>/dev/null || true
+done
+test -s "$TMPDIR/docker-started"
+kill -TERM "$wrapper_pid" 2>/dev/null || true
+wait "$wrapper_pid" 2>/dev/null || true
+for _ in $(seq 1 50); do
+  grep -qx "container-term" "$TMPDIR/docker-rm-seen" 2>/dev/null && break
+  /bin/sleep 0.01
+done
+grep -qx "container-term" "$TMPDIR/docker-rm-seen"
+test -z "$(find "$TMPDIR" -maxdepth 1 -name 'openclaw-docker-e2e-container.*' -print)"
+`,
+    },
+    {
+      title: "normalizes zero-padded Docker E2E stats heartbeat intervals",
+      tempPrefix: "openclaw-docker-e2e-stats-zero-heartbeat-",
+      scriptSource: (workDir: string) => repoShell(workDir)`
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+
+docker_e2e_docker_cmd() {
+  case "$1" in
+    inspect) return 0 ;;
+    stats) printf '{"MemUsage":"1MiB / 2MiB","CPUPerc":"0.1%%"}\\n'; return 0 ;;
+    *) return 0 ;;
+  esac
+}
+
+sleep() {
+  SECONDS=$((SECONDS + \${1%%.*}))
+}
+
+kill_checks=0
+kill() {
+  if [[ "\${1:-}" == "-0" && "\${2:-}" == "sampled-docker-pid" ]]; then
+    kill_checks=$((kill_checks + 1))
+    [[ "$kill_checks" -le 6 ]]
+    return
+  fi
+  command kill "$@"
+}
+
+stats_log="$TMPDIR/stats.log"
+run_log="$TMPDIR/run.log"
+sampler_log="$TMPDIR/sampler.log"
+printf "container output\\n" >"$run_log"
+
+docker_e2e_sample_stats_until_exit demo sampled-docker-pid "$stats_log" "$run_log" "Docker stats" 08 >"$sampler_log" 2>&1
+output="$(cat "$sampler_log")"
+
+[[ "$output" =~ Docker\\ stats\\ still\\ running\\ \\(([0-9]+)s\\ elapsed, ]]
+heartbeat_elapsed="\${BASH_REMATCH[1]}"
+(( heartbeat_elapsed >= 8 ))
+[[ "$output" != *"value too great for base"* ]]
+[[ -s "$stats_log" ]]
+`,
+    },
+  ])("$title", ({ tempPrefix, scriptSource }) => {
+    const workDir = tempDirs.make(tempPrefix);
+    const script = scriptSource(workDir);
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
   });
@@ -1178,93 +1902,6 @@ OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1 docker_e2e_docker_cmd run demo
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
   });
 
-  it("explains how to opt out when Docker rejects default resource limits", () => {
-    const workDir = tempDirs.make("openclaw-docker-resource-diagnostic-");
-    const script = repoShell(workDir)`
-export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
-unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
-unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
-
-docker() {
-  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
-  echo "docker: Error response from daemon: NanoCPUs can not be set, as the cgroup is not mounted" >&2
-  return 125
-}
-
-mktemp() {
-  local dir=""
-  dir="$(/usr/bin/mktemp "$@")" || return
-  printf "%s\\n" "$*" >"$TMPDIR/mktemp-seen"
-  printf "%s\\n" "$dir" >"$TMPDIR/diagnostic-dir"
-  printf "%s\\n" "$dir"
-}
-
-tail() {
-  printf "%s\\n" "$*" >"$TMPDIR/tail-seen"
-  /usr/bin/tail "$@"
-}
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
-docker_e2e_timeout_cmd() {
-  shift
-  "$@"
-}
-
-set +e
-printf "before Docker\\n" >"$TMPDIR/stderr"
-docker_e2e_docker_cmd run demo 2>>"$TMPDIR/stderr"
-status="$?"
-set -e
-
-stderr="$(<"$TMPDIR/stderr")"
-[[ "$status" = "125" ]]
-[[ "$stderr" = before\\ Docker* ]]
-[[ "$stderr" = *"NanoCPUs can not be set"* ]]
-[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
-[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
-[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
-[[ "$(<"$TMPDIR/tail-seen")" = "-c 65536" ]]
-[[ "$(<"$TMPDIR/mktemp-seen")" = -d* ]]
-[[ ! -e "$(<"$TMPDIR/diagnostic-dir")" ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("does not suggest resource opt-out for other Docker failures", () => {
-    const workDir = tempDirs.make("openclaw-docker-resource-unrelated-");
-    const script = repoShell(workDir)`
-export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
-unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
-unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
-
-docker() {
-  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
-  echo "docker: Error response from daemon: No such image: cgroup-helper" >&2
-  return 125
-}
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
-docker_e2e_timeout_cmd() {
-  shift
-  "$@"
-}
-
-set +e
-docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
-status="$?"
-set -e
-
-stderr="$(<"$TMPDIR/stderr")"
-[[ "$status" = "125" ]]
-[[ "$stderr" = *"No such image: cgroup-helper"* ]]
-[[ "$stderr" != *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS"* ]]
-[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
   it("runs Docker when resource diagnostic capture is unavailable", () => {
     const workDir = tempDirs.make("openclaw-docker-resource-no-temp-");
     const missingTmpDir = join(workDir, "missing");
@@ -1293,30 +1930,6 @@ set -e
 
 [[ "$status" = "7" ]]
 [[ "$(grep -c '^run ' ${shellQuote(join(workDir, "docker-seen"))})" = "1" ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("rejects invalid Docker run pids limits before invoking docker", () => {
-    const workDir = tempDirs.make("openclaw-docker-resource-pids-");
-    const script = repoShell(workDir)`
-
-docker() {
-  printf invoked >"$TMPDIR/docker-seen"
-}
-export -f docker
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
-
-set +e
-OPENCLAW_DOCKER_E2E_PIDS_LIMIT=many docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
-status="$?"
-set -e
-
-[[ "$status" = "2" ]]
-[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]]
-[[ ! -e "$TMPDIR/docker-seen" ]]
 `;
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
@@ -1477,34 +2090,6 @@ stderr="$(<"$TMPDIR/stderr")"
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
   });
 
-  it("rejects invalid package-backed Docker run pids limits before invoking docker", () => {
-    const workDir = tempDirs.make("openclaw-docker-package-pids-");
-    const script = repoShell(workDir)`
-
-dirname() {
-  /usr/bin/dirname "$@"
-}
-
-docker() {
-  printf invoked >"$TMPDIR/docker-seen"
-}
-export -f docker
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
-
-set +e
-OPENCLAW_DOCKER_E2E_PIDS_LIMIT=many docker_e2e_docker_run_cmd run demo 2>"$TMPDIR/stderr"
-status="$?"
-set -e
-
-[[ "$status" = "2" ]]
-[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]]
-[[ ! -e "$TMPDIR/docker-seen" ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
   it("uses gtimeout for package-backed Docker runs sourced through the package helper", () => {
     const workDir = tempDirs.make("openclaw-docker-package-gtimeout-");
     writeExecutables(join(workDir, "bin"), {
@@ -1541,321 +2126,6 @@ docker_e2e_docker_run_cmd run demo
 
 [[ "$(<"$TMPDIR/timeout-seen")" = "gtimeout:--kill-after=30s 15s|docker run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
 [[ "$(<"$TMPDIR/docker-seen")" = "run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("diagnoses rejected resource limits through the canonical package helper", () => {
-    const workDir = tempDirs.make("openclaw-docker-package-diagnostic-");
-    const script = repoShell(workDir)`
-export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
-unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
-unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
-
-timeout() {
-  if [[ "$1" = "--kill-after=1s" ]]; then
-    return 0
-  fi
-  shift 2
-  "$@"
-}
-
-docker() {
-  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
-  echo "OCI runtime create failed: crun: controller pids is not available" >&2
-  return 125
-}
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
-
-set +e
-docker_e2e_docker_run_cmd run demo 2>"$TMPDIR/stderr"
-status="$?"
-set -e
-
-stderr="$(<"$TMPDIR/stderr")"
-[[ "$status" = "125" ]]
-[[ "$stderr" = *"controller pids is not available"* ]]
-[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
-[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
-[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("removes functional Docker build package inputs after the build", () => {
-    const workDir = tempDirs.make("openclaw-docker-build-cleanup-");
-    const script = repoShell(workDir)`
-
-node() {
-  local script="$1"
-  shift
-  if [[ "$script" != "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" ]]; then
-    command node "$script" "$@"
-    return
-  fi
-
-  local output_dir=""
-  local output_name=""
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --output-dir)
-        output_dir="$2"
-        shift 2
-        ;;
-      --output-name)
-        output_name="$2"
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
-
-  mkdir -p "$output_dir"
-  printf fixture >"$output_dir/$output_name"
-  printf "%s\\n" "$output_dir/$output_name"
-}
-export -f node
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
-
-docker_build_run() {
-  local build_context=""
-  local arg
-  for arg in "$@"; do
-    case "$arg" in
-      openclaw_package=*)
-        build_context="\${arg#openclaw_package=}"
-        ;;
-    esac
-  done
-
-  test -n "$build_context"
-  test -f "$build_context/openclaw-current.tgz"
-  printf "%s\\n" "$build_context" >"$TMPDIR/build-context-seen"
-}
-
-docker_e2e_build_or_reuse \\
-  openclaw-test-image \\
-  cleanup-proof \\
-  "$ROOT_DIR/scripts/e2e/Dockerfile" \\
-  "$ROOT_DIR" \\
-  functional
-
-test -f "$TMPDIR/build-context-seen"
-leftovers="$(find "$TMPDIR" -maxdepth 1 \\( \\
-  -name 'openclaw-docker-e2e-pack.*' \\
-  -o -name 'openclaw-docker-e2e-package-context.*' \\
-\\) -print)"
-if [[ -n "$leftovers" ]]; then
-  printf 'leftover functional build inputs:\\n%s\\n' "$leftovers" >&2
-  exit 1
-fi
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("keeps caller-provided functional Docker build packages", () => {
-    const workDir = tempDirs.make("openclaw-docker-build-external-package-");
-    const script = repoShell(workDir)`
-
-external_dir="$TMPDIR/external-package"
-mkdir -p "$external_dir"
-printf fixture >"$external_dir/openclaw-current.tgz"
-OPENCLAW_CURRENT_PACKAGE_TGZ="$external_dir/openclaw-current.tgz"
-export OPENCLAW_CURRENT_PACKAGE_TGZ
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
-
-docker_build_run() {
-  local build_context=""
-  local arg
-  for arg in "$@"; do
-    case "$arg" in
-      openclaw_package=*)
-        build_context="\${arg#openclaw_package=}"
-        ;;
-    esac
-  done
-
-  test -n "$build_context"
-  test -f "$build_context/openclaw-current.tgz"
-  printf "%s\\n" "$build_context" >"$TMPDIR/build-context-seen"
-}
-
-docker_e2e_build_or_reuse \\
-  openclaw-test-image \\
-  external-package-proof \\
-  "$ROOT_DIR/scripts/e2e/Dockerfile" \\
-  "$ROOT_DIR" \\
-  functional
-
-test -f "$TMPDIR/build-context-seen"
-test -f "$OPENCLAW_CURRENT_PACKAGE_TGZ"
-leftovers="$(find "$TMPDIR" -maxdepth 1 -name 'openclaw-docker-e2e-package-context.*' -print)"
-if [[ -n "$leftovers" ]]; then
-  printf 'leftover functional build context:\\n%s\\n' "$leftovers" >&2
-  exit 1
-fi
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("cleans generated package mounts after harness Docker runs", () => {
-    const workDir = tempDirs.make("openclaw-docker-package-mount-cleanup-");
-    const script = repoShell(workDir)`
-export DOCKER_COMMAND_TIMEOUT=3s
-
-mkdir -p "$TMPDIR/bin"
-cat >"$TMPDIR/bin/timeout" <<'SH'
-#!/usr/bin/env bash
-case "$1" in
-  --kill-after=1s)
-    exit 0
-    ;;
-  --kill-after=30s)
-    timeout_args="$1 $2"
-    shift 2
-    ;;
-  *)
-    timeout_args="$1"
-    shift
-    ;;
-esac
-if [[ "\${1:-}" == "docker" && "\${2:-}" == "run" ]]; then
-  printf "%s\\n" "$timeout_args" >"$TMPDIR/docker-timeout-seen"
-fi
-"$@"
-SH
-chmod +x "$TMPDIR/bin/timeout"
-export PATH="$TMPDIR/bin:$PATH"
-
-node() {
-  local script="$1"
-  shift
-  if [[ "$script" != "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" ]]; then
-    command node "$script" "$@"
-    return
-  fi
-
-  local output_dir=""
-  local output_name=""
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --output-dir)
-        output_dir="$2"
-        shift 2
-        ;;
-      --output-name)
-        output_name="$2"
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
-
-  mkdir -p "$output_dir"
-  printf fixture >"$output_dir/$output_name"
-  printf "%s\\n" "$output_dir/$output_name"
-}
-export -f node
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
-
-docker() {
-  if [[ "$1" == "rm" ]]; then
-    shift
-    test "$1" = "-f"
-    shift
-    printf "%s\\n" "$1" >>"$TMPDIR/docker-rm-seen"
-    return 0
-  fi
-
-  local cidfile=""
-  local mount_path=""
-  local expect_volume_path=0
-  local expect_cidfile=0
-  local arg
-  for arg in "$@"; do
-    if [[ "$expect_cidfile" == "1" ]]; then
-      cidfile="$arg"
-      expect_cidfile=0
-      continue
-    fi
-    if [[ "$expect_volume_path" == "1" ]]; then
-      mount_path="\${arg%%:*}"
-      expect_volume_path=0
-      continue
-    fi
-    if [[ "$arg" == "--cidfile" ]]; then
-      expect_cidfile=1
-      continue
-    fi
-    if [[ "$arg" == "-v" ]]; then
-      expect_volume_path=1
-    fi
-  done
-
-  test -n "$cidfile"
-  test ! -e "$cidfile"
-  printf "container-%s\\n" "\${DOCKER_STUB_STATUS:-}" >"$cidfile"
-  test -n "$mount_path"
-  test -f "$mount_path"
-  printf "%s\\n" "$mount_path" >"$TMPDIR/package-mount-seen"
-  return "\${DOCKER_STUB_STATUS:-0}"
-}
-export -f docker
-
-package_tgz="$(docker_e2e_prepare_package_tgz mount-cleanup)"
-pack_dir="$(dirname "$package_tgz")"
-docker_e2e_package_mount_args "$package_tgz"
-DOCKER_STUB_STATUS=7 docker_e2e_run_with_harness image-name bash -lc true || run_status="$?"
-test "\${run_status:-0}" = "7"
-test "$(cat "$TMPDIR/docker-timeout-seen")" = "--kill-after=30s 3s"
-grep -qx "container-7" "$TMPDIR/docker-rm-seen"
-test -f "$TMPDIR/package-mount-seen"
-test ! -e "$pack_dir"
-test -z "$(find "$TMPDIR" -maxdepth 1 -name 'openclaw-docker-e2e-container.*' -print)"
-
-external_dir="$TMPDIR/external-package"
-mkdir -p "$external_dir"
-printf fixture >"$external_dir/openclaw-current.tgz"
-docker_e2e_package_mount_args "$external_dir/openclaw-current.tgz"
-unset DOCKER_COMMAND_TIMEOUT
-rm -f "$TMPDIR/docker-timeout-seen"
-docker_e2e_run_with_harness image-name bash -lc true
-test "$(cat "$TMPDIR/docker-timeout-seen")" = "--kill-after=30s 3600s"
-grep -qx "container-" "$TMPDIR/docker-rm-seen"
-test -f "$external_dir/openclaw-current.tgz"
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("propagates shared E2E command timeouts into package-backed containers", () => {
-    const workDir = tempDirs.make("openclaw-docker-package-timeout-env-");
-    const script = repoShell(workDir)`
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
-
-package="$TMPDIR/openclaw-current.tgz"
-printf fixture >"$package"
-export OPENCLAW_E2E_NPM_INSTALL_TIMEOUT=42s
-export OPENCLAW_E2E_COMMAND_TIMEOUT=23s
-docker_e2e_package_mount_args "$package"
-printf "%s\\n" "\${DOCKER_E2E_PACKAGE_ARGS[@]}" >"$TMPDIR/package-args"
-
-grep -qx -- "-e" "$TMPDIR/package-args"
-grep -qx -- "OPENCLAW_CURRENT_PACKAGE_TGZ=/tmp/openclaw-current.tgz" "$TMPDIR/package-args"
-grep -qx -- "OPENCLAW_E2E_NPM_INSTALL_TIMEOUT=42s" "$TMPDIR/package-args"
-grep -qx -- "OPENCLAW_E2E_COMMAND_TIMEOUT=23s" "$TMPDIR/package-args"
 `;
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });
@@ -2378,104 +2648,6 @@ fi
     expect(publishedRunner).not.toContain('cat "$log_file"');
   });
 
-  it("keeps both harness run wrappers available when the package helper is sourced directly", () => {
-    const workDir = tempDirs.make("openclaw-docker-package-helper-guard-");
-    const script = repoShell(workDir)`
-
-mkdir -p "$TMPDIR/bin"
-cat >"$TMPDIR/bin/timeout" <<'SH'
-#!/usr/bin/env bash
-case "$1" in
-  --kill-after=1s)
-    exit 0
-    ;;
-  --kill-after=30s)
-    shift 2
-    ;;
-  *)
-    shift
-    ;;
-esac
-"$@"
-SH
-chmod +x "$TMPDIR/bin/timeout"
-export PATH="$TMPDIR/bin:$PATH"
-
-docker() {
-  printf "%s\\n" "$*" >>"$TMPDIR/docker-run-seen"
-}
-export -f docker
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
-
-docker_e2e_run_with_harness image-name bash -lc true
-docker_e2e_run_detached_with_harness image-name
-[[ $(wc -l <"$TMPDIR/docker-run-seen") -eq 2 ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("forwards harness stdin to backgrounded Docker runs", () => {
-    const workDir = tempDirs.make("openclaw-docker-harness-stdin-");
-    const script = repoShell(workDir)`
-
-mkdir -p "$TMPDIR/bin"
-cat >"$TMPDIR/bin/timeout" <<'SH'
-#!/usr/bin/env bash
-case "$1" in
-  --kill-after=1s)
-    exit 0
-    ;;
-  --kill-after=30s)
-    shift 2
-    ;;
-  *)
-    shift
-    ;;
-esac
-"$@"
-SH
-chmod +x "$TMPDIR/bin/timeout"
-export PATH="$TMPDIR/bin:$PATH"
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
-
-docker() {
-  if [[ "$1" == "rm" ]]; then
-    return 0
-  fi
-
-  local cidfile=""
-  local expect_cidfile=0
-  local arg
-  for arg in "$@"; do
-    if [[ "$expect_cidfile" == "1" ]]; then
-      cidfile="$arg"
-      expect_cidfile=0
-      continue
-    fi
-    if [[ "$arg" == "--cidfile" ]]; then
-      expect_cidfile=1
-    fi
-  done
-
-  test -n "$cidfile"
-  printf "container-stdin\\n" >"$cidfile"
-  cat >"$TMPDIR/docker-stdin-seen"
-}
-export -f docker
-
-docker_e2e_run_with_harness image-name bash -s <<'SH'
-printf "heredoc reached docker\\n"
-SH
-
-grep -Fxq 'printf "heredoc reached docker\\n"' "$TMPDIR/docker-stdin-seen"
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
   it("preserves caller-owned file descriptors around harness runs", () => {
     const workDir = tempDirs.make("openclaw-docker-harness-fd-");
     const script = String.raw`
@@ -2859,22 +3031,6 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     expect(runner).not.toContain("docker run --rm");
   });
 
-  it("bounds printed Docker E2E logs to the configured tail", () => {
-    const workDir = tempDirs.make("openclaw-docker-e2e-log-print-tail-");
-    const script = repoShell(workDir)`
-export OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES=64
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
-
-output="$(run_logged_print_heartbeat plugins-run 30 bash -c 'printf "DO_NOT_PRINT_OLD_LOG_START"; printf "%0200d" 0; printf "recent container log tail\\\\n"')"
-[[ "$output" = *"truncated: showing last 64"* ]]
-[[ "$output" = *"recent container log tail"* ]]
-[[ "$output" != *"DO_NOT_PRINT_OLD_LOG_START"* ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
   it.each([
     ["printed log bytes", "OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES", "64kb"],
     ["heartbeat termination grace", "OPENCLAW_DOCKER_E2E_HEARTBEAT_TERM_GRACE_SECONDS", "soon"],
@@ -2916,22 +3072,6 @@ docker_e2e_run_logged_print_with_harness plugins-run image-name
     expect(result.stdout).toBe("");
   });
 
-  it("prints heartbeat progress for long successful Docker E2E log captures", () => {
-    const workDir = tempDirs.make("openclaw-docker-e2e-log-heartbeat-");
-    const script = repoShell(workDir)`
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
-
-printf "captured container log\\n" >"$TMPDIR/run.log"
-output="$(docker_e2e_maybe_print_log_heartbeat plugins-run 1 1 "$TMPDIR/run.log")"
-[[ "$output" = *"still running plugins-run ("* ]]
-[[ "$output" = *"log bytes captured"* ]]
-[[ "$output" != *"captured container log"* ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
   it("preserves heredoc stdin through Docker E2E heartbeat logging", () => {
     const workDir = tempDirs.make("openclaw-docker-e2e-log-stdin-");
     const script = repoShell(workDir)`
@@ -2967,125 +3107,6 @@ SH
     expect(result.stderr).toBe("");
   });
 
-  it("cleans the heartbeat command when the wrapper is terminated", () => {
-    const workDir = tempDirs.make("openclaw-docker-e2e-log-term-cleanup-");
-    const script = repoShell(workDir)`
-export OPENCLAW_DOCKER_E2E_HEARTBEAT_TERM_GRACE_SECONDS=1
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
-
-command_pid_file="$TMPDIR/command.pid"
-(
-  run_logged_print_heartbeat plugins-run 30 bash -c 'trap "exit 0" TERM; printf "%s" "$$" > "$1"; while true; do /bin/sleep 0.05; done' bash "$command_pid_file"
-) &
-wrapper_pid="$!"
-for _ in $(seq 1 100); do
-  [ -s "$command_pid_file" ] && break
-  /bin/sleep 0.01
-done
-if [ ! -s "$command_pid_file" ]; then
-  kill -TERM "$wrapper_pid" 2>/dev/null || true
-  echo "heartbeat command pid was not recorded" >&2
-  exit 1
-fi
-command_pid="$(cat "$command_pid_file")"
-kill -TERM "$wrapper_pid"
-for _ in $(seq 1 50); do
-  if ! kill -0 "$command_pid" 2>/dev/null; then
-    wait "$wrapper_pid" 2>/dev/null || true
-    exit 0
-  fi
-  /bin/sleep 0.01
-done
-kill -TERM "$command_pid" 2>/dev/null || true
-kill -TERM "$wrapper_pid" 2>/dev/null || true
-echo "heartbeat command still alive after wrapper termination: $command_pid" >&2
-exit 1
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("cleans harness containers when heartbeat-wrapped Docker runs are terminated", () => {
-    const workDir = tempDirs.make("openclaw-docker-e2e-harness-term-cleanup-");
-    const script = repoShell(workDir)`
-
-mkdir -p "$TMPDIR/bin"
-cat >"$TMPDIR/bin/timeout" <<'SH'
-#!/usr/bin/env bash
-case "$1" in
-  --kill-after=1s)
-    exit 0
-    ;;
-  --kill-after=30s)
-    shift 2
-    ;;
-  *)
-    shift
-    ;;
-esac
-"$@"
-SH
-chmod +x "$TMPDIR/bin/timeout"
-export PATH="$TMPDIR/bin:$PATH"
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
-
-docker() {
-  if [[ "$1" == "rm" ]]; then
-    shift
-    test "$1" = "-f"
-    shift
-    printf "%s\\n" "$1" >>"$TMPDIR/docker-rm-seen"
-    return 0
-  fi
-
-  local cidfile=""
-  local expect_cidfile=0
-  local arg
-  for arg in "$@"; do
-    if [[ "$expect_cidfile" == "1" ]]; then
-      cidfile="$arg"
-      expect_cidfile=0
-      continue
-    fi
-    if [[ "$arg" == "--cidfile" ]]; then
-      expect_cidfile=1
-    fi
-  done
-
-  test -n "$cidfile"
-  printf "container-term\\n" >"$cidfile"
-  printf "started\\n" >"$TMPDIR/docker-started"
-  printf "docker running\\n"
-  trap 'exit 143' TERM
-  while true; do /bin/sleep 0.05; done
-}
-export -f docker
-
-(
-  docker_e2e_run_logged_print_with_harness plugins-run image-name bash -lc true
-) &
-wrapper_pid="$!"
-for _ in $(seq 1 50); do
-  [ -s "$TMPDIR/docker-started" ] && break
-  /bin/sleep 0.01
-  kill -0 "$wrapper_pid" 2>/dev/null || true
-done
-test -s "$TMPDIR/docker-started"
-kill -TERM "$wrapper_pid" 2>/dev/null || true
-wait "$wrapper_pid" 2>/dev/null || true
-for _ in $(seq 1 50); do
-  grep -qx "container-term" "$TMPDIR/docker-rm-seen" 2>/dev/null && break
-  /bin/sleep 0.01
-done
-grep -qx "container-term" "$TMPDIR/docker-rm-seen"
-test -z "$(find "$TMPDIR" -maxdepth 1 -name 'openclaw-docker-e2e-container.*' -print)"
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
   it("does not delay fast successful Docker E2E log captures until the next heartbeat", () => {
     const workDir = tempDirs.make("openclaw-docker-e2e-log-fast-heartbeat-");
     const script = repoShell(workDir)`
@@ -3109,52 +3130,6 @@ export ROOT_DIR
 source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
 
 [[ "$(docker_e2e_normalize_positive_int_value 'Docker E2E log heartbeat interval' 08)" = "8" ]]
-`;
-
-    execFileSync("bash", ["-lc", script], { encoding: "utf8" });
-  });
-
-  it("normalizes zero-padded Docker E2E stats heartbeat intervals", () => {
-    const workDir = tempDirs.make("openclaw-docker-e2e-stats-zero-heartbeat-");
-    const script = repoShell(workDir)`
-
-source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
-
-docker_e2e_docker_cmd() {
-  case "$1" in
-    inspect) return 0 ;;
-    stats) printf '{"MemUsage":"1MiB / 2MiB","CPUPerc":"0.1%%"}\\n'; return 0 ;;
-    *) return 0 ;;
-  esac
-}
-
-sleep() {
-  SECONDS=$((SECONDS + \${1%%.*}))
-}
-
-kill_checks=0
-kill() {
-  if [[ "\${1:-}" == "-0" && "\${2:-}" == "sampled-docker-pid" ]]; then
-    kill_checks=$((kill_checks + 1))
-    [[ "$kill_checks" -le 6 ]]
-    return
-  fi
-  command kill "$@"
-}
-
-stats_log="$TMPDIR/stats.log"
-run_log="$TMPDIR/run.log"
-sampler_log="$TMPDIR/sampler.log"
-printf "container output\\n" >"$run_log"
-
-docker_e2e_sample_stats_until_exit demo sampled-docker-pid "$stats_log" "$run_log" "Docker stats" 08 >"$sampler_log" 2>&1
-output="$(cat "$sampler_log")"
-
-[[ "$output" =~ Docker\\ stats\\ still\\ running\\ \\(([0-9]+)s\\ elapsed, ]]
-heartbeat_elapsed="\${BASH_REMATCH[1]}"
-(( heartbeat_elapsed >= 8 ))
-[[ "$output" != *"value too great for base"* ]]
-[[ -s "$stats_log" ]]
 `;
 
     execFileSync("bash", ["-lc", script], { encoding: "utf8" });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2963,29 +2963,97 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
-  it("routes misc extensions to the misc extension shard", () => {
-    const plans = buildVitestRunPlans(["extensions/thread-ownership"], process.cwd());
+  it.each([
+    {
+      title: "routes misc extensions to the misc extension shard",
+      target: "extensions/thread-ownership",
+      config: "test/vitest/vitest.extension-misc.config.ts",
+      includePattern: "extensions/thread-ownership/**/*.test.ts",
+    },
+    {
+      title: "routes explicit plugin-sdk light tests to the lighter plugin-sdk lane",
+      target: "src/plugin-sdk/temp-path.test.ts",
+      config: "test/vitest/vitest.plugin-sdk-light.config.ts",
+      includePattern: "src/plugin-sdk/temp-path.test.ts",
+    },
+    {
+      title: "routes explicit commands light tests to the lighter commands lane",
+      target: "src/commands/status-json-runtime.test.ts",
+      config: "test/vitest/vitest.commands-light.config.ts",
+      includePattern: "src/commands/status-json-runtime.test.ts",
+    },
+    {
+      title: "routes fake-timer unit-fast tests to the serial fake-timer lane",
+      target: "src/acp/control-plane/manager.test.ts",
+      config: "test/vitest/vitest.unit-fast-fake-timers.config.ts",
+      includePattern: "src/acp/control-plane/manager.test.ts",
+    },
+  ])("$title", ({ target, config, includePattern }) => {
+    const plans = buildVitestRunPlans([target], process.cwd());
 
     expect(plans).toEqual([
       {
-        config: "test/vitest/vitest.extension-misc.config.ts",
+        config,
         forwardedArgs: [],
-        includePatterns: ["extensions/thread-ownership/**/*.test.ts"],
+        includePatterns: [includePattern],
         watchMode: false,
       },
     ]);
   });
 
-  it("routes browser extension changes to the browser extension lane", () => {
+  it.each([
+    {
+      title: "routes browser extension changes to the browser extension lane",
+      changedPath: "extensions/browser/src/browser/cdp.helpers.ts",
+      config: "test/vitest/vitest.extension-browser.config.ts",
+      testPath: "extensions/browser/src/browser/cdp.helpers.test.ts",
+    },
+    {
+      title: "keeps public plugin SDK changes focused by default",
+      changedPath: "src/plugin-sdk/provider-entry.ts",
+      config: "test/vitest/vitest.unit-fast.config.ts",
+      testPath: "src/plugin-sdk/provider-entry.test.ts",
+    },
+    {
+      title: "routes LM Studio changes to the provider extension lane",
+      changedPath: "extensions/lmstudio/src/runtime.ts",
+      config: "test/vitest/vitest.extension-providers.config.ts",
+      testPath: "extensions/lmstudio/src/runtime.test.ts",
+    },
+    {
+      title: "routes QA extension changes to the QA extension lane",
+      changedPath: "extensions/qa-lab/src/scenario-catalog.test.ts",
+      config: "test/vitest/vitest.extension-qa.config.ts",
+      testPath: "extensions/qa-lab/src/scenario-catalog.test.ts",
+    },
+    {
+      title: "routes changed source files to sibling tests when present",
+      changedPath: "src/agents/live-model-turn-probes.ts",
+      config: "test/vitest/vitest.unit-fast.config.ts",
+      testPath: "src/agents/live-model-turn-probes.test.ts",
+    },
+    {
+      title: "routes plugin-sdk source files with sibling tests narrowly by default",
+      changedPath: "src/plugin-sdk/facade-runtime.ts",
+      config: "test/vitest/vitest.bundled.config.ts",
+      testPath: "src/plugin-sdk/facade-runtime.test.ts",
+    },
+    {
+      title: "routes command source files with sibling tests narrowly on the command lane",
+      changedPath: "src/commands/channels.add.ts",
+      config: "test/vitest/vitest.commands.config.ts",
+      testPath: "src/commands/channels.add.test.ts",
+    },
+  ])("$title", ({ changedPath, config, testPath }) => {
     const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "extensions/browser/src/browser/cdp.helpers.ts",
+      changedPath,
     ]);
 
     expect(plans).toEqual([
       {
-        config: "test/vitest/vitest.extension-browser.config.ts",
+        config,
         forwardedArgs: [],
-        includePatterns: ["extensions/browser/src/browser/cdp.helpers.test.ts"],
+        includePatterns: [testPath],
         watchMode: false,
       },
     ]);
@@ -3159,21 +3227,6 @@ describe("scripts/test-projects changed-target routing", () => {
     ).toStrictEqual([]);
   });
 
-  it("keeps public plugin SDK changes focused by default", () => {
-    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "src/plugin-sdk/provider-entry.ts",
-    ]);
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/plugin-sdk/provider-entry.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
   it("adds extension tests for public plugin SDK changes in broad changed mode", () => {
     const plans = buildVitestRunPlans(
       ["--changed", "origin/main"],
@@ -3190,36 +3243,6 @@ describe("scripts/test-projects changed-target routing", () => {
         watchMode: false,
       },
       ...listExpectedFullExtensionRunPlans(),
-    ]);
-  });
-
-  it("routes LM Studio changes to the provider extension lane", () => {
-    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "extensions/lmstudio/src/runtime.ts",
-    ]);
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.extension-providers.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/lmstudio/src/runtime.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes QA extension changes to the QA extension lane", () => {
-    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "extensions/qa-lab/src/scenario-catalog.test.ts",
-    ]);
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.extension-qa.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["extensions/qa-lab/src/scenario-catalog.test.ts"],
-        watchMode: false,
-      },
     ]);
   });
 
@@ -3339,21 +3362,6 @@ describe("scripts/test-projects changed-target routing", () => {
         config: "test/vitest/vitest.unit.config.ts",
         forwardedArgs: ["packages/sdk/src/index.test.ts"],
         includePatterns: null,
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes changed source files to sibling tests when present", () => {
-    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "src/agents/live-model-turn-probes.ts",
-    ]);
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/agents/live-model-turn-probes.test.ts"],
         watchMode: false,
       },
     ]);
@@ -3601,19 +3609,6 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
-  it("routes explicit plugin-sdk light tests to the lighter plugin-sdk lane", () => {
-    const plans = buildVitestRunPlans(["src/plugin-sdk/temp-path.test.ts"], process.cwd());
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.plugin-sdk-light.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/plugin-sdk/temp-path.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
   it("uses collision-resistant include-file names for scoped Vitest specs", () => {
     const tempDir = path.join("tmp", "openclaw-vitest-specs");
     const [spec] = createVitestRunSpecs(["src/plugin-sdk/temp-path.test.ts"], {
@@ -3685,19 +3680,6 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
-  it("routes explicit commands light tests to the lighter commands lane", () => {
-    const plans = buildVitestRunPlans(["src/commands/status-json-runtime.test.ts"], process.cwd());
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.commands-light.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/commands/status-json-runtime.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
   it("routes the full commands test root to both command shards", () => {
     expect(findUnmatchedExplicitTestTargets(["src/commands"])).toEqual([]);
     expect(buildVitestRunPlans(["src/commands"], process.cwd())).toEqual([
@@ -3748,19 +3730,6 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
-  it("routes fake-timer unit-fast tests to the serial fake-timer lane", () => {
-    const plans = buildVitestRunPlans(["src/acp/control-plane/manager.test.ts"], process.cwd());
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.unit-fast-fake-timers.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/acp/control-plane/manager.test.ts"],
-        watchMode: false,
-      },
-    ]);
-  });
-
   it("routes changed commands source allowlist files to sibling light tests", () => {
     const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
       "src/commands/status-overview-values.ts",
@@ -3775,21 +3744,6 @@ describe("scripts/test-projects changed-target routing", () => {
           "src/commands/status-overview-values.test.ts",
           "src/commands/gateway-status/helpers.test.ts",
         ],
-        watchMode: false,
-      },
-    ]);
-  });
-
-  it("routes plugin-sdk source files with sibling tests narrowly by default", () => {
-    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "src/plugin-sdk/facade-runtime.ts",
-    ]);
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.bundled.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/plugin-sdk/facade-runtime.test.ts"],
         watchMode: false,
       },
     ]);
@@ -3811,21 +3765,6 @@ describe("scripts/test-projects changed-target routing", () => {
         watchMode: false,
       },
       ...listExpectedFullExtensionRunPlans(),
-    ]);
-  });
-
-  it("routes command source files with sibling tests narrowly on the command lane", () => {
-    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "src/commands/channels.add.ts",
-    ]);
-
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.commands.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/commands/channels.add.test.ts"],
-        watchMode: false,
-      },
     ]);
   });
 

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -326,64 +326,57 @@ describe("resolveTsdownBuildInvocation", () => {
     });
   });
 
-  it("keeps inherited Windows tsdown heap settings at the Windows build cap", () => {
-    const result = resolveTsdownBuildInvocation({
+  it.each([
+    {
+      title: "keeps inherited Windows tsdown heap settings at the Windows build cap",
       platform: "win32",
-      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
-      npmExecPath: "C:\\repo\\pnpm.cjs",
-      env: { NODE_OPTIONS: "--trace-warnings --max-old-space-size=8192" },
-      ...NO_MEMORY_LIMIT,
-    });
-
-    expect(result.options.env.NODE_OPTIONS).toBe("--trace-warnings --max-old-space-size=8192");
-  });
-
-  it("clamps explicit Windows tsdown heap settings to the Windows build cap", () => {
-    const result = resolveTsdownBuildInvocation({
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      pnpmPath: "C:\\repo\\pnpm.cjs",
+      nodeOptions: "--trace-warnings --max-old-space-size=8192",
+      expectedNodeOptions: "--trace-warnings --max-old-space-size=8192",
+    },
+    {
+      title: "clamps explicit Windows tsdown heap settings to the Windows build cap",
       platform: "win32",
-      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
-      npmExecPath: "C:\\repo\\pnpm.cjs",
-      env: { NODE_OPTIONS: "--trace-warnings --max-old-space-size=12288" },
-      ...NO_MEMORY_LIMIT,
-    });
-
-    expect(result.options.env.NODE_OPTIONS).toBe("--trace-warnings --max-old-space-size=8192");
-  });
-
-  it("preserves explicit tsdown heap settings", () => {
-    const result = resolveTsdownBuildInvocation({
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      pnpmPath: "C:\\repo\\pnpm.cjs",
+      nodeOptions: "--trace-warnings --max-old-space-size=12288",
+      expectedNodeOptions: "--trace-warnings --max-old-space-size=8192",
+    },
+    {
+      title: "preserves explicit tsdown heap settings",
       platform: "linux",
-      nodeExecPath: "/usr/bin/node",
-      npmExecPath: "/tmp/pnpm.cjs",
-      env: { NODE_OPTIONS: "--trace-warnings --max-old-space-size=12288" },
-      ...NO_MEMORY_LIMIT,
-    });
-
-    expect(result.options.env.NODE_OPTIONS).toBe("--trace-warnings --max-old-space-size=12288");
-  });
-
-  it("raises inherited lower tsdown heap settings to the build default", () => {
-    const result = resolveTsdownBuildInvocation({
+      execPath: "/usr/bin/node",
+      pnpmPath: "/tmp/pnpm.cjs",
+      nodeOptions: "--trace-warnings --max-old-space-size=12288",
+      expectedNodeOptions: "--trace-warnings --max-old-space-size=12288",
+    },
+    {
+      title: "raises inherited lower tsdown heap settings to the build default",
       platform: "linux",
-      nodeExecPath: "/usr/bin/node",
-      npmExecPath: "/tmp/pnpm.cjs",
-      env: { NODE_OPTIONS: "--trace-warnings --max-old-space-size=4096" },
-      ...NO_MEMORY_LIMIT,
-    });
-
-    expect(result.options.env.NODE_OPTIONS).toBe("--trace-warnings --max-old-space-size=12288");
-  });
-
-  it("raises split inherited lower tsdown heap settings to the build default", () => {
-    const result = resolveTsdownBuildInvocation({
+      execPath: "/usr/bin/node",
+      pnpmPath: "/tmp/pnpm.cjs",
+      nodeOptions: "--trace-warnings --max-old-space-size=4096",
+      expectedNodeOptions: "--trace-warnings --max-old-space-size=12288",
+    },
+    {
+      title: "raises split inherited lower tsdown heap settings to the build default",
       platform: "linux",
-      nodeExecPath: "/usr/bin/node",
-      npmExecPath: "/tmp/pnpm.cjs",
-      env: { NODE_OPTIONS: "--trace-warnings --max-old-space-size 4096" },
+      execPath: "/usr/bin/node",
+      pnpmPath: "/tmp/pnpm.cjs",
+      nodeOptions: "--trace-warnings --max-old-space-size 4096",
+      expectedNodeOptions: "--trace-warnings --max-old-space-size=12288",
+    },
+  ])("$title", ({ platform, execPath, pnpmPath, nodeOptions, expectedNodeOptions }) => {
+    const result = resolveTsdownBuildInvocation({
+      platform,
+      nodeExecPath: execPath,
+      npmExecPath: pnpmPath,
+      env: { NODE_OPTIONS: nodeOptions },
       ...NO_MEMORY_LIMIT,
     });
 
-    expect(result.options.env.NODE_OPTIONS).toBe("--trace-warnings --max-old-space-size=12288");
+    expect(result.options.env.NODE_OPTIONS).toBe(expectedNodeOptions);
   });
 
   it("keeps default tsdown heap below the container memory limit", () => {

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -269,51 +269,40 @@ describe("createScopedVitestConfig", () => {
     expect(testConfig.exclude).toContain("dist/**");
   });
 
-  it("narrows scoped includes to matching CLI file filters", () => {
-    const config = createScopedVitestConfig(["extensions/**/*.test.ts"], {
-      argv: ["node", "vitest", "run", "extensions/browser/index.test.ts"],
+  it.each([
+    {
+      title: "narrows scoped includes to matching CLI file filters",
+      includePattern: "extensions/**/*.test.ts",
+      target: "extensions/browser/index.test.ts",
+      expectedInclude: "browser/index.test.ts",
+    },
+    {
+      title: "narrows scoped includes to matching dot-prefixed CLI file filters",
+      includePattern: "extensions/codex/**/*.test.ts",
+      target: "./extensions/codex/src/app-server/client.test.ts",
+      expectedInclude: "codex/src/app-server/client.test.ts",
+    },
+    {
+      title: "narrows scoped includes to matching dir-relative CLI file filters",
+      includePattern: "extensions/codex/**/*.test.ts",
+      target: "codex/src/app-server/client.test.ts",
+      expectedInclude: "codex/src/app-server/client.test.ts",
+    },
+    {
+      title: "does not narrow scoped includes for bare Vitest name filters",
+      includePattern: "extensions/codex/**/*.test.ts",
+      target: "client",
+      expectedInclude: "codex/**/*.test.ts",
+    },
+  ])("$title", ({ includePattern, target, expectedInclude }) => {
+    const config = createScopedVitestConfig([includePattern], {
+      argv: ["node", "vitest", "run", target],
       dir: "extensions",
       env: {},
     });
     const testConfig = requireTestConfig(config);
 
-    expect(testConfig.include).toEqual(["browser/index.test.ts"]);
-    expect(testConfig.passWithNoTests).toBeUndefined();
-  });
-
-  it("narrows scoped includes to matching dot-prefixed CLI file filters", () => {
-    const config = createScopedVitestConfig(["extensions/codex/**/*.test.ts"], {
-      argv: ["node", "vitest", "run", "./extensions/codex/src/app-server/client.test.ts"],
-      dir: "extensions",
-      env: {},
-    });
-    const testConfig = requireTestConfig(config);
-
-    expect(testConfig.include).toEqual(["codex/src/app-server/client.test.ts"]);
-    expect(testConfig.passWithNoTests).toBeUndefined();
-  });
-
-  it("narrows scoped includes to matching dir-relative CLI file filters", () => {
-    const config = createScopedVitestConfig(["extensions/codex/**/*.test.ts"], {
-      argv: ["node", "vitest", "run", "codex/src/app-server/client.test.ts"],
-      dir: "extensions",
-      env: {},
-    });
-    const testConfig = requireTestConfig(config);
-
-    expect(testConfig.include).toEqual(["codex/src/app-server/client.test.ts"]);
-    expect(testConfig.passWithNoTests).toBeUndefined();
-  });
-
-  it("does not narrow scoped includes for bare Vitest name filters", () => {
-    const config = createScopedVitestConfig(["extensions/codex/**/*.test.ts"], {
-      argv: ["node", "vitest", "run", "client"],
-      dir: "extensions",
-      env: {},
-    });
-    const testConfig = requireTestConfig(config);
-
-    expect(testConfig.include).toEqual(["codex/**/*.test.ts"]);
+    expect(testConfig.include).toEqual([expectedInclude]);
     expect(testConfig.passWithNoTests).toBeUndefined();
   });
 
@@ -893,13 +882,26 @@ describe("scoped vitest configs", () => {
     ).toBe(true);
   });
 
-  it("keeps voice-call tests out of the shared extensions lane", () => {
+  it.each([
+    {
+      title: "keeps voice-call tests out of the shared extensions lane",
+      target: "voice-call/src/runtime.test.ts",
+    },
+    {
+      title: "keeps provider plugin tests out of the shared extensions lane",
+      target: "openai/openai-chatgpt-provider.test.ts",
+    },
+    {
+      title: "keeps mattermost tests out of the shared extensions lane",
+      target: "mattermost/src/channel.test.ts",
+    },
+    {
+      title: "keeps memory plugin tests out of the shared extensions lane",
+      target: "memory-core/src/memory/test-runtime-mocks.ts",
+    },
+  ])("$title", ({ target }) => {
     const extensionExcludes = defaultExtensionsConfig.test?.exclude ?? [];
-    expect(
-      extensionExcludes.some((pattern) =>
-        path.matchesGlob("voice-call/src/runtime.test.ts", pattern),
-      ),
-    ).toBe(true);
+    expect(extensionExcludes.some((pattern) => path.matchesGlob(target, pattern))).toBe(true);
   });
 
   it("keeps zalo tests out of the shared extensions lane", () => {
@@ -914,28 +916,10 @@ describe("scoped vitest configs", () => {
     ).toBe(true);
   });
 
-  it("keeps provider plugin tests out of the shared extensions lane", () => {
-    const extensionExcludes = defaultExtensionsConfig.test?.exclude ?? [];
-    expect(
-      extensionExcludes.some((pattern) =>
-        path.matchesGlob("openai/openai-chatgpt-provider.test.ts", pattern),
-      ),
-    ).toBe(true);
-  });
-
   it("keeps messaging plugin tests out of the shared extensions lane", () => {
     const extensionExcludes = defaultExtensionsConfig.test?.exclude ?? [];
     expect(
       extensionExcludes.some((pattern) => path.matchesGlob("matrix/src/channel.test.ts", pattern)),
-    ).toBe(true);
-  });
-
-  it("keeps mattermost tests out of the shared extensions lane", () => {
-    const extensionExcludes = defaultExtensionsConfig.test?.exclude ?? [];
-    expect(
-      extensionExcludes.some((pattern) =>
-        path.matchesGlob("mattermost/src/channel.test.ts", pattern),
-      ),
     ).toBe(true);
   });
 
@@ -949,15 +933,6 @@ describe("scoped vitest configs", () => {
     const testConfig = requireTestConfig(defaultHooksConfig);
     expect(testConfig.dir).toBe(path.join(process.cwd(), "src", "hooks"));
     expect(testConfig.include).toEqual(["**/*.test.ts"]);
-  });
-
-  it("keeps memory plugin tests out of the shared extensions lane", () => {
-    const extensionExcludes = defaultExtensionsConfig.test?.exclude ?? [];
-    expect(
-      extensionExcludes.some((pattern) =>
-        path.matchesGlob("memory-core/src/memory/test-runtime-mocks.ts", pattern),
-      ),
-    ).toBe(true);
   });
 
   it("keeps feishu tests out of the shared extensions lane", () => {


### PR DESCRIPTION
## What Problem This Solves

The repository still contained large groups of `it()`/`test()` blocks that were byte-identical after normalizing string and number literals. Repeating the full setup and assertion body made maintenance noisy and allowed structurally identical cases to drift.

This batch collapses the next ranked duplicate groups while preserving every case, assertion, literal, and test title.

## Why This Change Was Made

A throwaway TypeScript-AST audit under `/tmp` scanned repository `*.test.ts` files, normalized string/number literals, grouped identical test bodies within each file, and ranked files by collapsible LOC after applying the sibling/exclusion list.

The highest-ranked multiline-template group yielded much less real deletion than its normalized score because each shell script remains explicit row data. The batch therefore continued down the ranking until the measured test delta reached the requested range. Tables use `$title` interpolation and keep original titles; literal-sensitive fields use `as const` where required by test types.

The max-lines ratchet then identified `src/scripts/test-projects.test.ts` as below the grandfathered threshold, so this PR removes its shrink-only baseline entry.

## User Impact

No production behavior changes. This is test-only deduplication plus a one-line shrink of the max-lines baseline. All 35 touched test files retain equal before/after test-case counts.

## Evidence

### Before/after test counts

| File | Before | After |
| --- | ---: | ---: |
| `extensions/discord/src/send.webhook.proxy.test.ts` | 15 | 15 |
| `extensions/memory-core/src/memory-budget.test.ts` | 30 | 30 |
| `extensions/minimax/image-generation-provider.test.ts` | 13 | 13 |
| `extensions/msteams/src/outbound.test.ts` | 22 | 22 |
| `extensions/qa-lab/src/agentic-parity-report.test.ts` | 43 | 43 |
| `extensions/qa-lab/src/character-eval.test.ts` | 24 | 24 |
| `extensions/qa-lab/src/live-timeout.test.ts` | 7 | 7 |
| `extensions/qa-lab/src/suite-runtime-agent-process.test.ts` | 35 | 35 |
| `packages/ai/src/providers/openai-completions.test.ts` | 59 | 59 |
| `packages/markdown-core/src/ir.nested-lists.test.ts` | 27 | 27 |
| `src/agents/agent-tools.read.workspace-root-guard.test.ts` | 19 | 19 |
| `src/agents/apply-patch.test.ts` | 52 | 52 |
| `src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts` | 92 | 92 |
| `src/agents/embedded-agent-runner/run/payloads.errors.test.ts` | 80 | 80 |
| `src/agents/embedded-agent-utils.test.ts` | 52 | 52 |
| `src/agents/model-selection.test.ts` | 126 | 126 |
| `src/agents/openai-transport-stream.inline-reasoning-and-tool-calls.test.ts` | 40 | 40 |
| `src/agents/provider-transport-fetch.test.ts` | 95 | 95 |
| `src/agents/tool-policy-pipeline.test.ts` | 36 | 36 |
| `src/cli/plugins-update-selection.test.ts` | 12 | 12 |
| `src/commands/doctor-lint.test.ts` | 13 | 13 |
| `src/config/config.plugin-validation.test.ts` | 82 | 82 |
| `src/config/sessions/session-key.test.ts` | 8 | 8 |
| `src/cron/isolated-agent.model-formatting.test.ts` | 38 | 38 |
| `src/daemon/inspect.test.ts` | 33 | 33 |
| `src/infra/exec-approvals-allow-always.test.ts` | 129 | 129 |
| `src/infra/net/fetch-guard.ssrf.test.ts` | 104 | 104 |
| `src/scripts/test-projects.test.ts` | 85 | 85 |
| `src/shared/text/assistant-visible-text.test.ts` | 122 | 122 |
| `src/skills/loading/frontmatter.test.ts` | 21 | 21 |
| `test/scripts/check-dynamic-import-warts.test.ts` | 11 | 11 |
| `test/scripts/docker-build-helper.test.ts` | 180 | 180 |
| `test/scripts/test-projects.test.ts` | 250 | 250 |
| `test/scripts/tsdown-build.test.ts` | 58 | 58 |
| `test/vitest-scoped-config.test.ts` | 99 | 99 |

### Baseline pruning

- Removed exactly `src/scripts/test-projects.test.ts` from `config/max-lines-baseline.txt`.
- `node scripts/check-max-lines-ratchet.mjs --base origin/main` — passed: `max-lines ratchet OK: 989 grandfathered suppressions.`

### Validation

- `pnpm format <35 touched test files>` — passed.
- `node scripts/run-oxlint.mjs <35 touched test files>` — passed.
- `node scripts/run-vitest.mjs <file>` for 34 touched files — all passed.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts --reporter=verbose` with only the two changed tables selected — 11 passed; the unfiltered file also exposed an unrelated existing `routes nested e2e shell helpers through their sourced owner tests` timeout at 120 seconds under local load.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts` — 80 passed after literal-type tightening.
- `node scripts/run-vitest.mjs src/commands/doctor-lint.test.ts` — 13 passed after literal-type tightening.
- `node scripts/run-vitest.mjs src/daemon/inspect.test.ts` — 28 passed, 5 skipped after literal-type tightening.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — every preceding guard passed; core-test typecheck then stopped on unrelated existing missing names (`browser`, `server`) in `ui/src/e2e/appearance-settings-defaults.e2e.test.ts`. The three touched-file type errors initially found by this gate were fixed and no longer appear.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean after the table refactor, baseline prune, and literal-type repair; no accepted/actionable findings.

### Skips

- All sibling-owned files and explicit exclusion paths from the task brief were left untouched.
- `extensions/discord/src/client.proxy.test.ts` was skipped because moving its credential-shaped fixture caused the mandatory secret scan to fail closed; the file was restored unchanged.

### LOC delta

- Production: `+0 / -0` (net `0`).
- Tests: `+2,773 / -4,277` (net `-1,504`).
- Ratchet metadata: `+0 / -1` (net `-1`).

The worktree merge-base was `a73910dfba852e399b324114ff805a795aaa403c`; the task brief named the earlier `b4a26783f7606194d282c9e9bfbbe268794216c0` base.
