### PR TITLE
docs(plugins): note the factory tool execute signature

### DIFF
--- a/docs/plugins/tool-plugins.md
+++ b/docs/plugins/tool-plugins.md
@@ -161,9 +161,11 @@ account, thread, and local-media policy; plugins cannot retarget this helper,
 and retained copies stop working after the turn closes. The helper is unavailable
 for channels whose delivery is owned by a Gateway transport.
 
-A factory returns a core `AgentTool`, so its `execute` uses the runtime
-signature `execute(toolCallId, params, signal, onUpdate)` with the tool call ID
-first. That is the opposite argument order from the declarative
+A factory may return a core `AgentTool`, an array of them, or `null` or
+`undefined` to opt out, as the example above does. When it returns a concrete
+tool, that tool uses the core runtime signature
+`execute(toolCallId, params, signal?, onUpdate?)` with the tool call ID first.
+That is the opposite argument order from the declarative
 `execute(params, config, context)` shown above, and it matches the
 `api.registerTool` examples in [Building Plugins](/plugins/building-plugins).
 Reading `params` from the first argument of a factory tool returns the tool

--- a/docs/plugins/tool-plugins.md
+++ b/docs/plugins/tool-plugins.md
@@ -161,6 +161,14 @@ account, thread, and local-media policy; plugins cannot retarget this helper,
 and retained copies stop working after the turn closes. The helper is unavailable
 for channels whose delivery is owned by a Gateway transport.
 
+A factory returns a core `AgentTool`, so its `execute` uses the runtime
+signature `execute(toolCallId, params, signal, onUpdate)` with the tool call ID
+first. That is the opposite argument order from the declarative
+`execute(params, config, context)` shown above, and it matches the
+`api.registerTool` examples in [Building Plugins](/plugins/building-plugins).
+Reading `params` from the first argument of a factory tool returns the tool
+call ID string instead.
+
 Factories still declare a fixed tool name up front. Use `definePluginEntry`
 directly when the plugin computes tool names dynamically or combines tools
 with hooks, services, providers, or commands.


### PR DESCRIPTION
## What Problem This Solves

`docs/plugins/tool-plugins.md` shows a declarative tool whose handler is `execute({ symbol }, config, context)`, with params first. About thirty lines later, on the same page, it introduces factory tools without saying that a factory's tool uses the opposite argument order.

A plugin author who reads the page top to bottom, then writes a factory tool, gets the tool call ID where they expect their params. That is what #120061 reports: `args[0]` is `"toolu_01FJWJ..."` and `args[1]` is `{ path: "." }`.

The runtime is behaving correctly here, and so is every other page. `docs/plugins/building-plugins.md:144` and `:260` both show the `api.registerTool` form as `async execute(_id, params)`, which is right. The gap is only that the tool-plugins page never connects its own factory section to that contract, and it is the page a tool author is most likely to be reading.

## Why This Change Was Made

The two argument orders are both real and both intentional, so this documents the seam rather than changing it.

- Declarative tools go through an adapter. `src/plugin-sdk/tool-plugin.ts:230` registers `execute: async (toolCallId, params, signal, onUpdate) => ... execute(params, config, { api, signal, toolCallId, onUpdate })`, which is what turns the runtime signature into the documented `execute(params, config, context)` at `src/plugin-sdk/tool-plugin.ts:98`.
- Factory tools do not. `src/plugin-sdk/tool-plugin.ts:207` passes the factory straight to `api.registerTool` and `continue`s, so whatever the factory returns keeps the core contract at `packages/agent-core/src/types.ts:560`: `execute(toolCallId, params, signal?, onUpdate?)`.

So the note says exactly that, points at the `api.registerTool` examples that already show the same shape, and states the failure mode in the words an author will recognize.

I did not touch the signatures. Changing the core `AgentTool` argument order would reach every tool in the repo, and the shim suggested in #120061 (passing params at both `arg0` and `arg1`) would add a permanent compatibility branch to a public SDK surface to paper over a docs gap. Documenting the seam is the smaller and more honest fix.

## User Impact

Plugin authors reading the tool-plugins walkthrough now learn the factory argument order on the page where they need it, instead of discovering it by logging `args`.

Docs only. No code, config, schema, or default surface changes.

## Evidence

Claims verified against current `main` at `c245cfc19c7` rather than from memory:

- `src/plugin-sdk/tool-plugin.ts:98` declares the declarative handler as `(params, config, context)`.
- `src/plugin-sdk/tool-plugin.ts:207` registers a factory with no execute adapter.
- `src/plugin-sdk/tool-plugin.ts:230` is the adapter the declarative branch uses.
- `packages/agent-core/src/types.ts:560` is the core `execute(toolCallId, params, signal?, onUpdate?)` contract.
- `docs/plugins/building-plugins.md:144` and `:260` already show `async execute(_id, params)`, so the new text agrees with the rest of the docs.

`openclaw/plugin-sdk/tool-plugin` is a published subpath (`package.json` exports plus `scripts/lib/plugin-sdk-entrypoints.json:313`), so this is a public SDK surface and not an internal detail.

`git diff --check` is clean, the added link `/plugins/building-plugins` is root-relative with no extension per the docs guide, and the file has no em dashes.

One thing I did not do: I did not build a plugin and observe the argument order at runtime. The claim rests on reading the registration path end to end in the four places cited above. If a maintainer wants a live plugin trace before merging, say so and I will put one together.

AI-assisted: written with AI assistance. I read the registration path, the core tool type, and the existing docs pages myself before writing the note.

Refs #120061. I am deliberately not closing that issue with this PR: it asks for the factory argument order to change, and whether to alter a public SDK contract is a maintainer product decision. This only removes the documentation gap that made the current behavior surprising.
