### PR TITLE
fix(ui): make active-run steering reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI steering:** accept steer messages throughout active tool work instead of requiring token streaming, show definitive Gateway rejections as failed with their reason, and preserve exact steer intent across retries while labeling only ambiguous transport delivery as uncertain.
 - **Control UI read-only preferences:** keep personal preference edits browser-local without attempting unauthorized config writes or claiming server sync, preserve offline intent for a later authorized reconnect, and restore the current server value on local reset. Thanks @shakkernerd.
 - **Control UI owner handoff:** give browsers opened by host-issued dashboard and graphical onboarding links durable administrator access, including same-browser recovery from a limited credential, while keeping generic, Telegram, mobile, and ordinary scope-upgrade paths bounded. Thanks @shakkernerd.
 - **Control UI agent and skill permissions:** gate Agents, Skills, Skill Workshop, and delayed mutation dispatches by the current Gateway method catalog and operator scopes while preserving read-only browsing and legacy Gateway compatibility. Fixes #119176. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI steering:** accept steer messages throughout active tool work instead of requiring token streaming, show definitive Gateway rejections as failed with their reason, and preserve exact steer intent across retries while labeling only ambiguous transport delivery as uncertain.
 - **Control UI read-only preferences:** keep personal preference edits browser-local without attempting unauthorized config writes or claiming server sync, preserve offline intent for a later authorized reconnect, and restore the current server value on local reset. Thanks @shakkernerd.
 - **Control UI owner handoff:** give browsers opened by host-issued dashboard and graphical onboarding links durable administrator access, including same-browser recovery from a limited credential, while keeping generic, Telegram, mobile, and ordinary scope-upgrade paths bounded. Thanks @shakkernerd.
 - **Control UI agent and skill permissions:** gate Agents, Skills, Skill Workshop, and delayed mutation dispatches by the current Gateway method catalog and operator scopes while preserving read-only browsing and legacy Gateway compatibility. Fixes #119176. Thanks @shakkernerd.

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -107,20 +107,32 @@ describe("reply run registry", () => {
     expect(isReplyRunAbortableForCompaction("session-compact")).toBe(true);
   });
 
-  it("matches streaming owners only to their immutable originating leaf", () => {
+  it("matches injectable owners only to their immutable originating leaf", () => {
     const operation = createTestReplyOperation({ originatingLeafEntryId: "leaf-a" });
+    let stopped = false;
+    const queueMessage = vi.fn(async () => {});
     operation.setPhase("running");
     operation.attachBackend({
       kind: "embedded",
       cancel: () => {},
-      isStreaming: () => true,
-      queueMessage: async () => {},
+      isStreaming: () => false,
+      isStopped: () => stopped,
+      queueMessage,
     });
 
-    expect(replyRunRegistry.isStreamingFromOriginatingLeaf("agent:main:main", "leaf-a")).toBe(true);
-    expect(replyRunRegistry.isStreamingFromOriginatingLeaf("agent:main:main", "leaf-b")).toBe(
-      false,
-    );
+    expect(
+      replyRunRegistry.isMessageInjectableFromOriginatingLeaf("agent:main:main", "leaf-a"),
+    ).toBe(true);
+    expect(
+      replyRunRegistry.isMessageInjectableFromOriginatingLeaf("agent:main:main", "leaf-b"),
+    ).toBe(false);
+    expect(queueReplyRunMessage(operation.sessionId, "steer during tool work")).toBe(true);
+    expect(queueMessage).toHaveBeenCalledWith("steer during tool work");
+    stopped = true;
+    expect(
+      replyRunRegistry.isMessageInjectableFromOriginatingLeaf("agent:main:main", "leaf-a"),
+    ).toBe(false);
+    expect(queueReplyRunMessage(operation.sessionId, "late steer")).toBe(false);
   });
 
   it("records reply-operation progress without claiming embedded-run activity", () => {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -1216,28 +1216,40 @@ describe("reply run registry", () => {
     expect(queueMessage).toHaveBeenCalledWith("hello");
   });
 
-  it("refuses stale reply-run steering until real activity resumes", () => {
+  it("refuses stale injectable owners for admission and delivery until activity resumes", () => {
     vi.useFakeTimers();
     try {
       const queueMessage = vi.fn(async () => {});
       const operation = createTestReplyOperation({
         sessionId: "session-running",
+        originatingLeafEntryId: "leaf-a",
       });
       operation.attachBackend({
         kind: "embedded",
         cancel: vi.fn(),
-        isStreaming: () => true,
+        isStreaming: () => false,
+        isStopped: () => false,
         queueMessage,
       });
       operation.setPhase("running");
 
+      expect(
+        replyRunRegistry.isMessageInjectableFromOriginatingLeaf("agent:main:main", "leaf-a"),
+      ).toBe(true);
+
       vi.advanceTimersByTime(RUN_STALE_TAKEOVER_MS + 1);
 
+      expect(
+        replyRunRegistry.isMessageInjectableFromOriginatingLeaf("agent:main:main", "leaf-a"),
+      ).toBe(false);
       expect(queueReplyRunMessage("session-running", "stale")).toBe(false);
       expect(queueMessage).not.toHaveBeenCalled();
 
       operation.recordActivity();
 
+      expect(
+        replyRunRegistry.isMessageInjectableFromOriginatingLeaf("agent:main:main", "leaf-a"),
+      ).toBe(true);
       expect(queueReplyRunMessage("session-running", "fresh")).toBe(true);
       expect(queueMessage).toHaveBeenCalledWith("fresh");
     } finally {

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -240,7 +240,7 @@ type ReplyRunRegistry = {
   get(sessionKey: string): ReplyOperation | undefined;
   isActive(sessionKey: string): boolean;
   isStreaming(sessionKey: string): boolean;
-  isStreamingFromOriginatingLeaf(
+  isMessageInjectableFromOriginatingLeaf(
     sessionKey: string,
     originatingLeafEntryId: string | null,
   ): boolean;
@@ -1176,7 +1176,7 @@ export const replyRunRegistry: ReplyRunRegistry = {
     }
     return getAttachedBackend(operation)?.isStreaming() ?? false;
   },
-  isStreamingFromOriginatingLeaf(sessionKey, originatingLeafEntryId) {
+  isMessageInjectableFromOriginatingLeaf(sessionKey, originatingLeafEntryId) {
     const operation = this.get(sessionKey);
     if (
       !operation ||
@@ -1185,7 +1185,8 @@ export const replyRunRegistry: ReplyRunRegistry = {
     ) {
       return false;
     }
-    return getAttachedBackend(operation)?.isStreaming() ?? false;
+    const backend = getAttachedBackend(operation);
+    return backend ? isReplyBackendMessageInjectable(backend) : false;
   },
   abort(sessionKey) {
     const operation = this.get(sessionKey);

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -429,6 +429,15 @@ function isReplyBackendMessageInjectable(backend: ReplyBackendHandle): boolean {
   }
 }
 
+function isReplyOperationMessageInjectable(
+  operation: ReplyOperation,
+  backend: ReplyBackendHandle,
+): boolean {
+  // Admission and delivery must share freshness or a stale owner can waive the
+  // transcript-leaf fence and then reject the same steer during injection.
+  return !isReplyRunEvidenceStale(operation) && isReplyBackendMessageInjectable(backend);
+}
+
 /** Run work after an operation no longer owns its session lane. */
 export function runAfterReplyOperationClear(
   operation: ReplyOperation,
@@ -1186,7 +1195,7 @@ export const replyRunRegistry: ReplyRunRegistry = {
       return false;
     }
     const backend = getAttachedBackend(operation);
-    return backend ? isReplyBackendMessageInjectable(backend) : false;
+    return backend ? isReplyOperationMessageInjectable(operation, backend) : false;
   },
   abort(sessionKey) {
     const operation = this.get(sessionKey);
@@ -1295,12 +1304,7 @@ export function queueReplyRunMessage(
   if (!operation || operation.phase !== "running" || !backend?.queueMessage) {
     return false;
   }
-  // Steering into an evidence-dead run swallows the human message that would
-  // otherwise trigger stale takeover through normal reply admission.
-  if (isReplyRunEvidenceStale(operation)) {
-    return false;
-  }
-  if (!isReplyBackendMessageInjectable(backend)) {
+  if (!isReplyOperationMessageInjectable(operation, backend)) {
     return false;
   }
   if (resolveReplyBackendQueueMessageMismatch(backend, options)) {

--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -203,7 +203,10 @@ export async function admitChatSend(params: {
     const hasActiveSteeringOwner =
       p.queueMode === "steer" &&
       expectedLeafEntryId !== undefined &&
-      replyRunRegistry.isStreamingFromOriginatingLeaf(activeRunScopeKey, expectedLeafEntryId);
+      replyRunRegistry.isMessageInjectableFromOriginatingLeaf(
+        activeRunScopeKey,
+        expectedLeafEntryId,
+      );
     if (commitOutcome && expectedLeafEntryId !== undefined && !hasActiveSteeringOwner) {
       // Runtime session identity resolves through the canonical SQLite accessor;
       // legacy/reset-archive files are read-only history fallbacks, never send targets.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1358,7 +1358,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(context.addChatRun).not.toHaveBeenCalled();
   });
 
-  it("allows an explicit steer after its active owner advances the transcript leaf", async () => {
+  it("allows an explicit steer during injectable non-streaming tool work", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-moving-leaf-");
     await appendTranscriptMessage(transcriptScope(), {
       eventId: "current-leaf",
@@ -1377,7 +1377,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     operation.attachBackend({
       kind: "embedded",
       cancel: () => {},
-      isStreaming: () => true,
+      isStreaming: () => false,
+      isStopped: () => false,
       queueMessage: async () => {},
     });
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -33,6 +33,7 @@ import { waitForSessionTranscriptIndexReconcile } from "../../config/sessions/se
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import { getAgentRunContext } from "../../infra/agent-run-registry.js";
+import { RUN_STALE_TAKEOVER_MS } from "../../logging/diagnostic-run-activity.js";
 import { runExclusiveSessionLifecycleMutation } from "../../sessions/session-lifecycle-admission.js";
 import {
   disposeOpenClawAgentDatabaseByPath,
@@ -1402,6 +1403,54 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     expect(context.addChatRun).toHaveBeenCalledTimes(1);
     expect(mockState.lastDispatchOriginatingLeafEntryId).toBe("leaf-before-active-run-output");
+  });
+
+  it("rejects a moved-leaf steer when the non-streaming owner evidence is stale", async () => {
+    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-stale-owner-");
+    await appendTranscriptMessage(transcriptScope(), {
+      eventId: "current-leaf",
+      message: { role: "assistant", content: "stale tool work" },
+      now: 1,
+      parentId: null,
+    });
+    const { context, respond, send } = createChatRequestFixture();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const operation = replyRunRegistry.begin({
+      sessionKey: "main",
+      sessionId: mockState.sessionId,
+      resetTriggered: false,
+      originatingLeafEntryId: "leaf-before-stale-run-output",
+    });
+    operation.setPhase("running");
+    operation.attachBackend({
+      kind: "embedded",
+      cancel: () => {},
+      isStreaming: () => false,
+      isStopped: () => false,
+      queueMessage: async () => {},
+    });
+
+    try {
+      vi.advanceTimersByTime(RUN_STALE_TAKEOVER_MS + 1);
+      await send({
+        idempotencyKey: "idem-steer-stale-owner",
+        requestParams: {
+          expectedLeafEntryId: "leaf-before-stale-run-output",
+          queueMode: "steer",
+        },
+        waitFor: "none",
+      });
+    } finally {
+      operation.complete();
+      vi.useRealTimers();
+    }
+
+    expect(lastRespondCall(respond)).toEqual([
+      false,
+      undefined,
+      expect.objectContaining({ details: { reason: "active-leaf-changed" } }),
+    ]);
+    expect(context.addChatRun).not.toHaveBeenCalled();
   });
 
   it("rejects a stale explicit steer when a different leaf owns the active run", async () => {

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -578,7 +578,7 @@ suite.define(() => {
       await gateway.closeLatest(1006, "lost ack");
 
       const queue = page.locator(".chat-queue");
-      await queue.getByText("Needs review").waitFor({ timeout: 10_000 });
+      await queue.getByText("Delivery uncertain").waitFor({ timeout: 10_000 });
       expect(await gateway.getRequests("chat.send")).toHaveLength(1);
       await queue.locator(".chat-queue__retry").click();
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4286,6 +4286,8 @@ export const en: TranslationMap = {
   chat: {
     sendErrors: {
       activeLeafChanged: "The thread switched branches — review and resend.",
+      steerRunNoLongerActive:
+        "This steer still targets the previous run, but that run is no longer active.",
     },
     waitingForApproval: "Waiting for approval…",
     startupStatus: {
@@ -4712,7 +4714,7 @@ export const en: TranslationMap = {
         waitingForRun: "Waiting for current run",
         runningCommand: "Running command",
         waitingForReconnect: "Waiting for reconnect",
-        needsReview: "Needs review",
+        needsReview: "Delivery uncertain",
       },
       imageCount: "Image ({count})",
     },

--- a/ui/src/pages/chat/chat-send-actions.ts
+++ b/ui/src/pages/chat/chat-send-actions.ts
@@ -1,3 +1,4 @@
+import { GatewayRequestError } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { generateUUID } from "../../lib/uuid.ts";
@@ -27,12 +28,26 @@ import {
 } from "./chat-send-request.ts";
 import { listStoredChatOutboxes, storedChatOutboxScopeKey } from "./composer-persistence.ts";
 import { formatConnectError } from "./connect-error.ts";
+import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import {
   OFFLINE_QUEUE_STORAGE_ERROR,
   steerQueuedChatMessage as steerQueuedChatMessageLifecycle,
   type SteerSendDependencies,
 } from "./steer-lifecycle.ts";
 import { isInflightSteer } from "./steered-chip.ts";
+
+function applyChatSendError(state: ChatState, err: unknown, canApplyError: () => boolean): string {
+  const error = isActiveLeafChangedError(err)
+    ? t("chat.sendErrors.activeLeafChanged")
+    : formatConnectError(err);
+  if (canApplyError()) {
+    setChatError(state, error);
+    if (isActiveLeafChangedError(err)) {
+      void Promise.all([loadChatHistory(state), loadChatBranches(state)]);
+    }
+  }
+  return error;
+}
 
 export async function sendChatMessageWithGeneratedRunId(
   state: ChatState,
@@ -60,18 +75,8 @@ export async function sendChatMessageWithGeneratedRunId(
       ...(options.queueMode ? { queueMode: options.queueMode } : {}),
     });
   } catch (err) {
-    if (canApplyError()) {
-      setChatError(
-        state,
-        isActiveLeafChangedError(err)
-          ? t("chat.sendErrors.activeLeafChanged")
-          : formatConnectError(err),
-      );
-      if (isActiveLeafChangedError(err)) {
-        void Promise.all([loadChatHistory(state), loadChatBranches(state)]);
-      }
-    }
-    return null;
+    const error = applyChatSendError(state, err, canApplyError);
+    return err instanceof GatewayRequestError ? { kind: "rejected" as const, error } : null;
   }
 }
 
@@ -128,6 +133,25 @@ export async function retryQueuedChatMessage(host: ChatHost, id: string) {
     item.sendState === "sending" ||
     item.sendState === "waiting-model"
   ) {
+    return;
+  }
+  if (item.kind === "steered") {
+    if (!host.connected || !host.client || !hasAbortableSessionRun(host)) {
+      setChatError(host, t("chat.sendErrors.steerRunNoLongerActive"));
+      return;
+    }
+    const retry = updateQueuedMessage(host, id, (entry) => ({
+      ...entry,
+      sendAttempts: 0,
+      sendError: undefined,
+      sendRequestStartedAtMs: undefined,
+      sendState: "waiting-idle",
+    }));
+    if (!retry) {
+      setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
+      return;
+    }
+    await steerQueuedChatMessageLifecycle(host, id, steerSendDependencies);
     return;
   }
   let outbox = findStoredOutbox(host, item.id);

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -167,12 +167,17 @@ async function sendDetachedCommandMessage(
       runId: opts.runId,
     },
   );
-  const ok = ack?.status === "ok" || ack?.status === "started" || ack?.status === "in_flight";
+  const sendAck = ack && !("kind" in ack) ? ack : null;
+  const ok =
+    sendAck?.status === "ok" || sendAck?.status === "started" || sendAck?.status === "in_flight";
   if (!ok && !restoreFailedCommandComposer(host, opts.recovery)) {
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, opts.attachments));
   }
-  if (isTerminalFailureChatSendAck(ack) && submittedCommandScopeIsVisible(host, opts.recovery)) {
-    setChatError(host, formatTerminalChatSendAckError(ack, "detached"));
+  if (
+    isTerminalFailureChatSendAck(sendAck) &&
+    submittedCommandScopeIsVisible(host, opts.recovery)
+  ) {
+    setChatError(host, formatTerminalChatSendAckError(sendAck, "detached"));
   }
   if (ok) {
     const submittedScopeIsVisible = submittedCommandScopeIsVisible(host, opts.recovery);

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -8615,7 +8615,7 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main:main",
       agentId: "main",
     };
-    const host = makeHost({
+    const host = makeChatHost({
       requestHandlers: {
         "chat.send": (params: unknown) => {
           const payload = requireRecord(params, "definitive steer rejection payload");

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -8603,6 +8603,69 @@ describe("handleSendChat", () => {
     }
   });
 
+  it("keeps a definitive steer rejection retryable as the same steer", async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    const original = {
+      id: "rejected-durable-steer",
+      text: "tighten the plan",
+      createdAt: 1,
+      sendAttempts: 0,
+      sendRunId: "stable-steer-request",
+      sendState: "waiting-idle" as const,
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    };
+    const host = makeHost({
+      requestHandlers: {
+        "chat.send": (params: unknown) => {
+          const payload = requireRecord(params, "definitive steer rejection payload");
+          payloads.push(payload);
+          if (payloads.length === 1) {
+            throw new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "no active turn to steer",
+            });
+          }
+          return { status: "started", runId: payload.idempotencyKey };
+        },
+      },
+      chatRunId: "active-run",
+      chatQueue: [original],
+      sessionKey: original.sessionKey,
+    });
+    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+
+    await steerQueuedChatMessage(host, original.id);
+
+    expect(host.chatQueue).toEqual([
+      expect.objectContaining({
+        id: original.id,
+        kind: "steered",
+        sendError: "no active turn to steer",
+        sendRunId: original.sendRunId,
+        sendState: "failed",
+      }),
+    ]);
+    expect(host.lastError).toBe("no active turn to steer");
+
+    host.chatRunId = null;
+    await retryQueuedChatMessage(host, original.id);
+    expect(payloads).toHaveLength(1);
+    expect(host.lastError).toBe(
+      "This steer still targets the previous run, but that run is no longer active.",
+    );
+
+    host.chatRunId = "active-run";
+    await retryQueuedChatMessage(host, original.id);
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads.map((payload) => payload.idempotencyKey)).toEqual([
+      original.sendRunId,
+      original.sendRunId,
+    ]);
+    expect(payloads.map((payload) => payload.queueMode)).toEqual(["steer", "steer"]);
+  });
+
   it("removes queued steer indicators when chat.send returns terminal ok", async () => {
     const original = { id: "queued-1", text: "tighten the plan", createdAt: 1 };
     const host = makeChatHost({

--- a/ui/src/pages/chat/components/chat-composer-queue.ts
+++ b/ui/src/pages/chat/components/chat-composer-queue.ts
@@ -51,8 +51,8 @@ export function renderChatQueue(props: ChatQueueProps) {
 
 function renderChatQueueItem(item: ChatQueueItem, props: ChatQueueProps) {
   const stateLabel = sendStateLabel(item);
-  const steered = isSteeredQueueItem(item);
   const failed = item.sendState === "failed" || item.sendState === "unconfirmed";
+  const steered = isSteeredQueueItem(item) && !failed;
   const reconnecting = item.sendState === "waiting-reconnect";
   const busy = item.sendState === "executing-command" || isInflightSteer(item);
   const canSteer =

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -55,7 +55,7 @@ export type SteerSendDependencies = {
     message: string,
     attachments: ChatAttachment[] | undefined,
     options: { canApplyError: () => boolean; queueMode?: QueueMode; runId: string },
-  ) => Promise<ChatSendAck | null>;
+  ) => Promise<ChatSendAck | { kind: "rejected"; error: string } | null>;
 };
 
 export const OFFLINE_QUEUE_STORAGE_ERROR =
@@ -259,6 +259,7 @@ export async function sendQueuedChatMessageWithQueueMode(
   // replay the original queued turn after active-run admission may have succeeded.
   const claimed = updateQueuedMessage(host, id, (entry) => ({
     ...entry,
+    ...(isSteer ? { kind: "steered" as const } : {}),
     sendError: unconfirmedError,
     sendRunId: entry.sendRunId ?? generateUUID(),
     sendState: "unconfirmed",
@@ -297,7 +298,7 @@ export async function sendQueuedChatMessageWithQueueMode(
     return;
   }
   host.chatQueue = host.chatQueue.map((entry) => (entry.id === id ? pendingIndicator : entry));
-  const ack = await dependencies.sendChatMessage(
+  const result = await dependencies.sendChatMessage(
     host,
     message,
     attachments.length ? attachments : undefined,
@@ -319,7 +320,7 @@ export async function sendQueuedChatMessageWithQueueMode(
   }
   clearTransientQueuedMessageProjection(host, itemSessionKey, id, item.agentId);
   const itemStillVisible = visibleSessionMatches(host, itemSessionKey, item.agentId);
-  if (!ack) {
+  if (!result) {
     // A transport failure does not prove active-run admission was rejected. Keep the
     // durable row parked so reconnect cannot replay it as a separate turn.
     if (itemStillVisible) {
@@ -327,6 +328,18 @@ export async function sendQueuedChatMessageWithQueueMode(
     }
     return;
   }
+  if ("kind" in result && result.kind === "rejected") {
+    const failed = updateQueuedMessage(host, id, (entry) => ({
+      ...entry,
+      sendError: result.error,
+      sendState: "failed",
+    }));
+    if (itemStillVisible) {
+      setChatError(host, failed ? result.error : OFFLINE_QUEUE_STORAGE_ERROR);
+    }
+    return;
+  }
+  const ack = result;
   if (isTerminalFailureChatSendAck(ack)) {
     const restored = updateQueuedMessage(host, id, (entry) => ({
       ...item,

--- a/ui/src/pages/chat/steer-lifecycle.ts
+++ b/ui/src/pages/chat/steer-lifecycle.ts
@@ -55,8 +55,15 @@ export type SteerSendDependencies = {
     message: string,
     attachments: ChatAttachment[] | undefined,
     options: { canApplyError: () => boolean; queueMode?: QueueMode; runId: string },
-  ) => Promise<ChatSendAck | { kind: "rejected"; error: string } | null>;
+  ) => Promise<SteerChatSendResult>;
 };
+
+type RejectedSteerChatSend = { kind: "rejected"; error: string };
+type SteerChatSendResult = ChatSendAck | RejectedSteerChatSend | null;
+
+function isRejectedSteerChatSend(result: SteerChatSendResult): result is RejectedSteerChatSend {
+  return result !== null && "kind" in result && result.kind === "rejected";
+}
 
 export const OFFLINE_QUEUE_STORAGE_ERROR =
   "Could not store this message for reconnect. Free browser storage or reconnect before sending.";
@@ -328,7 +335,7 @@ export async function sendQueuedChatMessageWithQueueMode(
     }
     return;
   }
-  if ("kind" in result && result.kind === "rejected") {
+  if (isRejectedSteerChatSend(result)) {
     const failed = updateQueuedMessage(host, id, (entry) => ({
       ...entry,
       sendError: result.error,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users steering an active Control UI run during tool work could briefly see “Steered,” then have the message downgraded to the opaque “Needs review” state even though they had explicitly asked to steer. In the observed live failure, one unique steer changed from Steered to Needs review in about 3 seconds, the queue grew from 1 to 2, and no matching transcript entry appeared after 28 seconds.

## Why This Change Was Made

The Gateway treated token streaming as the proof that an active run could accept a message. Embedded runs remain steerable while tools execute even when token streaming is false, so admission could reject valid steering after the transcript leaf advanced. The shared reply-run owner now reports actual message-injection availability, preserving the existing originating-leaf fence and rejecting stopped, evidence-stale, or different-leaf owners. Admission and delivery use the same freshness-and-injectability predicate, so a stale owner cannot waive the leaf fence and then reject the same steer during injection.

The Control UI now distinguishes definitive Gateway rejection frames from ambiguous transport loss. Definitive rejections remain failed with the Gateway reason; transport loss remains parked as Delivery uncertain because admission may already have succeeded. Retrying either state preserves the durable steer kind, the original idempotency key, and steer queue mode, and refuses to turn the message into a normal chat turn when no active run exists.

The follow-up intentionally remains: **Gateway exact-run terminal evidence for restored outbox reconciliation**. The current shared API exposes active-run presence but not authoritative exact-run terminal evidence for every restored browser outbox.

## User Impact

Users can steer throughout active tool work. Errors now say whether the Gateway actually rejected the steer or whether delivery is merely uncertain, and Retry preserves the original steering intent instead of accidentally replaying it as a normal turn.

## Evidence

Focused proof on the final patch:

- `pnpm format` on the changed files: passed
- `pnpm ui:i18n:verify`: passed (`raw-copy: baseline entries=98`, `source: keys=4690`)
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-run-registry.test.ts`: 52 passed
- `node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts`: 163 passed
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts`: 269 passed
- `pnpm deadcode:unused-files`: production and full-tree scans passed with 0 entries
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`: clean, no accepted/actionable findings; overall correct at 0.97
- `git diff --check`: passed
- Exact-head hosted CI before the final stale-owner repair: 63 jobs passed, 0 failed; a new exact-head run is required after this repair.

The focused tests cover fresh non-streaming injectable tool work, evidence-stale owners at both registry and moved-leaf Gateway admission, stopped owners, different originating leaves, definitive Gateway rejection, active-run absence, preserved idempotency key and queue mode on retry, ambiguous transport parking, and no automatic normal-turn replay.

Codex contract evidence was checked directly at sibling Codex origin/main `842547640ee37451c2d66f7e01f8d762e07b336d`:

- `codex-rs/core/src/session/mod.rs:3983-4066`: active regular turns accept same-turn input atomically and independently of token streaming
- `codex-rs/app-server/src/request_processors/turn_processor.rs:910-1016`: no-active, expected-turn mismatch, and non-steerable turns are definitive request errors
- `codex-rs/core/tests/suite/pending_input.rs:497-510` and following: steering is accepted during wait/tool work

Production LOC: +89/-30 (net +59) | Tests: +149/-12 (net +137). The positive production delta adds the required transport-outcome distinction, durable steer retry ownership, and one canonical freshness-and-injectability owner predicate; no config, protocol, storage, or changelog surface changes.

Provenance: the streaming-only owner predicate was introduced in #119594 by PR/code author and merger @fuller-stack-dev on 2026-08-05 (squash `6d2ba0d5622fa7aa21a4770cb4c6fd93cae44e04`). This patch narrows that predicate to the canonical backend injection lifecycle rather than adding a parallel steering path.
