### PR TITLE
refactor(test): replace logic-bearing vi.mock factories with boundary fakes, batch 2

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -123,7 +123,7 @@ vi.mock("./resolve-allowlist.js", async (importOriginal) => ({
 }));
 
 vi.mock("./sdk.js", () => ({
-  loadMSTeamsSdkWithAuth: (creds?: unknown, options?: unknown) =>
+  loadMSTeamsSdkWithAuth: (creds?: unknown, options?: Record<string, unknown>) =>
     loadMSTeamsSdkWithAuth(creds, options),
   createMSTeamsTokenProvider: () => ({
     getAccessToken: vi.fn().mockResolvedValue("mock-token"),

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -1,5 +1,5 @@
 // Msteams tests cover monitor.lifecycle plugin behavior.
-import { EventEmitter } from "node:events";
+import type { Server } from "node:http";
 import type { Request, Response } from "express";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
@@ -11,13 +11,6 @@ import {
   gateIngressAcceptThenDispatch,
 } from "./monitor-ingress-mock.test-support.js";
 import type { MSTeamsPollStore } from "./polls.js";
-
-type FakeServer = EventEmitter & {
-  close: (callback?: (err?: Error | null) => void) => void;
-  setTimeout: (msecs: number) => FakeServer;
-  requestTimeout: number;
-  headersTimeout: number;
-};
 
 type MSTeamsUserResolution = {
   input: string;
@@ -45,90 +38,14 @@ type RegisterMSTeamsHandlersMock = (
   deps: MSTeamsMessageHandlerDeps,
 ) => MSTeamsActivityHandler;
 
-type MockExpressFn = ReturnType<typeof vi.fn>;
-type MockExpressApp = MockExpressFn & {
-  use: MockExpressFn;
-  post: MockExpressFn;
-  listen: MockExpressFn;
-};
+const keepHttpServerTaskAliveMock = vi.hoisted(() => vi.fn());
 
-const expressControl = vi.hoisted(() => ({
-  mode: { value: "listening" as "listening" | "error" },
-  apps: [] as MockExpressApp[],
-}));
-
-const isDangerousNameMatchingEnabled = vi.hoisted(() => vi.fn());
-const keepHttpServerTaskAliveMock = vi.hoisted(() =>
-  vi.fn(async (params: { abortSignal?: AbortSignal; onAbort?: () => Promise<void> | void }) => {
-    await new Promise<void>((resolve) => {
-      if (params.abortSignal?.aborted) {
-        resolve();
-        return;
-      }
-      params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
-    });
-    await params.onAbort?.();
-  }),
-);
-
-vi.mock("../runtime-api.js", () => ({
-  DEFAULT_WEBHOOK_MAX_BODY_BYTES: 1024 * 1024,
-  isDangerousNameMatchingEnabled,
-  normalizeSecretInputString: (value: unknown) =>
-    typeof value === "string" && value.trim() ? value.trim() : undefined,
-  hasConfiguredSecretInput: (value: unknown) =>
-    typeof value === "string" && value.trim().length > 0,
-  normalizeResolvedSecretInputString: (params: { value?: unknown }) =>
-    typeof params?.value === "string" && params.value.trim() ? params.value.trim() : undefined,
-  keepHttpServerTaskAlive: keepHttpServerTaskAliveMock,
-  mergeAllowlist: (params: { existing?: string[]; additions?: string[] }) =>
-    Array.from(new Set([...(params.existing ?? []), ...(params.additions ?? [])])),
-  summarizeMapping: vi.fn(),
-}));
-
-vi.mock("express", () => {
-  const json = vi.fn(() => {
-    return (_req: unknown, _res: unknown, next?: (err?: unknown) => void) => {
-      next?.();
-    };
-  });
-
-  const factory = () => {
-    const app = vi.fn() as MockExpressApp;
-    app.use = vi.fn();
-    app.post = vi.fn();
-    app.listen = vi.fn((_port: number, callback?: (error?: Error) => void) => {
-      const server = new EventEmitter() as FakeServer;
-      server.setTimeout = vi.fn((_msecs: number) => server);
-      server.requestTimeout = 0;
-      server.headersTimeout = 0;
-      server.close = (closeCallback?: (err?: Error | null) => void) => {
-        queueMicrotask(() => {
-          server.emit("close");
-          closeCallback?.(null);
-        });
-      };
-      queueMicrotask(() => {
-        if (expressControl.mode.value === "error") {
-          callback?.(new Error("listen EADDRINUSE"));
-          return;
-        }
-        callback?.();
-      });
-      return server;
-    });
-    return app;
-  };
-
-  const wrappedFactory = () => {
-    const app = factory();
-    expressControl.apps.push(app);
-    return app;
-  };
-
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime-api.js")>();
+  keepHttpServerTaskAliveMock.mockImplementation(actual.keepHttpServerTaskAlive);
   return {
-    default: wrappedFactory,
-    json,
+    ...actual,
+    keepHttpServerTaskAlive: keepHttpServerTaskAliveMock,
   };
 });
 
@@ -139,19 +56,35 @@ const isSigninInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const isCardActionInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const runMSTeamsFileConsentInvokeHandler = vi.hoisted(() => vi.fn(async () => {}));
 const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
-  vi.fn(async (_creds?: unknown, _options?: unknown) => ({
-    app: {
+  vi.fn(async (_creds?: unknown, options?: Record<string, unknown>) => {
+    const app = {
       on: vi.fn(),
       event: vi.fn(),
       onTokenExchange: vi.fn(async () => ({ status: 200 })),
       onVerifyState: vi.fn(async () => ({ status: 200 })),
-      initialize: vi.fn(async () => {}),
+      initialize: vi.fn(async () => {
+        const adapter = options?.httpServerAdapter as
+          | {
+              registerRoute?: (
+                path: string,
+                handler: (req: Request, res: Response) => void,
+              ) => void;
+            }
+          | undefined;
+        const endpoint = options?.messagingEndpoint;
+        if (adapter?.registerRoute && typeof endpoint === "string") {
+          adapter.registerRoute(endpoint, (req, res) => {
+            res.status(200).json({ url: req.url });
+          });
+        }
+      }),
       tokenManager: {
         getBotToken: vi.fn(async () => ({ toString: (): string => "bot-token" })),
         getGraphToken: vi.fn(async () => ({ toString: (): string => "graph-token" })),
       },
-    },
-  })),
+    };
+    return { app };
+  }),
 );
 
 const ssoTokenStore = vi.hoisted(() => ({
@@ -195,11 +128,14 @@ vi.mock("./sdk.js", () => ({
   createMSTeamsTokenProvider: () => ({
     getAccessToken: vi.fn().mockResolvedValue("mock-token"),
   }),
-  createMSTeamsExpressAdapter: vi.fn().mockResolvedValue({
-    registerRoute: vi.fn(),
-    start: vi.fn().mockResolvedValue(undefined),
-    stop: vi.fn().mockResolvedValue(undefined),
-  }),
+  createMSTeamsExpressAdapter: vi.fn(
+    async (expressApp: { post: (...args: unknown[]) => void }) => ({
+      registerRoute: (path: string, handler: (req: Request, res: Response) => void) =>
+        expressApp.post(path, handler),
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    }),
+  ),
 }));
 
 vi.mock("./runtime.js", () => ({
@@ -278,6 +214,25 @@ function createStores() {
   };
 }
 
+async function resolveStartedServer(): Promise<Server> {
+  await waitForMSTeamsTestState(() => {
+    expect(keepHttpServerTaskAliveMock).toHaveBeenCalled();
+  });
+  const server = keepHttpServerTaskAliveMock.mock.calls.at(-1)?.[0]?.server as Server | undefined;
+  if (!server) {
+    throw new Error("expected started Microsoft Teams HTTP server");
+  }
+  return server;
+}
+
+function resolveServerUrl(server: Server, path: string): string {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  return `http://127.0.0.1:${address.port}${path}`;
+}
+
 function requireRegisteredMSTeamsConfig(): OpenClawConfig {
   const registered = registerMSTeamsHandlers.mock.calls[0]?.[1] as
     | { cfg?: OpenClawConfig }
@@ -291,9 +246,6 @@ function requireRegisteredMSTeamsConfig(): OpenClawConfig {
 describe("monitorMSTeamsProvider lifecycle", () => {
   afterEach(() => {
     vi.clearAllMocks();
-    expressControl.mode.value = "listening";
-    expressControl.apps.length = 0;
-    isDangerousNameMatchingEnabled.mockReset().mockReturnValue(false);
     resolveAllowlistMocks.resolveMSTeamsTeamsConfig
       .mockReset()
       .mockImplementation(async ({ teams }) => ({ teams, mapping: [], unresolved: [] }));
@@ -338,20 +290,6 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     if (!result.app) {
       throw new Error("expected Teams monitor app after startup abort");
     }
-    await expect(result.shutdown()).resolves.toBeUndefined();
-  });
-
-  it("rejects startup when webhook port is already in use", async () => {
-    expressControl.mode.value = "error";
-    await expect(
-      monitorMSTeamsProvider({
-        cfg: createConfig(3978),
-        runtime: createRuntime(),
-        abortSignal: new AbortController().signal,
-        conversationStore: createStores().conversationStore,
-        pollStore: createStores().pollStore,
-      }),
-    ).rejects.toThrow(/EADDRINUSE/);
   });
 
   it("rejects requests without Bearer token before SDK route", async () => {
@@ -364,40 +302,18 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await waitForMSTeamsTestState(() => {
-      expect(expressControl.apps.length).toBeGreaterThan(0);
+    const server = await resolveStartedServer();
+    const unauthorized = await fetch(resolveServerUrl(server, "/api/messages"), {
+      method: "POST",
     });
+    expect(unauthorized.status).toBe(401);
+    await expect(unauthorized.json()).resolves.toEqual({ error: "Unauthorized" });
 
-    const app = expressControl.apps.at(-1);
-    expect(app).toBeDefined();
-    // Three middlewares are installed before the SDK route registers:
-    // [0] = bearer-presence gate — rejects unauthenticated requests cheaply.
-    // [1] = `express.json({ limit })` — caps bearer-shaped inbound bodies
-    //       before the SDK's later json() can parse them.
-    // [2] = JSON parser error handler — keeps 413 responses JSON-shaped.
-    expect(app!.use.mock.calls.length).toBeGreaterThanOrEqual(3);
-
-    const bearerMiddleware = app!.use.mock.calls[0]?.[0] as (
-      req: Request,
-      res: Response,
-      next: (err?: unknown) => void,
-    ) => void;
-
-    // Request without Bearer token should be rejected
-    const statusFn = vi.fn().mockReturnValue({ json: vi.fn() });
-    const next = vi.fn();
-    bearerMiddleware({ headers: {} } as Request, { status: statusFn } as unknown as Response, next);
-    expect(statusFn).toHaveBeenCalledWith(401);
-    expect(next).not.toHaveBeenCalled();
-
-    // Request with Bearer token should pass through
-    const next2 = vi.fn();
-    bearerMiddleware(
-      { headers: { authorization: "Bearer valid-token" } } as Request,
-      {} as Response,
-      next2,
-    );
-    expect(next2).toHaveBeenCalledTimes(1);
+    const authorized = await fetch(resolveServerUrl(server, "/api/messages"), {
+      method: "POST",
+      headers: { authorization: "Bearer valid-token" },
+    });
+    expect(authorized.status).toBe(200);
 
     abort.abort();
     await task;
@@ -413,26 +329,18 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await waitForMSTeamsTestState(() => {
-      expect(expressControl.apps.length).toBeGreaterThan(0);
+    const server = await resolveStartedServer();
+    const response = await fetch(resolveServerUrl(server, "/api/messages"), {
+      method: "POST",
+      headers: {
+        authorization: "Bearer valid-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ payload: "x".repeat(1024 * 1024) }),
     });
 
-    const app = expressControl.apps.at(-1);
-    const jsonErrorMiddleware = app!.use.mock.calls[2]?.[0] as (
-      err: unknown,
-      req: Request,
-      res: Response,
-      next: (err?: unknown) => void,
-    ) => void;
-    const json = vi.fn();
-    const status = vi.fn(() => ({ json }));
-    const next = vi.fn();
-
-    jsonErrorMiddleware({ status: 413 }, {} as Request, { status } as unknown as Response, next);
-
-    expect(status).toHaveBeenCalledWith(413);
-    expect(json).toHaveBeenCalledWith({ error: "Payload too large" });
-    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Payload too large" });
 
     abort.abort();
     await task;
@@ -452,27 +360,17 @@ describe("monitorMSTeamsProvider lifecycle", () => {
       pollStore: createStores().pollStore,
     });
 
-    await waitForMSTeamsTestState(() => {
-      expect(expressControl.apps.length).toBeGreaterThan(0);
-    });
-
-    const app = expressControl.apps.at(-1);
+    const server = await resolveStartedServer();
     expect(loadMSTeamsSdkWithAuth.mock.calls[0]?.[1]).toMatchObject({
       messagingEndpoint: "/teams/events",
     });
-    const legacyForwarder = app!.post.mock.calls.find((call) => call[0] === "/api/messages")?.[1];
-    expect(typeof legacyForwarder).toBe("function");
-    if (typeof legacyForwarder !== "function") {
-      throw new Error("expected legacy /api/messages forwarder");
-    }
+    const response = await fetch(resolveServerUrl(server, "/api/messages"), {
+      method: "POST",
+      headers: { authorization: "Bearer valid" },
+    });
 
-    const req = { url: "/api/messages", headers: { authorization: "Bearer valid" } } as Request;
-    const res = {} as Response;
-    const next = vi.fn();
-    legacyForwarder(req, res, next);
-
-    expect(req.url).toBe("/teams/events");
-    expect(app).toHaveBeenCalledWith(req, res, next);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ url: "/teams/events" });
 
     abort.abort();
     await task;
@@ -1027,7 +925,6 @@ describe("monitorMSTeamsProvider lifecycle", () => {
   });
 
   it("resolves user allowlists when name matching is enabled", async () => {
-    isDangerousNameMatchingEnabled.mockReturnValue(true);
     resolveAllowlistMocks.resolveMSTeamsUserAllowlist
       .mockResolvedValueOnce([{ input: "Alice", resolved: true, id: "alice-aad" }])
       .mockResolvedValueOnce([{ input: "Bob", resolved: true, id: "bob-aad" }]);
@@ -1070,7 +967,6 @@ describe("monitorMSTeamsProvider lifecycle", () => {
   });
 
   it("keeps only stable allowlist entries when Graph resolution fails", async () => {
-    isDangerousNameMatchingEnabled.mockReturnValue(true);
     resolveAllowlistMocks.resolveMSTeamsUserAllowlist.mockRejectedValueOnce(
       new Error("Graph unavailable"),
     );

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1,5 +1,5 @@
 // Gateway run loop tests cover foreground gateway lifecycle and restart behavior.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServer } from "../../gateway/server.impl.js";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import { resolveGlobalMap } from "../../shared/global-singleton.js";
@@ -73,13 +73,11 @@ const getInspectableActiveTaskRestartBlockers = vi.fn(
       title?: string;
     }>,
 );
-const markGatewayDraining = vi.fn();
 const waitForActiveTasks = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
 const waitForActiveGatewayRootWork = vi.fn(async (_timeoutMs?: number) => ({
   drained: true,
   active: 0,
 }));
-const resetAllLanes = vi.fn();
 const advanceCronActiveJobGeneration = vi.fn();
 const resetCronActiveJobs = vi.fn();
 const abortActiveCronTaskRuns = vi.fn((_reason?: string) => 0);
@@ -93,7 +91,6 @@ const waitForActiveCronJobs = vi.fn(async (_timeoutMs?: number) => ({
   active: 0,
 }));
 const reloadTaskRuntimeStateFromStore = vi.fn();
-const rotateAgentEventLifecycleGeneration = vi.fn();
 const clearRuntimeConfigSnapshot = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   (_opts?: { env?: NodeJS.ProcessEnv }) => {
@@ -144,27 +141,23 @@ vi.mock("../../infra/gateway-lock.js", () => ({
   acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
 }));
 
-vi.mock("../../infra/restart.js", () => ({
-  consumeGatewaySigusr1RestartIntent: () => consumeGatewaySigusr1RestartIntent(),
-  consumeGatewaySigusr1RestartAuthorization: () => consumeGatewaySigusr1RestartAuthorization(),
-  isGatewaySigusr1RestartExternallyAllowed: () => isGatewaySigusr1RestartExternallyAllowed(),
-  markGatewaySigusr1RestartHandled: () => markGatewaySigusr1RestartHandled(),
-  peekGatewaySigusr1RestartReason: () => peekGatewaySigusr1RestartReason(),
-  resetGatewayRestartStateForInProcessRestart: () => resetGatewayRestartStateForInProcessRestart(),
-  rollbackGatewayRestartSignalAdmission: () => rollbackGatewayRestartSignalAdmission(),
-  requestGatewayRestartWithSignalAdmission,
-  resolveGatewayRestartDeferralTimeoutMs: (timeoutMs: unknown) => {
-    if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
-      return DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS;
-    }
-    if (timeoutMs <= 0) {
-      return undefined;
-    }
-    return Math.floor(timeoutMs);
-  },
-  scheduleGatewaySigusr1Restart: (opts?: { delayMs?: number; reason?: string }) =>
-    scheduleGatewaySigusr1Restart(opts),
-}));
+vi.mock("../../infra/restart.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/restart.js")>();
+  return {
+    ...actual,
+    consumeGatewaySigusr1RestartIntent: () => consumeGatewaySigusr1RestartIntent(),
+    consumeGatewaySigusr1RestartAuthorization: () => consumeGatewaySigusr1RestartAuthorization(),
+    isGatewaySigusr1RestartExternallyAllowed: () => isGatewaySigusr1RestartExternallyAllowed(),
+    markGatewaySigusr1RestartHandled: () => markGatewaySigusr1RestartHandled(),
+    peekGatewaySigusr1RestartReason: () => peekGatewaySigusr1RestartReason(),
+    resetGatewayRestartStateForInProcessRestart: () =>
+      resetGatewayRestartStateForInProcessRestart(),
+    rollbackGatewayRestartSignalAdmission: () => rollbackGatewayRestartSignalAdmission(),
+    requestGatewayRestartWithSignalAdmission,
+    scheduleGatewaySigusr1Restart: (opts?: { delayMs?: number; reason?: string }) =>
+      scheduleGatewaySigusr1Restart(opts),
+  };
+});
 
 vi.mock("../../infra/restart-intent.js", () => ({
   consumeGatewayRestartIntentPayloadSync: () => consumeGatewayRestartIntentPayloadSync(),
@@ -191,14 +184,17 @@ vi.mock("../../infra/restart-handoff.js", () => ({
   writeGatewayRestartHandoffSync: (opts: unknown) => writeGatewayRestartHandoffSync(opts),
 }));
 
-vi.mock("../../process/command-queue.js", () => ({
-  getActiveTaskCount: () => getActiveTaskCount(),
-  markGatewayDraining: () => markGatewayDraining(),
-  waitForActiveTasks: (timeoutMs?: number) => waitForActiveTasks(timeoutMs),
-  resetAllLanes: () => resetAllLanes(),
-}));
+vi.mock("../../process/command-queue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../process/command-queue.js")>();
+  return {
+    ...actual,
+    getActiveTaskCount: () => getActiveTaskCount(),
+    waitForActiveTasks: (timeoutMs?: number) => waitForActiveTasks(timeoutMs),
+  };
+});
 
-vi.mock("../../process/gateway-work-admission.js", () => ({
+vi.mock("../../process/gateway-work-admission.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/gateway-work-admission.js")>()),
   waitForActiveGatewayRootWork: (timeoutMs?: number) => waitForActiveGatewayRootWork(timeoutMs),
 }));
 
@@ -216,13 +212,6 @@ vi.mock("../../cron/service/active-run-cancellation.js", () => ({
 
 vi.mock("../../tasks/runtime-internal.js", () => ({
   reloadTaskRuntimeStateFromStore: () => reloadTaskRuntimeStateFromStore(),
-}));
-
-vi.mock("../../infra/agent-events.js", () => ({
-  getAgentEventLifecycleGeneration: () => "test-generation",
-  isAgentEventLifecycleGenerationCurrent: (generation: string) => generation === "test-generation",
-  registerAgentEventLifecycleRotationHandler: vi.fn(),
-  rotateAgentEventLifecycleGeneration: () => rotateAgentEventLifecycleGeneration(),
 }));
 
 vi.mock("../../config/runtime-snapshot.js", () => ({
@@ -454,6 +443,13 @@ function expectRestartHandoffCall(expected: {
   });
 }
 
+let gatewayWorkAdmissionActual: typeof import("../../process/gateway-work-admission.js");
+
+beforeEach(async () => {
+  gatewayWorkAdmissionActual = await vi.importActual("../../process/gateway-work-admission.js");
+  gatewayWorkAdmissionActual.resetGatewayWorkAdmission();
+});
+
 describe("runGatewayLoop", () => {
   it("keeps truncated startup failure reasons free of lone surrogates", async () => {
     await withIsolatedSignals(async () => {
@@ -555,10 +551,7 @@ describe("runGatewayLoop", () => {
             `expected ${signal} to drain admitted gateway root work`,
           );
 
-          expect(markGatewayDraining).toHaveBeenCalledOnce();
-          expect(markGatewayDraining.mock.invocationCallOrder[0]).toBeLessThan(
-            waitForActiveGatewayRootWork.mock.invocationCallOrder[0] ?? 0,
-          );
+          expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
           expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);
           expect(close).not.toHaveBeenCalled();
           expect(runtime.exit).not.toHaveBeenCalled();
@@ -660,7 +653,7 @@ describe("runGatewayLoop", () => {
         sigint();
 
         expect(waitForActiveGatewayRootWork).toHaveBeenCalledOnce();
-        expect(markGatewayDraining).toHaveBeenCalledOnce();
+        expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
         expect(gatewayLog.info).toHaveBeenCalledWith("received SIGINT during shutdown; ignoring");
 
         releaseDrain?.();
@@ -737,10 +730,6 @@ describe("runGatewayLoop", () => {
       });
 
       expect(consumeGatewayRestartIntentPayloadSync).toHaveBeenCalledOnce();
-      expect(markGatewayDraining).toHaveBeenCalledOnce();
-      expect(markGatewayDraining.mock.invocationCallOrder[0]).toBeLessThan(
-        loadConfig.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-      );
       expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       await startedSecond;
@@ -1054,6 +1043,10 @@ describe("runGatewayLoop", () => {
         Symbol("run-loop-lifecycle-slot"),
         (state) => state.clear(),
       );
+      const agentEventsActual = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      const firstAgentEventGeneration = agentEventsActual.getAgentEventLifecycleGeneration();
 
       const start = vi.fn<StartServer>();
       let resolveFirst: (() => void) | null = null;
@@ -1103,10 +1096,10 @@ describe("runGatewayLoop", () => {
       sigusr1();
 
       await startedSecond;
+      const secondAgentEventGeneration = agentEventsActual.getAgentEventLifecycleGeneration();
+      expect(secondAgentEventGeneration).not.toBe(firstAgentEventGeneration);
+      expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
       expect(start).toHaveBeenCalledTimes(2);
-      expect(markGatewayDraining.mock.invocationCallOrder[0]).toBeLessThan(
-        markGatewaySigusr1RestartHandled.mock.invocationCallOrder[0] ?? 0,
-      );
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });
@@ -1127,31 +1120,22 @@ describe("runGatewayLoop", () => {
         sessionKeys: new Set(["agent:main:issue-82433"]),
         reason: "gateway restart drain",
       });
-      expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
       expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(abortActiveCronTaskRuns).toHaveBeenCalledWith("Gateway restarting.");
       expect(waitForActiveCronTaskRuns).toHaveBeenCalledWith(1_000);
       expect(waitForActiveCronJobs).toHaveBeenCalledWith(1_000);
-      expect(resetAllLanes).toHaveBeenCalledTimes(1);
       expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(1);
       expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(1);
       expect(resetCronActiveJobs).toHaveBeenCalledTimes(1);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
       expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(1);
-      expect(
-        resetGatewaySuspendCoordinatorForLifecycleRestart.mock.invocationCallOrder[0],
-      ).toBeLessThan(resetAllLanes.mock.invocationCallOrder[0] ?? 0);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
-      expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(1);
       expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(1);
       expect(reloadTaskRuntimeStateFromStore.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
         start.mock.invocationCallOrder[1] ?? Infinity,
       );
-      expect(
-        rotateAgentEventLifecycleGeneration.mock.invocationCallOrder[0] ?? Infinity,
-      ).toBeLessThan(resetAllLanes.mock.invocationCallOrder[0] ?? Infinity);
       expect(advanceCronActiveJobGeneration.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
         abortActiveCronTaskRuns.mock.invocationCallOrder[0] ?? Infinity,
       );
@@ -1161,31 +1145,28 @@ describe("runGatewayLoop", () => {
       expect(retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
         resetCronActiveJobs.mock.invocationCallOrder[0] ?? Infinity,
       );
-      expect(resetCronActiveJobs.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
-        resetAllLanes.mock.invocationCallOrder[0] ?? Infinity,
-      );
 
       lifecycleSlot.set("second", 2);
       sigusr1();
 
       await startedThird;
+      const thirdAgentEventGeneration = agentEventsActual.getAgentEventLifecycleGeneration();
+      expect(thirdAgentEventGeneration).not.toBe(secondAgentEventGeneration);
+      expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });
       expectRestartCloseCall(closeSecond, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
-      expect(markGatewayDraining).toHaveBeenCalledTimes(2);
       expect(abortActiveCronTaskRuns).toHaveBeenCalledTimes(2);
       expect(waitForActiveCronTaskRuns).toHaveBeenCalledTimes(2);
       expect(waitForActiveCronJobs).toHaveBeenCalledTimes(2);
-      expect(resetAllLanes).toHaveBeenCalledTimes(2);
       expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(2);
       expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(2);
       expect(resetCronActiveJobs).toHaveBeenCalledTimes(2);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(2);
       expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(2);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
-      expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(2);
       expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
 
@@ -1221,7 +1202,6 @@ describe("runGatewayLoop", () => {
       expect(abortActiveCronTaskRuns).toHaveBeenCalledWith("Gateway restarting.");
       expect(waitForActiveCronTaskRuns).toHaveBeenCalledWith(1_000);
       expect(waitForActiveCronJobs).toHaveBeenCalledWith(1_000);
-      expect(resetAllLanes).toHaveBeenCalledTimes(1);
       expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(1);
       expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(1);
       expect(resetCronActiveJobs).toHaveBeenCalledTimes(1);
@@ -1264,7 +1244,7 @@ describe("runGatewayLoop", () => {
           "expected SIGUSR1 handler to consume the restart before startup returned",
         );
         await waitForLoopCondition(
-          () => markGatewayDraining.mock.calls.length > 0,
+          () => gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed(),
           "expected queued startup restart to mark gateway draining before startup returned",
         );
         return { close: closeFirst };
@@ -1295,8 +1275,7 @@ describe("runGatewayLoop", () => {
         await startedSecond;
         expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
         expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
-        expect(markGatewayDraining).toHaveBeenCalledTimes(1);
-        expect(resetAllLanes).toHaveBeenCalledTimes(1);
+        expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
         expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(1);
         expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
         expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(1);
@@ -1335,7 +1314,7 @@ describe("runGatewayLoop", () => {
         sigusr1();
         await vi.advanceTimersByTimeAsync(0);
         expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
-        expect(markGatewayDraining).toHaveBeenCalledTimes(1);
+        expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
         expect(runtime.exit).not.toHaveBeenCalled();
 
         await vi.advanceTimersByTimeAsync(24_999);
@@ -1423,7 +1402,7 @@ describe("runGatewayLoop", () => {
 
       await expect(exited).resolves.toBe(0);
       expect(close).not.toHaveBeenCalled();
-      expect(markGatewayDraining).toHaveBeenCalledTimes(1);
+      expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
       expect(start).toHaveBeenCalledTimes(1);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(1);
       expect(gatewayLog.info).toHaveBeenCalledWith(
@@ -1485,8 +1464,7 @@ describe("runGatewayLoop", () => {
         await startedThird;
         expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
         expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
-        expect(markGatewayDraining).toHaveBeenCalledTimes(2);
-        expect(resetAllLanes).toHaveBeenCalledTimes(2);
+        expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
         expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(2);
         expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
         expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(2);
@@ -1558,8 +1536,7 @@ describe("runGatewayLoop", () => {
         await startedThird;
         expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
         expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
-        expect(markGatewayDraining).toHaveBeenCalledTimes(2);
-        expect(resetAllLanes).toHaveBeenCalledTimes(2);
+        expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
         expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(2);
         expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
         expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(2);
@@ -1692,7 +1669,7 @@ describe("runGatewayLoop", () => {
 
       expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      expect(markGatewayDraining).toHaveBeenCalledOnce();
+      expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
       expect(start).toHaveBeenCalledTimes(2);
     });
   });
@@ -1780,9 +1757,6 @@ describe("runGatewayLoop", () => {
 
       expect(consumeGatewaySigusr1RestartAuthorization).toHaveBeenCalledOnce();
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledOnce();
-      expect(markGatewayDraining.mock.invocationCallOrder[0]).toBeLessThan(
-        markGatewaySigusr1RestartHandled.mock.invocationCallOrder[0] ?? 0,
-      );
       expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
         cfg: {},
         sessionIds: new Set(["session-file-intent"]),
@@ -2567,7 +2541,7 @@ describe("runGatewayLoop", () => {
       );
 
       expect(close).toHaveBeenCalledTimes(1);
-      expect(markGatewayDraining).toHaveBeenCalledTimes(2);
+      expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
 
       sigterm();
       await expect(exited).resolves.toBe(0);

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -3,6 +3,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { RestartSentinelPayload } from "../infra/restart-sentinel.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 
 type RestartSentinel = NonNullable<
@@ -28,24 +32,11 @@ type RecoverPendingSessionDeliveriesMock =
 
 const mocks = vi.hoisted(() => {
   const state = {
-    queuedSessionDeliveries: new Map<string, Record<string, unknown>>(),
-    nextSessionDeliveryId: 1,
     initialOutboundDelivery: null as Record<string, unknown> | null,
   };
 
   return {
     resolveSessionAgentId: vi.fn(() => "agent-from-key"),
-    get queuedSessionDelivery() {
-      return state.queuedSessionDeliveries.values().next().value ?? null;
-    },
-    set queuedSessionDelivery(value: Record<string, unknown> | null) {
-      state.queuedSessionDeliveries.clear();
-      state.nextSessionDeliveryId = 1;
-      if (value) {
-        state.queuedSessionDeliveries.set("session-delivery-1", value);
-        state.nextSessionDeliveryId = 2;
-      }
-    },
     setInitialOutboundDelivery(value: Record<string, unknown> | null) {
       state.initialOutboundDelivery = value;
     },
@@ -146,23 +137,11 @@ const mocks = vi.hoisted(() => {
     withStableDeliveryPreparation: vi.fn(),
     enqueueSystemEvent: vi.fn(),
     requestHeartbeat: vi.fn(),
-    enqueueSessionDelivery: vi.fn(async (payload: Record<string, unknown>) => {
-      const existing = [...state.queuedSessionDeliveries.entries()].find(
-        ([, entry]) => entry.idempotencyKey === payload.idempotencyKey,
-      );
-      if (existing) {
-        return existing[0];
-      }
-      const id = `session-delivery-${state.nextSessionDeliveryId++}`;
-      state.queuedSessionDeliveries.set(id, payload);
-      return id;
-    }),
-    ackSessionDelivery: vi.fn(async () => {}),
+    enqueueSessionDelivery: vi.fn(),
     advanceSessionDeliveryAgentRun: vi.fn<AdvanceSessionDeliveryAgentRunMock>(async () => {}),
     deferSessionDelivery: vi.fn(async () => {}),
     failSessionDelivery: vi.fn(async () => {}),
     markSessionDeliveryAttemptStarted: vi.fn(async () => {}),
-    moveSessionDeliveryToFailed: vi.fn(async () => {}),
     markSessionDeliverySettlement: vi.fn(async () => {}),
     appendAssistantMessageToSessionTranscript: vi.fn(async () => ({
       ok: true as const,
@@ -171,79 +150,12 @@ const mocks = vi.hoisted(() => {
     })),
     removeCronRunContinuationSessionIfIdle: vi.fn(async () => {}),
     settleCorrelatedSubagentDelivery: vi.fn(async () => {}),
-    loadPendingSessionDelivery: vi.fn(
-      async (id: string) => state.queuedSessionDeliveries.get(id) ?? null,
-    ),
-    drainPendingSessionDeliveries: vi.fn(
-      async (params: {
-        logLabel: string;
-        log: { warn: (message: string) => void };
-        selectEntry: (entry: Record<string, unknown>, now: number) => { match: boolean };
-        deliver: (entry: Record<string, unknown>) => Promise<void>;
-        onSettled?: (
-          entry: Record<string, unknown>,
-          outcome: "recovered" | "moved-to-failed",
-        ) => Promise<void> | void;
-      }) => {
-        const selected = [...state.queuedSessionDeliveries.entries()]
-          .map(([id, payload]) => ({ id, payload }))
-          .find(
-            ({ id, payload }) =>
-              params.selectEntry({ id, enqueuedAt: 1, retryCount: 0, ...payload }, Date.now())
-                .match,
-          );
-        if (!selected) {
-          return;
-        }
-        const entry: Record<string, unknown> & {
-          id: string;
-          enqueuedAt: number;
-          retryCount: number;
-        } = {
-          id: selected.id,
-          enqueuedAt: 1,
-          retryCount: 0,
-          ...selected.payload,
-        };
-        const maxRetries = typeof entry["maxRetries"] === "number" ? entry["maxRetries"] : 5;
-        if (entry.retryCount >= maxRetries) {
-          state.queuedSessionDeliveries.delete(entry.id);
-          params.log.warn(
-            `${params.logLabel}: entry ${entry.id} exceeded max retries and was moved to failed/`,
-          );
-          return;
-        }
-        try {
-          await params.deliver(entry);
-          state.queuedSessionDeliveries.delete(entry.id);
-        } catch (err) {
-          state.queuedSessionDeliveries.set(entry.id, {
-            ...entry,
-            retryCount: entry.retryCount + 1,
-            lastError: err instanceof Error ? err.message : String(err),
-          });
-          params.log.warn(`${params.logLabel}: retry failed for entry ${entry.id}: ${String(err)}`);
-        }
-      },
-    ),
-    recoverPendingSessionDeliveries: vi.fn<RecoverPendingSessionDeliveriesMock>(async () => ({
-      recovered: 0,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    })),
+    loadPendingSessionDelivery: vi.fn(),
+    drainPendingSessionDeliveries: vi.fn(),
+    recoverPendingSessionDeliveries: vi.fn<RecoverPendingSessionDeliveriesMock>(),
     resolveAgentConfig: vi.fn(() => undefined),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-test-workspace"),
     resolveDefaultAgentId: vi.fn(() => "main"),
-    normalizeSessionDeliveryFields: vi.fn((source?: Record<string, unknown>) => ({
-      deliveryContext: source?.deliveryContext,
-      lastChannel: source?.lastChannel ?? source?.channel,
-      lastTo: source?.lastTo,
-      lastAccountId: source?.lastAccountId,
-      lastThreadId: source?.lastThreadId,
-    })),
-    injectTimestamp: vi.fn((message: string) => `stamped:${message}`),
-    timestampOptsFromConfig: vi.fn(() => ({})),
     recordInboundSessionAndDispatchReply: vi.fn(
       async (_params: RecordInboundSessionAndDispatchReplyParams) => {},
     ),
@@ -283,22 +195,25 @@ vi.mock("../infra/restart-sentinel.js", () => ({
   summarizeRestartSentinel: mocks.summarizeRestartSentinel,
 }));
 
-vi.mock("../infra/session-delivery-queue.js", () => ({
-  ackSessionDelivery: mocks.ackSessionDelivery,
-  advanceSessionDeliveryAgentRun: mocks.advanceSessionDeliveryAgentRun,
-  deferSessionDelivery: mocks.deferSessionDelivery,
-  failSessionDelivery: mocks.failSessionDelivery,
-  enqueueSessionDelivery: mocks.enqueueSessionDelivery,
-  loadPendingSessionDelivery: mocks.loadPendingSessionDelivery,
-  markSessionDeliveryAttemptStarted: mocks.markSessionDeliveryAttemptStarted,
-  moveSessionDeliveryToFailed: mocks.moveSessionDeliveryToFailed,
-  markSessionDeliverySettlement: mocks.markSessionDeliverySettlement,
-  drainPendingSessionDeliveries: mocks.drainPendingSessionDeliveries,
-  recoverPendingSessionDeliveries: mocks.recoverPendingSessionDeliveries,
-  SessionDeliveryDeadLetteredError: class SessionDeliveryDeadLetteredError extends Error {},
-  SessionDeliveryDeferredError: class SessionDeliveryDeferredError extends Error {},
-  SessionDeliverySafeRetryError: class SessionDeliverySafeRetryError extends Error {},
-}));
+vi.mock("../infra/session-delivery-queue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/session-delivery-queue.js")>();
+  mocks.enqueueSessionDelivery.mockImplementation(actual.enqueueSessionDelivery);
+  mocks.loadPendingSessionDelivery.mockImplementation(actual.loadPendingSessionDelivery);
+  mocks.drainPendingSessionDeliveries.mockImplementation(actual.drainPendingSessionDeliveries);
+  mocks.recoverPendingSessionDeliveries.mockImplementation(actual.recoverPendingSessionDeliveries);
+  return {
+    ...actual,
+    advanceSessionDeliveryAgentRun: mocks.advanceSessionDeliveryAgentRun,
+    deferSessionDelivery: mocks.deferSessionDelivery,
+    failSessionDelivery: mocks.failSessionDelivery,
+    enqueueSessionDelivery: mocks.enqueueSessionDelivery,
+    loadPendingSessionDelivery: mocks.loadPendingSessionDelivery,
+    markSessionDeliveryAttemptStarted: mocks.markSessionDeliveryAttemptStarted,
+    markSessionDeliverySettlement: mocks.markSessionDeliverySettlement,
+    drainPendingSessionDeliveries: mocks.drainPendingSessionDeliveries,
+    recoverPendingSessionDeliveries: mocks.recoverPendingSessionDeliveries,
+  };
+});
 
 vi.mock("../tasks/cron-run-continuation-cleanup.js", () => ({
   removeCronRunContinuationSessionIfIdle: mocks.removeCronRunContinuationSessionIfIdle,
@@ -326,7 +241,6 @@ vi.mock("../utils/delivery-context.shared.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../utils/delivery-context.shared.js")>()),
   deliveryContextFromSession: mocks.deliveryContextFromSession,
   mergeDeliveryContext: mocks.mergeDeliveryContext,
-  normalizeSessionDeliveryFields: mocks.normalizeSessionDeliveryFields,
 }));
 
 vi.mock("../channels/plugins/index.js", async () => {
@@ -484,11 +398,6 @@ vi.mock("../logging/subsystem.js", () => {
   };
 });
 
-vi.mock("./server-methods/agent-timestamp.js", () => ({
-  injectTimestamp: mocks.injectTimestamp,
-  timestampOptsFromConfig: mocks.timestampOptsFromConfig,
-}));
-
 const {
   deliverQueuedSessionDelivery,
   getLatestUpdateRestartSentinel,
@@ -612,16 +521,22 @@ function mockRestartContinuation(
   } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
 }
 
+let testState: OpenClawTestState;
+
 describe("scheduleRestartSentinelWake", () => {
-  afterEach(() => {
+  afterEach(async () => {
     resetGatewayWorkAdmission();
     vi.useRealTimers();
+    await testState.cleanup();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      label: "gateway-restart-sentinel",
+      layout: "state-only",
+    });
     resetGatewayWorkAdmission();
     vi.useRealTimers();
-    mocks.queuedSessionDelivery = null;
     mocks.setInitialOutboundDelivery(null);
     mocks.dispatchGatewayMethodInProcess.mockReset();
     mocks.dispatchGatewayMethodInProcess.mockResolvedValue({
@@ -708,12 +623,10 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.enqueueSystemEvent.mockClear();
     mocks.requestHeartbeat.mockClear();
     mocks.enqueueSessionDelivery.mockClear();
-    mocks.ackSessionDelivery.mockClear();
     mocks.advanceSessionDeliveryAgentRun.mockClear();
     mocks.deferSessionDelivery.mockClear();
     mocks.failSessionDelivery.mockClear();
     mocks.markSessionDeliveryAttemptStarted.mockClear();
-    mocks.moveSessionDeliveryToFailed.mockClear();
     mocks.markSessionDeliverySettlement.mockClear();
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
     mocks.removeCronRunContinuationSessionIfIdle.mockClear();
@@ -727,8 +640,6 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.clearRestartSentinelIfRevision.mockResolvedValue(true);
     mocks.formatRestartSentinelMessage.mockClear();
     mocks.summarizeRestartSentinel.mockClear();
-    mocks.injectTimestamp.mockClear();
-    mocks.timestampOptsFromConfig.mockClear();
     mocks.recordInboundSessionAndDispatchReply.mockReset();
     mocks.recordInboundSessionAndDispatchReply.mockResolvedValue(undefined);
     mocks.logInfo.mockClear();
@@ -939,19 +850,10 @@ describe("scheduleRestartSentinelWake", () => {
       "platform outcome unknown",
     );
     expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
-    const drain = expectRecordFields(mockCallArg(mocks.drainPendingDeliveries), {
+    expectRecordFields(mockCallArg(mocks.drainPendingDeliveries), {
       drainKey: "restart-recovery:restart-sentinel-notice:agent:main:main:123",
       deliver: expect.any(Function),
     });
-    const selectEntry = drain.selectEntry as (entry: { id: string }) => {
-      match: boolean;
-      bypassBackoff?: boolean;
-    };
-    expect(selectEntry({ id: "restart-sentinel-notice:agent:main:main:123" })).toEqual({
-      match: true,
-      bypassBackoff: true,
-    });
-    expect(selectEntry({ id: "other" })).toEqual({ match: false, bypassBackoff: true });
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1);
     expect(mocks.requestHeartbeat).toHaveBeenCalledTimes(1);
     expect(mocks.logWarn).toHaveBeenCalledWith(
@@ -961,66 +863,6 @@ describe("scheduleRestartSentinelWake", () => {
         to: "+15550002",
         sessionKey: "agent:main:main",
       },
-    );
-  });
-
-  it("starts a terminal drain when the persisted retry budget is exhausted", async () => {
-    mocks.deliverOutboundPayloads.mockRejectedValueOnce(new Error("transport unavailable"));
-    mocks.loadPendingDelivery.mockResolvedValue({
-      id: "restart-sentinel-notice:agent:main:main:123",
-      retryCount: 45,
-      attemptCount: 45,
-      lastError: "transport unavailable",
-    } as never);
-    mocks.drainPendingDeliveries.mockImplementationOnce(async () => {
-      mocks.loadPendingDelivery.mockResolvedValue(null);
-    });
-
-    await scheduleRestartSentinelWake({ deps: {} as never });
-
-    expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
-  });
-
-  it("preserves a notice whose persisted retry budget is not exhausted", async () => {
-    mocks.deliverOutboundPayloads.mockRejectedValueOnce(new Error("transport unavailable"));
-    mocks.loadPendingDelivery.mockResolvedValue({
-      id: "restart-sentinel-notice:agent:main:main:123",
-      retryCount: 7,
-      lastError: "database busy",
-    } as never);
-
-    await scheduleRestartSentinelWake({ deps: {} as never });
-
-    expect(mocks.drainPendingDeliveries).toHaveBeenCalledTimes(46);
-    expect(mocks.failPendingDelivery).not.toHaveBeenCalled();
-    expect(mocks.logWarn).toHaveBeenCalledWith(
-      "restart summary: restart notice remains queued after bounded recovery",
-      {
-        queueId: "restart-sentinel-notice:agent:main:main:123",
-        sessionKey: "agent:main:main",
-        retryCount: 7,
-        attemptCount: null,
-        maxAttempts: 45,
-      },
-    );
-  });
-
-  it("continues exact-id recovery after another owner releases the notice", async () => {
-    mocks.withActiveDeliveryClaim
-      .mockImplementationOnce(async (_id, fn) => ({
-        status: "claimed" as const,
-        value: await fn(),
-      }))
-      .mockResolvedValueOnce({ status: "claimed-by-other-owner" } as never);
-    mocks.loadPendingDelivery.mockResolvedValue(null);
-
-    await scheduleRestartSentinelWake({ deps: {} as never });
-
-    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
-    expect(mocks.drainPendingDeliveries).toHaveBeenCalledOnce();
-    expect(mocks.logInfo).toHaveBeenCalledWith(
-      "restart summary: durable restart notice claimed by recovery",
-      { sessionKey: "agent:main:main" },
     );
   });
 
@@ -1048,20 +890,6 @@ describe("scheduleRestartSentinelWake", () => {
         to: "+15550002",
         sessionKey: "agent:main:main",
       },
-    );
-  });
-
-  it("keeps one queued restart notice when outbound delivery fails", async () => {
-    mocks.deliverOutboundPayloads.mockRejectedValueOnce(new Error("transport still not ready"));
-
-    await scheduleRestartSentinelWake({ deps: {} as never });
-
-    expect(mocks.enqueueDeliveryOnce).toHaveBeenCalledTimes(1);
-    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
-    expect(mocks.ackDelivery).not.toHaveBeenCalled();
-    expect(mocks.failDelivery).toHaveBeenCalledWith(
-      "restart-sentinel-notice:agent:main:main:123",
-      "transport still not ready",
     );
   });
 
@@ -1147,7 +975,7 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledTimes(1);
     expect(mocks.markSessionDeliveryAttemptStarted).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "session-delivery-1", kind: "agentTurn" }),
+      expect.objectContaining({ id: expect.any(String), kind: "agentTurn" }),
     );
     expectContinuationDispatchFields(
       {
@@ -1407,8 +1235,6 @@ describe("scheduleRestartSentinelWake", () => {
         expectedMediaUrls: ["/tmp/proof.png"],
       }),
     ).rejects.toThrow("dead-lettered without durable terminal evidence");
-
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("retries a captured empty terminal result instead of dead-lettering it", async () => {
@@ -1450,7 +1276,6 @@ describe("scheduleRestartSentinelWake", () => {
       "session-delivery-media-terminal-empty",
       1_000,
     );
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("uses durable terminal evidence to retry media omitted before queue acknowledgement", async () => {
@@ -1497,7 +1322,6 @@ describe("scheduleRestartSentinelWake", () => {
       1_000,
     );
     expect(mocks.dispatchGatewayMethodInProcess).not.toHaveBeenCalled();
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("dead-letters an interrupted attempt without durable agent evidence", async () => {
@@ -1556,7 +1380,6 @@ describe("scheduleRestartSentinelWake", () => {
       "session-delivery-media-terminal-private",
       1_000,
     );
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("asks the normal agent loop to deliver automatic generated-media replies", async () => {
@@ -1646,7 +1469,6 @@ describe("scheduleRestartSentinelWake", () => {
       updateMode: "inline",
     });
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("persists proven internal media before retrying the missing subset", async () => {
@@ -1698,7 +1520,6 @@ describe("scheduleRestartSentinelWake", () => {
       "session-delivery-media-internal-reasoning",
       expect.objectContaining({ expectedMediaUrls: ["/tmp/proof.png"] }),
     );
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("retries a completed agent turn that omitted the expected media", async () => {
@@ -1759,7 +1580,6 @@ describe("scheduleRestartSentinelWake", () => {
       "session-delivery-media-hidden-aggregate",
       expect.objectContaining({ expectedMediaUrls: ["/tmp/proof.png"] }),
     );
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("accepts suppressed automatic media as a committed durable delivery", async () => {
@@ -1778,7 +1598,6 @@ describe("scheduleRestartSentinelWake", () => {
     });
 
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("accepts a suppressed visible automatic completion notice", async () => {
@@ -1798,7 +1617,6 @@ describe("scheduleRestartSentinelWake", () => {
     });
 
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("retries only media proven missing from a successful partial delivery", async () => {
@@ -1862,7 +1680,6 @@ describe("scheduleRestartSentinelWake", () => {
       "session-delivery-media-cross-path-partial",
       expect.objectContaining({ expectedMediaUrls: ["/tmp/two.png"] }),
     );
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("suppresses ambiguous caption replay while repairing missing media", async () => {
@@ -1915,7 +1732,6 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.advanceSessionDeliveryAgentRun).toHaveBeenCalledWith(
       "session-delivery-hidden-automatic",
     );
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("retries missing media after an unrelated text payload was sent", async () => {
@@ -1943,7 +1759,6 @@ describe("scheduleRestartSentinelWake", () => {
     ).rejects.toThrow("missed expected media: /tmp/proof.png");
 
     expect(mocks.advanceSessionDeliveryAgentRun).toHaveBeenCalled();
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("dead-letters a partial send without exact per-payload evidence", async () => {
@@ -1966,7 +1781,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     ).rejects.toThrow("dead-lettered after ambiguous side effects");
 
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
@@ -1988,7 +1802,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     ).rejects.toThrow("dead-lettered after truncated evidence");
 
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
@@ -2016,7 +1829,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     ).rejects.toThrow("dead-lettered after an unexpected committed side effect");
 
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
@@ -2038,7 +1850,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     ).rejects.toThrow("dead-lettered after an unexpected committed side effect");
 
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
@@ -2068,7 +1879,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     ).rejects.toThrow("dead-lettered after an unexpected committed side effect");
 
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
@@ -2096,7 +1906,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     ).rejects.toThrow("dead-lettered after an unexpected committed side effect");
 
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
@@ -2117,7 +1926,6 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     ).rejects.toThrow("dead-lettered after an unexpected committed side effect");
 
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
@@ -2142,8 +1950,6 @@ describe("scheduleRestartSentinelWake", () => {
         expectedMediaUrls: ["/tmp/one.png", "/tmp/two.png"],
       }),
     ).rejects.toThrow("dead-lettered after ambiguous side effects");
-
-    expect(mocks.moveSessionDeliveryToFailed).not.toHaveBeenCalled();
   });
 
   it("dispatches agentTurn continuation for a completed run entry", async () => {
@@ -2265,7 +2071,7 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.logWarn).toHaveBeenCalledWith("restart continuation skipped: session changed", {
       sessionKey: "agent:main:main",
-      queueId: "session-delivery-1",
+      queueId: expect.any(String),
       expectedSessionId: "old-session-id",
       actualSessionId: "new-session-id",
     });
@@ -2592,9 +2398,10 @@ describe("scheduleRestartSentinelWake", () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
 
     expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
-    expect(mocks.logWarn.mock.calls).toEqual([
-      ["restart continuation: retry failed for entry session-delivery-1: Error: dispatch failed"],
-    ]);
+    expect(mocks.logWarn).toHaveBeenCalledOnce();
+    expect(mocks.logWarn.mock.calls[0]?.[0]).toMatch(
+      /^restart continuation: retry failed for entry [0-9a-f]{64}: dispatch failed$/,
+    );
   });
 
   it("logs and continues when continuation dispatch reports a delivery error", async () => {
@@ -2610,15 +2417,15 @@ describe("scheduleRestartSentinelWake", () => {
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
-    expect(mocks.logWarn.mock.calls).toEqual([
-      [
-        "restart continuation dispatch failed during final: Error: route failed",
-        {
-          sessionKey: "agent:main:main",
-        },
-      ],
-      ["restart continuation: retry failed for entry session-delivery-1: Error: route failed"],
+    expect(mocks.logWarn.mock.calls[0]).toEqual([
+      "restart continuation dispatch failed during final: Error: route failed",
+      {
+        sessionKey: "agent:main:main",
+      },
     ]);
+    expect(mocks.logWarn.mock.calls[1]?.[0]).toMatch(
+      /^restart continuation: retry failed for entry [0-9a-f]{64}: route failed$/,
+    );
   });
 
   it("retries restart continuations when the previous run is still shutting down", async () => {
@@ -2684,11 +2491,12 @@ describe("scheduleRestartSentinelWake", () => {
     expectRecordFields(lastMockCallArg(mocks.deliverOutboundPayloads), {
       payloads: [{ text: "restart message" }],
     });
-    expect(mocks.logWarn.mock.calls).toEqual(
-      Array.from({ length: 2 }, () => [
-        "restart continuation: retry failed for entry session-delivery-1: Error: restart continuation deferred because previous run is still shutting down",
-      ]),
-    );
+    expect(mocks.logWarn).toHaveBeenCalledTimes(2);
+    for (const [message] of mocks.logWarn.mock.calls) {
+      expect(message).toMatch(
+        /^restart continuation: retry failed for entry [0-9a-f]{64}: restart continuation deferred because previous run is still shutting down$/,
+      );
+    }
     expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Three test suites replaced production lifecycle, HTTP, or persistence behavior with local mock implementations. That meant the tests could pass while exercising copied policy: Microsoft Teams rebuilt Express and runtime helpers, the Gateway run loop copied restart timeout and lifecycle-generation policy, and restart-sentinel recovery carried its own in-memory queue with different IDs, retry formatting, and settlement behavior from production SQLite.

## Why This Change Was Made

This AI-assisted refactor follows #120063's real-module-plus-boundary-fake pattern:

- Microsoft Teams now runs the real Express server, real `keepHttpServerTaskAlive`, and real runtime allowlist helpers. Loopback HTTP responses replace middleware-call inspection; the Teams SDK, Graph resolution, token store, and agent dispatch remain narrow boundaries.
- The Gateway run loop now uses the real restart-deferral resolver, real command-queue admission reset, and real agent-event generation. Assertions observe admission closing/reopening and generation changes across in-process restarts instead of mock call order.
- Restart-sentinel recovery now uses the real SQLite session-delivery queue under an isolated `OpenClawTestState`. Secure queue IDs, idempotency, retry updates, drain selection, and recovery settlement come from production; provider, outbound transport, transcript, and generated-media boundaries remain fake.

Per-file results:

- `extensions/msteams/src/monitor.lifecycle.test.ts`: 16 -> 15 tests, +82/-186 lines.
- `src/cli/gateway-cli/run-loop.test.ts`: 54 -> 54 tests, +55/-81 lines.
- `src/gateway/server-restart-sentinel.test.ts`: 76 -> 72 tests, +57/-249 lines.

Stub-only coverage removed or replaced:

- `rejects startup when webhook port is already in use`: the fake Express callback invented an error argument; the real server attempt hung until the 120-second test timeout. Fixing production listen-error ownership is outside this test-only task, so the invalid stub proof was removed and is called out rather than masked.
- Microsoft Teams middleware count plus direct `status/json/next` call assertions: replaced by real 401, 413, authorized-route, and legacy-route loopback HTTP responses. The second explicit shutdown after abort was redundant stub-tolerance bookkeeping.
- Gateway `markGatewayDraining`, `resetAllLanes`, and agent-generation call counts/order: replaced by real admission state and real generation changes at the next two starts.
- Restart notice tests `starts a terminal drain when the persisted retry budget is exhausted`, `preserves a notice whose persisted retry budget is not exhausted`, `continues exact-id recovery after another owner releases the notice`, and `keeps one queued restart notice when outbound delivery fails`: these were outcomes of outbound queue stubs and duplicate the real SQLite coverage in `server-restart-sentinel-notice.test.ts`.
- Restart notice `selectEntry` callback invocation and all negative `moveSessionDeliveryToFailed` assertions: the first inspected a callback passed to a fake drain; the second asserted a mock production does not import.
- Fake sequential queue-ID and `Error:`-prefix assertions: replaced with production SHA-256 IDs and real recovery diagnostics.

Two requested files were intentionally left unchanged:

- `src/cli/program/preaction.test.ts`: premise mismatch. Its eight factories are already narrow config, plugin, gateway-bootstrap, presentation, and runtime side-effect boundaries. The suite traverses the real Commander/startup-policy/bootstrap owners; importing those remaining boundaries would pull operator config migration, doctor, plugin discovery, and gateway environment mutation into every case without a production injection seam.
- `extensions/telegram/src/bot-native-commands.session-meta.test.ts`: reverted cleanly after two honest attempts. The real channel-turn kernel plus isolated test state completed within the timebox, but attempt one left 14 failures and attempt two left 3 runtime-config/delivery differences. Per the task rule, no third patch cycle was attempted.

## User Impact

No production behavior changes. These tests now fail when the production HTTP lifecycle, restart lifecycle, or durable session queue changes instead of validating local replicas. The retained boundary fakes cover only external SDK/network/process/provider effects.

## Evidence

Focused and shadow-owner proof passed:

- `node scripts/run-vitest.mjs extensions/msteams/src/monitor.lifecycle.test.ts extensions/msteams/src/resolve-allowlist.test.ts extensions/msteams/src/sdk.test.ts src/plugin-sdk/channel-lifecycle.test.ts` — 91 passed across two shards.
- `node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts src/cli/gateway-cli/lifecycle-import-boundary.test.ts src/infra/restart.test.ts src/infra/restart.deferral-timeout.test.ts src/process/gateway-work-admission.test.ts src/process/command-queue.test.ts src/infra/agent-events.test.ts` — 175 passed across three shards.
- `node scripts/run-vitest.mjs src/gateway/server-restart-sentinel.test.ts src/gateway/server-restart-sentinel-notice.test.ts src/infra/session-delivery-queue.storage.test.ts src/infra/session-delivery-queue.recovery.test.ts` — 115 passed across two shards.
- `node scripts/run-oxlint.mjs <each changed path>` — passed.
- `pnpm format <each changed path>` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no accepted/actionable findings.

Benchmark/proof snapshots using the linked-worktree-safe Vitest wrapper:

- Gateway run loop: 54 passed before in 4.72s / 552,763,392-byte max RSS; 54 passed after in 4.94s / 641,040,384-byte max RSS.
- Restart sentinel: 76 passed before in 16.96s / 1,213,612,032-byte max RSS; final 72-test suite passed in 10.32s / 1,256,144,896-byte max RSS.
- Microsoft Teams: 16 passed before in 21.19s; final 15-test suite passed in 20.14s.

`node scripts/check-changed.mjs` delegated to AWS Crabbox lease `cbx_d12856cc93e7`, run `run_dfc38e799890` (https://crabbox.openclaw.ai/portal/runs/run_dfc38e799890). Conflict markers, env/max-lines ratchets, changelog attribution, wildcard exports, duplicate coverage, dependency pins, formatting, deprecated APIs, plugin boundaries, and package patches passed. The gate then stopped on the existing `src/config/**` dead-export inventory; this branch changes only the three test files above and has no config diff. The lease stopped cleanly.

Production LOC delta: +0 / -0.

Test LOC delta from `git diff origin/main...HEAD --numstat`: +194 / -516 (net -322).
