### PR TITLE
test(ui): make gateway item style assertion deterministic

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -784,9 +784,17 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const styles = await page.evaluate(() => {
         const dropdown = document.querySelector<HTMLElement>(".chat-pane__gateway-menu")!;
         const menu = dropdown.shadowRoot!.querySelector<HTMLElement>('[part="menu"]')!;
-        const item = dropdown.querySelector<HTMLElement>(".chat-pane__gateway-menu-item")!;
         const menuStyle = getComputedStyle(menu);
-        const itemStyle = getComputedStyle(item);
+        const itemRule = Array.from(document.styleSheets)
+          .flatMap((sheet) => Array.from(sheet.cssRules))
+          .find(
+            (rule): rule is CSSStyleRule =>
+              rule instanceof CSSStyleRule && rule.selectorText === ".chat-pane__gateway-menu-item",
+          );
+        if (!itemRule) {
+          throw new Error("Expected gateway menu item style rule");
+        }
+        const itemStyle = itemRule.style;
         return {
           menu: {
             borderRadius: menuStyle.borderRadius,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the responsive chat browser test reads computed styles from a disconnected gateway menu item. Chromium returns empty computed values for that detached element, causing the UI validation lane to fail even when the stylesheet rule is correct.

## Why This Change Was Made

The assertion now reads the matching `CSSStyleRule` from `document.styleSheets` and fails explicitly if the expected rule is absent. This keeps the test focused on the authored gateway item rule without changing production UI behavior.

Provenance: exact cherry-pick of `dc48e2f712efe6e59e8e75c9a2be01debf7c9242`.

## User Impact

No production behavior changes. Maintainers get deterministic responsive-chat style validation in the UI lane.

## Evidence

- `node ../scripts/run-vitest.mjs run --config vitest.config.ts --configLoader runner src/pages/chat/chat-responsive.browser.test.ts` from `ui/`: 74 passed
- `pnpm format:check -- ui/src/pages/chat/chat-responsive.browser.test.ts`
- `git diff --check origin/main...HEAD`
- Diff scope: `ui/src/pages/chat/chat-responsive.browser.test.ts`, `+10/-2`
