### PR TITLE
test(channels): align prerelease fallback catalog spec

### DIFF
--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -1,4 +1,7 @@
 // Channel catalog contract tests cover bundled and registry-backed channel catalog invariants.
+import fs from "node:fs";
+import path from "node:path";
+import { isPrereleaseSemverVersion } from "../../../infra/npm-registry-spec.js";
 import {
   describeBundledMetadataOnlyChannelCatalogContract,
   describeChannelCatalogEntryContract,
@@ -20,6 +23,22 @@ const whatsappMeta = {
   blurb: "works with your own number; recommend a separate phone + eSIM.",
 };
 
+const whatsappPackageJson = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), "extensions", "whatsapp", "package.json"), "utf8"),
+) as {
+  name?: string;
+  version?: string;
+  openclaw?: { install?: { npmSpec?: string } };
+};
+const whatsappNpmSpec = whatsappPackageJson.openclaw?.install?.npmSpec ?? whatsappPackageJson.name;
+const whatsappVersion = whatsappPackageJson.version;
+if (!whatsappNpmSpec || !whatsappVersion) {
+  throw new Error("missing package metadata for whatsapp");
+}
+const whatsappOfficialFallbackNpmSpec = isPrereleaseSemverVersion(whatsappVersion)
+  ? `${whatsappNpmSpec}@${whatsappVersion}`
+  : whatsappNpmSpec;
+
 describeBundledMetadataOnlyChannelCatalogContract({
   pluginId: "whatsapp",
   packageName: "@openclaw/whatsapp",
@@ -30,7 +49,7 @@ describeBundledMetadataOnlyChannelCatalogContract({
 
 describeOfficialFallbackChannelCatalogContract({
   channelId: "whatsapp",
-  npmSpec: "@openclaw/whatsapp",
+  npmSpec: whatsappOfficialFallbackNpmSpec,
   meta: whatsappMeta,
   packageName: "@openclaw/whatsapp",
   pluginId: "whatsapp",


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the WhatsApp official fallback catalog contract expected a bare npm package name after release preparation correctly pinned the prerelease package version.

The failure was observed in Full Release Validation run https://github.com/openclaw/openclaw/actions/runs/31129806068, job https://github.com/openclaw/openclaw/actions/runs/31129806068/job/92718333675.

## Why This Change Was Made

The contract now derives the WhatsApp npm spec from its package metadata and appends the exact version only when that package version is a prerelease. The bundled WhatsApp fixture and Microsoft Teams assertion remain bare because those paths do not carry a prerelease package version.

This keeps production prerelease pinning unchanged and avoids hard-coding a release version in the test.

## User Impact

No runtime behavior changes. Beta release validation now accepts the intended exact prerelease install target instead of treating it as catalog drift.

## Evidence

- `node scripts/run-vitest.mjs src/channels/plugins/contracts/channel-catalog.contract.test.ts` (12 passed)
- `node scripts/run-vitest.mjs src/channels/plugins/contracts/plugins-core.catalog.entries.contract.test.ts` (7 passed)
- `./node_modules/.bin/oxfmt --check --threads=1 src/channels/plugins/contracts/channel-catalog.contract.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings, confidence 0.99
- `node scripts/check-changed.mjs -- src/channels/plugins/contracts/channel-catalog.contract.test.ts` passed formatting, guards, plugin boundaries, dead-code scans, core typecheck, and core-test typecheck. The unrelated extension-test lane remains red on unchanged `origin/main` at `extensions/qa-lab/src/live-timeout.test.ts:53`; current-main CI run: https://github.com/openclaw/openclaw/actions/runs/31133415715.
