### PR TITLE
fix(e2e): restart upgrade survivor after migration convergence

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/gateway-start.sh
+++ b/scripts/e2e/lib/upgrade-survivor/gateway-start.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+upgrade_survivor_start_gateway() {
+  local log="${1:?missing gateway log}" attempts="${2:?missing readiness attempts}"
+  local ready_port="${3:?missing gateway port}" readiness_mode="${4:-strict}"
+  shift 4
+  local refusal="OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory."
+  local attempt log_offset child_status
+  : >"$log"
+  for attempt in 1 2; do
+    log_offset="$(wc -c <"$log")"
+    "$@" >>"$log" 2>&1 &
+    gateway_pid="$!"
+    child_status=""
+    if openclaw_e2e_wait_gateway_ready \
+      "$gateway_pid" "$log" "$attempts" child_status "$ready_port" "$readiness_mode"; then
+      return 0
+    fi
+    if [ "$attempt" -ne 1 ] || [ "$child_status" != "1" ]; then
+      return 1
+    fi
+    tail -c "+$((log_offset + 1))" "$log" | grep -Fx -- "$refusal" >/dev/null || return 1
+  done
+}

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-source scripts/lib/openclaw-e2e-instance.sh
+source "${OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER:-scripts/lib/openclaw-e2e-instance.sh}"
+source "${OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER:-scripts/e2e/lib/upgrade-survivor/gateway-start.sh}"
 
 export npm_config_loglevel=error
 export npm_config_fund=false
@@ -1224,7 +1225,19 @@ ensure_gateway_started() {
   if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
     return 0
   fi
-  start_gateway
+  local port=18789 budget start_epoch ready_epoch
+  budget="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS 90)"
+  start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
+  upgrade_survivor_start_gateway "$GATEWAY_LOG" 360 "$port" strict \
+    env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD \
+    openclaw gateway --port "$port" --bind loopback --allow-unconfigured
+  ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
+  start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
+  if [ "$start_seconds" -gt "$budget" ]; then
+    echo "gateway startup exceeded survivor budget: ${start_seconds}s > ${budget}s" >&2
+    openclaw_e2e_print_log "$GATEWAY_LOG" >&2
+    return 1
+  fi
 }
 
 check_gateway_probes() {

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -279,10 +279,9 @@ prepare_update_restart_probe_current_install() {
     return 1
   fi
   start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-  env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured >"$log_file" 2>&1 &
-  gateway_pid="$!"
+  upgrade_survivor_start_gateway "$log_file" 360 "$port" strict \
+    env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured || return
   printf '%s\n' "$gateway_pid" >"$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE"
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port"
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   write_update_restart_service_auth_env

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -164,6 +164,10 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     "${PROBE_ENV_ARGS[@]}" \
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro" \
+    -v "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh:/tmp/openclaw-upgrade-survivor-instance.sh:ro" \
+    -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/gateway-start.sh:/tmp/openclaw-upgrade-survivor-gateway-start.sh:ro" \
+    -e OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER=/tmp/openclaw-upgrade-survivor-instance.sh \
+    -e OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER=/tmp/openclaw-upgrade-survivor-gateway-start.sh \
     "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
     "${DOCKER_RUN_USER_ARGS[@]}" \
     "$IMAGE_NAME" \
@@ -192,11 +196,16 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
   "${PROBE_ENV_ARGS[@]}" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
+  -v "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh:/tmp/openclaw-upgrade-survivor-instance.sh:ro" \
+  -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/gateway-start.sh:/tmp/openclaw-upgrade-survivor-gateway-start.sh:ro" \
+  -e OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER=/tmp/openclaw-upgrade-survivor-instance.sh \
+  -e OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER=/tmp/openclaw-upgrade-survivor-gateway-start.sh \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   "${DOCKER_RUN_USER_ARGS[@]}" \
   "$IMAGE_NAME" \
   timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" bash -lc 'set -euo pipefail
-source scripts/lib/openclaw-e2e-instance.sh
+source "${OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER:-scripts/lib/openclaw-e2e-instance.sh}"
+source "${OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER:-scripts/e2e/lib/upgrade-survivor/gateway-start.sh}"
 
 export npm_config_loglevel=error
 export npm_config_fund=false
@@ -407,9 +416,8 @@ if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
 else
   echo "Starting gateway from upgraded state..."
   start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-  openclaw gateway --port "$PORT" --bind loopback --allow-unconfigured >"$GATEWAY_LOG" 2>&1 &
-  gateway_pid="$!"
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$PORT"
+  upgrade_survivor_start_gateway "$GATEWAY_LOG" 360 "$PORT" strict \
+    openclaw gateway --port "$PORT" --bind loopback --allow-unconfigured
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   if [ "$start_seconds" -gt "$START_BUDGET" ]; then

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -392,12 +392,19 @@ openclaw_e2e_gateway_log_port_from_text() {
   sed -nE 's/.*(127\.0\.0\.1|localhost):([0-9]+).*/\2/p' | tail -n 1
 }
 openclaw_e2e_wait_gateway_ready() {
-  local pid="$1" log="$2" attempts="${3:-300}" ready_port="${4:-}" readiness_mode="${5:-strict}" _ saw_ready_log=false
+  local pid="$1" log="$2" attempts="${3:-300}" exit_status_out="" ready_port readiness_mode _ saw_ready_log=false
+  if [[ "${4:-}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    exit_status_out="$4"; ready_port="${5:-}"; readiness_mode="${6:-strict}"
+  else
+    ready_port="${4:-}"; readiness_mode="${5:-strict}"
+  fi
   local ready_scan_offset=0 ready_scan_carry="" ready_scan_carry_chars=256
   for _ in $(seq 1 "$attempts"); do
     ! kill -0 "$pid" >/dev/null 2>&1 && {
       echo "Gateway exited before becoming ready"
-      wait "$pid" || true
+      local waited_status
+      if wait "$pid"; then waited_status=0; else waited_status=$?; fi
+      [ -z "$exit_status_out" ] || printf -v "$exit_status_out" '%s' "$waited_status"
       tail -n 120 "$log" 2>/dev/null || true
       return 1
     }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -94,6 +94,7 @@ const RELEASE_TYPED_ONBOARDING_SCENARIO_PATH =
 const RELEASE_USER_JOURNEY_DOCKER_E2E_PATH = "scripts/e2e/release-user-journey-docker.sh";
 const RELEASE_USER_JOURNEY_SCENARIO_PATH = "scripts/e2e/lib/release-user-journey/scenario.sh";
 const UPGRADE_SURVIVOR_RUN_SCRIPT = "scripts/e2e/lib/upgrade-survivor/run.sh";
+const UPGRADE_SURVIVOR_GATEWAY_START_PATH = "scripts/e2e/lib/upgrade-survivor/gateway-start.sh";
 const UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH =
   "scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh";
 const GATEWAY_NETWORK_DOCKER_E2E_PATH = "scripts/e2e/gateway-network-docker.sh";
@@ -2136,6 +2137,51 @@ grep -qx -- "OPENCLAW_E2E_COMMAND_TIMEOUT=23s" "$TMPDIR/package-args"
     }
   });
 
+  it("limits convergence retry to manual upgrade survivor candidate starts", () => {
+    const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
+    const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+    const helper = readFileSync(UPGRADE_SURVIVOR_GATEWAY_START_PATH, "utf8");
+    const updateRestartAuth = readFileSync(UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH, "utf8");
+
+    expectTextToIncludeAll(runner, [
+      'source "${OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER:-scripts/lib/openclaw-e2e-instance.sh}"',
+      'source "${OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER:-scripts/e2e/lib/upgrade-survivor/gateway-start.sh}"',
+      'upgrade_survivor_start_gateway "$GATEWAY_LOG" 360 "$PORT" strict',
+      '-v "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh:/tmp/openclaw-upgrade-survivor-instance.sh:ro"',
+      "-e OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER=/tmp/openclaw-upgrade-survivor-instance.sh",
+      '-v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/gateway-start.sh:/tmp/openclaw-upgrade-survivor-gateway-start.sh:ro"',
+      "-e OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER=/tmp/openclaw-upgrade-survivor-gateway-start.sh",
+    ]);
+    expect(runner.split("openclaw-upgrade-survivor-instance.sh:ro").length - 1).toBe(2);
+    expect(runner.split("OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER=").length - 1).toBe(2);
+    expect(
+      runner.match(
+        /-v "\$HARNESS_ROOT_DIR\/scripts\/e2e\/lib\/upgrade-survivor\/gateway-start\.sh:\/tmp\/openclaw-upgrade-survivor-gateway-start\.sh:ro"/gu,
+      ),
+    ).toHaveLength(2);
+    expect(
+      runner.match(
+        /-e OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER=\/tmp\/openclaw-upgrade-survivor-gateway-start\.sh/gu,
+      ),
+    ).toHaveLength(2);
+    expectTextToIncludeAll(publishedRunner, [
+      'source "${OPENCLAW_UPGRADE_SURVIVOR_INSTANCE_HELPER:-scripts/lib/openclaw-e2e-instance.sh}"',
+      'source "${OPENCLAW_UPGRADE_SURVIVOR_GATEWAY_START_HELPER:-scripts/e2e/lib/upgrade-survivor/gateway-start.sh}"',
+      'upgrade_survivor_start_gateway "$GATEWAY_LOG" 360 "$port" strict',
+      "start_gateway legacy-ready-log-ok",
+    ]);
+    expect(helper).toContain('grep -Fx -- "$refusal" >/dev/null');
+    expect(updateRestartAuth).toContain(
+      'upgrade_survivor_start_gateway "$log_file" 360 "$port" strict',
+    );
+    expect(updateRestartAuth.indexOf("upgrade_survivor_start_gateway")).toBeLessThan(
+      updateRestartAuth.indexOf(
+        'printf \'%s\\n\' "$gateway_pid" >"$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE"',
+      ),
+    );
+    expect(updateRestartAuth).not.toContain("gateway-start.sh");
+  });
+
   it("keeps multi-node update Docker artifacts isolated by default", () => {
     const multiNode = readFileSync(MULTI_NODE_UPDATE_DOCKER_E2E_PATH, "utf8");
     expect(multiNode).toContain(
@@ -2286,7 +2332,7 @@ fi
     );
     expect(updateRestartAuth).toContain('openclaw gateway --port "$port" --bind loopback');
     expect(updateRestartAuth).toContain(
-      'openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port"',
+      'upgrade_survivor_start_gateway "$log_file" 360 "$port" strict',
     );
   });
 

--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -355,6 +355,20 @@ describe("scripts/lib/openclaw-e2e-instance.sh", () => {
     });
   });
 
+  it("captures the child exit status without weakening fail-fast readiness", () => {
+    const result = runBashWithHelper([
+      "bash -c 'exit 23' &",
+      'gateway_pid="$!"',
+      'child_status=""',
+      `if openclaw_e2e_wait_gateway_ready "$gateway_pid" /dev/null 2 child_status 23456; then exit 90; fi`,
+      'printf "status=%s\\n" "$child_status"',
+    ]);
+
+    expectShellSuccess(result);
+    expect(result.stdout).toContain("Gateway exited before becoming ready");
+    expect(result.stdout).toContain("status=23");
+  });
+
   it("wraps package installs with the configured timeout", () => {
     withTempDir("openclaw-e2e-instance-", (tempDir) => {
       const fixture = createPackageInstallFixture(tempDir);

--- a/test/scripts/upgrade-survivor-gateway-start.test.ts
+++ b/test/scripts/upgrade-survivor-gateway-start.test.ts
@@ -1,0 +1,182 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const instanceHelper = path.resolve("scripts/lib/openclaw-e2e-instance.sh");
+const gatewayHelper = path.resolve("scripts/e2e/lib/upgrade-survivor/gateway-start.sh");
+const updateRestartHelper = path.resolve("scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh");
+const refusal =
+  "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory.";
+
+function quote(value: string): string {
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+function runScenario(sequence: string, staleLog = "", prepare = false) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-upgrade-gateway-"));
+  const executable = path.join(root, "openclaw");
+  const log = path.join(root, "gateway.log");
+  const count = path.join(root, "count");
+  const trace = path.join(root, "trace");
+  const install = path.join(root, "install");
+  const pidFile = path.join(root, "gateway.pid");
+  fs.writeFileSync(log, staleLog);
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "doctor" ]; then exit 0; fi
+if [ "\${1:-}" = "gateway" ] && [ "\${2:-}" = "install" ]; then
+  printf 'install\n' >>"$FAKE_INSTALL"
+  exit 0
+fi
+if [ "\${1:-}" = "gateway" ]; then shift; fi
+attempt=0
+[ ! -f "$FAKE_COUNT" ] || attempt="$(cat "$FAKE_COUNT")"
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" >"$FAKE_COUNT"
+{
+  printf 'pid=%s\nmarker=%s\nstate=%s\nconfig=%s\nargc=%s\n' \
+    "$$" "$FAKE_MARKER" "$OPENCLAW_STATE_DIR" "$OPENCLAW_CONFIG_PATH" "$#"
+  printf 'arg=%s\n' "$@"
+  printf '%s\n' ---
+} >>"$FAKE_TRACE"
+IFS=, read -r -a steps <<<"$FAKE_SEQUENCE"
+behavior="\${steps[$((attempt - 1))]:-missing}"
+case "$behavior" in
+  success)
+    printf '[gateway] ready ws://127.0.0.1:24567\n'
+    trap 'exit 0' TERM INT
+    while :; do sleep 1; done
+    ;;
+  exact1large) printf '%s\n' ${quote(refusal)}; printf 'trailing diagnostic %.0s\n' {1..20000}; exit 1 ;;
+  exact1) printf '%s\n' ${quote(refusal)}; exit 1 ;;
+  exact2) printf '%s\n' ${quote(refusal)}; exit 2 ;;
+  near1) printf '%s extra\n' ${quote(refusal)}; exit 1 ;;
+  unrelated1) printf 'unrelated startup failure\n'; exit 1 ;;
+  *) exit 64 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+
+  const result = spawnSync(
+    "/bin/bash",
+    [
+      "-c",
+      `
+set -euo pipefail
+source ${quote(instanceHelper)}
+source ${quote(gatewayHelper)}
+openclaw_e2e_probe_http() { return 0; }
+openclaw_e2e_maybe_timeout() { shift; "$@"; }
+gateway_pid=""
+export PATH=${quote(root)}:"$PATH"
+export FAKE_COUNT=${quote(count)} FAKE_TRACE=${quote(trace)} FAKE_INSTALL=${quote(install)}
+export FAKE_SEQUENCE=${quote(sequence)} FAKE_MARKER=preserved
+export OPENCLAW_STATE_DIR=/state/cohort OPENCLAW_CONFIG_PATH=/config/openclaw.json
+export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE=${quote(pidFile)}
+export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON=${quote(path.join(root, "install.json"))}
+export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR=${quote(path.join(root, "install.err"))}
+${
+  prepare
+    ? `source ${quote(updateRestartHelper)}
+install_update_restart_systemctl_shim() { :; }
+seed_update_restart_probe_device_auth() { :; }
+write_update_restart_service_auth_env() { :; }
+command=(prepare_update_restart_probe_current_install 24567 ${quote(log)})`
+    : `command=(upgrade_survivor_start_gateway ${quote(log)} 8 24567 strict ${quote(executable)} --port 24567 --flag "two words")`
+}
+if "\${command[@]}"; then
+  helper_status=0
+else
+  helper_status=$?
+fi
+printf 'gateway_pid=%s\n' "$gateway_pid"
+printf 'shim_pid=%s\n' "$(cat ${quote(pidFile)} 2>/dev/null || true)"
+if [ -n "$gateway_pid" ]; then
+  kill "$gateway_pid" >/dev/null 2>&1 || true
+  wait "$gateway_pid" >/dev/null 2>&1 || true
+fi
+exit "$helper_status"
+`,
+    ],
+    { encoding: "utf8" },
+  );
+  const traceText = fs.existsSync(trace) ? fs.readFileSync(trace, "utf8") : "";
+  const logText = fs.readFileSync(log, "utf8");
+  const installCount = fs.existsSync(install)
+    ? fs.readFileSync(install, "utf8").trim().split("\n").length
+    : 0;
+  const pidText = fs.existsSync(pidFile) ? fs.readFileSync(pidFile, "utf8").trim() : "";
+  fs.rmSync(root, { force: true, recursive: true });
+  return { result, traceText, logText, installCount, pidText };
+}
+
+describe("upgrade survivor gateway convergence launcher", () => {
+  it("retries the exact refusal once with identical launch identity and a new pid", () => {
+    const { result, traceText } = runScenario("exact1,success");
+    const attempts = traceText.split("---\n").filter(Boolean);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(attempts).toHaveLength(2);
+    for (const attempt of attempts) {
+      expect(attempt).toContain("marker=preserved");
+      expect(attempt).toContain("state=/state/cohort");
+      expect(attempt).toContain("config=/config/openclaw.json");
+      expect(attempt).toContain("argc=4");
+      expect(attempt).toContain("arg=--port\narg=24567\narg=--flag\narg=two words");
+    }
+    expect(attempts[0]?.match(/pid=(\d+)/u)?.[1]).not.toBe(attempts[1]?.match(/pid=(\d+)/u)?.[1]);
+  });
+
+  it("returns immediately after a successful first launch", () => {
+    const { result, traceText } = runScenario("success");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(traceText.split("---\n").filter(Boolean)).toHaveLength(1);
+  });
+
+  it("consumes large trailing diagnostics before retrying the exact refusal", () => {
+    const { result, traceText } = runScenario("exact1large,success");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(traceText.split("---\n").filter(Boolean)).toHaveLength(2);
+  });
+
+  it("prepares update restart after convergence and records only the ready pid", () => {
+    const { result, traceText, installCount, pidText } = runScenario("exact1,success", "", true);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(traceText.split("---\n").filter(Boolean)).toHaveLength(2);
+    expect(pidText).toBe(result.stdout.match(/gateway_pid=(\d+)/u)?.[1]);
+    expect(installCount).toBe(1);
+  });
+
+  it("stops update restart preparation after an unrelated startup failure", () => {
+    const { result, traceText, installCount, pidText } = runScenario("unrelated1", "", true);
+
+    expect(result.status).toBe(1);
+    expect(traceText.split("---\n").filter(Boolean)).toHaveLength(1);
+    expect(installCount).toBe(0);
+    expect(pidText).toBe("");
+  });
+
+  it.each([
+    ["near match", "near1", "", 1],
+    ["unrelated status 1", "unrelated1", "", 1],
+    ["exact text with status 2", "exact2", "", 1],
+    ["second exact refusal", "exact1,exact1", "", 2],
+    ["stale prior refusal", "unrelated1", `${refusal}\n`, 1],
+  ])("does not retry %s", (_label, sequence, staleLog, expectedAttempts) => {
+    const { result, traceText, logText } = runScenario(sequence, staleLog);
+
+    expect(result.status).toBe(1);
+    expect(traceText.split("---\n").filter(Boolean)).toHaveLength(expectedAttempts);
+    if (staleLog) {
+      expect(logText).not.toContain(refusal);
+    }
+  });
+});


### PR DESCRIPTION
Related: #119051

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where manual Docker upgrade-survivor candidate starts could receive the explicit migration-convergence refusal and the harness would fail immediately instead of restarting against the converged state.

## Why This Change Was Made

The canonical upgrade-survivor launch path now retries exactly once, and only when the first candidate gateway exits with status 1 and emits the exact migration-convergence refusal. The retry preserves state, config, port, environment, and arguments. It now covers both the manual survivor start and the pre-update candidate-auth start used by update-restart-auth; package self-update remains excluded.

## User Impact

QA and release validation become reliable when a candidate needs one restart after migration convergence. Product runtime impact: 0.

## Evidence

- 191 focused helper and harness tests passed on exact head `895d15ff782299d27e5ad6b0bb66cd4ebeba372f`.
- The exact-refusal retry matrix covers near matches, unrelated status 1, non-1 exits, a second refusal, and stale prior logs.
- Bash syntax, formatting, and diff checks passed.
- Independent amendment review confirmed the retry predicate remains exact and package self-update stays excluded.

Remaining hosted proof:

- Exact-head Docker upgrade-survivor recovery.
- Exact-head Docker update-restart-auth: refusal/exit 1, one retry, readiness, package update, authenticated restart/handoff, and no third launch.

AI-assisted: yes. No agent transcript is included.


Punchcard-Session: cobalt-valley-meadow-mg


