### PR TITLE
test(file-transfer): cover final symlink write policy

### DIFF
--- a/extensions/file-transfer/src/node-host/file-write.test.ts
+++ b/extensions/file-transfer/src/node-host/file-write.test.ts
@@ -164,7 +164,7 @@ describe("handleFileWrite — parent directory handling", () => {
 });
 
 describe("handleFileWrite — symlink protection", () => {
-  it("refuses to write through an existing symlink (lstat)", async () => {
+  it("rejects a final symlink by default with the canonical target", async () => {
     const real = path.join(tmpRoot, "real.txt");
     const link = path.join(tmpRoot, "link.txt");
     await fs.writeFile(real, "untouched");
@@ -175,8 +175,24 @@ describe("handleFileWrite — symlink protection", () => {
       contentBase64: b64("evil"),
       overwrite: true,
     });
+    expectFailure(r, "SYMLINK_REDIRECT");
+    expect(r.ok ? null : r.canonicalPath).toBe(real);
+    expect(await fs.readFile(real, "utf-8")).toBe("untouched");
+  });
+
+  it("refuses to write through a final symlink when followSymlinks=true", async () => {
+    const real = path.join(tmpRoot, "real.txt");
+    const link = path.join(tmpRoot, "link.txt");
+    await fs.writeFile(real, "untouched");
+    await fs.symlink(real, link);
+
+    const r = await handleFileWrite({
+      path: link,
+      contentBase64: b64("evil"),
+      overwrite: true,
+      followSymlinks: true,
+    });
     expectFailure(r, "SYMLINK_TARGET_DENIED");
-    // The original file must be unchanged.
     expect(await fs.readFile(real, "utf-8")).toBe("untouched");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the file-write regression suite expected the pre-fs-safe 0.5 final-symlink error path. The stale assertion fails against current behavior and does not separately cover the explicit `followSymlinks: true` path.

## Why This Change Was Made

The default final-symlink test now expects `SYMLINK_REDIRECT` and the canonical target path. A separate explicit-follow test proves the final leaf guard still returns `SYMLINK_TARGET_DENIED` and leaves the target unchanged. No production code changes.

## User Impact

No runtime behavior changes. Maintainers regain accurate regression coverage for the two distinct final-symlink write policies.

## Evidence

- Baseline: `node scripts/run-vitest.mjs extensions/file-transfer/src/node-host/file-write.test.ts` failed 1 of 25 tests because the handler returned `SYMLINK_REDIRECT` while the stale test expected `SYMLINK_TARGET_DENIED`.
- Updated focused suite: the same repo-wrapper command passed 26 of 26 tests.
- Direct dependency contract: `@openclaw/fs-safe` v0.5.2 tag commit `32759e8923a121307d499c75c4e771c7307cf828` returns the lexical write path for explicit-follow mode, while reject mode throws a symlink error carrying the canonical path when the two differ ([source](https://github.com/openclaw/fs-safe/blob/v0.5.2/src/absolute-path.ts#L376-L407)). The OpenClaw handler maps those two paths to the assertions covered here.
- `./node_modules/.bin/oxfmt --check extensions/file-transfer/src/node-host/file-write.test.ts` passed.
- `git diff --check` passed.
- Blacksmith Testbox `tbx_01kzcs4zvx8jgc260m7g0j7vj3` passed changed-file guards, formatting, dependency pins, plugin boundaries, and dead-export checks. The extension-test typecheck then stopped on an untouched `extensions/qa-lab/src/live-timeout.test.ts:53` error; that file has no diff from `origin/main`.
- Production LOC: 0. Test LOC: +18/-2.
