### PR TITLE
fix(qa-lab): keep live timeout table type-safe

### DIFF
--- a/extensions/qa-lab/src/live-timeout.test.ts
+++ b/extensions/qa-lab/src/live-timeout.test.ts
@@ -46,7 +46,7 @@ describe("qa live timeout policy", () => {
       fallbackModel: "claude-cli/claude-opus-4-8",
       expectedTimeoutMs: 240_000,
     },
-  ])("$title", ({ mode, model, fallbackModel, expectedTimeoutMs }) => {
+  ] as const)("$title", ({ mode, model, fallbackModel, expectedTimeoutMs }) => {
     expect(
       resolveQaLiveTurnTimeoutMs(
         {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the QA Lab live-timeout table widened provider-mode literals to `string`, causing the extension test TypeScript graph to fail on current `main`.

## Why This Change Was Made

The table is marked `as const` so Vitest preserves each fixture's literal provider mode while leaving the runtime timeout policy and assertions unchanged.

## User Impact

No user-visible behavior changes. Maintainers regain a green extension-test typecheck for the QA Lab timeout tests.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-timeout.test.ts` — 7 tests passed
- `pnpm tsgo:extensions:test` — passed
- `git diff --check` — passed
