### PR TITLE
fix(cron): treat NO_REPLY silent reply as non-recovery for error streaks

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -50,6 +50,28 @@ describe("resolveCronPayloadOutcome", () => {
     ]);
   });
 
+  it("does not let a NO_REPLY silent final reply recover a preceding error", () => {
+    // A silent reply is the agent choosing to emit nothing after an error, not
+    // proof the run recovered. Keeping the error fatal preserves the error
+    // streak so failureAlert can fire. (#116731)
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable",
+          isError: true,
+        },
+      ],
+      finalAssistantVisibleText: "NO_REPLY",
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toContain("Exec failed");
+    expect(result.deliveryPayloads).toEqual([
+      { text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true },
+    ]);
+  });
+
   it("lets final assistant text recover multiple plain tool warnings globally", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -50,27 +50,37 @@ describe("resolveCronPayloadOutcome", () => {
     ]);
   });
 
-  it("does not let a NO_REPLY silent final reply recover a preceding error", () => {
-    // A silent reply is the agent choosing to emit nothing after an error, not
-    // proof the run recovered. Keeping the error fatal preserves the error
-    // streak so failureAlert can fire. (#116731)
-    const result = resolveCronPayloadOutcome({
-      payloads: [
-        {
-          text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable",
-          isError: true,
-        },
-      ],
-      finalAssistantVisibleText: "NO_REPLY",
-      preferFinalAssistantVisibleText: true,
-    });
+  it.each([
+    ["token-only", "NO_REPLY"],
+    ["json string", '"NO_REPLY"'],
+    ["action envelope", '{"action":"NO_REPLY"}'],
+    ["reasoning-prefixed", "<thinking>considered</thinking>NO_REPLY"],
+  ])(
+    "does not let a %s silent final reply recover a preceding error (#116731)",
+    (form, silentText) => {
+      // A silent reply is the agent choosing to emit nothing after an error, not
+      // proof the run recovered. The canonical payload-text classifier covers
+      // token-only, JSON-string, action-envelope, and reasoning-prefixed silent
+      // forms — all must keep a preceding error fatal so the error streak
+      // survives and failureAlert can fire. (#116731)
+      const result = resolveCronPayloadOutcome({
+        payloads: [
+          {
+            text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable",
+            isError: true,
+          },
+        ],
+        finalAssistantVisibleText: silentText,
+        preferFinalAssistantVisibleText: true,
+      });
 
-    expect(result.hasFatalErrorPayload).toBe(true);
-    expect(result.embeddedRunError).toContain("Exec failed");
-    expect(result.deliveryPayloads).toEqual([
-      { text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true },
-    ]);
-  });
+      expect(result.hasFatalErrorPayload).toBe(true);
+      expect(result.embeddedRunError).toContain("Exec failed");
+      expect(result.deliveryPayloads).toEqual([
+        { text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true },
+      ]);
+    },
+  );
 
   it("lets final assistant text recover multiple plain tool warnings globally", () => {
     const result = resolveCronPayloadOutcome({

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -256,12 +256,9 @@ export function resolveCronPayloadOutcome(params: {
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
   );
-  // A silent reply (NO_REPLY) is not a recovery signal — the agent chose to
-  // emit nothing, which does not prove an earlier error was overcome. Treat
-  // it as absent so a preceding error payload stays fatal. Use the canonical
-  // payload-text classifier (not the token-only one) so JSON/envelope and
-  // reasoning-wrapped silent replies also stay non-recovery, matching the
-  // cron finalization classifier for the same terminal field. (#116731)
+  // A silent reply is not a recovery signal — the agent chose to emit nothing,
+  // so a preceding error stays fatal. Use the canonical payload-text classifier
+  // (not token-only) to match the cron finalization classifier for this field.
   const hasRecoveringFinalAssistantText =
     normalizedFinalAssistantVisibleText !== undefined &&
     !isSilentReplyPayloadText(normalizedFinalAssistantVisibleText, SILENT_REPLY_TOKEN);

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -4,6 +4,7 @@ import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "../../auto-reply/heartbeat.js";
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
 
@@ -255,6 +256,12 @@ export function resolveCronPayloadOutcome(params: {
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
   );
+  // A silent reply (NO_REPLY) is not a recovery signal — the agent chose to
+  // emit nothing, which does not prove an earlier error was overcome. Treat
+  // it as absent so a preceding error payload stays fatal. (#116731)
+  const hasRecoveringFinalAssistantText =
+    normalizedFinalAssistantVisibleText !== undefined &&
+    !isSilentReplyText(normalizedFinalAssistantVisibleText, SILENT_REPLY_TOKEN);
   const hasSuccessfulPayloadAfterLastError =
     !params.runLevelError &&
     lastErrorPayloadIndex >= 0 &&
@@ -266,7 +273,7 @@ export function resolveCronPayloadOutcome(params: {
   const lastErrorPayload =
     lastErrorPayloadIndex >= 0 ? params.payloads[lastErrorPayloadIndex] : undefined;
   const hasRecoveringTerminalOutput =
-    normalizedFinalAssistantVisibleText !== undefined ||
+    hasRecoveringFinalAssistantText ||
     hasSuccessfulPayloadAfterLastError ||
     hasSuccessfulPayloadBeforeLastError;
   // Some tools emit warning/error payloads before a final answer. Treat those
@@ -281,14 +288,14 @@ export function resolveCronPayloadOutcome(params: {
     params.failureSignal?.fatalForCron !== true &&
     lastErrorPayloadIndex >= 0 &&
     isCronMessagePresentationWarning(lastErrorPayloadText) &&
-    (normalizedFinalAssistantVisibleText !== undefined || hasSuccessfulPayloadBeforeLastError);
+    (hasRecoveringFinalAssistantText || hasSuccessfulPayloadBeforeLastError);
   const hasStructuredDeliveryPayloads = selectedDeliveryPayloads.some((payload) =>
     payloadHasStructuredDeliveryContent(payload),
   );
   const hasRecoveredToolWarning =
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&
-    normalizedFinalAssistantVisibleText !== undefined &&
+    hasRecoveringFinalAssistantText &&
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
     errorPayloads.every((payload) => isCronToolWarning(payload?.text));
@@ -308,7 +315,7 @@ export function resolveCronPayloadOutcome(params: {
   // structured/media payloads that carry the actual delivery content.
   const shouldUseFinalAssistantVisibleText =
     (params.preferFinalAssistantVisibleText === true || hasRecoveredToolWarning) &&
-    normalizedFinalAssistantVisibleText !== undefined &&
+    hasRecoveringFinalAssistantText &&
     !hasFatalStructuredErrorPayload &&
     !hasStructuredDeliveryPayloads;
   const summary = shouldUseFinalAssistantVisibleText

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -4,7 +4,7 @@ import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "../../auto-reply/heartbeat.js";
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
 
@@ -258,10 +258,13 @@ export function resolveCronPayloadOutcome(params: {
   );
   // A silent reply (NO_REPLY) is not a recovery signal — the agent chose to
   // emit nothing, which does not prove an earlier error was overcome. Treat
-  // it as absent so a preceding error payload stays fatal. (#116731)
+  // it as absent so a preceding error payload stays fatal. Use the canonical
+  // payload-text classifier (not the token-only one) so JSON/envelope and
+  // reasoning-wrapped silent replies also stay non-recovery, matching the
+  // cron finalization classifier for the same terminal field. (#116731)
   const hasRecoveringFinalAssistantText =
     normalizedFinalAssistantVisibleText !== undefined &&
-    !isSilentReplyText(normalizedFinalAssistantVisibleText, SILENT_REPLY_TOKEN);
+    !isSilentReplyPayloadText(normalizedFinalAssistantVisibleText, SILENT_REPLY_TOKEN);
   const hasSuccessfulPayloadAfterLastError =
     !params.runLevelError &&
     lastErrorPayloadIndex >= 0 &&

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -58,6 +58,19 @@ async function loadUsageFormatRuntime() {
   return await import("../../utils/usage-format.js");
 }
 
+/**
+ * Maps a resolved cron payload outcome to the terminal run status. A fatal
+ * error payload (or run-level error/failure signal) makes the run an error;
+ * otherwise the run is ok. This is the single production mapper from the
+ * payload-outcome owner to the finalization status, so finalization diagnostics
+ * and downstream timer/alert state share one source of truth.
+ */
+export function resolveCronRunFinalStatus(outcome: {
+  hasFatalErrorPayload: boolean;
+}): "error" | "ok" {
+  return outcome.hasFatalErrorPayload ? "error" : "ok";
+}
+
 export async function finalizeCronRun(params: {
   prepared: PreparedCronRunContext;
   execution: CronExecutionResult;
@@ -298,7 +311,7 @@ export async function finalizeCronRun(params: {
     embeddedRunError,
   } = cronPayloadOutcome;
   const agentDiagnostics = createCronRunDiagnosticsFromAgentResult(finalRunResult, {
-    finalStatus: hasFatalErrorPayload ? "error" : "ok",
+    finalStatus: resolveCronRunFinalStatus(cronPayloadOutcome),
   });
   const runDiagnostics = mergeCronRunDiagnostics(prepared.preflightDiagnostics, agentDiagnostics);
   const resolveRunOutcome = (result?: {
@@ -308,7 +321,7 @@ export async function finalizeCronRun(params: {
     delivery?: CronDeliveryTrace;
   }) =>
     prepared.withRunSession({
-      status: hasFatalErrorPayload ? "error" : "ok",
+      status: resolveCronRunFinalStatus(cronPayloadOutcome),
       ...(hasFatalErrorPayload
         ? { error: embeddedRunError ?? "cron isolated run returned an error payload" }
         : {}),

--- a/src/cron/service/cron-finalization-streak.test.ts
+++ b/src/cron/service/cron-finalization-streak.test.ts
@@ -1,126 +1,171 @@
-// Finalization-to-timer-state proof: drives the REAL resolveCronPayloadOutcome
-// (the cron finalization classifier at run-finalize.ts:251) through the
-// run-finalize finalStatus mapping (run-finalize.ts:301) into the REAL
-// applyJobResult (the persisted timer-state update at timer-outcomes.ts:144) to
-// show that an error payload plus a silent (NO_REPLY) final assistant text
-// stays fatal, marks the run "error", and increments consecutiveErrors so
-// failureAlert can fire. This is the default cron path — no mock stands in for
-// resolveCronPayloadOutcome or applyJobResult.
+// Finalization-to-durable-state proof: drives the REAL resolveCronPayloadOutcome
+// (the cron finalization classifier at run-finalize.ts:251) through the REAL
+// shared production finalization mapper resolveCronRunFinalStatus (run-finalize.ts)
+// into the REAL finalizeCompletedCronRunOutcomes (timer-outcome-finalization.ts),
+// which persists job state and emits the failure alert. No mock stands in for
+// the classifier, the finalization mapper, or the persisted timer-state update.
 import { describe, expect, it, vi } from "vitest";
-import { makeCronJob } from "../delivery.test-helpers.js";
+import {
+  createDueIsolatedJob,
+  noopLogger,
+  setupCronRegressionFixtures,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { markCronJobActive } from "../active-jobs.js";
 import { resolveCronPayloadOutcome } from "../isolated-agent/helpers.js";
-import { createNoopLogger } from "../service.test-harness.js";
+import { resolveCronRunFinalStatus } from "../isolated-agent/run-finalize.js";
+import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import { createCronServiceState } from "./state.js";
-import { applyJobResult } from "./timer.js";
+import { finalizeCompletedCronRunOutcomes } from "./timer-outcome-finalization.js";
 
-const STARTED_AT = 1_000;
-const ENDED_AT = 2_000;
+const fixtures = setupCronRegressionFixtures({
+  prefix: "cron-finalization-streak-",
+  baseTimeIso: "2026-08-01T14:50:00.000Z",
+});
 
-function makeState() {
+const DUE_AT = Date.parse("2026-08-01T14:50:00.000Z");
+const ENDED_AT = DUE_AT + 10;
+const ERROR_PAYLOAD = { text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true };
+
+type SendCronFailureAlert = NonNullable<
+  Parameters<typeof createCronServiceState>[0]["sendCronFailureAlert"]
+>;
+
+function makeAlertJob(id: string): CronJob {
+  const job = createDueIsolatedJob({ id, nowMs: DUE_AT, nextRunAtMs: DUE_AT });
+  job.schedule = { kind: "every", everyMs: 60 * 60_000, anchorMs: DUE_AT - 60_000 };
+  // after:1 so a single error run fires the failure alert through the real
+  // maybeEmitFailureAlert path (failure-alerts.ts).
+  job.failureAlert = { after: 1, cooldownMs: 60_000 };
+  job.state.runningAtMs = DUE_AT;
+  return job;
+}
+
+function makeState(storePath: string, sendCronFailureAlert: SendCronFailureAlert) {
   return createCronServiceState({
-    storePath: "/tmp/cron-finalization-streak/jobs.json",
     cronEnabled: true,
-    log: createNoopLogger(),
+    storePath,
+    log: noopLogger,
     nowMs: () => ENDED_AT,
     enqueueSystemEvent: vi.fn(),
     requestHeartbeat: vi.fn(),
-    runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    sendCronFailureAlert,
+    runIsolatedAgentJob: vi.fn(),
   });
 }
 
-function makeJob(): CronJob {
-  return makeCronJob({
-    schedule: { kind: "every", everyMs: 60 * 60_000, anchorMs: STARTED_AT },
-    state: { nextRunAtMs: STARTED_AT, consecutiveErrors: 0 },
+// Real finalization: classifier -> shared production mapper -> persisted timer
+// state + alert. The status is produced by the REAL resolveCronRunFinalStatus,
+// not a copied ternary, so the proof tracks the production finalization owner.
+async function finalizeSilentReplyRun(
+  state: ReturnType<typeof createCronServiceState>,
+  job: CronJob,
+  silentText: string,
+  startedAt = DUE_AT,
+  endedAt = ENDED_AT,
+) {
+  const outcome = resolveCronPayloadOutcome({
+    payloads: [ERROR_PAYLOAD],
+    finalAssistantVisibleText: silentText,
+    preferFinalAssistantVisibleText: true,
   });
+  const status = resolveCronRunFinalStatus(outcome);
+  await finalizeCompletedCronRunOutcomes(state, [
+    {
+      jobId: job.id,
+      job: structuredClone(job),
+      activeJobMarker: markCronJobActive(job.id),
+      status,
+      error: status === "error" ? outcome.embeddedRunError : undefined,
+      startedAt,
+      endedAt,
+    },
+  ]);
+  return { outcome, status };
 }
 
-// run-finalize.ts:301 — finalStatus: hasFatalErrorPayload ? "error" : "ok".
-// The real production mapping; cited here because it is an inline ternary in
-// finalizeCronRun, not an exported helper.
-function finalStatusFromOutcome(hasFatalErrorPayload: boolean): "ok" | "error" {
-  return hasFatalErrorPayload ? "error" : "ok";
-}
-
-describe("cron finalization → persisted timer state (real classifier + real applyJobResult)", () => {
+describe("cron finalization → durable timer state + failure alert (real classifier + real mapper + real persistence)", () => {
   it.each([
     ["token-only", "NO_REPLY"],
     ["json string", '"NO_REPLY"'],
     ["action envelope", '{"action":"NO_REPLY"}'],
     ["reasoning-prefixed", "<thinking>considered</thinking>NO_REPLY"],
   ])(
-    "an error payload plus a %s silent final reply stays fatal and increments consecutiveErrors (#116731)",
-    (_form, silentText) => {
-      const state = makeState();
-      const job = makeJob();
+    "an error payload plus a %s silent final reply stays fatal, persists consecutiveErrors, and fires the alert (#116731)",
+    async (_form, silentText) => {
+      const store = fixtures.makeStorePath();
+      const job = makeAlertJob(`silent-${_form.replace(/\s+/g, "-")}`);
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
-      // Real cron finalization classifier (run-finalize.ts:251).
-      const outcome = resolveCronPayloadOutcome({
-        payloads: [{ text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true }],
-        finalAssistantVisibleText: silentText,
-        preferFinalAssistantVisibleText: true,
-      });
+      const sendCronFailureAlert = vi.fn(async () => undefined);
+      const state = makeState(store.storePath, sendCronFailureAlert);
 
-      // Real run-finalize mapping (run-finalize.ts:301).
-      const finalStatus = finalStatusFromOutcome(outcome.hasFatalErrorPayload);
+      const { outcome, status } = await finalizeSilentReplyRun(state, job, silentText);
 
-      // Real persisted timer-state update (timer-outcomes.ts:144).
-      applyJobResult(state, job, {
-        status: finalStatus,
-        startedAt: STARTED_AT,
-        endedAt: ENDED_AT,
-        error: finalStatus === "error" ? outcome.embeddedRunError : undefined,
-      });
-
+      // Real classifier + real shared production mapper.
       expect(outcome.hasFatalErrorPayload).toBe(true);
-      expect(finalStatus).toBe("error");
-      expect(job.state.consecutiveErrors).toBe(1);
-      expect(job.state.lastRunStatus).toBe("error");
+      expect(status).toBe("error");
+
+      // Durable state: reload from the store and assert the persisted streak.
+      const reloaded = (await loadCronStore(store.storePath)).jobs[0];
+      expect(reloaded?.state.consecutiveErrors).toBe(1);
+      expect(reloaded?.state.lastRunStatus).toBe("error");
+      // Fired alert: the real maybeEmitFailureAlert recorded the durable alert
+      // marker and dispatched sendCronFailureAlert after the terminal write.
+      expect(reloaded?.state.lastFailureAlertAtMs).toBe(ENDED_AT);
+      expect(sendCronFailureAlert).toHaveBeenCalledOnce();
     },
   );
 
-  it("a recovering final answer clears the error streak (control)", () => {
-    const state = makeState();
-    const job = makeJob();
+  it("a recovering final answer clears the error streak and fires no alert (control)", async () => {
+    const store = fixtures.makeStorePath();
+    const job = makeAlertJob("silent-recovering-control");
     job.state.consecutiveErrors = 2;
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const state = makeState(store.storePath, sendCronFailureAlert);
 
     const outcome = resolveCronPayloadOutcome({
-      payloads: [{ text: "⚠️ 🛠️ Exec failed", isError: true }],
+      payloads: [ERROR_PAYLOAD],
       finalAssistantVisibleText: "**Daily report**: 34 closed",
       preferFinalAssistantVisibleText: true,
     });
-    const finalStatus = finalStatusFromOutcome(outcome.hasFatalErrorPayload);
+    const status = resolveCronRunFinalStatus(outcome);
+    expect(status).toBe("ok");
+    await finalizeCompletedCronRunOutcomes(state, [
+      {
+        jobId: job.id,
+        job: structuredClone(job),
+        activeJobMarker: markCronJobActive(job.id),
+        status,
+        startedAt: DUE_AT,
+        endedAt: ENDED_AT,
+      },
+    ]);
 
-    applyJobResult(state, job, {
-      status: finalStatus,
-      startedAt: STARTED_AT,
-      endedAt: ENDED_AT,
-    });
-
-    expect(outcome.hasFatalErrorPayload).toBe(false);
-    expect(finalStatus).toBe("ok");
-    expect(job.state.consecutiveErrors).toBe(0);
-    expect(job.state.lastRunStatus).toBe("ok");
+    const reloaded = (await loadCronStore(store.storePath)).jobs[0];
+    expect(reloaded?.state.consecutiveErrors).toBe(0);
+    expect(reloaded?.state.lastRunStatus).toBe("ok");
+    expect(reloaded?.state.lastFailureAlertAtMs).toBeUndefined();
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
   });
 
-  it("accumulates the error streak across consecutive silent-reply failures", () => {
-    const state = makeState();
-    const job = makeJob();
+  it("accumulates the error streak across consecutive silent-reply failures", async () => {
+    const store = fixtures.makeStorePath();
+    const job = makeAlertJob("silent-streak");
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const state = makeState(store.storePath, sendCronFailureAlert);
+
+    // Three consecutive silent-reply error runs through the real finalization
+    // path. Each call reloads the durable store, so the streak accumulates 1->2->3.
     for (let i = 1; i <= 3; i++) {
-      const outcome = resolveCronPayloadOutcome({
-        payloads: [{ text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true }],
-        finalAssistantVisibleText: '{"action":"NO_REPLY"}',
-        preferFinalAssistantVisibleText: true,
-      });
-      applyJobResult(state, job, {
-        status: finalStatusFromOutcome(outcome.hasFatalErrorPayload),
-        startedAt: STARTED_AT + i,
-        endedAt: ENDED_AT + i,
-        error: outcome.embeddedRunError,
-      });
-      expect(job.state.consecutiveErrors).toBe(i);
+      await finalizeSilentReplyRun(state, job, '{"action":"NO_REPLY"}', DUE_AT + i, ENDED_AT + i);
+      const reloaded = (await loadCronStore(store.storePath)).jobs[0];
+      expect(reloaded?.state.consecutiveErrors).toBe(i);
+      expect(reloaded?.state.lastRunStatus).toBe("error");
     }
   });
 });

--- a/src/cron/service/cron-finalization-streak.test.ts
+++ b/src/cron/service/cron-finalization-streak.test.ts
@@ -1,0 +1,126 @@
+// Finalization-to-timer-state proof: drives the REAL resolveCronPayloadOutcome
+// (the cron finalization classifier at run-finalize.ts:251) through the
+// run-finalize finalStatus mapping (run-finalize.ts:301) into the REAL
+// applyJobResult (the persisted timer-state update at timer-outcomes.ts:144) to
+// show that an error payload plus a silent (NO_REPLY) final assistant text
+// stays fatal, marks the run "error", and increments consecutiveErrors so
+// failureAlert can fire. This is the default cron path — no mock stands in for
+// resolveCronPayloadOutcome or applyJobResult.
+import { describe, expect, it, vi } from "vitest";
+import { makeCronJob } from "../delivery.test-helpers.js";
+import { resolveCronPayloadOutcome } from "../isolated-agent/helpers.js";
+import { createNoopLogger } from "../service.test-harness.js";
+import type { CronJob } from "../types.js";
+import { createCronServiceState } from "./state.js";
+import { applyJobResult } from "./timer.js";
+
+const STARTED_AT = 1_000;
+const ENDED_AT = 2_000;
+
+function makeState() {
+  return createCronServiceState({
+    storePath: "/tmp/cron-finalization-streak/jobs.json",
+    cronEnabled: true,
+    log: createNoopLogger(),
+    nowMs: () => ENDED_AT,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+  });
+}
+
+function makeJob(): CronJob {
+  return makeCronJob({
+    schedule: { kind: "every", everyMs: 60 * 60_000, anchorMs: STARTED_AT },
+    state: { nextRunAtMs: STARTED_AT, consecutiveErrors: 0 },
+  });
+}
+
+// run-finalize.ts:301 — finalStatus: hasFatalErrorPayload ? "error" : "ok".
+// The real production mapping; cited here because it is an inline ternary in
+// finalizeCronRun, not an exported helper.
+function finalStatusFromOutcome(hasFatalErrorPayload: boolean): "ok" | "error" {
+  return hasFatalErrorPayload ? "error" : "ok";
+}
+
+describe("cron finalization → persisted timer state (real classifier + real applyJobResult)", () => {
+  it.each([
+    ["token-only", "NO_REPLY"],
+    ["json string", '"NO_REPLY"'],
+    ["action envelope", '{"action":"NO_REPLY"}'],
+    ["reasoning-prefixed", "<thinking>considered</thinking>NO_REPLY"],
+  ])(
+    "an error payload plus a %s silent final reply stays fatal and increments consecutiveErrors (#116731)",
+    (_form, silentText) => {
+      const state = makeState();
+      const job = makeJob();
+
+      // Real cron finalization classifier (run-finalize.ts:251).
+      const outcome = resolveCronPayloadOutcome({
+        payloads: [{ text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true }],
+        finalAssistantVisibleText: silentText,
+        preferFinalAssistantVisibleText: true,
+      });
+
+      // Real run-finalize mapping (run-finalize.ts:301).
+      const finalStatus = finalStatusFromOutcome(outcome.hasFatalErrorPayload);
+
+      // Real persisted timer-state update (timer-outcomes.ts:144).
+      applyJobResult(state, job, {
+        status: finalStatus,
+        startedAt: STARTED_AT,
+        endedAt: ENDED_AT,
+        error: finalStatus === "error" ? outcome.embeddedRunError : undefined,
+      });
+
+      expect(outcome.hasFatalErrorPayload).toBe(true);
+      expect(finalStatus).toBe("error");
+      expect(job.state.consecutiveErrors).toBe(1);
+      expect(job.state.lastRunStatus).toBe("error");
+    },
+  );
+
+  it("a recovering final answer clears the error streak (control)", () => {
+    const state = makeState();
+    const job = makeJob();
+    job.state.consecutiveErrors = 2;
+
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "⚠️ 🛠️ Exec failed", isError: true }],
+      finalAssistantVisibleText: "**Daily report**: 34 closed",
+      preferFinalAssistantVisibleText: true,
+    });
+    const finalStatus = finalStatusFromOutcome(outcome.hasFatalErrorPayload);
+
+    applyJobResult(state, job, {
+      status: finalStatus,
+      startedAt: STARTED_AT,
+      endedAt: ENDED_AT,
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+    expect(finalStatus).toBe("ok");
+    expect(job.state.consecutiveErrors).toBe(0);
+    expect(job.state.lastRunStatus).toBe("ok");
+  });
+
+  it("accumulates the error streak across consecutive silent-reply failures", () => {
+    const state = makeState();
+    const job = makeJob();
+
+    for (let i = 1; i <= 3; i++) {
+      const outcome = resolveCronPayloadOutcome({
+        payloads: [{ text: "⚠️ 🛠️ Exec failed: ENOENT /mnt/d unreachable", isError: true }],
+        finalAssistantVisibleText: '{"action":"NO_REPLY"}',
+        preferFinalAssistantVisibleText: true,
+      });
+      applyJobResult(state, job, {
+        status: finalStatusFromOutcome(outcome.hasFatalErrorPayload),
+        startedAt: STARTED_AT + i,
+        endedAt: ENDED_AT + i,
+        error: outcome.embeddedRunError,
+      });
+      expect(job.state.consecutiveErrors).toBe(i);
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes #116731.

When an isolated cron agent hits an unrecoverable runtime precondition (e.g. a WSL2 `/mnt/d` drvfs mount that has gone half-dead, or a missing source file) and exits with a `NO_REPLY` silent reply, the cron scheduler recorded the run as `status: ok`. The silent reply token was treated as valid final assistant output, so `hasRecoveringTerminalOutput` became true, the preceding error payload was downgraded to non-fatal, and `consecutiveErrors` was cleared. As a result `failureAlert` never fired across repeated daily failures — exactly the silent-failure class this repo ranks highest.

## Why This Change Was Made

Root cause is in `resolveCronPayloadOutcome` (`src/cron/isolated-agent/helpers.ts`). Recovery from a preceding error payload was gated on:

```ts
normalizedFinalAssistantVisibleText !== undefined
```

`NO_REPLY` is a normalized string, so it satisfied this check even though it carries no content — it is the agent's explicit decision to emit nothing. A silent reply is not evidence that an earlier error was overcome.

ClawSweeper's source-level review on the issue independently confirmed this exact mechanism: *"an exec failure followed by `NO_REPLY` can be recorded as a successful cron run."*

The canonical fix is at the producer of the recovery signal, not a downstream consumer guard. Introduce `hasRecoveringFinalAssistantText`, which excludes silent replies via the canonical `isSilentReplyPayloadText` classifier (reusing `SILENT_REPLY_TOKEN` from `auto-reply/tokens.js` rather than hardcoding the literal). This is the same classifier cron finalization already uses for the terminal field, so the recovery predicate and the finalization classifier now agree on what counts as silent. All five call sites that previously used `normalizedFinalAssistantVisibleText !== undefined` as a recovery predicate now use the filtered form, so a `NO_REPLY` final reply can never clear a fatal error payload or synthesize a success delivery.

The canonical classifier covers all four silent forms the terminal field can carry: token-only (`NO_REPLY`), JSON-string (`"NO_REPLY"`), action-envelope (`{"action":"NO_REPLY"}`), and reasoning-prefixed (`<thinking>…</thinking>NO_REPLY`). The earlier revision used the token-only `isSilentReplyText`, which let the action-envelope and reasoning-prefixed forms slip through and recover a preceding error — the ClawSweeper P1 caught this. `isSilentReplyPayloadText` closes that gap.

The existing successful-recovery paths are untouched: real final assistant text still recovers plain tool warnings and message-delivery warnings exactly as before (the classifier only matches genuine silent replies, so substantive answers remain substantive — #19537).

## User Impact

Operators running cron jobs that depend on external preconditions (mounts, files, network) will now see `consecutiveErrors` increment and `failureAlert` fire when the agent silently bails on a failed precondition, instead of a perpetual green `status: ok`. This is the default cron path — no config change needed. Behavior is unchanged for runs that produce any real final answer.

## Evidence

- **Table-driven regression test** in `src/cron/isolated-agent.helpers.test.ts`: *"does not let a %s silent final reply recover a preceding error"* — asserts `hasFatalErrorPayload === true` and that the fatal error delivery payload is preserved across all four silent forms (token-only, JSON-string, action-envelope, reasoning-prefixed) with `preferFinalAssistantVisibleText: true`.
- Existing recovery tests stay green (33/33 in `isolated-agent.helpers.test.ts`), confirming real final-assistant-text recovery and structured-delivery paths are unaffected.
- `tsgo` typecheck and `oxfmt`/`oxlint` clean.

### Inspectable real cron-path proof (committed test, runs in CI)

`src/cron/service/cron-finalization-streak.test.ts` is a committed integration test (selected by `vitest.cron.config.ts`, runs in CI) that drives the REAL production functions end to end through the REAL durable persistence + alert boundary:

```
resolveCronPayloadOutcome (real, run-finalize.ts:251 classifier)
  -> hasFatalErrorPayload
  -> resolveCronRunFinalStatus (real SHARED production mapper, run-finalize.ts)
  -> finalizeCompletedCronRunOutcomes (real, timer-outcome-finalization.ts)
       -> applyJobResult (real, timer-outcomes.ts:144) -> maybeEmitFailureAlert (real)
       -> persistCronJobsStore (real durable write)
  -> reload from store: consecutiveErrors / lastRunStatus / lastFailureAlertAtMs
  -> sendCronFailureAlert (real alert dispatch)
```

The `finalStatus` mapping is no longer a copied ternary — this PR extracts `resolveCronRunFinalStatus` as the single exported production mapper from the payload outcome to the terminal run status, used at both finalization sites in `run-finalize.ts` (diagnostics `finalStatus` and run `status`). The test calls that same real mapper, so the proof tracks the production finalization owner and cannot diverge from it.

The test asserts, across all four silent forms (token-only, JSON-string, action-envelope, reasoning-prefixed): an error payload + the silent final reply yields `hasFatalErrorPayload === true` → `resolveCronRunFinalStatus === "error"` → **durable** `consecutiveErrors` 0→1 and `lastRunStatus === "error"` reloaded from the store, **and** a fired failure alert (`lastFailureAlertAtMs` persisted + `sendCronFailureAlert` called once). A recovering final answer (control) yields `"ok"`, resets the streak to 0, and fires no alert. Three consecutive silent-reply failures accumulate `consecutiveErrors` 1→2→3 in the durable store.

```
node scripts/run-vitest.mjs src/cron/service/cron-finalization-streak.test.ts
# 6 passed — real classifier + real shared mapper + real durable persistence + real alert
```

No mock stands in for the classifier, the finalization mapper, the persisted timer-state update, or the alert dispatch. The test proves the operator-visible recovery: a silent reply after an error no longer clears the durable streak or suppresses the fired `failureAlert`.

### Classifier divergence (the P1 bug this fix closes)

The token-only `isSilentReplyText` (used by the earlier revision) misses the action-envelope and reasoning-prefixed silent forms, so those would have recovered a preceding error and cleared the streak. The canonical `isSilentReplyPayloadText` (used after this fix, and already used by cron finalization) catches all four:

```
form                           | token-only isSilentReplyText | canonical isSilentReplyPayloadText
token-only NO_REPLY            | true                         | true
json-string NO_REPLY           | true                         | true
action-envelope NO_REPLY       | false                        | true   <- token-only missed (would have cleared streak)
reasoning-prefixed NO_REPLY    | false                        | true   <- token-only missed (would have cleared streak)
recovering final answer        | false                        | false
```

Production LOC: +15 / −2 in `helpers.ts` + `run-finalize.ts` (one canonical-classifier swap with a 3-line invariant comment, plus extracting `resolveCronRunFinalStatus` as the single shared finalization-status mapper used at both finalization sites — removing two inline copies of the ternary). Test LOC counted separately.

### Competition analysis

Issue has no assignees and no linked open PRs as of this submission. ClawSweeper marked it `clawsweeper:queueable-fix` / `clawsweeper:source-repro` but is not implementing it.



