### PR TITLE
fix: reject missing oxlint shard selectors

### DIFF
--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -250,15 +250,15 @@ export async function main(extraArgs = process.argv.slice(2), runtimeEnv = proce
           })
         : () => {};
 
-  const shards = createOxlintShards({
-    cwd: process.cwd(),
-    env,
-    platform: process.platform,
-    splitCore: shardArgs.splitCore,
-  });
-  const selectedShards = filterOxlintShards(shards, shardArgs.only);
-
   try {
+    const shards = createOxlintShards({
+      cwd: process.cwd(),
+      env,
+      platform: process.platform,
+      splitCore: shardArgs.splitCore,
+    });
+    const selectedShards = filterOxlintShards(shards, shardArgs.only);
+
     ensureRepoToolNodeModulesLink(resolveRepoToolBinPath("oxlint"));
     const prepareResult = spawnSync(
       process.execPath,
@@ -331,20 +331,12 @@ export function parseShardRunnerArgs(args) {
       continue;
     }
     if (arg === "--only") {
-      const value = args[index + 1];
-      if (!value || value.startsWith("-")) {
-        throw new Error("--only requires a shard name");
-      }
-      only.add(value);
+      only.add(requireShardSelector(args[index + 1]));
       index += 1;
       continue;
     }
     if (arg.startsWith("--only=")) {
-      const value = arg.slice("--only=".length);
-      if (!value) {
-        throw new Error("--only requires a shard name");
-      }
-      only.add(value);
+      only.add(requireShardSelector(arg.slice("--only=".length)));
       continue;
     }
     oxlintArgs.push(arg);
@@ -354,14 +346,37 @@ export function parseShardRunnerArgs(args) {
 }
 
 /**
- * Filters shards by an optional comma-separated shard name list.
+ * Filters shards by optional shard names and rejects unknown selectors.
  */
 export function filterOxlintShards(shards, only) {
   if (only.size === 0) {
     return shards;
   }
 
-  return shards.filter((shard) => only.has(shard.name) || only.has(shard.name.split(":")[0]));
+  const selectors = [...only];
+  const unknownSelectors = selectors.filter(
+    (selector) => !shards.some((shard) => matchesShardSelector(shard, selector)),
+  );
+  if (unknownSelectors.length > 0) {
+    throw new Error(
+      `Unknown oxlint shard selector${unknownSelectors.length === 1 ? "" : "s"}: ${unknownSelectors.join(", ")}`,
+    );
+  }
+
+  return shards.filter((shard) =>
+    selectors.some((selector) => matchesShardSelector(shard, selector)),
+  );
+}
+
+function requireShardSelector(value) {
+  if (!value || value.startsWith("-")) {
+    throw new Error("--only requires a shard name");
+  }
+  return value;
+}
+
+function matchesShardSelector(shard, selector) {
+  return selector === shard.name || selector === shard.name.split(":")[0];
 }
 
 /**

--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -332,17 +332,19 @@ export function parseShardRunnerArgs(args) {
     }
     if (arg === "--only") {
       const value = args[index + 1];
-      if (value) {
-        only.add(value);
-        index += 1;
+      if (!value || value.startsWith("-")) {
+        throw new Error("--only requires a shard name");
       }
+      only.add(value);
+      index += 1;
       continue;
     }
     if (arg.startsWith("--only=")) {
       const value = arg.slice("--only=".length);
-      if (value) {
-        only.add(value);
+      if (!value) {
+        throw new Error("--only requires a shard name");
       }
+      only.add(value);
       continue;
     }
     oxlintArgs.push(arg);

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -495,7 +495,7 @@ describe("run-oxlint", () => {
     expect(parsed.oxlintArgs).toEqual(["--max-warnings", "0"]);
   });
 
-  it.each([["--only"], ["--only", "--split-core"], ["--only="]])(
+  it.each([["--only"], ["--only", "--split-core"], ["--only="], ["--only=-h"]])(
     "rejects shard selectors without a name: %s",
     (...args) => {
       expect(() => parseShardRunnerArgs(args)).toThrow("--only requires a shard name");
@@ -517,6 +517,44 @@ describe("run-oxlint", () => {
       "core:ui",
       "core:packages",
     ]);
+  });
+
+  it.each([
+    { selectors: ["wat"], message: "Unknown oxlint shard selector: wat" },
+    {
+      selectors: ["core", "wat"],
+      message: "Unknown oxlint shard selector: wat",
+    },
+  ])("rejects unmatched shard selectors: $selectors", ({ selectors, message }) => {
+    expect(() =>
+      filterOxlintShards(createOxlintShards({ cwd: "/repo" }), new Set(selectors)),
+    ).toThrow(message);
+  });
+
+  it.each([
+    ["--only"],
+    ["--only", "--split-core"],
+    ["--only="],
+    ["--only=-h"],
+    ["--only=wat"],
+    ["--only=core", "--only=wat"],
+  ])("rejects invalid shard CLI input before starting work: %s", (...args) => {
+    const tempDir = createTempDir("openclaw-oxlint-selector-");
+    const result = spawnSync(process.execPath, [RUN_OXLINT_SHARDS_URL, ...args], {
+      cwd: tempDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_HEAVY_CHECK_LOCK_SCOPE: "worktree",
+        OPENCLAW_LOCAL_CHECK: "1",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).not.toContain("[oxlint:");
+    expect(existsSync(join(tempDir, ".artifacts/openclaw-local-checks/heavy-check.lock"))).toBe(
+      false,
+    );
   });
 
   it("falls back to the full extension shard when Windows extension dirs are unavailable", () => {

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -495,6 +495,13 @@ describe("run-oxlint", () => {
     expect(parsed.oxlintArgs).toEqual(["--max-warnings", "0"]);
   });
 
+  it.each([["--only"], ["--only", "--split-core"], ["--only="]])(
+    "rejects shard selectors without a name: %s",
+    (...args) => {
+      expect(() => parseShardRunnerArgs(args)).toThrow("--only requires a shard name");
+    },
+  );
+
   it("filters split core shards by shard family", () => {
     const shards = filterOxlintShards(
       createOxlintShards({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed or misspelled oxlint shard selectors could silently run every shard or no shards while returning success.

## Why This Change Was Made

The shard runner now validates both `--only value` and `--only=value` through one syntax guard, rejects every unmatched selector including mixed valid/invalid sets, and performs shard creation and filtering inside the heavy-check lock's `try/finally`.

## User Impact

Invalid shard-runner commands fail immediately with a clear non-zero error. They do not start lint shards, prepare boundary artifacts, or leave the heavy-check lock behind.

## Evidence

- Sanitized AWS Crabbox run `run_858101e2ef15` on lease `cbx_699b5557ee46`: `pnpm test test/scripts/run-oxlint.test.ts` passed 45/45.
- Targeted selector/parser/filter/subprocess regressions passed 12/12 across three bounded repeats.
- `pnpm format:check -- scripts/run-oxlint-shards.mjs test/scripts/run-oxlint.test.ts` passed.
- `git diff --check` passed.
- Scoped `pnpm check:changed -- scripts/run-oxlint-shards.mjs test/scripts/run-oxlint.test.ts` passed.
- Max-P1 autoreview was clean with overall correctness confidence 0.98.
- Exact maintainer-fix head: `c623f4a314c4dcbbc36b46363ebb93954bcf90d3`.

AI-assisted change; implementation and proof reviewed directly.

Punchcard-Session: clear-harbor-river-2k
