### PR TITLE
fix: gateway stalls for tens of seconds after each agent turn on multi-agent installs

### DIFF
--- a/src/config/sessions/session-sqlite-target.ts
+++ b/src/config/sessions/session-sqlite-target.ts
@@ -31,16 +31,18 @@ type ResolveSqliteStoreTargetOptions = {
   defaultAgentId?: string;
   env?: NodeJS.ProcessEnv;
   registeredDatabases?: readonly Pick<OpenClawRegisteredAgentDatabase, "agentId" | "path">[];
+  isSameDatabasePath?: (left: string, right: string) => boolean;
 };
 
 function resolveRegisteredOwners(
   pathname: string,
   registeredDatabases: readonly Pick<OpenClawRegisteredAgentDatabase, "agentId" | "path">[],
+  isSameDatabasePath: (left: string, right: string) => boolean,
 ): string[] {
   return [
     ...new Set(
       registeredDatabases
-        .filter((entry) => isSameOpenClawAgentDatabasePath(entry.path, pathname))
+        .filter((entry) => isSameDatabasePath(entry.path, pathname))
         .map((entry) => normalizeAgentId(entry.agentId)),
     ),
   ];
@@ -78,8 +80,13 @@ function resolveCustomStoreSqlitePath(params: {
   const registeredDatabases =
     params.options.registeredDatabases ??
     listOpenClawRegisteredAgentDatabases(params.options.env ? { env: params.options.env } : {});
+  const isSameDatabasePath = params.options.isSameDatabasePath ?? isSameOpenClawAgentDatabasePath;
   const resolvePersistedOwner = (candidatePath: string) => {
-    const registeredOwners = resolveRegisteredOwners(candidatePath, registeredDatabases);
+    const registeredOwners = resolveRegisteredOwners(
+      candidatePath,
+      registeredDatabases,
+      isSameDatabasePath,
+    );
     const databaseOwner = resolveDatabaseOwner(candidatePath);
     return {
       effectiveOwner:
@@ -91,7 +98,11 @@ function resolveCustomStoreSqlitePath(params: {
       registeredOwners,
     };
   };
-  const registeredUnsuffixedOwners = resolveRegisteredOwners(unsuffixedPath, registeredDatabases);
+  const registeredUnsuffixedOwners = resolveRegisteredOwners(
+    unsuffixedPath,
+    registeredDatabases,
+    isSameDatabasePath,
+  );
   const durableUnsuffixedOwner = resolveDatabaseOwner(unsuffixedPath);
   const persistedUnsuffixedOwner =
     registeredUnsuffixedOwners.length === 1
@@ -121,7 +132,7 @@ function resolveCustomStoreSqlitePath(params: {
     };
     const occupiedIndexes = new Set<number>();
     for (const registered of registeredDatabases) {
-      if (!isSameOpenClawAgentDatabasePath(path.dirname(registered.path), sessionsDir)) {
+      if (!isSameDatabasePath(path.dirname(registered.path), sessionsDir)) {
         continue;
       }
       const index = parseIndex(path.basename(registered.path));
@@ -259,7 +270,11 @@ export function resolveSqliteTargetFromSessionStorePath(
     const registeredDatabases =
       options.registeredDatabases ??
       listOpenClawRegisteredAgentDatabases(options.env ? { env: options.env } : {});
-    const registeredOwners = resolveRegisteredOwners(unsuffixedTarget.path, registeredDatabases);
+    const registeredOwners = resolveRegisteredOwners(
+      unsuffixedTarget.path,
+      registeredDatabases,
+      options.isSameDatabasePath ?? isSameOpenClawAgentDatabasePath,
+    );
     const databaseOwner = resolveDatabaseOwner(unsuffixedTarget.path);
     const configuredDefaultAgentId = normalizeAgentId(
       options.defaultAgentId ?? LEGACY_IMPLICIT_AGENT_ID,

--- a/src/config/sessions/targets-collision.ts
+++ b/src/config/sessions/targets-collision.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import {
-  isSameOpenClawAgentDatabasePath,
+  createOpenClawAgentDatabasePathMatcher,
   listOpenClawRegisteredAgentDatabases,
 } from "../../state/openclaw-agent-db-registry.js";
 import {
@@ -56,8 +56,11 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
       unsuffixedOwnerAgentId?: string;
     }>
   >();
+  // Alias targets can change between calls. Reuse prepared identities only for this
+  // synchronous dedupe invocation so collision ownership never relies on stale paths.
+  const isSameDatabasePath = createOpenClawAgentDatabasePathMatcher();
   const resolvePhysicalGroupKey = <T>(groups: ReadonlyMap<string, T>, pathname: string) =>
-    [...groups.keys()].find((candidate) => isSameOpenClawAgentDatabasePath(candidate, pathname)) ??
+    [...groups.keys()].find((candidate) => isSameDatabasePath(candidate, pathname)) ??
     path.resolve(pathname);
   for (const target of targets) {
     const resolvedUnsuffixedPath = path.resolve(
@@ -68,6 +71,7 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
       defaultAgentId: options.defaultAgentId,
       env: options.env,
       registeredDatabases,
+      isSameDatabasePath,
     });
     const sqlitePath = resolvePhysicalGroupKey(grouped, resolved.path ?? target.storePath);
     const group = grouped.get(sqlitePath) ?? [];
@@ -125,7 +129,7 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
     const registeredOwners = [
       ...new Set(
         registeredDatabases
-          .filter((entry) => isSameOpenClawAgentDatabasePath(entry.path, sqlitePath))
+          .filter((entry) => isSameDatabasePath(entry.path, sqlitePath))
           .map((entry) => normalizeAgentId(entry.agentId)),
       ),
     ];

--- a/src/config/sessions/targets-dedupe.test.ts
+++ b/src/config/sessions/targets-dedupe.test.ts
@@ -1,0 +1,81 @@
+import { realpathSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { withTempHome } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+import { dedupeSessionStoreTargetsBySqliteTarget } from "./targets.js";
+
+describe("session store target dedupe", () => {
+  it.runIf(process.platform !== "win32")(
+    "refreshes aliased SQLite locators between dedupe calls",
+    async () => {
+      await withTempHome(async (home) => {
+        const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(home, ".openclaw") };
+        const realDir = path.join(home, "real-stores");
+        const aliasDir = path.join(home, "alias-stores");
+        await fs.mkdir(realDir, { recursive: true });
+        await fs.symlink(realDir, aliasDir, "dir");
+        const targets = [
+          { agentId: "main", storePath: path.join(realDir, "shared.sqlite") },
+          { agentId: "ops", storePath: path.join(aliasDir, "shared.sqlite") },
+        ];
+        const diagnostics: string[] = [];
+
+        expect(
+          dedupeSessionStoreTargetsBySqliteTarget(targets, {
+            defaultAgentId: "main",
+            env,
+            onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
+          }),
+        ).toEqual([targets[0]]);
+        expect(diagnostics).toContainEqual(expect.stringContaining('ignored owner(s): "ops"'));
+
+        const otherDir = path.join(home, "other-stores");
+        await fs.mkdir(otherDir);
+        await fs.unlink(aliasDir);
+        await fs.symlink(otherDir, aliasDir, "dir");
+        expect(
+          dedupeSessionStoreTargetsBySqliteTarget(targets, { defaultAgentId: "main", env }),
+        ).toHaveLength(2);
+      });
+    },
+  );
+
+  it("prepares each SQLite identity once during one dedupe pass", async () => {
+    await withTempHome(async (home) => {
+      const realHome = realpathSync(home);
+      const targets = Array.from({ length: 29 }, (_, index) => ({
+        agentId: `agent-${index}`,
+        storePath: path.join(
+          realHome,
+          ".openclaw",
+          "agents",
+          `agent-${index}`,
+          "sessions",
+          "sessions.json",
+        ),
+      }));
+      const databaseDirs = new Set(
+        targets.map((target) => path.join(path.dirname(path.dirname(target.storePath)), "agent")),
+      );
+      await Promise.all(
+        [...databaseDirs].map((databaseDir) => fs.mkdir(databaseDir, { recursive: true })),
+      );
+      const realpathNative = vi.spyOn(realpathSync, "native");
+      try {
+        expect(
+          dedupeSessionStoreTargetsBySqliteTarget([...targets, ...targets], {
+            defaultAgentId: targets[0]!.agentId,
+          }),
+        ).toEqual(targets);
+        const preparedPaths = realpathNative.mock.calls.flatMap(([pathname]) =>
+          typeof pathname === "string" && databaseDirs.has(pathname) ? [pathname] : [],
+        );
+        expect(preparedPaths).toHaveLength(targets.length);
+        expect(new Set(preparedPaths).size).toBe(preparedPaths.length);
+      } finally {
+        realpathNative.mockRestore();
+      }
+    });
+  });
+});

--- a/src/config/sessions/targets.test.ts
+++ b/src/config/sessions/targets.test.ts
@@ -13,7 +13,6 @@ import { resolveStorePath } from "./paths.js";
 import { listSessionEntriesReadOnly, replaceSessionEntry } from "./session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import {
-  dedupeSessionStoreTargetsBySqliteTarget,
   resolveAgentSessionStoreTargetsSync,
   resolveAllAgentSessionStoreCandidateTargetsSync,
   resolveAllAgentSessionStoreTargetsSync,

--- a/src/config/sessions/targets.test.ts
+++ b/src/config/sessions/targets.test.ts
@@ -1,9 +1,8 @@
 // Session target tests cover persisted channel targets for sessions.
-import { realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   registerOpenClawAgentDatabase,
   unregisterOpenClawAgentDatabase,
@@ -338,88 +337,6 @@ describe("resolveSessionStoreTargets", () => {
           env,
         }).path,
       ).toBe(path.join(home, "shared.worker.2.sqlite"));
-    });
-  });
-
-  it.runIf(process.platform !== "win32")(
-    "deduplicates aliased SQLite locators by physical identity",
-    async () => {
-      await withTempHome(async (home) => {
-        const stateDir = path.join(home, ".openclaw");
-        const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
-        const realDir = path.join(home, "real-stores");
-        const aliasDir = path.join(home, "alias-stores");
-        await fs.mkdir(realDir, { recursive: true });
-        await fs.symlink(realDir, aliasDir, "dir");
-        const diagnostics: string[] = [];
-
-        expect(
-          dedupeSessionStoreTargetsBySqliteTarget(
-            [
-              { agentId: "main", storePath: path.join(realDir, "shared.sqlite") },
-              { agentId: "ops", storePath: path.join(aliasDir, "shared.sqlite") },
-            ],
-            {
-              defaultAgentId: "main",
-              env,
-              onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
-            },
-          ),
-        ).toEqual([{ agentId: "main", storePath: path.join(realDir, "shared.sqlite") }]);
-        expect(diagnostics).toContainEqual(expect.stringContaining('ignored owner(s): "ops"'));
-
-        const otherDir = path.join(home, "other-stores");
-        await fs.mkdir(otherDir);
-        await fs.unlink(aliasDir);
-        await fs.symlink(otherDir, aliasDir, "dir");
-        expect(
-          dedupeSessionStoreTargetsBySqliteTarget(
-            [
-              { agentId: "main", storePath: path.join(realDir, "shared.sqlite") },
-              { agentId: "ops", storePath: path.join(aliasDir, "shared.sqlite") },
-            ],
-            { defaultAgentId: "main", env },
-          ),
-        ).toHaveLength(2);
-      });
-    },
-  );
-
-  it("prepares each SQLite identity once during one dedupe pass", async () => {
-    await withTempHome(async (home) => {
-      const realHome = realpathSync(home);
-      const targets = Array.from({ length: 29 }, (_, index) => ({
-        agentId: `agent-${index}`,
-        storePath: path.join(
-          realHome,
-          ".openclaw",
-          "agents",
-          `agent-${index}`,
-          "sessions",
-          "sessions.json",
-        ),
-      }));
-      const databaseDirs = new Set(
-        targets.map((target) => path.join(path.dirname(path.dirname(target.storePath)), "agent")),
-      );
-      await Promise.all(
-        [...databaseDirs].map((databaseDir) => fs.mkdir(databaseDir, { recursive: true })),
-      );
-      const realpathNative = vi.spyOn(realpathSync, "native");
-      try {
-        expect(
-          dedupeSessionStoreTargetsBySqliteTarget([...targets, ...targets], {
-            defaultAgentId: targets[0]!.agentId,
-          }),
-        ).toEqual(targets);
-        const preparedPaths = realpathNative.mock.calls.flatMap(([pathname]) =>
-          typeof pathname === "string" && databaseDirs.has(pathname) ? [pathname] : [],
-        );
-        expect(preparedPaths).toHaveLength(targets.length);
-        expect(new Set(preparedPaths).size).toBe(preparedPaths.length);
-      } finally {
-        realpathNative.mockRestore();
-      }
     });
   });
 

--- a/src/config/sessions/targets.test.ts
+++ b/src/config/sessions/targets.test.ts
@@ -1,8 +1,9 @@
 // Session target tests cover persisted channel targets for sessions.
+import { realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   registerOpenClawAgentDatabase,
   unregisterOpenClawAgentDatabase,
@@ -366,9 +367,61 @@ describe("resolveSessionStoreTargets", () => {
           ),
         ).toEqual([{ agentId: "main", storePath: path.join(realDir, "shared.sqlite") }]);
         expect(diagnostics).toContainEqual(expect.stringContaining('ignored owner(s): "ops"'));
+
+        const otherDir = path.join(home, "other-stores");
+        await fs.mkdir(otherDir);
+        await fs.unlink(aliasDir);
+        await fs.symlink(otherDir, aliasDir, "dir");
+        expect(
+          dedupeSessionStoreTargetsBySqliteTarget(
+            [
+              { agentId: "main", storePath: path.join(realDir, "shared.sqlite") },
+              { agentId: "ops", storePath: path.join(aliasDir, "shared.sqlite") },
+            ],
+            { defaultAgentId: "main", env },
+          ),
+        ).toHaveLength(2);
       });
     },
   );
+
+  it("prepares each SQLite identity once during one dedupe pass", async () => {
+    await withTempHome(async (home) => {
+      const realHome = realpathSync(home);
+      const targets = Array.from({ length: 29 }, (_, index) => ({
+        agentId: `agent-${index}`,
+        storePath: path.join(
+          realHome,
+          ".openclaw",
+          "agents",
+          `agent-${index}`,
+          "sessions",
+          "sessions.json",
+        ),
+      }));
+      const databaseDirs = new Set(
+        targets.map((target) => path.join(path.dirname(path.dirname(target.storePath)), "agent")),
+      );
+      await Promise.all(
+        [...databaseDirs].map((databaseDir) => fs.mkdir(databaseDir, { recursive: true })),
+      );
+      const realpathNative = vi.spyOn(realpathSync, "native");
+      try {
+        expect(
+          dedupeSessionStoreTargetsBySqliteTarget([...targets, ...targets], {
+            defaultAgentId: targets[0]!.agentId,
+          }),
+        ).toEqual(targets);
+        const preparedPaths = realpathNative.mock.calls.flatMap(([pathname]) =>
+          typeof pathname === "string" && databaseDirs.has(pathname) ? [pathname] : [],
+        );
+        expect(preparedPaths).toHaveLength(targets.length);
+        expect(new Set(preparedPaths).size).toBe(preparedPaths.length);
+      } finally {
+        realpathNative.mockRestore();
+      }
+    });
+  });
 
   it("retains a shared-store claimant when the physical owner left the roster", async () => {
     await withTempHome(async (home) => {

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -11,7 +11,7 @@ import {
 } from "../../routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
-  isSameOpenClawAgentDatabasePath,
+  createOpenClawAgentDatabasePathMatcher,
   listOpenClawRegisteredAgentDatabases,
 } from "../../state/openclaw-agent-db-registry.js";
 import { resolveStateDir } from "../paths.js";
@@ -126,6 +126,7 @@ export function listKnownSessionStoreAgentIds(
 ): string[] {
   const env = params.env ?? process.env;
   const defaultAgentId = resolveDefaultAgentId(cfg);
+  const isSameDatabasePath = createOpenClawAgentDatabasePathMatcher();
   const ids = new Set(listConfiguredSessionStoreAgentIds(cfg));
   if (!isPerAgentSessionStoreConfig(cfg.session?.store)) {
     const storePath = resolveStorePath(cfg.session?.store, { agentId: defaultAgentId, env });
@@ -133,6 +134,7 @@ export function listKnownSessionStoreAgentIds(
       agentId: defaultAgentId,
       defaultAgentId,
       env,
+      isSameDatabasePath,
     });
     // Fixed stores can outlive their registry row. Preserve the database-recorded
     // owner so combined views and reapers do not drop a retired agent's live sessions.
@@ -173,8 +175,9 @@ export function listKnownSessionStoreAgentIds(
       agentId,
       defaultAgentId,
       env,
+      isSameDatabasePath,
     }).path;
-    if (isSameOpenClawAgentDatabasePath(registered.path, expectedPath)) {
+    if (isSameDatabasePath(registered.path, expectedPath)) {
       ids.add(agentId);
     }
   }

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -528,10 +528,10 @@ function resolveAgentDatabasePathIdentity(pathname: string): AgentDatabasePathId
   }
 }
 
-/** Compare two database locators by canonical filesystem identity when available. */
-export function isSameOpenClawAgentDatabasePath(left: string, right: string): boolean {
-  const leftIdentity = resolveAgentDatabasePathIdentity(left);
-  const rightIdentity = resolveAgentDatabasePathIdentity(right);
+function areSameAgentDatabasePathIdentities(
+  leftIdentity: AgentDatabasePathIdentity,
+  rightIdentity: AgentDatabasePathIdentity,
+): boolean {
   if (leftIdentity.lexicalPath === rightIdentity.lexicalPath) {
     return true;
   }
@@ -564,6 +564,32 @@ export function isSameOpenClawAgentDatabasePath(left: string, right: string): bo
       leftIdentity.device === rightIdentity.device &&
       leftIdentity.inode === rightIdentity.inode) ||
     (sameMissingParent && sameMissingSuffix)
+  );
+}
+
+/** Create a synchronous-operation matcher that prepares each exact locator once. */
+export function createOpenClawAgentDatabasePathMatcher(): (left: string, right: string) => boolean {
+  const identities = new Map<string, AgentDatabasePathIdentity>();
+  const resolveIdentity = (pathname: string): AgentDatabasePathIdentity => {
+    const lexicalPath = anchorDatabasePathWithoutNormalizing(pathname);
+    const cached = identities.get(lexicalPath);
+    if (cached) {
+      return cached;
+    }
+    // Cache successes only. Filesystem errors must be retried if the caller recovers.
+    const identity = resolveAgentDatabasePathIdentity(lexicalPath);
+    identities.set(lexicalPath, identity);
+    return identity;
+  };
+  return (left, right) =>
+    areSameAgentDatabasePathIdentities(resolveIdentity(left), resolveIdentity(right));
+}
+
+/** Compare two database locators by canonical filesystem identity when available. */
+export function isSameOpenClawAgentDatabasePath(left: string, right: string): boolean {
+  return areSameAgentDatabasePathIdentities(
+    resolveAgentDatabasePathIdentity(left),
+    resolveAgentDatabasePathIdentity(right),
   );
 }
 

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -29,6 +29,7 @@ import {
 } from "./openclaw-agent-db-lease.js";
 import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.js";
 import {
+  createOpenClawAgentDatabasePathMatcher,
   isSameOpenClawAgentDatabasePath,
   registerOpenClawAgentDatabase,
   unregisterOpenClawAgentDatabase,
@@ -1944,6 +1945,59 @@ describe("openclaw agent database", () => {
         .map((entry) => entry.path),
     ).toEqual([defaultDatabase.path, relocated.path].toSorted());
   });
+
+  it.runIf(process.platform !== "win32")(
+    "reuses successful identities only within one path matcher",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const realDir = path.join(stateDir, "cached-real");
+      const aliasDir = path.join(stateDir, "cached-alias");
+      const otherDir = path.join(stateDir, "cached-other");
+      fs.mkdirSync(realDir, { recursive: true });
+      fs.mkdirSync(otherDir);
+      fs.symlinkSync(realDir, aliasDir, "dir");
+      const realPath = path.join(realDir, "worker.sqlite");
+      const aliasPath = path.join(aliasDir, "worker.sqlite");
+      fs.writeFileSync(realPath, "live");
+
+      const realpathNative = vi.spyOn(fs.realpathSync, "native");
+      try {
+        const matchesPath = createOpenClawAgentDatabasePathMatcher();
+        expect(matchesPath(realPath, aliasPath)).toBe(true);
+        expect(matchesPath(aliasPath, realPath)).toBe(true);
+        const resolvedLocators = realpathNative.mock.calls.flatMap(([pathname]) =>
+          pathname === realPath || pathname === aliasPath ? [pathname] : [],
+        );
+        expect(resolvedLocators.toSorted()).toEqual([aliasPath, realPath].toSorted());
+      } finally {
+        realpathNative.mockRestore();
+      }
+
+      fs.unlinkSync(aliasDir);
+      fs.symlinkSync(otherDir, aliasDir, "dir");
+      expect(createOpenClawAgentDatabasePathMatcher()(realPath, aliasPath)).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "retries path resolution failures within one matcher",
+    () => {
+      const stateDir = fs.realpathSync(createTempStateDir());
+      const loopPath = path.join(stateDir, "loop.sqlite");
+      fs.symlinkSync("loop.sqlite", loopPath);
+      expect(() => isSameOpenClawAgentDatabasePath(loopPath, loopPath)).toThrow(
+        expect.objectContaining({ code: "ELOOP" }),
+      );
+      const matchesPath = createOpenClawAgentDatabasePathMatcher();
+      expect(() => matchesPath(loopPath, loopPath)).toThrow(
+        expect.objectContaining({ code: "ELOOP" }),
+      );
+
+      fs.unlinkSync(loopPath);
+      fs.writeFileSync(loopPath, "recovered");
+      expect(matchesPath(loopPath, loopPath)).toBe(true);
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "resolves registered owners through symlinked database paths",


### PR DESCRIPTION
Closes #120074

AI-assisted PR (written with Claude). Diagnosis came from a CPU profile of a live
multi-agent gateway; the reasoning and evidence are reproduced below.

## What Problem This Solves

Resolves a problem where operators running several agents in one gateway see the
assistant appear to "type very slowly", and every other agent and channel in that
process stalls at the same time. The model has already produced the whole answer;
the gateway is pinning a core and cannot flush it to the client.

On a gateway whose state dirs hold 29 agent databases, one ordinary web-chat turn
with no tool calls spent 14.9 s in the model and then **38.1 s** blocked before the
run finalized. A single-agent gateway spent 3.7 s for the same prompt. The stall
scales with the number of agent databases, so it gets worse as an operator adds
agents.

## Why This Change Was Made

`dedupeSessionStoreTargetsBySqliteTarget` compares each session-store path against
every group key found so far, and `isSameOpenClawAgentDatabasePath` resolves the
filesystem identity of *both* sides on every comparison — a `statSync` plus a
`realpathSync.native` each. The helper runs twice per target (physical and logical
grouping) and again when mapping registered owners, so the syscalls grow
quadratically in the number of targets.

Two changes:

1. **An optional per-operation identity cache**, created inside
   `dedupeSessionStoreTargetsBySqliteTarget` and dropped when that call returns, so
   distinct paths are resolved once per pass instead of once per comparison. Entries
   are keyed by the anchored `lexicalPath` the identity itself carries, not by the
   caller's spelling, and only successful resolutions are stored — a throw (EACCES,
   ELOOP, a transient EMFILE) must not stick for the rest of the pass.
2. **Answer equal anchored paths after resolving one of them.** Both spellings name
   the same filesystem object, so the first resolution already settles the
   comparison and the second is redundant.

The cache is deliberately **not** module-level. Identities read live filesystem
state, and callers do mutate that state between resolutions of the same path
(`registerOpenClawAgentDatabase` runs after archive/migration work in the same
synchronous region), so a longer-lived memo could hand back a stale ENOENT-shaped
identity and bypass the imports-directory containment check. Scoping it to one
dedupe pass keeps that class of staleness out by construction.

### Correcting an earlier revision of this PR

An earlier head compared the two anchored spellings *before* resolving either one,
and this description claimed that was "the same predicate with no state added".
That was wrong, and the ClawSweeper review was right to block on it.

It is the same predicate only on the success path. For a self-referential symlink
or an unreadable locator, resolution is what raises ELOOP or EACCES — the resolver
rethrows everything that is not ENOENT — so answering from the strings alone
turned a surfaced filesystem error into a successful self-match. Existing coverage
depends on that propagation.

`2227b959` resolves the left locator first and only then answers equal
anchored paths. The redundant half is still skipped and the memo still makes the
remaining half free on repeats, so the saving is intact; what changed is that a
broken locator now raises as it did before. `openclaw-agent-db.test.ts` asserts the
contract first: a self-equal ELOOP link must throw, with and without a cache.
Reverting only the production change fails exactly that assertion
(`expected function to throw an error, but it didn't`) and nothing else.

**On `AGENTS.md` "do not fix repeated request-time discovery with scattered
caches":** I read that line as aimed at long-lived caches that paper over a
canonical fact resolved too late, and I think this qualifies for the neighbouring
allowance — "process-local metadata caches ok when lifecycle-owned and
bounded/single-slot". The change also directly serves "runtime hot paths: no
freshness polling (`stat`/`realpath`/JSON reread/hash)".

**Named follow-up (Pathfinder).** This makes each call much cheaper; it does not
reduce how often the call happens. Reconciling profile time against the measured
per-call cost puts that at roughly a thousand
`resolveAllAgentSessionStoreTargetsSync` calls inside a single turn, which still
looks high for "which session stores exist". I did not chase it here because it
needs live instrumentation rather than a change to this function, and this fix
stands on its own.

While measuring I also found that `resolveSessionStoreDiscoveryState` seeds its
configured targets through `resolveSessionStoreTargets({allAgents:true})`, which
already dedupes, and the only caller dedupes again over configured plus discovered
targets — so the pass runs twice over an overlapping set. Removing the inner dedupe
is behavior-identical (verified: same 22 targets on the live config), but it is
worth only a small share of wall time here, so I left it out rather than pad this
PR with a refactor.

## User Impact

Operators running several agents in one gateway get most of the post-turn stall
back, and the gateway stays responsive to other agents, channels, and the Control
UI while a turn finalizes. The benefit grows with the number of agent databases;
single-agent setups are unaffected in practice.

No config, API, or schema changes. `isSameOpenClawAgentDatabasePath` gains an
optional third parameter; all existing call sites are untouched and behave as
before.

## Evidence

Raw artifacts and the harness that produced them:
https://gist.github.com/sercada/7602a4ebd27b3ed69e0e97c56274a9a0

### Post-turn finalization, real turns, at this exact head

The review asked for an ordinary multi-agent turn progressing from model completion
to run finalization on the exact head. This is that.

`mock-model.mjs` is a minimal OpenAI-compatible endpoint whose only real job is to
stamp the wall-clock moment its response finished flushing; the harness stamps when
each `openclaw agent` turn returned. **post-model = turn returned − model flushed**,
which is the gateway's own finalization work. Both stamps use `Date.now()`: `hrtime`
is monotonic per process, so a stamp taken in the mock would not be comparable with
one taken in the CLI runner. The interval includes one loopback WebSocket round trip,
which is sub-millisecond here.

Median of 8 turns each, same machine, same fixtures, builds identified by
`dist/build-info.json`:

| agents | merge base `3bc188ef` | this head `adb16822` |
| --- | --- | --- |
| 22 | 236 ms (213–346) | **146 ms** (139–233) |
| 40 | 415 ms (405–498) | **153 ms** (138–290) |

The shape is the claim. After the change, finalization is flat in agent count
(146 → 153 ms); before it, it grows (236 → 415 ms). The attributable difference goes
90 ms → 262 ms, **2.91x for 1.8x the agents** — the quadratic term this PR removes.

Per-turn rows, including a slot for any turn that failed to reach the model, are in
`turn-proof-*.json` in the gist. No turn failed in these runs.

This does not reproduce the 38 s production stall: that gateway had a live provider,
a much larger real store, and roughly a thousand discovery calls per turn. What it
shows is the same interval, on the same code path, moving in the predicted direction
and losing its dependence on agent count.

### Gateway CPU profile, same builds

Two ephemeral gateways, one per build, each on an isolated `OPENCLAW_STATE_DIR`
and a free port, both reading a state dir shaped like a real multi-agent install (22 agents, per-agent stores at
`<state>/agents/<id>/sessions/sessions.json`, `agent_databases` seeded). Each
gateway process was profiled through the inspector while it served the same
workload of 8 `openclaw sessions list --all-agents` calls. The CLI runs in a
separate process, so its startup never enters the gateway profile.

Self time is attributed to the dedupe chain by walking each sample's ancestry to a
`isSameOpenClawAgentDatabasePath` / `resolveAgentDatabasePathIdentity` /
`dedupeSessionStoreTargetsBySqliteTarget` / `resolvePhysicalGroupKey` frame, since
`realpath` self time only counts once you know which caller asked for it.

| build | `dist/build-info.json` commit | dedupe chain | share of busy CPU |
| --- | --- | --- | --- |
| merge base | `3bc188efe55eede47c13f97e9ab172754a0bed9e` | 0.17 s | 1.1% |
| **this head** | `adb16822dc79f9f1b6905c1701ac247fafe2010b` | **0.02 s** | **0.1%** |

Busy CPU over the window was comparable (15.52 s vs 15.57 s); this workload is
dominated by gateway startup and store I/O, so the chain is a small share of it in
both builds. What the run demonstrates is that the chain shrinks ~8x inside a real
gateway process at this head, not that this workload reproduces the 38 s stall —
that path is post-turn finalization, which needs a model provider.

### Per-call cost, same fixture, both builds

`resolveAllAgentSessionStoreTargetsSync` loaded from each built `dist` and driven
against **one shared state dir**, so the only difference is the code:

| agents / targets | merge base `3bc188ef` | this head `adb16822` | |
| --- | --- | --- | --- |
| 22 | 22.51 ms/call | **1.83 ms/call** | 12.3x |
| 40 | 86.99 ms/call | **2.65 ms/call** | 32.8x |

The scaling is the point. Going from 22 to 40 targets (1.8x) costs the merge base
3.86x — the quadratic term. At this head it costs 1.45x. The patch changes the shape
of the curve, not just the constant.

Two fixture details are load-bearing: the store must sit at
`<state>/agents/<id>/sessions/sessions.json` (putting it under `agent/` routes
through `resolveCustomStoreSqlitePath`, which opens a sqlite handle per target per
pass — work the real layout never does), and `agent_databases` must be seeded,
because the registered-owner filter is skipped entirely against an empty registry
and hides half the resolutions. The registry also has to be written into the table
the gateway itself created; hand-written DDL drifts (`size_bytes` is nullable) and
the gateway then refuses to start.

### Original diagnosis

CPU profile plus precise coverage collected over the *same* 180 s window on a live
gateway, containing one webchat turn with 0 tool calls that showed a 38.1 s
post-model stall. Of 40.8 s non-idle CPU in that window, **28.95 s** is self time in
`realpath`/`stat` under one chain:

```
12.56s  realpath <- resolveAgentDatabasePathIdentity <- isSameOpenClawAgentDatabasePath
        <- resolvePhysicalGroupKey
11.58s  realpath <- ... <- dedupeSessionStoreTargetsBySqliteTarget
 2.50s  statSync <- ... <- resolvePhysicalGroupKey
 2.31s  statSync <- ... <- dedupeSessionStoreTargetsBySqliteTarget
```

`areMissingSuffixAliases` and `resolveDanglingSymlinkTargetPath` recorded zero
calls in that window, so this is plain path resolution, not the alias-probe path.

**Methodology caveat worth knowing.** `Profiler.startPreciseCoverage` under-reports
invocation counts for functions V8 has optimized. On the live gateway it reported
1,690 resolutions for a window whose profile time implies far more. Short benchmark
runs stay in the interpreter and count correctly, which is why per-pass figures are
trustworthy while live per-turn counts are derived from profile time divided by
measured per-call cost instead.

### Checks

A later commit (`adb16822`) makes `AgentDatabasePathIdentityCache` and
`AgentDatabasePathIdentity` module-local again. Knip's all-exports lane failed on the
previous head because nothing names either type — callers take the cache from
`createAgentDatabasePathIdentityCache()` and let inference carry it — and
`AgentDatabasePathIdentity` was module-local before this branch touched it. Both
tables above were re-measured at `adb16822`, not carried over.

```
pnpm deadcode:full                                                clean
node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts   96 passed, 6 skipped
node scripts/run-vitest.mjs src/config/sessions/targets.test.ts   38 passed
node scripts/run-tsgo.mjs -p tsconfig.core.json                   clean
node scripts/run-oxlint.mjs <changed files>                       clean
oxfmt --check <changed files>                                     clean
git diff --check                                                  clean
pnpm build                                                        ok (both builds above)
```

Rebased onto `origin/main`; the branch is no longer behind.

**Proof gaps, stated plainly.** `scripts/check-changed.mjs` delegates to Crabbox,
which is not reachable from this environment, so I ran the local typecheck, lint and
format lanes instead per the `AGENTS.md` fallback rule. I could not run the
`autoreview` skill — it is not available here. Full `pnpm test` was not run; the two
suites covering the changed surface were. The gateway run above exercises the
changed path in a real gateway process at this head, but it does not reproduce the
38 s post-turn stall, which needs a live model provider; the 38 s figure remains a
production observation rather than something reproduced here.
