### PR TITLE
fix(channels): bound errored ingress settlements

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -24,6 +24,7 @@ import {
   preflightDiscordMessageMock,
   processDiscordMessageMock,
 } from "./message-handler.module-test-helpers.js";
+import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
 import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
 import {
   createDiscordHandlerParams,
@@ -564,6 +565,69 @@ describe("createDiscordMessageHandler queue behavior", () => {
             true,
           );
           expect(runtimeErrors.join("\n")).not.toContain("hello");
+        } finally {
+          await handler.deactivate();
+        }
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dead-letters an exhausted queued processing failure and releases its Discord lane", async () => {
+    vi.useFakeTimers();
+    try {
+      await withDiscordQueue(async (queue) => {
+        const receivedAt = 1;
+        const ingressPayload = (id: string): DiscordIngressPayload => ({
+          version: 1,
+          receivedAt,
+          rawMessage: createRawMessage(id, "lane-a"),
+        });
+        const poisonPayload = ingressPayload("processing-poison");
+        const followerPayload = ingressPayload("processing-follower");
+        const lane = { laneKey: "channel:lane-a" };
+        await queue.enqueue("processing-poison", poisonPayload, { ...lane, receivedAt });
+        await queue.enqueue("processing-follower", followerPayload, {
+          ...lane,
+          receivedAt: receivedAt + 1,
+        });
+        for (let attempt = 1; attempt < DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS; attempt += 1) {
+          const claim = await queue.claim("processing-poison", {
+            ownerId: `seed-failure-${attempt}`,
+          });
+          if (!claim) {
+            throw new Error(`failed to seed retry ${attempt}`);
+          }
+          await queue.release(claim, {
+            lastError: `seed processing failure ${attempt}`,
+            releasedAt: poisonPayload.receivedAt + attempt,
+          });
+        }
+        const processed: string[] = [];
+        const handler = createDurableDiscordMessageHandler({
+          ...createDiscordHandlerParams(),
+          client: {} as never,
+          testing: {
+            preflightDiscordMessage: (async (preflightParams: DiscordMessagePreflightParams) => ({
+              ...createPreflightContextForMessage(preflightParams.data),
+              turnAdoptionLifecycle: preflightParams.turnAdoptionLifecycle,
+            })) as never,
+            processDiscordMessage: async (ctx) => {
+              processed.push(ctx.message.id);
+              if (ctx.message.id === "processing-poison") {
+                throw new Error("deterministic queued processing failure");
+              }
+            },
+            createIngressMonitor: (monitorParams) =>
+              createDiscordIngressMonitor({ ...monitorParams, queue }),
+          },
+        });
+        try {
+          await vi.advanceTimersByTimeAsync(1_000);
+          await vi.waitFor(() => expect(processed).toHaveLength(2));
+          expect(processed).toEqual(["processing-poison", "processing-follower"]);
+          expect((await queue.listFailed?.())?.[0]?.reason).toBe("retry-limit-exceeded");
         } finally {
           await handler.deactivate();
         }

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -58,13 +58,14 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
 
   it("settles or abandons claims that no reply lane adopted", async () => {
     const adopted = vi.fn(async () => {});
+    const failed = vi.fn(async () => {});
     const abandoned = vi.fn(async () => {});
     const lifecycle = {
       abortSignal: new AbortController().signal,
       onAdopted: adopted,
       onDeferred: vi.fn(),
       onAdoptionFinalizing: vi.fn(),
-      onFailed: vi.fn(async () => {}),
+      onFailed: failed,
       onAbandoned: abandoned,
     };
 
@@ -73,6 +74,7 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
 
     expect(adopted).toHaveBeenCalledOnce();
     expect(abandoned).toHaveBeenCalledOnce();
+    expect(failed).not.toHaveBeenCalled();
     expect(fanInChannelIngressLifecycles([]).lifecycle).toBeUndefined();
   });
 
@@ -127,7 +129,8 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
     expect(second.cancellationCount).toBe(1);
   });
 
-  it("can abandon claims after terminal settlement adoption fails", async () => {
+  it("fails claims with the exact error after terminal settlement adoption fails", async () => {
+    const failed = vi.fn(async () => {});
     const abandoned = vi.fn(async () => {});
     const combined = fanInChannelIngressLifecycles([
       {
@@ -137,15 +140,17 @@ describe("plugin-sdk/channel-ingress-runtime", () => {
         },
         onDeferred: vi.fn(),
         onAdoptionFinalizing: vi.fn(),
-        onFailed: vi.fn(async () => {}),
+        onFailed: failed,
         onAbandoned: abandoned,
       },
     ]);
 
     await expect(combined.settle()).rejects.toThrow("adoption failed");
-    await combined.abandon(new Error("dispatch failed"));
+    const failure = new Error("dispatch failed");
+    await combined.abandon(failure);
 
-    expect(abandoned).toHaveBeenCalledOnce();
+    expect(failed).toHaveBeenCalledExactlyOnceWith(failure);
+    expect(abandoned).not.toHaveBeenCalled();
   });
 
   it("derives store allowlists, command auth, sender separation, and redaction", async () => {

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -209,10 +209,10 @@ export function fanInChannelIngressLifecycles(
         handedOff = true;
       }
     },
-    abandon: async (_error?: unknown) => {
+    abandon: async (error?: unknown) => {
       if (!handedOff) {
         handedOff = true;
-        await abandonAll();
+        await (error === undefined ? abandonAll() : failAll(error));
       }
     },
     // Source-compatible lifecycles predate onCancelled. Settle each source through


### PR DESCRIPTION
Refs #108865

## What Problem This Solves

A queued channel message can fail before reply-lane adoption. Discord already passed that real processing error into `fanInChannelIngressLifecycles().abandon(error)`, but the shared fan-in helper discarded the error and invoked `onAbandoned` instead of `onFailed`.

That bypassed the ingress retry/dead-letter policy. A deterministic poison row could therefore keep returning to `pending` as `turn-abandoned` after the configured retry limit and starve every later message in the same lane.

The original implementation on this PR targeted an execution-layer fallback. Current main already fixed that separate debounce failure through #122384; this rewrite addresses the distinct error-bearing fan-in path at its actual owner.

## Why This Change Was Made

The existing lifecycle contract already separates the two outcomes:

- `abandon()` without an error remains a retryable non-adoption outcome.
- `abandon(error)` now preserves the error through `onFailed`, where the existing bounded retry/dead-letter policy owns settlement.

No new API, configuration, schema, dependency, or compatibility path is added. Archived sessions remain explicit stops; this change makes their rejected inbound work terminalize through the normal policy instead of poisoning the lane indefinitely.

## User Impact

A real pre-adoption processing error can no longer retry forever as generic abandonment. Once the configured retry limit is reached, the failed row is retained with its original payload and error, and same-lane followers can continue.

Cancellation and argument-free abandonment keep their existing replay behavior.

## Evidence

The new Discord regression uses the real SQLite ingress queue, Discord ingress monitor, fan-in settlement, and Discord message run queue. It seeds a poison event with seven prior failures, injects the eighth processing error, and verifies that the poison row dead-letters while its same-lane follower completes.

Before the production fix, that regression failed for the intended reason: the follower never ran (`expected 2 calls, got 1`) because the poison row remained pending as `turn-abandoned`.

After the fix:

- `node scripts/run-vitest.mjs src/plugin-sdk/channel-ingress-runtime.test.ts` — 7 passed
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.queue.test.ts` — 23 passed
- `git diff --check` — passed
- Codex autoreview, uncommitted diff — clean, no accepted/actionable findings

Live operator evidence matched the repaired boundary: one pending Discord row repeatedly recorded `turn-abandoned` beyond the configured maximum while holding its lane, with no live ingress claim owner. Host, message, and account details are intentionally omitted.

Production LOC: +2/-2 (net 0). Tests: +74/-5 (net +69).
