### PR TITLE
fix(test): restart shared gateway after migration convergence

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOpenClawTestInstance, testing } from "./openclaw-test-instance.js";
 import { isProcessAlive } from "./process-wait.js";
@@ -63,6 +64,12 @@ if (kind === "resist-after-exit") {
   const resistant = spawn(process.execPath, ["-e", 'const fs = require("node:fs");fs.writeFileSync(process.argv[1], String(process.pid));process.on("SIGTERM", () => fs.appendFileSync(process.argv[2], "SIGTERM"));process.send("ready");setInterval(() => {}, 1_000);', tracePath + ".resistant-pid", tracePath + ".signals"], { stdio: ["ignore", "ignore", "inherit", "ipc"] });
   await new Promise((resolve) => resistant.once("message", resolve));
   process.stderr.write("unrelated startup failure\\n"); process.exit(1);
+}
+if (kind === "terminal-drain") {
+  const draining = spawn(process.execPath, ["-e", 'const fs = require("node:fs");const release = process.argv[1];const deadline = Date.now() + 5_000;const timer = setInterval(() => { if (fs.existsSync(release) || Date.now() >= deadline) clearInterval(timer); }, 10);', tracePath + ".draining-release"], { detached: true, stdio: ["ignore", "ignore", "inherit"] });
+  draining.unref();
+  writeFileSync(tracePath + ".draining-pid", String(draining.pid));
+  process.stderr.write("terminal startup failure\\n"); process.exit(7);
 }
 if (kind === "near") { process.stderr.write(refusal.slice(0, -1) + " fixture\\n"); process.exit(1); }
 if (kind === "stdout") { process.stdout.write(refusal + " fixture\\n"); process.exit(1); }
@@ -196,6 +203,81 @@ describe("openclaw test instance", () => {
       await expectPathMissing(stateRoot);
     },
   );
+
+  it.runIf(process.platform !== "win32")(
+    "reaps terminal children with inherited stdio before starting a new gateway",
+    async () => {
+      const { instance, readAttempts, tracePath } = await createFakeGateway(
+        "terminal-drain,ready",
+        300,
+        100,
+      );
+
+      const startupError = await instance.startGateway().catch((error: unknown) => error);
+      expect(startupError).toBeInstanceOf(Error);
+      expect((startupError as Error).message).toContain(
+        "gateway exited before readiness (code=7 signal=null)",
+      );
+      expect((startupError as Error).message).toContain("terminal startup failure");
+      expect(instance.child?.exitCode).toBe(7);
+      expect(instance.child?.stderr.closed).toBe(false);
+      const firstAttempt = (await readAttempts())[0];
+      const drainingPid = Number(await fs.readFile(`${tracePath}.draining-pid`, "utf8"));
+      expect(isProcessAlive(drainingPid)).toBe(true);
+
+      await fs.writeFile(`${tracePath}.draining-release`, "");
+      await instance.startGateway();
+
+      const attempts = await readAttempts();
+      expect(attempts).toHaveLength(2);
+      expect(attempts[1]?.pid).not.toBe(firstAttempt?.pid);
+      expect(instance.child?.pid).toBe(attempts[1]?.pid);
+      await instance.stopGateway();
+      expect(instance.child).toBeUndefined();
+      expect(isProcessAlive(attempts[1]?.pid as number)).toBe(false);
+      await expect.poll(() => isProcessAlive(drainingPid), { timeout: 500 }).toBe(false);
+    },
+  );
+
+  it("force-kills Windows gateway descendants before retry cleanup settles", async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = {
+      exitCode: 1,
+      kill: vi.fn(() => true),
+      pid: 12345,
+      signalCode: null,
+      stderr,
+      stdout,
+    } as unknown as Parameters<typeof testing.stopGatewayProcess>[0];
+    const runTaskkill = vi.fn(() => {
+      stdout.destroy();
+      stderr.destroy();
+      return { status: 0 };
+    });
+
+    await expect(
+      testing.stopGatewayProcess(child, Date.now() + 500, 250, {
+        forceWindowsTree: true,
+        platform: "win32",
+        runTaskkill,
+      }),
+    ).resolves.toBe(true);
+
+    expect(runTaskkill).toHaveBeenCalledOnce();
+    expect(runTaskkill).toHaveBeenCalledWith(
+      path.win32.join("C:\\Windows", "System32", "taskkill.exe"),
+      ["/PID", "12345", "/T", "/F"],
+      {
+        killSignal: "SIGKILL",
+        stdio: "ignore",
+        timeout: 10_000,
+      },
+    );
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(stdout.closed).toBe(true);
+    expect(stderr.closed).toBe(true);
+  });
 
   it("keeps only bounded child output tails in helper logs", () => {
     const stdout = testing.createBoundedStringLog();

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -1,9 +1,103 @@
 // OpenClaw test instance tests cover spawned test instance lifecycle.
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOpenClawTestInstance, testing } from "./openclaw-test-instance.js";
+import { isProcessAlive } from "./process-wait.js";
+
+const MIGRATION_CONVERGENCE_REFUSAL =
+  "OpenClaw plugin migration inputs changed during startup convergence;";
+const RESTART_MARKER =
+  "[openclaw-test-instance] restarting gateway after migration convergence refusal";
+const fakeInstances: Awaited<ReturnType<typeof createOpenClawTestInstance>>[] = [];
+const fakeRoots: string[] = [];
+
+type FakeGatewayAttempt = {
+  argv: string[];
+  config: unknown;
+  cwd: string;
+  env: Record<string, string | undefined>;
+  pid: number;
+  port: number;
+};
+
+afterEach(async () => {
+  await Promise.allSettled(fakeInstances.splice(0).map((instance) => instance.cleanup()));
+  await Promise.allSettled(fakeRoots.splice(0).map((root) => fs.rm(root, { recursive: true })));
+});
+
+async function createFakeGateway(sequence: string, startTimeoutMs = 1_000, stopTimeoutMs = 1_500) {
+  const cwd = await fs.mkdtemp(path.join(tmpdir(), "openclaw-test-instance-gateway-"));
+  fakeRoots.push(cwd);
+  const distDir = path.join(cwd, "dist");
+  const tracePath = path.join(cwd, "attempts.jsonl");
+  await fs.mkdir(distDir);
+  await Promise.all([
+    fs.writeFile(path.join(distDir, ".buildstamp"), ""),
+    fs.writeFile(path.join(distDir, ".runtime-postbuildstamp"), ""),
+    fs.writeFile(
+      path.join(distDir, "index.mjs"),
+      `
+import { spawn } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+const tracePath = process.env.OPENCLAW_FAKE_GATEWAY_TRACE;
+const countPath = tracePath + ".count";
+let attempt = 1;
+try { attempt = Number(readFileSync(countPath, "utf8")) + 1; } catch {}
+writeFileSync(countPath, String(attempt));
+const argv = process.argv.slice(2);
+const port = Number(argv[argv.indexOf("--port") + 1]);
+const env = Object.fromEntries(["HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_STATE_DIR"].map((key) => [key, process.env[key]]));
+appendFileSync(tracePath, JSON.stringify({ argv, config: JSON.parse(readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8")), cwd: process.cwd(), env, pid: process.pid, port }) + "\\n");
+const action = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[attempt - 1] || "ready";
+const [kind, delay] = action.split(":");
+if (delay) await new Promise((resolve) => setTimeout(resolve, Number(delay)));
+process.stdout.write("fake gateway attempt " + attempt + "\\n");
+const refusal = ${JSON.stringify(MIGRATION_CONVERGENCE_REFUSAL)};
+if (kind === "refuse") { process.stderr.write(refusal + " fixture\\n"); process.exit(1); }
+if (kind === "late-refuse") { spawn(process.execPath, ["-e", 'setTimeout(() => process.stderr.write(process.argv[1]), 50)', refusal + " delayed fixture\\n"], { stdio: ["ignore", "ignore", "inherit"] }); process.exit(1); }
+if (kind === "resist-after-exit") {
+  const resistant = spawn(process.execPath, ["-e", 'const fs = require("node:fs");fs.writeFileSync(process.argv[1], String(process.pid));process.on("SIGTERM", () => fs.appendFileSync(process.argv[2], "SIGTERM"));process.send("ready");setInterval(() => {}, 1_000);', tracePath + ".resistant-pid", tracePath + ".signals"], { stdio: ["ignore", "ignore", "inherit", "ipc"] });
+  await new Promise((resolve) => resistant.once("message", resolve));
+  process.stderr.write("unrelated startup failure\\n"); process.exit(1);
+}
+if (kind === "near") { process.stderr.write(refusal.slice(0, -1) + " fixture\\n"); process.exit(1); }
+if (kind === "stdout") { process.stdout.write(refusal + " fixture\\n"); process.exit(1); }
+if (kind === "status2") { process.stderr.write(refusal + " fixture\\n"); process.exit(2); }
+if (kind === "signal") { process.stderr.write(refusal + " fixture\\n"); process.kill(process.pid, "SIGTERM"); }
+if (kind === "unrelated") { process.stderr.write("unrelated startup failure\\n"); process.exit(1); }
+if (kind === "hang") { process.on("SIGTERM", () => process.exit(0)); setInterval(() => {}, 1_000); } else {
+  const server = createServer((req, res) => { res.writeHead(req.url === "/readyz" ? 200 : 404, { "content-type": "application/json" }); res.end(JSON.stringify({ ready: req.url === "/readyz" })); });
+  process.on("SIGTERM", () => server.close(() => process.exit(0))); server.listen(port, "127.0.0.1");
+}
+`,
+    ),
+  ]);
+  const instance = await createOpenClawTestInstance({
+    name: `fake-gateway-${path.basename(cwd)}`,
+    cwd,
+    env: {
+      OPENCLAW_FAKE_GATEWAY_SEQUENCE: sequence,
+      OPENCLAW_FAKE_GATEWAY_TRACE: tracePath,
+    },
+    startTimeoutMs,
+    stopTimeoutMs,
+  });
+  fakeInstances.push(instance);
+  return {
+    instance,
+    tracePath,
+    readAttempts: async (): Promise<FakeGatewayAttempt[]> =>
+      (await fs.readFile(tracePath, "utf8"))
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as FakeGatewayAttempt),
+  };
+}
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
@@ -26,6 +120,83 @@ function createGatewayProcessState(
 }
 
 describe("openclaw test instance", () => {
+  it("classifies only exact stderr convergence refusals with status 1", () => {
+    const classify = testing.isGatewayMigrationConvergenceRefusal;
+    expect(classify(1, null, `notice\n${MIGRATION_CONVERGENCE_REFUSAL} retry\n`)).toBe(true);
+    for (const candidate of [
+      [2, null, MIGRATION_CONVERGENCE_REFUSAL],
+      [1, "SIGTERM", MIGRATION_CONVERGENCE_REFUSAL],
+      [1, null, MIGRATION_CONVERGENCE_REFUSAL.slice(0, -1)],
+      [1, null, `prefix ${MIGRATION_CONVERGENCE_REFUSAL}`],
+    ]) {
+      expect(classify(...(candidate as [number, NodeJS.Signals | null, string]))).toBe(false);
+    }
+  });
+
+  it.each(["refuse", "late-refuse"])(
+    "restarts one %s refusal with identical launch state and owns the ready child",
+    async (refusalAction) => {
+      const { instance, readAttempts } = await createFakeGateway(`${refusalAction},ready`);
+      await instance.startGateway();
+      const attempts = await readAttempts();
+      expect(attempts).toHaveLength(2);
+      expect(attempts[0]?.pid).not.toBe(attempts[1]?.pid);
+      expect({ ...attempts[0], pid: 0 }).toEqual({ ...attempts[1], pid: 0 });
+      expect(instance.logs()).toContain(MIGRATION_CONVERGENCE_REFUSAL);
+      expect(instance.logs()).toContain(RESTART_MARKER);
+      const readyPid = instance.child?.pid;
+      expect(readyPid).toBeTypeOf("number");
+      await instance.stopGateway();
+      expect(instance.child).toBeUndefined();
+      expect(isProcessAlive(readyPid as number)).toBe(false);
+    },
+  );
+
+  it.each(["near", "stdout", "status2", "signal", "unrelated"])(
+    "keeps %s convergence lookalikes terminal",
+    async (action) => {
+      const { instance, readAttempts } = await createFakeGateway(`${action},ready`);
+      await expect(instance.startGateway()).rejects.toThrow("gateway exited before readiness");
+      expect(await readAttempts()).toHaveLength(1);
+      expect(instance.logs()).not.toContain(RESTART_MARKER);
+      expect(instance.child).toBeUndefined();
+    },
+  );
+
+  it("preserves both refusals and never spawns a third gateway", async () => {
+    const { instance, readAttempts } = await createFakeGateway("refuse,refuse,ready");
+    await expect(instance.startGateway()).rejects.toThrow("gateway exited before readiness");
+    expect(await readAttempts()).toHaveLength(2);
+    expect(instance.logs().split(MIGRATION_CONVERGENCE_REFUSAL)).toHaveLength(3);
+    expect(instance.logs().split(RESTART_MARKER)).toHaveLength(2);
+  });
+
+  it("bounds both attempts by one startup deadline", async () => {
+    const { instance, readAttempts } = await createFakeGateway("refuse:200,hang", 500);
+    const startedAt = Date.now();
+    await expect(instance.startGateway()).rejects.toThrow("timeout waiting for gateway readiness");
+    expect(await readAttempts()).toHaveLength(2);
+    expect(Date.now() - startedAt).toBeLessThan(650);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "SIGKILLs a TERM-resistant gateway group before releasing state",
+    async () => {
+      const { instance, tracePath } = await createFakeGateway("resist-after-exit", 500, 40);
+      const stateRoot = instance.state.root;
+      const startedAt = Date.now();
+      await expect(instance.startGateway()).rejects.toThrow("gateway exited before readiness");
+      const resistantPid = Number(await fs.readFile(`${tracePath}.resistant-pid`, "utf8"));
+      expect(await fs.readFile(`${tracePath}.signals`, "utf8")).toBe("SIGTERM");
+      expect(instance.child).toBeUndefined();
+      expect(Date.now() - startedAt).toBeLessThan(500);
+      await expect.poll(() => isProcessAlive(resistantPid), { timeout: 500 }).toBe(false);
+      await expect(fs.stat(stateRoot)).resolves.toBeDefined();
+      await instance.cleanup();
+      await expectPathMissing(stateRoot);
+    },
+  );
+
   it("keeps only bounded child output tails in helper logs", () => {
     const stdout = testing.createBoundedStringLog();
     const stderr = testing.createBoundedStringLog();

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -70,6 +70,11 @@ const GATEWAY_STOP_TIMEOUT_MS = 1_500;
 const GATEWAY_ENTRYPOINT_PREPARE_TIMEOUT_MS = 120_000;
 const COMMAND_TIMEOUT_MS = 30_000;
 const LOG_TAIL_MAX_BYTES = 256 * 1024;
+const GATEWAY_MIGRATION_CONVERGENCE_MAX_RESTARTS = 1;
+const GATEWAY_MIGRATION_CONVERGENCE_REFUSAL_PREFIX =
+  "OpenClaw plugin migration inputs changed during startup convergence;";
+const GATEWAY_MIGRATION_CONVERGENCE_RESTART_MARKER =
+  "[openclaw-test-instance] restarting gateway after migration convergence refusal\n";
 const entrypointPromises = new Map<string, Promise<string[]>>();
 
 type BoundedStringLog = string[] & {
@@ -130,6 +135,20 @@ function readLogBuffer(log: string[]): string {
   return (log as BoundedStringLog).truncated
     ? `[output truncated to last ${LOG_TAIL_MAX_BYTES} bytes]\n${text}`
     : text;
+}
+
+function isGatewayMigrationConvergenceRefusal(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string,
+): boolean {
+  return (
+    code === 1 &&
+    signal === null &&
+    stderr
+      .split(/\r?\n/u)
+      .some((line) => line.startsWith(GATEWAY_MIGRATION_CONVERGENCE_REFUSAL_PREFIX))
+  );
 }
 
 async function resolveBuiltGatewayEntrypoint(cwd: string): Promise<string[] | null> {
@@ -297,17 +316,49 @@ async function waitForGatewayReady(
   );
 }
 
-async function waitForGatewayExit(child: OpenClawTestProcess, timeoutMs: number): Promise<boolean> {
-  return await Promise.race([
-    new Promise<boolean>((resolve) => {
-      if (child.exitCode !== null || child.signalCode !== null) {
-        resolve(true);
-        return;
-      }
-      child.once("exit", () => resolve(true));
-    }),
-    sleep(timeoutMs).then(() => false),
-  ]);
+function hasGatewayProcessClosed(child: OpenClawTestProcess): boolean {
+  return hasChildExited(child) && child.stdout.closed && child.stderr.closed;
+}
+
+async function waitForGatewayClose(
+  child: OpenClawTestProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  while (!hasGatewayProcessClosed(child) && Date.now() < deadline) {
+    await sleep(Math.min(10, deadline - Date.now()));
+  }
+  return hasGatewayProcessClosed(child);
+}
+
+async function stopGatewayProcess(
+  child: OpenClawTestProcess,
+  deadline: number,
+  stopTimeoutMs: number,
+): Promise<boolean> {
+  const waitForClose = (deadlineShare: number) =>
+    waitForGatewayClose(
+      child,
+      Math.min(stopTimeoutMs, Math.max(0, Math.floor((deadline - Date.now()) / deadlineShare))),
+    );
+  // Reserve enough of the shared deadline for TERM and KILL after natural stdio drain.
+  if (hasChildExited(child) && (await waitForClose(3))) {
+    return true;
+  }
+  for (const signal of ["SIGTERM", "SIGKILL"] as const) {
+    if (hasGatewayProcessClosed(child)) {
+      return true;
+    }
+    try {
+      signalOpenClawTestProcess(child, signal);
+    } catch {
+      // ignore
+    }
+    if (await waitForClose(signal === "SIGTERM" ? 2 : 1)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function hasChildExited(child: Pick<OpenClawTestProcess, "exitCode" | "signalCode">) {
@@ -400,6 +451,33 @@ export async function createOpenClawTestInstance(
   });
   let child: OpenClawTestProcess | undefined;
   let cleaned = false;
+  const stopTimeoutMs = options.stopTimeoutMs ?? GATEWAY_STOP_TIMEOUT_MS;
+  const spawnGatewayProcess = (args: string[], attemptStderr: string[]): OpenClawTestProcess => {
+    const next = spawn("node", args, {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: shouldUseOpenClawTestProcessGroup(),
+    });
+    next.stdout.setEncoding("utf8");
+    next.stderr.setEncoding("utf8");
+    next.stdout.on("data", (chunk) => appendLogChunk(stdout, chunk));
+    next.stderr.on("data", (chunk) => {
+      appendLogChunk(stderr, chunk);
+      appendLogChunk(attemptStderr, chunk);
+    });
+    return next;
+  };
+  const releaseGatewayChild = async (
+    target: OpenClawTestProcess,
+    deadline: number,
+  ): Promise<boolean> => {
+    const closed = await stopGatewayProcess(target, deadline, stopTimeoutMs);
+    if (closed && child === target) {
+      child = undefined;
+    }
+    return closed;
+  };
 
   const instance: OpenClawTestInstance = {
     name: options.name,
@@ -428,73 +506,63 @@ export async function createOpenClawTestInstance(
       });
     },
     startGateway: async () => {
-      if (child && !hasChildExited(child) && !child.killed) {
+      if (child && !hasGatewayProcessClosed(child)) {
         return;
       }
       const entrypoint = await resolveGatewayEntrypoint(cwd);
-      child = spawn(
-        "node",
-        [
-          ...entrypoint,
-          "gateway",
-          "--port",
-          String(port),
-          "--bind",
-          "loopback",
-          "--allow-unconfigured",
-          ...(options.gatewayArgs ?? []),
-        ],
-        {
-          cwd,
-          env,
-          stdio: ["ignore", "pipe", "pipe"],
-          detached: shouldUseOpenClawTestProcessGroup(),
-        },
-      );
+      const gatewayArgs = [
+        ...entrypoint,
+        "gateway",
+        "--port",
+        String(port),
+        "--bind",
+        "loopback",
+        "--allow-unconfigured",
+        ...(options.gatewayArgs ?? []),
+      ];
+      const deadline = Date.now() + (options.startTimeoutMs ?? GATEWAY_START_TIMEOUT_MS);
+      let restarts = 0;
 
-      child.stdout?.setEncoding("utf8");
-      child.stderr?.setEncoding("utf8");
-      child.stdout?.on("data", (d) => appendLogChunk(stdout, d));
-      child.stderr?.on("data", (d) => appendLogChunk(stderr, d));
-
-      try {
-        await waitForGatewayReady(
-          child,
-          stdout,
-          stderr,
-          port,
-          options.startTimeoutMs ?? GATEWAY_START_TIMEOUT_MS,
-        );
-      } catch (err) {
-        await instance.stopGateway();
-        throw err;
+      while (true) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new Error(
+            `timeout waiting for gateway readiness on port ${port}\n${formatLogs(stdout, stderr)}`,
+          );
+        }
+        const attemptStderr = createBoundedStringLog();
+        const attempt = spawnGatewayProcess(gatewayArgs, attemptStderr);
+        child = attempt;
+        try {
+          await waitForGatewayReady(attempt, stdout, stderr, port, remainingMs);
+          return;
+        } catch (err) {
+          const closed = await releaseGatewayChild(attempt, deadline);
+          const shouldRestart =
+            closed &&
+            restarts < GATEWAY_MIGRATION_CONVERGENCE_MAX_RESTARTS &&
+            isGatewayMigrationConvergenceRefusal(
+              attempt.exitCode,
+              attempt.signalCode,
+              readLogBuffer(attemptStderr),
+            );
+          if (shouldRestart && Date.now() < deadline) {
+            restarts += 1;
+            appendLogChunk(stderr, GATEWAY_MIGRATION_CONVERGENCE_RESTART_MARKER);
+            continue;
+          }
+          throw err;
+        }
       }
     },
     stopGateway: async () => {
-      if (!child) {
+      const target = child;
+      if (!target) {
         return;
       }
-      if (!hasChildExited(child) && !child.killed) {
-        try {
-          signalOpenClawTestProcess(child, "SIGTERM");
-        } catch {
-          // ignore
-        }
-      }
-      let exited = await waitForGatewayExit(
-        child,
-        options.stopTimeoutMs ?? GATEWAY_STOP_TIMEOUT_MS,
-      );
-      if (!exited && !hasChildExited(child) && !child.killed) {
-        try {
-          signalOpenClawTestProcess(child, "SIGKILL");
-        } catch {
-          // ignore
-        }
-        exited = await waitForGatewayExit(child, options.stopTimeoutMs ?? GATEWAY_STOP_TIMEOUT_MS);
-      }
-      if (exited) {
-        child = undefined;
+      const closed = await releaseGatewayChild(target, Date.now() + stopTimeoutMs * 2);
+      if (!closed) {
+        throw new Error(`gateway process did not close before stop deadline\n${instance.logs()}`);
       }
     },
     logs: () => formatLogs(stdout, stderr),
@@ -502,9 +570,9 @@ export async function createOpenClawTestInstance(
       if (cleaned) {
         return;
       }
-      cleaned = true;
       await instance.stopGateway();
       await state.cleanup();
+      cleaned = true;
     },
   };
 
@@ -543,7 +611,7 @@ async function runCommand(params: {
   ]);
   if (completed === null) {
     signalOpenClawTestProcess(child, "SIGKILL");
-    await waitForGatewayExit(child, GATEWAY_STOP_TIMEOUT_MS);
+    await waitForGatewayClose(child, GATEWAY_STOP_TIMEOUT_MS);
     throw new Error(
       `command timed out after ${params.timeoutMs}ms: ${params.args.join(" ")}\n${formatLogs(stdout, stderr)}`,
     );
@@ -581,6 +649,7 @@ export const testing = {
   createBoundedStringLog,
   formatLogs,
   hasChildExited,
+  isGatewayMigrationConvergenceRefusal,
   signalOpenClawTestProcess,
   waitForGatewayReady,
 };

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -9,6 +9,7 @@ import {
   BUILD_STAMP_FILE,
   RUNTIME_POSTBUILD_STAMP_FILE,
 } from "../../scripts/lib/local-build-metadata-paths.mjs";
+import { terminateManagedChild } from "../../scripts/lib/managed-child-process.mjs";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -86,6 +87,9 @@ type OpenClawTestChildProcess = Pick<OpenClawTestProcess, "kill" | "pid">;
 type OpenClawTestProcessReadiness = Pick<OpenClawTestProcess, "exitCode" | "signalCode"> & {
   once: (event: "exit", listener: () => void) => unknown;
   off: (event: "exit", listener: () => void) => unknown;
+};
+type GatewayProcessStopOptions = NonNullable<Parameters<typeof terminateManagedChild>[2]> & {
+  forceWindowsTree?: boolean;
 };
 
 function createBoundedStringLog(): string[] {
@@ -335,30 +339,56 @@ async function stopGatewayProcess(
   child: OpenClawTestProcess,
   deadline: number,
   stopTimeoutMs: number,
+  options: GatewayProcessStopOptions = {},
 ): Promise<boolean> {
-  const waitForClose = (deadlineShare: number) =>
+  const platform = options.platform ?? process.platform;
+  const waitForClose = (remainingSteps: number) =>
     waitForGatewayClose(
       child,
-      Math.min(stopTimeoutMs, Math.max(0, Math.floor((deadline - Date.now()) / deadlineShare))),
+      Math.min(
+        stopTimeoutMs,
+        Math.max(0, Math.floor((deadline - Date.now()) / Math.max(1, remainingSteps))),
+      ),
     );
-  // Reserve enough of the shared deadline for TERM and KILL after natural stdio drain.
-  if (hasChildExited(child) && (await waitForClose(3))) {
+  const terminate = (signal: NodeJS.Signals) => {
+    terminateManagedChild(
+      child,
+      signal,
+      options.runTaskkill
+        ? { platform, runTaskkill: options.runTaskkill }
+        : {
+            platform,
+          },
+    );
+  };
+  const forceWindowsTree = options.forceWindowsTree === true && platform === "win32";
+  const signals = forceWindowsTree ? (["SIGKILL"] as const) : (["SIGTERM", "SIGKILL"] as const);
+
+  if (hasGatewayProcessClosed(child)) {
     return true;
   }
-  for (const signal of ["SIGTERM", "SIGKILL"] as const) {
+  // An exited leader can leave inherited stdio open in descendants. Let it
+  // settle briefly, then terminate the owned tree before releasing the slot.
+  if (!forceWindowsTree && hasChildExited(child) && (await waitForClose(signals.length + 1))) {
+    return true;
+  }
+  for (const [index, signal] of signals.entries()) {
     if (hasGatewayProcessClosed(child)) {
       return true;
     }
+    if (Date.now() >= deadline) {
+      break;
+    }
     try {
-      signalOpenClawTestProcess(child, signal);
+      terminate(signal);
     } catch {
       // ignore
     }
-    if (await waitForClose(signal === "SIGTERM" ? 2 : 1)) {
+    if (await waitForClose(signals.length - index)) {
       return true;
     }
   }
-  return false;
+  return hasGatewayProcessClosed(child);
 }
 
 function hasChildExited(child: Pick<OpenClawTestProcess, "exitCode" | "signalCode">) {
@@ -471,8 +501,9 @@ export async function createOpenClawTestInstance(
   const releaseGatewayChild = async (
     target: OpenClawTestProcess,
     deadline: number,
+    options: GatewayProcessStopOptions = {},
   ): Promise<boolean> => {
-    const closed = await stopGatewayProcess(target, deadline, stopTimeoutMs);
+    const closed = await stopGatewayProcess(target, deadline, stopTimeoutMs, options);
     if (closed && child === target) {
       child = undefined;
     }
@@ -506,7 +537,7 @@ export async function createOpenClawTestInstance(
       });
     },
     startGateway: async () => {
-      if (child && !hasGatewayProcessClosed(child)) {
+      if (child && !hasChildExited(child)) {
         return;
       }
       const entrypoint = await resolveGatewayEntrypoint(cwd);
@@ -523,6 +554,18 @@ export async function createOpenClawTestInstance(
       const deadline = Date.now() + (options.startTimeoutMs ?? GATEWAY_START_TIMEOUT_MS);
       let restarts = 0;
 
+      if (child) {
+        const staleChild = child;
+        const closed = await releaseGatewayChild(staleChild, deadline, {
+          forceWindowsTree: true,
+        });
+        if (!closed) {
+          throw new Error(
+            `gateway process did not close before restart deadline\n${formatLogs(stdout, stderr)}`,
+          );
+        }
+      }
+
       while (true) {
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) {
@@ -537,19 +580,24 @@ export async function createOpenClawTestInstance(
           await waitForGatewayReady(attempt, stdout, stderr, port, remainingMs);
           return;
         } catch (err) {
-          const closed = await releaseGatewayChild(attempt, deadline);
+          const exitCode = attempt.exitCode;
+          const signalCode = attempt.signalCode;
+          const closed = await releaseGatewayChild(attempt, deadline, {
+            forceWindowsTree: true,
+          });
           const shouldRestart =
-            closed &&
             restarts < GATEWAY_MIGRATION_CONVERGENCE_MAX_RESTARTS &&
             isGatewayMigrationConvergenceRefusal(
-              attempt.exitCode,
-              attempt.signalCode,
+              exitCode,
+              signalCode,
               readLogBuffer(attemptStderr),
             );
           if (shouldRestart && Date.now() < deadline) {
-            restarts += 1;
-            appendLogChunk(stderr, GATEWAY_MIGRATION_CONVERGENCE_RESTART_MARKER);
-            continue;
+            if (closed) {
+              restarts += 1;
+              appendLogChunk(stderr, GATEWAY_MIGRATION_CONVERGENCE_RESTART_MARKER);
+              continue;
+            }
           }
           throw err;
         }
@@ -651,5 +699,6 @@ export const testing = {
   hasChildExited,
   isGatewayMigrationConvergenceRefusal,
   signalOpenClawTestProcess,
+  stopGatewayProcess,
   waitForGatewayReady,
 };


### PR DESCRIPTION
Related: #109291
Related: #119051

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where shared test gateway startup could exit with the exact
doctor migration-convergence refusal before Codex/auth assertions ran. An exited
child with inherited stdio still open could also be mistaken for a running
Gateway, leaving mixed-profile and other shared consumers flaky or continuing
without a live Gateway.

## Why This Change Was Made

The shared test helper now treats only a non-exited child as running. It
boundedly reaps an exited child before starting another Gateway, preserves the
original exit status and error, and retries only exit code 1 with no signal and
the exact refusal prefix under one overall startup deadline with identical
launch state. Failed launches terminate and reap the owned process tree through
the established managed-child helper; Windows retry cleanup uses its canonical
`taskkill /T /F` path and waits for actual stdio closure. Product runtime
behavior is unchanged.

## User Impact

No product runtime change. Maintainers get deterministic shared gateway startup
for Codex/auth and other integration tests when doctor convergence completes
during the first launch, including when descendants temporarily retain inherited
stdio.

## Evidence

- Shared helper suite: 21/21 passed with
  `node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts`.
- Focused regressions cover terminal exit with inherited stdio open, a second
  start spawning a distinct ready Gateway, Windows descendant-tree cleanup,
  original exit status/error preservation, and process cleanup without leaks.
- Formatting, shared-helper import boundary, `git diff --check`, and structured
  autoreview are clean.
- Exact-head AWS Linux changed gate passed in Crabbox run `run_3a1370530539`:
  head `47dcc69ff1144e3509ab13366d54d6a822cdacce`, Node `v24.18.1`,
  `testRoot` + `tooling` lanes, exit 0, and lease released.
- Durable exact-head ClawSweeper run
  https://github.com/openclaw/clawsweeper/actions/runs/31141412453 found no
  actionable findings and confirmed the prior restart and Windows cleanup
  findings are resolved.
- Node.js 26.7 child-process source and the `@types/node` contract were inspected:
  process exit can precede stdio closure, while close reflects the fully closed
  child-process surface.
- Sibling Codex `origin/main` at `4d7e3e90d9781514f9b3b99c95169a2386868ad9`
  was inspected directly. `AuthManager::shared_from_config` initializes cached
  auth and `auth()` exposes or refreshes it for consumers; no Codex behavior is
  modified. The failure and retry remain owned by OpenClaw's shared Gateway
  process lifecycle before downstream auth assertions.
- Current `origin/main` has zero touched-path overlap and produces a clean
  merge-tree.

Branch base: `dc0b9958999b114a8f7f5547c80f303c250b37cf`

Current main checked: `0f92db6a5ad55b2cfb46e71ed7da04889a31fc35`

Head: `47dcc69ff1144e3509ab13366d54d6a822cdacce`

AI-assisted: yes.

Punchcard-Session: cobalt-valley-meadow-mg
