### PR TITLE
fix: prevent duplicate and lost agent delivery

### DIFF
--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -1,5 +1,9 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
+  isSyntheticSourceReplyTurn,
+  resolveSourceReplyDeliveryMode,
+} from "../../auto-reply/reply/source-reply-delivery-mode.js";
+import {
   formatThinkingLevels,
   normalizeThinkLevel,
   normalizeVerboseLevel,
@@ -27,6 +31,10 @@ import {
   resolveAgentHarnessSessionContextError,
 } from "../../sessions/agent-harness-session-key.js";
 import { resolveUserPath } from "../../utils.js";
+import {
+  sessionDeliveryChannel,
+  sessionDeliveryOrigin,
+} from "../../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel, resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAgentRuntimeConfig } from "../agent-runtime-config.js";
 import {
@@ -37,6 +45,7 @@ import {
   resolveAgentWorkspaceDir,
 } from "../agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import { selectAgentHarness } from "../harness/selection.js";
 import { AGENT_LANE_SUBAGENT } from "../lanes.js";
 import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import { buildConfiguredModelCatalog, resolveConfiguredModelRef } from "../model-selection.js";
@@ -233,7 +242,7 @@ export async function prepareAgentCommandExecution(opts: AgentCommandOpts, runti
   if (explicitRecipientSession?.error) {
     throw explicitRecipientSession.error;
   }
-  const commandOpts = explicitRecipientSession?.sessionKey
+  let commandOpts: AgentCommandOpts = explicitRecipientSession?.sessionKey
     ? {
         ...selectedCommandOpts,
         channel: explicitRecipientSession.channel,
@@ -328,6 +337,54 @@ export async function prepareAgentCommandExecution(opts: AgentCommandOpts, runti
     sessionKey,
     sessionEntry: sessionEntryRaw,
   });
+  if (
+    sessionEntryRaw &&
+    commandOpts.cliSessionBindingFacts === undefined &&
+    isSyntheticSourceReplyTurn({
+      inputProvenance: commandOpts.inputProvenance,
+      isHeartbeat: commandOpts.bootstrapContextRunKind === "heartbeat",
+    })
+  ) {
+    // Lifecycle turns keep their effective delivery mode, but CLI reuse belongs
+    // to the existing session's normal source-reply policy.
+    const stableReplyContext = {
+      CommandAuthorized: false,
+      ChatType: sessionEntryRaw.chatType,
+      Provider: sessionDeliveryOrigin(sessionEntryRaw)?.provider,
+      Surface: sessionDeliveryChannel(sessionEntryRaw),
+      InputProvenance: commandOpts.inputProvenance,
+    };
+    const stableProvider = sessionEntryRaw.modelProvider ?? configuredModel.provider;
+    const stableModel = sessionEntryRaw.model ?? configuredModel.model;
+    const stableRuntime = resolveEffectiveAgentRuntime({
+      cfg,
+      provider: stableProvider,
+      modelId: stableModel,
+      agentId: sessionAgentId,
+      sessionKey,
+      sessionEntry: sessionEntryRaw,
+    });
+    const harness = selectAgentHarness({
+      provider: stableProvider,
+      modelId: stableModel,
+      config: cfg,
+      agentId: sessionAgentId,
+      sessionKey,
+      agentHarnessRuntimeOverride: stableRuntime,
+    });
+    const defaultVisibleReplies =
+      harness.deliveryDefaults?.visibleReplies ?? harness.deliveryDefaults?.sourceVisibleReplies;
+    commandOpts = {
+      ...commandOpts,
+      cliSessionBindingFacts: {
+        sourceReplyDeliveryMode: resolveSourceReplyDeliveryMode({
+          cfg,
+          ctx: stableReplyContext,
+          defaultVisibleReplies,
+        }),
+      },
+    };
+  }
   const thinkingLevelsHint = formatThinkingLevels(
     configuredModel.provider,
     configuredModel.model,

--- a/src/agents/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-restart-dispatch.ts
@@ -137,7 +137,7 @@ export function resolveRestartRecoveryDeliveryContext(params: {
   entry: SessionEntry;
   includeSessionDeliveryFallback?: boolean;
   sessionKey: string;
-}): DeliveryContext | undefined {
+}): (DeliveryContext & { channel: string; to: string }) | undefined {
   const activeRunDeliveryContext = normalizeDeliveryContext(
     params.entry.restartRecoveryDeliveryContext,
   );

--- a/src/agents/main-session-restart-recovery-notice.ts
+++ b/src/agents/main-session-restart-recovery-notice.ts
@@ -1,4 +1,3 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
 import type {
   SessionTranscriptTurnExpectedState,
@@ -21,36 +20,24 @@ import {
 } from "./main-session-restart-recovery-shared.js";
 
 export async function sendUnresumableSessionNotice(params: {
-  deliveryContext: DeliveryContext;
+  deliveryContext: DeliveryContext & { channel: string; to: string };
   entry: SessionEntry;
   gatewayRuntime: GatewayRecoveryRuntime;
   reason: string;
   sessionKey: string;
   text: string;
 }): Promise<void> {
-  const messageParams: Record<string, unknown> = {
-    to: params.deliveryContext.to,
-    message: params.text,
-    bestEffort: true,
-  };
-  if (params.deliveryContext.threadId != null) {
-    messageParams.threadId = params.deliveryContext.threadId;
-  }
-  const actionParams: Record<string, unknown> = {
+  const notice = {
     channel: params.deliveryContext.channel,
-    action: "send",
-    sessionKey: params.sessionKey,
-    sessionId: params.entry.sessionId,
+    to: params.deliveryContext.to,
+    accountId: params.deliveryContext.accountId,
+    threadId: params.deliveryContext.threadId,
+    text: params.text,
     idempotencyKey: buildUnresumableSessionNoticeIdempotencyKey(params.entry),
-    params: messageParams,
   };
-  const accountId = normalizeOptionalString(params.deliveryContext.accountId);
-  if (accountId) {
-    actionParams.accountId = accountId;
-  }
 
   try {
-    await params.gatewayRuntime.sendRecoveryNotice(actionParams, 10_000);
+    await params.gatewayRuntime.sendRecoveryNotice(notice);
     log.info(
       `sent interrupted main session recovery notice: ${params.sessionKey} (${params.reason})`,
     );

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -105,13 +105,15 @@ vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async () => ({ runId: "run-resumed" })),
 }));
 
+const sendRecoveryNotice = vi.fn<GatewayRecoveryRuntime["sendRecoveryNotice"]>(
+  async () => undefined,
+);
 const mockRecoveryRuntime = {
   dispatchAgent: async <T>(params: Record<string, unknown>, timeoutMs?: number) =>
     (await callGateway({ method: "agent", params, timeoutMs })) as T,
   waitForAgent: async <T>(params: Record<string, unknown>, timeoutMs?: number) =>
     (await callGateway({ method: "agent.wait", params, timeoutMs })) as T,
-  sendRecoveryNotice: async <T>(params: Record<string, unknown>, timeoutMs?: number) =>
-    (await callGateway({ method: "message.action", params, timeoutMs })) as T,
+  sendRecoveryNotice,
 };
 
 type RecoveryParams<T extends { gatewayRuntime: unknown }> = Omit<T, "gatewayRuntime"> &
@@ -1820,9 +1822,7 @@ describe("main-session-restart-recovery", () => {
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 }, {});
 
     expect(runtimePluginMocks.findRestartRecoveryUnsafeReplyHook).toHaveBeenCalledOnce();
-    expect(vi.mocked(callGateway).mock.calls[0]?.[0]).toMatchObject({
-      method: "message.action",
-    });
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
 
@@ -3031,14 +3031,8 @@ describe("main-session-restart-recovery", () => {
     });
 
     await expectRecovery({ recovered: 0, failed: 0, skipped: 1 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    expect(callGateway).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "message.action",
-        params: expect.objectContaining({
-          params: expect.objectContaining({ message: expect.stringContaining("/new or /reset") }),
-        }),
-      }),
+    expect(sendRecoveryNotice).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("/new or /reset") }),
     );
     expect(
       loadSessionEntry({ sessionKey: "agent:main:discord:direct:123", storePath }),
@@ -3250,17 +3244,14 @@ describe("main-session-restart-recovery", () => {
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    const [gatewayRequest] = vi.mocked(callGateway).mock.calls[0] ?? [];
-    expect(gatewayRequest?.method).toBe("message.action");
-    expect(gatewayRequest?.params).toMatchObject({
-      action: "send",
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledWith({
       accountId: "work",
       channel: "discord",
-      params: {
-        to: "discord:dm:main",
-        message: expect.stringContaining("couldn't safely resume"),
-      },
+      to: "discord:dm:main",
+      threadId: undefined,
+      idempotencyKey: "main-session-restart-recovery:recovery-main:failed-notice",
+      text: expect.stringContaining("couldn't safely resume"),
     });
     const failedEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
     expect(failedEntry).toMatchObject({
@@ -3626,9 +3617,7 @@ describe("main-session-restart-recovery", () => {
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 }, {});
 
     expect(runtimePluginMocks.findRestartRecoveryUnsafeReplyHook).toHaveBeenCalledOnce();
-    expect(vi.mocked(callGateway).mock.calls[0]?.[0]).toMatchObject({
-      method: "message.action",
-    });
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
   it("resumes a Control UI turn after proving the current runtime is hookless", async () => {
@@ -3781,9 +3770,7 @@ describe("main-session-restart-recovery", () => {
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
-    expect(vi.mocked(callGateway).mock.calls[0]?.[0]).toMatchObject({
-      method: "message.action",
-    });
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     const failed = loadSessionEntry({ sessionKey, storePath });
     expect(failed?.status).toBe("failed");
     expect(failed?.restartRecoveryDeliveryReceiptState).toBeUndefined();
@@ -3934,7 +3921,7 @@ describe("main-session-restart-recovery", () => {
         expected,
       );
 
-      expect(callGateway).toHaveBeenCalledTimes(gatewayCalls);
+      expect(sendRecoveryNotice).toHaveBeenCalledTimes(gatewayCalls);
       expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe(expectedStatus);
       const transcript = await loadTestTranscript(sessionKey, storePath);
       expect(
@@ -4001,7 +3988,7 @@ describe("main-session-restart-recovery", () => {
               "restart-recovery:message-tool-result:discord-message-1:message-call-1",
           ),
       ).toBe(false);
-      expect(callGateway).toHaveBeenCalledOnce();
+      expect(sendRecoveryNotice).toHaveBeenCalledOnce();
       expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
     },
   );
@@ -4021,7 +4008,7 @@ describe("main-session-restart-recovery", () => {
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
     const transcript = await loadTranscriptEvents({
       sessionId: "main-session",
@@ -4057,9 +4044,7 @@ describe("main-session-restart-recovery", () => {
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
-    expect(vi.mocked(callGateway).mock.calls[0]?.[0]).toMatchObject({
-      method: "message.action",
-    });
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
       status: "failed",
       abortedLastRun: true,
@@ -4144,7 +4129,7 @@ describe("main-session-restart-recovery", () => {
             "restart-recovery:message-tool-result:discord-message-current:message-call-reused",
         ),
     ).toBe(false);
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
 
@@ -4188,7 +4173,7 @@ describe("main-session-restart-recovery", () => {
             message?.role === "toolResult" && message.toolCallId === "message-call-current",
         ),
     ).toHaveLength(1);
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
 
@@ -4236,7 +4221,7 @@ describe("main-session-restart-recovery", () => {
             message?.role === "toolResult" && message.toolCallId === "message-call-current",
         ),
     ).toHaveLength(1);
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
 
@@ -4280,7 +4265,7 @@ describe("main-session-restart-recovery", () => {
             message?.role === "toolResult" && message.toolCallId === "message-call-current",
         ),
     ).toHaveLength(1);
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
 
@@ -4340,7 +4325,7 @@ describe("main-session-restart-recovery", () => {
         expected,
       );
 
-      expect(callGateway).toHaveBeenCalledTimes(gatewayCalls);
+      expect(sendRecoveryNotice).toHaveBeenCalledTimes(gatewayCalls);
       expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe(expectedStatus);
     },
   );
@@ -4415,7 +4400,7 @@ describe("main-session-restart-recovery", () => {
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
 
@@ -4434,7 +4419,7 @@ describe("main-session-restart-recovery", () => {
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     const failed = loadSessionEntry({ sessionKey, storePath });
     expect(failed).toMatchObject({ status: "failed", abortedLastRun: true });
     expect(failed?.restartRecoveryDeliveryRunId).toBeUndefined();
@@ -4463,9 +4448,7 @@ describe("main-session-restart-recovery", () => {
 
       await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
-      expect(vi.mocked(callGateway).mock.calls[0]?.[0]).toMatchObject({
-        method: "message.action",
-      });
+      expect(sendRecoveryNotice).toHaveBeenCalledOnce();
       expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
     },
   );
@@ -4499,7 +4482,7 @@ describe("main-session-restart-recovery", () => {
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -4771,7 +4754,7 @@ describe("main-session-restart-recovery", () => {
       unresumableAssistantMessage(),
     ]);
     let entryAtExternalSend: SessionEntry | undefined;
-    vi.mocked(callGateway).mockImplementationOnce(async () => {
+    sendRecoveryNotice.mockImplementationOnce(async () => {
       entryAtExternalSend = loadSessionEntry({ sessionKey, storePath });
       await replaceSessionEntry(
         { sessionKey, storePath },
@@ -4784,11 +4767,11 @@ describe("main-session-restart-recovery", () => {
           restartRecoveryDeliverySourceRunId: "replacement-source",
         },
       );
-      return { status: "ok" };
     });
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
     expect(entryAtExternalSend).toMatchObject({
       sessionId: "interrupted-session",
       status: "failed",
@@ -4825,29 +4808,18 @@ describe("main-session-restart-recovery", () => {
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    const gatewayCall = vi.mocked(callGateway).mock.calls[0]?.[0] as
-      | {
-          method?: string;
-          params?: Record<string, unknown>;
-        }
-      | undefined;
-    expect(gatewayCall?.method).toBe("message.action");
-    expect(gatewayCall?.params).toMatchObject({
+    expect(sendRecoveryNotice).toHaveBeenCalledOnce();
+    const notice = sendRecoveryNotice.mock.calls[0]?.[0];
+    expect(notice).toMatchObject({
       channel: "discord",
-      action: "send",
       accountId: "default",
-      sessionKey: "agent:main:demo-channel:room-1",
-      sessionId: "main-session",
-    });
-    expect(gatewayCall?.params?.params).toMatchObject({
       to: "discord:channel:room-1",
       threadId: "thread-1",
-      bestEffort: true,
+      idempotencyKey: "main-session-restart-recovery:main-session:failed-notice",
+      text: expect.stringContaining("couldn't safely resume"),
     });
-    expect(String((gatewayCall?.params?.params as Record<string, unknown>)?.message)).toContain(
-      "couldn't safely resume",
-    );
+    expect(notice).not.toHaveProperty("sessionKey");
+    expect(notice).not.toHaveProperty("sessionId");
 
     const store = readStore(path.join(sessionsDir, "sessions.json"));
     expect(store["agent:main:demo-channel:room-1"]?.status).toBe("failed");

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -526,6 +526,7 @@ describe("message tool gateway timeout", () => {
 
   it("does not advertise the Codex-only final delivery control", () => {
     expect(getToolProperties(createMessageTool())).not.toHaveProperty("final");
+    expect(getToolProperties(createMessageTool())).not.toHaveProperty("idempotencyKey");
   });
 
   it("advertises timeoutMs as a positive integer", () => {
@@ -1178,6 +1179,17 @@ describe("message tool secret scoping", () => {
     expect(input?.params?.idempotencyKey).toMatch(
       /^run-message-tool:message-tool:[A-Za-z0-9_-]+:[A-Za-z0-9._:-]+$/,
     );
+  });
+
+  it("preserves a host-supplied retry idempotency key", async () => {
+    mockSendResult();
+
+    const input = await executeSend({
+      action: { message: "hi", idempotencyKey: "stable-retry-key" },
+      toolOptions: { runId: "run-message-tool" },
+    });
+
+    expect(input?.params?.idempotencyKey).toBe("stable-retry-key");
   });
 
   it("keeps the Codex final control out of delivery and retry idempotency", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -315,6 +315,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     shouldSuppressTyping: state.shouldSuppressTyping,
     messageToolAvailable,
     defaultVisibleReplies: harnessDefaultVisibleReplies,
+    isHeartbeat: params.replyOptions?.isHeartbeat,
   });
   const {
     sourceReplyDeliveryMode,

--- a/src/auto-reply/reply/source-reply-delivery-mode.test.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.test.ts
@@ -522,6 +522,44 @@ describe("resolveSourceReplyVisibilityPolicy", () => {
     );
   });
 
+  it.each([
+    {
+      name: "inter-session handoff",
+      ctx: {
+        ChatType: "direct",
+        InputProvenance: { kind: "inter_session" as const, sourceTool: "sessions_send" },
+      },
+    },
+    {
+      name: "internal lifecycle handoff",
+      ctx: {
+        ChatType: "direct",
+        InputProvenance: { kind: "internal_system" as const, sourceTool: "restart-sentinel" },
+      },
+    },
+    {
+      name: "heartbeat handoff",
+      ctx: { ChatType: "direct" },
+      isHeartbeat: true,
+    },
+  ])("keeps $name overrides out of session-stable policy", ({ ctx, isHeartbeat }) => {
+    expectPolicyFields(
+      resolveSourceReplyVisibilityPolicy({
+        cfg: emptyConfig,
+        ctx,
+        requested: "message_tool_only",
+        isHeartbeat,
+        sendPolicy: "allow",
+      }),
+      {
+        sourceReplyDeliveryMode: "message_tool_only",
+        sessionStableSourceReplyDeliveryMode: "automatic",
+        suppressAutomaticSourceDelivery: true,
+        suppressDelivery: true,
+      },
+    );
+  });
+
   it("lets sendPolicy deny suppress delivery and typing", () => {
     expectPolicyFields(
       resolveSourceReplyVisibilityPolicy({

--- a/src/auto-reply/reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.ts
@@ -2,6 +2,7 @@
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { SessionSendPolicyDecision } from "../../sessions/send-policy.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveCommandTurnContext, type CommandTurnContext } from "../command-turn-context.js";
@@ -20,6 +21,7 @@ export type SourceReplyDeliveryModeContext = {
   CommandSource?: "text" | "native";
   CommandTurn?: CommandTurnContext;
   BotUsername?: string;
+  InputProvenance?: InputProvenance;
 };
 
 function toSessionStableDeliveryModeContext(
@@ -115,6 +117,18 @@ export function resolveSourceReplyDeliveryMode(params: {
   return mode;
 }
 
+/** Returns true when a lifecycle turn must not redefine session-stable reply policy. */
+export function isSyntheticSourceReplyTurn(params: {
+  inputProvenance?: InputProvenance;
+  isHeartbeat?: boolean;
+}): boolean {
+  return (
+    params.isHeartbeat === true ||
+    params.inputProvenance?.kind === "inter_session" ||
+    params.inputProvenance?.kind === "internal_system"
+  );
+}
+
 /** Full source-reply suppression decision consumed by run and hook code. */
 type SourceReplyVisibilityPolicy = {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode;
@@ -140,6 +154,7 @@ export function resolveSourceReplyVisibilityPolicy(params: {
   shouldSuppressTyping?: boolean;
   messageToolAvailable?: boolean;
   defaultVisibleReplies?: "automatic" | "message_tool";
+  isHeartbeat?: boolean;
 }): SourceReplyVisibilityPolicy {
   const sourceReplyDeliveryMode = resolveSourceReplyDeliveryMode({
     cfg: params.cfg,
@@ -149,9 +164,13 @@ export function resolveSourceReplyVisibilityPolicy(params: {
     messageToolAvailable: params.messageToolAvailable,
     defaultVisibleReplies: params.defaultVisibleReplies,
   });
-  const hasTurnDeliveryOverride =
-    params.requested !== undefined || isExplicitSourceReplyCommand(params.ctx, params.cfg);
-  const sessionStableSourceReplyDeliveryMode = hasTurnDeliveryOverride
+  const hasStableTurnOverride =
+    !isSyntheticSourceReplyTurn({
+      inputProvenance: params.ctx.InputProvenance,
+      isHeartbeat: params.isHeartbeat,
+    }) &&
+    (params.requested !== undefined || isExplicitSourceReplyCommand(params.ctx, params.cfg));
+  const sessionStableSourceReplyDeliveryMode = hasStableTurnOverride
     ? sourceReplyDeliveryMode
     : resolveSourceReplyDeliveryMode({
         cfg: params.cfg,

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -1170,6 +1170,61 @@ describe("agentCommand", () => {
     });
   });
 
+  it("keeps synthetic direct-DM delivery mode out of existing CLI binding facts", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const sessionKey = "agent:main:discord:direct:requester";
+      await writeSessionStoreSeed(store, {
+        [sessionKey]: {
+          sessionId: "requester-session",
+          updatedAt: Date.now(),
+          chatType: "direct",
+          modelProvider: "anthropic",
+          model: "claude-opus-4-6",
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: "native-claude-session",
+              messageToolPolicyHash: "automatic-policy-hash",
+            },
+          },
+          delivery: normalizeSessionDeliveryState({
+            context: { channel: "discord", to: "user:requester" },
+            origin: { provider: "discord", chatType: "direct", to: "user:requester" },
+          }),
+        },
+      });
+      const cfg = mockConfig(home, store, {
+        models: {
+          "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
+        },
+      });
+      cfg.messages = { visibleReplies: "automatic" };
+
+      const prepared = await agentCommandTesting.prepareAgentCommandExecution(
+        {
+          message: "child completed",
+          sessionKey,
+          sourceReplyDeliveryMode: "message_tool_only",
+          inputProvenance: {
+            kind: "inter_session",
+            sourceSessionKey: "agent:main:subagent:child",
+            sourceTool: "subagent_announce",
+          },
+        },
+        runtime,
+      );
+
+      expect(prepared.opts.sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(prepared.opts.cliSessionBindingFacts).toEqual({
+        sourceReplyDeliveryMode: "automatic",
+      });
+      expect(prepared.sessionEntry?.cliSessionBindings?.["claude-cli"]).toMatchObject({
+        sessionId: "native-claude-session",
+        messageToolPolicyHash: "automatic-policy-hash",
+      });
+    });
+  });
+
   it("passes resolved session-id resume files to embedded runs", async () => {
     await withTempHome(async (home) => {
       const resumeStore = path.join(home, "sessions-resume.json");

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { GatewayNativeApprovalMethod } from "../infra/approval-gateway-runtime-methods.js";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
 import { createGatewayInstanceRuntime } from "./server-instance-runtime.js";
@@ -10,6 +14,8 @@ import { getGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js"
 
 function createContext(): GatewayRequestContext {
   return {
+    deps: {},
+    getRuntimeConfig: () => ({}),
     logGateway: {
       warn: vi.fn(),
       error: vi.fn(),
@@ -66,6 +72,76 @@ describe("createGatewayInstanceRuntime", () => {
     await expect(runtime.recovery.waitForAgent({ runId: "run-1" })).rejects.toThrow(
       "Gateway instance dispatch unavailable",
     );
+  });
+
+  it("sends recovery notices through normal outbound without invoking plugin actions", async () => {
+    await withOpenClawTestState({ layout: "state-only", prefix: "recovery-notice-" }, async () => {
+      const sendText = vi.fn(async () => ({ channel: "signal", messageId: "signal-message-1" }));
+      const handleAction = vi.fn(async () => {
+        throw new Error("recovery notice must not invoke message actions");
+      });
+      const plugin: ChannelPlugin = {
+        id: "signal",
+        meta: {
+          id: "signal",
+          label: "Signal",
+          selectionLabel: "Signal",
+          docsPath: "/channels/signal",
+          blurb: "Signal-shaped recovery test plugin.",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => ["work"],
+          resolveAccount: () => ({}),
+          isConfigured: () => true,
+        },
+        actions: {
+          describeMessageTool: () => ({ actions: ["send"] }),
+          supportsAction: () => false,
+          handleAction,
+        },
+        outbound: {
+          deliveryMode: "direct",
+          resolveTarget: ({ to }) => ({ ok: true, to: to?.trim() ?? "" }),
+          sendText,
+        },
+      };
+      setActivePluginRegistry(createTestRegistry([{ pluginId: "signal", source: "test", plugin }]));
+      const context = {
+        ...createContext(),
+        getRuntimeConfig: () => ({ channels: { signal: { enabled: true } } }),
+      } as GatewayRequestContext;
+      const runtime = createGatewayInstanceRuntime({
+        getContext: () => context,
+        getMethodRegistry: () => createRegistry({}),
+        isDispatchAvailable: () => true,
+      });
+
+      try {
+        await runtime.recovery.sendRecoveryNotice({
+          channel: "signal",
+          to: "+15551234567",
+          accountId: "work",
+          threadId: "thread-1",
+          text: "Recovery notice",
+          idempotencyKey: "main-session-restart-recovery:run-1:failed-notice",
+        });
+
+        expect(sendText).toHaveBeenCalledOnce();
+        expect(sendText).toHaveBeenCalledWith(
+          expect.objectContaining({
+            to: "+15551234567",
+            accountId: "work",
+            threadId: "thread-1",
+            text: "Recovery notice",
+          }),
+        );
+        expect(handleAction).not.toHaveBeenCalled();
+      } finally {
+        runtime.close();
+        setActivePluginRegistry(createTestRegistry([]));
+      }
+    });
   });
 
   it("keeps approval subscribers isolated by Gateway instance and unregisters exactly once", () => {

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
+import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import {
   GATEWAY_NATIVE_APPROVAL_METHODS,
   type GatewayNativeApprovalMethod,
@@ -10,6 +11,7 @@ import type {
   GatewayApprovalResolved,
 } from "../infra/approval-gateway-runtime.types.js";
 import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-route-coordinator.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
@@ -20,6 +22,16 @@ import type {
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 import { registerGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
+
+const loadOutboundMessageRuntime = createLazyRuntimeModule(
+  () => import("../infra/outbound/message.js"),
+);
+
+const RECOVERY_NOTICE_COMPLETION_RETENTION = {
+  idPrefix: "main-session-restart-recovery:",
+  maxAgeMs: 24 * 60 * 60_000,
+  maxEntries: 2_000,
+} as const;
 
 type GatewayInstanceRuntimeOptions = {
   getContext: () => GatewayRequestContext;
@@ -60,7 +72,6 @@ export function createGatewayInstanceRuntime(
 
   const recoveryClient = createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] });
   const recoveryMethods = new Set(["agent", "agent.wait"]);
-  const recoveryNoticeMethods = new Set(["message.action"]);
   const approvalClient = createSyntheticPluginRuntimeClient({ scopes: [APPROVALS_SCOPE] });
   const approvalMethods = new Set<GatewayNativeApprovalMethod>(GATEWAY_NATIVE_APPROVAL_METHODS);
   const approvalRouteClient = createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] });
@@ -83,14 +94,32 @@ export function createGatewayInstanceRuntime(
         payload,
         timeoutMs,
       }),
-    sendRecoveryNotice: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
-      await dispatch<T>({
-        allowedMethods: recoveryNoticeMethods,
-        client: recoveryClient,
-        method: "message.action",
-        payload,
-        timeoutMs,
-      }),
+    sendRecoveryNotice: async (payload) => {
+      if (closed || !options.isDispatchAvailable()) {
+        throw new Error("Gateway instance dispatch unavailable for recovery notice");
+      }
+      const { sendMessage } = await loadOutboundMessageRuntime();
+      const context = options.getContext();
+      const result = await sendMessage({
+        cfg: context.getRuntimeConfig(),
+        deps: createOutboundSendDeps(context.deps),
+        channel: payload.channel,
+        to: payload.to,
+        accountId: payload.accountId,
+        threadId: payload.threadId,
+        content: payload.text,
+        gatewayOwnedDelivery: true,
+        bestEffort: true,
+        idempotencyKey: payload.idempotencyKey,
+        deliveryIntentId: payload.idempotencyKey,
+        reusePendingDeliveryIntent: true,
+        completionRetention: RECOVERY_NOTICE_COMPLETION_RETENTION,
+        abortSignal: AbortSignal.timeout(10_000),
+      });
+      if (result.deliveryStatus === "failed" || result.deliveryStatus === "partial_failed") {
+        throw new Error(result.error ?? "recovery notice delivery failed");
+      }
+    },
   };
   const releaseRecoveryRuntime = registerGatewayRecoveryRuntime(recovery);
 

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -11,10 +11,14 @@ export type GatewayApprovalEventPublisher = {
 export type GatewayRecoveryRuntime = {
   dispatchAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
   waitForAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
-  sendRecoveryNotice: <T = unknown>(
-    params: Record<string, unknown>,
-    timeoutMs?: number,
-  ) => Promise<T>;
+  sendRecoveryNotice: (params: {
+    channel: string;
+    to: string;
+    accountId?: string;
+    threadId?: string | number;
+    text: string;
+    idempotencyKey: string;
+  }) => Promise<void>;
 };
 
 export type GatewayInstanceRuntime = {

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -301,6 +301,25 @@ describe("runMessageAction media behavior", () => {
     expect(sendArgs.asVoice).toBe(true);
   });
 
+  it("copies the normalized idempotency key into send execution context", async () => {
+    setTestPlugin(workspacePlugin, "workspace");
+
+    await runDrySend({
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "workspace",
+        target: "12345678",
+        message: "hello",
+        idempotencyKey: " run-1:message-tool:send-1:fingerprint ",
+      },
+    });
+
+    const sendArgs = firstMockArg(channelResolutionMocks.executeSendAction, "executeSendAction");
+    expect(requireRecord(sendArgs.ctx).idempotencyKey).toBe(
+      "run-1:message-tool:send-1:fingerprint",
+    );
+  });
+
   it("rejects plugin-declined attachment actions before loading media", async () => {
     const handleAction = vi.fn(async () => jsonResult({ ok: true }));
     const textOnlyPlugin: ChannelPlugin = {

--- a/src/infra/outbound/message-action-runner.poll.test.ts
+++ b/src/infra/outbound/message-action-runner.poll.test.ts
@@ -120,7 +120,11 @@ async function runPollAction(params: {
       maxSelections?: number;
       threadId?: string;
     };
-    ctx?: { inboundEventKind?: string; params?: Record<string, unknown> };
+    ctx?: {
+      inboundEventKind?: string;
+      idempotencyKey?: string;
+      params?: Record<string, unknown>;
+    };
   };
   return {
     ...call.resolveCorePoll?.(),
@@ -224,6 +228,21 @@ describe("runMessageAction poll handling", () => {
     });
 
     expect(call?.ctx?.inboundEventKind).toBe("room_event");
+  });
+
+  it("copies the normalized idempotency key into poll execution context", async () => {
+    const call = await runPollAction({
+      cfg: pollerConfig,
+      actionParams: {
+        channel: "poller",
+        target: "poller:123",
+        pollQuestion: "Lunch?",
+        pollOption: ["Pizza", "Sushi"],
+        idempotencyKey: " run-1:message-tool:poll-1:fingerprint ",
+      },
+    });
+
+    expect(call?.ctx?.idempotencyKey).toBe("run-1:message-tool:poll-1:fingerprint");
   });
 
   it("expands maxSelections when pollMulti is enabled", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -716,6 +716,7 @@ async function resolveResolvedTargetOrThrow(params: {
 type ResolvedActionContext = {
   cfg: OpenClawConfig;
   params: Record<string, unknown>;
+  idempotencyKey?: string;
   channel: ChannelId;
   channelPlugin?: ChannelPlugin;
   mediaAccess: OutboundMediaAccess;
@@ -1635,6 +1636,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       cfg,
       channel,
       params,
+      idempotencyKey: ctx.idempotencyKey,
       agentId,
       sessionKey: input.sessionKey,
       requesterAccountId: input.requesterAccountId ?? undefined,
@@ -1801,6 +1803,7 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
       cfg,
       channel,
       params,
+      idempotencyKey: ctx.idempotencyKey,
       accountId: accountId ?? undefined,
       agentId,
       requesterAccountId: input.requesterAccountId ?? undefined,
@@ -2222,6 +2225,7 @@ export async function runMessageAction(
   const context: ResolvedActionContext = {
     cfg,
     params,
+    idempotencyKey: normalizeOptionalString(params.idempotencyKey),
     channel,
     channelPlugin,
     mediaAccess,

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -260,9 +260,11 @@ describe("sendPoll channel normalization", () => {
       question: "Lunch?",
       options: ["Pizza", "Sushi"],
       channel: "Workspace-Chat",
+      idempotencyKey: "stable-poll-key",
     });
 
     expect(gatewayCall()?.params?.channel).toBe("demo-alias-channel");
+    expect(gatewayCall()?.params?.idempotencyKey).toBe("stable-poll-key");
     expect(result.channel).toBe("demo-alias-channel");
     expect(result.via).toBe("gateway");
   });
@@ -425,6 +427,17 @@ describe("gateway url override hardening", () => {
           forceDocument: true,
           silent: true,
           parseMode: "HTML",
+        },
+      },
+    },
+    {
+      name: "preserves an explicit send idempotency key",
+      params: {
+        idempotencyKey: "stable-send-key",
+      },
+      expected: {
+        params: {
+          idempotencyKey: "stable-send-key",
         },
       },
     },

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -1003,6 +1003,7 @@ describe("executeSendAction", () => {
         cfg: {},
         channel: "demo-outbound",
         params: { to: "channel:123", message: "hello" },
+        idempotencyKey: "stable-send-key",
         dryRun: true,
         silent: true,
         gateway: {
@@ -1023,6 +1024,7 @@ describe("executeSendAction", () => {
       content: "hello",
       dryRun: true,
       silent: true,
+      idempotencyKey: "stable-send-key",
     });
     expectFields(requireRecord(sendArgs.gateway, "send gateway"), {
       url: "http://127.0.0.1:18789",
@@ -1200,6 +1202,7 @@ describe("executeSendAction", () => {
         cfg: {},
         channel: "demo-outbound",
         params: {},
+        idempotencyKey: "stable-poll-key",
         dryRun: true,
         silent: true,
         gateway: {
@@ -1226,6 +1229,7 @@ describe("executeSendAction", () => {
       durationHours: 6,
       dryRun: true,
       silent: true,
+      idempotencyKey: "stable-poll-key",
     });
     expectFields(requireRecord(pollArgs.gateway, "poll gateway"), {
       url: "http://127.0.0.1:18789",

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -52,6 +52,7 @@ type OutboundSendContext = {
   cfg: OpenClawConfig;
   channel: ChannelId;
   params: Record<string, unknown>;
+  idempotencyKey?: string;
   /** Active agent id for per-agent outbound media root scoping. */
   agentId?: string;
   sessionKey?: string;
@@ -172,6 +173,7 @@ async function sendCoreMessage(params: {
     queuePolicy: params.queuePolicy,
     deps: params.ctx.deps,
     gateway: params.ctx.gateway,
+    idempotencyKey: params.ctx.idempotencyKey,
     mirror: params.ctx.mirror,
     abortSignal: params.ctx.abortSignal,
     silent: params.ctx.silent,
@@ -516,6 +518,7 @@ export async function executePollAction(params: {
     isAnonymous: corePoll.isAnonymous ?? undefined,
     dryRun: params.ctx.dryRun,
     gateway: params.ctx.gateway,
+    idempotencyKey: params.ctx.idempotencyKey,
   });
 
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes three delivery failures found in production: synthetic sub-agent and lifecycle turns could invalidate an existing Claude CLI session and reseed it from a lossy text-only transcript; message-tool sends and polls could discard their host-generated idempotency key before reaching the Gateway; and failed-session recovery notices could bypass normal outbound delivery and disappear on Signal and other plugins that intentionally do not implement send as a message action.

## Why This Change Was Made

Synthetic turns now keep their turn-local reply policy separate from the existing session's stable CLI binding policy. Core outbound send and poll paths carry the host-owned idempotency key end to end. Main-session recovery notices now use a typed Gateway-owned normal outbound path with durable delivery identity, no plugin action fallback, and no transcript mirroring into a rebound session.

The reported `openclaw models list` Sonnet 5 crash was also checked and is already fixed on `main` by #102186; this PR does not change model code.

AI-assisted: implementation and review used Codex and Claude Code; the final diff was manually inspected and source-aware autoreview found no actionable issue.

## User Impact

Sub-agent completions and internal lifecycle turns no longer force unnecessary Claude CLI reseeds or invite repeated agent actions from reconstructed history. Retried gateway-mode sends retain the same logical delivery identity, and operators on Signal and other outbound-only plugins receive the visible notice when a main session cannot be resumed after restart.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/source-reply-delivery-mode.test.ts src/commands/agent.test.ts src/agents/main-session-restart-recovery.test.ts src/gateway/server-instance-runtime.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-runner.poll.test.ts src/infra/outbound/message.channels.test.ts src/infra/outbound/outbound-send-service.test.ts src/agents/tools/message-tool.test.ts` — 9 files / 563 tests passed across 6 shards.
- Exact behavior filters passed for stable synthetic CLI binding facts, send/poll idempotency propagation, successful/parallel identical-send separation, Signal-shaped normal outbound recovery, failure-before-send ordering, and canonical recovery routing.
- `pnpm tsgo` — passed.
- `pnpm check:test-types` — passed.
- targeted `node scripts/run-oxlint.mjs ...` for all changed files — passed.
- `pnpm build` — passed, including CLI import guard and plugin SDK export checks.
- `git diff --check` — passed.
- Codex autoreview (`gpt-5.6-sol`, high) — clean, no accepted/actionable findings.
- Blacksmith Testbox was unavailable locally because the `blacksmith` executable was absent; repository policy fallback was the successful local heavy gate above. Exact-head hosted CI remains required before landing.
