### PR TITLE
fix(media): preserve encoded image filenames across delivery

### DIFF
--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { createSolidPngBuffer } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../../qqbot-test-support.js";
 import { normalizeSource } from "../messaging/media-source.js";
 import {
   ApiError,

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { createSolidPngBuffer } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../../test/helpers/temp-dir.js";
 import { normalizeSource } from "../messaging/media-source.js";
 import {
   ApiError,
@@ -81,6 +82,7 @@ function makePrepareResponse(uploadId: string, parts: number): UploadPrepareResp
 /** Fixture: a 20-byte buffer that spans 3 parts at block_size=8. */
 const FIXTURE_BUFFER = Buffer.from("0123456789abcdefghij"); // 20 bytes
 const IMAGE_FIXTURE_BUFFER = createSolidPngBuffer(2, 2, { r: 40, g: 90, b: 180, a: 96 });
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 // ============ fetch stub for COS PUT ============
 
@@ -452,7 +454,7 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
   ])(
     "reconciles chunked image filenames without changing source custody: $label",
     async ({ fileType, storedName, expectedName, bytes }) => {
-      const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "chunked-image-name-"));
+      const tmp = tempDirs.make("chunked-image-name-");
       const filePath = path.join(tmp, storedName);
       await fs.promises.writeFile(filePath, bytes);
       const source = await normalizeSource({ localPath: filePath }, { maxSize: 1024 * 1024 });
@@ -497,7 +499,6 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
         if (source.kind === "localPath") {
           await source.opened?.close().catch(() => undefined);
         }
-        await fs.promises.rm(tmp, { recursive: true, force: true });
       }
     },
   );

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -429,6 +429,8 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
       storedName: "queued.webp",
       expectedName: "queued.png",
       bytes: IMAGE_FIXTURE_BUFFER,
+      sourceKind: "localPath",
+      fileNameOverride: undefined,
     },
     {
       label: "matching mixed-case PNG alias",
@@ -436,6 +438,8 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
       storedName: "queued.PNG",
       expectedName: "queued.PNG",
       bytes: IMAGE_FIXTURE_BUFFER,
+      sourceKind: "localPath",
+      fileNameOverride: undefined,
     },
     {
       label: "unknown image bytes",
@@ -443,6 +447,8 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
       storedName: "queued.webp",
       expectedName: "queued.webp",
       bytes: FIXTURE_BUFFER,
+      sourceKind: "localPath",
+      fileNameOverride: undefined,
     },
     {
       label: "non-image upload",
@@ -450,14 +456,28 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
       storedName: "queued.webp",
       expectedName: "queued.webp",
       bytes: IMAGE_FIXTURE_BUFFER,
+      sourceKind: "localPath",
+      fileNameOverride: undefined,
+    },
+    {
+      label: "Windows-style buffer override",
+      fileType: MediaFileType.IMAGE,
+      storedName: "buffer.webp",
+      expectedName: "transparent.png",
+      bytes: IMAGE_FIXTURE_BUFFER,
+      sourceKind: "buffer",
+      fileNameOverride: String.raw`C:\images\transparent.webp`,
     },
   ])(
     "reconciles chunked image filenames without changing source custody: $label",
-    async ({ fileType, storedName, expectedName, bytes }) => {
+    async ({ fileType, storedName, expectedName, bytes, sourceKind, fileNameOverride }) => {
       const tmp = tempDirs.make("chunked-image-name-");
       const filePath = path.join(tmp, storedName);
       await fs.promises.writeFile(filePath, bytes);
-      const source = await normalizeSource({ localPath: filePath }, { maxSize: 1024 * 1024 });
+      const source =
+        sourceKind === "buffer"
+          ? ({ kind: "buffer", buffer: bytes, fileName: storedName } as const)
+          : await normalizeSource({ localPath: filePath }, { maxSize: 1024 * 1024 });
       try {
         const client = mockApiClient();
         const fetchSpy = stubFetchOk();
@@ -481,6 +501,7 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
           fileType,
           source,
           creds: { appId: "a", clientSecret: "s" },
+          fileName: fileNameOverride,
         });
 
         const prepareCall = client.request.mock.calls.find((call) =>

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -3,6 +3,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { createSolidPngBuffer } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeSource } from "../messaging/media-source.js";
 import {
@@ -79,6 +80,7 @@ function makePrepareResponse(uploadId: string, parts: number): UploadPrepareResp
 
 /** Fixture: a 20-byte buffer that spans 3 parts at block_size=8. */
 const FIXTURE_BUFFER = Buffer.from("0123456789abcdefghij"); // 20 bytes
+const IMAGE_FIXTURE_BUFFER = createSolidPngBuffer(2, 2, { r: 40, g: 90, b: 180, a: 96 });
 
 // ============ fetch stub for COS PUT ============
 
@@ -417,6 +419,88 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
       await fs.promises.rm(tmp, { recursive: true, force: true });
     }
   });
+
+  it.each([
+    {
+      label: "converted PNG image",
+      fileType: MediaFileType.IMAGE,
+      storedName: "queued.webp",
+      expectedName: "queued.png",
+      bytes: IMAGE_FIXTURE_BUFFER,
+    },
+    {
+      label: "matching mixed-case PNG alias",
+      fileType: MediaFileType.IMAGE,
+      storedName: "queued.PNG",
+      expectedName: "queued.PNG",
+      bytes: IMAGE_FIXTURE_BUFFER,
+    },
+    {
+      label: "unknown image bytes",
+      fileType: MediaFileType.IMAGE,
+      storedName: "queued.webp",
+      expectedName: "queued.webp",
+      bytes: FIXTURE_BUFFER,
+    },
+    {
+      label: "non-image upload",
+      fileType: MediaFileType.VIDEO,
+      storedName: "queued.webp",
+      expectedName: "queued.webp",
+      bytes: IMAGE_FIXTURE_BUFFER,
+    },
+  ])(
+    "reconciles chunked image filenames without changing source custody: $label",
+    async ({ fileType, storedName, expectedName, bytes }) => {
+      const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "chunked-image-name-"));
+      const filePath = path.join(tmp, storedName);
+      await fs.promises.writeFile(filePath, bytes);
+      const source = await normalizeSource({ localPath: filePath }, { maxSize: 1024 * 1024 });
+      try {
+        const client = mockApiClient();
+        const fetchSpy = stubFetchOk();
+        client.request.mockImplementation(async (_token, _method, requestPath) => {
+          if (requestPath.endsWith("/upload_prepare")) {
+            return { ...makePrepareResponse("uid-image-name", 1), block_size: bytes.length };
+          }
+          if (requestPath.endsWith("/upload_part_finish")) {
+            return {};
+          }
+          if (requestPath.endsWith("/files")) {
+            return { file_uuid: "u", file_info: "fi", ttl: 10 } satisfies UploadMediaResponse;
+          }
+          throw new Error(`unexpected ${requestPath}`);
+        });
+
+        const api = new ChunkedMediaApi(client, mockTokenManager());
+        await api.uploadChunked({
+          scope: "c2c",
+          targetId: "u1",
+          fileType,
+          source,
+          creds: { appId: "a", clientSecret: "s" },
+        });
+
+        const prepareCall = client.request.mock.calls.find((call) =>
+          call[2].endsWith("/upload_prepare"),
+        );
+        expect(prepareCall?.[3]).toMatchObject({
+          file_type: fileType,
+          file_name: expectedName,
+          file_size: bytes.length,
+          md5: crypto.createHash("md5").update(bytes).digest("hex"),
+        });
+        const upload = fetchSpy.mock.calls[0]?.[0] as { init?: { body?: Blob } };
+        expect(Buffer.from(await upload.init!.body!.arrayBuffer())).toEqual(bytes);
+        expect(await fs.promises.readFile(filePath)).toEqual(bytes);
+      } finally {
+        if (source.kind === "localPath") {
+          await source.opened?.close().catch(() => undefined);
+        }
+        await fs.promises.rm(tmp, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("uses the verified localPath handle if the path is replaced before chunked upload", async () => {
     const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "chunked-verified-"));

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -481,18 +481,19 @@ async function readPart(input: ChunkedInput, offset: number, length: number): Pr
 }
 
 async function resolveChunkedImageFileName(input: ChunkedInput): Promise<string> {
+  const fileName = input.fileName.split(/[/\\]/).pop() || input.fileName;
   const contentType = await detectMime({
     buffer: await readPart(input, 0, Math.min(input.size, IMAGE_MIME_SNIFF_BYTES)),
   });
-  if (!contentType?.startsWith("image/") || mimeTypeFromFilePath(input.fileName) === contentType) {
-    return input.fileName;
+  if (!contentType?.startsWith("image/") || mimeTypeFromFilePath(fileName) === contentType) {
+    return fileName;
   }
   const extension = extensionForMime(contentType);
   if (!extension) {
-    return input.fileName;
+    return fileName;
   }
-  const parsed = nodePath.parse(input.fileName);
-  return nodePath.format({ name: parsed.name || input.fileName, ext: extension });
+  const parsed = nodePath.parse(fileName);
+  return nodePath.format({ name: parsed.name || fileName, ext: extension });
 }
 
 // ============ Hash computation ============

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -36,6 +36,12 @@
 
 import * as crypto from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
+import * as path from "node:path";
+import {
+  detectMime,
+  extensionForMime,
+  mimeTypeFromFilePath,
+} from "openclaw/plugin-sdk/media-mime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -144,6 +150,8 @@ const MAX_PART_FINISH_RETRY_TIMEOUT_MS = 10 * 60 * 1000;
 /** Per-part PUT timeout (5 minutes). Matches the low-bandwidth tolerance. */
 const PART_UPLOAD_TIMEOUT_MS = 300_000;
 const PART_UPLOAD_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+// file-type's reasonableDetectionSizeInBytes bounds probes on the already verified descriptor.
+const IMAGE_MIME_SNIFF_BYTES = 4100;
 
 /**
  * Boundary used by `md5_10m` — first 10,002,432 bytes.
@@ -189,7 +197,10 @@ export class ChunkedMediaApi {
     const input = await resolveSource(opts.source, opts.fileName);
 
     try {
-      const displayName = input.fileName;
+      const displayName =
+        opts.fileType === MediaFileType.IMAGE
+          ? await resolveChunkedImageFileName(input)
+          : input.fileName;
       const fileSize = input.size;
       const pathLabel = input.kind === "localPath" ? input.path : "<buffer>";
 
@@ -471,6 +482,21 @@ async function readPart(input: ChunkedInput, offset: number, length: number): Pr
   const buf = Buffer.alloc(length);
   const { bytesRead } = await input.opened.handle.read(buf, 0, length, offset);
   return bytesRead < length ? buf.subarray(0, bytesRead) : buf;
+}
+
+async function resolveChunkedImageFileName(input: ChunkedInput): Promise<string> {
+  const contentType = await detectMime({
+    buffer: await readPart(input, 0, Math.min(input.size, IMAGE_MIME_SNIFF_BYTES)),
+  });
+  if (!contentType?.startsWith("image/") || mimeTypeFromFilePath(input.fileName) === contentType) {
+    return input.fileName;
+  }
+  const extension = extensionForMime(contentType);
+  if (!extension) {
+    return input.fileName;
+  }
+  const parsed = path.parse(input.fileName);
+  return path.format({ name: parsed.name || input.fileName, ext: extension });
 }
 
 // ============ Hash computation ============

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -36,7 +36,7 @@
 
 import * as crypto from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
-import * as path from "node:path";
+import * as nodePath from "node:path";
 import { detectMime, extensionForMime, mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
@@ -491,8 +491,8 @@ async function resolveChunkedImageFileName(input: ChunkedInput): Promise<string>
   if (!extension) {
     return input.fileName;
   }
-  const parsed = path.parse(input.fileName);
-  return path.format({ name: parsed.name || input.fileName, ext: extension });
+  const parsed = nodePath.parse(input.fileName);
+  return nodePath.format({ name: parsed.name || input.fileName, ext: extension });
 }
 
 // ============ Hash computation ============

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -37,11 +37,7 @@
 import * as crypto from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
 import * as path from "node:path";
-import {
-  detectMime,
-  extensionForMime,
-  mimeTypeFromFilePath,
-} from "openclaw/plugin-sdk/media-mime";
+import { detectMime, extensionForMime, mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";

--- a/extensions/qqbot/src/qqbot-test-support.ts
+++ b/extensions/qqbot/src/qqbot-test-support.ts
@@ -1,5 +1,29 @@
 // Qqbot plugin module implements qqbot test support behavior.
+import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+
+type RegisterTempDirCleanup = (cleanup: () => void) => unknown;
+
+/** Creates plugin-owned temp directories that the supplied test hook removes. */
+export function useAutoCleanupTempDirTracker(registerCleanup: RegisterTempDirCleanup) {
+  const dirs = new Set<string>();
+  registerCleanup(() => {
+    for (const dir of dirs) {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+    dirs.clear();
+  });
+  return {
+    make(prefix: string): string {
+      // openclaw-temp-dir: allow extension-local test support cannot import the core-only tracker.
+      const dir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), prefix));
+      dirs.add(dir);
+      return dir;
+    },
+  };
+}
 
 export function makeQqbotSecretRefConfig(): OpenClawConfig {
   return {

--- a/src/infra/outbound/delivery-queue-media-spool.test.ts
+++ b/src/infra/outbound/delivery-queue-media-spool.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../../test/helpers/image-fixtures.js";
+import { createImageProcessor } from "../../media/media-services.js";
+import { loadWebMedia } from "../../media/web-media.js";
 
 const storeSpy = vi.hoisted(() => ({
   onMove: null as ((from: string, to: string, rootDir: string) => void) | null,
@@ -246,6 +249,67 @@ describe("staging", () => {
     expect(await fs.readFile(staged, "utf8")).toBe("opus-bytes");
     expect(livePayload.mediaUrl).toBe(source);
     expect(result.artifacts).toEqual([staged]);
+  });
+
+  it("replays converted transparent images with encoded filenames and unchanged custody", async () => {
+    const imageProcessor = createImageProcessor();
+    const sourceBytes = (
+      await imageProcessor.encode(createSolidPngBuffer(2050, 2, { r: 40, g: 90, b: 180, a: 96 }), {
+        format: "webp",
+      })
+    ).data;
+    expect(sourceBytes.toString("ascii", 8, 12)).toBe("WEBP");
+    expect((await imageProcessor.transparency(sourceBytes)).hasTransparentPixels).toBe(true);
+    const source = path.join(sourceDir, "transparent.webp");
+    await fs.writeFile(source, sourceBytes);
+
+    const staged = await stageQueuePayloadMedia({
+      payloads: [{ mediaUrl: source }],
+      mediaAccess: mediaAccessFor([sourceDir]),
+      maxBytes: 1024 * 1024,
+      stateDir,
+    });
+    expect(staged.status).toBe("staged");
+    if (staged.status !== "staged") {
+      return;
+    }
+    await enqueueDelivery(
+      {
+        channel: "matrix",
+        to: "!room:example",
+        payloads: staged.payloads,
+      },
+      stateDir,
+      staged.mediaStageId,
+    );
+    await fs.rm(source);
+
+    const queued = await loadPendingDeliveries(stateDir);
+    const queuedEntry = queued[0]?.preparedBatch.entries[0];
+    expect(queuedEntry?.status).toBe("accepted");
+    if (!queuedEntry || queuedEntry.status !== "accepted") {
+      throw new Error("Expected queued prepared media");
+    }
+    const replayPath = queuedEntry.payload.mediaUrl;
+    expect(replayPath).toBe(staged.artifacts[0]);
+    if (!replayPath) {
+      throw new Error("Expected queued media artifact");
+    }
+    // SQLite owns this preplanned path; only public image metadata changes.
+    expect(path.extname(replayPath)).toBe(".webp");
+    const encodedBytes = await fs.readFile(replayPath);
+    expect(encodedBytes.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    );
+
+    const replayed = await loadWebMedia(replayPath, {
+      maxBytes: 1024 * 1024,
+      localRoots: [spoolRoot],
+    });
+    expect(replayed.kind).toBe("image");
+    expect(replayed.contentType).toBe("image/png");
+    expect(replayed.fileName).toBe(`${path.basename(replayPath, ".webp")}.png`);
+    expect(replayed.buffer).toEqual(encodedBytes);
   });
 
   it("leaves replayable remote media untouched without creating the spool", async () => {

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -7,13 +7,13 @@ import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import JSZip from "jszip";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { createSolidPngBuffer, createTinyJpegBuffer } from "../../test/helpers/image-fixtures.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { resizeToJpeg } from "./media-services.js";
+import { createImageProcessor, resizeToJpeg } from "./media-services.js";
 import { encodePngRgba, fillPixel } from "./png-encode.js";
 
 let effectiveImageBytesCap: typeof import("./web-media.js").effectiveImageBytesCap;
@@ -486,6 +486,114 @@ describe("loadWebMedia", () => {
       expect(result.buffer.subarray(0, 3)).toEqual(Buffer.from([0xff, 0xd8, 0xff]));
       expect(readJpegDimensions(result.buffer)).toEqual({ width: 32, height: 32 });
     }
+  });
+
+  it("renames transparent WebP images converted to PNG across direct, local, and remote owners", async () => {
+    const { optimizeImageBufferForWebMedia } = await import("./web-media.js");
+    const imageProcessor = createImageProcessor();
+    const sourceWebp = (
+      await imageProcessor.encode(createLargeTransparentColorBlockPng(64), { format: "webp" })
+    ).data;
+    expect(sourceWebp.toString("ascii", 8, 12)).toBe("WEBP");
+    expect((await imageProcessor.transparency(sourceWebp)).hasTransparentPixels).toBe(true);
+    const imageCompression = { models: [{ maxSidePx: 32, preferredSidePx: 32 }] };
+
+    const direct = await optimizeImageBufferForWebMedia({
+      buffer: sourceWebp,
+      contentType: "image/webp",
+      fileName: String.raw`C:\images\transparent.webp`,
+      maxBytes: 1024 * 1024,
+      imageCompression,
+    });
+    const unnamed = await optimizeImageBufferForWebMedia({
+      buffer: sourceWebp,
+      contentType: "image/webp",
+      maxBytes: 1024 * 1024,
+      imageCompression,
+    });
+    const convertedPath = path.join(fixtureRoot, "transparent.webp");
+    await fs.writeFile(convertedPath, sourceWebp);
+    const loaded = await loadWebMedia(convertedPath, {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+      imageCompression,
+    });
+    const remote = await loadWebMedia("https://93.184.216.34/transparent.webp", {
+      maxBytes: 1024 * 1024,
+      imageCompression,
+      fetchImpl: async () =>
+        new Response(sourceWebp, {
+          status: 200,
+          headers: { "content-type": "image/webp" },
+        }),
+    });
+
+    for (const result of [direct, loaded, remote]) {
+      expect(result.kind).toBe("image");
+      expect(result.contentType).toBe("image/png");
+      expect(result.fileName).toBe("transparent.png");
+      expect(result.buffer.subarray(0, 8)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      );
+      expect(readPngDimensions(result.buffer)).toEqual({ width: 32, height: 32 });
+    }
+    expect(unnamed.contentType).toBe("image/png");
+    expect(unnamed.fileName).toBeUndefined();
+
+    const unchanged = await optimizeImageBufferForWebMedia({
+      buffer: sourceWebp,
+      contentType: "image/webp",
+      fileName: "transparent.webp",
+      maxBytes: 1024 * 1024,
+    });
+    expect(unchanged.contentType).toBe("image/webp");
+    expect(unchanged.fileName).toBe("transparent.webp");
+    expect(unchanged.buffer).toBe(sourceWebp);
+  });
+
+  it("reconciles sniffed image filenames without optimization while preserving raw metadata", async () => {
+    const disguisedPng = path.join(fixtureRoot, "converted.webp");
+    await fs.writeFile(disguisedPng, TINY_PNG_BUFFER);
+    const options = {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+      optimizeImages: false,
+    };
+
+    const publicImage = await loadWebMedia(disguisedPng, options);
+    expect(publicImage.contentType).toBe("image/png");
+    expect(publicImage.fileName).toBe("converted.png");
+    expect(publicImage.buffer).toEqual(TINY_PNG_BUFFER);
+
+    const rawImage = await loadWebMediaRaw(disguisedPng, options);
+    expect(rawImage.contentType).toBe("image/png");
+    expect(rawImage.fileName).toBe("converted.webp");
+    expect(rawImage.buffer).toEqual(TINY_PNG_BUFFER);
+  });
+
+  it("preserves equivalent JPEG aliases and unknown image MIME types", async () => {
+    const jpegAlias = path.join(fixtureRoot, "portrait.JpEg");
+    await fs.writeFile(jpegAlias, createTinyJpegBuffer());
+    const aliasedImage = await loadWebMedia(jpegAlias, {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+      optimizeImages: false,
+    });
+    expect(aliasedImage.contentType).toBe("image/jpeg");
+    expect(aliasedImage.fileName).toBe("portrait.JpEg");
+
+    const unknownImage = await loadWebMedia("https://93.184.216.34/portrait.mystery", {
+      maxBytes: 1024 * 1024,
+      optimizeImages: false,
+      fetchImpl: async () =>
+        new Response("unrecognized image bytes", {
+          status: 200,
+          headers: { "content-type": "image/x-private-format" },
+        }),
+    });
+    expect(unknownImage.kind).toBe("image");
+    expect(unknownImage.contentType).toBe("image/x-private-format");
+    expect(unknownImage.fileName).toBe("portrait.mystery");
   });
 
   it("applies model image maxBytes to the effective image cap", async () => {

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -522,7 +522,7 @@ describe("loadWebMedia", () => {
       maxBytes: 1024 * 1024,
       imageCompression,
       fetchImpl: async () =>
-        new Response(sourceWebp, {
+        new Response(new Uint8Array(sourceWebp), {
           status: 200,
           headers: { "content-type": "image/webp" },
         }),

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -596,6 +596,22 @@ describe("loadWebMedia", () => {
     expect(unknownImage.fileName).toBe("portrait.mystery");
   });
 
+  it("strips matching image filename paths without changing equivalent extensions", async () => {
+    const { optimizeImageBufferForWebMedia } = await import("./web-media.js");
+    const sourceJpeg = createTinyJpegBuffer();
+
+    const result = await optimizeImageBufferForWebMedia({
+      buffer: sourceJpeg,
+      contentType: "image/jpeg",
+      fileName: String.raw`C:\Users\alice\portrait.JpEg`,
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result.contentType).toBe("image/jpeg");
+    expect(result.fileName).toBe("portrait.JpEg");
+    expect(result.buffer).toBe(sourceJpeg);
+  });
+
   it("applies model image maxBytes to the effective image cap", async () => {
     await expect(
       loadWebMediaRaw(tinyPngFile, {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -613,19 +613,20 @@ function assertHostReadMediaAllowed(params: {
 
 // Queue custody preserves artifact paths; outbound image metadata must still match encoded bytes.
 function reconcileImageFileName(media: WebMediaResult): WebMediaResult {
-  const contentType = normalizeMimeType(media.contentType);
-  if (
-    media.kind !== "image" ||
-    !media.fileName ||
-    !contentType ||
-    mimeTypeFromFilePath(media.fileName) === contentType
-  ) {
+  if (media.kind !== "image" || !media.fileName) {
     return media;
   }
   const fileName = basenameFromAnyPath(media.fileName.trim());
-  const extension = extensionForMime(contentType);
-  if (!fileName || !extension) {
+  if (!fileName) {
     return media;
+  }
+  const contentType = normalizeMimeType(media.contentType);
+  if (!contentType || mimeTypeFromFilePath(fileName) === contentType) {
+    return fileName === media.fileName ? media : { ...media, fileName };
+  }
+  const extension = extensionForMime(contentType);
+  if (!extension) {
+    return fileName === media.fileName ? media : { ...media, fileName };
   }
   const parsed = path.parse(fileName);
   return {
@@ -972,12 +973,12 @@ export async function optimizeImageBufferForWebMedia(params: {
       throw new Error(formatCapLimit("GIF", cap, params.buffer.length));
     }
     assertImageSatisfiesHardDimensionPolicy(params.buffer, params.imageCompression);
-    return {
+    return reconcileImageFileName({
       buffer: params.buffer,
       contentType: params.contentType,
       kind: "image",
       fileName: params.fileName,
-    };
+    });
   }
   const meta = { contentType: params.contentType, fileName: params.fileName };
   const originalContentType = resolvePreservableOriginalImageContentType({
@@ -988,12 +989,12 @@ export async function optimizeImageBufferForWebMedia(params: {
     policy: params.imageCompression,
   });
   if (originalContentType) {
-    return {
+    return reconcileImageFileName({
       buffer: params.buffer,
       contentType: originalContentType,
       kind: "image",
       fileName: params.fileName,
-    };
+    });
   }
   const optimized = await optimizeImageWithFallback({
     buffer: params.buffer,

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -611,19 +611,27 @@ function assertHostReadMediaAllowed(params: {
   );
 }
 
-function toJpegFileName(fileName?: string): string | undefined {
-  if (!fileName) {
-    return undefined;
+// Queue custody preserves artifact paths; outbound image metadata must still match encoded bytes.
+function reconcileImageFileName(media: WebMediaResult): WebMediaResult {
+  const contentType = normalizeMimeType(media.contentType);
+  if (
+    media.kind !== "image" ||
+    !media.fileName ||
+    !contentType ||
+    mimeTypeFromFilePath(media.fileName) === contentType
+  ) {
+    return media;
   }
-  const trimmed = basenameFromAnyPath(fileName.trim());
-  if (!trimmed) {
-    return fileName;
+  const fileName = basenameFromAnyPath(media.fileName.trim());
+  const extension = extensionForMime(contentType);
+  if (!fileName || !extension) {
+    return media;
   }
-  const parsed = path.parse(trimmed);
-  if (!parsed.ext || HEIC_EXT_RE.test(parsed.ext)) {
-    return path.format({ dir: parsed.dir, name: parsed.name || trimmed, ext: ".jpg" });
-  }
-  return path.format({ dir: parsed.dir, name: parsed.name, ext: ".jpg" });
+  const parsed = path.parse(fileName);
+  return {
+    ...media,
+    fileName: path.format({ name: parsed.name || fileName, ext: extension }),
+  };
 }
 
 type OptimizedImage = {
@@ -997,12 +1005,12 @@ export async function optimizeImageBufferForWebMedia(params: {
   if (optimized.buffer.length > cap) {
     throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
   }
-  return {
+  return reconcileImageFileName({
     buffer: optimized.buffer,
     contentType: optimized.mimeType,
     kind: "image",
-    fileName: optimized.format === "jpeg" ? toJpegFileName(params.fileName) : params.fileName,
-  };
+    fileName: params.fileName,
+  });
 }
 
 async function loadWebMediaInternal(
@@ -1061,13 +1069,11 @@ async function loadWebMediaInternal(
       throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
     }
 
-    const fileName = optimized.format === "jpeg" ? toJpegFileName(meta?.fileName) : meta?.fileName;
-
     return {
       buffer: optimized.buffer,
       contentType: optimized.mimeType,
       kind: "image" as const,
-      fileName,
+      fileName: meta?.fileName,
     };
   };
 
@@ -1283,9 +1289,11 @@ export async function loadWebMedia(
   maxBytesOrOptions?: number | WebMediaOptions,
   options?: { ssrfPolicy?: SsrFPolicy; localRoots?: readonly string[] | "any" },
 ): Promise<WebMediaResult> {
-  return await loadWebMediaInternal(
-    mediaUrl,
-    resolveWebMediaOptions({ maxBytesOrOptions, options, optimizeImages: true }),
+  return reconcileImageFileName(
+    await loadWebMediaInternal(
+      mediaUrl,
+      resolveWebMediaOptions({ maxBytesOrOptions, options, optimizeImages: true }),
+    ),
   );
 }
 


### PR DESCRIPTION
Closes #120118

## What Problem This Solves

Image optimization and MIME sniffing can change the encoded format without changing the public filename. A transparent WebP converted to PNG was returned and durably queued as PNG bytes with `image/png` while still named `.webp`; large QQBot image uploads then submitted that stale name to `upload_prepare`.

The same public metadata owner must also strip source path components even when the encoded MIME already matches the extension. Otherwise a direct Windows/local filename can leak directory information into outbound metadata.

## Why This Change Was Made

The shared web-media result reconciles image leaf names with the normalized output MIME while leaving raw-loader metadata and durable artifact paths untouched. Every optimized image result—preserved or converted—passes through that public metadata owner. QQBot performs the same narrow reconciliation only at its chunked image-upload boundary, reading the bounded prefix from the already-verified descriptor so it does not reopen, rename, or replace source custody.

The split is intentional: normal direct/local/remote and queue replay paths belong to `loadWebMedia`; large QQBot local paths can bypass that loader, and only the chunked endpoint sends a server-visible image filename.

Production LOC: +55/-23 (net +32). Tests and test support: +320/-2 (net +318). The production growth implements the shared filename/MIME/privacy invariant plus the QQBot verified-descriptor boundary; it adds no config, protocol, dependency, storage schema, or compatibility surface.

## User Impact

Converted and sniffed images now carry leaf filenames that match their encoded bytes without exposing source directories. Equivalent aliases such as `.jpeg` for `image/jpeg`, unknown image formats, non-image uploads, raw-loader metadata, and SQLite-owned spool paths remain unchanged.

## Evidence

- Original source-blind reproduction on `804ae7f1217fd095484485a05798f6816db0ca0f`: queue replay returned PNG bytes/MIME named `transparent.webp`, preserved a `.webp` spool path containing the PNG signature, and replayed the same UUID `.webp` name: https://github.com/openclaw/openclaw/actions/runs/31139366120
- Original repaired behavior proof returned `transparent.png` and a UUID `.png` public name while the durable path remained `.webp` with the same PNG bytes: https://github.com/openclaw/openclaw/actions/runs/31139880371
- The clean rebase onto current `main` preserved all seven original commits exactly under `git range-diff`.
- Rebased focused proof: web-media 91/91, delivery spool 15/15, QQBot chunk upload 13/13 on Testbox `tbx_01kzf3jxy2w1anmcsrpsdh50m2`: https://github.com/openclaw/openclaw/actions/runs/31221922361
- AutoReview found that preserved matching-extension images could bypass leaf-name sanitization. The owner was repaired before publication, and the new Windows-path/mixed-case JPEG regression passes in the 92/92 media suite on Testbox `tbx_01kzf513vdj9101cb4khagfys4`: https://github.com/openclaw/openclaw/actions/runs/31223486982
- Final rebased `check:changed` passed core/extension production and test typechecks, lint, formatting, plugin boundaries, dead-code, import cycles, storage guards, and media guards on Testbox `tbx_01kzf5b4bs9s7dmpz90xvxpnkz`: https://github.com/openclaw/openclaw/actions/runs/31223810874
- Exact-head hosted CI passed on attempt 2: https://github.com/openclaw/openclaw/actions/runs/31224540204/attempts/2. Attempt 1 had one unrelated `assistant-transcript-repair` shard failure; that exact file passed 7/7 on Testbox `tbx_01kzf6edj53w91ddr4w8yp0xd9` (https://github.com/openclaw/openclaw/actions/runs/31224920438) and the full shard rerun passed without a code change.
- Final xhigh P2 AutoReview returned clean with no accepted/actionable findings (0.94 confidence); TruffleHog was clean.
- Direct dependency source: `file-type@22.0.1` exports `reasonableDetectionSizeInBytes = 4100` from its shipped `source/index.js`; QQBot bounds its verified-descriptor probe to that value.

## Remaining pre-land proof

- Authenticated QQBot chunked image upload confirming the server accepts the reconciled leaf filename for the real large-image path.
- `QQBOT_APP_ID` and `QQBOT_CLIENT_SECRET` are not exported and no matching QQBot/QQ/Tencent credential exists in the service-account-accessible Molty vault. The mandatory one-password workflow requires explicit consent before searching or using the personal 1Password account.

The final exact head is `4942a882bb5f51938f22bcc40730248ed9c17190`.

AI-assisted: yes. No agent transcript is included because public transcript insertion requires separate explicit consent.
