### PR TITLE
fix(release): restart gateway after migration convergence

### DIFF
--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -42,7 +42,9 @@ export type LaneState = {
 export type GatewayHandle = {
   child: ChildProcess;
   closeLog: () => Promise<void>;
+  launchLogOffset: number;
   logPath: string;
+  waitForClose: () => Promise<void>;
 };
 export type CommandResult = { exitCode: number; stdout: string; stderr: string };
 export type AgentTurnResult = CommandResult | { status: number; stdout: string; stderr: string };

--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -39,9 +39,11 @@ import {
 import { readLogFileSize, readLogTextSince } from "./logs.ts";
 import {
   canConnectToLoopbackPort,
+  hasChildExited,
   resolveCommandSpawnInvocation,
   runCommand,
   runCommandInvocation,
+  waitForGatewayWithStartupMigrationRestart,
   withAllocatedGatewayPort,
 } from "./process.ts";
 import { formatError, shellEscapeForSh, sleep } from "./shared.ts";
@@ -506,6 +508,7 @@ export async function startManualGatewayFromInstalledCli(params: {
   logPath: string;
 }): Promise<GatewayHandle> {
   mkdirSync(dirname(params.logPath), { recursive: true });
+  const launchLogOffset = readLogFileSize(params.logPath);
   const gatewayLog = createWriteStream(params.logPath, { flags: "a" });
   const invocation = resolveInstalledCliInvocation(
     params.cliPath,
@@ -529,24 +532,33 @@ export async function startManualGatewayFromInstalledCli(params: {
   child.stderr?.on("data", (chunk) => {
     gatewayLog.write(chunk);
   });
-  let logClosed = false;
-  const closeLog = async () => {
-    if (logClosed) {
-      return;
-    }
-    logClosed = true;
-    await new Promise<void>((resolvePromise) => {
+  let resolveChildClose: () => void;
+  const childClosePromise = new Promise<void>((resolvePromise) => {
+    resolveChildClose = resolvePromise;
+  });
+  let closeLogPromise: Promise<void> | undefined;
+  const closeLog = () => {
+    closeLogPromise ??= new Promise<void>((resolvePromise) => {
       gatewayLog.once("error", () => resolvePromise());
       gatewayLog.end(() => resolvePromise());
     });
+    return closeLogPromise;
   };
   child.once("close", () => {
+    resolveChildClose();
     void closeLog();
   });
   child.once("error", () => {
+    resolveChildClose();
     void closeLog();
   });
-  return { child, closeLog, logPath: params.logPath };
+  return {
+    child,
+    closeLog,
+    launchLogOffset,
+    logPath: params.logPath,
+    waitForClose: () => childClosePromise,
+  };
 }
 
 async function resolveInstalledGatewayStatusArgs(params: {
@@ -609,8 +621,37 @@ export async function waitForInstalledGateway(params: {
   lane: LaneState;
   cliPath: string;
   env: NodeJS.ProcessEnv;
+  gateway?: GatewayHandle;
+  gatewayHolder?: { current: GatewayHandle | null };
+  gatewayLogPath?: string;
   logPath: string;
 }) {
+  if (params.gatewayHolder) {
+    if (!params.gatewayLogPath) {
+      throw new Error("Gateway restart coordination requires a gateway log path.");
+    }
+    const gatewayLogPath = params.gatewayLogPath;
+    await waitForGatewayWithStartupMigrationRestart({
+      gatewayHolder: params.gatewayHolder,
+      restartGateway: () =>
+        startManualGatewayFromInstalledCli({
+          lane: params.lane,
+          cliPath: params.cliPath,
+          env: params.env,
+          logPath: gatewayLogPath,
+        }),
+      waitUntilReady: (gateway) =>
+        waitForInstalledGateway({
+          lane: params.lane,
+          cliPath: params.cliPath,
+          env: params.env,
+          gateway,
+          logPath: params.logPath,
+        }),
+    });
+    return;
+  }
+
   const statusArgs = await resolveInstalledGatewayStatusArgs({
     cliPath: params.cliPath,
     cwd: params.lane.homeDir,
@@ -619,6 +660,9 @@ export async function waitForInstalledGateway(params: {
   });
   const deadline = Date.now() + gatewayReadyDeadlineMs();
   while (Date.now() < deadline) {
+    if (params.gateway && hasChildExited(params.gateway.child)) {
+      throw new Error(`Gateway exited before becoming ready on port ${params.lane.gatewayPort}.`);
+    }
     const result = await runInstalledCli({
       cliPath: params.cliPath,
       args: statusArgs,
@@ -630,6 +674,9 @@ export async function waitForInstalledGateway(params: {
     });
     if (result.exitCode === 0) {
       return;
+    }
+    if (params.gateway && hasChildExited(params.gateway.child)) {
+      throw new Error(`Gateway exited before becoming ready on port ${params.lane.gatewayPort}.`);
     }
     await sleep(2_000);
   }

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -82,6 +82,7 @@ import { formatError, trimForSummary } from "./shared.ts";
 export async function runFreshLane(params: LaneBaseParams & { build: CandidateBuild }) {
   const lane = createLaneState("fresh");
   const cleanup: Cleanup[] = [];
+  const gatewayHolder: { current: GatewayHandle | null } = { current: null };
   try {
     const env = buildLaneEnv(lane, params.providerConfig, params.providerSecretValue);
     await runTimedLanePhase(lane, "install-candidate", async () => {
@@ -143,12 +144,15 @@ export async function runFreshLane(params: LaneBaseParams & { build: CandidateBu
         logPath: join(params.logsDir, "fresh-gateway.log"),
       }),
     );
-    cleanup.push(() => stopGateway(gateway));
+    gatewayHolder.current = gateway;
+    cleanup.push(() => stopGateway(gatewayHolder.current));
 
     await runTimedLanePhase(lane, "wait-gateway", async () => {
       await waitForGateway({
         lane,
         env,
+        gatewayHolder,
+        gatewayLogPath: join(params.logsDir, "fresh-gateway.log"),
         logPath: join(params.logsDir, "fresh-gateway-status.log"),
       });
     });
@@ -200,6 +204,7 @@ export async function runUpgradeLane(
   }
   const lane = createLaneState("upgrade");
   const cleanup: Cleanup[] = [];
+  const gatewayHolder: { current: GatewayHandle | null } = { current: null };
   try {
     const env = buildLaneEnv(lane, params.providerConfig, params.providerSecretValue);
     await runTimedLanePhase(lane, "install-baseline", async () => {
@@ -348,12 +353,15 @@ export async function runUpgradeLane(
         logPath: join(params.logsDir, "upgrade-gateway.log"),
       }),
     );
-    cleanup.push(() => stopGateway(gateway));
+    gatewayHolder.current = gateway;
+    cleanup.push(() => stopGateway(gatewayHolder.current));
 
     await runTimedLanePhase(lane, "wait-gateway", async () => {
       await waitForGateway({
         lane,
         env,
+        gatewayHolder,
+        gatewayLogPath: join(params.logsDir, "upgrade-gateway.log"),
         logPath: join(params.logsDir, "upgrade-gateway-status.log"),
       });
     });
@@ -560,6 +568,8 @@ export async function runInstallerFreshSuite(
         lane,
         cliPath: freshShell.cliPath,
         env,
+        gatewayHolder: manualGateway,
+        gatewayLogPath: join(params.logsDir, "installer-fresh-gateway.log"),
         logPath: join(params.logsDir, "installer-fresh-gateway-status.log"),
       });
     }
@@ -790,6 +800,8 @@ export async function runDevUpdateSuite(
         lane,
         cliPath: verifiedShell.cliPath,
         env,
+        gatewayHolder: manualGateway,
+        gatewayLogPath: join(params.logsDir, "dev-update-gateway.log"),
         logPath: join(params.logsDir, "dev-update-gateway-status.log"),
       });
     } else {

--- a/scripts/lib/cross-os-release-checks/network-smokes.ts
+++ b/scripts/lib/cross-os-release-checks/network-smokes.ts
@@ -37,12 +37,50 @@ export function buildDiscordSmokeGuildsConfig(guildId: string, channelId: string
   };
 }
 
+export async function restartManualGatewayForDiscordSmoke(params: {
+  lane: LaneState;
+  cliPath: string;
+  env: NodeJS.ProcessEnv;
+  gatewayHolder: { current: GatewayHandle | null };
+  gatewayLogPath: string;
+  statusLogPath: string;
+  operations?: {
+    startGateway: typeof startManualGatewayFromInstalledCli;
+    stopGateway: typeof stopGateway;
+    waitForGateway: typeof waitForInstalledGateway;
+  };
+}) {
+  const operations = params.operations ?? {
+    startGateway: startManualGatewayFromInstalledCli,
+    stopGateway,
+    waitForGateway: waitForInstalledGateway,
+  };
+  if (params.gatewayHolder.current) {
+    await operations.stopGateway(params.gatewayHolder.current);
+    params.gatewayHolder.current = null;
+  }
+  params.gatewayHolder.current = await operations.startGateway({
+    lane: params.lane,
+    cliPath: params.cliPath,
+    env: params.env,
+    logPath: params.gatewayLogPath,
+  });
+  await operations.waitForGateway({
+    lane: params.lane,
+    cliPath: params.cliPath,
+    env: params.env,
+    gatewayHolder: params.gatewayHolder,
+    gatewayLogPath: params.gatewayLogPath,
+    logPath: params.statusLogPath,
+  });
+}
+
 async function configureDiscordSmoke(params: {
   lane: LaneState;
   cliPath: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
-  gatewayHolder?: { current: GatewayHandle | null };
+  gatewayHolder: { current: GatewayHandle | null };
   logPath: string;
   token: string;
   guildId: string;
@@ -95,24 +133,17 @@ async function configureDiscordSmoke(params: {
   });
   if (!shouldUseManagedGatewayService()) {
     const gatewayEnv = { ...params.env, DISCORD_BOT_TOKEN: params.token };
-    if (params.gatewayHolder?.current) {
-      await stopGateway(params.gatewayHolder.current);
-      params.gatewayHolder.current = null;
-    }
-    const gateway = await startManualGatewayFromInstalledCli({
+    const gatewayLogPath = join(
+      params.cwd,
+      `.openclaw/logs/${params.lane.name}-discord-gateway.log`,
+    );
+    await restartManualGatewayForDiscordSmoke({
       lane: params.lane,
       cliPath: params.cliPath,
       env: gatewayEnv,
-      logPath: join(params.cwd, `.openclaw/logs/${params.lane.name}-discord-gateway.log`),
-    });
-    if (params.gatewayHolder) {
-      params.gatewayHolder.current = gateway;
-    }
-    await waitForInstalledGateway({
-      lane: params.lane,
-      cliPath: params.cliPath,
-      env: gatewayEnv,
-      logPath: params.logPath,
+      gatewayHolder: params.gatewayHolder,
+      gatewayLogPath,
+      statusLogPath: params.logPath,
     });
     return;
   }

--- a/scripts/lib/cross-os-release-checks/process.ts
+++ b/scripts/lib/cross-os-release-checks/process.ts
@@ -29,6 +29,7 @@ import {
   CROSS_OS_COMMAND_HEARTBEAT_SECONDS,
   CROSS_OS_PROCESS_TREE_KILL_AFTER_MS,
 } from "./config.ts";
+import { readLogTextSince } from "./logs.ts";
 import { formatError, sleep, toLintErrorObject, trimForSummary } from "./shared.ts";
 
 const CROSS_OS_SIGNAL_EXIT_CODES: Partial<Record<NodeJS.Signals, number>> = {
@@ -37,6 +38,8 @@ const CROSS_OS_SIGNAL_EXIT_CODES: Partial<Record<NodeJS.Signals, number>> = {
   SIGTERM: 143,
 };
 const CROSS_OS_ACTIVE_CHILD_TREE_KILLERS = new Set<(signal: NodeJS.Signals) => void>();
+const STARTUP_MIGRATION_RESTART_PREFIX =
+  "OpenClaw plugin migration inputs changed during startup convergence;";
 let forwardedSignalExitCode: number | undefined;
 let forwardedSignalForceKillTimer: NodeJS.Timeout | undefined;
 
@@ -117,8 +120,38 @@ export async function canConnectToLoopbackPort(port: number, timeoutMs = 1_000) 
   });
 }
 
-function hasChildExited(child: ChildProcess) {
+export function hasChildExited(child: ChildProcess) {
   return child.exitCode !== null || (child.signalCode ?? null) !== null;
+}
+
+export async function waitForGatewayWithStartupMigrationRestart(params: {
+  gatewayHolder: { current: GatewayHandle | null };
+  restartGateway: () => Promise<GatewayHandle>;
+  waitUntilReady: (gateway: GatewayHandle) => Promise<void>;
+}) {
+  let gateway = params.gatewayHolder.current;
+  if (!gateway) {
+    throw new Error("Gateway restart coordination requires an active gateway handle.");
+  }
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await params.waitUntilReady(gateway);
+      return;
+    } catch (error) {
+      if (!hasChildExited(gateway.child)) {
+        throw error;
+      }
+      await gateway.waitForClose();
+      await gateway.closeLog();
+      const startupLog = readLogTextSince(gateway.logPath, gateway.launchLogOffset);
+      if (attempt > 0 || !startupLog.includes(STARTUP_MIGRATION_RESTART_PREFIX)) {
+        throw error;
+      }
+      gateway = await params.restartGateway();
+      params.gatewayHolder.current = gateway;
+    }
+  }
 }
 
 export async function stopGateway(gateway: GatewayHandle | null) {

--- a/scripts/lib/cross-os-release-checks/runtime.ts
+++ b/scripts/lib/cross-os-release-checks/runtime.ts
@@ -42,7 +42,13 @@ import {
   resolveDashboardAssetUrls,
   verifyDashboardAssetUrls,
 } from "./network-smokes.ts";
-import { registerActiveChildProcessTree, runCommand, withAllocatedGatewayPort } from "./process.ts";
+import {
+  hasChildExited,
+  registerActiveChildProcessTree,
+  runCommand,
+  waitForGatewayWithStartupMigrationRestart,
+  withAllocatedGatewayPort,
+} from "./process.ts";
 import { logLanePhase } from "./reporting.ts";
 import { formatError, sleep } from "./shared.ts";
 
@@ -139,6 +145,7 @@ export async function exerciseManagedGatewayLifecycle(
 }
 
 export async function startGateway(params: LaneCommandParams): Promise<GatewayHandle> {
+  const launchLogOffset = readLogFileSize(params.logPath);
   const gatewayLog = createWriteStream(params.logPath, { flags: "a" });
   const useProcessGroup = process.platform !== "win32";
   const child = spawn(
@@ -168,32 +175,74 @@ export async function startGateway(params: LaneCommandParams): Promise<GatewayHa
   child.stderr?.on("data", (chunk) => {
     gatewayLog.write(chunk);
   });
-  let logClosed = false;
-  const closeLog = async () => {
-    if (logClosed) {
-      return;
-    }
-    logClosed = true;
-    await new Promise<void>((resolvePromise) => {
+  let resolveChildClose: () => void;
+  const childClosePromise = new Promise<void>((resolvePromise) => {
+    resolveChildClose = resolvePromise;
+  });
+  let closeLogPromise: Promise<void> | undefined;
+  const closeLog = () => {
+    closeLogPromise ??= new Promise<void>((resolvePromise) => {
       gatewayLog.once("error", () => resolvePromise());
       gatewayLog.end(() => resolvePromise());
     });
+    return closeLogPromise;
   };
   child.once("close", () => {
+    resolveChildClose();
     activeChildTree.unregister();
     void closeLog();
   });
   child.once("error", () => {
+    resolveChildClose();
     activeChildTree.unregister();
     void closeLog();
   });
-  return { child, closeLog, logPath: params.logPath };
+  return {
+    child,
+    closeLog,
+    launchLogOffset,
+    logPath: params.logPath,
+    waitForClose: () => childClosePromise,
+  };
 }
 
-export async function waitForGateway(params: LaneCommandParams) {
+export async function waitForGateway(
+  params: LaneCommandParams & {
+    gateway?: GatewayHandle;
+    gatewayHolder?: { current: GatewayHandle | null };
+    gatewayLogPath?: string;
+  },
+) {
+  if (params.gatewayHolder) {
+    if (!params.gatewayLogPath) {
+      throw new Error("Gateway restart coordination requires a gateway log path.");
+    }
+    const gatewayLogPath = params.gatewayLogPath;
+    await waitForGatewayWithStartupMigrationRestart({
+      gatewayHolder: params.gatewayHolder,
+      restartGateway: () =>
+        startGateway({
+          lane: params.lane,
+          env: params.env,
+          logPath: gatewayLogPath,
+        }),
+      waitUntilReady: (gateway) =>
+        waitForGateway({
+          lane: params.lane,
+          env: params.env,
+          gateway,
+          logPath: params.logPath,
+        }),
+    });
+    return;
+  }
+
   const statusArgs = await resolveGatewayStatusArgs(params.lane, params.env, params.logPath);
   const deadline = Date.now() + gatewayReadyDeadlineMs();
   while (Date.now() < deadline) {
+    if (params.gateway && hasChildExited(params.gateway.child)) {
+      throw new Error(`Gateway exited before becoming ready on port ${params.lane.gatewayPort}.`);
+    }
     let result;
     try {
       result = await runOpenClaw({
@@ -210,6 +259,9 @@ export async function waitForGateway(params: LaneCommandParams) {
     }
     if (result.exitCode === 0) {
       return;
+    }
+    if (params.gateway && hasChildExited(params.gateway.child)) {
+      throw new Error(`Gateway exited before becoming ready on port ${params.lane.gatewayPort}.`);
     }
     await sleep(2_000);
   }

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -1,6 +1,7 @@
 // Openclaw Cross Os Release Checks tests cover openclaw cross os release checks script behavior.
 import { spawn } from "node:child_process";
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -41,6 +42,7 @@ import {
   buildDiscordSmokeGuildsConfig,
   buildRealUpdateEnv,
   dashboardHtmlMarkerStatus,
+  type GatewayHandle,
   CROSS_OS_FETCH_BODY_MAX_CHARS,
   CROSS_OS_GATEWAY_READY_TIMEOUT_MS,
   CROSS_OS_GATEWAY_STATUS_COMMAND_TIMEOUT_MS,
@@ -82,6 +84,7 @@ import {
   resolveInstalledPackageRootFromCliPath,
   resolveNpmPackTarballFileName,
   resolveNpmDebugLogDirs,
+  restartManualGatewayForDiscordSmoke,
   resolveManagedGatewayInstallerEnv,
   resolvePackDestinationTarball,
   resolvePackageCandidatePackCommand,
@@ -108,6 +111,7 @@ import {
   verifyDevUpdateStatus,
   verifyPackagedUpgradeUpdateResult,
   verifyWindowsPackagedUpgradeFallbackInstall,
+  waitForGatewayWithStartupMigrationRestart,
   writePackageDistInventoryForCandidate,
 } from "../../scripts/lib/cross-os-release-checks/index.ts";
 import { LOCAL_BUILD_METADATA_DIST_PATHS } from "../../scripts/lib/local-build-metadata-paths.mjs";
@@ -179,6 +183,47 @@ async function withTempDirAsync<T>(prefix: string, run: (dir: string) => Promise
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+}
+
+function createGatewayHandleFixture(params: {
+  dir: string;
+  name: string;
+  beforeLaunch?: string;
+  afterLaunch?: string;
+  appendOnWaitForClose?: string;
+  appendOnClose?: string;
+  exited: boolean;
+}) {
+  const logPath = join(params.dir, `${params.name}.log`);
+  const beforeLaunch = params.beforeLaunch ?? "";
+  writeFileSync(logPath, beforeLaunch);
+  if (params.afterLaunch) {
+    appendFileSync(logPath, params.afterLaunch);
+  }
+  const state = { closeCalls: 0, waitForCloseCalls: 0, order: [] as string[] };
+  const handle: GatewayHandle = {
+    child: {
+      exitCode: params.exited ? 1 : null,
+      signalCode: null,
+    } as GatewayHandle["child"],
+    closeLog: async () => {
+      state.closeCalls += 1;
+      state.order.push("closeLog");
+      if (params.appendOnClose) {
+        appendFileSync(logPath, params.appendOnClose);
+      }
+    },
+    launchLogOffset: Buffer.byteLength(beforeLaunch),
+    logPath,
+    waitForClose: async () => {
+      state.waitForCloseCalls += 1;
+      state.order.push("waitForClose");
+      if (params.appendOnWaitForClose) {
+        appendFileSync(logPath, params.appendOnWaitForClose);
+      }
+    },
+  };
+  return { handle, state };
 }
 
 describe("scripts/openclaw-cross-os-release-checks", () => {
@@ -471,6 +516,232 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         requireRpc: false,
       }),
     ).toEqual(["gateway", "status"]);
+  });
+
+  it("restarts an exited manual gateway once after the exact startup migration refusal", async () => {
+    await withTempDirAsync("openclaw-cross-os-gateway-restart-", async (dir) => {
+      const refusal =
+        "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready.";
+      const first = createGatewayHandleFixture({
+        dir,
+        name: "first",
+        appendOnWaitForClose: refusal,
+        exited: true,
+      });
+      const second = createGatewayHandleFixture({
+        dir,
+        name: "second",
+        exited: false,
+      });
+      const holder = { current: first.handle as GatewayHandle | null };
+      const firstError = new Error("first gateway exited");
+      let restartCalls = 0;
+
+      await waitForGatewayWithStartupMigrationRestart({
+        gatewayHolder: holder,
+        restartGateway: async () => {
+          restartCalls += 1;
+          return second.handle;
+        },
+        waitUntilReady: async (gateway) => {
+          if (gateway === first.handle) {
+            throw firstError;
+          }
+        },
+      });
+
+      expect(restartCalls).toBe(1);
+      expect(first.state.waitForCloseCalls).toBe(1);
+      expect(first.state.closeCalls).toBe(1);
+      expect(first.state.order).toEqual(["waitForClose", "closeLog"]);
+      expect(holder.current).toBe(second.handle);
+    });
+  });
+
+  it.each([
+    {
+      name: "generic child exit",
+      beforeLaunch: "",
+      afterLaunch: "gateway crashed before binding\n",
+    },
+    {
+      name: "paraphrased refusal",
+      beforeLaunch: "",
+      afterLaunch:
+        "OpenClaw plugin migration inputs changed during startup convergence: refusing to report the gateway ready.\n",
+    },
+    {
+      name: "stale refusal from an earlier launch",
+      beforeLaunch:
+        "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready.\n",
+      afterLaunch: "gateway crashed before binding\n",
+    },
+  ])("does not restart after $name", async ({ beforeLaunch, afterLaunch }) => {
+    await withTempDirAsync("openclaw-cross-os-gateway-no-restart-", async (dir) => {
+      const gateway = createGatewayHandleFixture({
+        dir,
+        name: "gateway",
+        beforeLaunch,
+        afterLaunch,
+        exited: true,
+      });
+      const holder = { current: gateway.handle as GatewayHandle | null };
+      const startupError = new Error("gateway exited");
+      let restartCalls = 0;
+
+      await expect(
+        waitForGatewayWithStartupMigrationRestart({
+          gatewayHolder: holder,
+          restartGateway: async () => {
+            restartCalls += 1;
+            return gateway.handle;
+          },
+          waitUntilReady: async () => {
+            throw startupError;
+          },
+        }),
+      ).rejects.toBe(startupError);
+
+      expect(restartCalls).toBe(0);
+      expect(gateway.state.waitForCloseCalls).toBe(1);
+      expect(gateway.state.closeCalls).toBe(1);
+      expect(holder.current).toBe(gateway.handle);
+    });
+  });
+
+  it("does not restart a live gateway after a readiness failure", async () => {
+    await withTempDirAsync("openclaw-cross-os-gateway-live-", async (dir) => {
+      const gateway = createGatewayHandleFixture({
+        dir,
+        name: "gateway",
+        afterLaunch:
+          "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready.\n",
+        exited: false,
+      });
+      const holder = { current: gateway.handle as GatewayHandle | null };
+      const readinessError = new Error("gateway readiness timed out");
+      let restartCalls = 0;
+
+      await expect(
+        waitForGatewayWithStartupMigrationRestart({
+          gatewayHolder: holder,
+          restartGateway: async () => {
+            restartCalls += 1;
+            return gateway.handle;
+          },
+          waitUntilReady: async () => {
+            throw readinessError;
+          },
+        }),
+      ).rejects.toBe(readinessError);
+
+      expect(restartCalls).toBe(0);
+      expect(gateway.state.waitForCloseCalls).toBe(0);
+      expect(gateway.state.closeCalls).toBe(0);
+    });
+  });
+
+  it("fails after a second startup migration refusal without looping", async () => {
+    await withTempDirAsync("openclaw-cross-os-gateway-second-refusal-", async (dir) => {
+      const refusal =
+        "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready.\n";
+      const first = createGatewayHandleFixture({
+        dir,
+        name: "first",
+        afterLaunch: refusal,
+        exited: true,
+      });
+      const second = createGatewayHandleFixture({
+        dir,
+        name: "second",
+        afterLaunch: refusal,
+        exited: true,
+      });
+      const holder = { current: first.handle as GatewayHandle | null };
+      const secondError = new Error("second gateway exited");
+      let restartCalls = 0;
+
+      await expect(
+        waitForGatewayWithStartupMigrationRestart({
+          gatewayHolder: holder,
+          restartGateway: async () => {
+            restartCalls += 1;
+            return second.handle;
+          },
+          waitUntilReady: async (gateway) => {
+            if (gateway === first.handle) {
+              throw new Error("first gateway exited");
+            }
+            throw secondError;
+          },
+        }),
+      ).rejects.toBe(secondError);
+
+      expect(restartCalls).toBe(1);
+      expect(first.state.waitForCloseCalls).toBe(1);
+      expect(first.state.closeCalls).toBe(1);
+      expect(second.state.waitForCloseCalls).toBe(1);
+      expect(second.state.closeCalls).toBe(1);
+      expect(holder.current).toBe(second.handle);
+    });
+  });
+
+  it("routes the Discord manual relaunch through the bounded retry wait", async () => {
+    await withTempDirAsync("openclaw-cross-os-discord-gateway-", async (dir) => {
+      const previous = createGatewayHandleFixture({
+        dir,
+        name: "previous",
+        exited: false,
+      });
+      const started = createGatewayHandleFixture({
+        dir,
+        name: "started",
+        exited: false,
+      });
+      const lane = {
+        name: "installer-fresh",
+        rootDir: dir,
+        prefixDir: join(dir, "prefix"),
+        homeDir: join(dir, "home"),
+        stateDir: join(dir, "state"),
+        appDataDir: join(dir, "app-data"),
+        gatewayPort: 18_789,
+        phaseTimings: [],
+      };
+      const gatewayHolder = { current: previous.handle as GatewayHandle | null };
+      const gatewayLogPath = join(dir, "discord-gateway.log");
+      const statusLogPath = join(dir, "discord-status.log");
+      const calls: Array<{ name: string; params: unknown }> = [];
+
+      await restartManualGatewayForDiscordSmoke({
+        lane,
+        cliPath: join(dir, "openclaw"),
+        env: { OPENCLAW_HOME: lane.homeDir },
+        gatewayHolder,
+        gatewayLogPath,
+        statusLogPath,
+        operations: {
+          stopGateway: async (gateway) => {
+            calls.push({ name: "stop", params: gateway });
+          },
+          startGateway: async (params) => {
+            calls.push({ name: "start", params });
+            return started.handle;
+          },
+          waitForGateway: async (params) => {
+            calls.push({ name: "wait", params });
+          },
+        },
+      });
+
+      expect(gatewayHolder.current).toBe(started.handle);
+      expect(calls.map((call) => call.name)).toEqual(["stop", "start", "wait"]);
+      expect(calls[2]?.params).toMatchObject({
+        gatewayHolder,
+        gatewayLogPath,
+        logPath: statusLogPath,
+      });
+    });
   });
 
   it("gives the Windows packaged updater wrapper enough headroom for OpenClaw timeout output", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where prepublication cross-OS release checks would fail after a manual gateway intentionally exited to converge plugin migration state during first startup.

The failure affected packaged fresh, packaged upgrade, installer manual fallback, and dev-update manual gateway lanes in the `2026.8.1-beta.1` candidate run.

## Why This Change Was Made

The release harness now records each manual gateway launch's log offset and retries that launch exactly once only when the child has exited, reached the child-close/stdio-drain boundary, and its flushed current-launch log contains the exact startup-migration refusal prefix. The retry reuses the same home/config, environment, port, CLI, and log path, and replaces the cleanup handle.

Generic exits, paraphrased or stale markers, live readiness failures, and a second refusal still fail. The same bounded path covers the Discord manual gateway relaunch. Managed gateway services are intentionally unchanged; the Windows Scheduled Task failure remains a separate release blocker.

## User Impact

Release validation can continue through the gateway's intentional one-time migration convergence restart without hiding unrelated startup failures.

This adds a bounded release-harness capability across the two manual gateway launch owners; it does not change product runtime behavior.

## Evidence

- Failure evidence: cross-OS release run `31131961509` showed the exact startup-migration refusal in all manual gateway lanes after install, onboarding, and model setup completed.
- `node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts` - 130 tests passed.
- Tests cover exact-marker retry, child-close and log-flush ordering, stale/paraphrased/generic rejection, live-child rejection, cleanup-handle replacement, Discord relaunch wiring, and second-refusal failure.
- `pnpm format:check` and scoped `oxlint` passed for all changed scripts.
- `check:changed` Testbox delegation could not sync this GWT because omitted tracked paths made the remote checkout unsafe. Its exact trusted local fallback passed all lightweight guards; the full script/test type lanes stopped on unrelated stale shared-checkout errors in untouched files before reaching this change.
- Final whole-branch autoreview: clean, no accepted/actionable findings.
