### PR TITLE
fix(channels): align WhatsApp fallback contract for prereleases

### DIFF
--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -1,4 +1,6 @@
 // Channel catalog contract tests cover bundled and registry-backed channel catalog invariants.
+import whatsappPackageJson from "../../../../extensions/whatsapp/package.json" with { type: "json" };
+import { isPrereleaseSemverVersion } from "../../../infra/npm-registry-spec.js";
 import {
   describeBundledMetadataOnlyChannelCatalogContract,
   describeChannelCatalogEntryContract,
@@ -20,6 +22,14 @@ const whatsappMeta = {
   blurb: "works with your own number; recommend a separate phone + eSIM.",
 };
 
+const whatsappOfficialFallbackNpmSpec =
+  whatsappPackageJson.openclaw.install.npmSpec ?? whatsappPackageJson.name;
+const expectedWhatsappOfficialFallbackNpmSpec = isPrereleaseSemverVersion(
+  whatsappPackageJson.version,
+)
+  ? `${whatsappOfficialFallbackNpmSpec}@${whatsappPackageJson.version}`
+  : whatsappOfficialFallbackNpmSpec;
+
 describeBundledMetadataOnlyChannelCatalogContract({
   pluginId: "whatsapp",
   packageName: "@openclaw/whatsapp",
@@ -30,7 +40,7 @@ describeBundledMetadataOnlyChannelCatalogContract({
 
 describeOfficialFallbackChannelCatalogContract({
   channelId: "whatsapp",
-  npmSpec: "@openclaw/whatsapp",
+  npmSpec: expectedWhatsappOfficialFallbackNpmSpec,
   meta: whatsappMeta,
   packageName: "@openclaw/whatsapp",
   pluginId: "whatsapp",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where prerelease release validation expected the bare WhatsApp
npm package spec even though the generated official fallback catalog correctly
pins that package to the exact prerelease version.

## Why This Change Was Made

The WhatsApp official-fallback contract now derives its expected npm spec from
the plugin package manifest and appends the manifest version only for
prereleases. Bundled WhatsApp and Microsoft Teams expectations remain bare.

## User Impact

No runtime behavior changes. This keeps release validation aligned with the
existing prerelease catalog behavior and unblocks beta preparation.

## Evidence

- `node scripts/run-vitest.mjs src/channels/plugins/contracts/channel-catalog.contract.test.ts src/channels/plugins/contracts/plugins-core.catalog.entries.contract.test.ts`
  - 19 tests passed across two contract shards.
- Replayed the WhatsApp package manifest and generated official channel catalog
  at `2026.8.1-beta.1`.
  - 12 catalog contract tests passed.
  - Both temporary version-owned artifacts were restored before commit.
- Autoreview: clean, no accepted/actionable findings.
- `node scripts/check-changed.mjs -- src/channels/plugins/contracts/channel-catalog.contract.test.ts`
  - Formatting, boundaries, dependency guards, dead-code checks, core
    typechecks, and extension production typecheck passed.
  - Extension test typecheck stopped on the unchanged main-branch error at
    `extensions/qa-lab/src/live-timeout.test.ts:53` (`string` is not assignable
    to `QaProviderMode`).
  - Testbox run: https://github.com/openclaw/openclaw/actions/runs/31134659055
