### PR TITLE
fix(qa): retain redacted update restart failure logs

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -237,6 +237,108 @@ cleanup() {
   fi
 }
 
+print_redacted_update_restart_log() {
+  local source_path="$1"
+  [ -f "$source_path" ] || return 0
+
+  local redacted_path=""
+  local original_umask
+  original_umask="$(umask)"
+  umask 077
+  redacted_path="$(mktemp "$ARTIFACT_ROOT/update-restart-redacted.XXXXXX")"
+  local create_status=$?
+  umask "$original_umask"
+  if [ "$create_status" -ne 0 ] || [ -z "$redacted_path" ]; then
+    echo "Could not create redacted update restart diagnostic for $source_path." >&2
+    return 1
+  fi
+
+  local redact_status=0
+  OPENCLAW_E2E_REDACT_SOURCE="$source_path" \
+    OPENCLAW_E2E_REDACT_TARGET="$redacted_path" \
+    node -e '
+const fs = require("node:fs");
+
+const source = process.env.OPENCLAW_E2E_REDACT_SOURCE;
+const target = process.env.OPENCLAW_E2E_REDACT_TARGET;
+if (!source || !target) {
+  throw new Error("missing update restart diagnostic redaction path");
+}
+
+let text = fs.readFileSync(source, "utf8");
+for (const name of [
+  "GATEWAY_AUTH_TOKEN_REF",
+  "OPENAI_API_KEY",
+  "DISCORD_BOT_TOKEN",
+  "TELEGRAM_BOT_TOKEN",
+  "FEISHU_APP_SECRET",
+  "MATRIX_ACCESS_TOKEN",
+  "BRAVE_API_KEY",
+]) {
+  const secret = process.env[name];
+  if (secret) {
+    text = text.split(secret).join("[REDACTED]");
+  }
+}
+
+const sensitiveHeaderKeys = String.raw`(?:proxy-)?authorization|x-goog-api-key|api-key|apikey|x-api-token|x-access-token|x-openclaw-token|x-pomerium-jwt-assertion|x-api-key|x-auth-token`;
+const escapedHeaderPattern = new RegExp(String.raw`(\\"(?:${sensitiveHeaderKeys})\\"\s*[:=]\s*\\")[^\r\n]*?(?=\\"\s*(?:,\s*\\"[^"\r\n]+\\"\s*[:=]|\}))`, "giu");
+const jsonHeaderPattern = new RegExp(String.raw`("(?:${sensitiveHeaderKeys})"\s*[:=]\s*")(?:(?:\\.)|[^"\\])*(?=")`, "giu");
+const quotedHeaderPattern = new RegExp(String.raw`((["\x27])(?:${sensitiveHeaderKeys})\s*[:=]\s*)(?:(?!\2)[^\r\n])*(\2)`, "giu");
+const rawHeaderPattern = new RegExp(String.raw`(^|[^A-Za-z0-9_\x27"\\-])((?:${sensitiveHeaderKeys})\s*[:=]\s*)[^\r\n]*(?:\r?\n[ \t]+[^\r\n]*)*`, "gimu");
+text = text
+  .replace(escapedHeaderPattern, "$1[REDACTED]")
+  .replace(jsonHeaderPattern, "$1[REDACTED]")
+  .replace(quotedHeaderPattern, "$1[REDACTED]$3")
+  .replace(rawHeaderPattern, "$1$2[REDACTED]")
+  .replace(
+    /("(?:[^"\\]|\\.)*(?:token|password|secret|api[_-]?key|access[_-]?key)(?:[^"\\]|\\.)*"\s*:\s*)"(?:[^"\\]|\\.)*"/giu,
+    "$1\"[REDACTED]\"",
+  )
+  .replace(
+    /(\b(?:export\s+)?(?:[A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET)[A-Z0-9_]*|[A-Z0-9_]*(?:API|ACCESS)_KEY[A-Z0-9_]*)\s*=\s*)(?:"(?:[^"\\]|\\.)*"|\x27[^\x27]*\x27|[^\s;]+)/giu,
+    "$1[REDACTED]",
+  )
+  .replace(
+    /(\s--(?:token|password|secret|api-key|access-key)(?:=|\s+))(?:"(?:[^"\\]|\\.)*"|\x27[^\x27]*\x27|[^\s]+)/giu,
+    "$1[REDACTED]",
+  );
+
+fs.writeFileSync(target, text, { encoding: "utf8", mode: 0o600 });
+fs.chmodSync(target, 0o600);
+if ((fs.statSync(target).mode & 0o777) !== 0o600) {
+  throw new Error("redacted update restart diagnostic is not mode 0600");
+}
+' || redact_status=$?
+
+  if [ "$redact_status" -ne 0 ]; then
+    echo "Could not redact update restart diagnostic $source_path." >&2
+    rm -f "$redacted_path"
+    return "$redact_status"
+  fi
+
+  echo "--- redacted update restart diagnostic: $source_path ---" >&2
+  openclaw_e2e_print_log "$redacted_path" >&2 || redact_status=$?
+  rm -f "$redacted_path"
+  return "$redact_status"
+}
+
+print_update_restart_failure_diagnostics() {
+  local status=0
+  local state_dir="${OPENCLAW_STATE_DIR:-${HOME:?missing HOME}/.openclaw}"
+  local path
+  for path in \
+    "$SYSTEMCTL_SHIM_LOG" \
+    "$SYSTEMCTL_SHIM_DAEMON_LOG" \
+    "$UPDATE_ERR" \
+    "$UPDATE_JSON" \
+    "$state_dir/logs/gateway-restart.log" \
+    "$GATEWAY_LOG"; do
+    print_redacted_update_restart_log "$path" || status=1
+  done
+  return "$status"
+}
+
 on_error() {
   local status="$1"
   FAILURE_PHASE="${CURRENT_PHASE:-unknown}"
@@ -248,6 +350,9 @@ on_error() {
 on_exit() {
   local status="$1"
   set +e
+  if [ "$status" -ne 0 ] && [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
+    print_update_restart_failure_diagnostics || true
+  fi
   cleanup
   if [ "$status" -eq 0 ]; then
     write_summary passed ""
@@ -1122,8 +1227,10 @@ update_candidate() {
   fi
   if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" "${update_env[@]}" openclaw "${update_args[@]}" >"$UPDATE_JSON" 2>"$UPDATE_ERR"; then
     echo "openclaw update failed" >&2
-    openclaw_e2e_print_log "$UPDATE_ERR" >&2
-    openclaw_e2e_print_log "$UPDATE_JSON" >&2
+    if [ "$UPDATE_RESTART_MODE" != "auto-auth" ]; then
+      openclaw_e2e_print_log "$UPDATE_ERR" >&2
+      openclaw_e2e_print_log "$UPDATE_JSON" >&2
+    fi
     return 1
   fi
   if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
@@ -1241,15 +1348,19 @@ check_gateway_status() {
   status_start="$(node -e "process.stdout.write(String(Date.now()))")"
   if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw gateway status --url "ws://127.0.0.1:$port" --token "$GATEWAY_AUTH_TOKEN_REF" --require-rpc --timeout 30000 --json >"$STATUS_JSON" 2>"$STATUS_ERR"; then
     echo "gateway status failed" >&2
-    openclaw_e2e_print_log "$STATUS_ERR" >&2
-    openclaw_e2e_print_log "$GATEWAY_LOG" >&2
+    if [ "$UPDATE_RESTART_MODE" != "auto-auth" ]; then
+      openclaw_e2e_print_log "$STATUS_ERR" >&2
+      openclaw_e2e_print_log "$GATEWAY_LOG" >&2
+    fi
     return 1
   fi
   status_end="$(node -e "process.stdout.write(String(Date.now()))")"
   status_seconds=$(((status_end - status_start + 999) / 1000))
   if [ "$status_seconds" -gt "$budget" ]; then
     echo "gateway status exceeded survivor budget: ${status_seconds}s > ${budget}s" >&2
-    openclaw_e2e_print_log "$STATUS_JSON" >&2
+    if [ "$UPDATE_RESTART_MODE" != "auto-auth" ]; then
+      openclaw_e2e_print_log "$STATUS_JSON" >&2
+    fi
     return 1
   fi
   node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-status-json "$STATUS_JSON"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -188,6 +188,17 @@ function cleanupSmokeLogTailHelpers(): string {
   return helpers;
 }
 
+function upgradeSurvivorRestartDiagnosticHelpers(): string {
+  const script = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+  const match = script.match(
+    /(print_redacted_update_restart_log\(\) \{[\s\S]*?\n\}\n\nprint_update_restart_failure_diagnostics\(\) \{[\s\S]*?\n\})\n\non_error\(\)/u,
+  );
+  if (!match?.[1]) {
+    throw new Error("upgrade survivor restart diagnostic helpers were not found");
+  }
+  return match[1];
+}
+
 function runCleanupDefaultPlatform(env: Record<string, string>, hostArch: string): string {
   const script = readFileSync(CLEANUP_DOCKER_SMOKE_PATH, "utf8");
   const match = script.match(/(resolve_default_cleanup_platform\(\) \{[\s\S]*?\n\})\n\nPLATFORM=/u);
@@ -2635,6 +2646,23 @@ fi
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$STATUS_ERR"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$STATUS_JSON"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$log_file"');
+    expectTextToIncludeAll(publishedRunner, [
+      'print_redacted_update_restart_log "$path"',
+      '"$SYSTEMCTL_SHIM_LOG"',
+      '"$SYSTEMCTL_SHIM_DAEMON_LOG"',
+      '"$UPDATE_ERR"',
+      '"$UPDATE_JSON"',
+      '"$state_dir/logs/gateway-restart.log"',
+      '"$GATEWAY_LOG"',
+      'if [ "$status" -ne 0 ] && [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then',
+      "print_update_restart_failure_diagnostics || true",
+      "umask 077",
+      "mode: 0o600",
+      "fs.chmodSync(target, 0o600)",
+    ]);
+    expect(
+      publishedRunner.indexOf("print_update_restart_failure_diagnostics || true"),
+    ).toBeLessThan(publishedRunner.indexOf("  cleanup\n"));
     expect(publishedRunner).not.toContain('cat "$BASELINE_INSTALL_LOG"');
     expect(publishedRunner).not.toContain('cat "$BASELINE_CONFIG_VALIDATE_LOG"');
     expect(publishedRunner).not.toContain('cat "$BASELINE_SERVICE_INSTALL_ERR"');
@@ -2646,6 +2674,158 @@ fi
     expect(publishedRunner).not.toContain('cat "$STATUS_ERR"');
     expect(publishedRunner).not.toContain('cat "$STATUS_JSON"');
     expect(publishedRunner).not.toContain('cat "$log_file"');
+  });
+
+  it("redacts update restart diagnostics before exposing private temporary files", () => {
+    const workDir = tempDirs.make("openclaw-update-restart-redaction-");
+    const logPath = join(workDir, "gateway-restart.log");
+    const missingPath = join(workDir, "missing.log");
+    const helpersPath = join(workDir, "restart-diagnostic-helpers.sh");
+    const sensitiveHeaders = [
+      ["x-goog-api-key", "google-header-secret"],
+      ["api-key", "api-header-secret"],
+      ["apikey", "apikey-header-secret"],
+      ["x-api-token", "api-token-header-secret"],
+      ["x-access-token", "access-token-header-secret"],
+      ["X-OpenClaw-Token", "openclaw-header-secret"],
+      ["x-pomerium-jwt-assertion", "pomerium-header-secret"],
+      ["X-Api-Key", "gateway-api-header-secret"],
+      ["X-Auth-Token", "gateway-auth-header-secret"],
+    ] as const;
+    const secrets = [
+      "upgrade-survivor-token",
+      "sk-openclaw-upgrade-survivor",
+      "upgrade-survivor-discord-token",
+      "123456:upgrade-survivor-telegram-token",
+      "upgrade-survivor-feishu-secret",
+      "upgrade-survivor-matrix-token",
+      "BSA_upgrade_survivor_brave_key",
+      "bearer-sensitive-value",
+      "json-token-value",
+      "json-password-value",
+      "json-api-key-value",
+      "json-client-secret-value",
+      "shell-token-value",
+      "shell-password-value",
+      "shell-api-value",
+      "cli-token-value",
+      "basic-sensitive-value",
+      "digest-sensitive-value",
+      "proxy-sensitive-value",
+      "aws-sensitive-value",
+      "aws-signature-sensitive-value",
+      "serialized-sensitive-value",
+      "folded-sensitive-value",
+      "serialized-continuation-sensitive-value",
+      ...sensitiveHeaders.map(([, secret]) => secret),
+      "quoted-auth-secret",
+      "serialized-api-secret",
+      "folded-gateway-secret",
+    ];
+    writeFileSync(
+      logPath,
+      [
+        "useful gateway failure",
+        ...secrets.slice(0, 7),
+        "Authorization: Bearer bearer-sensitive-value",
+        '{"token":"json-token-value","password":"json-password-value","apiKey":"json-api-key-value","clientSecret":"json-client-secret-value","safe":"useful-json"}',
+        "export SERVICE_TOKEN=shell-token-value",
+        "GATEWAY_PASSWORD='shell-password-value'",
+        'API_KEY="shell-api-value"',
+        "gateway --token cli-token-value",
+        "authorization: Basic basic-sensitive-value",
+        'AuThOrIzAtIoN: Digest username="digest-sensitive-value",',
+        "\tfolded=folded-sensitive-value",
+        "pRoXy-AuThOrIzAtIoN: Negotiate proxy-sensitive-value",
+        '{"Proxy-Authorization":"AWS4-HMAC-SHA256 Credential=aws-sensitive-value/20260807/us-east-1/service/aws4_request, Signature=aws-signature-sensitive-value","safeProxy":"useful-proxy-json"}',
+        String.raw`serialized={\"Authorization\":\"Digest username=\\\"serialized-sensitive-value\\\",\\n\\tcontinuation=serialized-continuation-sensitive-value\",\"safe\":\"useful-serialized\"}`,
+        ...sensitiveHeaders.map(
+          ([name, secret]) => `${name}${name === "X-Api-Key" ? "=" : ":"} ${secret}`,
+        ),
+        'curl -H "Authorization: Basic quoted-auth-secret" --retry 2',
+        String.raw`serializedHeader={\"x-goog-api-key\":\"serialized-api-secret\",\"safeHeader\":\"useful-header-serialized\"}`,
+        "X-OpenClaw-Token: folded-gateway-secret\n\tcontinued=folded-gateway-secret",
+        "X-Authorization: ordinary-value",
+        "the authorization model is useful",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(helpersPath, upgradeSurvivorRestartDiagnosticHelpers());
+    const script = repoShell(workDir)`
+ARTIFACT_ROOT="$TMPDIR"
+export GATEWAY_AUTH_TOKEN_REF=upgrade-survivor-token
+export OPENAI_API_KEY=sk-openclaw-upgrade-survivor
+export DISCORD_BOT_TOKEN=upgrade-survivor-discord-token
+export TELEGRAM_BOT_TOKEN=123456:upgrade-survivor-telegram-token
+export FEISHU_APP_SECRET=upgrade-survivor-feishu-secret
+export MATRIX_ACCESS_TOKEN=upgrade-survivor-matrix-token
+export BRAVE_API_KEY=BSA_upgrade_survivor_brave_key
+
+source ${shellQuote(helpersPath)}
+
+openclaw_e2e_print_log() {
+  node -e '
+    const fs = require("node:fs");
+    const mode = fs.statSync(process.argv[1]).mode & 0o777;
+    process.stdout.write(\`mode=\${mode.toString(8)}\\n\`);
+  ' "$1"
+  cat "$1"
+}
+
+print_redacted_update_restart_log ${shellQuote(missingPath)}
+print_redacted_update_restart_log ${shellQuote(logPath)}
+`;
+
+    const result = spawnSync("bash", ["-lc", script], { encoding: "utf8" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("mode=600");
+    expect(result.stderr).toContain("useful gateway failure");
+    expect(result.stderr).toContain("useful-json");
+    expect(result.stderr).toContain("useful-proxy-json");
+    expect(result.stderr).toContain("useful-serialized");
+    expect(result.stderr).toContain("useful-header-serialized");
+    expect(result.stderr).toContain('" --retry 2');
+    expect(result.stderr).toContain("X-Authorization: ordinary-value");
+    expect(result.stderr).toContain("the authorization model is useful");
+    expect(result.stderr).toContain("[REDACTED]");
+    expect(result.stderr).not.toContain(missingPath);
+    for (const secret of secrets) {
+      expect(result.stderr).not.toContain(secret);
+    }
+    expect(readdirSync(workDir).filter((entry) => entry.includes("redacted"))).toEqual([]);
+  });
+
+  it("redacts complete update restart logs before bounded tailing", () => {
+    const workDir = tempDirs.make("openclaw-update-restart-redaction-tail-");
+    const logPath = join(workDir, "gateway-restart.log");
+    const helpersPath = join(workDir, "restart-diagnostic-helpers.sh");
+    const secret = "sk-openclaw-upgrade-survivor";
+    writeFileSync(
+      logPath,
+      `old-output-that-must-be-truncated\n${"x".repeat(200)}${secret}${"y".repeat(40)}\nuseful-tail\n`,
+    );
+    writeFileSync(helpersPath, upgradeSurvivorRestartDiagnosticHelpers());
+    const script = repoShell(workDir)`
+ARTIFACT_ROOT="$TMPDIR"
+export OPENAI_API_KEY=${shellQuote(secret)}
+export OPENCLAW_E2E_LOG_TAIL_BYTES=64
+export OPENCLAW_E2E_LOG_TAIL_LINES=120
+source "$ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh"
+
+source ${shellQuote(helpersPath)}
+
+print_redacted_update_restart_log ${shellQuote(logPath)}
+`;
+
+    const result = spawnSync("bash", ["-lc", script], { encoding: "utf8" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("useful-tail");
+    expect(result.stderr).not.toContain("old-output-that-must-be-truncated");
+    expect(result.stderr).not.toContain(secret);
+    expect(result.stderr).not.toContain(secret.slice(-10));
+    expect(readdirSync(workDir).filter((entry) => entry.includes("redacted"))).toEqual([]);
   });
 
   it("preserves caller-owned file descriptors around harness runs", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the package acceptance `update-restart-auth` lane reported that the gateway failed to restart without retaining the daemon evidence needed to identify the startup failure.

## Why This Change Was Made

The published upgrade survivor now emits one failure diagnostic bundle from its exit handler before service cleanup. It allowlists only the systemctl shim, shim daemon, update outputs, gateway restart transcript, and gateway log; each complete source is redacted into a mode-0600 temporary file before the existing bounded log printer reads it.

Manual restart lanes retain their existing diagnostics. This change does not alter product restart behavior or the frozen release candidate.

## User Impact

Release operators can diagnose automatic update restart failures from the existing Docker E2E artifact instead of rerunning blind or weakening the release gate.

## Evidence

- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh`
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` (`183/183` passed at the exact head)
- injected auto-auth exit-7 artifact proof: useful failure text, closing quote, and the trailing `--retry 4` suffix survived; the injected secret was absent; the temporary redacted artifact was cleaned
- earlier branch changed-gate Actions run: https://github.com/openclaw/openclaw/actions/runs/31135474390
- exact-head hosted PR CI is in progress with no failing or cancelled checks at the latest evidence snapshot
- signed and GitHub-verified commit: `fee32377d80e1e90a6d2a1b39a178f9d89920227`

The executable tests cover exact fixture secrets; quoted and unquoted Authorization and Proxy-Authorization; Basic, Digest, Negotiate, and AWS4 values; and the canonical credential/Gateway header family (`x-goog-api-key`, `api-key`, `apikey`, `x-api-token`, `x-access-token`, `X-OpenClaw-Token`, `x-pomerium-jwt-assertion`, `X-Api-Key`, and `X-Auth-Token`) in colon, equals, JSON, escaped serialized, and folded forms. They also prove that useful neighboring text, `X-Authorization`, and ordinary authorization prose remain visible, while missing files, mode `0600`, bounded output, cleanup, and a secret crossing the tail boundary retain coverage.

AI-assisted: yes. The implementation and evidence were reviewed by the maintainer.
