### PR TITLE
fix(i18n): keep surrogate pairs intact when bounding process output tail

### DIFF
--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { completeSimple, type AssistantMessage, type Model } from "openclaw/plugin-sdk/llm";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
+import { sliceUtf16Safe } from "../packages/normalization-core/src/utf16-slice.ts";
 import { formatErrorMessage } from "../src/infra/errors.ts";
 import { formatDurationCompact } from "../src/infra/format-time/format-duration.ts";
 import {
@@ -526,7 +527,7 @@ export function appendBoundedProcessOutput(
     return { text: nextText, truncatedChars: capture.truncatedChars };
   }
   const truncatedChars = capture.truncatedChars + nextText.length - maxChars;
-  return { text: nextText.slice(-maxChars), truncatedChars };
+  return { text: sliceUtf16Safe(nextText, -maxChars), truncatedChars };
 }
 
 function formatProcessOutput(capture: ProcessOutputCapture): string {

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -526,8 +526,9 @@ export function appendBoundedProcessOutput(
   if (nextText.length <= maxChars) {
     return { text: nextText, truncatedChars: capture.truncatedChars };
   }
-  const truncatedChars = capture.truncatedChars + nextText.length - maxChars;
-  return { text: sliceUtf16Safe(nextText, -maxChars), truncatedChars };
+  const text = sliceUtf16Safe(nextText, -maxChars);
+  const truncatedChars = capture.truncatedChars + nextText.length - text.length;
+  return { text, truncatedChars };
 }
 
 function formatProcessOutput(capture: ProcessOutputCapture): string {

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -416,13 +416,15 @@ describe("control-ui-i18n process runner", () => {
     // "ab😀cdef" is 8 UTF-16 code units: a, b, <high>, <low>, c, d, e, f.
     // maxChars = 5 forces a tail slice whose boundary lands inside the surrogate pair.
     // The raw `slice(-5)` would return "<low>cdef" (leading dangling low surrogate).
+    // sliceUtf16Safe advances past the low surrogate, retaining "cdef" (4 units);
+    // truncatedChars must reflect the 4 actually-dropped units, not maxChars.
     const result = appendBoundedProcessOutput({ text: "", truncatedChars: 0 }, "ab😀cdef", 5);
     expect(result.text.length).toBeLessThanOrEqual(5);
     // No dangling surrogate (high 0xd800-0xdbff or low 0xdc00-0xdfff) at either edge.
     expect(result.text.charCodeAt(0)).toBeLessThan(0xd800);
     expect(result.text.charCodeAt(result.text.length - 1)).toBeLessThan(0xd800);
     expect(result.text).toBe("cdef");
-    expect(result.truncatedChars).toBe(3);
+    expect(result.truncatedChars).toBe(4);
   });
 
   it("bounds failure diagnostics to the newest output", async () => {

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -412,6 +412,19 @@ describe("control-ui-i18n process runner", () => {
     expect(second).toEqual({ text: "fghij", truncatedChars: 5 });
   });
 
+  it("does not split a UTF-16 surrogate pair at the tail boundary", () => {
+    // "ab😀cdef" is 8 UTF-16 code units: a, b, <high>, <low>, c, d, e, f.
+    // maxChars = 5 forces a tail slice whose boundary lands inside the surrogate pair.
+    // The raw `slice(-5)` would return "<low>cdef" (leading dangling low surrogate).
+    const result = appendBoundedProcessOutput({ text: "", truncatedChars: 0 }, "ab😀cdef", 5);
+    expect(result.text.length).toBeLessThanOrEqual(5);
+    // No dangling surrogate (high 0xd800-0xdbff or low 0xdc00-0xdfff) at either edge.
+    expect(result.text.charCodeAt(0)).toBeLessThan(0xd800);
+    expect(result.text.charCodeAt(result.text.length - 1)).toBeLessThan(0xd800);
+    expect(result.text).toBe("cdef");
+    expect(result.truncatedChars).toBe(3);
+  });
+
   it("bounds failure diagnostics to the newest output", async () => {
     await expect(
       runProcess(


### PR DESCRIPTION
## What Problem This Solves

`appendBoundedProcessOutput` in `scripts/control-ui-i18n.ts` kept the newest `maxChars` of captured process output with `nextText.slice(-maxChars)`. When the boundary landed inside a UTF-16 surrogate pair (e.g. an emoji in stderr), the retained tail began with a **dangling low surrogate**, corrupting downstream JSON serialization and fatal `TextDecoder` paths.

## User Impact

Control UI localization process diagnostics preserve complete Unicode characters and accurately report how much output was discarded.

## Reproduction

```js
appendBoundedProcessOutput({ text: "", truncatedChars: 0 }, "ab\uD83D\uDE00cdef", 5)
// "ab\uD83D\uDE00cdef" is 8 UTF-16 code units (a b <high> <low> c d e f).
// before: { text: "\uDE00cdef" (leading dangling low surrogate), truncatedChars: 3 }
// after:  { text: "cdef", truncatedChars: 4 }
```

`slice(-5)` starts at index 3 (the low surrogate of U+1F600) and returns a string with an unpaired low surrogate at the front.

## Why This Change Was Made

`String.prototype.slice` operates on UTF-16 code units and does not avoid surrogate-pair boundaries.

## Fix

Use `sliceUtf16Safe(nextText, -maxChars)` from `packages/normalization-core/src/utf16-slice.ts`, which adjusts the slice boundary off the surrogate pair. The helper already supports negative `start` and is dependency-free.

`sliceUtf16Safe` advances past a low surrogate at the boundary, so the retained tail can be shorter than `maxChars` (here 4 instead of 5). `truncatedChars` is therefore derived from the actual retained tail length (`nextText.length - text.length`) rather than `maxChars`, so the operator-visible diagnostic accurately reports how many code units were dropped.

## Evidence

- New unit test `does not split a UTF-16 surrogate pair at the tail boundary` in `test/scripts/control-ui-i18n.test.ts`.
- Confirmed the test **fails before the fix** (`AssertionError: expected 56832 to be less than 55296` - 56832 = 0xDDC0 dangling low surrogate) and **passes after**.
- `pnpm oxlint` - 0 warnings, 0 errors.
- `pnpm oxfmt` - applied.
- `pnpm vitest run test/scripts/control-ui-i18n.test.ts` - 18 passed | 2 skipped.

## Real behavior proof

Exercised the real `appendBoundedProcessOutput` (imported from `scripts/control-ui-i18n.ts`) with an emoji-surrogate chunk at the `maxChars` boundary. The script imports the production module and replicates the operator-visible `formatProcessOutput` diagnostic (source lines 534-537) to show both the pre-fix raw-`slice` behavior and the post-fix safe-slice behavior.

```
=== PR #120114 real behavior proof ===
input chunk        : "ab\uD83D\uDE00cdef" (length=8 UTF-16 code units, maxChars=5)

--- BEFORE fix (raw nextText.slice(-maxChars)) ---
retained text      : "\uDE00cdef" (length=5)
truncatedChars     : 3
first code unit    : U+DE00 (DANGLING SURROGATE)
operator diagnostic:
[output truncated 3 chars; showing tail]
\uDE00cdef   (leading replacement char / unpaired low surrogate)

--- AFTER fix (sliceUtf16Safe(nextText, -maxChars), count from retained length) ---
retained text      : "cdef" (length=4)
truncatedChars     : 4  (8 input - 4 retained = 4)
first code unit    : U+0063 (safe)
operator diagnostic:
[output truncated 4 chars; showing tail]
cdef
```

The pre-fix retained text begins with U+DE00, an unpaired low surrogate (0xDC00-0xDFFF), which corrupts JSON serialization and fatal `TextDecoder` decoding. The post-fix retained text begins with U+0063 (`c`), safely below the surrogate range, and `truncatedChars` correctly reports the 4 actually-dropped code units.

## Diff size

+15 / -1, 2 files.
