### PR TITLE
test(qa): keep Control UI parity fixture typed

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-parity-runner.control-ui.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.control-ui.test.ts
@@ -3,7 +3,7 @@ import { createQaBusState } from "./bus-state.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
-import type { QaSuiteResolvedRunContext, QaSuiteRunParams } from "./suite-types.js";
+import type { QaSuiteResolvedRunContext, QaSuiteResult, QaSuiteRunParams } from "./suite-types.js";
 
 const mocks = vi.hoisted(() => ({
   readQaBootstrapScenarioCatalog: vi.fn(),
@@ -54,13 +54,21 @@ beforeEach(() => {
     ],
   });
   mocks.runQaFlowSuiteStandard.mockImplementation(
-    async (params: QaSuiteRunParams | undefined, context: QaSuiteResolvedRunContext) => ({
+    async (
+      params: QaSuiteRunParams | undefined,
+      context: QaSuiteResolvedRunContext,
+    ): Promise<QaSuiteResult> => ({
       outputDir: context.outputDir,
       evidencePath: "/qa-output/qa-evidence.json",
       reportPath: "/qa-output/qa-suite-report.md",
       summaryPath: "/qa-output/qa-suite-summary.json",
       report: "",
-      scenarios: [{ name: context.selectedScenarios[0]?.title, status: "pass", steps: [] }],
+      scenarios: context.selectedScenarios.map((scenario) => ({
+        name: scenario.title,
+        status: "pass",
+        steps: [],
+      })),
+      startedScenarioIds: context.selectedScenarios.map((scenario) => scenario.id),
       watchUrl: "http://127.0.0.1:43123",
       runtimeParityCell: {
         runtime: params?.forcedRuntime ?? "openclaw",
@@ -117,7 +125,7 @@ describe("runtime parity Control UI ownership", () => {
   ])("preserves Control UI policy in both runtime cells for $label", async (testCase) => {
     const lab = createControlUiTestLab();
 
-    await runQaFlowSuiteFromRuntime({
+    const result = await runQaFlowSuiteFromRuntime({
       repoRoot: "/qa-repo",
       outputDir: "/qa-output",
       providerMode: "mock-openai",
@@ -137,5 +145,6 @@ describe("runtime parity Control UI ownership", () => {
       { runtime: "openclaw", controlUiEnabled: testCase.enabled },
       { runtime: "codex", controlUiEnabled: testCase.enabled },
     ]);
+    expect(result.startedScenarioIds).toEqual([testCase.scenarioId]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where all five runtime-parity Control UI tests crashed because their suite-result mock omitted the required producer-owned `startedScenarioIds` field.

## Why This Change Was Made

The fixture now returns a typed `QaSuiteResult`, derives scenario results and started scenario IDs from the selected scenarios, and asserts that the runtime-parity aggregate preserves the selected ID. Production runtime behavior is unchanged.

## User Impact

Maintainers can run the Control UI parity suite and prerelease validation without this stale test fixture failing. There is no user-facing runtime change.

## Evidence

- Exact head: `ff6b82140351cae5fa31ce0ab3aa12e0b347c3c2`
- Original hosted failure: https://github.com/openclaw/openclaw/actions/runs/31131961019/job/92723640801
- Focused test: `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-parity-runner.control-ui.test.ts` - 5 passed.
- Changed-file routing: `extensionTests`, including `tsgo:extensions:test`.
- Testbox: `tbx_01kzcsr24cc961s81bkejpj663`; all routed guards through dead-export checks passed. The extension test type lane reproduced the unrelated `live-timeout.test.ts:53` TS2322 already present on exact-base `main`.
- Exact-base CI proof for that pre-existing type failure: https://github.com/openclaw/openclaw/actions/runs/31133415715/job/92728389507
- Targeted format and `git diff --check`: passed.
- Autoreview: clean, no accepted or actionable findings; overall 0.99.
- LOC: production `+0/-0`; tests `+13/-4`.

No changelog entry: test-only release-validation repair.
