### PR TITLE
refactor(ui): adopt shared chat-host fixture across chat suites

### DIFF
--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -4,21 +4,12 @@ import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setAvatarGatewayOrigin } from "../../lib/identity-avatar.ts";
 import { invalidateChatAvatarCache, refreshChatAvatar, renderChatAvatar } from "./chat-avatar.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
 
 function renderAvatar(params: Parameters<typeof renderChatAvatar>) {
   const container = document.createElement("div");
   render(renderChatAvatar(...params), container);
   return container.querySelector<HTMLElement>(".chat-avatar");
-}
-
-function createHost(): Parameters<typeof refreshChatAvatar>[0] {
-  return {
-    basePath: "",
-    chatAvatarUrl: null,
-    connected: true,
-    hello: null,
-    sessionKey: "agent:main",
-  };
 }
 
 function pendingUntilAbort<T>(signal: AbortSignal | null | undefined): Promise<T> {
@@ -112,7 +103,7 @@ describe("refreshChatAvatar", () => {
     );
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    const host = createHost();
+    const host = makeChatHost();
     const refresh = refreshChatAvatar(host);
     const signal = fetchMock.mock.calls[0]?.[1]?.signal;
     expect(signal?.aborted).toBe(false);
@@ -143,7 +134,7 @@ describe("refreshChatAvatar", () => {
       );
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    const host = createHost();
+    const host = makeChatHost();
     const refresh = refreshChatAvatar(host);
     await vi.advanceTimersByTimeAsync(0);
 
@@ -175,7 +166,7 @@ describe("refreshChatAvatar", () => {
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:main-avatar");
 
-    const host = createHost();
+    const host = makeChatHost();
     host.sessionKey = "agent:main:first";
     await refreshChatAvatar(host);
     expect(host.chatAvatarUrl).toBe("blob:main-avatar");
@@ -208,7 +199,7 @@ describe("refreshChatAvatar", () => {
       .mockReturnValueOnce("blob:first-avatar")
       .mockReturnValueOnce("blob:second-avatar");
 
-    const host = createHost();
+    const host = makeChatHost();
     host.sessionKey = "agent:main:first";
     await refreshChatAvatar(host);
     now.mockReturnValue(61_001);
@@ -235,7 +226,7 @@ describe("refreshChatAvatar", () => {
     vi.spyOn(URL, "createObjectURL")
       .mockReturnValueOnce("blob:first-avatar")
       .mockReturnValueOnce("blob:second-avatar");
-    const host = createHost();
+    const host = makeChatHost();
 
     await refreshChatAvatar(host);
     now.mockReturnValue(61_001);
@@ -259,7 +250,7 @@ describe("refreshChatAvatar", () => {
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:shared-avatar");
     const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL");
-    const host = createHost();
+    const host = makeChatHost();
     host.sessionKey = "agent:main:first";
 
     const first = refreshChatAvatar(host);
@@ -282,7 +273,7 @@ describe("refreshChatAvatar", () => {
       .mockResolvedValueOnce({ ok: true, blob: async () => new Blob(["avatar"]) });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:retried-avatar");
-    const host = createHost();
+    const host = makeChatHost();
 
     await refreshChatAvatar(host);
     expect(host.chatAvatarUrl).toBeNull();
@@ -303,7 +294,7 @@ describe("refreshChatAvatar", () => {
     vi.spyOn(URL, "createObjectURL")
       .mockReturnValueOnce("blob:first-avatar")
       .mockReturnValueOnce("blob:second-avatar");
-    const host = createHost();
+    const host = makeChatHost();
 
     await refreshChatAvatar(host);
     invalidateChatAvatarCache(host);

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -52,6 +52,118 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+type HistoryResult = {
+  messages: Array<unknown>;
+  thinkingLevel?: string;
+  verboseLevel?: string;
+};
+
+function createTestClient(request: unknown): NonNullable<ChatState["client"]> {
+  return { request } as unknown as NonNullable<ChatState["client"]>;
+}
+
+function createHistoryState(request: unknown, overrides: Partial<ChatState> = {}): ChatState {
+  return createState({
+    client: createTestClient(request),
+    ...overrides,
+  });
+}
+
+function createResolvedHistoryState(result: unknown, overrides: Partial<ChatState> = {}) {
+  const request = vi.fn().mockResolvedValue(result);
+  return { request, state: createHistoryState(request, overrides) };
+}
+
+function createHistorySnapshot(messages: Array<unknown>, overrides: Partial<ChatState> = {}) {
+  return createResolvedHistoryState({ messages, thinkingLevel: "low" }, overrides);
+}
+
+function createHistoryStateForClient(
+  client: NonNullable<ChatState["client"]>,
+  overrides: Partial<ChatState> = {},
+) {
+  return createState({ client, ...overrides });
+}
+
+function createDeferredHistoryState(overrides: Partial<ChatState> = {}) {
+  const history = createDeferred<HistoryResult>();
+  const request = vi.fn(() => history.promise);
+  return { history, request, state: createHistoryState(request, overrides) };
+}
+
+function createAssistantHistory(text: string, overrides: Omit<HistoryResult, "messages"> = {}) {
+  return {
+    messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+    ...overrides,
+  };
+}
+
+type SessionTestState = ChatState & {
+  [key: string]: unknown;
+  chatRunStatus?: { phase: string; runId: string | null; sessionKey: string } | null;
+  lastLocalTerminalReconcile?: { sessionStatus: string } | null;
+  sessionsResult: {
+    [key: string]: unknown;
+    sessions: Array<Record<string, unknown>>;
+  };
+};
+
+function createStateWithRunningSession(overrides: Partial<ChatState>): SessionTestState {
+  const state = createState(overrides) as SessionTestState;
+  state.sessionsResult = {
+    ts: 0,
+    path: "",
+    count: 1,
+    defaults: {},
+    sessions: [
+      {
+        key: "main",
+        kind: "direct",
+        updatedAt: 1,
+        hasActiveRun: true,
+        activeRunIds: ["run-1"],
+        status: "running",
+        startedAt: 100,
+      },
+    ],
+  };
+  return state;
+}
+
+type HistoryToolSegment = { text: string; ts: number; toolCallId?: string };
+type LiveToolState = ChatState & {
+  chatStreamSegments: HistoryToolSegment[];
+  chatToolMessages: Record<string, unknown>[];
+  toolStreamById: Map<string, unknown>;
+  toolStreamOrder: string[];
+  toolStreamSyncTimer: number | null;
+};
+
+function attachLiveToolState(
+  state: ChatState,
+  tools: Record<string, unknown>[],
+  segments: HistoryToolSegment[],
+): LiveToolState {
+  const liveState = state as LiveToolState;
+  liveState.chatStreamSegments = segments;
+  liveState.chatToolMessages = tools;
+  liveState.toolStreamById = new Map(
+    tools.map((tool) => [String(tool.toolCallId), { message: tool }]),
+  );
+  liveState.toolStreamOrder = tools.map((tool) => String(tool.toolCallId));
+  liveState.toolStreamSyncTimer = null;
+  return liveState;
+}
+
+function createLiveToolHistoryState(
+  messages: Array<unknown>,
+  overrides: Partial<ChatState>,
+  tools: Record<string, unknown>[],
+  segments: HistoryToolSegment[],
+): LiveToolState {
+  return attachLiveToolState(createHistorySnapshot(messages, overrides).state, tools, segments);
+}
+
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 
 function expectTextChatMessage(message: unknown, role: string, text: string): void {
@@ -616,11 +728,9 @@ describe("handleChatGatewayEvent", () => {
   ])("keeps a delivered $name visible exactly once across stale history", async ({ final }) => {
     const user = createTextChatMessage("user", "Ask", { id: "persisted-user", seq: 1 });
     const request = vi.fn().mockResolvedValue({ messages: [user] });
-    const state = createState({
+    const state = createHistoryState(request, {
       chatMessages: [user],
       chatRunId: "delivered-run",
-      client: { request } as unknown as ChatState["client"],
-      sessionKey: "main",
     });
 
     expect(
@@ -883,39 +993,11 @@ describe("handleChatGatewayEvent", () => {
     ({ event, projectionStatus, sessionStatus, errorSummary }) => {
       vi.useFakeTimers();
       try {
-        const state = createState({
-          sessionKey: "main",
+        const state = createStateWithRunningSession({
           chatRunId: "run-1",
           chatStream: "Partial assistant reply",
           chatStreamStartedAt: 100,
-        }) as ChatState & {
-          chatRunStatus?: { phase: string; runId: string | null; sessionKey: string } | null;
-          lastLocalTerminalReconcile?: { sessionStatus: string } | null;
-          sessionsResult?: {
-            ts: number;
-            path: string;
-            count: number;
-            defaults: Record<string, unknown>;
-            sessions: Array<Record<string, unknown>>;
-          };
-        };
-        state.sessionsResult = {
-          ts: 0,
-          path: "",
-          count: 1,
-          defaults: {},
-          sessions: [
-            {
-              key: "main",
-              kind: "direct",
-              updatedAt: 1,
-              hasActiveRun: true,
-              activeRunIds: ["run-1"],
-              status: "running",
-              startedAt: 100,
-            },
-          ],
-        };
+        });
 
         expect(
           handleChatGatewayEvent(state, {
@@ -953,25 +1035,11 @@ describe("handleChatGatewayEvent", () => {
   it("reconciles cached run and indicator state on terminal events", () => {
     vi.useFakeTimers();
     try {
-      const state = createState({
-        sessionKey: "main",
+      const state = createStateWithRunningSession({
         chatRunId: "run-1",
         chatStream: "Live reply",
         chatStreamStartedAt: 100,
-      }) as ChatState & {
-        chatRunStatus?: unknown;
-        compactionStatus?: unknown;
-        compactionClearTimer?: ReturnType<typeof setTimeout> | null;
-        fallbackStatus?: unknown;
-        fallbackClearTimer?: ReturnType<typeof setTimeout> | null;
-        sessionsResult?: {
-          ts: number;
-          path: string;
-          count: number;
-          defaults: Record<string, unknown>;
-          sessions: Array<Record<string, unknown>>;
-        };
-      };
+      });
       state.compactionStatus = {
         phase: "active",
         runId: "run-1",
@@ -986,23 +1054,6 @@ describe("handleChatGatewayEvent", () => {
         occurredAt: 100,
       };
       state.fallbackClearTimer = setTimeout(() => undefined, 1_000);
-      state.sessionsResult = {
-        ts: 0,
-        path: "",
-        count: 1,
-        defaults: {},
-        sessions: [
-          {
-            key: "main",
-            kind: "direct",
-            updatedAt: 1,
-            hasActiveRun: true,
-            activeRunIds: ["run-1"],
-            status: "running",
-            startedAt: 100,
-          },
-        ],
-      };
       const payload: ChatEventPayload = {
         runId: "run-1",
         sessionKey: "main",
@@ -1036,38 +1087,11 @@ describe("handleChatGatewayEvent", () => {
   it("does not publish Done while a yielded turn has registered continuation work", () => {
     vi.useFakeTimers();
     try {
-      const state = createState({
-        sessionKey: "main",
+      const state = createStateWithRunningSession({
         chatRunId: "run-1",
         chatStream: "Restarting now",
         chatStreamStartedAt: 100,
-      }) as ChatState & {
-        chatRunStatus?: unknown;
-        sessionsResult?: {
-          ts: number;
-          path: string;
-          count: number;
-          defaults: Record<string, unknown>;
-          sessions: Array<Record<string, unknown>>;
-        };
-      };
-      state.sessionsResult = {
-        ts: 0,
-        path: "",
-        count: 1,
-        defaults: {},
-        sessions: [
-          {
-            key: "main",
-            kind: "direct",
-            updatedAt: 1,
-            hasActiveRun: true,
-            activeRunIds: ["run-1"],
-            status: "running",
-            startedAt: 100,
-          },
-        ],
-      };
+      });
 
       expect(
         handleChatGatewayEvent(state, {
@@ -2380,12 +2404,10 @@ describe("loadChatHistory filtering", () => {
       { role: "assistant", content: [{ type: "text", text: "Real answer" }] },
       { role: "assistant", text: "  NO_REPLY  " },
     ];
-    const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages, thinkingLevel: "low", verboseLevel: "full" }),
-    };
-    const state = createState({
-      client: mockClient as unknown as ChatState["client"],
-      connected: true,
+    const { state } = createResolvedHistoryState({
+      messages,
+      thinkingLevel: "low",
+      verboseLevel: "full",
     });
 
     await loadChatHistory(state);
@@ -2403,13 +2425,7 @@ describe("loadChatHistory filtering", () => {
 
   it("keeps assistant message when text field has real content but content is NO_REPLY", async () => {
     const messages = [{ role: "assistant", text: "real reply", content: "NO_REPLY" }];
-    const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages }),
-    };
-    const state = createState({
-      client: mockClient as unknown as ChatState["client"],
-      connected: true,
-    });
+    const { state } = createResolvedHistoryState({ messages });
 
     await loadChatHistory(state);
 
@@ -2439,13 +2455,7 @@ describe("loadChatHistory filtering", () => {
         content: [{ type: "text", text: "real tool output" }],
       },
     ];
-    const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages }),
-    };
-    const state = createState({
-      client: mockClient as unknown as ChatState["client"],
-      connected: true,
-    });
+    const { state } = createResolvedHistoryState({ messages });
 
     await loadChatHistory(state);
 
@@ -2468,13 +2478,7 @@ describe("loadChatHistory filtering", () => {
       },
       { role: "user", content: "" },
     ];
-    const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages }),
-    };
-    const state = createState({
-      client: mockClient as unknown as ChatState["client"],
-      connected: true,
-    });
+    const { state } = createResolvedHistoryState({ messages });
 
     await loadChatHistory(state);
 
@@ -2488,13 +2492,7 @@ describe("loadChatHistory filtering", () => {
         "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.",
       ),
     ];
-    const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages }),
-    };
-    const state = createState({
-      client: mockClient as unknown as ChatState["client"],
-      connected: true,
-    });
+    const { state } = createResolvedHistoryState({ messages });
 
     await loadChatHistory(state);
 
@@ -2502,7 +2500,7 @@ describe("loadChatHistory filtering", () => {
   });
 
   it("applies current session metadata from chat history", async () => {
-    const request = vi.fn().mockResolvedValue({
+    const { state } = createResolvedHistoryState({
       messages: [],
       sessionId: "legacy-session",
       thinkingLevel: "low",
@@ -2519,10 +2517,6 @@ describe("loadChatHistory filtering", () => {
         updatedAt: 123,
       },
     });
-    const state = createState({
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-    });
 
     const result = await loadChatHistory(state);
 
@@ -2536,19 +2530,17 @@ describe("loadChatHistory filtering", () => {
   });
 
   it("preserves the displayed leaf when history metadata is not authoritative for it", async () => {
-    const request = vi.fn().mockResolvedValue({
-      messages: [],
-      sessionInfo: {
-        key: "main",
-        sessionId: "session-main",
-        updatedAt: 123,
+    const { state } = createResolvedHistoryState(
+      {
+        messages: [],
+        sessionInfo: {
+          key: "main",
+          sessionId: "session-main",
+          updatedAt: 123,
+        },
       },
-    });
-    const state = createState({
-      chatDisplayedLeafEntryId: "leaf-from-tail",
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-    });
+      { chatDisplayedLeafEntryId: "leaf-from-tail" },
+    );
 
     await loadChatHistory(state);
 
@@ -2556,12 +2548,12 @@ describe("loadChatHistory filtering", () => {
   });
 
   it("omits literal global agentId until selected/default agent is known", async () => {
-    const request = vi.fn().mockResolvedValue({ messages: [] });
-    const state = createState({
-      sessionKey: "global",
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-    });
+    const { request, state } = createResolvedHistoryState(
+      { messages: [] },
+      {
+        sessionKey: "global",
+      },
+    );
 
     await loadChatHistory(state);
 
@@ -2572,18 +2564,18 @@ describe("loadChatHistory filtering", () => {
   });
 
   it("uses hello default agent for literal global history before agents list loads", async () => {
-    const request = vi.fn().mockResolvedValue({ messages: [] });
-    const state = createState({
-      sessionKey: "global",
-      hello: {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: [] },
-        snapshot: { sessionDefaults: { defaultAgentId: "ops" } },
+    const { request, state } = createResolvedHistoryState(
+      { messages: [] },
+      {
+        sessionKey: "global",
+        hello: {
+          type: "hello-ok",
+          protocol: 4,
+          auth: { role: "operator", scopes: [] },
+          snapshot: { sessionDefaults: { defaultAgentId: "ops" } },
+        },
       },
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-    });
+    );
 
     await loadChatHistory(state);
 
@@ -2595,15 +2587,15 @@ describe("loadChatHistory filtering", () => {
 
   it("caches global history under the selected agent only", async () => {
     const messages = [{ role: "assistant", content: [{ type: "text", text: "work history" }] }];
-    const request = vi.fn().mockResolvedValue({ messages });
-    const state = createState({
-      sessionKey: "global",
-      assistantAgentId: "work",
-      agentsList: { defaultId: "main" },
-      chatMessagesBySession: new Map(),
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-    });
+    const { state } = createResolvedHistoryState(
+      { messages },
+      {
+        sessionKey: "global",
+        assistantAgentId: "work",
+        agentsList: { defaultId: "main" },
+        chatMessagesBySession: new Map(),
+      },
+    );
 
     await loadChatHistory(state);
 
@@ -2617,21 +2609,18 @@ describe("loadChatHistory filtering", () => {
   });
 
   it("loads startup history with agents in one request", async () => {
-    const request = vi.fn().mockResolvedValue({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "ready" }] }],
-      agentsList: {
-        agents: [{ id: "ops", name: "Ops" }],
-        defaultId: "ops",
-        mainKey: "main",
-        scope: "agent",
+    const { request, state } = createResolvedHistoryState(
+      {
+        messages: [{ role: "assistant", content: [{ type: "text", text: "ready" }] }],
+        agentsList: {
+          agents: [{ id: "ops", name: "Ops" }],
+          defaultId: "ops",
+          mainKey: "main",
+          scope: "agent",
+        },
       },
-    });
-    const state = createState({
-      agentsError: "previous agents.list failure",
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-      sessionKey: "global",
-    });
+      { agentsError: "previous agents.list failure", sessionKey: "global" },
+    );
 
     await loadChatHistory(state, { startup: true });
 
@@ -2647,68 +2636,34 @@ describe("loadChatHistory filtering", () => {
     expect(state.agentsSelectedId).toBe("ops");
   });
 
-  it("coalesces matching startup requests across chat pane states", async () => {
-    const startup = createDeferred<{
-      messages: Array<{ role: string; content: Array<{ type: string; text: string }> }>;
-    }>();
+  it.each([
+    { name: "coalesces matching startup requests across chat pane states", refresh: false },
+    {
+      name: "coalesces overlapping pane startup loads when rendered message arrays change",
+      refresh: true,
+    },
+  ])("$name", async ({ refresh }) => {
+    const startup = createDeferred<HistoryResult>();
     const request = vi.fn(() => startup.promise);
-    const client = { request } as unknown as ChatState["client"];
-    const firstState = createState({
-      client,
-      connected: true,
-      sessionKey: "agent:main:main",
-    });
-    const secondState = createState({
-      client,
-      connected: true,
-      sessionKey: "agent:main:main",
-    });
+    const client = createTestClient(request);
+    const firstState = createHistoryStateForClient(client, { sessionKey: "agent:main:main" });
+    const secondState = createHistoryStateForClient(client, { sessionKey: "agent:main:main" });
 
-    const firstLoad = loadChatHistory(firstState, { startup: true });
-    const secondLoad = loadChatHistory(secondState, { startup: true });
-
-    expect(request).toHaveBeenCalledTimes(1);
-    startup.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "shared" }] }],
-    });
-    await Promise.all([firstLoad, secondLoad]);
-
-    expect(firstState.chatMessages).toEqual([
-      { role: "assistant", content: [{ type: "text", text: "shared" }] },
-    ]);
-    expect(secondState.chatMessages).toEqual(firstState.chatMessages);
-  });
-
-  it("coalesces overlapping pane startup loads when rendered message arrays change", async () => {
-    type StartupResult = {
-      messages: Array<{ role: string; content: Array<{ type: string; text: string }> }>;
-    };
-    const sharedStartup = createDeferred<StartupResult>();
-    const request = vi.fn(() => sharedStartup.promise);
-    const client = { request } as unknown as ChatState["client"];
-    const firstState = createState({
-      client,
-      connected: true,
-      sessionKey: "agent:main:main",
-    });
-    const secondState = createState({
-      client,
-      connected: true,
-      sessionKey: "agent:main:main",
-    });
-
-    const firstSharedLoad = loadChatHistory(firstState, { startup: true });
-    const secondSharedLoad = loadChatHistory(secondState, { startup: true });
-    firstState.chatMessages = [...firstState.chatMessages];
-    const firstFreshLoad = loadChatHistory(firstState, { startup: true });
-    secondState.chatMessages = [...secondState.chatMessages];
-    const secondFreshLoad = loadChatHistory(secondState, { startup: true });
-
-    expect(request).toHaveBeenCalledOnce();
-    sharedStartup.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "shared" }] }],
-    });
-    await Promise.all([firstSharedLoad, secondSharedLoad, firstFreshLoad, secondFreshLoad]);
+    const loads = [
+      loadChatHistory(firstState, { startup: true }),
+      loadChatHistory(secondState, { startup: true }),
+    ];
+    if (refresh) {
+      firstState.chatMessages = [...firstState.chatMessages];
+      loads.push(loadChatHistory(firstState, { startup: true }));
+      secondState.chatMessages = [...secondState.chatMessages];
+      loads.push(loadChatHistory(secondState, { startup: true }));
+      expect(request).toHaveBeenCalledOnce();
+    } else {
+      expect(request).toHaveBeenCalledTimes(1);
+    }
+    startup.resolve(createAssistantHistory("shared"));
+    await Promise.all(loads);
 
     expect(firstState.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "shared" }] },
@@ -2718,17 +2673,9 @@ describe("loadChatHistory filtering", () => {
 
   it("keeps startup requests separate for different pane sessions", async () => {
     const request = vi.fn().mockResolvedValue({ messages: [] });
-    const client = { request } as unknown as ChatState["client"];
-    const firstState = createState({
-      client,
-      connected: true,
-      sessionKey: "agent:main:first",
-    });
-    const secondState = createState({
-      client,
-      connected: true,
-      sessionKey: "agent:main:second",
-    });
+    const client = createTestClient(request);
+    const firstState = createHistoryStateForClient(client, { sessionKey: "agent:main:first" });
+    const secondState = createHistoryStateForClient(client, { sessionKey: "agent:main:second" });
 
     await Promise.all([
       loadChatHistory(firstState, { startup: true }),
@@ -2747,25 +2694,17 @@ describe("loadChatHistory filtering", () => {
   });
 
   it("keeps startup requests separate across pane connection epochs", async () => {
-    const staleStartup = createDeferred<{
-      messages: Array<{ role: string; content: Array<{ type: string; text: string }> }>;
-    }>();
+    const staleStartup = createDeferred<HistoryResult>();
     const request = vi
       .fn()
       .mockImplementationOnce(() => staleStartup.promise)
-      .mockResolvedValueOnce({
-        messages: [{ role: "assistant", content: [{ type: "text", text: "fresh" }] }],
-      });
-    const client = { request } as unknown as ChatState["client"];
-    const staleState = createState({
-      client,
-      connected: true,
+      .mockResolvedValueOnce(createAssistantHistory("fresh"));
+    const client = createTestClient(request);
+    const staleState = createHistoryStateForClient(client, {
       connectionEpoch: 1,
       sessionKey: "agent:main:main",
     });
-    const freshState = createState({
-      client,
-      connected: true,
+    const freshState = createHistoryStateForClient(client, {
       connectionEpoch: 2,
       sessionKey: "agent:main:main",
     });
@@ -2775,9 +2714,7 @@ describe("loadChatHistory filtering", () => {
 
     expect(request).toHaveBeenCalledTimes(2);
     await freshLoad;
-    staleStartup.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "stale" }] }],
-    });
+    staleStartup.resolve(createAssistantHistory("stale"));
     await staleLoad;
 
     expect(freshState.chatMessages).toEqual([
@@ -2786,17 +2723,17 @@ describe("loadChatHistory filtering", () => {
   });
 
   it("falls back to chat.history when startup history is not advertised", async () => {
-    const request = vi.fn().mockResolvedValue({ messages: [] });
-    const state = createState({
-      client: { request } as unknown as ChatState["client"],
-      connected: true,
-      hello: {
-        type: "hello-ok",
-        protocol: 4,
-        auth: { role: "operator", scopes: [] },
-        features: { methods: ["chat.history"], events: [] },
+    const { request, state } = createResolvedHistoryState(
+      { messages: [] },
+      {
+        hello: {
+          type: "hello-ok",
+          protocol: 4,
+          auth: { role: "operator", scopes: [] },
+          features: { methods: ["chat.history"], events: [] },
+        },
       },
-    });
+    );
 
     await loadChatHistory(state, { startup: true });
 
@@ -2809,15 +2746,10 @@ describe("loadChatHistory filtering", () => {
 
 describe("chat send Gateway requests", () => {
   it("clears reconnect resume when history returns a different backing session", async () => {
-    const request = vi.fn().mockResolvedValue({
-      sessionId: "session-after-reconnect",
-      messages: [],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      reconnectResumeSessionId: "session-before-reconnect",
-    });
+    const { state } = createResolvedHistoryState(
+      { sessionId: "session-after-reconnect", messages: [] },
+      { reconnectResumeSessionId: "session-before-reconnect" },
+    );
 
     await loadChatHistory(state);
 
@@ -2836,13 +2768,8 @@ describe("loadChatHistory retry handling", () => {
           message: "unknown method: chat.startup",
         }),
       )
-      .mockResolvedValueOnce({
-        messages: [{ role: "assistant", content: [{ type: "text", text: "fallback" }] }],
-      });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+      .mockResolvedValueOnce(createAssistantHistory("fallback"));
+    const state = createHistoryState(request);
 
     await loadChatHistory(state, { startup: true });
 
@@ -2873,14 +2800,8 @@ describe("loadChatHistory retry handling", () => {
             retryAfterMs: 250,
           }),
         )
-        .mockResolvedValueOnce({
-          messages: [{ role: "assistant", content: [{ type: "text", text: "awake" }] }],
-          thinkingLevel: "low",
-        });
-      const state = createState({
-        connected: true,
-        client: { request } as unknown as ChatState["client"],
-      });
+        .mockResolvedValueOnce(createAssistantHistory("awake", { thinkingLevel: "low" }));
+      const state = createHistoryState(request);
 
       const load = loadChatHistory(state);
       await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
@@ -2925,12 +2846,10 @@ describe("loadChatHistory retry handling", () => {
           }),
         )
         .mockImplementationOnce(() => secondAttempt.promise)
-        .mockResolvedValueOnce({
-          messages: [{ role: "assistant", content: [{ type: "text", text: "awake" }] }],
-        });
-      const client = { request } as unknown as ChatState["client"];
-      const firstState = createState({ client, connected: true });
-      const secondState = createState({ client, connected: true });
+        .mockResolvedValueOnce(createAssistantHistory("awake"));
+      const client = createTestClient(request);
+      const firstState = createHistoryStateForClient(client);
+      const secondState = createHistoryStateForClient(client);
 
       const firstLoad = loadChatHistory(firstState);
       await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
@@ -2955,18 +2874,11 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("filters assistant NO_REPLY messages and keeps user NO_REPLY messages", async () => {
-    const request = vi.fn().mockResolvedValue({
-      messages: [
-        { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
-        { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
-        { role: "user", content: [{ type: "text", text: "NO_REPLY" }] },
-      ],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+    const { request, state } = createHistorySnapshot([
+      { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+      { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
+      { role: "user", content: [{ type: "text", text: "NO_REPLY" }] },
+    ]);
 
     await loadChatHistory(state);
 
@@ -2984,25 +2896,18 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("filters heartbeat acknowledgements and internal-only user messages", async () => {
-    const request = vi.fn().mockResolvedValue({
-      messages: [
-        { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }] },
-        createTextChatMessage(
-          "user",
-          [
-            "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
-            "subagent completion payload",
-            "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
-          ].join("\n"),
-        ),
-        { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
-      ],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+    const { state } = createHistorySnapshot([
+      { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }] },
+      createTextChatMessage(
+        "user",
+        [
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          "subagent completion payload",
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+      ),
+      { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
+    ]);
 
     await loadChatHistory(state);
 
@@ -3129,13 +3034,13 @@ describe("loadChatHistory retry handling", () => {
     },
   ])("$name", async (fixture) => {
     const { history, visible, expected, state: overrides, verify } = fixture.create();
-    const request = vi.fn().mockResolvedValue({ messages: history });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: visible,
-      ...overrides,
-    });
+    const { request, state } = createResolvedHistoryState(
+      { messages: history },
+      {
+        chatMessages: visible,
+        ...overrides,
+      },
+    );
 
     await loadChatHistory(state);
 
@@ -3143,7 +3048,6 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toEqual(expected);
     verify?.(state);
   });
-  type HistoryToolSegment = { text: string; ts: number; toolCallId?: string };
   type RecoveredToolFixture = {
     tools: Record<string, unknown>[];
     persistedCount: number;
@@ -3273,31 +3177,17 @@ describe("loadChatHistory retry handling", () => {
       remainingSegments = [],
     } = fixture.create();
     const persistedUser = createTextChatMessage("user", "latest ask", { seq: 1 });
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, ...tools.slice(0, persistedCount)],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: stream,
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: HistoryToolSegment[];
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = segments;
-    state.chatToolMessages = tools;
-    state.toolStreamById = new Map(
-      tools.map((tool) => [String(tool.toolCallId), { message: tool }]),
+    const state = createLiveToolHistoryState(
+      [persistedUser, ...tools.slice(0, persistedCount)],
+      {
+        chatMessages: [persistedUser],
+        chatRunId: "run-1",
+        chatStream: stream,
+        chatStreamStartedAt: 100,
+      },
+      tools,
+      segments,
     );
-    state.toolStreamOrder = tools.map((tool) => String(tool.toolCallId));
-    state.toolStreamSyncTimer = null;
 
     await loadChatHistory(state);
 
@@ -3340,29 +3230,17 @@ describe("loadChatHistory retry handling", () => {
       runId: "run-1",
       content: [{ type: "toolcall", name: "shell", arguments: {} }],
     };
-    const request = vi.fn().mockResolvedValue({
-      messages: [olderUser, olderToolResult, latestUser],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [olderUser, olderToolResult, latestUser],
-      chatRunId: "run-1",
-      chatStream: "Still answering.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "before current tool", ts: 1 }];
-    state.chatToolMessages = [liveToolMessage];
-    state.toolStreamById = new Map([["call_current", { message: liveToolMessage }]]);
-    state.toolStreamOrder = ["call_current"];
-    state.toolStreamSyncTimer = null;
+    const state = createLiveToolHistoryState(
+      [olderUser, olderToolResult, latestUser],
+      {
+        chatMessages: [olderUser, olderToolResult, latestUser],
+        chatRunId: "run-1",
+        chatStream: "Still answering.",
+        chatStreamStartedAt: 100,
+      },
+      [liveToolMessage],
+      [{ text: "before current tool", ts: 1 }],
+    );
 
     await loadChatHistory(state);
 
@@ -3391,36 +3269,24 @@ describe("loadChatHistory retry handling", () => {
       timestamp: 2,
       __openclaw: { seq: 2 },
     };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, persistedToolCall],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: "Still answering.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
-    state.chatToolMessages = [
+    const state = createLiveToolHistoryState(
+      [persistedUser, persistedToolCall],
       {
-        role: "assistant",
-        toolCallId: "call_1",
-        runId: "run-1",
-        content: [{ type: "toolcall", name: "shell", arguments: {} }],
+        chatMessages: [persistedUser],
+        chatRunId: "run-1",
+        chatStream: "Still answering.",
+        chatStreamStartedAt: 100,
       },
-    ];
-    state.toolStreamById = new Map([["call_1", { message: state.chatToolMessages[0] }]]);
-    state.toolStreamOrder = ["call_1"];
-    state.toolStreamSyncTimer = null;
+      [
+        {
+          role: "assistant",
+          toolCallId: "call_1",
+          runId: "run-1",
+          content: [{ type: "toolcall", name: "shell", arguments: {} }],
+        },
+      ],
+      [{ text: "before tool", ts: 1 }],
+    );
 
     await loadChatHistory(state);
 
@@ -3448,29 +3314,17 @@ describe("loadChatHistory retry handling", () => {
       timestamp: 2,
       __openclaw: { seq: 2 },
     };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, persistedToolResult],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: null,
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
-    state.chatToolMessages = [persistedToolResult];
-    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
-    state.toolStreamOrder = ["call_1"];
-    state.toolStreamSyncTimer = null;
+    const state = createLiveToolHistoryState(
+      [persistedUser, persistedToolResult],
+      {
+        chatMessages: [persistedUser],
+        chatRunId: "run-1",
+        chatStream: null,
+        chatStreamStartedAt: 100,
+      },
+      [persistedToolResult],
+      [{ text: "before tool", ts: 1 }],
+    );
 
     await loadChatHistory(state);
 
@@ -3488,15 +3342,16 @@ describe("loadChatHistory retry handling", () => {
     expect(state.toolStreamOrder).toEqual([]);
   });
 
-  it("materializes orphaned streamed assistant text when history reload is stale", async () => {
-    const persistedUser = createTextChatMessage("user", "first", { seq: 1 });
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
+  it.each([
+    { name: "materializes orphaned streamed assistant text when history reload is stale" },
+    {
+      name: "timestamps materialized streamed text after the persisted user prompt",
+      userTimestamp: 200,
+      verifyTimestamp: true,
+    },
+  ])("$name", async ({ userTimestamp, verifyTimestamp }) => {
+    const persistedUser = createTextChatMessage("user", "first", { seq: 1 }, userTimestamp);
+    const { state } = createHistorySnapshot([persistedUser], {
       chatMessages: [persistedUser],
       chatRunId: null,
       chatStream: "Partial answer before history catch-up.",
@@ -3512,35 +3367,9 @@ describe("loadChatHistory retry handling", () => {
       "assistant",
       "Partial answer before history catch-up.",
     );
-    expect(state.chatStream).toBeNull();
-    expect(state.chatStreamStartedAt).toBeNull();
-  });
-
-  it("timestamps materialized streamed text after the persisted user prompt", async () => {
-    const persistedUser = createTextChatMessage("user", "first", { seq: 1 }, 200);
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: null,
-      chatStream: "Partial answer before history catch-up.",
-      chatStreamStartedAt: 100,
-    });
-
-    await loadChatHistory(state);
-
-    expect(state.chatMessages).toHaveLength(2);
-    expect(state.chatMessages[0]).toEqual(persistedUser);
-    expectTextChatMessage(
-      state.chatMessages[1],
-      "assistant",
-      "Partial answer before history catch-up.",
-    );
-    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(201);
+    if (verifyTimestamp) {
+      expect(requireRecord(state.chatMessages[1]).timestamp).toBe(201);
+    }
     expect(state.chatStream).toBeNull();
     expect(state.chatStreamStartedAt).toBeNull();
   });
@@ -3554,29 +3383,17 @@ describe("loadChatHistory retry handling", () => {
       content: [{ type: "text", text: "tool output" }],
       __openclaw: { seq: 2 },
     };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, persistedToolResult],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: null,
-      chatStream: null,
-      chatStreamStartedAt: null,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
-    state.chatToolMessages = [persistedToolResult];
-    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
-    state.toolStreamOrder = ["call_1"];
-    state.toolStreamSyncTimer = null;
+    const state = createLiveToolHistoryState(
+      [persistedUser, persistedToolResult],
+      {
+        chatMessages: [persistedUser],
+        chatRunId: null,
+        chatStream: null,
+        chatStreamStartedAt: null,
+      },
+      [persistedToolResult],
+      [{ text: "before tool", ts: 1 }],
+    );
 
     await loadChatHistory(state);
 
@@ -3599,13 +3416,7 @@ describe("loadChatHistory retry handling", () => {
       "First visible stream text. More final text.",
       { seq: 2 },
     );
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, historyAssistant],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
+    const { state } = createHistorySnapshot([persistedUser, historyAssistant], {
       chatMessages: [persistedUser],
       chatRunId: "run-1",
       chatStream: "First visible stream text.",
@@ -3632,29 +3443,17 @@ describe("loadChatHistory retry handling", () => {
       runId: "run-1",
       content: [{ type: "toolcall", name: "shell", arguments: {} }],
     };
-    const request = vi.fn().mockResolvedValue({
-      messages: [persistedUser, historyAssistant],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [persistedUser],
-      chatRunId: "run-1",
-      chatStream: "First visible stream text.",
-      chatStreamStartedAt: 100,
-    }) as ChatState & {
-      chatStreamSegments: Array<{ text: string; ts: number }>;
-      chatToolMessages: Record<string, unknown>[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      toolStreamSyncTimer: number | null;
-    };
-    state.chatStreamSegments = [{ text: "First visible stream text.", ts: 90 }];
-    state.chatToolMessages = [liveToolMessage];
-    state.toolStreamById = new Map([["call_current", { message: liveToolMessage }]]);
-    state.toolStreamOrder = ["call_current"];
-    state.toolStreamSyncTimer = null;
+    const state = createLiveToolHistoryState(
+      [persistedUser, historyAssistant],
+      {
+        chatMessages: [persistedUser],
+        chatRunId: "run-1",
+        chatStream: "First visible stream text.",
+        chatStreamStartedAt: 100,
+      },
+      [liveToolMessage],
+      [{ text: "First visible stream text.", ts: 90 }],
+    );
 
     await loadChatHistory(state);
 
@@ -3674,15 +3473,7 @@ describe("loadChatHistory retry handling", () => {
       { idempotencyKey: "pending-run:user" },
       10,
     );
-    const request = vi.fn().mockResolvedValue({
-      messages: [],
-      thinkingLevel: "low",
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [optimisticUser],
-    });
+    const { state } = createHistorySnapshot([], { chatMessages: [optimisticUser] });
 
     await loadChatHistory(state);
 
@@ -3703,14 +3494,10 @@ describe("loadChatHistory retry handling", () => {
       seq: 1,
     });
     const historyAssistant = createTextChatMessage("assistant", "latest answer", { seq: 2 });
-    const request = vi.fn().mockResolvedValue({
-      messages: [historyUser, historyAssistant],
-    });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-      chatMessages: [optimisticUser],
-    });
+    const { state } = createResolvedHistoryState(
+      { messages: [historyUser, historyAssistant] },
+      { chatMessages: [optimisticUser] },
+    );
 
     await loadChatHistory(state);
 
@@ -3725,9 +3512,7 @@ describe("loadChatHistory retry handling", () => {
         details: { code: "AUTH_UNAUTHORIZED" },
       }),
     );
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
+    const state = createHistoryState(request, {
       chatMessages: [{ role: "assistant", content: [{ type: "text", text: "old" }] }],
       chatThinkingLevel: "high",
       chatVerboseLevel: "full",
@@ -3745,21 +3530,13 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("coalesces duplicate in-flight history loads for the selected session", async () => {
-    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
-    const request = vi.fn(() => history.promise);
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+    const { history, request, state } = createDeferredHistoryState();
 
     const firstLoad = loadChatHistory(state);
     const secondLoad = loadChatHistory(state);
 
     expect(request).toHaveBeenCalledTimes(1);
-    history.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "ready" }] }],
-      thinkingLevel: "low",
-    });
+    history.resolve(createAssistantHistory("ready", { thinkingLevel: "low" }));
     await firstLoad;
     await secondLoad;
 
@@ -3771,12 +3548,7 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("preserves a first send appended while the startup history request is in flight", async () => {
-    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
-    const request = vi.fn(() => history.promise);
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+    const { history, request, state } = createDeferredHistoryState();
 
     const load = loadChatHistory(state);
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
@@ -3808,12 +3580,7 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("preserves late assistant messages when startup history only catches up to the user turn", async () => {
-    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
-    const request = vi.fn(() => history.promise);
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+    const { history, request, state } = createDeferredHistoryState();
 
     const load = loadChatHistory(state);
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
@@ -3855,12 +3622,7 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("keeps repeated late prompts when startup history only has an older matching prompt", async () => {
-    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
-    const request = vi.fn(() => history.promise);
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+    const { history, request, state } = createDeferredHistoryState();
 
     const load = loadChatHistory(state);
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
@@ -3895,12 +3657,7 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("coalesces same-session history while a proven pending send changes local messages", async () => {
-    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
-    const request = vi.fn(() => history.promise);
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
-    });
+    const { history, request, state } = createDeferredHistoryState();
 
     const firstLoad = loadChatHistory(state);
     const pending = createTextChatMessage("user", "new local ask", {
@@ -3929,18 +3686,16 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("rejects stale success and cleanup after a same-client reconnect", async () => {
-    const staleRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
-    const freshRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const staleRequest = createDeferred<HistoryResult>();
+    const freshRequest = createDeferred<HistoryResult>();
     const request = vi
       .fn()
       .mockImplementationOnce(() => staleRequest.promise)
       .mockImplementationOnce(() => freshRequest.promise);
-    const client = { request } as unknown as NonNullable<ChatState["client"]>;
+    const client = createTestClient(request);
     const visibleMessage = createTextChatMessage("assistant", "visible before reconnect");
-    const state = createState({
+    const state = createHistoryStateForClient(client, {
       chatMessages: [visibleMessage],
-      client,
-      connected: true,
       connectionEpoch: 1,
     });
 
@@ -3952,20 +3707,14 @@ describe("loadChatHistory retry handling", () => {
     const freshLoad = loadChatHistory(state);
 
     expect(request).toHaveBeenCalledTimes(2);
-    staleRequest.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "stale history" }] }],
-      thinkingLevel: "high",
-    });
+    staleRequest.resolve(createAssistantHistory("stale history", { thinkingLevel: "high" }));
     await staleLoad;
 
     expect(state.chatMessages).toEqual([visibleMessage]);
     expect(state.chatThinkingLevel).toBeNull();
     expect(state.chatLoading).toBe(true);
 
-    freshRequest.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "fresh history" }] }],
-      thinkingLevel: "low",
-    });
+    freshRequest.resolve(createAssistantHistory("fresh history", { thinkingLevel: "low" }));
     await freshLoad;
 
     expect(state.chatMessages).toEqual([
@@ -3976,12 +3725,10 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("rejects stale errors and cleanup after a same-client reconnect", async () => {
-    const staleRequest = createDeferred<{ messages: Array<unknown> }>();
+    const staleRequest = createDeferred<HistoryResult>();
     const request = vi.fn(() => staleRequest.promise);
-    const client = { request } as unknown as NonNullable<ChatState["client"]>;
-    const state = createState({
-      client,
-      connected: true,
+    const client = createTestClient(request);
+    const state = createHistoryStateForClient(client, {
       connectionEpoch: 1,
     });
 
@@ -4002,16 +3749,8 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("ignores stale history responses after switching sessions", async () => {
-    const mainRequest = createDeferred<{
-      messages: Array<unknown>;
-      thinkingLevel?: string;
-      verboseLevel?: string;
-    }>();
-    const otherRequest = createDeferred<{
-      messages: Array<unknown>;
-      thinkingLevel?: string;
-      verboseLevel?: string;
-    }>();
+    const mainRequest = createDeferred<HistoryResult>();
+    const otherRequest = createDeferred<HistoryResult>();
     const request = vi.fn((_method: string, params?: { sessionKey?: string }) => {
       if (params?.sessionKey === "main") {
         return mainRequest.promise;
@@ -4021,9 +3760,7 @@ describe("loadChatHistory retry handling", () => {
       }
       throw new Error(`Unexpected sessionKey: ${String(params?.sessionKey)}`);
     });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
+    const state = createHistoryState(request, {
       chatMessages: [{ role: "assistant", content: [{ type: "text", text: "visible old" }] }],
     });
 
@@ -4031,11 +3768,9 @@ describe("loadChatHistory retry handling", () => {
     state.sessionKey = "other";
     const secondLoad = loadChatHistory(state);
 
-    mainRequest.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "main history" }] }],
-      thinkingLevel: "high",
-      verboseLevel: "full",
-    });
+    mainRequest.resolve(
+      createAssistantHistory("main history", { thinkingLevel: "high", verboseLevel: "full" }),
+    );
     await firstLoad;
 
     expect(state.chatLoading).toBe(true);
@@ -4045,11 +3780,9 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatThinkingLevel).toBeNull();
     expect(state.chatVerboseLevel).toBeNull();
 
-    otherRequest.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "other history" }] }],
-      thinkingLevel: "low",
-      verboseLevel: "full",
-    });
+    otherRequest.resolve(
+      createAssistantHistory("other history", { thinkingLevel: "low", verboseLevel: "full" }),
+    );
     await secondLoad;
 
     expect(state.chatLoading).toBe(false);
@@ -4061,16 +3794,14 @@ describe("loadChatHistory retry handling", () => {
   });
 
   it("ignores stale global history responses after switching selected agents", async () => {
-    const workRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const workRequest = createDeferred<HistoryResult>();
     const request = vi.fn((_method: string, params?: { agentId?: string; sessionKey?: string }) => {
       if (params?.sessionKey === "global" && params.agentId === "work") {
         return workRequest.promise;
       }
       throw new Error(`Unexpected request: ${JSON.stringify(params)}`);
     });
-    const state = createState({
-      connected: true,
-      client: { request } as unknown as ChatState["client"],
+    const state = createHistoryState(request, {
       sessionKey: "global",
       assistantAgentId: "work",
       agentsList: { defaultId: "main" },
@@ -4079,10 +3810,7 @@ describe("loadChatHistory retry handling", () => {
 
     const load = loadChatHistory(state);
     state.assistantAgentId = "main";
-    workRequest.resolve({
-      messages: [{ role: "assistant", content: [{ type: "text", text: "work history" }] }],
-      thinkingLevel: "high",
-    });
+    workRequest.resolve(createAssistantHistory("work history", { thinkingLevel: "high" }));
     await load;
 
     expect(state.chatLoading).toBe(false);

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -3,37 +3,36 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { handleChatGatewayEvent } from "./chat-gateway.ts";
 import { loadChatHistory, type ChatHistoryResult, type ChatState } from "./chat-history.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
 import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
 import { handleAgentEvent, type ToolStreamEntry } from "./tool-stream.ts";
 
 type TestState = ChatState & Parameters<typeof handleAgentEvent>[0];
+type TestSessions = NonNullable<ChatState["sessions"]> &
+  Parameters<typeof handleAgentEvent>[0]["sessions"];
 
 function createState(result: ChatHistoryResult): TestState {
-  return {
-    client: { request: vi.fn().mockResolvedValue(result) } as unknown as GatewayBrowserClient,
-    connected: true,
-    connectionEpoch: 1,
+  const host = makeChatHost({
+    requestHandlers: { "chat.history": result },
     sessionKey: "main",
-    chatLoading: false,
-    chatMessages: [],
+  });
+  const sessions: TestSessions = {
+    setModelOverride: vi.fn(),
+    reconcileRunTerminal: vi.fn(),
+  };
+  return {
+    ...host,
+    chatToolMessages: host.chatToolMessages ?? [],
+    chatStreamSegments: host.chatStreamSegments ?? [],
+    connectionEpoch: 1,
     chatThinkingLevel: null,
     chatVerboseLevel: null,
-    chatSending: false,
-    chatMessage: "",
-    chatAttachments: [],
-    chatQueue: [],
-    chatRunId: null,
-    chatStream: null,
     chatStreamStartedAt: null,
-    chatStreamSegments: [],
-    toolStreamById: new Map<string, ToolStreamEntry>(),
-    toolStreamOrder: [],
-    chatToolMessages: [],
-    toolStreamSyncTimer: null,
     planStatus: null,
-    lastError: null,
-    hello: null,
-    sessions: { setModelOverride: vi.fn(), reconcileRunTerminal: vi.fn() },
+    sessions,
+    toolStreamById: host.toolStreamById ?? new Map<string, ToolStreamEntry>(),
+    toolStreamOrder: host.toolStreamOrder ?? [],
+    toolStreamSyncTimer: host.toolStreamSyncTimer ?? null,
     requestUpdate: vi.fn(),
   };
 }

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -10,6 +10,7 @@ import {
   type ChatHistoryResult,
   type ChatState,
 } from "./chat-history.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
 import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
 import {
   cacheChatSessionSnapshot,
@@ -23,41 +24,31 @@ type TestState = ChatState &
   Parameters<typeof handleAgentEvent>[0] & {
     requestUpdate: () => void;
   };
+type TestSessions = NonNullable<ChatState["sessions"]> &
+  Parameters<typeof handleAgentEvent>[0]["sessions"];
 
 function createState(result: ChatHistoryResult): TestState {
-  const client = {
-    request: vi.fn().mockResolvedValue(result),
-  } as unknown as GatewayBrowserClient;
-  return {
-    client,
-    connected: true,
-    connectionEpoch: 1,
+  const host = makeChatHost({
+    requestHandlers: { "chat.history": result },
     sessionKey: "main",
-    chatLoading: false,
-    chatMessages: [],
+  });
+  const sessions: TestSessions = { setModelOverride: vi.fn() };
+  return {
+    ...host,
+    chatToolMessages: host.chatToolMessages ?? [],
+    chatStreamSegments: host.chatStreamSegments ?? [],
+    connectionEpoch: 1,
     chatThinkingLevel: null,
     chatVerboseLevel: null,
-    chatSending: false,
-    chatMessage: "",
-    chatAttachments: [],
-    chatQueue: [],
-    chatRunId: null,
-    chatStream: null,
     chatStreamStartedAt: null,
-    chatStreamSegments: [],
-    toolStreamById: new Map<string, ToolStreamEntry>(),
-    toolStreamOrder: [],
-    chatToolMessages: [],
-    toolStreamSyncTimer: null,
     planStatus: {
       runId: "stale-run",
       steps: [{ step: "Reset me", status: "in_progress" }],
     },
-    lastError: null,
-    hello: null,
-    sessions: {
-      setModelOverride: vi.fn(),
-    },
+    sessions,
+    toolStreamById: host.toolStreamById ?? new Map<string, ToolStreamEntry>(),
+    toolStreamOrder: host.toolStreamOrder ?? [],
+    toolStreamSyncTimer: host.toolStreamSyncTimer ?? null,
     requestUpdate: vi.fn(),
   };
 }

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -15,6 +15,7 @@ import {
   clearChatComposerMemoryFallback,
   retainChatComposerMemoryFallback,
 } from "./chat-composer-memory-fallback.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
 import {
   admitQueuedMessageForSession,
   removeQueuedMessage,
@@ -71,25 +72,15 @@ describe("canonical session message recovery", () => {
       thinkingLevel: null,
     });
     const state = {
+      ...makeChatHost(),
       client: { request } as unknown as GatewayBrowserClient,
-      connected: true,
       connectionEpoch: 1,
       sessionKey: "agent:main:main",
       currentSessionId: "selected-session",
-      chatLoading: false,
-      chatMessages: [],
       chatMessagesBySession: new Map(),
       chatThinkingLevel: null,
       chatVerboseLevel: null,
-      chatSending: false,
-      chatMessage: "",
-      chatAttachments: [],
-      chatQueue: [],
-      chatRunId: null,
-      chatStream: null,
       chatStreamStartedAt: null,
-      lastError: null,
-      hello: null,
       sessions: {
         reconcileChanged: vi.fn().mockReturnValue({ applied: false }),
         refresh: vi.fn().mockResolvedValue(undefined),
@@ -355,6 +346,83 @@ describe("canonical session message recovery", () => {
 });
 
 describe("ChatStateController render lifecycle", () => {
+  function createObserverState(overrides: Partial<Record<keyof ChatPageHost, unknown>> = {}) {
+    return {
+      sessionKey: "agent:main:current",
+      assistantAgentId: "main",
+      agentsList: { defaultId: "main" },
+      chatRunId: null,
+      observerDigest: null,
+      requestUpdate: vi.fn(),
+      ...overrides,
+    } as unknown as ChatPageHost;
+  }
+
+  function createControllerHost(overrides: Partial<ReactiveControllerHost> = {}) {
+    return {
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate: () => undefined,
+      updateComplete: Promise.resolve(true),
+      ...overrides,
+    } satisfies ReactiveControllerHost;
+  }
+
+  function createInputHistoryState(
+    renderLifecycle: NonNullable<ChatPageHost["renderLifecycle"]>,
+    navigateHistory: ReturnType<typeof vi.fn>,
+  ) {
+    return {
+      settings: undefined,
+      assistantAgentId: null,
+      agentsList: null,
+      hello: null,
+      sessionKey: "agent:main:current",
+      chatLoading: false,
+      chatMessages: [],
+      chatQueue: [],
+      renderLifecycle,
+      handleSendChat: vi.fn().mockResolvedValue(undefined),
+      handleChatDraftChange: vi.fn(),
+      handleChatInputHistoryKey: navigateHistory,
+    } as unknown as ChatPageHost;
+  }
+
+  function createInputHistoryKey(
+    selectionStart: number,
+    selectionEnd: number,
+    valueLength: number,
+  ) {
+    return {
+      key: "ArrowUp" as const,
+      selectionStart,
+      selectionEnd,
+      valueLength,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      keyCode: 0,
+    };
+  }
+
+  function createStreamEventState(overrides: Partial<ChatPageHost> = {}) {
+    return {
+      chatMessages: [],
+      chatMessagesBySession: new Map(),
+      chatRunId: "run-1",
+      chatStream: null,
+      chatStreamRenderFrame: null,
+      chatStreamStartedAt: 1,
+      lastError: null,
+      pendingSessionMessageReloadSessionKey: null,
+      requestUpdate: vi.fn(),
+      sessionKey: "main",
+      ...overrides,
+    } as unknown as ChatPageHost;
+  }
+
   it("keeps the active observer digest when another run streams in the same session", () => {
     const projectedDigest = {
       sessionKey: "agent:main:current",
@@ -364,14 +432,11 @@ describe("ChatStateController render lifecycle", () => {
       headline: "The active run's status",
       health: "on-track" as const,
     };
-    const state = {
+    const state = createObserverState({
       sessionKey: projectedDigest.sessionKey,
-      assistantAgentId: "main",
-      agentsList: { defaultId: "main" },
       chatRunId: "run-1",
       observerDigest: projectedDigest,
-      requestUpdate: vi.fn(),
-    } as unknown as ChatPageHost;
+    });
 
     handlePageGatewayEvent(state, {
       type: "event",
@@ -396,14 +461,12 @@ describe("ChatStateController render lifecycle", () => {
       health: "on-track" as const,
     };
     const requestUpdate = vi.fn();
-    const state = {
+    const state = createObserverState({
       sessionKey: projectedDigest.sessionKey,
-      assistantAgentId: "main",
-      agentsList: { defaultId: "main" },
       chatRunId: "run-1",
       observerDigest: projectedDigest,
       requestUpdate,
-    } as unknown as ChatPageHost;
+    });
 
     handlePageGatewayEvent(state, {
       type: "event",
@@ -431,11 +494,8 @@ describe("ChatStateController render lifecycle", () => {
       health: "on-track" as const,
     };
     const requestUpdate = vi.fn();
-    const state = {
+    const state = createObserverState({
       sessionKey: projectedDigest.sessionKey,
-      assistantAgentId: "main",
-      agentsList: { defaultId: "main" },
-      chatRunId: null,
       observerDigest: projectedDigest,
       sessionsResult: {
         sessions: [
@@ -447,7 +507,7 @@ describe("ChatStateController render lifecycle", () => {
         ],
       },
       requestUpdate,
-    } as unknown as ChatPageHost;
+    });
     const observerEvent = (runId?: string) =>
       ({
         type: "event" as const,
@@ -474,14 +534,13 @@ describe("ChatStateController render lifecycle", () => {
 
   it("accepts global observer digests only from the selected agent", () => {
     const requestUpdate = vi.fn();
-    const state = {
+    const state = createObserverState({
       sessionKey: "global",
       assistantAgentId: "work",
       agentsList: { defaultId: "main", scope: "global" },
       chatRunId: "run-work",
-      observerDigest: null,
       requestUpdate,
-    } as unknown as ChatPageHost;
+    });
     const observerEvent = (agentId: string) =>
       ({
         type: "event" as const,
@@ -508,7 +567,7 @@ describe("ChatStateController render lifecycle", () => {
 
   it("keeps a fresher selected-agent digest when reconnect replays stale global events", () => {
     const requestUpdate = vi.fn();
-    const state = {
+    const state = createObserverState({
       sessionKey: "global",
       assistantAgentId: "work",
       agentsList: { defaultId: "main", scope: "global" },
@@ -523,7 +582,7 @@ describe("ChatStateController render lifecycle", () => {
         health: "grinding" as const,
       },
       requestUpdate,
-    } as unknown as ChatPageHost;
+    });
 
     for (const payload of [
       {
@@ -558,7 +617,7 @@ describe("ChatStateController render lifecycle", () => {
 
   it("reconciles a selected global alias with its scoped canonical row after reconnect", () => {
     const requestUpdate = vi.fn();
-    const state = {
+    const state = createObserverState({
       sessionKey: "agent:work:main",
       assistantAgentId: "work",
       agentsList: { defaultId: "main", mainKey: "main", scope: "global" },
@@ -600,7 +659,7 @@ describe("ChatStateController render lifecycle", () => {
         ],
       },
       requestUpdate,
-    } as unknown as ChatPageHost;
+    });
 
     expect(selectedChatSessionRow(state)?.key).toBe("global");
     handlePageGatewayEvent(state, {
@@ -645,13 +704,13 @@ describe("ChatStateController render lifecycle", () => {
       expectedKey: undefined,
     },
   ])("$name", ({ rows, expectedKey }) => {
-    const state = {
+    const state = createObserverState({
       sessionKey: "agent:work:main",
       assistantAgentId: "work",
       agentsList: { defaultId: "main", mainKey: "main", scope: "per-sender" },
       sessionsResultAgentId: "work",
       sessionsResult: { sessions: rows },
-    } as unknown as ChatPageHost;
+    });
 
     expect(selectedChatSessionRow(state)?.key).toBe(expectedKey);
   });
@@ -732,18 +791,9 @@ describe("ChatStateController render lifecycle", () => {
       frames.delete(id);
     });
     const requestUpdate = vi.fn();
-    const state = {
-      chatMessages: [],
-      chatMessagesBySession: new Map(),
-      chatRunId: "run-1",
-      chatStream: null,
-      chatStreamRenderFrame: null,
-      chatStreamStartedAt: 1,
-      lastError: null,
-      pendingSessionMessageReloadSessionKey: null,
+    const state = createStreamEventState({
       requestUpdate,
-      sessionKey: "main",
-    } as unknown as ChatPageHost;
+    });
 
     for (const deltaText of ["A", "B", "C"]) {
       handlePageGatewayEvent(state, {
@@ -786,18 +836,9 @@ describe("ChatStateController render lifecycle", () => {
       return 1;
     });
     const requestUpdate = vi.fn();
-    const state = {
-      chatMessages: [],
-      chatMessagesBySession: new Map(),
-      chatRunId: "run-1",
-      chatStream: null,
-      chatStreamRenderFrame: null,
-      chatStreamStartedAt: 1,
-      lastError: null,
-      pendingSessionMessageReloadSessionKey: null,
+    const state = createStreamEventState({
       requestUpdate,
-      sessionKey: "main",
-    } as unknown as ChatPageHost;
+    });
 
     for (const deltaText of ["A", "B", "C"]) {
       handlePageGatewayEvent(state, {
@@ -816,19 +857,9 @@ describe("ChatStateController render lifecycle", () => {
   it("forces one PR-chips refresh per PR link seen in the live stream", () => {
     vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation(() => 1);
     const refreshSessionPullRequests = vi.fn(() => Promise.resolve());
-    const state = {
-      chatMessages: [],
-      chatMessagesBySession: new Map(),
-      chatRunId: "run-1",
-      chatStream: null,
-      chatStreamRenderFrame: null,
-      chatStreamStartedAt: 1,
-      lastError: null,
-      pendingSessionMessageReloadSessionKey: null,
+    const state = createStreamEventState({
       refreshSessionPullRequests,
-      requestUpdate: vi.fn(),
-      sessionKey: "main",
-    } as unknown as ChatPageHost;
+    });
     const delta = (deltaText: string, runId = "run-1") =>
       handlePageGatewayEvent(state, {
         type: "event",
@@ -902,12 +933,9 @@ describe("ChatStateController render lifecycle", () => {
     const completion = new Promise<boolean>((resolve) => {
       resolveCommit = resolve;
     });
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
+    const host = createControllerHost({
       updateComplete: completion,
-    } satisfies ReactiveControllerHost;
+    });
     const controller = new ChatStateController<ChatPageHost>(host);
     controller.hostConnected();
     const renderLifecycle = controller.createRenderLifecycle();
@@ -922,12 +950,7 @@ describe("ChatStateController render lifecycle", () => {
   });
 
   it("fully tears down realtime Talk when its state owner disconnects", () => {
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+    const host = createControllerHost();
     const controller = new ChatStateController<ChatPageHost>(host);
     controller.hostConnected();
     const renderLifecycle = controller.createRenderLifecycle();
@@ -984,12 +1007,7 @@ describe("ChatStateController render lifecycle", () => {
   });
 
   it("aborts attachment reads when a pane adopts a different session", () => {
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+    const host = createControllerHost();
     const controller = new ChatStateController<ChatPageHost>(host);
     const previousSignal = controller.attachmentReads.readSignal;
 
@@ -1006,12 +1024,7 @@ describe("ChatStateController render lifecycle", () => {
   });
 
   it("aborts attachment reads when a chat pane disconnects", () => {
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate: () => undefined,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+    const host = createControllerHost();
     const controller = new ChatStateController<ChatPageHost>(host);
     const previousSignal = controller.attachmentReads.readSignal;
 
@@ -1027,12 +1040,7 @@ describe("ChatStateController render lifecycle", () => {
 
   it("rejects lifecycle work from detached and replaced state epochs", async () => {
     const requestUpdate = vi.fn();
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+    const host = createControllerHost({ requestUpdate });
     const controller = new ChatStateController<ChatPageHost>(host);
     controller.hostConnected();
     const first = controller.createRenderLifecycle();
@@ -1078,12 +1086,9 @@ describe("ChatStateController render lifecycle", () => {
       .mockImplementation((id) => {
         frames.delete(id);
       });
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
+    const host = createControllerHost({
       requestUpdate: vi.fn(),
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+    });
     const controller = new ChatStateController<ChatPageHost>(host);
     controller.hostConnected();
     const renderLifecycle = controller.createRenderLifecycle();
@@ -1108,12 +1113,7 @@ describe("ChatStateController render lifecycle", () => {
 
   it("invalidates the render lifecycle when input history recall mutates the draft", () => {
     const requestUpdate = vi.fn();
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+    const host = createControllerHost({ requestUpdate });
     const controller = new ChatStateController<ChatPageHost>(host);
     controller.hostConnected();
     const renderLifecycle = controller.createRenderLifecycle();
@@ -1130,35 +1130,11 @@ describe("ChatStateController render lifecycle", () => {
       valueLength: 10,
     });
 
-    const state = {
-      settings: undefined,
-      assistantAgentId: null,
-      agentsList: null,
-      hello: null,
-      sessionKey: "agent:main:current",
-      chatLoading: false,
-      chatMessages: [],
-      chatQueue: [],
-      renderLifecycle,
-      handleSendChat: vi.fn().mockResolvedValue(undefined),
-      handleChatDraftChange: vi.fn(),
-      handleChatInputHistoryKey: navigateHistory,
-    } as unknown as ChatPageHost;
+    const state = createInputHistoryState(renderLifecycle, navigateHistory);
 
     controller.attach(state);
 
-    const input = {
-      key: "ArrowUp" as const,
-      selectionStart: 0,
-      selectionEnd: 0,
-      valueLength: 0,
-      altKey: false,
-      ctrlKey: false,
-      metaKey: false,
-      shiftKey: false,
-      isComposing: false,
-      keyCode: 0,
-    };
+    const input = createInputHistoryKey(0, 0, 0);
     const result = state.handleChatInputHistoryKey!(input);
 
     expect(result.handled).toBe(true);
@@ -1168,12 +1144,7 @@ describe("ChatStateController render lifecycle", () => {
 
   it("does not invalidate the render lifecycle when input history key is not handled", () => {
     const requestUpdate = vi.fn();
-    const host = {
-      addController: () => undefined,
-      removeController: () => undefined,
-      requestUpdate,
-      updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+    const host = createControllerHost({ requestUpdate });
     const controller = new ChatStateController<ChatPageHost>(host);
     controller.hostConnected();
     const renderLifecycle = controller.createRenderLifecycle();
@@ -1190,35 +1161,11 @@ describe("ChatStateController render lifecycle", () => {
       valueLength: 10,
     });
 
-    const state = {
-      settings: undefined,
-      assistantAgentId: null,
-      agentsList: null,
-      hello: null,
-      sessionKey: "agent:main:current",
-      chatLoading: false,
-      chatMessages: [],
-      chatQueue: [],
-      renderLifecycle,
-      handleSendChat: vi.fn().mockResolvedValue(undefined),
-      handleChatDraftChange: vi.fn(),
-      handleChatInputHistoryKey: navigateHistory,
-    } as unknown as ChatPageHost;
+    const state = createInputHistoryState(renderLifecycle, navigateHistory);
 
     controller.attach(state);
 
-    const input = {
-      key: "ArrowUp" as const,
-      selectionStart: 5,
-      selectionEnd: 5,
-      valueLength: 10,
-      altKey: false,
-      ctrlKey: false,
-      metaKey: false,
-      shiftKey: false,
-      isComposing: false,
-      keyCode: 0,
-    };
+    const input = createInputHistoryKey(5, 5, 10);
     const result = state.handleChatInputHistoryKey!(input);
 
     expect(result.handled).toBe(false);
@@ -1235,24 +1182,15 @@ describe("session pull request refresh", () => {
 
   function createFinalReplyState(refreshSessionPullRequests: ReturnType<typeof vi.fn>) {
     return {
-      chatComposerFallbackByScope: {},
-      chatMessages: [],
+      ...makeChatHost(),
       chatMessagesBySession: new Map(),
-      chatQueue: [],
-      chatRunId: null,
-      chatStream: null,
       chatStreamRenderFrame: null,
-      chatStreamSegments: [],
-      chatToolMessages: [],
-      lastError: null,
       pendingSessionMessageReloadSessionKey: null,
       refreshSessionPullRequests,
       requestUpdate: vi.fn(),
       sessionKey: "main",
       sessions: { reconcileRunTerminal: vi.fn() },
       settings: {},
-      toolStreamById: new Map(),
-      toolStreamOrder: [],
     } as unknown as ChatPageHost;
   }
 
@@ -1368,31 +1306,24 @@ describe("route composer fallback", () => {
     const resetChatInputHistoryNavigation = vi.fn();
     const resetChatScroll = vi.fn();
     const state = {
+      ...makeChatHost({
+        assistantAgentId: "main",
+        agentsList: { defaultId: "main", mainKey: "main" },
+        sessionKey: "agent:main:first",
+        chatMessage,
+        chatAttachments: [
+          {
+            id: "staged-image",
+            mimeType: "image/png",
+            dataUrl: "data:image/png;base64,AAA",
+          },
+        ],
+      }),
       settings: { gatewayUrl: "ws://gateway.test/control" },
-      assistantAgentId: "main",
-      agentsList: { defaultId: "main", mainKey: "main" },
-      hello: null,
       initialUserMessage: createInitialUserMessageHandoff(),
-      sessionKey: "agent:main:first",
-      chatMessage,
-      chatComposerFallbackByScope: {},
-      chatQueue: [],
-      chatMessages: [],
       chatMessagesBySession: new Map(),
       imageLightbox: null,
       imageLightboxRequestVersion: 0,
-      chatAttachments: [
-        {
-          id: "staged-image",
-          mimeType: "image/png",
-          dataUrl: "data:image/png;base64,AAA",
-        },
-      ],
-      chatToolMessages: [],
-      chatStreamSegments: [],
-      toolStreamById: new Map(),
-      toolStreamOrder: [],
-      sessionsResult: null,
       ...createInitialChatRealtimeState(),
       resetChatInputHistoryNavigation,
       resetChatScroll,
@@ -2404,13 +2335,10 @@ describe("refreshChatMetadata", () => {
     } = {},
   ): ChatPageHost {
     return {
+      ...makeChatHost(),
       agentsList: null,
       assistantAgentId: "main",
-      chatMetadataRequestVersion: 0,
-      chatModelCatalog: [],
-      chatModelsLoading: false,
       client: { request },
-      connected: true,
       hello: { features: { methods: ["chat.metadata"] } },
       sessionKey: "agent:work:main",
       ...overrides,

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -62,6 +62,7 @@ describe("persistedMessageEntryId", () => {
 });
 
 type CachedChatItemsProps = Parameters<typeof buildCachedChatItems>[0];
+type ChatQueueItem = NonNullable<CachedChatItemsProps["queue"]>[number];
 type WorkGroupItem = Extract<
   ReturnType<typeof collapseCompletedTurnWork>[number],
   { kind: "work-group" }
@@ -84,6 +85,107 @@ function createProps(overrides: Partial<CachedChatItemsProps> = {}): CachedChatI
     showToolCalls: true,
     ...overrides,
   };
+}
+
+function chatMessage(
+  role: string,
+  content: unknown,
+  timestamp?: number,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    role,
+    content,
+    ...(timestamp === undefined ? {} : { timestamp }),
+    ...overrides,
+  };
+}
+
+function userMessage(
+  content: unknown,
+  timestamp?: number,
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return chatMessage("user", content, timestamp, overrides);
+}
+
+function assistantMessage(
+  content: unknown,
+  timestamp?: number,
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return chatMessage("assistant", content, timestamp, overrides);
+}
+
+function toolUseMessage(
+  id: string,
+  name: string,
+  input: unknown,
+  timestamp: number,
+): Record<string, unknown> {
+  return assistantMessage([{ type: "tool_use", id, name, input }], timestamp);
+}
+
+function toolResultMessage(
+  toolCallId: string,
+  toolName: string,
+  content: unknown,
+  timestamp: number,
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return chatMessage("toolResult", content, timestamp, { toolCallId, toolName, ...overrides });
+}
+
+function toolMessage(
+  toolCallId: string,
+  toolName: string,
+  content: unknown,
+  timestamp: number,
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return chatMessage("tool", content, timestamp, { toolCallId, toolName, ...overrides });
+}
+
+function queuedSend(
+  id: string,
+  text: string,
+  createdAt: number,
+  sendState: ChatQueueItem["sendState"],
+  overrides: Partial<ChatQueueItem> = {},
+): ChatQueueItem {
+  return { id, text, createdAt, sendState, ...overrides };
+}
+
+function compactionMessage(id: string, metrics: Record<string, unknown> = {}) {
+  return {
+    role: "system",
+    timestamp: 2_000,
+    __openclaw: { kind: "compaction", id, ...metrics },
+  };
+}
+
+function canvasToolOutput(viewId: string, title: string, preferredHeight: number): string {
+  return JSON.stringify({
+    kind: "canvas",
+    view: {
+      backend: "canvas",
+      id: viewId,
+      url: `/__openclaw__/canvas/documents/${viewId}/index.html`,
+      title,
+      preferred_height: preferredHeight,
+    },
+    presentation: { target: "assistant_message" },
+  });
+}
+
+function commentaryMessage(content: string, timestamp: number, itemId: string) {
+  return assistantMessage(content, timestamp, {
+    openclawStreamFallback: {
+      replacementText: content,
+      source: "segment",
+      itemId,
+    },
+  });
 }
 
 function messageGroups(props: Partial<CachedChatItemsProps>): MessageGroup[] {
@@ -122,10 +224,7 @@ describe("assistant commentary grouping", () => {
     // Stable transcript rows must stay in insertion order; only tool/stream
     // items get reordered by timestamp.
     const groups = messageGroups({
-      messages: [
-        { role: "user", content: "User prompt", timestamp: 2_000 },
-        { role: "assistant", content: "Server reply.", timestamp: 1_000 },
-      ],
+      messages: [userMessage("User prompt", 2_000), assistantMessage("Server reply.", 1_000)],
     });
 
     expect(groups.map((group) => group.role)).toEqual(["user", "assistant"]);
@@ -133,15 +232,10 @@ describe("assistant commentary grouping", () => {
 
   it("keeps a skewed live tool below its user boundary when it becomes stable", () => {
     const paneId = "clock-skew-tool-transition";
-    const user = { role: "user", content: "User prompt", timestamp: 2_000 };
-    const tool = {
-      role: "toolResult",
+    const user = userMessage("User prompt", 2_000);
+    const tool = toolResultMessage("call-clock-skew", "shell", "Tool output", 1_000, {
       runId: "run-active",
-      toolCallId: "call-clock-skew",
-      toolName: "shell",
-      content: "Tool output",
-      timestamp: 1_000,
-    };
+    });
     const liveGroups = messageGroups({
       paneId,
       runId: "run-active",
@@ -157,36 +251,20 @@ describe("assistant commentary grouping", () => {
 
   it("keeps current live work above a future queued user turn when it becomes stable", () => {
     const paneId = "clock-skew-future-queue-transition";
-    const activeUser = {
-      role: "user",
-      content: "Active prompt",
-      timestamp: 2_000,
+    const activeUser = userMessage("Active prompt", 2_000, {
       __openclaw: { idempotencyKey: "run-active:user" },
-    };
-    const liveTool = {
-      role: "toolResult",
+    });
+    const liveTool = toolResultMessage("call-active", "shell", "Current tool output", 1_000, {
       runId: "run-active",
-      toolCallId: "call-active",
-      toolName: "shell",
-      content: "Current tool output",
-      timestamp: 1_000,
-    };
-    const activeSend = {
-      id: "active-send",
-      text: "Active prompt",
-      createdAt: 2_000,
+    });
+    const activeSend = queuedSend("active-send", "Active prompt", 2_000, "waiting-model", {
       sendRunId: "run-active",
       sendSubmittedAtMs: 10,
-      sendState: "waiting-model" as const,
-    };
-    const futureSend = {
-      id: "future-send",
-      text: "Future prompt",
-      createdAt: 3_000,
+    });
+    const futureSend = queuedSend("future-send", "Future prompt", 3_000, "waiting-reconnect", {
       sendAttempts: 1,
       sendRunId: "run-future",
-      sendState: "waiting-reconnect" as const,
-    };
+    });
     const liveGroups = messageGroups({
       paneId,
       runId: "run-active",
@@ -207,28 +285,17 @@ describe("assistant commentary grouping", () => {
 
   it("keeps an active stream above a future queued user turn when it becomes stable", () => {
     const paneId = "clock-skew-stream-queue-transition";
-    const activeUser = {
-      role: "user",
-      content: "Active prompt",
-      timestamp: 2_000,
+    const activeUser = userMessage("Active prompt", 2_000, {
       __openclaw: { idempotencyKey: "run-active:user" },
-    };
-    const activeSend = {
-      id: "active-send",
-      text: "Active prompt",
-      createdAt: 2_000,
+    });
+    const activeSend = queuedSend("active-send", "Active prompt", 2_000, "waiting-model", {
       sendRunId: "run-active",
       sendSubmittedAtMs: 10,
-      sendState: "waiting-model" as const,
-    };
-    const futureSend = {
-      id: "future-send",
-      text: "Future prompt",
-      createdAt: 3_000,
+    });
+    const futureSend = queuedSend("future-send", "Future prompt", 3_000, "waiting-reconnect", {
       sendAttempts: 1,
       sendRunId: "run-future",
-      sendState: "waiting-reconnect" as const,
-    };
+    });
     const liveItems = buildCachedChatItems(
       createProps({
         paneId,
@@ -240,10 +307,7 @@ describe("assistant commentary grouping", () => {
     const stableItems = buildCachedChatItems(
       createProps({
         paneId,
-        messages: [
-          activeUser,
-          { role: "assistant", content: "Current partial reply", timestamp: 1_000 },
-        ],
+        messages: [activeUser, assistantMessage("Current partial reply", 1_000)],
         queue: [futureSend],
       }),
     );
@@ -259,7 +323,7 @@ describe("assistant commentary grouping", () => {
     const items = buildCachedChatItems(
       createProps({
         runId: "run-active",
-        messages: [{ role: "user", content: "Current prompt", timestamp: 2_000 }],
+        messages: [userMessage("Current prompt", 2_000)],
         streamSegments: [{ text: "Current progress", ts: 1_000, runId: "run-active" }],
       }),
     );
@@ -275,33 +339,22 @@ describe("assistant commentary grouping", () => {
       createProps({
         runId: "run-current",
         messages: [
-          {
-            role: "user",
-            content: "Earlier prompt",
-            timestamp: 1_000,
+          userMessage("Earlier prompt", 1_000, {
             __openclaw: { idempotencyKey: "run-earlier:user" },
-          },
-          { role: "assistant", content: "Earlier reply", timestamp: 1_300 },
-          {
-            role: "user",
-            content: "Current prompt",
-            timestamp: 2_000,
+          }),
+          assistantMessage("Earlier reply", 1_300),
+          userMessage("Current prompt", 2_000, {
             __openclaw: { idempotencyKey: "run-current:user" },
-          },
+          }),
         ],
         streamSegments: [
           { text: "Earlier commentary", ts: 500, runId: "run-earlier", itemId: "earlier" },
           { text: "Current commentary", ts: 1_200, runId: "run-current", itemId: "current" },
         ],
         toolMessages: [
-          {
-            role: "toolResult",
+          toolResultMessage("call-earlier", "shell", "Earlier tool output", 3_000, {
             runId: "run-earlier",
-            toolCallId: "call-earlier",
-            toolName: "shell",
-            content: "Earlier tool output",
-            timestamp: 3_000,
-          },
+          }),
         ],
       }),
     );
@@ -321,21 +374,16 @@ describe("assistant commentary grouping", () => {
       createProps({
         runId: "run-current",
         messages: [
-          { role: "user", content: "First prompt", timestamp: 1_000 },
-          { role: "assistant", content: "First reply", timestamp: 1_300 },
-          { role: "user", content: "Second prompt", timestamp: 2_000 },
-          { role: "assistant", content: "Second reply", timestamp: 2_300 },
-          { role: "user", content: "Current prompt", timestamp: 3_000 },
+          userMessage("First prompt", 1_000),
+          assistantMessage("First reply", 1_300),
+          userMessage("Second prompt", 2_000),
+          assistantMessage("Second reply", 2_300),
+          userMessage("Current prompt", 3_000),
         ],
         toolMessages: [
-          {
-            role: "toolResult",
+          toolResultMessage("call-legacy", "shell", "Legacy tool output", 1_100, {
             runId: "legacy-unmatched-run",
-            toolCallId: "call-legacy",
-            toolName: "shell",
-            content: "Legacy tool output",
-            timestamp: 1_100,
-          },
+          }),
         ],
       }),
     );
@@ -352,14 +400,16 @@ describe("assistant commentary grouping", () => {
 
   it("keeps a reconnecting current prompt above its retained stream", () => {
     const paneId = "clock-skew-reconnecting-current-turn";
-    const reconnectingSend = {
-      id: "reconnecting-send",
-      text: "Current prompt",
-      createdAt: 2_000,
-      sendAttempts: 1,
-      sendRunId: "run-active",
-      sendState: "waiting-reconnect" as const,
-    };
+    const reconnectingSend = queuedSend(
+      "reconnecting-send",
+      "Current prompt",
+      2_000,
+      "waiting-reconnect",
+      {
+        sendAttempts: 1,
+        sendRunId: "run-active",
+      },
+    );
     const items = buildCachedChatItems(
       createProps({
         paneId,
@@ -378,14 +428,16 @@ describe("assistant commentary grouping", () => {
   });
 
   it("keeps a restored reconnect prompt above its active server tool projection", () => {
-    const reconnectingSend = {
-      id: "reconnecting-send",
-      text: "Current prompt",
-      createdAt: 2_000,
-      sendAttempts: 1,
-      sendRunId: "run-restored",
-      sendState: "waiting-reconnect" as const,
-    };
+    const reconnectingSend = queuedSend(
+      "reconnecting-send",
+      "Current prompt",
+      2_000,
+      "waiting-reconnect",
+      {
+        sendAttempts: 1,
+        sendRunId: "run-restored",
+      },
+    );
     const runId = resolveChatProjectionRunId({
       activeRunIds: ["run-restored"],
       queue: [reconnectingSend],
@@ -395,14 +447,9 @@ describe("assistant commentary grouping", () => {
         runId,
         queue: [reconnectingSend],
         toolMessages: [
-          {
-            role: "toolResult",
+          toolResultMessage("call-restored", "shell", "Restored tool output", 1_000, {
             runId: "run-restored",
-            toolCallId: "call-restored",
-            toolName: "shell",
-            content: "Restored tool output",
-            timestamp: 1_000,
-          },
+          }),
         ],
       }),
     );
@@ -416,17 +463,13 @@ describe("assistant commentary grouping", () => {
   it("keeps a queued current prompt before a terminal delivered ahead of its ACK", () => {
     const paneId = "terminal-before-send-ack";
     const terminal = rememberLiveTerminalRun(
-      { role: "assistant", content: "Terminal reply", timestamp: 1_000 },
+      assistantMessage("Terminal reply", 1_000),
       "run-active",
     );
-    const sending = {
-      id: "sending-current",
-      text: "Current prompt",
-      createdAt: 2_000,
+    const sending = queuedSend("sending-current", "Current prompt", 2_000, "sending", {
       sendAttempts: 1,
       sendRunId: "run-active",
-      sendState: "sending" as const,
-    };
+    });
     const liveItems = buildCachedChatItems(
       createProps({ paneId, runId: "run-active", messages: [terminal], queue: [sending] }),
     );
@@ -434,12 +477,9 @@ describe("assistant commentary grouping", () => {
       createProps({
         paneId,
         messages: [
-          {
-            role: "user",
-            content: "Current prompt",
-            timestamp: 2_000,
+          userMessage("Current prompt", 2_000, {
             __openclaw: { idempotencyKey: "run-active:user" },
-          },
+          }),
           terminal,
         ],
       }),
@@ -455,28 +495,10 @@ describe("assistant commentary grouping", () => {
   it("keeps keyed commentary separate from the terminal assistant reply", () => {
     const groups = messageGroups({
       messages: [
-        { role: "user", content: "do it", timestamp: 1_000 },
-        {
-          role: "assistant",
-          content: "Checking the workspace.",
-          timestamp: 2_000,
-          openclawStreamFallback: {
-            replacementText: "Checking the workspace.",
-            source: "segment",
-            itemId: "preamble-1",
-          },
-        },
-        {
-          role: "assistant",
-          content: "Inspecting the result.",
-          timestamp: 3_000,
-          openclawStreamFallback: {
-            replacementText: "Inspecting the result.",
-            source: "segment",
-            itemId: "preamble-2",
-          },
-        },
-        { role: "assistant", content: "All done.", timestamp: 4_000 },
+        userMessage("do it", 1_000),
+        commentaryMessage("Checking the workspace.", 2_000, "preamble-1"),
+        commentaryMessage("Inspecting the result.", 3_000, "preamble-2"),
+        assistantMessage("All done.", 4_000),
       ],
     });
 
@@ -488,18 +510,9 @@ describe("assistant commentary grouping", () => {
   it("hides durable commentary when the display preference is disabled", () => {
     const paneId = "commentary-visibility";
     const messages = [
-      { role: "user", content: "do it", timestamp: 1_000 },
-      {
-        role: "assistant",
-        content: "Checking the workspace.",
-        timestamp: 2_000,
-        openclawStreamFallback: {
-          replacementText: "Checking the workspace.",
-          source: "segment",
-          itemId: "preamble-1",
-        },
-      },
-      { role: "assistant", content: "All done.", timestamp: 3_000 },
+      userMessage("do it", 1_000),
+      commentaryMessage("Checking the workspace.", 2_000, "preamble-1"),
+      assistantMessage("All done.", 3_000),
     ];
 
     const visible = buildCachedChatItems(createProps({ paneId, messages }));
@@ -541,10 +554,10 @@ describe("collapseCompletedTurnWork", () => {
   it("collapses a completed turn's work behind one worked-for rollup", () => {
     const items = collapsedItems({
       messages: [
-        { role: "user", content: "do it", timestamp: 1_000 },
-        { role: "assistant", content: "Checking…", timestamp: 2_000 },
+        userMessage("do it", 1_000),
+        assistantMessage("Checking…", 2_000),
         toolResult("call-1", 3_000),
-        { role: "assistant", content: "All done.", timestamp: 10_000 },
+        assistantMessage("All done.", 10_000),
       ],
     });
 
@@ -567,10 +580,10 @@ describe("collapseCompletedTurnWork", () => {
         createProps({
           sessionKey,
           messages: [
-            { role: "user", content: "do it", timestamp: 1_000 },
-            { role: "assistant", content: "Checking…", timestamp: 2_000 },
+            userMessage("do it", 1_000),
+            assistantMessage("Checking…", 2_000),
             toolResult("call-1", 3_000),
-            { role: "assistant", content: "All done.", timestamp: 10_000 },
+            assistantMessage("All done.", 10_000),
           ],
         }),
       ),
@@ -585,10 +598,7 @@ describe("collapseCompletedTurnWork", () => {
     const items = collapsedItems(
       {
         runWorking: true,
-        messages: [
-          { role: "user", content: "do it", timestamp: 1_000 },
-          toolResult("call-1", 2_000),
-        ],
+        messages: [userMessage("do it", 1_000), toolResult("call-1", 2_000)],
       },
       true,
     );
@@ -597,10 +607,7 @@ describe("collapseCompletedTurnWork", () => {
   });
 
   it("keeps reply-less turns expanded after the run finishes", () => {
-    const messages = [
-      { role: "user", content: "do it", timestamp: 1_000 },
-      toolResult("call-1", 2_000),
-    ];
+    const messages = [userMessage("do it", 1_000), toolResult("call-1", 2_000)];
 
     // A reply-less executing turn stays expanded while live and remains visible
     // after completion instead of becoming an opaque worked-for rollup.
@@ -615,10 +622,7 @@ describe("collapseCompletedTurnWork", () => {
 
   it("keeps failed work visible in turns that never replied", () => {
     const items = collapsedItems({
-      messages: [
-        { role: "user", content: "go", timestamp: 1_000 },
-        toolResult("call-1", 2_000, true),
-      ],
+      messages: [userMessage("go", 1_000), toolResult("call-1", 2_000, true)],
     });
 
     expect(items.map((item) => item.kind)).toEqual(["group", "group"]);
@@ -628,9 +632,9 @@ describe("collapseCompletedTurnWork", () => {
   it("does not flag errors once the turn recovered with a reply", () => {
     const items = collapsedItems({
       messages: [
-        { role: "user", content: "go", timestamp: 1_000 },
+        userMessage("go", 1_000),
         toolResult("call-1", 2_000, true),
-        { role: "assistant", content: "Recovered via another route.", timestamp: 3_000 },
+        assistantMessage("Recovered via another route.", 3_000),
       ],
     });
 
@@ -640,9 +644,9 @@ describe("collapseCompletedTurnWork", () => {
   it("keeps work after the final reply visible", () => {
     const items = collapsedItems({
       messages: [
-        { role: "user", content: "go", timestamp: 1_000 },
+        userMessage("go", 1_000),
         toolResult("call-1", 2_000),
-        { role: "assistant", content: "Done.", timestamp: 3_000 },
+        assistantMessage("Done.", 3_000),
         toolResult("call-2", 4_000),
       ],
     });
@@ -654,7 +658,7 @@ describe("collapseCompletedTurnWork", () => {
   it("does not collapse across dividers", () => {
     const items = collapsedItems({
       messages: [
-        { role: "user", content: "go", timestamp: 1_000 },
+        userMessage("go", 1_000),
         toolResult("call-1", 2_000),
         {
           role: "system",
@@ -662,7 +666,7 @@ describe("collapseCompletedTurnWork", () => {
           timestamp: 3_000,
           __openclaw: { kind: "compaction", id: "c1" },
         },
-        { role: "assistant", content: "Done.", timestamp: 4_000 },
+        assistantMessage("Done.", 4_000),
       ],
     });
 
@@ -673,19 +677,18 @@ describe("collapseCompletedTurnWork", () => {
   it("keeps attachment-only final replies outside the work rollup", () => {
     const items = collapsedItems({
       messages: [
-        { role: "user", content: "render it", timestamp: 1_000 },
+        userMessage("render it", 1_000),
         toolResult("call-1", 2_000),
-        {
-          role: "assistant",
-          content: [
+        assistantMessage(
+          [
             {
               type: "image",
               url: "/media/screenshot.png",
               source: { type: "url", url: "/media/screenshot.png" },
             },
           ],
-          timestamp: 3_000,
-        },
+          3_000,
+        ),
       ],
     });
 
@@ -699,9 +702,9 @@ describe("collapseCompletedTurnWork", () => {
         buildCachedChatItems(
           createProps({
             messages: [
-              { role: "user", content: "do it", timestamp: 1_000 },
+              userMessage("do it", 1_000),
               toolResult("call-1", 2_000),
-              { role: "assistant", content: "All done.", timestamp: 3_000 },
+              assistantMessage("All done.", 3_000),
             ],
             searchOpen: true,
             searchQuery: "ok",
@@ -721,12 +724,12 @@ describe("collapseCompletedTurnWork", () => {
   it("collapses each completed turn independently", () => {
     const items = collapsedItems({
       messages: [
-        { role: "user", content: "first", timestamp: 1_000 },
+        userMessage("first", 1_000),
         toolResult("call-1", 2_000),
-        { role: "assistant", content: "First done.", timestamp: 3_000 },
-        { role: "user", content: "second", timestamp: 4_000 },
+        assistantMessage("First done.", 3_000),
+        userMessage("second", 4_000),
         toolResult("call-2", 5_000),
-        { role: "assistant", content: "Second done.", timestamp: 6_000 },
+        assistantMessage("Second done.", 6_000),
       ],
     });
 
@@ -742,22 +745,16 @@ describe("collapseCompletedTurnWork", () => {
           ...toolResult("call-1", 1_000),
           __openclaw: { id: "work-1", seq: 1, turnBoundary: true },
         },
-        {
-          role: "assistant",
-          content: "First run done.",
-          timestamp: 3_000,
+        assistantMessage("First run done.", 3_000, {
           __openclaw: { id: "reply-1", seq: 2 },
-        },
+        }),
         {
           ...toolResult("call-2", 4_000),
           __openclaw: { id: "work-2", seq: 3, turnBoundary: true },
         },
-        {
-          role: "assistant",
-          content: "Second run done.",
-          timestamp: 9_000,
+        assistantMessage("Second run done.", 9_000, {
           __openclaw: { id: "reply-2", seq: 4 },
-        },
+        }),
       ],
     });
 
@@ -768,12 +765,9 @@ describe("collapseCompletedTurnWork", () => {
 
   it("keeps a completed-work row keyed to its final reply as older work is prepended", () => {
     resetChatThreadState();
-    const finalReply = {
+    const finalReply = assistantMessage("Done.", 3_000, {
       __openclaw: { id: "final-reply", seq: 3 },
-      role: "assistant",
-      content: "Done.",
-      timestamp: 3_000,
-    };
+    });
     const initial = collapsedItems({
       messages: [toolResult("call-1", 2_000), finalReply],
     });
@@ -781,12 +775,9 @@ describe("collapseCompletedTurnWork", () => {
 
     const prepended = collapsedItems({
       messages: [
-        {
+        assistantMessage("Checking.", 1_000, {
           __openclaw: { id: "older-commentary", seq: 1 },
-          role: "assistant",
-          content: "Checking.",
-          timestamp: 1_000,
-        },
+        }),
         toolResult("call-1", 2_000),
         finalReply,
       ],
@@ -1302,7 +1293,7 @@ describe("buildCachedChatItems working spark", () => {
       hasReadingIndicator({
         runWorking: true,
         loading: true,
-        messages: [{ role: "assistant", content: "answer", timestamp: 1 }],
+        messages: [assistantMessage("answer", 1)],
       }),
     ).toBe(true);
   });
@@ -1347,20 +1338,14 @@ describe("buildCachedChatItems", () => {
   it("keeps consecutive user messages from different senders in separate groups", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "user",
-          content: "first",
+        userMessage("first", 1000, {
           senderLabel: "Iris",
           __openclaw: { senderId: "iris", senderName: "Iris" },
-          timestamp: 1000,
-        },
-        {
-          role: "user",
-          content: "second",
+        }),
+        userMessage("second", 1001, {
           senderLabel: "Joaquin De Rojas",
           __openclaw: { senderId: "joaquin", senderName: "Joaquin De Rojas" },
-          timestamp: 1001,
-        },
+        }),
       ],
     });
 
@@ -1392,21 +1377,15 @@ describe("buildCachedChatItems", () => {
   it("attributes assistant groups to the latest user in multi-sender threads", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "user",
-          content: "Alice asks",
+        userMessage("Alice asks", 1000, {
           __openclaw: { senderId: "alice", senderName: "Alice" },
-          timestamp: 1000,
-        },
-        { role: "assistant", content: "For Alice", timestamp: 1001 },
-        {
-          role: "user",
-          content: "Bob asks",
+        }),
+        assistantMessage("For Alice", 1001),
+        userMessage("Bob asks", 1002, {
           __openclaw: { senderId: "bob", senderName: "Bob" },
-          timestamp: 1002,
-        },
-        { role: "user", content: "Local follow-up", timestamp: 1003 },
-        { role: "assistant", content: "For Bob", timestamp: 1004 },
+        }),
+        userMessage("Local follow-up", 1003),
+        assistantMessage("For Bob", 1004),
       ],
     });
 
@@ -1420,13 +1399,10 @@ describe("buildCachedChatItems", () => {
   it("does not add reply attribution in a single-sender thread", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "user",
-          content: "Alice asks",
+        userMessage("Alice asks", 1000, {
           __openclaw: { senderId: "alice", senderName: "Alice" },
-          timestamp: 1000,
-        },
-        { role: "assistant", content: "For Alice", timestamp: 1001 },
+        }),
+        assistantMessage("For Alice", 1001),
       ],
     });
 
@@ -1474,17 +1450,10 @@ describe("buildCachedChatItems", () => {
   it("keeps forwarded assistant display messages separate from local assistant replies", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: "local reply",
-          timestamp: 1000,
-        },
-        {
-          role: "assistant",
-          content: "forwarded report",
+        assistantMessage("local reply", 1000),
+        assistantMessage("forwarded report", 1001, {
           senderLabel: "Forwarded from main",
-          timestamp: 1001,
-        },
+        }),
       ],
     });
 
@@ -1495,25 +1464,15 @@ describe("buildCachedChatItems", () => {
   it("marks earlier tool groups as succeeded when the same turn has an assistant reply", () => {
     const groups = messageGroups({
       messages: [
-        { role: "user", content: "search", timestamp: 1000 },
-        {
-          role: "toolResult",
-          toolCallId: "call-1",
-          toolName: "web_search",
+        userMessage("search", 1000),
+        toolResultMessage("call-1", "web_search", JSON.stringify({ error: "No matches" }), 1001, {
           isError: true,
-          content: JSON.stringify({ error: "No matches" }),
-          timestamp: 1001,
-        },
-        { role: "assistant", content: "I found another route.", timestamp: 1002 },
-        { role: "user", content: "again", timestamp: 1003 },
-        {
-          role: "toolResult",
-          toolCallId: "call-2",
-          toolName: "web_search",
+        }),
+        assistantMessage("I found another route.", 1002),
+        userMessage("again", 1003),
+        toolResultMessage("call-2", "web_search", JSON.stringify({ error: "No matches" }), 1004, {
           isError: true,
-          content: JSON.stringify({ error: "No matches" }),
-          timestamp: 1004,
-        },
+        }),
       ],
     });
 
@@ -1524,29 +1483,17 @@ describe("buildCachedChatItems", () => {
   it("coalesces adjacent tool calls and results into one activity item", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_use",
-              id: "call-shell",
-              name: "bash",
-              input: { command: "run openclaw doctor" },
-            },
-          ],
-          timestamp: 1000,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-shell",
-          toolName: "bash",
-          content: [
+        toolUseMessage("call-shell", "bash", { command: "run openclaw doctor" }, 1000),
+        toolResultMessage(
+          "call-shell",
+          "bash",
+          [
             { type: "text", text: "Doctor complete" },
             { type: "image", data: "fixture-image", mimeType: "image/png" },
           ],
-          isError: false,
-          timestamp: 1001,
-        },
+          1001,
+          { isError: false },
+        ),
       ],
     });
 
@@ -1570,30 +1517,10 @@ describe("buildCachedChatItems", () => {
   it("coalesces interleaved parallel call/result pairs by call id", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-a", name: "read", input: { path: "a.ts" } }],
-          timestamp: 1000,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-b", name: "read", input: { path: "b.ts" } }],
-          timestamp: 1001,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-a",
-          toolName: "read",
-          content: [{ type: "toolResult", text: "contents of a" }],
-          timestamp: 1002,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-b",
-          toolName: "read",
-          content: [{ type: "toolResult", text: "contents of b" }],
-          timestamp: 1003,
-        },
+        toolUseMessage("call-a", "read", { path: "a.ts" }, 1000),
+        toolUseMessage("call-b", "read", { path: "b.ts" }, 1001),
+        toolResultMessage("call-a", "read", [{ type: "toolResult", text: "contents of a" }], 1002),
+        toolResultMessage("call-b", "read", [{ type: "toolResult", text: "contents of b" }], 1003),
       ],
     });
 
@@ -1611,23 +1538,9 @@ describe("buildCachedChatItems", () => {
   it("replaces a repeated unresolved single-call snapshot", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-x", name: "read", input: { path: "old.ts" } }],
-          timestamp: 1000,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-x", name: "read", input: { path: "new.ts" } }],
-          timestamp: 1001,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-x",
-          toolName: "read",
-          content: [{ type: "text", text: "new contents" }],
-          timestamp: 1002,
-        },
+        toolUseMessage("call-x", "read", { path: "old.ts" }, 1000),
+        toolUseMessage("call-x", "read", { path: "new.ts" }, 1001),
+        toolResultMessage("call-x", "read", [{ type: "text", text: "new contents" }], 1002),
       ],
     });
 
@@ -1645,25 +1558,10 @@ describe("buildCachedChatItems", () => {
   it("keeps more than sixteen parallel calls open by call id", () => {
     const groups = messageGroups({
       messages: [
-        ...Array.from({ length: 17 }, (_, index) => ({
-          role: "assistant",
-          content: [
-            {
-              type: "tool_use",
-              id: `call-${index}`,
-              name: "read",
-              input: { path: `${index}.ts` },
-            },
-          ],
-          timestamp: 1000 + index,
-        })),
-        {
-          role: "toolResult",
-          toolCallId: "call-0",
-          toolName: "read",
-          content: [{ type: "text", text: "first contents" }],
-          timestamp: 1017,
-        },
+        ...Array.from({ length: 17 }, (_, index) =>
+          toolUseMessage(`call-${index}`, "read", { path: `${index}.ts` }, 1000 + index),
+        ),
+        toolResultMessage("call-0", "read", [{ type: "text", text: "first contents" }], 1017),
       ],
     });
 
@@ -1681,24 +1579,15 @@ describe("buildCachedChatItems", () => {
   it("distributes one typed multi-result message across separate open calls", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-a", name: "read", input: { path: "a.ts" } }],
-          timestamp: 1000,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-b", name: "read", input: { path: "b.ts" } }],
-          timestamp: 1001,
-        },
-        {
-          role: "user",
-          content: [
+        toolUseMessage("call-a", "read", { path: "a.ts" }, 1000),
+        toolUseMessage("call-b", "read", { path: "b.ts" }, 1001),
+        userMessage(
+          [
             { type: "tool_result", tool_use_id: "call-a", content: "contents of a" },
             { type: "tool_result", tool_use_id: "call-b", content: "contents of b" },
           ],
-          timestamp: 1002,
-        },
+          1002,
+        ),
       ],
     });
 
@@ -1716,28 +1605,15 @@ describe("buildCachedChatItems", () => {
   it("coalesces a canonical multi-call assistant message with standalone results", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [
+        assistantMessage(
+          [
             { type: "toolCall", id: "call-a", name: "read", arguments: { path: "a.ts" } },
             { type: "toolCall", id: "call-b", name: "read", arguments: { path: "b.ts" } },
           ],
-          timestamp: 1000,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-a",
-          toolName: "read",
-          content: [{ type: "text", text: "contents of a" }],
-          timestamp: 1001,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-b",
-          toolName: "read",
-          content: [{ type: "text", text: "contents of b" }],
-          timestamp: 1002,
-        },
+          1000,
+        ),
+        toolResultMessage("call-a", "read", [{ type: "text", text: "contents of a" }], 1001),
+        toolResultMessage("call-b", "read", [{ type: "text", text: "contents of b" }], 1002),
       ],
     });
 
@@ -1761,22 +1637,20 @@ describe("buildCachedChatItems", () => {
   it("coalesces canonical multi-call results delivered in one provider message", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [
+        assistantMessage(
+          [
             { type: "tool_use", id: "call-a", name: "read", input: { path: "a.ts" } },
             { type: "tool_use", id: "call-b", name: "read", input: { path: "b.ts" } },
           ],
-          timestamp: 1000,
-        },
-        {
-          role: "user",
-          content: [
+          1000,
+        ),
+        userMessage(
+          [
             { type: "tool_result", tool_use_id: "call-a", content: "contents of a" },
             { type: "tool_result", tool_use_id: "call-b", content: "contents of b" },
           ],
-          timestamp: 1001,
-        },
+          1001,
+        ),
       ],
     });
 
@@ -1793,19 +1667,9 @@ describe("buildCachedChatItems", () => {
   it("does not pair results across a user message boundary", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-x", name: "read", input: { path: "x.ts" } }],
-          timestamp: 1000,
-        },
-        { role: "user", content: "never mind", timestamp: 1001 },
-        {
-          role: "toolResult",
-          toolCallId: "call-x",
-          toolName: "read",
-          content: [{ type: "toolResult", text: "late result" }],
-          timestamp: 1002,
-        },
+        toolUseMessage("call-x", "read", { path: "x.ts" }, 1000),
+        userMessage("never mind", 1001),
+        toolResultMessage("call-x", "read", [{ type: "toolResult", text: "late result" }], 1002),
       ],
     });
 
@@ -1857,18 +1721,8 @@ describe("buildCachedChatItems", () => {
   it("keeps adjacent tool messages separate when their call ids differ", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call-a", name: "bash", input: { command: "one" } }],
-          timestamp: 1000,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-b",
-          toolName: "bash",
-          content: "Different call",
-          timestamp: 1001,
-        },
+        toolUseMessage("call-a", "bash", { command: "one" }, 1000),
+        toolResultMessage("call-b", "bash", "Different call", 1001),
       ],
     });
 
@@ -1879,12 +1733,9 @@ describe("buildCachedChatItems", () => {
   it("keeps empty forwarded assistant display groups", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "" }],
+        assistantMessage([{ type: "text", text: "" }], 1000, {
           senderLabel: "Forwarded from main",
-          timestamp: 1000,
-        },
+        }),
       ],
     });
 
@@ -1897,9 +1748,9 @@ describe("buildCachedChatItems", () => {
   it("collapses consecutive duplicate text messages into one rendered item with a count", () => {
     const groups = messageGroups({
       messages: [
-        { role: "assistant", content: [{ type: "text", text: "Same update" }], timestamp: 1 },
-        { role: "assistant", content: [{ type: "text", text: "Same update" }], timestamp: 2 },
-        { role: "assistant", content: [{ type: "text", text: "Same update" }], timestamp: 3 },
+        assistantMessage([{ type: "text", text: "Same update" }], 1),
+        assistantMessage([{ type: "text", text: "Same update" }], 2),
+        assistantMessage([{ type: "text", text: "Same update" }], 3),
       ],
     });
 
@@ -1908,22 +1759,43 @@ describe("buildCachedChatItems", () => {
     expect(messageAt(groupAt(groups, 0), 0).duplicateCount).toBe(3);
   });
 
-  it("deduplicates relay-labeled assistant copies by source message id", () => {
+  it.each([
+    {
+      name: "deduplicates relay-labeled assistant copies by source message id",
+      relayIdentity: { id: "reply-1" },
+      nativeIdentity: { id: "reply-1" },
+      relayText: "Parzival There it is.",
+      nativeText: "There it is.",
+    },
+    {
+      name: "deduplicates relay-labeled assistant copies by event messageId",
+      relayIdentity: { messageId: "reply-2" },
+      nativeIdentity: { messageId: "reply-2" },
+      relayText: "Parzival Found it.",
+      nativeText: "Found it.",
+    },
+    {
+      name: "deduplicates relay-labeled assistant copies by OpenClaw transcript metadata id",
+      relayIdentity: { __openclaw: { id: "reply-3" } },
+      nativeIdentity: { __openclaw: { id: "reply-3" } },
+      relayText: "Parzival On it.",
+      nativeText: "On it.",
+    },
+    {
+      name: "deduplicates relay-labeled assistant copies by OpenClaw metadata before surface ids",
+      relayIdentity: { id: "relay-surface-copy", __openclaw: { id: "reply-4" } },
+      nativeIdentity: { id: "native-surface-copy", __openclaw: { id: "reply-4" } },
+      relayText: "Parzival Ship it.",
+      nativeText: "Ship it.",
+    },
+  ])("$name", ({ relayIdentity, nativeIdentity, relayText, nativeText }) => {
     const groups = messageGroups({
       messages: [
-        {
-          id: "reply-1",
-          role: "assistant",
-          content: [{ type: "text", text: "Parzival There it is." }],
+        assistantMessage([{ type: "text", text: relayText }], 1, {
+          ...relayIdentity,
           senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
-          id: "reply-1",
-          role: "assistant",
-          content: [{ type: "text", text: "There it is." }],
-          timestamp: 2,
-        },
+        }),
+        assistantMessage([{ type: "text", text: nativeText }], 2, nativeIdentity),
       ],
     });
 
@@ -1931,108 +1803,19 @@ describe("buildCachedChatItems", () => {
     expect(groupAt(groups, 0).senderLabel).toBeNull();
     expect(groupAt(groups, 0).messages).toHaveLength(1);
     expect(messageRecord(groupAt(groups, 0)).content).toStrictEqual([
-      { type: "text", text: "There it is." },
-    ]);
-  });
-
-  it("deduplicates relay-labeled assistant copies by event messageId", () => {
-    const groups = messageGroups({
-      messages: [
-        {
-          messageId: "reply-2",
-          role: "assistant",
-          content: [{ type: "text", text: "Parzival Found it." }],
-          senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
-          messageId: "reply-2",
-          role: "assistant",
-          content: [{ type: "text", text: "Found it." }],
-          timestamp: 2,
-        },
-      ],
-    });
-
-    expect(groups).toHaveLength(1);
-    expect(groupAt(groups, 0).senderLabel).toBeNull();
-    expect(groupAt(groups, 0).messages).toHaveLength(1);
-    expect(messageRecord(groupAt(groups, 0)).content).toStrictEqual([
-      { type: "text", text: "Found it." },
-    ]);
-  });
-
-  it("deduplicates relay-labeled assistant copies by OpenClaw transcript metadata id", () => {
-    const groups = messageGroups({
-      messages: [
-        {
-          __openclaw: { id: "reply-3" },
-          role: "assistant",
-          content: [{ type: "text", text: "Parzival On it." }],
-          senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
-          __openclaw: { id: "reply-3" },
-          role: "assistant",
-          content: [{ type: "text", text: "On it." }],
-          timestamp: 2,
-        },
-      ],
-    });
-
-    expect(groups).toHaveLength(1);
-    expect(groupAt(groups, 0).senderLabel).toBeNull();
-    expect(groupAt(groups, 0).messages).toHaveLength(1);
-    expect(messageRecord(groupAt(groups, 0)).content).toStrictEqual([
-      { type: "text", text: "On it." },
-    ]);
-  });
-
-  it("deduplicates relay-labeled assistant copies by OpenClaw metadata before surface ids", () => {
-    const groups = messageGroups({
-      messages: [
-        {
-          id: "relay-surface-copy",
-          __openclaw: { id: "reply-4" },
-          role: "assistant",
-          content: [{ type: "text", text: "Parzival Ship it." }],
-          senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
-          id: "native-surface-copy",
-          __openclaw: { id: "reply-4" },
-          role: "assistant",
-          content: [{ type: "text", text: "Ship it." }],
-          timestamp: 2,
-        },
-      ],
-    });
-
-    expect(groups).toHaveLength(1);
-    expect(groupAt(groups, 0).senderLabel).toBeNull();
-    expect(groupAt(groups, 0).messages).toHaveLength(1);
-    expect(messageRecord(groupAt(groups, 0)).content).toStrictEqual([
-      { type: "text", text: "Ship it." },
+      { type: "text", text: nativeText },
     ]);
   });
 
   it("keeps native assistant updates separate when source message id repeats with new text", () => {
     const groups = messageGroups({
       messages: [
-        {
+        assistantMessage([{ type: "text", text: "Draft one" }], 1, {
           __openclaw: { id: "reply-5" },
-          role: "assistant",
-          content: [{ type: "text", text: "Draft one" }],
-          timestamp: 1,
-        },
-        {
+        }),
+        assistantMessage([{ type: "text", text: "Draft two" }], 2, {
           __openclaw: { id: "reply-5" },
-          role: "assistant",
-          content: [{ type: "text", text: "Draft two" }],
-          timestamp: 2,
-        },
+        }),
       ],
     });
 
@@ -2046,79 +1829,52 @@ describe("buildCachedChatItems", () => {
     ]);
   });
 
-  it("keeps formatting-only assistant updates separate for the same source message", () => {
+  it.each([
+    {
+      name: "keeps formatting-only assistant updates separate for the same source message",
+      id: "reply-formatted",
+      relayText: "Parzival first\n\nsecond",
+      nativeText: "first second",
+    },
+    {
+      name: "keeps differently cased sender text separate for the same source message",
+      id: "reply-case-change",
+      relayText: "PARZIVAL answer",
+      nativeText: "answer",
+    },
+  ])("$name", ({ id, relayText, nativeText }) => {
     const groups = messageGroups({
       messages: [
-        {
-          __openclaw: { id: "reply-formatted" },
-          role: "assistant",
-          content: [{ type: "text", text: "Parzival first\n\nsecond" }],
+        assistantMessage([{ type: "text", text: relayText }], 1, {
+          __openclaw: { id },
           senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
-          __openclaw: { id: "reply-formatted" },
-          role: "assistant",
-          content: [{ type: "text", text: "first second" }],
-          timestamp: 2,
-        },
+        }),
+        assistantMessage([{ type: "text", text: nativeText }], 2, {
+          __openclaw: { id },
+        }),
       ],
     });
 
     expect(groups).toHaveLength(2);
     expect(messageRecord(groupAt(groups, 0)).content).toStrictEqual([
-      { type: "text", text: "Parzival first\n\nsecond" },
+      { type: "text", text: relayText },
     ]);
     expect(messageRecord(groupAt(groups, 1)).content).toStrictEqual([
-      { type: "text", text: "first second" },
-    ]);
-  });
-
-  it("keeps differently cased sender text separate for the same source message", () => {
-    const groups = messageGroups({
-      messages: [
-        {
-          __openclaw: { id: "reply-case-change" },
-          role: "assistant",
-          content: [{ type: "text", text: "PARZIVAL answer" }],
-          senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
-          __openclaw: { id: "reply-case-change" },
-          role: "assistant",
-          content: [{ type: "text", text: "answer" }],
-          timestamp: 2,
-        },
-      ],
-    });
-
-    expect(groups).toHaveLength(2);
-    expect(messageRecord(groupAt(groups, 0)).content).toStrictEqual([
-      { type: "text", text: "PARZIVAL answer" },
-    ]);
-    expect(messageRecord(groupAt(groups, 1)).content).toStrictEqual([
-      { type: "text", text: "answer" },
+      { type: "text", text: nativeText },
     ]);
   });
 
   it("keeps relay-labeled assistant updates separate when source message id repeats with new text", () => {
     const groups = messageGroups({
       messages: [
-        {
+        assistantMessage([{ type: "text", text: "Parzival Draft one" }], 1, {
           __openclaw: { id: "reply-6" },
-          role: "assistant",
-          content: [{ type: "text", text: "Parzival Draft one" }],
           senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
+        }),
+        assistantMessage([{ type: "text", text: "Parzival Draft two" }], 2, {
           __openclaw: { id: "reply-6" },
-          role: "assistant",
-          content: [{ type: "text", text: "Parzival Draft two" }],
           senderLabel: "Parzival",
-          timestamp: 2,
-        },
+        }),
       ],
     });
 
@@ -2136,20 +1892,14 @@ describe("buildCachedChatItems", () => {
   it("keeps identical assistant text separate when source message ids differ", () => {
     const groups = messageGroups({
       messages: [
-        {
+        assistantMessage([{ type: "text", text: "Same update" }], 1, {
           id: "reply-7",
-          role: "assistant",
-          content: [{ type: "text", text: "Same update" }],
           senderLabel: "Parzival",
-          timestamp: 1,
-        },
-        {
+        }),
+        assistantMessage([{ type: "text", text: "Same update" }], 2, {
           id: "reply-8",
-          role: "assistant",
-          content: [{ type: "text", text: "Same update" }],
           senderLabel: "Parzival",
-          timestamp: 2,
-        },
+        }),
       ],
     });
 
@@ -2362,10 +2112,10 @@ describe("buildCachedChatItems", () => {
   it("suppresses assistant HEARTBEAT_OK acknowledgements before rendering history", () => {
     const groups = messageGroups({
       messages: [
-        { role: "assistant", content: [{ type: "text", text: "HEARTBEAT_OK" }], timestamp: 1 },
-        { role: "assistant", content: "HEARTBEAT_OK", timestamp: 2 },
-        { role: "user", content: [{ type: "text", text: "HEARTBEAT_OK" }], timestamp: 3 },
-        { role: "assistant", content: [{ type: "text", text: "Visible reply" }], timestamp: 4 },
+        assistantMessage([{ type: "text", text: "HEARTBEAT_OK" }], 1),
+        assistantMessage("HEARTBEAT_OK", 2),
+        userMessage([{ type: "text", text: "HEARTBEAT_OK" }], 3),
+        assistantMessage([{ type: "text", text: "Visible reply" }], 4),
       ],
     });
 
@@ -2380,9 +2130,8 @@ describe("buildCachedChatItems", () => {
   it("suppresses assistant HEARTBEAT_OK acknowledgements that carry hidden thinking blocks", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [
+        assistantMessage(
+          [
             { type: "thinking", thinking: "Checking scheduled work." },
             {
               type: "text",
@@ -2390,24 +2139,22 @@ describe("buildCachedChatItems", () => {
               textSignature: JSON.stringify({ v: 1, phase: "final_answer" }),
             },
           ],
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          content: [
+          1,
+        ),
+        assistantMessage(
+          [
             { id: "rs_1", type: "reasoning" },
             { type: "text", text: "HEARTBEAT_OK" },
           ],
-          timestamp: 2,
-        },
-        {
-          role: "assistant",
-          content: [
+          2,
+        ),
+        assistantMessage(
+          [
             { type: "thinking", thinking: "Useful hidden reasoning." },
             { type: "text", text: "Visible reply" },
           ],
-          timestamp: 3,
-        },
+          3,
+        ),
       ],
     });
 
@@ -2422,13 +2169,7 @@ describe("buildCachedChatItems", () => {
   it("keeps HEARTBEAT_OK turns that carry visible non-text content", () => {
     const canvasBlock = createAssistantCanvasBlock({ suffix: "heartbeat_visible_content" });
     const groups = messageGroups({
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "HEARTBEAT_OK" }, canvasBlock],
-          timestamp: 1,
-        },
-      ],
+      messages: [assistantMessage([{ type: "text", text: "HEARTBEAT_OK" }, canvasBlock], 1)],
     });
 
     expect(groups).toHaveLength(1);
@@ -2436,21 +2177,19 @@ describe("buildCachedChatItems", () => {
     expect(canvasBlocksIn(groupAt(groups, 0))).toHaveLength(1);
   });
 
-  it("suppresses active HEARTBEAT_OK streams before rendering", () => {
+  it.each([
+    {
+      name: "suppresses active HEARTBEAT_OK streams before rendering",
+      stream: "HEARTBEAT_OK",
+    },
+    {
+      name: "suppresses active sender metadata streams before rendering",
+      stream: SENDER_METADATA_BLOCK,
+    },
+  ])("$name", ({ stream }) => {
     const items = buildCachedChatItems(
       createProps({
-        stream: "HEARTBEAT_OK",
-        streamStartedAt: 1,
-      }),
-    );
-
-    expect(items).toStrictEqual([]);
-  });
-
-  it("suppresses active sender metadata streams before rendering", () => {
-    const items = buildCachedChatItems(
-      createProps({
-        stream: SENDER_METADATA_BLOCK,
+        stream,
         streamStartedAt: 1,
       }),
     );
@@ -2484,8 +2223,8 @@ describe("buildCachedChatItems", () => {
           { text: "First thought. After tool.", ts: 3 },
         ],
         toolMessages: [
-          { role: "toolResult", content: "Tool one", timestamp: 2 },
-          { role: "toolResult", content: "Tool two", timestamp: 4 },
+          chatMessage("toolResult", "Tool one", 2),
+          chatMessage("toolResult", "Tool two", 4),
         ],
         stream: "First thought. After tool. Final sentence.",
         streamStartedAt: 5,
@@ -2507,7 +2246,7 @@ describe("buildCachedChatItems", () => {
           { text: "Checking workspace", ts: 0, itemId: "preamble-2" },
           { text: "Checking workspace details", ts: 0, itemId: "preamble-3" },
         ],
-        toolMessages: [{ role: "toolResult", content: "Tool output", timestamp: 1 }],
+        toolMessages: [chatMessage("toolResult", "Tool output", 1)],
       }),
     );
 
@@ -2523,7 +2262,7 @@ describe("buildCachedChatItems", () => {
     const items = buildCachedChatItems(
       createProps({
         streamSegments: [{ text: "Checking after the tool", ts: 1, itemId: "preamble-after-tool" }],
-        toolMessages: [{ role: "toolResult", content: "Tool output", timestamp: 1 }],
+        toolMessages: [chatMessage("toolResult", "Tool output", 1)],
       }),
     );
 
@@ -2543,8 +2282,8 @@ describe("buildCachedChatItems", () => {
           { text: "Planning the next step", ts: 2, itemId: "preamble-between-tools" },
         ],
         toolMessages: [
-          { role: "toolResult", content: "First tool", timestamp: 1 },
-          { role: "toolResult", content: "Second tool", timestamp: 3 },
+          chatMessage("toolResult", "First tool", 1),
+          chatMessage("toolResult", "Second tool", 3),
         ],
       }),
     );
@@ -2562,15 +2301,7 @@ describe("buildCachedChatItems", () => {
     const items = buildCachedChatItems(
       createProps({
         streamSegments: [{ text: "I will inspect the file.", ts: 2_000, toolCallId: "call-read" }],
-        toolMessages: [
-          {
-            role: "toolResult",
-            toolCallId: "call-read",
-            toolName: "read",
-            content: "file contents",
-            timestamp: 1_000,
-          },
-        ],
+        toolMessages: [toolResultMessage("call-read", "read", "file contents", 1_000)],
       }),
     );
 
@@ -2586,10 +2317,9 @@ describe("buildCachedChatItems", () => {
     const groups = messageGroups({
       runId: "run-live",
       messages: [
-        { role: "user", content: "Read the file.", timestamp: 1 },
-        {
-          role: "assistant",
-          content: [
+        userMessage("Read the file.", 1),
+        assistantMessage(
+          [
             { type: "text", text: "I will read it." },
             {
               type: "toolCall",
@@ -2598,8 +2328,8 @@ describe("buildCachedChatItems", () => {
               arguments: { path: "README.md" },
             },
           ],
-          timestamp: 2,
-        },
+          2,
+        ),
       ],
       toolMessages: [
         {
@@ -2632,20 +2362,8 @@ describe("buildCachedChatItems", () => {
           { text: "First tool. Second tool.", ts: 2_000, toolCallId: "call-list" },
         ],
         toolMessages: [
-          {
-            role: "toolResult",
-            toolCallId: "call-read",
-            toolName: "read",
-            content: "file contents",
-            timestamp: 1_000,
-          },
-          {
-            role: "toolResult",
-            toolCallId: "call-list",
-            toolName: "list",
-            content: "file list",
-            timestamp: 1_000,
-          },
+          toolResultMessage("call-read", "read", "file contents", 1_000),
+          toolResultMessage("call-list", "list", "file list", 1_000),
         ],
       }),
     );
@@ -2668,15 +2386,7 @@ describe("buildCachedChatItems", () => {
             toolCallId: "call-read",
           },
         ],
-        toolMessages: [
-          {
-            role: "toolResult",
-            toolCallId: "call-read",
-            toolName: "read",
-            content: "file contents",
-            timestamp: 1_000,
-          },
-        ],
+        toolMessages: [toolResultMessage("call-read", "read", "file contents", 1_000)],
       }),
     );
 
@@ -2696,12 +2406,9 @@ describe("buildCachedChatItems", () => {
   it("suppresses metadata-only history messages before grouping", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "user",
-          content: SENDER_METADATA_BLOCK,
+        userMessage(SENDER_METADATA_BLOCK, 1, {
           senderLabel: "openclaw-control-ui",
-          timestamp: 1,
-        },
+        }),
       ],
     });
 
@@ -2794,9 +2501,9 @@ describe("buildCachedChatItems", () => {
   it("does not collapse duplicate text messages separated by another message", () => {
     const groups = messageGroups({
       messages: [
-        { role: "assistant", content: [{ type: "text", text: "same" }], timestamp: 1 },
-        { role: "user", content: [{ type: "text", text: "break" }], timestamp: 2 },
-        { role: "assistant", content: [{ type: "text", text: "same" }], timestamp: 3 },
+        assistantMessage([{ type: "text", text: "same" }], 1),
+        userMessage([{ type: "text", text: "break" }], 2),
+        assistantMessage([{ type: "text", text: "same" }], 3),
       ],
     });
 
@@ -2809,16 +2516,8 @@ describe("buildCachedChatItems", () => {
     const canvasBlock = createAssistantCanvasBlock({ suffix: "duplicate_guard" });
     const groups = messageGroups({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "preview" }, canvasBlock],
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "preview" }, canvasBlock],
-          timestamp: 2,
-        },
+        assistantMessage([{ type: "text", text: "preview" }, canvasBlock], 1),
+        assistantMessage([{ type: "text", text: "preview" }, canvasBlock], 2),
       ],
     });
 
@@ -2829,22 +2528,8 @@ describe("buildCachedChatItems", () => {
 
   it("orders live tool messages before newer history messages", () => {
     const groups = messageGroups({
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "Newer history reply." }],
-          timestamp: 2_000,
-        },
-      ],
-      toolMessages: [
-        {
-          role: "tool",
-          toolCallId: "call-older-tool",
-          toolName: "shell",
-          content: "Older live tool output.",
-          timestamp: 1_000,
-        },
-      ],
+      messages: [assistantMessage([{ type: "text", text: "Newer history reply." }], 2_000)],
+      toolMessages: [toolMessage("call-older-tool", "shell", "Older live tool output.", 1_000)],
     });
 
     expect(groups).toHaveLength(2);
@@ -2858,13 +2543,7 @@ describe("buildCachedChatItems", () => {
   it("orders completed stream segments before newer history messages", () => {
     const items = buildCachedChatItems(
       createProps({
-        messages: [
-          {
-            role: "assistant",
-            content: [{ type: "text", text: "Newer history reply." }],
-            timestamp: 2_000,
-          },
-        ],
+        messages: [assistantMessage([{ type: "text", text: "Newer history reply." }], 2_000)],
         streamSegments: [{ text: "Older streamed output.", ts: 1_000 }],
       }),
     );
@@ -2900,13 +2579,7 @@ describe("buildCachedChatItems", () => {
   it("renders an active stream after the persisted user turn it answers", () => {
     const items = buildCachedChatItems(
       createProps({
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "Persisted prompt." }],
-            timestamp: 2_000,
-          },
-        ],
+        messages: [userMessage([{ type: "text", text: "Persisted prompt." }], 2_000)],
         stream: "Visible partial answer.",
         streamStartedAt: 1_000,
       }),
@@ -2924,16 +2597,12 @@ describe("buildCachedChatItems", () => {
 
   it("renders submitted queued sends as user turns before chat.send ACK", () => {
     const groups = messageGroups({
-      messages: [{ role: "assistant", content: "Ready.", timestamp: 1 }],
+      messages: [assistantMessage("Ready.", 1)],
       queue: [
-        {
-          id: "pending-send-1",
-          text: "first visible send",
-          createdAt: 2,
+        queuedSend("pending-send-1", "first visible send", 2, "sending", {
           sendSubmittedAtMs: 10,
-          sendState: "sending",
           sender: { id: "alice@example.com", name: "Alice Example" },
-        },
+        }),
       ],
     });
 
@@ -2989,12 +2658,8 @@ describe("buildCachedChatItems", () => {
   it("renders submitted queued attachment sends with attachment blocks before chat.send ACK", () => {
     const groups = messageGroups({
       queue: [
-        {
-          id: "pending-attachment-send-1",
-          text: "see attached",
-          createdAt: 2,
+        queuedSend("pending-attachment-send-1", "see attached", 2, "sending", {
           sendSubmittedAtMs: 10,
-          sendState: "sending",
           attachments: [
             {
               id: "attachment-1",
@@ -3003,7 +2668,7 @@ describe("buildCachedChatItems", () => {
               previewUrl: "/media/screenshot.png",
             },
           ],
-        },
+        }),
       ],
     });
 
@@ -3020,15 +2685,11 @@ describe("buildCachedChatItems", () => {
 
   it("does not collapse pending sends with matching history text", () => {
     const groups = messageGroups({
-      messages: [{ role: "user", content: "same prompt", timestamp: 1 }],
+      messages: [userMessage("same prompt", 1)],
       queue: [
-        {
-          id: "pending-send-1",
-          text: "same prompt",
-          createdAt: 2,
+        queuedSend("pending-send-1", "same prompt", 2, "sending", {
           sendSubmittedAtMs: 10,
-          sendState: "sending",
-        },
+        }),
       ],
     });
 
@@ -3041,22 +2702,15 @@ describe("buildCachedChatItems", () => {
   it("hides a pending send after history accepts its idempotency key", () => {
     const groups = messageGroups({
       messages: [
-        {
-          role: "user",
-          content: "accepted prompt",
-          timestamp: 1,
+        userMessage("accepted prompt", 1, {
           __openclaw: { idempotencyKey: "accepted-run:user", seq: 1 },
-        },
+        }),
       ],
       queue: [
-        {
-          id: "pending-send-1",
-          text: "accepted prompt",
-          createdAt: 2,
+        queuedSend("pending-send-1", "accepted prompt", 2, "sending", {
           sendRunId: "accepted-run",
           sendSubmittedAtMs: 10,
-          sendState: "sending",
-        },
+        }),
       ],
     });
 
@@ -3071,13 +2725,9 @@ describe("buildCachedChatItems", () => {
   it("keeps failed queued sends out of the thread", () => {
     const groups = messageGroups({
       queue: [
-        {
-          id: "failed-send-1",
-          text: "restore me to the composer",
-          createdAt: 1,
+        queuedSend("failed-send-1", "restore me to the composer", 1, "failed", {
           sendSubmittedAtMs: 10,
-          sendState: "failed",
-        },
+        }),
       ],
     });
 
@@ -3089,20 +2739,12 @@ describe("buildCachedChatItems", () => {
       searchOpen: true,
       searchQuery: "matching",
       queue: [
-        {
-          id: "pending-send-1",
-          text: "matching prompt",
-          createdAt: 1,
+        queuedSend("pending-send-1", "matching prompt", 1, "sending", {
           sendSubmittedAtMs: 10,
-          sendState: "sending",
-        },
-        {
-          id: "pending-send-2",
-          text: "unrelated prompt",
-          createdAt: 2,
+        }),
+        queuedSend("pending-send-2", "unrelated prompt", 2, "sending", {
           sendSubmittedAtMs: 11,
-          sendState: "sending",
-        },
+        }),
       ],
     });
 
@@ -3115,40 +2757,21 @@ describe("buildCachedChatItems", () => {
   it("attaches lifted canvas previews to the nearest assistant turn", () => {
     const groups = messageGroups({
       messages: [
-        {
+        assistantMessage([{ type: "text", text: "First reply." }], 1_000, {
           id: "assistant-with-canvas",
-          role: "assistant",
-          content: [{ type: "text", text: "First reply." }],
-          timestamp: 1_000,
-        },
-        {
+        }),
+        assistantMessage([{ type: "text", text: "Later unrelated reply." }], 2_000, {
           id: "assistant-without-canvas",
-          role: "assistant",
-          content: [{ type: "text", text: "Later unrelated reply." }],
-          timestamp: 2_000,
-        },
+        }),
       ],
       toolMessages: [
-        {
-          id: "tool-canvas-for-first-reply",
-          role: "tool",
-          toolCallId: "call-canvas-old",
-          toolName: "canvas_render",
-          content: JSON.stringify({
-            kind: "canvas",
-            view: {
-              backend: "canvas",
-              id: "cv_nearest_turn",
-              url: "/__openclaw__/canvas/documents/cv_nearest_turn/index.html",
-              title: "Nearest turn demo",
-              preferred_height: 320,
-            },
-            presentation: {
-              target: "assistant_message",
-            },
-          }),
-          timestamp: 1_001,
-        },
+        toolMessage(
+          "call-canvas-old",
+          "canvas_render",
+          canvasToolOutput("cv_nearest_turn", "Nearest turn demo", 320),
+          1_001,
+          { id: "tool-canvas-for-first-reply" },
+        ),
       ],
     });
 
@@ -3159,9 +2782,9 @@ describe("buildCachedChatItems", () => {
   it("keeps a clock-skewed live App preview after the latest user boundary", () => {
     const groups = messageGroups({
       messages: [
-        { role: "user", content: "Earlier request", timestamp: 1_000 },
-        { role: "assistant", content: "Earlier response", timestamp: 1_100 },
-        { role: "user", content: "Current request", timestamp: 2_000 },
+        userMessage("Earlier request", 1_000),
+        assistantMessage("Earlier response", 1_100),
+        userMessage("Current request", 2_000),
       ],
       toolMessages: [
         { ...mcpAppResult("mcp-app-skewed", "call-skewed", 900), runId: "run-active" },
@@ -3177,7 +2800,7 @@ describe("buildCachedChatItems", () => {
 
   it("keeps a live App preview on an assistant search match", () => {
     const groups = messageGroups({
-      messages: [{ role: "assistant", content: "Matching preview", timestamp: 1_000 }],
+      messages: [assistantMessage("Matching preview", 1_000)],
       toolMessages: [mcpAppResult("mcp-app-search", "call-search", 1_001)],
       searchOpen: true,
       searchQuery: "matching",
@@ -3191,9 +2814,9 @@ describe("buildCachedChatItems", () => {
     for (const showToolCalls of [false, true]) {
       const groups = messageGroups({
         messages: [
-          { role: "user", content: "Show the App", timestamp: 1_000 },
+          userMessage("Show the App", 1_000),
           mcpAppResult("mcp-app-persisted-search", "call-persisted-search", 1_001),
-          { role: "assistant", content: "Matching preview", timestamp: 1_002 },
+          assistantMessage("Matching preview", 1_002),
         ],
         toolMessages: [],
         searchOpen: true,
@@ -3210,34 +2833,18 @@ describe("buildCachedChatItems", () => {
   it("preserves a metadata-only assistant anchor when lifting canvas previews", () => {
     const groups = messageGroups({
       messages: [
-        {
+        assistantMessage(SENDER_METADATA_BLOCK, 1_000, {
           id: "assistant-metadata-anchor",
-          role: "assistant",
-          content: SENDER_METADATA_BLOCK,
-          timestamp: 1_000,
-        },
+        }),
       ],
       toolMessages: [
-        {
-          id: "tool-canvas-for-empty-anchor",
-          role: "tool",
-          toolCallId: "call-canvas-empty-anchor",
-          toolName: "canvas_render",
-          content: JSON.stringify({
-            kind: "canvas",
-            view: {
-              backend: "canvas",
-              id: "cv_empty_anchor",
-              url: "/__openclaw__/canvas/documents/cv_empty_anchor/index.html",
-              title: "Empty anchor demo",
-              preferred_height: 320,
-            },
-            presentation: {
-              target: "assistant_message",
-            },
-          }),
-          timestamp: 1_001,
-        },
+        toolMessage(
+          "call-canvas-empty-anchor",
+          "canvas_render",
+          canvasToolOutput("cv_empty_anchor", "Empty anchor demo", 320),
+          1_001,
+          { id: "tool-canvas-for-empty-anchor" },
+        ),
       ],
     });
 
@@ -3249,19 +2856,15 @@ describe("buildCachedChatItems", () => {
   it("creates an assistant anchor for a silent App turn", () => {
     const groups = messageGroups({
       messages: [
-        { role: "user", content: "First request", timestamp: 1_000 },
-        { role: "assistant", content: "First response", timestamp: 1_001 },
-        { role: "user", content: "Show the App", timestamp: 2_000 },
+        userMessage("First request", 1_000),
+        assistantMessage("First response", 1_001),
+        userMessage("Show the App", 2_000),
       ],
       toolMessages: [mcpAppResult("mcp-app-silent", "call-silent", 2_001)],
       queue: [
-        {
-          id: "queued-next-turn",
-          text: "Next request",
-          createdAt: 2_100,
+        queuedSend("queued-next-turn", "Next request", 2_100, "sending", {
           sendSubmittedAtMs: 2_100,
-          sendState: "sending",
-        },
+        }),
       ],
       showToolCalls: false,
     });
@@ -3274,10 +2877,7 @@ describe("buildCachedChatItems", () => {
 
   it("keeps an earlier silent App preview before the next user turn", () => {
     const groups = messageGroups({
-      messages: [
-        { role: "user", content: "Show the App", timestamp: 1_000 },
-        { role: "user", content: "Next request", timestamp: 2_000 },
-      ],
+      messages: [userMessage("Show the App", 1_000), userMessage("Next request", 2_000)],
       toolMessages: [mcpAppResult("mcp-app-earlier", "call-earlier", 1_001)],
       showToolCalls: false,
     });
@@ -3288,25 +2888,14 @@ describe("buildCachedChatItems", () => {
 
   it("places an App preview after its queued user prompt", () => {
     const groups = messageGroups({
-      messages: [
-        { role: "user", content: "First request", timestamp: 1_000 },
-        { role: "assistant", content: "First response", timestamp: 1_001 },
-      ],
+      messages: [userMessage("First request", 1_000), assistantMessage("First response", 1_001)],
       queue: [
-        {
-          id: "queued-app-turn",
-          text: "Show the App",
-          createdAt: 2_000,
+        queuedSend("queued-app-turn", "Show the App", 2_000, "waiting-model", {
           sendSubmittedAtMs: 2_000,
-          sendState: "waiting-model",
-        },
-        {
-          id: "queued-future-turn",
-          text: "Later request",
-          createdAt: 2_001,
+        }),
+        queuedSend("queued-future-turn", "Later request", 2_001, "waiting-reconnect", {
           sendSubmittedAtMs: 2_001,
-          sendState: "waiting-reconnect",
-        },
+        }),
       ],
       toolMessages: [mcpAppResult("mcp-app-queued", "call-queued", 2_002)],
       showToolCalls: false,
@@ -3326,7 +2915,7 @@ describe("buildCachedChatItems", () => {
     for (const showToolCalls of [false, true]) {
       const groups = messageGroups({
         messages: [
-          { role: "user", content: "Show the App", timestamp: 1_000 },
+          userMessage("Show the App", 1_000),
           mcpAppResult("mcp-app-persisted", "call-persisted", 1_001),
         ],
         toolMessages: [],
@@ -3342,7 +2931,7 @@ describe("buildCachedChatItems", () => {
   it("deduplicates persisted and live copies of an App preview", () => {
     const result = mcpAppResult("mcp-app-overlap", "call-overlap", 1_001);
     const groups = messageGroups({
-      messages: [{ role: "user", content: "Show the App", timestamp: 1_000 }, result],
+      messages: [userMessage("Show the App", 1_000), result],
       toolMessages: [result],
       showToolCalls: false,
     });
@@ -3358,7 +2947,7 @@ describe("buildCachedChatItems", () => {
       timestamp: undefined,
     };
     const groups = messageGroups({
-      messages: [{ role: "user", content: "Show the App", timestamp: 1_000 }, persisted],
+      messages: [userMessage("Show the App", 1_000), persisted],
       toolMessages: [mcpAppLiveResult("mcp-app-untimestamped", "call-untimestamped", 1_001)],
       showToolCalls: false,
     });
@@ -3373,11 +2962,7 @@ describe("buildCachedChatItems", () => {
     };
     const second = mcpAppLiveResult("mcp-app-second", "call-reused", undefined);
     const groups = messageGroups({
-      messages: [
-        { role: "user", content: "First App", timestamp: 1_000 },
-        first,
-        { role: "user", content: "Second App", timestamp: 2_000 },
-      ],
+      messages: [userMessage("First App", 1_000), first, userMessage("Second App", 2_000)],
       toolMessages: [second],
       showToolCalls: false,
     });
@@ -3390,20 +2975,15 @@ describe("buildCachedChatItems", () => {
   it("does not lift generic view handles from non-canvas payloads", () => {
     const groups = messageGroups({
       messages: [
-        {
+        assistantMessage([{ type: "text", text: "Rendered the item inline." }], 1000, {
           id: "assistant-generic-inline",
-          role: "assistant",
-          content: [{ type: "text", text: "Rendered the item inline." }],
-          timestamp: 1000,
-        },
+        }),
       ],
       toolMessages: [
-        {
-          id: "tool-generic-inline",
-          role: "tool",
-          toolCallId: "call-generic-inline",
-          toolName: "plugin_card_details",
-          content: JSON.stringify({
+        toolMessage(
+          "call-generic-inline",
+          "plugin_card_details",
+          JSON.stringify({
             selected_item: {
               summary: {
                 label: "Alpha",
@@ -3418,8 +2998,9 @@ describe("buildCachedChatItems", () => {
               },
             },
           }),
-          timestamp: 1001,
-        },
+          1001,
+          { id: "tool-generic-inline" },
+        ),
       ],
     });
 
@@ -3429,20 +3010,13 @@ describe("buildCachedChatItems", () => {
   it("lifts streamed canvas toolresult blocks into the assistant bubble", () => {
     const groups = messageGroups({
       messages: [
-        {
+        assistantMessage([{ type: "text", text: "Done." }], 1000, {
           id: "assistant-streamed-artifact",
-          role: "assistant",
-          content: [{ type: "text", text: "Done." }],
-          timestamp: 1000,
-        },
+        }),
       ],
       toolMessages: [
-        {
-          id: "tool-streamed-artifact",
-          role: "assistant",
-          toolCallId: "call_streamed_artifact",
-          timestamp: 999,
-          content: [
+        assistantMessage(
+          [
             {
               type: "toolcall",
               name: "canvas_render",
@@ -3451,22 +3025,15 @@ describe("buildCachedChatItems", () => {
             {
               type: "toolresult",
               name: "canvas_render",
-              text: JSON.stringify({
-                kind: "canvas",
-                view: {
-                  backend: "canvas",
-                  id: "cv_streamed_artifact",
-                  url: "/__openclaw__/canvas/documents/cv_streamed_artifact/index.html",
-                  title: "Streamed demo",
-                  preferred_height: 320,
-                },
-                presentation: {
-                  target: "assistant_message",
-                },
-              }),
+              text: canvasToolOutput("cv_streamed_artifact", "Streamed demo", 320),
             },
           ],
-        },
+          999,
+          {
+            id: "tool-streamed-artifact",
+            toolCallId: "call_streamed_artifact",
+          },
+        ),
       ],
     });
 
@@ -3484,16 +3051,7 @@ describe("buildCachedChatItems", () => {
   it("explains compaction boundaries and exposes the checkpoint action", () => {
     const items = buildCachedChatItems(
       createProps({
-        messages: [
-          {
-            role: "system",
-            timestamp: 2_000,
-            __openclaw: {
-              kind: "compaction",
-              id: "checkpoint-1",
-            },
-          },
-        ],
+        messages: [compactionMessage("checkpoint-1")],
       }),
     );
 
@@ -3513,16 +3071,10 @@ describe("buildCachedChatItems", () => {
     const items = buildCachedChatItems(
       createProps({
         messages: [
-          {
-            role: "system",
-            timestamp: 2_000,
-            __openclaw: {
-              kind: "compaction",
-              id: "checkpoint-with-metrics",
-              tokensBefore: 900_000,
-              tokensAfter: 24_700,
-            },
-          },
+          compactionMessage("checkpoint-with-metrics", {
+            tokensBefore: 900_000,
+            tokensAfter: 24_700,
+          }),
         ],
       }),
     );
@@ -4246,11 +3798,7 @@ function createAssistantCanvasBlock(params: { suffix: string }) {
 }
 
 function mcpAppResult(viewId: string, toolCallId: string, timestamp: number) {
-  return {
-    role: "toolResult",
-    toolCallId,
-    toolName: "demo__show",
-    content: [{ type: "text", text: "ok" }],
+  return toolResultMessage(toolCallId, "demo__show", [{ type: "text", text: "ok" }], timestamp, {
     details: {
       mcpAppPreview: {
         kind: "canvas",
@@ -4265,17 +3813,13 @@ function mcpAppResult(viewId: string, toolCallId: string, timestamp: number) {
         },
       },
     },
-    timestamp,
-  };
+  });
 }
 
 function mcpAppLiveResult(viewId: string, toolCallId: string, timestamp: number | undefined) {
   const persisted = mcpAppResult(viewId, toolCallId, timestamp ?? 0);
-  return {
-    role: "assistant",
-    toolCallId,
-    runId: "run-live",
-    content: [
+  return assistantMessage(
+    [
       { type: "toolcall", name: "demo__show", arguments: {} },
       {
         type: "toolresult",
@@ -4284,83 +3828,76 @@ function mcpAppLiveResult(viewId: string, toolCallId: string, timestamp: number 
         details: persisted.details,
       },
     ],
-    ...(timestamp == null ? {} : { timestamp }),
-    __openclawToolStreamLive: true,
-    __openclawToolStreamResultReceived: true,
-  };
+    timestamp,
+    {
+      toolCallId,
+      runId: "run-live",
+      __openclawToolStreamLive: true,
+      __openclawToolStreamResultReceived: true,
+    },
+  );
 }
 
 describe("tool turn outcome annotation (#89683)", () => {
   function failedTool(timestamp: number) {
-    return {
-      role: "toolResult",
+    return chatMessage("toolResult", JSON.stringify({ status: "failed", exitCode: 1 }), timestamp, {
       toolName: "shell",
-      content: JSON.stringify({ status: "failed", exitCode: 1 }),
       isError: true,
-      timestamp,
-    };
-  }
-  function userMsg(text: string, timestamp: number) {
-    return { role: "user", content: text, timestamp };
+    });
   }
   function assistantReply(text: string, timestamp: number) {
-    return { role: "assistant", content: [{ type: "text", text }], timestamp };
+    return assistantMessage([{ type: "text", text }], timestamp);
   }
   function toolGroups(messages: unknown[]): MessageGroup[] {
     return messageGroups({ messages }).filter((group) => group.role === "tool");
   }
 
-  it("marks a failed tool followed by an assistant reply as turnSucceeded", () => {
+  it.each([
+    {
+      name: "marks a failed tool followed by an assistant reply as turnSucceeded",
+      reply: assistantReply("No matches found.", 3),
+      expected: true,
+    },
+    {
+      name: "leaves a terminal failed tool (no assistant reply) as not-succeeded",
+      reply: null,
+      expected: false,
+    },
+  ])("$name", ({ reply, expected }) => {
     const tools = toolGroups([
-      userMsg("search foo", 1),
+      userMessage("search foo", 1),
       failedTool(2),
-      assistantReply("No matches found.", 3),
+      ...(reply ? [reply] : []),
     ]);
     expect(tools).toHaveLength(1);
-    expect(groupAt(tools, 0).turnSucceeded).toBe(true);
-  });
-
-  it("leaves a terminal failed tool (no assistant reply) as not-succeeded", () => {
-    const tools = toolGroups([userMsg("search foo", 1), failedTool(2)]);
-    expect(tools).toHaveLength(1);
-    expect(groupAt(tools, 0).turnSucceeded).toBe(false);
+    expect(groupAt(tools, 0).turnSucceeded).toBe(expected);
   });
 
   it("does not count an assistant group without reply text as success", () => {
     const tools = toolGroups([
-      userMsg("search foo", 1),
+      userMessage("search foo", 1),
       failedTool(2),
-      { role: "assistant", content: [], timestamp: 3 },
+      assistantMessage([], 3),
     ]);
     expect(groupAt(tools, 0).turnSucceeded).toBe(false);
   });
 
-  it("scopes adjacent autonomous turns at an empty forwarded boundary", () => {
+  it.each([
+    {
+      name: "scopes adjacent autonomous turns at an empty forwarded boundary",
+      content: [],
+    },
+    {
+      name: "does not treat a forwarded message as the prior turn's reply",
+      content: [{ type: "text", text: "Start the next autonomous task." }],
+    },
+  ])("$name", ({ content }) => {
     const tools = toolGroups([
       failedTool(1),
-      {
-        role: "assistant",
-        content: [],
+      assistantMessage(content, 2, {
         provenance: { kind: "inter_session", sourceTool: "sessions_send" },
         senderLabel: "Forwarded from main",
-        timestamp: 2,
-      },
-      failedTool(3),
-      assistantReply("Recovered on the next autonomous turn.", 4),
-    ]);
-    expect(tools.map((group) => group.turnSucceeded)).toEqual([false, true]);
-  });
-
-  it("does not treat a forwarded message as the prior turn's reply", () => {
-    const tools = toolGroups([
-      failedTool(1),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Start the next autonomous task." }],
-        provenance: { kind: "inter_session", sourceTool: "sessions_send" },
-        senderLabel: "Forwarded from main",
-        timestamp: 2,
-      },
+      }),
       failedTool(3),
       assistantReply("Recovered on the next autonomous turn.", 4),
     ]);
@@ -4369,27 +3906,20 @@ describe("tool turn outcome annotation (#89683)", () => {
 
   it("treats an ordinary labeled assistant message as a reply", () => {
     const tools = toolGroups([
-      userMsg("check the service", 1),
+      userMessage("check the service", 1),
       failedTool(2),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Parzival recovered the service." }],
+      assistantMessage([{ type: "text", text: "Parzival recovered the service." }], 3, {
         senderLabel: "Parzival",
-        timestamp: 3,
-      },
+      }),
     ]);
     expect(groupAt(tools, 0).turnSucceeded).toBe(true);
   });
 
   it("does not treat non-text assistant content as a turn boundary", () => {
     const tools = toolGroups([
-      userMsg("make a preview", 1),
+      userMessage("make a preview", 1),
       failedTool(2),
-      {
-        role: "assistant",
-        content: [createAssistantCanvasBlock({ suffix: "tool_turn_outcome" })],
-        timestamp: 3,
-      },
+      assistantMessage([createAssistantCanvasBlock({ suffix: "tool_turn_outcome" })], 3),
       failedTool(4),
       assistantReply("Done.", 5),
     ]);
@@ -4398,10 +3928,10 @@ describe("tool turn outcome annotation (#89683)", () => {
 
   it("scopes the outcome per turn at user boundaries", () => {
     const tools = toolGroups([
-      userMsg("first", 1),
+      userMessage("first", 1),
       failedTool(2),
       assistantReply("done", 3),
-      userMsg("second", 4),
+      userMessage("second", 4),
       failedTool(5),
     ]);
     expect(tools.map((group) => group.turnSucceeded)).toEqual([true, false]);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -251,6 +251,15 @@ type ChatHeaderTestState = {
   resetToolStream(): void;
 };
 
+type ChatProps = Parameters<typeof renderChat>[0];
+
+function createOpenAiModelCatalog(): ModelCatalogEntry[] {
+  return [
+    { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+    { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+  ];
+}
+
 function requireFirstAttachmentsChange(
   onAttachmentsChange: ReturnType<typeof vi.fn>,
 ): ChatAttachment[] {
@@ -515,6 +524,15 @@ function createReasoningHeaderState(
   return result;
 }
 
+function createOpenAiHeaderState(overrides: Parameters<typeof createChatHeaderState>[0] = {}) {
+  return createChatHeaderState({
+    model: "gpt-5.5",
+    modelProvider: "openai",
+    models: createOpenAiModelCatalog(),
+    ...overrides,
+  });
+}
+
 function getChatModelSelect(container: Element): HTMLElement {
   const select = container.querySelector<HTMLElement>('[data-chat-model-select="true"]');
   expect(select).toBeInstanceOf(HTMLElement);
@@ -562,8 +580,8 @@ function createChatModelControlsProps(state: ChatHeaderTestState): ChatModelCont
 function renderModelControls(
   state: ChatHeaderTestState,
   overrides: Partial<ChatModelControlsProps> = {},
+  container = document.createElement("div"),
 ) {
-  const container = document.createElement("div");
   render(
     renderChatModelControls({ ...createChatModelControlsProps(state), ...overrides }),
     container,
@@ -635,9 +653,7 @@ function itemAt<T>(items: ArrayLike<T>, index: number, label: string): T {
   return expectDefined(items[index], `${label} ${index}`);
 }
 
-function createChatProps(
-  overrides: Partial<Parameters<typeof renderChat>[0]> = {},
-): Parameters<typeof renderChat>[0] {
+function createChatProps(overrides: Partial<ChatProps> = {}): ChatProps {
   const transcript = createTestTranscript();
   return {
     transcript,
@@ -710,10 +726,71 @@ function createChatProps(
   };
 }
 
-function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {}) {
+function renderChatView(overrides: Partial<ChatProps> = {}) {
   const container = document.createElement("div");
   render(renderChat(createChatProps(overrides)), container);
   return container;
+}
+
+function renderChatInto(container: HTMLElement, overrides: Partial<ChatProps> = {}) {
+  render(renderChat(createChatProps(overrides)), container);
+}
+
+function createSessionWorkspace(
+  overrides: Partial<NonNullable<ChatProps["sessionWorkspace"]>> = {},
+): NonNullable<ChatProps["sessionWorkspace"]> {
+  return {
+    collapsed: false,
+    sessionKey: "agent:main",
+    list: null,
+    loading: false,
+    error: null,
+    activeId: null,
+    dock: "right",
+    narrowLayout: false,
+    dockDragging: false,
+    dockDragZone: null,
+    onToggleCollapsed: () => undefined,
+    onSetDock: () => undefined,
+    onDockDragStart: () => undefined,
+    onRefresh: () => undefined,
+    onBrowsePath: () => undefined,
+    onCopyPath: () => undefined,
+    onOpenFile: () => undefined,
+    onSearch: () => undefined,
+    onOpenArtifact: () => undefined,
+    ...overrides,
+  };
+}
+
+function createBackgroundTasks(
+  overrides: Partial<NonNullable<ChatProps["backgroundTasks"]>> = {},
+): NonNullable<ChatProps["backgroundTasks"]> {
+  return {
+    sessionKey: "agent:main:main",
+    statusRowId: "chat-tasks-status-test",
+    collapsed: false,
+    narrowLayout: false,
+    connected: true,
+    canCancel: false,
+    loading: false,
+    error: null,
+    tasks: [],
+    cancellingTaskIds: new Set<string>(),
+    finishedCollapsed: false,
+    selectedTaskId: null,
+    taskDetails: new Map(),
+    taskDetailErrors: new Map(),
+    taskDetailLoadingIds: new Set<string>(),
+    onToggleCollapsed: () => undefined,
+    onToggleFinished: () => undefined,
+    onRefresh: () => undefined,
+    onCancel: () => undefined,
+    onSelectTask: () => undefined,
+    onBackToList: () => undefined,
+    onOpenSession: () => undefined,
+    ...overrides,
+  };
 }
 
 function createDeferred<T>() {
@@ -897,10 +974,10 @@ describe("cloud workspace conflict notice", () => {
 
   it("hides the notice after the cleared projection drops the conflict", () => {
     const container = document.createElement("div");
-    render(renderChat(createChatProps({ workspaceConflict: conflict })), container);
+    renderChatInto(container, { workspaceConflict: conflict });
     expect(container.querySelector(".chat-workspace-conflict-notice")).not.toBeNull();
 
-    render(renderChat(createChatProps()), container);
+    renderChatInto(container);
     expect(container.querySelector(".chat-workspace-conflict-notice")).toBeNull();
   });
 
@@ -1302,7 +1379,7 @@ describe("chat transcript rendering", () => {
       content,
     });
     const renderMessages = (messages: unknown[]) =>
-      render(renderChat(createChatProps({ transcript, messages })), container);
+      renderChatInto(container, { transcript, messages });
 
     const existing = [
       message("user-1", "user", "Question"),
@@ -1346,20 +1423,12 @@ describe("chat transcript rendering", () => {
       content: "New answer",
     };
 
-    render(
-      renderChat(createChatProps({ announceTranscript: false, transcript, messages: [existing] })),
-      container,
-    );
-    render(
-      renderChat(
-        createChatProps({
-          announceTranscript: false,
-          transcript,
-          messages: [existing, appended],
-        }),
-      ),
-      container,
-    );
+    renderChatInto(container, { announceTranscript: false, transcript, messages: [existing] });
+    renderChatInto(container, {
+      announceTranscript: false,
+      transcript,
+      messages: [existing, appended],
+    });
 
     expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe("");
   });
@@ -1561,9 +1630,7 @@ describe("chat composer workbench", () => {
     const onSearch = vi.fn();
     const container = renderChatView({
       composerControls: html`<button class="test-composer-control">Model</button>`,
-      sessionWorkspace: {
-        collapsed: false,
-        sessionKey: "agent:main",
+      sessionWorkspace: createSessionWorkspace({
         list: {
           sessionKey: "agent:main",
           root: "/workspace",
@@ -1595,23 +1662,14 @@ describe("chat composer workbench", () => {
           },
           artifacts: [],
         },
-        loading: false,
-        error: null,
         activeId: "file:/workspace/AGENTS.md",
-        dock: "right",
-        narrowLayout: false,
-        dockDragging: false,
-        dockDragZone: null,
         onToggleCollapsed,
-        onSetDock: () => undefined,
-        onDockDragStart: () => undefined,
         onRefresh,
         onBrowsePath,
         onCopyPath,
         onOpenFile,
         onSearch,
-        onOpenArtifact: () => undefined,
-      },
+      }),
     });
 
     const composerControl = container.querySelector(
@@ -1697,27 +1755,9 @@ describe("chat composer workbench", () => {
 
   it("forces the workspace rail to the bottom dock and drops side-dock controls on narrow panes", () => {
     const container = renderChatView({
-      sessionWorkspace: {
-        collapsed: false,
-        sessionKey: "agent:main",
-        list: null,
-        loading: false,
-        error: null,
-        activeId: null,
-        dock: "right",
+      sessionWorkspace: createSessionWorkspace({
         narrowLayout: true,
-        dockDragging: false,
-        dockDragZone: null,
-        onToggleCollapsed: () => undefined,
-        onSetDock: () => undefined,
-        onDockDragStart: () => undefined,
-        onRefresh: () => undefined,
-        onBrowsePath: () => undefined,
-        onCopyPath: () => undefined,
-        onOpenFile: () => undefined,
-        onSearch: () => undefined,
-        onOpenArtifact: () => undefined,
-      },
+      }),
     });
 
     const workbench = container.querySelector(".chat-workbench");
@@ -1728,30 +1768,7 @@ describe("chat composer workbench", () => {
   });
 
   it("moves the background-tasks rail to a bottom strip on narrow panes", () => {
-    const backgroundTasks = {
-      sessionKey: "agent:main:main",
-      statusRowId: "chat-tasks-status-test",
-      collapsed: false,
-      narrowLayout: false,
-      connected: true,
-      canCancel: false,
-      loading: false,
-      error: null,
-      tasks: [],
-      cancellingTaskIds: new Set<string>(),
-      finishedCollapsed: false,
-      selectedTaskId: null,
-      taskDetails: new Map(),
-      taskDetailErrors: new Map(),
-      taskDetailLoadingIds: new Set<string>(),
-      onToggleCollapsed: () => undefined,
-      onToggleFinished: () => undefined,
-      onRefresh: () => undefined,
-      onCancel: () => undefined,
-      onSelectTask: () => undefined,
-      onBackToList: () => undefined,
-      onOpenSession: () => undefined,
-    };
+    const backgroundTasks = createBackgroundTasks();
 
     const wide = renderChatView({ backgroundTasks });
     const wideWorkbench = wide.querySelector(".chat-workbench");
@@ -1766,15 +1783,8 @@ describe("chat composer workbench", () => {
   });
 
   it("shows the running-tasks status row after the turn settles, not while working", () => {
-    const backgroundTasks = {
-      sessionKey: "agent:main:main",
-      statusRowId: "chat-tasks-status-test",
+    const backgroundTasks = createBackgroundTasks({
       collapsed: true,
-      narrowLayout: false,
-      connected: true,
-      canCancel: false,
-      loading: false,
-      error: null,
       tasks: [
         {
           id: "task-1",
@@ -1785,20 +1795,7 @@ describe("chat composer workbench", () => {
           startedAt: 1_500,
         },
       ],
-      cancellingTaskIds: new Set<string>(),
-      finishedCollapsed: false,
-      selectedTaskId: null,
-      taskDetails: new Map(),
-      taskDetailErrors: new Map(),
-      taskDetailLoadingIds: new Set<string>(),
-      onToggleCollapsed: () => undefined,
-      onToggleFinished: () => undefined,
-      onRefresh: () => undefined,
-      onCancel: () => undefined,
-      onSelectTask: () => undefined,
-      onBackToList: () => undefined,
-      onOpenSession: () => undefined,
-    };
+    });
     const messages = [{ role: "assistant", content: "done", timestamp: 1 }];
 
     const settled = renderChatView({ messages, backgroundTasks });
@@ -2001,7 +1998,7 @@ describe("per-pane chat presentation state", () => {
     const paneA = document.createElement("div");
     const paneB = document.createElement("div");
     const renderPane = (container: HTMLElement, paneId: string, draft: string) => {
-      render(renderChat(createChatProps({ paneId, draft, getDraft: () => draft })), container);
+      renderChatInto(container, { paneId, draft, getDraft: () => draft });
     };
     const openSlashMenu = (container: HTMLElement) => {
       const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
@@ -2035,7 +2032,7 @@ describe("per-pane chat presentation state", () => {
     const paneA = document.createElement("div");
     const paneB = document.createElement("div");
     const renderPane = (container: HTMLElement, paneId: string, draft: string) => {
-      render(renderChat(createChatProps({ paneId, draft, getDraft: () => draft })), container);
+      renderChatInto(container, { paneId, draft, getDraft: () => draft });
     };
 
     toggleChatThreadSearch("pane-a", vi.fn());
@@ -2084,15 +2081,9 @@ describe("chat transcript rendering cache", () => {
     const queue: ChatQueueItem[] = [];
     const container = document.createElement("div");
 
-    render(
-      renderChat(createChatProps({ messages, toolMessages, streamSegments, queue })),
-      container,
-    );
+    renderChatInto(container, { messages, toolMessages, streamSegments, queue });
     assistantAttachmentRenderVersionMock.value += 1;
-    render(
-      renderChat(createChatProps({ messages, toolMessages, streamSegments, queue, draft: "h" })),
-      container,
-    );
+    renderChatInto(container, { messages, toolMessages, streamSegments, queue, draft: "h" });
 
     expect(renderMessageGroupMock).toHaveBeenCalledTimes(2);
   });
@@ -2136,6 +2127,40 @@ describe("chat transcript rendering cache", () => {
 });
 
 describe("chat loading skeleton", () => {
+  function createPendingSend(overrides: Partial<ChatQueueItem> = {}): ChatQueueItem {
+    return {
+      id: "send-main",
+      text: "hello",
+      createdAt: 1,
+      sendRunId: "run-main",
+      sendState: "sending",
+      sessionKey: "main",
+      ...overrides,
+    };
+  }
+
+  function createContextUsageSessions(): SessionsListResult {
+    return {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: {
+        modelProvider: "openai",
+        model: "gpt-5.5",
+        contextTokens: 200_000,
+      },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 1,
+          totalTokens: 46_000,
+          totalTokensFresh: true,
+        },
+      ],
+    };
+  }
+
   it("renders realtime Talk transcript as ordered voice turns", () => {
     const container = renderChatView({
       realtimeTalkActive: true,
@@ -2364,7 +2389,7 @@ describe("chat loading skeleton", () => {
       replyGroup,
       readingIndicator,
     ] as ReturnType<typeof chatThread.buildCachedChatItems>);
-    render(renderChat(createChatProps(props)), container);
+    renderChatInto(container, props);
     expect(renderMessageGroupMock.mock.calls.at(-1)?.[1].activeContinuation).toBeDefined();
 
     renderMessageGroupMock.mockClear();
@@ -2373,7 +2398,7 @@ describe("chat loading skeleton", () => {
       toolGroup,
       readingIndicator,
     ] as ReturnType<typeof chatThread.buildCachedChatItems>);
-    render(renderChat(createChatProps(props)), container);
+    renderChatInto(container, props);
 
     const replyCall = renderMessageGroupMock.mock.calls.find(
       ([group]) => group.key === replyGroup.key,
@@ -2401,10 +2426,7 @@ describe("chat loading skeleton", () => {
       isStreaming: false,
     };
     const renderWithUsage = (container: HTMLElement, runOutputTokens: number) => {
-      render(
-        renderChat(createChatProps({ canAbort: true, runOutputTokens, stream: null })),
-        container,
-      );
+      renderChatInto(container, { canAbort: true, runOutputTokens, stream: null });
     };
 
     const streamGroupSpy = vi.fn(renderStreamGroupMock);
@@ -2465,7 +2487,7 @@ describe("chat loading skeleton", () => {
     vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([firstReply] as ReturnType<
       typeof chatThread.buildCachedChatItems
     >);
-    render(renderChat(createChatProps(props)), container);
+    renderChatInto(container, props);
     expect(renderMessageGroupMock.mock.calls.at(-1)?.[1].turnRecap).toBeDefined();
 
     renderMessageGroupMock.mockClear();
@@ -2473,7 +2495,7 @@ describe("chat loading skeleton", () => {
       firstReply,
       secondReply,
     ] as ReturnType<typeof chatThread.buildCachedChatItems>);
-    render(renderChat(createChatProps(props)), container);
+    renderChatInto(container, props);
 
     const firstCall = renderMessageGroupMock.mock.calls.find(
       ([group]) => group.key === firstReply.key,
@@ -2514,35 +2536,8 @@ describe("chat loading skeleton", () => {
       composerControls: html`<button class="chat-view-menu-trigger" type="button">
         Settings
       </button>`,
-      queue: [
-        {
-          id: "send-main",
-          text: "hello",
-          createdAt: 1,
-          sendRunId: "run-main",
-          sendState: "sending",
-          sessionKey: "main",
-        },
-      ],
-      sessions: {
-        ts: 0,
-        path: "",
-        count: 1,
-        defaults: {
-          modelProvider: "openai",
-          model: "gpt-5.5",
-          contextTokens: 200_000,
-        },
-        sessions: [
-          {
-            key: "main",
-            kind: "direct",
-            updatedAt: 1,
-            totalTokens: 46_000,
-            totalTokensFresh: true,
-          },
-        ],
-      },
+      queue: [createPendingSend()],
+      sessions: createContextUsageSessions(),
     });
 
     // The composer shows no working chrome; the thread spark is the visible
@@ -2582,25 +2577,7 @@ describe("chat loading skeleton", () => {
           cost: { input: 0.001, output: 0.002 },
         },
       ],
-      sessions: {
-        ts: 0,
-        path: "",
-        count: 1,
-        defaults: {
-          modelProvider: "openai",
-          model: "gpt-5.5",
-          contextTokens: 200_000,
-        },
-        sessions: [
-          {
-            key: "main",
-            kind: "direct",
-            updatedAt: 1,
-            totalTokens: 46_000,
-            totalTokensFresh: true,
-          },
-        ],
-      },
+      sessions: createContextUsageSessions(),
     });
 
     const context = container.querySelector(".context-ring");
@@ -2627,14 +2604,12 @@ describe("chat loading skeleton", () => {
         sessionKey: "session-b",
         sending: true,
         queue: [
-          {
+          createPendingSend({
             id: "send-a",
             text: "hello from A",
-            createdAt: 1,
             sendRunId: "run-a",
-            sendState: "sending" as const,
             sessionKey: "session-a",
-          },
+          }),
         ],
       },
       announcement: "",
@@ -2644,16 +2619,7 @@ describe("chat loading skeleton", () => {
     {
       name: "shows the working spark while the current session send waits for model switching",
       props: {
-        queue: [
-          {
-            id: "send-main",
-            text: "hello",
-            createdAt: 1,
-            sendRunId: "run-main",
-            sendState: "waiting-model" as const,
-            sessionKey: "main",
-          },
-        ],
+        queue: [createPendingSend({ sendState: "waiting-model" })],
       },
       announcement: "Preparing model",
       exact: false,
@@ -2668,16 +2634,7 @@ describe("chat loading skeleton", () => {
           sessionKey: "main",
           occurredAt: 1_000,
         },
-        queue: [
-          {
-            id: "send-main",
-            text: "hello",
-            createdAt: 999,
-            sendRunId: "run-main",
-            sendState: "waiting-model" as const,
-            sessionKey: "main",
-          },
-        ],
+        queue: [createPendingSend({ createdAt: 999, sendState: "waiting-model" })],
       },
       announcement: "Preparing model",
       exact: false,
@@ -2692,16 +2649,7 @@ describe("chat loading skeleton", () => {
           sessionKey: "main",
           occurredAt: Date.now(),
         },
-        queue: [
-          {
-            id: "send-main",
-            text: "hello",
-            createdAt: 999,
-            sendRunId: "run-main",
-            sendState: "sending" as const,
-            sessionKey: "main",
-          },
-        ],
+        queue: [createPendingSend({ createdAt: 999 })],
       },
       announcement: "Done",
       exact: true,
@@ -2710,16 +2658,7 @@ describe("chat loading skeleton", () => {
     {
       name: "does not announce progress for reconnect-waiting sends",
       props: {
-        queue: [
-          {
-            id: "send-main",
-            text: "hello",
-            createdAt: 1,
-            sendRunId: "run-main",
-            sendState: "waiting-reconnect" as const,
-            sessionKey: "main",
-          },
-        ],
+        queue: [createPendingSend({ sendState: "waiting-reconnect" })],
       },
       announcement: "",
       exact: true,
@@ -3309,11 +3248,33 @@ describe("chat composer sizing", () => {
 });
 
 describe("chat slash menu accessibility", () => {
+  function replaceSkillCommands(
+    ...skills: Array<{ key: string; name?: string; description: string }>
+  ) {
+    replaceSlashCommands([
+      ...buildFallbackSlashCommands(),
+      ...skills.map(({ key, name = key, description }) => ({
+        key,
+        name,
+        description,
+        source: "skill" as const,
+        skillModelVisible: true,
+      })),
+    ]);
+  }
+
   function inputDraft(container: HTMLElement, value: string) {
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
     textarea!.value = value;
     textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  function inputDraftAtEnd(container: HTMLElement, value: string) {
+    const textarea = getComposerTextarea(container);
+    textarea.value = value;
+    textarea.setSelectionRange(value.length, value.length);
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
   }
 
   function keydownComposer(container: HTMLElement, key: string, init: KeyboardEventInit = {}) {
@@ -3342,11 +3303,47 @@ describe("chat slash menu accessibility", () => {
     const onSend = vi.fn(() => {
       draft = "";
     });
-    render(
-      renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
-      container,
-    );
+    renderChatInto(container, { draft, getDraft: () => draft, onDraftChange, onSend });
     return { container, onDraftChange, onSend };
+  }
+
+  function createReactiveDraftHarness({
+    onDraftChange: observeDraftChange,
+    ...overrides
+  }: Partial<ChatProps> = {}) {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+      observeDraftChange?.(next);
+    });
+    const renderCurrent = () => {
+      renderChatInto(container, {
+        draft,
+        getDraft: () => draft,
+        onDraftChange,
+        onRequestUpdate: renderCurrent,
+        ...overrides,
+      });
+    };
+    renderCurrent();
+    return { container };
+  }
+
+  function createSlashRerenderHarness() {
+    let draft = "";
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const renderCurrent = () => renderChatView({ draft, onDraftChange });
+    return {
+      container: renderCurrent(),
+      inputAndRender(container: HTMLElement, value: string) {
+        inputDraft(container, value);
+        return renderCurrent();
+      },
+      renderCurrent,
+    };
   }
 
   function createSessionDraftHarness(prefix: string) {
@@ -3355,22 +3352,18 @@ describe("chat slash menu accessibility", () => {
       drafts[sessionKey] = next;
     });
     const container = document.createElement("div");
-    const renderSession = (sessionKey: string) =>
-      render(
-        renderChat(
-          createChatProps({
-            currentAgentId: `${prefix}-agent`,
-            draft: expectDefined(drafts[sessionKey], "session draft"),
-            getDraft: () => expectDefined(drafts[sessionKey], "session draft"),
-            onDraftChange: (next) => onDraftChange(sessionKey, next),
-            onSend: () => {
-              drafts[sessionKey] = "";
-            },
-            sessionKey,
-          }),
-        ),
-        container,
-      );
+    const renderSession = (sessionKey: string) => {
+      renderChatInto(container, {
+        currentAgentId: `${prefix}-agent`,
+        draft: expectDefined(drafts[sessionKey], "session draft"),
+        getDraft: () => expectDefined(drafts[sessionKey], "session draft"),
+        onDraftChange: (next) => onDraftChange(sessionKey, next),
+        onSend: () => {
+          drafts[sessionKey] = "";
+        },
+        sessionKey,
+      });
+    };
     return { container, drafts, onDraftChange, renderSession };
   }
 
@@ -3388,44 +3381,14 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("hydrates the skill catalog once per active $ reference", async () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "prose",
-        name: "prose",
-        description: "Prose skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
-    let draft = "";
+    replaceSkillCommands({ key: "prose", description: "Prose skill." });
     const onSlashIntent = vi.fn(async () => undefined);
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-            onSlashIntent,
-          }),
-        ),
-        container,
-      );
-    };
+    const { container } = createReactiveDraftHarness({ onSlashIntent });
     const type = async (value: string) => {
-      const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-      textarea.value = value;
-      textarea.setSelectionRange(value.length, value.length);
-      textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+      inputDraftAtEnd(container, value);
       await Promise.resolve();
       await Promise.resolve();
     };
-    renderCurrent();
 
     await type("Use $");
     await type("Use $p");
@@ -3435,42 +3398,11 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("opens a skill picker for $ references anywhere in a normal prompt", async () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "prose",
-        name: "prose",
-        description: "Draft polished prose.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
-    let draft = "";
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
+    replaceSkillCommands({ key: "prose", description: "Draft polished prose." });
     const onSlashIntent = vi.fn(async () => undefined);
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange,
-            onRequestUpdate: renderCurrent,
-            onSlashIntent,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
+    const { container } = createReactiveDraftHarness({ onSlashIntent });
 
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = "Polish this with $pro:";
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    inputDraftAtEnd(container, "Polish this with $pro:");
     await Promise.resolve();
     await Promise.resolve();
 
@@ -3484,41 +3416,14 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("fills a selected $ skill without submitting the surrounding prompt", async () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "prose",
-        name: "prose",
-        description: "Draft polished prose.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
+    replaceSkillCommands({ key: "prose", description: "Draft polished prose." });
     let draft = "";
     const onDraftChange = vi.fn((next: string) => {
       draft = next;
     });
     const onSend = vi.fn();
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange,
-            onRequestUpdate: renderCurrent,
-            onSend,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = "Polish this with $pro:";
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    const { container } = createReactiveDraftHarness({ onDraftChange, onSend });
+    inputDraftAtEnd(container, "Polish this with $pro:");
 
     keydownComposer(container, "Enter");
 
@@ -3531,38 +3436,14 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("consumes a trailing hyphen from an incomplete skill query", () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "release_notes",
-        name: "release_notes",
-        description: "Draft release notes.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
+    replaceSkillCommands({ key: "release_notes", description: "Draft release notes." });
     let draft = "";
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = "Use $release-";
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    const { container } = createReactiveDraftHarness({
+      onDraftChange: (next) => {
+        draft = next;
+      },
+    });
+    inputDraftAtEnd(container, "Use $release-");
 
     keydownComposer(container, "Enter");
 
@@ -3570,83 +3451,21 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("does not treat common uppercase shell variables as skill references", () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "home",
-        name: "home",
-        description: "Home skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-      {
-        key: "editor",
-        name: "editor",
-        description: "Editor skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
-    let draft = "";
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
+    replaceSkillCommands(
+      { key: "home", description: "Home skill." },
+      { key: "editor", description: "Editor skill." },
+    );
+    const { container } = createReactiveDraftHarness();
     for (const variable of ["HOME", "EDITOR"]) {
-      const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-      textarea.value = `Inspect $${variable}`;
-      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-      textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+      inputDraftAtEnd(container, `Inspect $${variable}`);
       expect(container.querySelector(".skill-menu")).toBeNull();
     }
   });
 
   it("does not offer skill references inside a slash-command draft", () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "prose",
-        name: "prose",
-        description: "Prose skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
-    let draft = "";
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = "/status $pro";
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    replaceSkillCommands({ key: "prose", description: "Prose skill." });
+    const { container } = createReactiveDraftHarness();
+    inputDraftAtEnd(container, "/status $pro");
 
     expect(container.querySelector(".skill-menu")).toBeNull();
   });
@@ -3656,29 +3475,14 @@ describe("chat slash menu accessibility", () => {
     const refresh = createDeferred<void>();
     let draft = "";
     const onSend = vi.fn();
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-            onSend,
-            onSlashIntent: () => refresh.promise,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = "Use $pro";
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    const { container } = createReactiveDraftHarness({
+      onDraftChange: (next) => {
+        draft = next;
+      },
+      onSend,
+      onSlashIntent: () => refresh.promise,
+    });
+    inputDraftAtEnd(container, "Use $pro");
     expect(container.querySelector(".skill-menu")?.textContent).toContain("Loading skills");
     const send = container.querySelector<HTMLButtonElement>(".chat-send-btn");
     expect(send?.disabled).toBe(true);
@@ -3691,45 +3495,17 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("keeps skill keyboard navigation and selection on the same highlighted item", () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "alpha",
-        name: "alpha",
-        description: "Alpha skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-      {
-        key: "beta",
-        name: "beta",
-        description: "Beta skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
+    replaceSkillCommands(
+      { key: "alpha", description: "Alpha skill." },
+      { key: "beta", description: "Beta skill." },
+    );
     let draft = "";
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = "Use $";
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    const { container } = createReactiveDraftHarness({
+      onDraftChange: (next) => {
+        draft = next;
+      },
+    });
+    inputDraftAtEnd(container, "Use $");
 
     keydownComposer(container, "ArrowDown");
     expect(
@@ -3742,40 +3518,12 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("does not reopen a dismissed skill picker after a slow refresh", async () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "prose",
-        name: "prose",
-        description: "Prose skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
+    replaceSkillCommands({ key: "prose", description: "Prose skill." });
     const refresh = createDeferred<void>();
-    let draft = "";
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-            onSlashIntent: () => refresh.promise,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = "$pro";
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    const { container } = createReactiveDraftHarness({
+      onSlashIntent: () => refresh.promise,
+    });
+    inputDraftAtEnd(container, "$pro");
     expect(container.querySelector(".skill-menu")?.textContent).toContain("Loading skills");
     expect(container.querySelectorAll(".skill-menu [role='option']")).toHaveLength(0);
 
@@ -3789,35 +3537,9 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("closes a stale skill picker when the caret leaves its token", () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "prose",
-        name: "prose",
-        description: "Prose skill.",
-        source: "skill",
-        skillModelVisible: true,
-      },
-    ]);
-    let draft = "";
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    let textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
+    replaceSkillCommands({ key: "prose", description: "Prose skill." });
+    const { container } = createReactiveDraftHarness();
+    let textarea = getComposerTextarea(container);
     textarea.value = "Use $pro then continue";
     textarea.setSelectionRange("Use $pro".length, "Use $pro".length);
     textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
@@ -3831,41 +3553,13 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("matches backend escape parity and absorbs rejected skill refreshes", async () => {
-    replaceSlashCommands([
-      ...buildFallbackSlashCommands(),
-      {
-        key: "prose",
-        name: "prose",
-        description: "Prose skill.",
-        source: "skill",
-        skillModelVisible: true,
+    replaceSkillCommands({ key: "prose", description: "Prose skill." });
+    const { container } = createReactiveDraftHarness({
+      onSlashIntent: async () => {
+        throw new Error("catalog unavailable");
       },
-    ]);
-    let draft = "";
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange: (next) => {
-              draft = next;
-            },
-            onRequestUpdate: renderCurrent,
-            onSlashIntent: async () => {
-              throw new Error("catalog unavailable");
-            },
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-    textarea.value = String.raw`Use \\$pro`;
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    });
+    inputDraftAtEnd(container, String.raw`Use \\$pro`);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -3873,28 +3567,9 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("does not reopen slash suggestions when command hydration finishes after plain typing", async () => {
-    let draft = "";
     const hydration = createDeferred<void>();
     const onSlashIntent = vi.fn(() => hydration.promise);
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    const container = document.createElement("div");
-    const renderCurrent = () => {
-      render(
-        renderChat(
-          createChatProps({
-            draft,
-            getDraft: () => draft,
-            onDraftChange,
-            onRequestUpdate: renderCurrent,
-            onSlashIntent,
-          }),
-        ),
-        container,
-      );
-    };
-    renderCurrent();
+    const { container } = createReactiveDraftHarness({ onSlashIntent });
 
     inputDraft(container, "/");
     expect(container.querySelector(".slash-menu")).not.toBeNull();
@@ -3916,18 +3591,13 @@ describe("chat slash menu accessibility", () => {
     const onSend = vi.fn();
     const container = document.createElement("div");
     const renderCurrent = (connected: boolean) => {
-      render(
-        renderChat(
-          createChatProps({
-            connected,
-            draft,
-            getDraft: () => draft,
-            onDraftChange,
-            onSend,
-          }),
-        ),
-        container,
-      );
+      renderChatInto(container, {
+        connected,
+        draft,
+        getDraft: () => draft,
+        onDraftChange,
+        onSend,
+      });
     };
 
     renderCurrent(true);
@@ -4124,14 +3794,8 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("wires command suggestions to the composer with stable active option ids", () => {
-    let draft = "";
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    let container = renderChatView({ draft, onDraftChange });
-
-    inputDraft(container, "/");
-    container = renderChatView({ draft, onDraftChange });
+    const harness = createSlashRerenderHarness();
+    const container = harness.inputAndRender(harness.container, "/");
 
     const wrapper = container.querySelector<HTMLElement>(".agent-chat__composer-combobox");
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
@@ -4153,20 +3817,14 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("updates the active descendant and live announcement during command navigation", () => {
-    let draft = "";
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    let container = renderChatView({ draft, onDraftChange });
-
-    inputDraft(container, "/");
-    container = renderChatView({ draft, onDraftChange });
+    const harness = createSlashRerenderHarness();
+    let container = harness.inputAndRender(harness.container, "/");
     const initialActiveId = container
       .querySelector<HTMLTextAreaElement>("textarea")
       ?.getAttribute("aria-activedescendant");
 
     keydownComposer(container, "ArrowDown");
-    container = renderChatView({ draft, onDraftChange });
+    container = harness.renderCurrent();
 
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     const nextActiveId = textarea?.getAttribute("aria-activedescendant");
@@ -4204,14 +3862,8 @@ describe("chat slash menu accessibility", () => {
     clearCommand.descriptionKey = "common.health";
     await i18n.setLocale("zh-CN");
     try {
-      let draft = "";
-      const onDraftChange = vi.fn((next: string) => {
-        draft = next;
-      });
-      let container = renderChatView({ draft, onDraftChange });
-
-      inputDraft(container, "/clear");
-      container = renderChatView({ draft, onDraftChange });
+      const harness = createSlashRerenderHarness();
+      const container = harness.inputAndRender(harness.container, "/clear");
 
       const status = container.querySelector<HTMLElement>("#chat-single-slash-active-announcement");
       expect(status?.textContent?.trim()).toBe(`/clear ${t("common.health")}`);
@@ -4222,14 +3874,8 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("wires fixed argument suggestions with command-and-argument option ids", () => {
-    let draft = "";
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    let container = renderChatView({ draft, onDraftChange });
-
-    inputDraft(container, "/tools ");
-    container = renderChatView({ draft, onDraftChange });
+    const harness = createSlashRerenderHarness();
+    const container = harness.inputAndRender(harness.container, "/tools ");
 
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     const listbox = container.querySelector<HTMLElement>("#chat-single-slash-menu-listbox");
@@ -4241,14 +3887,8 @@ describe("chat slash menu accessibility", () => {
   });
 
   it("clears active descendant when suggestions close", () => {
-    let draft = "";
-    const onDraftChange = vi.fn((next: string) => {
-      draft = next;
-    });
-    let container = renderChatView({ draft, onDraftChange });
-
-    inputDraft(container, "/");
-    container = renderChatView({ draft, onDraftChange });
+    const harness = createSlashRerenderHarness();
+    let container = harness.inputAndRender(harness.container, "/");
     const activeDescendant = container
       .querySelector<HTMLTextAreaElement>("textarea")
       ?.getAttribute("aria-activedescendant");
@@ -4256,8 +3896,7 @@ describe("chat slash menu accessibility", () => {
       throw new Error("Expected slash suggestions to set aria-activedescendant");
     }
 
-    inputDraft(container, "plain message");
-    container = renderChatView({ draft, onDraftChange });
+    container = harness.inputAndRender(container, "plain message");
 
     expect(container.querySelector(".slash-menu")).toBeNull();
     expect(
@@ -4277,6 +3916,38 @@ describe("chat slash menu accessibility", () => {
 });
 
 describe("chat attachment picker", () => {
+  function renderAttachmentHarness(
+    getAttachments: () => ChatAttachment[],
+    onAttachmentsChange: (attachments: ChatAttachment[]) => void,
+  ) {
+    return renderChatView({
+      attachments: getAttachments(),
+      getAttachments,
+      onAttachmentsChange,
+    });
+  }
+
+  function selectFile(input: HTMLInputElement, file: File) {
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function getAttachmentMenuOption(container: Element, label: string) {
+    return Array.from(
+      container.querySelectorAll<HTMLButtonElement>(".agent-chat__attach-menu-option"),
+    ).find((button) => button.textContent?.trim() === label);
+  }
+
+  function requireAttachmentInput(container: Element, selector: string, label: string) {
+    return requireElement(container, selector, label) as HTMLInputElement;
+  }
+
+  function selectAttachmentMenuOption(button: HTMLButtonElement | undefined) {
+    button
+      ?.closest("wa-dropdown")
+      ?.dispatchEvent(new CustomEvent("wa-select", { detail: { item: button }, bubbles: true }));
+  }
+
   it.each(["clipboard", "file picker", "drop"] as const)(
     "waits for an in-flight %s attachment before accepting an immediate send",
     async (entry) => {
@@ -4328,13 +3999,12 @@ describe("chat attachment picker", () => {
         });
         getComposerTextarea(container).dispatchEvent(paste);
       } else if (entry === "file picker") {
-        const input = requireElement(
+        const input = requireAttachmentInput(
           container,
           ".agent-chat__file-input",
           "attachment file input",
-        ) as HTMLInputElement;
-        Object.defineProperty(input, "files", { configurable: true, value: [file] });
-        input.dispatchEvent(new Event("change", { bubbles: true }));
+        );
+        selectFile(input, file);
       } else {
         const drop = new Event("drop", { bubbles: true, cancelable: true });
         Object.defineProperty(drop, "dataTransfer", {
@@ -4532,11 +4202,7 @@ describe("chat attachment picker", () => {
     const onAttachmentsChange = vi.fn((next: ChatAttachment[]) => {
       attachments = next;
     });
-    const container = renderChatView({
-      attachments,
-      getAttachments: () => attachments,
-      onAttachmentsChange,
-    });
+    const container = renderAttachmentHarness(() => attachments, onAttachmentsChange);
     const textarea = getComposerTextarea(container);
     const paste = (text: string) => {
       textarea.dispatchEvent(createPasteEvent(text));
@@ -4565,11 +4231,7 @@ describe("chat attachment picker", () => {
     const onAttachmentsChange = vi.fn((next: ChatAttachment[]) => {
       attachments = next;
     });
-    const container = renderChatView({
-      attachments,
-      getAttachments: () => attachments,
-      onAttachmentsChange,
-    });
+    const container = renderAttachmentHarness(() => attachments, onAttachmentsChange);
     const textarea = getComposerTextarea(container);
     const chat = requireElement(container, "section.card.chat", "chat drop target");
     const pastedText = `large paste ${"x".repeat(1100)}`;
@@ -4650,13 +4312,12 @@ describe("chat attachment picker", () => {
 
   it("shows a cached short preview for pasted text", () => {
     let attachments: ChatAttachment[] = [];
-    let container = renderChatView({
-      attachments,
-      getAttachments: () => attachments,
-      onAttachmentsChange: (next) => {
+    let container = renderAttachmentHarness(
+      () => attachments,
+      (next) => {
         attachments = next;
       },
-    });
+    );
     const textarea = getComposerTextarea(container);
     const text = `First words from a long pasted note ${"x".repeat(1100)}`;
     textarea.dispatchEvent(createPasteEvent(text));
@@ -4672,13 +4333,12 @@ describe("chat attachment picker", () => {
 
   it("keeps large paste previews UTF-16 well-formed at the display boundary", () => {
     let attachments: ChatAttachment[] = [];
-    let container = renderChatView({
-      attachments,
-      getAttachments: () => attachments,
-      onAttachmentsChange: (next) => {
+    let container = renderAttachmentHarness(
+      () => attachments,
+      (next) => {
         attachments = next;
       },
-    });
+    );
     const textarea = getComposerTextarea(container);
     const text = `${"a".repeat(19)}🦞${"x".repeat(1100)}`;
     textarea.dispatchEvent(createPasteEvent(text));
@@ -4782,22 +4442,16 @@ describe("chat attachment picker", () => {
 
   it("opens the scoped file input from the attachment menu", () => {
     const container = renderChatView();
-    const input = requireElement(
+    const input = requireAttachmentInput(
       container,
       ".agent-chat__file-input",
       "attachment file input",
-    ) as HTMLInputElement;
-    const attachButton = Array.from(
-      container.querySelectorAll<HTMLButtonElement>(".agent-chat__attach-menu-option"),
-    ).find((button) => button.textContent?.trim() === t("chat.composer.attachFileOption"));
+    );
+    const attachButton = getAttachmentMenuOption(container, t("chat.composer.attachFileOption"));
     const clickInput = vi.spyOn(input, "click").mockImplementation(() => undefined);
 
     expect(attachButton).toBeInstanceOf(HTMLElement);
-    attachButton!
-      .closest("wa-dropdown")
-      ?.dispatchEvent(
-        new CustomEvent("wa-select", { detail: { item: attachButton }, bubbles: true }),
-      );
+    selectAttachmentMenuOption(attachButton);
 
     expect(clickInput).toHaveBeenCalledTimes(1);
   });
@@ -4812,33 +4466,23 @@ describe("chat attachment picker", () => {
   it("opens the camera input from the attachment menu and attaches the captured photo", async () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });
-    const input = requireElement(
+    const input = requireAttachmentInput(
       container,
       ".agent-chat__camera-input",
       "camera capture input",
-    ) as HTMLInputElement;
-    const cameraButton = Array.from(
-      container.querySelectorAll<HTMLButtonElement>(".agent-chat__attach-menu-option"),
-    ).find((button) => button.textContent?.trim() === t("chat.composer.takePhoto"));
+    );
+    const cameraButton = getAttachmentMenuOption(container, t("chat.composer.takePhoto"));
     const clickInput = vi.spyOn(input, "click").mockImplementation(() => undefined);
 
     expect(input.accept).toBe("image/*");
     expect(input.getAttribute("capture")).toBe("environment");
     expect(cameraButton).toBeInstanceOf(HTMLElement);
     expect(container.querySelector(".agent-chat__camera-btn")).toBeNull();
-    cameraButton!
-      .closest("wa-dropdown")
-      ?.dispatchEvent(
-        new CustomEvent("wa-select", { detail: { item: cameraButton }, bubbles: true }),
-      );
+    selectAttachmentMenuOption(cameraButton);
     expect(clickInput).toHaveBeenCalledTimes(1);
 
     const photo = new File(["photo"], "camera.jpg", { type: "image/jpeg" });
-    Object.defineProperty(input, "files", {
-      configurable: true,
-      value: [photo],
-    });
-    input.dispatchEvent(new Event("change", { bubbles: true }));
+    selectFile(input, photo);
 
     await waitForFast(() => {
       const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
@@ -4850,9 +4494,7 @@ describe("chat attachment picker", () => {
 
   it("keeps the camera attachment option available when the composer has text", () => {
     const container = renderChatView({ draft: "Ready to send" });
-    const cameraButton = Array.from(
-      container.querySelectorAll<HTMLButtonElement>(".agent-chat__attach-menu-option"),
-    ).find((button) => button.textContent?.trim() === t("chat.composer.takePhoto"));
+    const cameraButton = getAttachmentMenuOption(container, t("chat.composer.takePhoto"));
 
     expect(cameraButton).toBeInstanceOf(HTMLElement);
     expect(container.querySelector(".agent-chat__camera-btn")).toBeNull();
@@ -4866,11 +4508,7 @@ describe("chat attachment picker", () => {
     const file = new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" });
 
     expect(input).toBeInstanceOf(HTMLInputElement);
-    Object.defineProperty(input!, "files", {
-      configurable: true,
-      value: [file],
-    });
-    input!.dispatchEvent(new Event("change", { bubbles: true }));
+    selectFile(input!, file);
 
     await waitForFast(() => {
       const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
@@ -4897,11 +4535,7 @@ describe("chat attachment picker", () => {
 
     expect(input).toBeInstanceOf(HTMLInputElement);
     expect(input?.accept).toContain("video/*");
-    Object.defineProperty(input!, "files", {
-      configurable: true,
-      value: [file],
-    });
-    input!.dispatchEvent(new Event("change", { bubbles: true }));
+    selectFile(input!, file);
 
     await waitForFast(() => {
       const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
@@ -5131,14 +4765,7 @@ describe("chat model controls", () => {
   });
 
   it("applies a model selection immediately", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
-    });
+    const { state } = createOpenAiHeaderState();
     const onModelSelect = vi.fn(async () => true);
     const container = renderModelControls(state, { onModelSelect });
     const modelOption = Array.from(
@@ -5151,14 +4778,7 @@ describe("chat model controls", () => {
   });
 
   it("disables runtime overrides with the exact mutation reason", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
-    });
+    const { state } = createOpenAiHeaderState();
     const onFastModeSelect = vi.fn(async () => true);
     const onModelSelect = vi.fn(async () => true);
     const onThinkingSelect = vi.fn(async () => true);
@@ -5185,10 +4805,7 @@ describe("chat model controls", () => {
   it("marks the inherited default muted and resets an override from the provenance row", () => {
     const { state } = createChatHeaderState({
       model: null,
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
+      models: createOpenAiModelCatalog(),
     });
     const container = renderModelControls(state);
 
@@ -5198,12 +4815,9 @@ describe("chat model controls", () => {
     expect(container.querySelector("[data-chat-model-reset]")).toBeNull();
 
     const onModelSelect = vi.fn(async () => true);
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        modelOverrides: { main: "openai/gpt-5.4" },
-        onModelSelect,
-      }),
+    renderModelControls(
+      state,
+      { modelOverrides: { main: "openai/gpt-5.4" }, onModelSelect },
       container,
     );
 
@@ -5302,14 +4916,7 @@ describe("chat model controls", () => {
   });
 
   it("does not patch the model for a locked session", async () => {
-    const { state, request } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
-    });
+    const { state, request } = createOpenAiHeaderState();
     state.sessionsResult = createSessionsResultFromRows([
       {
         key: "agent:main:main",
@@ -5328,14 +4935,7 @@ describe("chat model controls", () => {
   });
 
   it("ignores model clicks while a run is active", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
-    });
+    const { state } = createOpenAiHeaderState();
     state.chatRunId = "run-123";
     state.chatStream = "Working";
     const onModelSelect = vi.fn(async () => true);
@@ -5603,13 +5203,7 @@ describe("chat model controls", () => {
       },
     };
     const container = document.createElement("div");
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        modelOverrides: { main: null },
-      }),
-      container,
-    );
+    renderModelControls(state, { modelOverrides: { main: null } }, container);
 
     expect(
       container.querySelector(".chat-controls__inline-select-label")?.textContent?.trim(),
@@ -5634,10 +5228,7 @@ describe("chat model controls", () => {
     {
       name: "clears a different model override from the actual default model row",
       model: "gpt-5.4",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
+      models: createOpenAiModelCatalog(),
       sessionKey: "default-clear",
       selected: "false",
     },
@@ -5781,10 +5372,7 @@ describe("chat model controls", () => {
 
   it("applies model, reasoning, and speed immediately for the session that opened the picker", () => {
     const { state } = createReasoningHeaderState({
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
+      models: createOpenAiModelCatalog(),
     });
     const onModelSelect = vi.fn(async () => true);
     const onThinkingSelect = vi.fn(async () => true);
@@ -5832,10 +5420,7 @@ describe("chat model controls", () => {
 
   it("locks reasoning and speed while a model switch is pending", () => {
     const { state } = createReasoningHeaderState({
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
+      models: createOpenAiModelCatalog(),
     });
     const container = renderModelControls(state, { modelSwitching: true });
 
@@ -6151,14 +5736,7 @@ describe("chat model controls", () => {
   });
 
   it("renders the committed model selection when a model switch fails", async () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
-    });
+    const { state } = createOpenAiHeaderState();
     const onModelSelect = vi.fn(async () => false);
     const container = document.createElement("div");
     const props = {
@@ -6429,27 +6007,39 @@ describe("chat model controls", () => {
 
 describe("right-click Reply", () => {
   const replyTarget = { messageId: "msg-1", text: "quoted", senderLabel: "User" };
-  const renderReply = (overrides: Partial<Parameters<typeof renderChat>[0]> = {}) =>
+  const renderReply = (overrides: Partial<ChatProps> = {}) =>
     renderChatView({ replyTarget, ...overrides });
+
+  function dispatchContextMenu(target: EventTarget): MouseEvent {
+    const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+    return event;
+  }
+
+  function renderChatBubble(
+    chatOverrides: Partial<ChatProps> = {},
+    bubbleOverrides: Parameters<typeof appendChatBubble>[1] = {},
+  ) {
+    const container = renderChatView(chatOverrides);
+    return { container, ...appendChatBubble(container, bubbleOverrides) };
+  }
 
   it("keeps inline actions in the context menu alongside user rewind and fork", () => {
     const onRewindMessage = vi.fn().mockResolvedValue(true);
     const onForkMessage = vi.fn();
     const onCopy = vi.fn();
-    const container = renderChatView({
-      onRewindMessage,
-      onForkMessage,
-      onSetReply: vi.fn(),
-    });
-    const { bubble, group } = appendChatBubble(container, {
-      entryId: "persisted-user",
-      groupClass: "chat-group user",
-      messageId: "message-1",
-      text: "hello",
-    });
+    const { bubble, group } = renderChatBubble(
+      { onRewindMessage, onForkMessage, onSetReply: vi.fn() },
+      {
+        entryId: "persisted-user",
+        groupClass: "chat-group user",
+        messageId: "message-1",
+        text: "hello",
+      },
+    );
     group.dataset.chatRowKey = "group:user:persisted";
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
 
     const labels = [...document.querySelectorAll(".chat-reply-context-menu button")].map((button) =>
       button.textContent?.trim(),
@@ -6468,7 +6058,7 @@ describe("right-click Reply", () => {
     actionOwner.dataset.messageActionsFor = "message-1";
     actionOwner.append(copyButton);
     group.append(siblingActionOwner, actionOwner);
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
     expect(
       [...document.querySelectorAll(".chat-reply-context-menu button")].map((button) =>
         button.textContent?.trim(),
@@ -6478,7 +6068,7 @@ describe("right-click Reply", () => {
       document.querySelector('.chat-reply-context-menu [aria-label="Reply to message"] svg'),
     ).toBeNull();
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
     document.querySelector<HTMLButtonElement>('[aria-label="Copy as markdown"]')!.click();
     expect(onCopy).toHaveBeenCalledOnce();
   });
@@ -6496,13 +6086,13 @@ describe("right-click Reply", () => {
       setItem: (key: string, value: string) => storedValues.set(key, value),
     } satisfies Storage);
     const onRequestUpdate = vi.fn();
-    const container = renderChatView({ sessionKey: "context-hide-test", onRequestUpdate });
-    const { bubble, group } = appendChatBubble(container, {
-      groupClass: "chat-group assistant",
-    });
+    const { bubble, group } = renderChatBubble(
+      { sessionKey: "context-hide-test", onRequestUpdate },
+      { groupClass: "chat-group assistant" },
+    );
     group.dataset.chatRowKey = "group:assistant:persisted";
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
     document.querySelector<HTMLButtonElement>('[aria-label="Hide message"]')!.click();
     expect(document.querySelector(".chat-delete-confirm")).not.toBeNull();
     document.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!.click();
@@ -6529,7 +6119,7 @@ describe("right-click Reply", () => {
 
     try {
       expect(confirmation?.isConnected).toBe(true);
-      bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+      dispatchContextMenu(bubble);
 
       expect(confirmation?.isConnected).toBe(false);
       expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
@@ -6541,17 +6131,12 @@ describe("right-click Reply", () => {
   });
 
   it("disables rewind and fork context actions during an active run", () => {
-    const container = renderChatView({
-      canAbort: true,
-      onRewindMessage: vi.fn(),
-      onForkMessage: vi.fn(),
-    });
-    const { bubble } = appendChatBubble(container, {
-      entryId: "persisted-user",
-      groupClass: "chat-group user",
-    });
+    const { bubble } = renderChatBubble(
+      { canAbort: true, onRewindMessage: vi.fn(), onForkMessage: vi.fn() },
+      { entryId: "persisted-user", groupClass: "chat-group user" },
+    );
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
 
     expect(
       document.querySelector<HTMLButtonElement>('[aria-label="Rewind to here"]')?.disabled,
@@ -6568,15 +6153,16 @@ describe("right-click Reply", () => {
 
   it("opens context menu and calls onSetReply when Reply is selected", () => {
     const onSetReply = vi.fn();
-    const container = renderChatView({ onSetReply });
-    const { bubble } = appendChatBubble(container, {
-      messageId: "msg-stable-1",
-      senderLabel: "User",
-      text: "hello world",
-    });
+    const { bubble } = renderChatBubble(
+      { onSetReply },
+      {
+        messageId: "msg-stable-1",
+        senderLabel: "User",
+        text: "hello world",
+      },
+    );
 
-    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-    bubble.dispatchEvent(evt);
+    dispatchContextMenu(bubble);
 
     const menu = document.querySelector(".chat-reply-context-menu");
     expect(menu).not.toBeNull();
@@ -6595,10 +6181,9 @@ describe("right-click Reply", () => {
 
   it("backs off before an emoji that crosses the reply target limit", () => {
     const onSetReply = vi.fn();
-    const container = renderChatView({ onSetReply });
-    const { bubble } = appendChatBubble(container, { text: "x".repeat(499) + "🧠tail" });
+    const { bubble } = renderChatBubble({ onSetReply }, { text: "x".repeat(499) + "🧠tail" });
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
     document.querySelector<HTMLButtonElement>(".chat-reply-context-menu button")!.click();
 
     const target = itemAt(
@@ -6610,27 +6195,23 @@ describe("right-click Reply", () => {
   });
 
   it("keeps the native context menu for links inside a replyable bubble", () => {
-    const container = renderChatView({ onSetReply: vi.fn() });
-    const { bubble } = appendChatBubble(container, { text: "hello world" });
+    const { bubble } = renderChatBubble({ onSetReply: vi.fn() }, { text: "hello world" });
     const link = document.createElement("a");
     link.href = "https://example.com";
     link.textContent = "Example";
     bubble.appendChild(link);
 
-    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-    link.dispatchEvent(evt);
+    const evt = dispatchContextMenu(link);
 
     expect(evt.defaultPrevented).toBe(false);
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
 
   it("keeps the native context menu when Reply is unavailable", () => {
-    const container = renderChatView();
-    const { bubble } = appendChatBubble(container, { text: "still streaming" });
+    const { bubble } = renderChatBubble({}, { text: "still streaming" });
     bubble.classList.add("streaming");
 
-    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-    bubble.dispatchEvent(evt);
+    const evt = dispatchContextMenu(bubble);
 
     expect(evt.defaultPrevented).toBe(false);
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
@@ -6639,10 +6220,9 @@ describe("right-click Reply", () => {
   it("dismisses the reply context menu with Escape after delayed listeners register", () => {
     const onSetReply = vi.fn();
     const flushFrames = stubAnimationFrames();
-    const container = renderChatView({ onSetReply });
-    const { bubble } = appendChatBubble(container, { text: "hello world" });
+    const { bubble } = renderChatBubble({ onSetReply }, { text: "hello world" });
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
     flushFrames();
 
     const menu = document.querySelector<HTMLElement>(".chat-reply-context-menu");
@@ -6662,17 +6242,12 @@ describe("right-click Reply", () => {
 
   it("dismisses a context-menu Rewind confirmation with Escape before closing the menu", () => {
     const flushFrames = stubAnimationFrames();
-    const container = renderChatView({
-      paneId: "pane-a",
-      onRewindMessage: vi.fn(),
-    });
-    const { bubble } = appendChatBubble(container, {
-      entryId: "persisted-user",
-      groupClass: "chat-group user",
-      text: "hello",
-    });
+    const { bubble } = renderChatBubble(
+      { paneId: "pane-a", onRewindMessage: vi.fn() },
+      { entryId: "persisted-user", groupClass: "chat-group user", text: "hello" },
+    );
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
     flushFrames();
     const rewindButton = document.querySelector<HTMLButtonElement>(
       '.chat-reply-context-menu [aria-label="Rewind to here"]',
@@ -6707,14 +6282,12 @@ describe("right-click Reply", () => {
     const removeDocumentListener = vi.spyOn(document, "removeEventListener");
     const removeWindowListener = vi.spyOn(window, "removeEventListener");
     const onRewindMessage = vi.fn();
-    const container = renderChatView({ paneId: "pane-a", onRewindMessage });
-    const { bubble } = appendChatBubble(container, {
-      entryId: "persisted-user",
-      groupClass: "chat-group user",
-      text: "hello",
-    });
+    const { bubble } = renderChatBubble(
+      { paneId: "pane-a", onRewindMessage },
+      { entryId: "persisted-user", groupClass: "chat-group user", text: "hello" },
+    );
 
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(bubble);
     flushFrames();
     document
       .querySelector<HTMLButtonElement>('.chat-reply-context-menu [aria-label="Rewind to here"]')!
@@ -6736,13 +6309,12 @@ describe("right-click Reply", () => {
 
   it("dismisses the reply context menu before a later context menu opens", () => {
     const flushFrames = stubAnimationFrames();
-    const container = renderChatView({ onSetReply: vi.fn() });
-    const { bubble } = appendChatBubble(container, { text: "hello world" });
-    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    const { bubble } = renderChatBubble({ onSetReply: vi.fn() }, { text: "hello world" });
+    dispatchContextMenu(bubble);
     flushFrames();
     expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
 
-    document.body.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    dispatchContextMenu(document.body);
 
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
@@ -6855,8 +6427,7 @@ describe("right-click Reply", () => {
     } as unknown as Selection;
     vi.spyOn(window, "getSelection").mockReturnValue(mockSelection);
 
-    const selectedEvent = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-    bubble.dispatchEvent(selectedEvent);
+    const selectedEvent = dispatchContextMenu(bubble);
 
     expect(selectedEvent.defaultPrevented).toBe(true);
     expect(
@@ -6869,8 +6440,7 @@ describe("right-click Reply", () => {
 
     selectedRange = document.createRange();
     selectedRange.selectNodeContents(otherBubble);
-    const disjointEvent = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-    bubble.dispatchEvent(disjointEvent);
+    const disjointEvent = dispatchContextMenu(bubble);
 
     expect(disjointEvent.defaultPrevented).toBe(true);
     expect(

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -68,6 +68,57 @@ function createHost(options?: {
 
 const openSession = { onOpenSession: () => {} };
 
+function makeProps(overrides: Partial<BackgroundTasksProps> = {}): BackgroundTasksProps {
+  return {
+    sessionKey: "agent:main:current",
+    statusRowId: "chat-tasks-status-test",
+    collapsed: true,
+    narrowLayout: false,
+    connected: true,
+    canCancel: false,
+    loading: false,
+    error: null,
+    tasks: null,
+    cancellingTaskIds: new Set(),
+    finishedCollapsed: false,
+    selectedTaskId: null,
+    taskDetails: new Map(),
+    taskDetailErrors: new Map(),
+    taskDetailLoadingIds: new Set(),
+    onToggleCollapsed: () => {},
+    onToggleFinished: () => {},
+    onRefresh: () => {},
+    onCancel: () => {},
+    onSelectTask: () => {},
+    onBackToList: () => {},
+    onOpenSession: () => {},
+    ...overrides,
+  };
+}
+
+function renderTaskRail(overrides: Partial<BackgroundTasksProps>) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  render(
+    html`${renderBackgroundTasksRail(
+      makeProps({
+        collapsed: false,
+        tasks: [],
+        ...overrides,
+      }),
+    )}`,
+    container,
+  );
+  return container;
+}
+
+function renderStatusRow(overrides: Partial<BackgroundTasksProps>) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  render(html`${renderBackgroundTasksStatusRow(makeProps(overrides))}`, container);
+  return container;
+}
+
 afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
@@ -539,48 +590,26 @@ describe("background tasks rail rendering", () => {
     const onCancel = vi.fn();
     const onOpenSession = vi.fn();
     const onSelectTask = vi.fn();
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksRail({
-        sessionKey: "agent:main:current",
-        statusRowId: "chat-tasks-status-test",
-        collapsed: false,
-        narrowLayout: false,
-        connected: true,
-        canCancel: true,
-        loading: false,
-        error: null,
-        tasks: [
-          makeTask({
-            id: "task-1",
-            taskId: "runtime-task-1",
-            childSessionKey: "agent:main:subagent:abc",
-          }),
-          makeTask({
-            id: "task-2",
-            status: "completed",
-            runtime: "cli",
-            title: "Finished work",
-            sessionKey: "agent:main:cli:finished",
-          }),
-        ],
-        cancellingTaskIds: new Set(),
-        finishedCollapsed: false,
-        selectedTaskId: null,
-        taskDetails: new Map(),
-        taskDetailErrors: new Map(),
-        taskDetailLoadingIds: new Set(),
-        onToggleCollapsed: () => {},
-        onToggleFinished: () => {},
-        onRefresh: () => {},
-        onCancel,
-        onSelectTask,
-        onBackToList: () => {},
-        onOpenSession,
-      })}`,
-      container,
-    );
+    const container = renderTaskRail({
+      canCancel: true,
+      tasks: [
+        makeTask({
+          id: "task-1",
+          taskId: "runtime-task-1",
+          childSessionKey: "agent:main:subagent:abc",
+        }),
+        makeTask({
+          id: "task-2",
+          status: "completed",
+          runtime: "cli",
+          title: "Finished work",
+          sessionKey: "agent:main:cli:finished",
+        }),
+      ],
+      onCancel,
+      onSelectTask,
+      onOpenSession,
+    });
 
     const rows = container.querySelectorAll(".chat-tasks-rail__task");
     expect(rows.length).toBe(2);
@@ -605,45 +634,19 @@ describe("background tasks rail rendering", () => {
   });
 
   it("shows live tool activity for running tasks and duration for finished tasks", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksRail({
-        sessionKey: "agent:main:current",
-        statusRowId: "chat-tasks-status-test",
-        collapsed: false,
-        narrowLayout: false,
-        connected: true,
-        canCancel: false,
-        loading: false,
-        error: null,
-        tasks: [
-          makeTask({ id: "task-1", toolUseCount: 12, lastToolName: "read" }),
-          makeTask({
-            id: "task-2",
-            status: "completed",
-            startedAt: 1_000,
-            endedAt: 66_000,
-            updatedAt: 70_000,
-            toolUseCount: 1,
-          }),
-        ],
-        cancellingTaskIds: new Set(),
-        finishedCollapsed: false,
-        selectedTaskId: null,
-        taskDetails: new Map(),
-        taskDetailErrors: new Map(),
-        taskDetailLoadingIds: new Set(),
-        onToggleCollapsed: () => {},
-        onToggleFinished: () => {},
-        onRefresh: () => {},
-        onCancel: () => {},
-        onSelectTask: () => {},
-        onBackToList: () => {},
-        onOpenSession: () => {},
-      })}`,
-      container,
-    );
+    const container = renderTaskRail({
+      tasks: [
+        makeTask({ id: "task-1", toolUseCount: 12, lastToolName: "read" }),
+        makeTask({
+          id: "task-2",
+          status: "completed",
+          startedAt: 1_000,
+          endedAt: 66_000,
+          updatedAt: 70_000,
+          toolUseCount: 1,
+        }),
+      ],
+    });
 
     const running = container.querySelector('[data-task-id="task-1"]');
     expect(running?.textContent).toContain("12 tool uses");
@@ -663,40 +666,17 @@ describe("background tasks rail rendering", () => {
       status: "completed",
       terminalSummary: "Audit complete",
     });
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksRail({
-        sessionKey: "agent:main:current",
-        statusRowId: "chat-tasks-status-test",
-        collapsed: false,
-        narrowLayout: false,
-        connected: true,
-        canCancel: false,
-        loading: false,
-        error: null,
-        tasks: [task],
-        cancellingTaskIds: new Set(),
-        finishedCollapsed: false,
-        selectedTaskId: "task-1",
-        taskDetails: new Map([
-          [
-            "task-1",
-            { ...task, terminalSummary: "Stale running progress", prompt: "Review running tasks" },
-          ],
-        ]),
-        taskDetailErrors: new Map(),
-        taskDetailLoadingIds: new Set(),
-        onToggleCollapsed: () => {},
-        onToggleFinished: () => {},
-        onRefresh: () => {},
-        onCancel: () => {},
-        onSelectTask: () => {},
-        onBackToList,
-        onOpenSession: () => {},
-      })}`,
-      container,
-    );
+    const container = renderTaskRail({
+      tasks: [task],
+      selectedTaskId: "task-1",
+      taskDetails: new Map([
+        [
+          "task-1",
+          { ...task, terminalSummary: "Stale running progress", prompt: "Review running tasks" },
+        ],
+      ]),
+      onBackToList,
+    });
 
     const detail = container.querySelector('[data-task-detail="task-1"]');
     expect(detail?.textContent).toContain("Review running tasks");
@@ -724,35 +704,11 @@ describe("background tasks rail rendering", () => {
       terminalSummary: "Finished in lookup",
       prompt: "Review running tasks",
     });
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksRail({
-        sessionKey: "agent:main:current",
-        statusRowId: "chat-tasks-status-test",
-        collapsed: false,
-        narrowLayout: false,
-        connected: true,
-        canCancel: false,
-        loading: false,
-        error: null,
-        tasks: [listTask],
-        cancellingTaskIds: new Set(),
-        finishedCollapsed: false,
-        selectedTaskId: "task-1",
-        taskDetails: new Map([["task-1", lookupTask]]),
-        taskDetailErrors: new Map(),
-        taskDetailLoadingIds: new Set(),
-        onToggleCollapsed: () => {},
-        onToggleFinished: () => {},
-        onRefresh: () => {},
-        onCancel: () => {},
-        onSelectTask: () => {},
-        onBackToList: () => {},
-        onOpenSession: () => {},
-      })}`,
-      container,
-    );
+    const container = renderTaskRail({
+      tasks: [listTask],
+      selectedTaskId: "task-1",
+      taskDetails: new Map([["task-1", lookupTask]]),
+    });
 
     const detail = container.querySelector('[data-task-detail="task-1"]');
     expect(detail?.textContent).toContain("Finished in lookup");
@@ -760,35 +716,10 @@ describe("background tasks rail rendering", () => {
   });
 
   it("collapses the finished section", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksRail({
-        sessionKey: "agent:main:current",
-        statusRowId: "chat-tasks-status-test",
-        collapsed: false,
-        narrowLayout: false,
-        connected: true,
-        canCancel: false,
-        loading: false,
-        error: null,
-        tasks: [makeTask({ id: "task-2", status: "completed" })],
-        cancellingTaskIds: new Set(),
-        finishedCollapsed: true,
-        selectedTaskId: null,
-        taskDetails: new Map(),
-        taskDetailErrors: new Map(),
-        taskDetailLoadingIds: new Set(),
-        onToggleCollapsed: () => {},
-        onToggleFinished: () => {},
-        onRefresh: () => {},
-        onCancel: () => {},
-        onSelectTask: () => {},
-        onBackToList: () => {},
-        onOpenSession: () => {},
-      })}`,
-      container,
-    );
+    const container = renderTaskRail({
+      tasks: [makeTask({ id: "task-2", status: "completed" })],
+      finishedCollapsed: true,
+    });
 
     expect(container.querySelectorAll(".chat-tasks-rail__task").length).toBe(0);
     expect(
@@ -798,49 +729,14 @@ describe("background tasks rail rendering", () => {
 });
 
 describe("running-tasks status row", () => {
-  function makeProps(overrides: Partial<BackgroundTasksProps>): BackgroundTasksProps {
-    return {
-      sessionKey: "agent:main:current",
-      statusRowId: "chat-tasks-status-test",
-      collapsed: true,
-      narrowLayout: false,
-      connected: true,
-      canCancel: false,
-      loading: false,
-      error: null,
-      tasks: null,
-      cancellingTaskIds: new Set(),
-      finishedCollapsed: false,
-      selectedTaskId: null,
-      taskDetails: new Map(),
-      taskDetailErrors: new Map(),
-      taskDetailLoadingIds: new Set(),
-      onToggleCollapsed: () => {},
-      onToggleFinished: () => {},
-      onRefresh: () => {},
-      onCancel: () => {},
-      onSelectTask: () => {},
-      onBackToList: () => {},
-      onOpenSession: () => {},
-      ...overrides,
-    };
-  }
-
   it("ticks from the oldest active start and counts only active tasks", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksStatusRow(
-        makeProps({
-          tasks: [
-            makeTask({ id: "t1", startedAt: 9_000 }),
-            makeTask({ id: "t2", status: "queued", startedAt: undefined, createdAt: 4_000 }),
-            makeTask({ id: "t3", status: "completed", startedAt: 100 }),
-          ],
-        }),
-      )}`,
-      container,
-    );
+    const container = renderStatusRow({
+      tasks: [
+        makeTask({ id: "t1", startedAt: 9_000 }),
+        makeTask({ id: "t2", status: "queued", startedAt: undefined, createdAt: 4_000 }),
+        makeTask({ id: "t3", status: "completed", startedAt: 100 }),
+      ],
+    });
 
     const elapsed = container.querySelector<HTMLElement & { startMs: number | null }>(
       "openclaw-elapsed-time",
@@ -853,17 +749,10 @@ describe("running-tasks status row", () => {
 
   it("renders count, ticking elapsed time, and opens the collapsed rail", () => {
     const onToggleCollapsed = vi.fn();
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksStatusRow(
-        makeProps({
-          tasks: [makeTask({ id: "t1", startedAt: 9_000 })],
-          onToggleCollapsed,
-        }),
-      )}`,
-      container,
-    );
+    const container = renderStatusRow({
+      tasks: [makeTask({ id: "t1", startedAt: 9_000 })],
+      onToggleCollapsed,
+    });
 
     const row = container.querySelector(".chat-tasks-status");
     expect(row).not.toBeNull();
@@ -879,18 +768,11 @@ describe("running-tasks status row", () => {
 
   it("pluralizes the label and leaves an open rail alone", () => {
     const onToggleCollapsed = vi.fn();
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksStatusRow(
-        makeProps({
-          collapsed: false,
-          tasks: [makeTask({ id: "t1" }), makeTask({ id: "t2", status: "queued" })],
-          onToggleCollapsed,
-        }),
-      )}`,
-      container,
-    );
+    const container = renderStatusRow({
+      collapsed: false,
+      tasks: [makeTask({ id: "t1" }), makeTask({ id: "t2", status: "queued" })],
+      onToggleCollapsed,
+    });
 
     const link = container.querySelector<HTMLButtonElement>(".chat-tasks-status__link");
     expect(link?.textContent?.trim()).toBe("2 running tasks");
@@ -899,23 +781,16 @@ describe("running-tasks status row", () => {
   });
 
   it("anchors a hover preview of the latest tasks, active first, capped at five", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksStatusRow(
-        makeProps({
-          tasks: [
-            makeTask({ id: "a1", title: "Active one", updatedAt: 9_000 }),
-            makeTask({ id: "a2", status: "queued", title: "Queued two", updatedAt: 8_000 }),
-            makeTask({ id: "f1", status: "completed", title: "Finished one", updatedAt: 7_000 }),
-            makeTask({ id: "f2", status: "failed", title: "Finished two", updatedAt: 6_000 }),
-            makeTask({ id: "f3", status: "completed", title: "Finished three", updatedAt: 5_000 }),
-            makeTask({ id: "f4", status: "completed", title: "Finished four", updatedAt: 4_000 }),
-          ],
-        }),
-      )}`,
-      container,
-    );
+    const container = renderStatusRow({
+      tasks: [
+        makeTask({ id: "a1", title: "Active one", updatedAt: 9_000 }),
+        makeTask({ id: "a2", status: "queued", title: "Queued two", updatedAt: 8_000 }),
+        makeTask({ id: "f1", status: "completed", title: "Finished one", updatedAt: 7_000 }),
+        makeTask({ id: "f2", status: "failed", title: "Finished two", updatedAt: 6_000 }),
+        makeTask({ id: "f3", status: "completed", title: "Finished three", updatedAt: 5_000 }),
+        makeTask({ id: "f4", status: "completed", title: "Finished four", updatedAt: 4_000 }),
+      ],
+    });
 
     const preview = container.querySelector("openclaw-tooltip.chat-tasks-status__preview");
     expect(preview?.firstElementChild?.classList.contains("chat-tasks-status__link")).toBe(true);
@@ -937,40 +812,26 @@ describe("running-tasks status row", () => {
   });
 
   it("sizes the preview to the task list without an overflow line", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksStatusRow(
-        makeProps({ tasks: [makeTask({ id: "t1", title: "Only task" })] }),
-      )}`,
-      container,
-    );
+    const container = renderStatusRow({
+      tasks: [makeTask({ id: "t1", title: "Only task" })],
+    });
 
     expect(container.querySelectorAll(".chat-tasks-preview__row").length).toBe(1);
     expect(container.querySelector(".chat-tasks-preview__more")).toBeNull();
   });
 
   it("renders nothing without active tasks", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksStatusRow(
-        makeProps({ tasks: [makeTask({ id: "t1", status: "completed" })] }),
-      )}`,
-      container,
-    );
+    const container = renderStatusRow({
+      tasks: [makeTask({ id: "t1", status: "completed" })],
+    });
     expect(container.querySelector(".chat-tasks-status")).toBeNull();
   });
 
   it("hides the stale snapshot while disconnected", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    render(
-      html`${renderBackgroundTasksStatusRow(
-        makeProps({ connected: false, tasks: [makeTask({ id: "t1" })] }),
-      )}`,
-      container,
-    );
+    const container = renderStatusRow({
+      connected: false,
+      tasks: [makeTask({ id: "t1" })],
+    });
     expect(container.querySelector(".chat-tasks-status")).toBeNull();
   });
 });

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -80,6 +80,88 @@ beforeEach(() => {
 });
 
 type RenderMessageGroupOptions = Parameters<typeof renderMessageGroup>[1];
+type TestMessage = Record<string, unknown>;
+
+function messageTimestamp(message: unknown): number {
+  return typeof message === "object" &&
+    message !== null &&
+    typeof (message as { timestamp?: unknown }).timestamp === "number"
+    ? (message as { timestamp: number }).timestamp
+    : Date.now();
+}
+
+function createAssistantMessage(content: unknown, overrides: TestMessage = {}): TestMessage {
+  const timestamp = typeof overrides.timestamp === "number" ? overrides.timestamp : Date.now();
+  return { role: "assistant", content, timestamp, ...overrides };
+}
+
+function createUserMessage(content: unknown, overrides: TestMessage = {}): TestMessage {
+  const timestamp = typeof overrides.timestamp === "number" ? overrides.timestamp : Date.now();
+  return { role: "user", content, timestamp, ...overrides };
+}
+
+function createToolCall(id: string, name: string, args: unknown, overrides: TestMessage = {}) {
+  return { type: "toolcall", id, name, arguments: args, ...overrides };
+}
+
+function createToolResultBlock(
+  id: string,
+  name: string,
+  text: string,
+  overrides: TestMessage = {},
+) {
+  return { type: "tool_result", id, name, text, ...overrides };
+}
+
+function createToolResultMessage(
+  toolCallId: string,
+  toolName: string,
+  content: unknown,
+  overrides: TestMessage = {},
+): TestMessage {
+  const timestamp = typeof overrides.timestamp === "number" ? overrides.timestamp : Date.now();
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName,
+    content,
+    timestamp,
+    ...overrides,
+  };
+}
+
+function createMediaBlock(overrides: TestMessage) {
+  return { type: "image", ...overrides };
+}
+
+function createAssistantImageMessage(
+  url: string,
+  alt: string,
+  imageOverrides: TestMessage = {},
+  messageOverrides: TestMessage = {},
+) {
+  return createAssistantMessage(
+    [createMediaBlock({ url, alt, ...imageOverrides })],
+    messageOverrides,
+  );
+}
+
+function createAssistantAudioMessage(
+  url: string,
+  audioOverrides: TestMessage = {},
+  messageOverrides: TestMessage = {},
+) {
+  return createAssistantMessage([{ type: "audio", url, ...audioOverrides }], messageOverrides);
+}
+
+function createAttachmentBlock(
+  url: string,
+  kind: "audio" | "video" | "document",
+  label: string,
+  mimeType: string,
+) {
+  return { type: "attachment", attachment: { url, kind, label, mimeType } };
+}
 
 function expectElement<T extends Element>(
   container: Element,
@@ -115,6 +197,19 @@ function rejectWhenAborted<T>(signal: AbortSignal, rejection: () => Error): Prom
   });
 }
 
+function renderTestMessageGroup(
+  group: MessageGroup,
+  opts: Partial<RenderMessageGroupOptions> = {},
+) {
+  return renderMessageGroup(group, {
+    showReasoning: true,
+    showToolCalls: true,
+    assistantName: "OpenClaw",
+    assistantAvatar: null,
+    ...opts,
+  });
+}
+
 function renderAssistantMessage(
   container: HTMLElement,
   message: unknown,
@@ -128,33 +223,14 @@ function renderAssistantMessages(
   messages: unknown[],
   opts: Partial<RenderMessageGroupOptions> = {},
 ) {
-  const timestamp =
-    typeof messages[0] === "object" &&
-    messages[0] !== null &&
-    typeof (messages[0] as { timestamp?: unknown }).timestamp === "number"
-      ? (messages[0] as { timestamp: number }).timestamp
-      : Date.now();
-  const group: MessageGroup = {
-    kind: "group",
+  const group = createMessageGroup(messages[0], "assistant", {
     key: "assistant-group",
-    role: "assistant",
     messages: messages.map((message, index) => ({
       key: `assistant-message-${index}`,
       message,
     })),
-    timestamp,
-    isStreaming: false,
-  };
-  render(
-    renderMessageGroup(group, {
-      showReasoning: true,
-      showToolCalls: true,
-      assistantName: "OpenClaw",
-      assistantAvatar: null,
-      ...opts,
-    }),
-    container,
-  );
+  });
+  render(renderTestMessageGroup(group, opts), container);
 }
 
 function renderAssistantMessageEntries(
@@ -162,24 +238,12 @@ function renderAssistantMessageEntries(
   entries: MessageGroup["messages"],
   opts: Partial<RenderMessageGroupOptions> = {},
 ) {
-  const group: MessageGroup = {
-    kind: "group",
+  const group = createMessageGroup(entries[0]?.message, "assistant", {
     key: "assistant-group",
-    role: "assistant",
     messages: entries,
     timestamp: Date.now(),
-    isStreaming: false,
-  };
-  render(
-    renderMessageGroup(group, {
-      showReasoning: true,
-      showToolCalls: true,
-      assistantName: "OpenClaw",
-      assistantAvatar: null,
-      ...opts,
-    }),
-    container,
-  );
+  });
+  render(renderTestMessageGroup(group, opts), container);
 }
 
 function renderGroupedMessage(
@@ -188,39 +252,19 @@ function renderGroupedMessage(
   role: string,
   opts: Partial<RenderMessageGroupOptions> = {},
 ) {
-  const timestamp =
-    typeof message === "object" &&
-    message !== null &&
-    typeof (message as { timestamp?: unknown }).timestamp === "number"
-      ? (message as { timestamp: number }).timestamp
-      : Date.now();
-  const group: MessageGroup = {
-    kind: "group",
+  const group = createMessageGroup(message, role, {
     key: `${role}-group`,
-    role,
     messages: [{ key: `${role}-message`, message }],
-    timestamp,
-    isStreaming: false,
-  };
-  render(
-    renderMessageGroup(group, {
-      showReasoning: true,
-      showToolCalls: true,
-      assistantName: "OpenClaw",
-      assistantAvatar: null,
-      ...opts,
-    }),
-    container,
-  );
+  });
+  render(renderTestMessageGroup(group, opts), container);
 }
 
-function createMessageGroup(message: unknown, role: string): MessageGroup {
-  const timestamp =
-    typeof message === "object" &&
-    message !== null &&
-    typeof (message as { timestamp?: unknown }).timestamp === "number"
-      ? (message as { timestamp: number }).timestamp
-      : Date.now();
+function createMessageGroup(
+  message: unknown,
+  role: string,
+  overrides: Partial<MessageGroup> = {},
+): MessageGroup {
+  const timestamp = overrides.timestamp ?? messageTimestamp(message);
   return {
     kind: "group",
     key: `${role}:${timestamp}`,
@@ -228,7 +272,20 @@ function createMessageGroup(message: unknown, role: string): MessageGroup {
     messages: [{ key: `${role}:${timestamp}:message`, message }],
     timestamp,
     isStreaming: false,
+    ...overrides,
   };
+}
+
+function createMessageEntry(key: string, message: unknown): MessageGroup["messages"][number] {
+  return { key, message };
+}
+
+function createToolGroup(
+  key: string,
+  messages: MessageGroup["messages"],
+  overrides: Partial<MessageGroup> = {},
+): MessageGroup {
+  return createMessageGroup(messages[0]?.message, "tool", { key, messages, ...overrides });
 }
 
 describe("cloud workspace conflict transcript messages", () => {
@@ -291,6 +348,23 @@ describe("cloud workspace conflict transcript messages", () => {
   });
 });
 
+function createCanvasPreview(params: {
+  viewId: string;
+  title?: string;
+  url?: string;
+  preferredHeight?: number;
+}) {
+  return {
+    kind: "canvas",
+    surface: "assistant_message",
+    render: "url",
+    viewId: params.viewId,
+    title: params.title ?? "Inline demo",
+    url: params.url ?? `/__openclaw__/canvas/documents/${params.viewId}/index.html`,
+    preferredHeight: params.preferredHeight ?? 360,
+  };
+}
+
 function createAssistantCanvasBlock(params: {
   suffix: string;
   title?: string;
@@ -299,28 +373,18 @@ function createAssistantCanvasBlock(params: {
   presentationTarget?: "assistant_message" | "tool_card";
 }) {
   const viewId = `cv_inline_${params.suffix}`;
-  const url = params.url ?? `/__openclaw__/canvas/documents/${viewId}/index.html`;
-  const title = params.title ?? "Inline demo";
-  const preferredHeight = params.preferredHeight ?? 360;
+  const preview = createCanvasPreview({ ...params, viewId });
   return {
     type: "canvas",
-    preview: {
-      kind: "canvas",
-      surface: "assistant_message",
-      render: "url",
-      viewId,
-      title,
-      url,
-      preferredHeight,
-    },
+    preview,
     rawText: JSON.stringify({
       kind: "canvas",
       view: {
         backend: "canvas",
         id: viewId,
-        url,
-        title,
-        preferred_height: preferredHeight,
+        url: preview.url,
+        title: preview.title,
+        preferred_height: preview.preferredHeight,
       },
       presentation: {
         target: params.presentationTarget ?? "assistant_message",
@@ -334,18 +398,7 @@ function renderMessageGroups(
   groups: MessageGroup[],
   opts: Partial<RenderMessageGroupOptions> = {},
 ) {
-  render(
-    html`${groups.map((group) =>
-      renderMessageGroup(group, {
-        showReasoning: true,
-        showToolCalls: true,
-        assistantName: "OpenClaw",
-        assistantAvatar: null,
-        ...opts,
-      }),
-    )}`,
-    container,
-  );
+  render(html`${groups.map((group) => renderTestMessageGroup(group, opts))}`, container);
 }
 
 function clearDeleteConfirmSkip() {
@@ -625,11 +678,13 @@ describe("grouped chat rendering", () => {
   it("preserves paragraph breaks around assistant attachments in rendered markdown", () => {
     const container = document.createElement("div");
 
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: "First paragraph\n \nMEDIA:https://example.com/image.png\n\t\nSecond paragraph",
-      timestamp: 1000,
-    });
+    renderAssistantMessage(
+      container,
+      createAssistantMessage(
+        "First paragraph\n \nMEDIA:https://example.com/image.png\n\t\nSecond paragraph",
+        { timestamp: 1000 },
+      ),
+    );
 
     expect(markdownRenderMock).toHaveBeenCalledWith(
       "First paragraph\n\nSecond paragraph",
@@ -642,11 +697,9 @@ describe("grouped chat rendering", () => {
     renderAssistantMessageEntries(container, [
       {
         key: "assistant-heartbeat",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "HEARTBEAT_OK" }],
+        message: createAssistantMessage([{ type: "text", text: "HEARTBEAT_OK" }], {
           timestamp: 1,
-        },
+        }),
         duplicateCount: 4,
       },
     ]);
@@ -658,11 +711,10 @@ describe("grouped chat rendering", () => {
 
   it("does not render the stale assistant read-aloud footer action", () => {
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: "hello from assistant",
-      timestamp: 1000,
-    });
+    renderAssistantMessage(
+      container,
+      createAssistantMessage("hello from assistant", { timestamp: 1000 }),
+    );
 
     expect(container.querySelector(".chat-tts-btn")).toBeNull();
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
@@ -670,11 +722,7 @@ describe("grouped chat rendering", () => {
 
   it("renders assistant message actions in the footer row", () => {
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: "Short reply",
-      timestamp: 1000,
-    });
+    renderAssistantMessage(container, createAssistantMessage("Short reply", { timestamp: 1000 }));
 
     const assistantGroup = expectElement(container, ".chat-group.assistant", HTMLElement);
     expect(assistantGroup.querySelector(".chat-bubble-actions")).toBeNull();
@@ -682,15 +730,7 @@ describe("grouped chat rendering", () => {
       assistantGroup.querySelector(".chat-group-footer-actions .chat-copy-btn"),
     ).toBeInstanceOf(HTMLElement);
 
-    renderGroupedMessage(
-      container,
-      {
-        role: "user",
-        content: "Short reply",
-        timestamp: 1001,
-      },
-      "user",
-    );
+    renderGroupedMessage(container, createUserMessage("Short reply", { timestamp: 1001 }), "user");
 
     const userBubble = expectElement(container, ".chat-group.user .chat-bubble", HTMLElement);
     expect(userBubble.classList.contains("has-copy")).toBe(false);
@@ -702,12 +742,10 @@ describe("grouped chat rendering", () => {
     const onReply = vi.fn();
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: "Reply with this context.",
+      createAssistantMessage("Reply with this context.", {
         timestamp: 1000,
         __openclaw: { id: "assistant-entry-1" },
-      },
+      }),
       { onDelete: vi.fn(), onReply },
     );
 
@@ -732,12 +770,10 @@ describe("grouped chat rendering", () => {
     const userContainer = document.createElement("div");
     renderGroupedMessage(
       userContainer,
-      {
-        role: "user",
-        content: "User reply context.",
+      createUserMessage("User reply context.", {
         timestamp: 1001,
         __openclaw: { id: "user-entry-1" },
-      },
+      }),
       "user",
       { onReply, userName: "Jason" },
     );
@@ -753,21 +789,12 @@ describe("grouped chat rendering", () => {
 
   it("orders user footer actions before the sender name and timestamp", () => {
     const container = document.createElement("div");
-    renderGroupedMessage(
-      container,
-      {
-        role: "user",
-        content: "User footer order.",
-        timestamp: Date.now(),
-      },
-      "user",
-      {
-        onDelete: vi.fn(),
-        onReply: vi.fn(),
-        onRewind: vi.fn(),
-        userName: "Jason",
-      },
-    );
+    renderGroupedMessage(container, createUserMessage("User footer order."), "user", {
+      onDelete: vi.fn(),
+      onReply: vi.fn(),
+      onRewind: vi.fn(),
+      userName: "Jason",
+    });
 
     const footer = expectElement(container, ".chat-group.user .chat-group-footer", HTMLElement);
     const order = [
@@ -790,11 +817,9 @@ describe("grouped chat rendering", () => {
     const onReply = vi.fn();
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: "<thinking>private reasoning</thinking>Visible answer.",
+      createAssistantMessage("<thinking>private reasoning</thinking>Visible answer.", {
         timestamp: 1000,
-      },
+      }),
       { onReply },
     );
 
@@ -803,11 +828,7 @@ describe("grouped chat rendering", () => {
 
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: "<thinking>private reasoning only</thinking>",
-        timestamp: 1001,
-      },
+      createAssistantMessage("<thinking>private reasoning only</thinking>", { timestamp: 1001 }),
       { onReply },
     );
     expect(container.querySelector('[aria-label="Reply to message"]')).toBeNull();
@@ -815,11 +836,10 @@ describe("grouped chat rendering", () => {
 
   it("does not replay an arrival animation when a message row mounts", () => {
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: "Stable transcript row",
-      timestamp: 1000,
-    });
+    renderAssistantMessage(
+      container,
+      createAssistantMessage("Stable transcript row", { timestamp: 1000 }),
+    );
 
     const bubble = expectElement(container, ".chat-bubble", HTMLElement);
     expect(bubble.classList.contains("fade-in")).toBe(false);
@@ -832,11 +852,7 @@ describe("grouped chat rendering", () => {
 
     renderGroupedMessage(
       container,
-      {
-        role: "user",
-        content: markdownContent,
-        timestamp: 1001,
-      },
+      createUserMessage(markdownContent, { timestamp: 1001 }),
       "user",
     );
 
@@ -857,11 +873,7 @@ describe("grouped chat rendering", () => {
 
     renderGroupedMessage(
       container,
-      {
-        role: "user",
-        content: markdownContent,
-        timestamp: 1001,
-      },
+      createUserMessage(markdownContent, { timestamp: 1001 }),
       "user",
       {
         isUserMessageExpanded: () => false,
@@ -883,11 +895,7 @@ describe("grouped chat rendering", () => {
 
     renderGroupedMessage(
       container,
-      {
-        role: "user",
-        content: markdownContent,
-        timestamp: 1001,
-      },
+      createUserMessage(markdownContent, { timestamp: 1001 }),
       "user",
       {
         isUserMessageExpanded: () => true,
@@ -937,11 +945,7 @@ describe("grouped chat rendering", () => {
 
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: "Long reply ".repeat(100),
-        timestamp: 1002,
-      },
+      createAssistantMessage("Long reply ".repeat(100), { timestamp: 1002 }),
       { onToggleUserMessageExpanded },
     );
     expect(container.querySelector(".chat-message-disclosure")).toBeNull();
@@ -951,11 +955,7 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     const markdownContent = "```bash\necho ok\n```";
 
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: markdownContent,
-      timestamp: 1000,
-    });
+    renderAssistantMessage(container, createAssistantMessage(markdownContent, { timestamp: 1000 }));
 
     expect(markdownRenderMock).toHaveBeenCalledWith(markdownContent, {
       assistantTranscriptRoleHeaders: true,
@@ -1304,13 +1304,11 @@ describe("grouped chat rendering", () => {
       const container = document.createElement("div");
       renderAssistantMessage(
         container,
-        {
-          role: "assistant",
-          content: "Done",
+        createAssistantMessage("Done", {
           usage,
           model: "anthropic/claude-opus-4-7",
           timestamp: 1000,
-        },
+        }),
         { contextWindow },
       );
       return container;
@@ -1354,13 +1352,11 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: "Done",
+      createAssistantMessage("Done", {
         usage: { input: 12_000, output: 300 },
         model: "openai/gpt-5.5",
         timestamp: 1000,
-      },
+      }),
       { contextWindow: 100_000 },
     );
 
@@ -1389,18 +1385,14 @@ describe("grouped chat rendering", () => {
     renderAssistantMessages(
       container,
       [
-        {
-          role: "assistant",
-          content: "Checking",
+        createAssistantMessage("Checking", {
           usage: { input: 105_944, output: 100 },
           timestamp: 1000,
-        },
-        {
-          role: "assistant",
-          content: "Done",
+        }),
+        createAssistantMessage("Done", {
           usage: { input: 108_577, output: 100 },
           timestamp: 1001,
-        },
+        }),
       ],
       { contextWindow: 258_400 },
     );
@@ -1415,11 +1407,7 @@ describe("grouped chat rendering", () => {
     vi.setSystemTime(timestamp + 5 * 60 * 1000);
     const container = document.createElement("div");
 
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: "Done",
-      timestamp,
-    });
+    renderAssistantMessage(container, createAssistantMessage("Done", { timestamp }));
 
     let time = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
     expect(time?.dateTime).toBe(new Date(timestamp).toISOString());
@@ -1449,7 +1437,7 @@ describe("grouped chat rendering", () => {
     vi.setSystemTime(now);
     const container = document.createElement("div");
     const renderTimestamp = (timestamp: number) => {
-      renderAssistantMessage(container, { role: "assistant", content: "Done", timestamp });
+      renderAssistantMessage(container, createAssistantMessage("Done", { timestamp }));
       return container.querySelector<HTMLTimeElement>(".chat-group-timestamp")?.textContent?.trim();
     };
 
@@ -1497,11 +1485,7 @@ describe("grouped chat rendering", () => {
   it("uses the browser locale for timestamp tooltips", () => {
     const timestamp = Date.UTC(2026, 0, 15, 19, 30);
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: "Done",
-      timestamp,
-    });
+    renderAssistantMessage(container, createAssistantMessage("Done", { timestamp }));
 
     expect(container.querySelector("openclaw-tooltip")?.getAttribute("content")).toBe(
       new Date(timestamp).toLocaleString([], {
@@ -1812,11 +1796,7 @@ describe("grouped chat rendering", () => {
       const container = document.createElement("div");
       renderGroupedMessage(
         container,
-        {
-          role: "user",
-          content: "hello",
-          timestamp: 1000,
-        },
+        createUserMessage("hello", { timestamp: 1000 }),
         "user",
         opts,
       );
@@ -1833,31 +1813,16 @@ describe("grouped chat rendering", () => {
 
   it("keeps the sender name visible without duplicating a gutter avatar", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
+    const message = { role: "user", content: "hello", timestamp: 1000 };
+    const group = createMessageGroup(message, "user", {
       key: "attributed-user-group",
-      role: "user",
       senderLabel: "alice",
       sender: { id: "profile-1", name: "Alice Example" },
-      messages: [
-        {
-          key: "attributed-user-message",
-          message: { role: "user", content: "hello", timestamp: 1000 },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+      messages: [createMessageEntry("attributed-user-message", message)],
+    });
 
     render(
-      renderMessageGroup(group, {
-        showReasoning: true,
-        showToolCalls: true,
-        assistantName: "OpenClaw",
-        assistantAvatar: null,
-        userName: "Local User",
-        showAvatarGutter: true,
-      }),
+      renderTestMessageGroup(group, { userName: "Local User", showAvatarGutter: true }),
       container,
     );
 
@@ -1877,17 +1842,18 @@ describe("grouped chat rendering", () => {
       const container = document.createElement("div");
       render(
         renderMessageGroup(
-          {
-            kind: "group",
+          createMessageGroup({ role: "user", content: "hi" }, "user", {
             key: "tint-group",
-            role: "user",
             ...(sender ? { sender, senderLabel: sender.name } : {}),
             messages: [
-              { key: "tint-message", message: { role: "user", content: "hi", timestamp: 1000 } },
+              createMessageEntry("tint-message", {
+                role: "user",
+                content: "hi",
+                timestamp: 1000,
+              }),
             ],
             timestamp: 1000,
-            isStreaming: false,
-          },
+          }),
           { showReasoning: true, showToolCalls: true },
         ),
         container,
@@ -1925,15 +1891,12 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     render(
       renderMessageGroup(
-        {
-          kind: "group",
+        createMessageGroup({ role: "user", content: "hi" }, "user", {
           key: "peer-group",
-          role: "user",
           ...(sender ? { sender } : {}),
           messages: [{ key: "peer-message", message: { role: "user", content: "hi" } }],
           timestamp: 1000,
-          isStreaming: false,
-        },
+        }),
         { showReasoning: true, showToolCalls: true, userId },
       ),
       container,
@@ -1948,15 +1911,12 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     render(
       renderMessageGroup(
-        {
-          kind: "group",
+        createMessageGroup({ role: "assistant", content: "hello" }, "assistant", {
           key: "reply-attribution",
-          role: "assistant",
           replyToSender: { id: "alice@example.com", name: "Alice" },
           messages: [{ key: "reply", message: { role: "assistant", content: "hello" } }],
           timestamp: 1000,
-          isStreaming: false,
-        },
+        }),
         { showReasoning: true, showToolCalls: true },
       ),
       container,
@@ -1999,10 +1959,8 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     render(
       renderMessageGroup(
-        {
-          kind: "group",
+        createMessageGroup({ role: "user", content: "hello", timestamp: 1000 }, "user", {
           key: "current-user-group",
-          role: "user",
           senderLabel: "fullerstackd",
           sender: { id: "profile-1", username: "fullerstackd" },
           messages: [
@@ -2012,8 +1970,7 @@ describe("grouped chat rendering", () => {
             },
           ],
           timestamp: 1000,
-          isStreaming: false,
-        },
+        }),
         {
           showReasoning: true,
           showToolCalls: true,
@@ -2039,10 +1996,8 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     render(
       renderMessageGroup(
-        {
-          kind: "group",
+        createMessageGroup({ role: "user", content: "hello", timestamp: 1000 }, "user", {
           key: "attributed-user",
-          role: "user",
           senderLabel: "Alice Example",
           sender: { id: "profile_123", name: "Alice Example" },
           messages: [
@@ -2052,8 +2007,7 @@ describe("grouped chat rendering", () => {
             },
           ],
           timestamp: 1000,
-          isStreaming: false,
-        },
+        }),
         {
           showReasoning: true,
           showToolCalls: true,
@@ -2078,23 +2032,15 @@ describe("grouped chat rendering", () => {
 
   it("falls back to initials when a user avatar image fails", async () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
+    const message = { role: "user", content: "hello", timestamp: 1000 };
+    const group = createMessageGroup(message, "user", {
       key: "gravatar-user",
-      role: "user",
       senderLabel: "alice",
       // profileAvatarUrl exercises the img tier; bare emails render initials
       // only (no third-party avatar fetch without a gateway proxy base).
       sender: { id: "alice@example.com", profileAvatarUrl: "/api/users/alice/avatar" },
-      messages: [
-        {
-          key: "gravatar-message",
-          message: { role: "user", content: "hello", timestamp: 1000 },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+      messages: [createMessageEntry("gravatar-message", message)],
+    });
     render(
       renderMessageGroup(group, {
         showReasoning: true,
@@ -2120,27 +2066,19 @@ describe("grouped chat rendering", () => {
 
   it("does not render an author avatar for a user group without sender identity", () => {
     const container = document.createElement("div");
-    renderGroupedMessage(container, { role: "user", content: "hello", timestamp: 1000 }, "user");
+    renderGroupedMessage(container, createUserMessage("hello", { timestamp: 1000 }), "user");
     expect(container.querySelector(".chat-author-avatar")).toBeNull();
   });
 
   it("never renders a user author avatar on assistant output", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
+    const message = { role: "assistant", content: "hello", timestamp: 1000 };
+    const group = createMessageGroup(message, "assistant", {
       key: "assistant-with-sender",
-      role: "assistant",
       senderLabel: "Forwarded Agent",
       sender: { id: "agent@example.com", name: "Forwarded Agent" },
-      messages: [
-        {
-          key: "assistant-message",
-          message: { role: "assistant", content: "hello", timestamp: 1000 },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+      messages: [createMessageEntry("assistant-message", message)],
+    });
     render(
       renderMessageGroup(group, {
         showReasoning: true,
@@ -2154,30 +2092,14 @@ describe("grouped chat rendering", () => {
 
   it("uses assistant senderLabel for forwarded assistant-side groups", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
+    const message = { role: "assistant", content: "forwarded report", timestamp: 1000 };
+    const group = createMessageGroup(message, "assistant", {
       key: "forwarded-group",
-      role: "assistant",
       senderLabel: "Forwarded from main",
-      messages: [
-        {
-          key: "forwarded-message",
-          message: { role: "assistant", content: "forwarded report", timestamp: 1000 },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+      messages: [createMessageEntry("forwarded-message", message)],
+    });
 
-    render(
-      renderMessageGroup(group, {
-        showReasoning: true,
-        showToolCalls: true,
-        assistantName: "OpenClaw",
-        assistantAvatar: null,
-      }),
-      container,
-    );
+    render(renderTestMessageGroup(group), container);
 
     const sender = container.querySelector<HTMLElement>(".chat-group.assistant .chat-sender-name");
     expect(sender?.textContent).toBe("Forwarded from main");
@@ -2187,7 +2109,7 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderGroupedMessage(
       container,
-      { role: "assistant", content: "hello", timestamp: 1000 },
+      createAssistantMessage("hello", { timestamp: 1000 }),
       "assistant",
       { assistantName: "OpenClaw", userName: "Fuller Stack" },
     );
@@ -2199,35 +2121,18 @@ describe("grouped chat rendering", () => {
 
   it("collapses consecutive tool results into an activity group", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
-      key: "tool-group",
-      role: "tool",
-      messages: [
-        {
-          key: "tool-message-1",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "read_file",
-            content: "File one",
-            timestamp: 1000,
-          },
-        },
-        {
-          key: "tool-message-2",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-2",
-            toolName: "run_command",
-            content: "Command output",
-            timestamp: 1001,
-          },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+    const group = createToolGroup("tool-group", [
+      createMessageEntry(
+        "tool-message-1",
+        createToolResultMessage("call-1", "read_file", "File one", { timestamp: 1000 }),
+      ),
+      createMessageEntry(
+        "tool-message-2",
+        createToolResultMessage("call-2", "run_command", "Command output", {
+          timestamp: 1001,
+        }),
+      ),
+    ]);
 
     renderMessageGroups(container, [group], {
       isToolMessageExpanded: (id) => (id === "activity:tool-group" ? false : undefined),
@@ -2244,48 +2149,20 @@ describe("grouped chat rendering", () => {
 
   it("collapses paired parallel tool cards from one message into an activity group", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
-      key: "parallel-tool-group",
-      role: "tool",
-      messages: [
-        {
-          key: "parallel-tool-message",
-          message: {
-            role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: "call-a",
-                name: "read",
-                arguments: { path: "/repo/a.ts" },
-              },
-              {
-                type: "toolCall",
-                id: "call-b",
-                name: "read",
-                arguments: { path: "/repo/b.ts" },
-              },
-              {
-                type: "tool_result",
-                id: "call-a",
-                name: "read",
-                text: "File A",
-              },
-              {
-                type: "tool_result",
-                id: "call-b",
-                name: "read",
-                text: "File B",
-              },
-            ],
-            timestamp: 1000,
-          },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+    const group = createToolGroup("parallel-tool-group", [
+      createMessageEntry(
+        "parallel-tool-message",
+        createAssistantMessage(
+          [
+            createToolCall("call-a", "read", { path: "/repo/a.ts" }, { type: "toolCall" }),
+            createToolCall("call-b", "read", { path: "/repo/b.ts" }, { type: "toolCall" }),
+            createToolResultBlock("call-a", "read", "File A"),
+            createToolResultBlock("call-b", "read", "File B"),
+          ],
+          { timestamp: 1000 },
+        ),
+      ),
+    ]);
 
     renderMessageGroups(container, [group], {
       isToolMessageExpanded: (id) => (id === "activity:parallel-tool-group" ? false : undefined),
@@ -2302,40 +2179,31 @@ describe("grouped chat rendering", () => {
 
   it("uses the running mutation verb in an active group summary", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
-      key: "running-tool-group",
-      role: "tool",
-      messages: [
-        {
-          key: "finished-read",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-read",
-            toolName: "read",
-            content: "done",
-          },
-        },
-        {
-          key: "running-edit",
-          message: {
-            role: "assistant",
-            __openclawToolStreamLive: true,
-            __openclawToolStreamResultReceived: false,
-            content: [
-              {
-                type: "tool_use",
-                id: "call-edit",
-                name: "edit",
-                input: { path: "/repo/src/a.ts", oldText: "old", newText: "new" },
-              },
-            ],
-          },
-        },
+    const group = createToolGroup(
+      "running-tool-group",
+      [
+        createMessageEntry("finished-read", {
+          role: "toolResult",
+          toolCallId: "call-read",
+          toolName: "read",
+          content: "done",
+        }),
+        createMessageEntry("running-edit", {
+          role: "assistant",
+          __openclawToolStreamLive: true,
+          __openclawToolStreamResultReceived: false,
+          content: [
+            {
+              type: "tool_use",
+              id: "call-edit",
+              name: "edit",
+              input: { path: "/repo/src/a.ts", oldText: "old", newText: "new" },
+            },
+          ],
+        }),
       ],
-      timestamp: 1000,
-      isStreaming: true,
-    };
+      { timestamp: 1000, isStreaming: true },
+    );
 
     renderMessageGroups(container, [group], { runActive: true });
 
@@ -2348,36 +2216,21 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     document.body.append(container);
     const onToggleToolMessageExpanded = vi.fn();
-    const group: MessageGroup = {
-      kind: "group",
-      key: "tool-group",
-      role: "tool",
-      messages: [
-        {
-          key: "tool-message-1",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "read_file",
-            isError: true,
-            content: JSON.stringify({ error: "Read failed" }),
-            timestamp: 1000,
-          },
-        },
-        {
-          key: "tool-message-2",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-2",
-            toolName: "run_command",
-            content: "Command output",
-            timestamp: 1001,
-          },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+    const group = createToolGroup("tool-group", [
+      createMessageEntry(
+        "tool-message-1",
+        createToolResultMessage("call-1", "read_file", JSON.stringify({ error: "Read failed" }), {
+          isError: true,
+          timestamp: 1000,
+        }),
+      ),
+      createMessageEntry(
+        "tool-message-2",
+        createToolResultMessage("call-2", "run_command", "Command output", {
+          timestamp: 1001,
+        }),
+      ),
+    ]);
 
     renderMessageGroups(container, [group], { onToggleToolMessageExpanded });
 
@@ -2412,37 +2265,25 @@ describe("grouped chat rendering", () => {
 
   it("keeps recovered grouped activity collapsed while retaining its failure summary", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
-      key: "tool-group",
-      role: "tool",
-      turnSucceeded: true,
-      messages: [
-        {
-          key: "tool-message-1",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "web_search",
+    const group = createToolGroup(
+      "tool-group",
+      [
+        createMessageEntry(
+          "tool-message-1",
+          createToolResultMessage("call-1", "web_search", JSON.stringify({ error: "No matches" }), {
             isError: true,
-            content: JSON.stringify({ error: "No matches" }),
             timestamp: 1000,
-          },
-        },
-        {
-          key: "tool-message-2",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-2",
-            toolName: "read_file",
-            content: "Fallback context",
+          }),
+        ),
+        createMessageEntry(
+          "tool-message-2",
+          createToolResultMessage("call-2", "read_file", "Fallback context", {
             timestamp: 1001,
-          },
-        },
+          }),
+        ),
       ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+      { turnSucceeded: true },
+    );
 
     renderMessageGroups(container, [group]);
 
@@ -2456,49 +2297,35 @@ describe("grouped chat rendering", () => {
 
   it("keeps recovered coalesced tool failures neutral in the activity list", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
-      key: "recovered-tool-group",
-      role: "tool",
-      turnSucceeded: true,
-      messages: [
-        {
-          key: "recovered-tool-message",
-          message: {
-            role: "assistant",
-            isError: true,
-            content: [
+    const group = createToolGroup(
+      "recovered-tool-group",
+      [
+        createMessageEntry(
+          "recovered-tool-message",
+          createAssistantMessage(
+            [
               {
                 type: "tool_use",
                 id: "call-recovered",
                 name: "bash",
                 input: { command: "run fallback" },
               },
-              {
-                type: "tool_result",
-                id: "call-recovered",
-                name: "bash",
-                text: "Primary path failed",
+              createToolResultBlock("call-recovered", "bash", "Primary path failed", {
                 isError: true,
-              },
+              }),
             ],
-            timestamp: 1000,
-          },
-        },
-        {
-          key: "recovered-followup",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-followup",
-            toolName: "read_file",
-            content: "Fallback context",
+            { isError: true, timestamp: 1000 },
+          ),
+        ),
+        createMessageEntry(
+          "recovered-followup",
+          createToolResultMessage("call-followup", "read_file", "Fallback context", {
             timestamp: 1001,
-          },
-        },
+          }),
+        ),
       ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+      { turnSucceeded: true },
+    );
 
     renderMessageGroups(container, [group], {
       isToolMessageExpanded: (id) => id === "activity:recovered-tool-group",
@@ -2518,35 +2345,18 @@ describe("grouped chat rendering", () => {
 
   it("hides grouped tool activity when tool calls are disabled", () => {
     const container = document.createElement("div");
-    const group: MessageGroup = {
-      kind: "group",
-      key: "tool-group",
-      role: "tool",
-      messages: [
-        {
-          key: "tool-message-1",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "read_file",
-            content: "File one",
-            timestamp: 1000,
-          },
-        },
-        {
-          key: "tool-message-2",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-2",
-            toolName: "run_command",
-            content: "Command output",
-            timestamp: 1001,
-          },
-        },
-      ],
-      timestamp: 1000,
-      isStreaming: false,
-    };
+    const group = createToolGroup("tool-group", [
+      createMessageEntry(
+        "tool-message-1",
+        createToolResultMessage("call-1", "read_file", "File one", { timestamp: 1000 }),
+      ),
+      createMessageEntry(
+        "tool-message-2",
+        createToolResultMessage("call-2", "run_command", "Command output", {
+          timestamp: 1001,
+        }),
+      ),
+    ]);
 
     renderMessageGroups(container, [group], { showToolCalls: false });
 
@@ -2555,26 +2365,15 @@ describe("grouped chat rendering", () => {
 
   it("keeps inline tool cards collapsed by default and renders expanded state", () => {
     const container = document.createElement("div");
-    const message = {
-      id: "assistant-1",
-      role: "assistant",
-      toolCallId: "call-1",
-      content: [
-        {
-          type: "toolcall",
-          id: "call-1",
-          name: "browser.open",
-          arguments: { url: "https://example.com" },
-        },
-        {
+    const message = createAssistantMessage(
+      [
+        createToolCall("call-1", "browser.open", { url: "https://example.com" }),
+        createToolResultBlock("call-1", "browser.open", "Opened page", {
           type: "toolresult",
-          id: "call-1",
-          name: "browser.open",
-          text: "Opened page",
-        },
+        }),
       ],
-      timestamp: Date.now(),
-    };
+      { id: "assistant-1", toolCallId: "call-1" },
+    );
     renderAssistantMessage(container, message, {
       isToolExpanded: () => false,
     });
@@ -2598,20 +2397,10 @@ describe("grouped chat rendering", () => {
 
   it("renders expanded standalone tool-call rows", () => {
     const container = document.createElement("div");
-    const message = {
-      id: "assistant-4b",
-      role: "assistant",
-      toolCallId: "call-4b",
-      content: [
-        {
-          type: "toolcall",
-          id: "call-4b",
-          name: "sessions_spawn",
-          arguments: { mode: "session", thread: true },
-        },
-      ],
-      timestamp: Date.now(),
-    };
+    const message = createAssistantMessage(
+      [createToolCall("call-4b", "sessions_spawn", { mode: "session", thread: true })],
+      { id: "assistant-4b", toolCallId: "call-4b" },
+    );
     renderAssistantMessage(container, message, {
       isToolExpanded: () => false,
     });
@@ -2641,10 +2430,8 @@ describe("grouped chat rendering", () => {
 
   it("renders assistant tool content as a flat concise tool row without a top-level call id", () => {
     const container = document.createElement("div");
-    const message = {
-      id: "assistant-tool-content",
-      role: "assistant",
-      content: [
+    const message = createAssistantMessage(
+      [
         {
           type: "tool_use",
           id: "call-content-only",
@@ -2652,8 +2439,8 @@ describe("grouped chat rendering", () => {
           input: { command: "bash" },
         },
       ],
-      timestamp: Date.now(),
-    };
+      { id: "assistant-tool-content" },
+    );
 
     renderAssistantMessage(container, message, {
       isToolMessageExpanded: () => false,
@@ -2670,12 +2457,9 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
+      createAssistantMessage("A long tool result that should stay behind the disclosure.", {
         toolName: "bash",
-        content: "A long tool result that should stay behind the disclosure.",
-        timestamp: Date.now(),
-      },
+      }),
       { isToolMessageExpanded: () => false },
     );
 
@@ -2687,19 +2471,13 @@ describe("grouped chat rendering", () => {
 
   it("omits normalized duplicate names from standalone tool results", () => {
     const container = document.createElement("div");
-    const message = {
-      role: "toolResult",
-      toolCallId: "call-heartbeat",
-      toolName: "heartbeat_respond",
-      content: [
-        {
-          type: "tool_result",
-          name: "heartbeat_respond",
-          text: "Acknowledged",
-        },
-      ],
-      timestamp: Date.now(),
-    };
+    const message = createToolResultMessage("call-heartbeat", "heartbeat_respond", [
+      {
+        type: "tool_result",
+        name: "heartbeat_respond",
+        text: "Acknowledged",
+      },
+    ]);
 
     renderAssistantMessage(container, message, {
       isToolMessageExpanded: () => false,
@@ -2714,20 +2492,10 @@ describe("grouped chat rendering", () => {
 
   it("cleans collapsed tool connector copy while preserving expanded raw input", () => {
     const container = document.createElement("div");
-    const message = {
-      id: "assistant-string-tool",
-      role: "assistant",
-      toolCallId: "call-string-tool",
-      content: [
-        {
-          type: "toolcall",
-          id: "call-string-tool",
-          name: "presentation_create",
-          arguments: "with Example Deck",
-        },
-      ],
-      timestamp: Date.now(),
-    };
+    const message = createAssistantMessage(
+      [createToolCall("call-string-tool", "presentation_create", "with Example Deck")],
+      { id: "assistant-string-tool", toolCallId: "call-string-tool" },
+    );
     renderAssistantMessage(container, message, {
       isToolExpanded: () => false,
     });
@@ -2759,29 +2527,17 @@ describe("grouped chat rendering", () => {
       container,
       [
         createMessageGroup(
-          {
-            id: "assistant-5",
-            role: "assistant",
-            toolCallId: "call-5",
-            content: [
-              {
-                type: "toolcall",
-                id: "call-5",
-                name: "sessions_spawn",
-                arguments: { mode: "session", thread: true },
-              },
-            ],
-            timestamp: Date.now(),
-          },
+          createAssistantMessage(
+            [createToolCall("call-5", "sessions_spawn", { mode: "session", thread: true })],
+            { id: "assistant-5", toolCallId: "call-5" },
+          ),
           "assistant",
         ),
         createMessageGroup(
-          {
-            id: "tool-5",
-            role: "tool",
-            toolCallId: "call-5",
-            toolName: "sessions_spawn",
-            content: JSON.stringify(
+          createToolResultMessage(
+            "call-5",
+            "sessions_spawn",
+            JSON.stringify(
               {
                 status: "error",
                 error: "Session mode is unavailable for this target.",
@@ -2790,8 +2546,8 @@ describe("grouped chat rendering", () => {
               null,
               2,
             ),
-            timestamp: Date.now() + 1,
-          },
+            { id: "tool-5", role: "tool", timestamp: Date.now() + 1 },
+          ),
           "tool",
         ),
       ],
@@ -2829,18 +2585,15 @@ describe("grouped chat rendering", () => {
       container,
       [
         createMessageGroup(
-          {
-            id: "tool-error-collapsed",
-            role: "toolResult",
-            toolCallId: "call-error-collapsed",
-            toolName: "web_search",
-            isError: false,
-            content: JSON.stringify({
+          createToolResultMessage(
+            "call-error-collapsed",
+            "web_search",
+            JSON.stringify({
               error: "missing_brave_api_key",
               message: "BRAVE_API_KEY is not configured",
             }),
-            timestamp: Date.now(),
-          },
+            { id: "tool-error-collapsed", isError: false },
+          ),
           "tool",
         ),
       ],
@@ -2863,18 +2616,15 @@ describe("grouped chat rendering", () => {
       container,
       [
         createMessageGroup(
-          {
-            id: "tool-error-collapsed-mcp",
-            role: "toolResult",
-            toolCallId: "call-error-collapsed-mcp",
-            toolName: "memory_forget",
-            isError: false,
-            content: JSON.stringify({
+          createToolResultMessage(
+            "call-error-collapsed-mcp",
+            "memory_forget",
+            JSON.stringify({
               isError: true,
               content: [{ type: "text", text: "Tool error: boom" }],
             }),
-            timestamp: Date.now(),
-          },
+            { id: "tool-error-collapsed-mcp", isError: false },
+          ),
           "tool",
         ),
       ],
@@ -2898,14 +2648,12 @@ describe("grouped chat rendering", () => {
     const onToggleToolMessageExpanded = vi.fn();
     const groups = [
       createMessageGroup(
-        {
-          id: "tool-status-error",
-          role: "toolResult",
-          toolCallId: "call-status-error",
-          toolName: "sessions_spawn",
-          content: JSON.stringify({ status: "error" }, null, 2),
-          timestamp: Date.now(),
-        },
+        createToolResultMessage(
+          "call-status-error",
+          "sessions_spawn",
+          JSON.stringify({ status: "error" }, null, 2),
+          { id: "tool-status-error" },
+        ),
         "tool",
       ),
     ];
@@ -2946,14 +2694,12 @@ describe("grouped chat rendering", () => {
     const groups = [
       {
         ...createMessageGroup(
-          {
-            id: "tool-status-error",
-            role: "toolResult",
-            toolCallId: "call-status-error",
-            toolName: "sessions_spawn",
-            content: JSON.stringify({ status: "error" }, null, 2),
-            timestamp: Date.now(),
-          },
+          createToolResultMessage(
+            "call-status-error",
+            "sessions_spawn",
+            JSON.stringify({ status: "error" }, null, 2),
+            { id: "tool-status-error" },
+          ),
           "tool",
         ),
         turnSucceeded: true,
@@ -2974,31 +2720,24 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     const groups = [
       createMessageGroup(
-        {
-          id: "assistant-tool-messages",
-          role: "assistant",
-          toolCallId: "call-tool-messages",
-          content: [
-            {
-              type: "toolcall",
-              id: "call-tool-messages",
-              name: "sessions_spawn",
-              arguments: { mode: "session", thread: true },
-            },
+        createAssistantMessage(
+          [
+            createToolCall("call-tool-messages", "sessions_spawn", {
+              mode: "session",
+              thread: true,
+            }),
           ],
-          timestamp: Date.now(),
-        },
+          { id: "assistant-tool-messages", toolCallId: "call-tool-messages" },
+        ),
         "assistant",
       ),
       createMessageGroup(
-        {
-          id: "tool-tool-messages",
-          role: "tool",
-          toolCallId: "call-tool-messages",
-          toolName: "sessions_spawn",
-          content: JSON.stringify({ status: "error" }, null, 2),
-          timestamp: Date.now() + 1,
-        },
+        createToolResultMessage(
+          "call-tool-messages",
+          "sessions_spawn",
+          JSON.stringify({ status: "error" }, null, 2),
+          { id: "tool-tool-messages", role: "tool", timestamp: Date.now() + 1 },
+        ),
         "tool",
       ),
     ];
@@ -3044,13 +2783,12 @@ describe("grouped chat rendering", () => {
     const onOpenImage = vi.fn();
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-media-inline",
-        role: "assistant",
-        content:
-          "[[reply_to_current]]Here is the image.\nMEDIA:https://example.com/photo.png\nMEDIA:https://example.com/voice.ogg\n[[audio_as_voice]]",
-        timestamp: Date.now(),
-      },
+      createAssistantMessage(
+        "[[reply_to_current]]Here is the image.\nMEDIA:https://example.com/photo.png\nMEDIA:https://example.com/voice.ogg\n[[audio_as_voice]]",
+        {
+          id: "assistant-media-inline",
+        },
+      ),
       { showToolCalls: false, onOpenImage },
     );
 
@@ -3082,13 +2820,12 @@ describe("grouped chat rendering", () => {
 
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-media-layout",
-        role: "assistant",
-        content:
-          "Audio and video\nMEDIA:https://example.com/voice.ogg\nMEDIA:https://example.com/clip.mp4",
-        timestamp: Date.now(),
-      },
+      createAssistantMessage(
+        "Audio and video\nMEDIA:https://example.com/voice.ogg\nMEDIA:https://example.com/clip.mp4",
+        {
+          id: "assistant-media-layout",
+        },
+      ),
       { showToolCalls: false, onAssistantAttachmentLoaded },
     );
 
@@ -3120,12 +2857,9 @@ describe("grouped chat rendering", () => {
     const renderMessage = () =>
       renderAssistantMessage(
         container,
-        {
+        createAssistantMessage(`Your recording\nMEDIA:${source}`, {
           id: "assistant-local-audio-bootstrap-roots",
-          role: "assistant",
-          content: `Your recording\nMEDIA:${source}`,
-          timestamp: Date.now(),
-        },
+        }),
         {
           showToolCalls: false,
           basePath: "/openclaw",
@@ -3165,23 +2899,18 @@ describe("grouped chat rendering", () => {
     const rerender = () =>
       renderAssistantMessage(
         container,
-        {
-          id: "assistant-managed-transcode-audio",
-          role: "assistant",
-          content: [
-            {
-              type: "audio",
-              artifactId,
-              url: source,
-              fileName: "voice.caf",
-              mimeType: "audio/x-caf",
-              playback: "transcode",
-              sizeBytes: 4_096,
-              durationMs: 2_345,
-            },
-          ],
-          timestamp: Date.now(),
-        },
+        createAssistantAudioMessage(
+          source,
+          {
+            artifactId,
+            fileName: "voice.caf",
+            mimeType: "audio/x-caf",
+            playback: "transcode",
+            sizeBytes: 4_096,
+            durationMs: 2_345,
+          },
+          { id: "assistant-managed-transcode-audio" },
+        ),
         {
           showToolCalls: false,
           assistantAttachmentAuthToken: "must-not-be-forwarded",
@@ -3490,21 +3219,16 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-managed-media-without-resolver",
-        role: "assistant",
-        content: [
-          {
-            type: "audio",
-            artifactId: `artifact_managed_media_${crypto.randomUUID()}`,
-            url: source,
-            fileName: "voice.mp3",
-            mimeType: "audio/mpeg",
-            playback: "native",
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantAudioMessage(
+        source,
+        {
+          artifactId: `artifact_managed_media_${crypto.randomUUID()}`,
+          fileName: "voice.mp3",
+          mimeType: "audio/mpeg",
+          playback: "native",
+        },
+        { id: "assistant-managed-media-without-resolver" },
+      ),
       { showToolCalls: false },
     );
 
@@ -3527,12 +3251,14 @@ describe("grouped chat rendering", () => {
     const renderMessage = () =>
       renderAssistantMessage(
         container,
-        {
-          id: "assistant-local-image-bootstrap-roots",
-          role: "assistant",
-          content: [{ type: "image", url: source, alt: "Local bootstrap image" }],
-          timestamp: Date.now(),
-        },
+        createAssistantImageMessage(
+          source,
+          "Local bootstrap image",
+          {},
+          {
+            id: "assistant-local-image-bootstrap-roots",
+          },
+        ),
         {
           showToolCalls: false,
           basePath: "/openclaw",
@@ -3577,12 +3303,9 @@ describe("grouped chat rendering", () => {
       const renderMessage = () =>
         renderAssistantMessage(
           container,
-          {
+          createAssistantMessage(`Unavailable recording\nMEDIA:${source}`, {
             id: `assistant-bootstrap-blocked-${code}`,
-            role: "assistant",
-            content: `Unavailable recording\nMEDIA:${source}`,
-            timestamp: Date.now(),
-          },
+          }),
           {
             showToolCalls: false,
             basePath: "/openclaw",
@@ -3614,22 +3337,10 @@ describe("grouped chat rendering", () => {
 
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-video-unplayable",
-        role: "assistant",
-        content: [
-          {
-            type: "attachment",
-            attachment: {
-              url: "https://example.com/clip.mp4",
-              kind: "video",
-              label: "clip.mp4",
-              mimeType: "video/mp4",
-            },
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantMessage(
+        [createAttachmentBlock("https://example.com/clip.mp4", "video", "clip.mp4", "video/mp4")],
+        { id: "assistant-video-unplayable" },
+      ),
       { showToolCalls: false },
     );
 
@@ -3662,40 +3373,14 @@ describe("grouped chat rendering", () => {
 
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-unsafe-attachment-links",
-        role: "assistant",
-        content: [
-          {
-            type: "attachment",
-            attachment: {
-              url: "javascript:audio()",
-              kind: "audio",
-              label: "unsafe.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-          {
-            type: "attachment",
-            attachment: {
-              url: "data:text/html,video",
-              kind: "video",
-              label: "unsafe.mp4",
-              mimeType: "video/mp4",
-            },
-          },
-          {
-            type: "attachment",
-            attachment: {
-              url: "vbscript:document",
-              kind: "document",
-              label: "unsafe.pdf",
-              mimeType: "application/pdf",
-            },
-          },
+      createAssistantMessage(
+        [
+          createAttachmentBlock("javascript:audio()", "audio", "unsafe.mp3", "audio/mpeg"),
+          createAttachmentBlock("data:text/html,video", "video", "unsafe.mp4", "video/mp4"),
+          createAttachmentBlock("vbscript:document", "document", "unsafe.pdf", "application/pdf"),
         ],
-        timestamp: Date.now(),
-      },
+        { id: "assistant-unsafe-attachment-links" },
+      ),
       { showToolCalls: false },
     );
 
@@ -3719,12 +3404,9 @@ describe("grouped chat rendering", () => {
     const renderMessage = () =>
       renderAssistantMessage(
         container,
-        {
+        createAssistantMessage(`Local image\nMEDIA:${source}`, {
           id: "assistant-local-media-inline",
-          role: "assistant",
-          content: `Local image\nMEDIA:${source}`,
-          timestamp: Date.now(),
-        },
+        }),
         {
           showToolCalls: false,
           basePath: "/openclaw",
@@ -3772,12 +3454,9 @@ describe("grouped chat rendering", () => {
     const rerender = () =>
       renderAssistantMessage(
         container,
-        {
+        createAssistantMessage(`Local document\nMEDIA:${source}`, {
           id: "assistant-local-media-stalled-metadata",
-          role: "assistant",
-          content: `Local document\nMEDIA:${source}`,
-          timestamp: Date.now(),
-        },
+        }),
         {
           showToolCalls: false,
           basePath: "/openclaw",
@@ -4064,13 +3743,12 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-same-origin-media-inline",
-        role: "assistant",
-        content:
-          "Inline\nMEDIA:/media/inbound/test-image.png\nMEDIA:/__openclaw__/media/test-doc.pdf",
-        timestamp: Date.now(),
-      },
+      createAssistantMessage(
+        "Inline\nMEDIA:/media/inbound/test-image.png\nMEDIA:/__openclaw__/media/test-doc.pdf",
+        {
+          id: "assistant-same-origin-media-inline",
+        },
+      ),
       {
         showToolCalls: false,
         basePath: "/openclaw",
@@ -4093,12 +3771,9 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
+      createAssistantMessage("Blocked\nMEDIA:/Users/test/Documents/private.pdf\nDone", {
         id: "assistant-blocked-local-media",
-        role: "assistant",
-        content: "Blocked\nMEDIA:/Users/test/Documents/private.pdf\nDone",
-        timestamp: Date.now(),
-      },
+      }),
       {
         showToolCalls: false,
         basePath: "/openclaw",
@@ -4124,13 +3799,10 @@ describe("grouped chat rendering", () => {
 
     renderGroupedMessage(
       container,
-      {
+      createUserMessage("", {
         id: "user-encoded-video",
-        role: "user",
-        content: "",
         __openclaw: { media: [{ url: mediaUrl, contentType: "video/mp4" }] },
-        timestamp: Date.now(),
-      },
+      }),
       "user",
       { showToolCalls: false },
     );
@@ -4164,32 +3836,30 @@ describe("grouped chat rendering", () => {
       rerender();
     };
 
-    renderUserMedia({
-      id: "user-history-image-octet-stream",
-      role: "user",
-      content: "",
-      __openclaw: {
-        media: [{ path: firstSource, contentType: "application/octet-stream" }],
-      },
-      timestamp: Date.now(),
-    });
+    renderUserMedia(
+      createUserMessage("", {
+        id: "user-history-image-octet-stream",
+        __openclaw: {
+          media: [{ path: firstSource, contentType: "application/octet-stream" }],
+        },
+      }),
+    );
     await flushAssistantAttachmentAvailabilityChecks();
     expect(
       container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
     ).toContain(`source=${encodeURIComponent(firstSource)}`);
 
-    renderUserMedia({
-      id: "user-history-images",
-      role: "user",
-      content: "",
-      __openclaw: {
-        media: [
-          { path: firstSource, contentType: "image/png" },
-          { path: secondSource, contentType: "application/octet-stream" },
-        ],
-      },
-      timestamp: Date.now(),
-    });
+    renderUserMedia(
+      createUserMessage("", {
+        id: "user-history-images",
+        __openclaw: {
+          media: [
+            { path: firstSource, contentType: "image/png" },
+            { path: secondSource, contentType: "application/octet-stream" },
+          ],
+        },
+      }),
+    );
     await flushAssistantAttachmentAvailabilityChecks();
     expect(
       [...container.querySelectorAll<HTMLImageElement>(".chat-message-image")].map((image) =>
@@ -4200,11 +3870,10 @@ describe("grouped chat rendering", () => {
       expect.stringContaining(`source=${encodeURIComponent(secondSource)}`),
     ]);
 
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: [{ type: "input_image", image_url: "data:image/png;base64,cG5n" }],
-      timestamp: Date.now(),
-    });
+    renderAssistantMessage(
+      container,
+      createAssistantMessage([{ type: "input_image", image_url: "data:image/png;base64,cG5n" }]),
+    );
     expect(
       container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
     ).toBe("data:image/png;base64,cG5n");
@@ -4224,13 +3893,10 @@ describe("grouped chat rendering", () => {
     const rerender = () =>
       renderGroupedMessage(
         container,
-        {
+        createUserMessage("", {
           id: "user-inbound-media-ref",
-          role: "user",
-          content: "",
           __openclaw: { media: [{ path: source, contentType: "image/png" }] },
-          timestamp: Date.now(),
-        },
+        }),
         "user",
         {
           showToolCalls: false,
@@ -4260,18 +3926,14 @@ describe("grouped chat rendering", () => {
 
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "openclaw_pairing_qr",
-            image_url: "data:image/png;base64,cXJwbmc=",
-            alt: "OpenClaw pairing QR code",
-            expiresAtMs: Date.now() + 1_000,
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantMessage([
+        {
+          type: "openclaw_pairing_qr",
+          image_url: "data:image/png;base64,cXJwbmc=",
+          alt: "OpenClaw pairing QR code",
+          expiresAtMs: Date.now() + 1_000,
+        },
+      ]),
       { showToolCalls: false, onRequestUpdate },
     );
 
@@ -4283,18 +3945,17 @@ describe("grouped chat rendering", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(onRequestUpdate).toHaveBeenCalledTimes(1);
 
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: [
+    renderAssistantMessage(
+      container,
+      createAssistantMessage([
         {
           type: "openclaw_pairing_qr",
           image_url: "data:image/png;base64,ZXhwaXJlZA==",
           alt: "OpenClaw pairing QR code",
           expiresAtMs: Date.now() - 1,
         },
-      ],
-      timestamp: Date.now(),
-    });
+      ]),
+    );
     expect(container.querySelector(".chat-message-image")).toBeNull();
     expect(container.textContent).toContain("Pairing QR expired");
   });
@@ -4316,13 +3977,10 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderGroupedMessage(
       container,
-      {
+      createUserMessage("", {
         id: "user-invalid-inbound-media-ref",
-        role: "user",
-        content: "",
         __openclaw: { media: [{ path: source, contentType: "image/png" }] },
-        timestamp: Date.now(),
-      },
+      }),
       "user",
       {
         showToolCalls: false,
@@ -4358,19 +4016,10 @@ describe("grouped chat rendering", () => {
     const onOpenImage = vi.fn();
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "image",
-            url: managedChatImageUrl,
-            alt: "Generated image 1",
-            width: 1,
-            height: 1,
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantImageMessage(managedChatImageUrl, "Generated image 1", {
+        width: 1,
+        height: 1,
+      }),
       {
         showToolCalls: false,
         assistantAttachmentAuthToken: "test-auth-token",
@@ -4414,18 +4063,7 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "image",
-            artifactId,
-            url: managedChatImageUrl,
-            alt: "Ticketed image",
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantImageMessage(managedChatImageUrl, "Ticketed image", { artifactId }),
       {
         showToolCalls: false,
         assistantAttachmentAuthToken: "must-not-be-forwarded",
@@ -4458,19 +4096,10 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "image",
-            url: managedChatImageUrl,
-            alt: "Generated image timeout",
-            width: 1,
-            height: 1,
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantImageMessage(managedChatImageUrl, "Generated image timeout", {
+        width: 1,
+        height: 1,
+      }),
       {
         showToolCalls: false,
         assistantAttachmentAuthToken: "test-auth-token",
@@ -4512,19 +4141,13 @@ describe("grouped chat rendering", () => {
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: [
-        {
-          type: "image",
-          url: managedChatImageUrl,
-          alt: "Generated image body stall",
-          width: 1,
-          height: 1,
-        },
-      ],
-      timestamp: Date.now(),
-    });
+    renderAssistantMessage(
+      container,
+      createAssistantImageMessage(managedChatImageUrl, "Generated image body stall", {
+        width: 1,
+        height: 1,
+      }),
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, fetchInit] = requireFetchCallForUrl(fetchMock, managedChatImageUrl);
@@ -4547,17 +4170,10 @@ describe("grouped chat rendering", () => {
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: [
-        {
-          type: "image",
-          url: managedChatImageUrl,
-          alt: "Unavailable generated image",
-        },
-      ],
-      timestamp: Date.now(),
-    });
+    renderAssistantMessage(
+      container,
+      createAssistantImageMessage(managedChatImageUrl, "Unavailable generated image"),
+    );
 
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     await flushAssistantAttachmentAvailabilityChecks();
@@ -4704,17 +4320,10 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "image",
-            url: "https://evil.example/api/chat/media/outgoing/agent%3Amain%3Amain/00000000-0000-4000-8000-000000000000/full",
-            alt: "Untrusted image",
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantImageMessage(
+        "https://evil.example/api/chat/media/outgoing/agent%3Amain%3Amain/00000000-0000-4000-8000-000000000000/full",
+        "Untrusted image",
+      ),
       {
         showToolCalls: false,
         assistantAttachmentAuthToken: "session-token",
@@ -4732,17 +4341,7 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "image",
-            data: "cG5n",
-            mimeType: "image/png",
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantMessage([createMediaBlock({ data: "cG5n", mimeType: "image/png" })]),
       { showToolCalls: false },
     );
     expect(
@@ -4754,16 +4353,7 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "image",
-            data: "data:image/png;base64,cG5n",
-          },
-        ],
-        timestamp: Date.now(),
-      },
+      createAssistantMessage([createMediaBlock({ data: "data:image/png;base64,cG5n" })]),
       { showToolCalls: false },
     );
     expect(
@@ -4775,17 +4365,15 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-canvas-only",
-        role: "assistant",
-        content: [
+      createAssistantMessage(
+        [
           {
             type: "text",
             text: '[embed ref="cv_tictactoe" title="Tic-Tac-Toe" /]',
           },
         ],
-        timestamp: Date.now(),
-      },
+        { id: "assistant-canvas-only" },
+      ),
       { showToolCalls: false },
     );
 
@@ -4803,11 +4391,7 @@ describe("grouped chat rendering", () => {
     const renderAssistantImage = (url: string) =>
       renderAssistantMessage(
         container,
-        {
-          role: "assistant",
-          content: [{ type: "image_url", image_url: { url } }],
-          timestamp: Date.now(),
-        },
+        createAssistantMessage([{ type: "image_url", image_url: { url } }]),
         { onOpenImage },
       );
 
@@ -4838,26 +4422,20 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-scoped-canvas",
-        role: "assistant",
-        content: [
+      createAssistantMessage(
+        [
           { type: "text", text: "Rendered inline." },
           {
             type: "canvas",
-            preview: {
-              kind: "canvas",
-              surface: "assistant_message",
-              render: "url",
+            preview: createCanvasPreview({
               viewId: "cv_inline_scoped",
               title: "Scoped preview",
-              url: "/__openclaw__/canvas/documents/cv_inline_scoped/index.html",
               preferredHeight: 320,
-            },
+            }),
           },
         ],
-        timestamp: Date.now(),
-      },
+        { id: "assistant-scoped-canvas" },
+      ),
       {
         canvasPluginSurfaceUrl: "http://127.0.0.1:19003/__openclaw__/cap/cap_123",
       },
@@ -4873,23 +4451,17 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-final-live-shape",
-        role: "assistant",
-        content: [
+      createAssistantMessage(
+        [
           { type: "thinking", thinking: "", thinkingSignature: "sig-2" },
           { type: "text", text: "This item is ready." },
           {
             type: "canvas",
-            preview: {
-              kind: "canvas",
-              surface: "assistant_message",
-              render: "url",
+            preview: createCanvasPreview({
               viewId: "cv_canvas_live_history",
               title: "Live history preview",
-              url: "/__openclaw__/canvas/documents/cv_canvas_live_history/index.html",
               preferredHeight: 420,
-            },
+            }),
             rawText: JSON.stringify({
               kind: "canvas",
               view: {
@@ -4903,8 +4475,8 @@ describe("grouped chat rendering", () => {
             }),
           },
         ],
-        timestamp: Date.now() + 2,
-      },
+        { id: "assistant-final-live-shape", timestamp: Date.now() + 2 },
+      ),
       { showToolCalls: true },
     );
 
@@ -4925,11 +4497,8 @@ describe("grouped chat rendering", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
       container,
-      {
-        id: "assistant-tool-canvas",
-        role: "assistant",
-        toolName: "bash",
-        content: [
+      createAssistantMessage(
+        [
           {
             type: "tool_use",
             id: "call-tool-canvas",
@@ -4938,8 +4507,8 @@ describe("grouped chat rendering", () => {
           },
           createAssistantCanvasBlock({ suffix: "tool_canvas" }),
         ],
-        timestamp: Date.now(),
-      },
+        { id: "assistant-tool-canvas", toolName: "bash" },
+      ),
       { showToolCalls: true, isToolMessageExpanded: () => true },
     );
 
@@ -4953,12 +4522,10 @@ describe("grouped chat rendering", () => {
 
   it("keeps assistant message actions outside the bubble", () => {
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      id: "assistant-action-space",
-      role: "assistant",
-      content: "Copyable assistant text.",
-      timestamp: Date.now(),
-    });
+    renderAssistantMessage(
+      container,
+      createAssistantMessage("Copyable assistant text.", { id: "assistant-action-space" }),
+    );
 
     const bubble = container.querySelector(".chat-group.assistant .chat-bubble");
     expect(bubble?.classList.contains("chat-bubble--has-actions")).toBe(false);
@@ -4975,15 +4542,13 @@ describe("grouped chat rendering", () => {
         container,
         [
           createMessageGroup(
-            {
-              id: `assistant-canvas-inline-${params.suffix}`,
-              role: "assistant",
-              content: [
+            createAssistantMessage(
+              [
                 { type: "text", text: "Inline canvas result." },
                 createAssistantCanvasBlock({ suffix: params.suffix }),
               ],
-              timestamp: Date.now(),
-            },
+              { id: `assistant-canvas-inline-${params.suffix}` },
+            ),
             "assistant",
           ),
         ],
@@ -5021,15 +4586,13 @@ describe("grouped chat rendering", () => {
         container,
         [
           createMessageGroup(
-            {
-              id: "assistant-canvas-inline-sandbox-change",
-              role: "assistant",
-              content: [
+            createAssistantMessage(
+              [
                 { type: "text", text: "Inline canvas result." },
                 createAssistantCanvasBlock({ suffix: "sandbox-change" }),
               ],
-              timestamp: Date.now(),
-            },
+              { id: "assistant-canvas-inline-sandbox-change" },
+            ),
             "assistant",
           ),
         ],
@@ -5060,24 +4623,20 @@ describe("grouped chat rendering", () => {
       container,
       [
         createMessageGroup(
-          {
-            id: "assistant-canvas-inline-visible",
-            role: "assistant",
-            content: [
+          createAssistantMessage(
+            [
               { type: "text", text: "Inline canvas result." },
               createAssistantCanvasBlock({ suffix: "visible" }),
             ],
-            timestamp: Date.now(),
-          },
+            { id: "assistant-canvas-inline-visible" },
+          ),
           "assistant",
         ),
         createMessageGroup(
-          {
-            id: "tool-artifact-inline-visible",
-            role: "tool",
-            toolCallId: "call-artifact-inline-visible",
-            toolName: "canvas_render",
-            content: JSON.stringify({
+          createToolResultMessage(
+            "call-artifact-inline-visible",
+            "canvas_render",
+            JSON.stringify({
               kind: "canvas",
               view: {
                 backend: "canvas",
@@ -5090,8 +4649,12 @@ describe("grouped chat rendering", () => {
                 target: "assistant_message",
               },
             }),
-            timestamp: Date.now() + 1,
-          },
+            {
+              id: "tool-artifact-inline-visible",
+              role: "tool",
+              timestamp: Date.now() + 1,
+            },
+          ),
           "tool",
         ),
       ],
@@ -5126,21 +4689,16 @@ describe("grouped chat rendering", () => {
       container,
       [
         createMessageGroup(
-          {
+          createAssistantMessage([{ type: "text", text: "Sidebar canvas result." }], {
             id: "assistant-canvas-sidebar",
-            role: "assistant",
-            content: [{ type: "text", text: "Sidebar canvas result." }],
-            timestamp: Date.now(),
-          },
+          }),
           "assistant",
         ),
         createMessageGroup(
-          {
-            id: "tool-artifact-sidebar",
-            role: "tool",
-            toolCallId: "call-artifact-sidebar",
-            toolName: "canvas_render",
-            content: JSON.stringify({
+          createToolResultMessage(
+            "call-artifact-sidebar",
+            "canvas_render",
+            JSON.stringify({
               kind: "canvas",
               view: {
                 backend: "canvas",
@@ -5153,8 +4711,8 @@ describe("grouped chat rendering", () => {
                 target: "tool_card",
               },
             }),
-            timestamp: Date.now() + 1,
-          },
+            { id: "tool-artifact-sidebar", role: "tool", timestamp: Date.now() + 1 },
+          ),
           "tool",
         ),
       ],

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -215,6 +215,20 @@ function makeHost(over: Partial<ReconcileHost> = {}): ReconcileHost {
   };
 }
 
+type LocalTerminalReconcile = NonNullable<ReconcileHost["lastLocalTerminalReconcile"]>;
+
+function makeLocalTerminalReconcile(
+  overrides: Partial<LocalTerminalReconcile> = {},
+): LocalTerminalReconcile {
+  return {
+    sessionKey: "s1",
+    runId: "r1",
+    phase: "done",
+    sessionStatus: "done",
+    ...overrides,
+  };
+}
+
 function rowActive(host: ReconcileHost): boolean {
   const row = host.sessionsResult?.sessions.find((r) => r.key === host.sessionKey);
   return Boolean(row && isSessionRunActive(row));
@@ -397,12 +411,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
           status: "running",
         },
       ]),
-      lastLocalTerminalReconcile: {
-        sessionKey: "main",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile({ sessionKey: "main" }),
     });
 
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);
@@ -411,12 +420,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
 
   it("suppresses a stale active row after a recent local completion", () => {
     const host = makeHost({
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);
     expect(rowActive(host)).toBe(false);
@@ -432,12 +436,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
   it("retains the completed run identity while the session row is unavailable", () => {
     const host = makeHost({
       sessionsResult: null,
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
 
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
@@ -453,12 +452,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
   it("keeps suppressing the exact completed run without a time limit", () => {
     vi.useFakeTimers();
     const host = makeHost({
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
     try {
       vi.advanceTimersByTime(60_000);
@@ -474,12 +468,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     const host = makeHost({
       sessionKey: "s2",
       sessionsResult: makeSessionsResult([{ key: "s2", hasActiveRun: true, status: "running" }]),
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
     expect(rowActive(host)).toBe(true);
@@ -488,12 +477,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
   it("retains completed run identity across a terminal row projection", () => {
     const host = makeHost({
       sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: false, status: "done" }]),
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
     expect(host.lastLocalTerminalReconcile?.runId).toBe("r1");
@@ -548,12 +532,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
           startedAt: Date.now() - 60_000,
         },
       ]),
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
     expect(rowActive(host)).toBe(true);
@@ -563,12 +542,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
   it("does not suppress an active row without run identity", () => {
     const host = makeHost({
       sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: true, status: "running" }]),
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
 
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
@@ -802,12 +776,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
         sessionKey: "s1",
         occurredAt: completedAt,
       },
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
 
     expect(reconcileStaleChatRunAfterSessionStatePublication(host)).toBe(true);
@@ -816,12 +785,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
 
   it("keeps suppressing repeated stale active refreshes for the completed run", () => {
     const host = makeHost({
-      lastLocalTerminalReconcile: {
-        sessionKey: "s1",
-        runId: "r1",
-        phase: "done",
-        sessionStatus: "done",
-      },
+      lastLocalTerminalReconcile: makeLocalTerminalReconcile(),
     });
 
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);

--- a/ui/src/pages/chat/session-message-cache.test.ts
+++ b/ui/src/pages/chat/session-message-cache.test.ts
@@ -16,6 +16,10 @@ function createHost() {
   };
 }
 
+function createCacheContext() {
+  return { host: createHost(), cache: new Map() as ChatMessageCache };
+}
+
 function cacheChatMessages(
   cache: ChatMessageCache,
   host: Parameters<typeof cacheChatSessionSnapshot>[1],
@@ -29,10 +33,17 @@ function cacheChatMessages(
   });
 }
 
+function cacheHomeSnapshot(
+  cache: ChatMessageCache,
+  host: Parameters<typeof cacheChatSessionSnapshot>[1],
+  snapshot: Parameters<typeof cacheChatSessionSnapshot>[3],
+): void {
+  cacheChatSessionSnapshot(cache, host, { sessionKey: "home" }, snapshot);
+}
+
 describe("session message cache", () => {
   it("canonicalizes main aliases without crossing agent scopes", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
 
     cacheChatMessages(cache, host, { sessionKey: "home" }, ["ops"]);
 
@@ -73,8 +84,7 @@ describe("session message cache", () => {
   ])(
     "keeps case-distinct $name in separate transcript caches",
     ({ sessionKey, canonicalKey, distinctKey }) => {
-      const host = createHost();
-      const cache: ChatMessageCache = new Map();
+      const { host, cache } = createCacheContext();
 
       cacheChatMessages(cache, host, { sessionKey }, ["first session"]);
       cacheChatMessages(cache, host, { sessionKey: distinctKey }, ["second session"]);
@@ -123,8 +133,7 @@ describe("session message cache", () => {
   });
 
   it("keeps only the 20 most recently used sessions", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
     for (let index = 0; index < 20; index += 1) {
       cacheChatMessages(cache, host, { sessionKey: `agent:ops:session-${index}` }, [index]);
     }
@@ -140,18 +149,12 @@ describe("session message cache", () => {
   });
 
   it("restores messages, pagination, and backing session identity together", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: ["oldest", "latest"],
-        pagination: { hasMore: true, nextOffset: 400, totalMessages: 718 },
-        sessionId: "session-1",
-      },
-    );
+    const { host, cache } = createCacheContext();
+    cacheHomeSnapshot(cache, host, {
+      messages: ["oldest", "latest"],
+      pagination: { hasMore: true, nextOffset: 400, totalMessages: 718 },
+      sessionId: "session-1",
+    });
 
     expect(readChatSessionSnapshot(cache, host, { sessionKey: "home" })).toEqual({
       messages: ["oldest", "latest"],
@@ -161,18 +164,12 @@ describe("session message cache", () => {
   });
 
   it("appends an inactive-session message without losing snapshot metadata", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: ["oldest"],
-        pagination: { hasMore: true, nextOffset: 400, totalMessages: 718 },
-        sessionId: "session-1",
-      },
-    );
+    const { host, cache } = createCacheContext();
+    cacheHomeSnapshot(cache, host, {
+      messages: ["oldest"],
+      pagination: { hasMore: true, nextOffset: 400, totalMessages: 718 },
+      sessionId: "session-1",
+    });
 
     appendChatMessageToCache(cache, host, { sessionKey: "home" }, "latest");
 
@@ -184,37 +181,26 @@ describe("session message cache", () => {
   });
 
   it("keeps deeper same-session history when another pane saves only the latest tail", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
     const retained = Array.from({ length: 140 }, (_, index) => ({
       content: `retained-${index + 1}`,
       __openclaw: { seq: index + 1 },
     }));
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: retained,
-        pagination: { hasMore: false, totalMessages: 140 },
-        sessionId: "session-1",
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: retained,
+      pagination: { hasMore: false, totalMessages: 140 },
+      sessionId: "session-1",
+    });
     const refreshedTail = Array.from({ length: 40 }, (_, index) => ({
       content: `fresh-${index + 101}`,
       __openclaw: { seq: index + 101 },
     }));
 
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: refreshedTail,
-        pagination: { hasMore: true, nextOffset: 40, totalMessages: 140 },
-        sessionId: "session-1",
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: refreshedTail,
+      pagination: { hasMore: true, nextOffset: 40, totalMessages: 140 },
+      sessionId: "session-1",
+    });
 
     const snapshot = readChatSessionSnapshot(cache, host, { sessionKey: "home" });
     expect(snapshot?.messages).toHaveLength(140);
@@ -224,33 +210,22 @@ describe("session message cache", () => {
   });
 
   it("keeps the newer same-depth snapshot when a stale pane saves later", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
     const current = [1, 2, 3].map((seq) => ({
       content: `current-${seq}`,
       __openclaw: { seq },
     }));
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: current,
-        pagination: { hasMore: false, totalMessages: 3 },
-        sessionId: "session-1",
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: current,
+      pagination: { hasMore: false, totalMessages: 3 },
+      sessionId: "session-1",
+    });
 
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: current.slice(0, 2),
-        pagination: { hasMore: true, nextOffset: 2, totalMessages: 3 },
-        sessionId: "session-1",
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: current.slice(0, 2),
+      pagination: { hasMore: true, nextOffset: 2, totalMessages: 3 },
+      sessionId: "session-1",
+    });
 
     expect(readChatSessionSnapshot(cache, host, { sessionKey: "home" })).toEqual({
       messages: current,
@@ -260,30 +235,19 @@ describe("session message cache", () => {
   });
 
   it("does not retain history across backing session changes", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: [{ content: "old", __openclaw: { seq: 1 } }],
-        pagination: { hasMore: false, totalMessages: 1 },
-        sessionId: "session-1",
-      },
-    );
+    const { host, cache } = createCacheContext();
+    cacheHomeSnapshot(cache, host, {
+      messages: [{ content: "old", __openclaw: { seq: 1 } }],
+      pagination: { hasMore: false, totalMessages: 1 },
+      sessionId: "session-1",
+    });
     const replacement = [{ content: "new", __openclaw: { seq: 1 } }];
 
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: replacement,
-        pagination: { hasMore: false, totalMessages: 1 },
-        sessionId: "session-2",
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: replacement,
+      pagination: { hasMore: false, totalMessages: 1 },
+      sessionId: "session-2",
+    });
 
     expect(readChatSessionSnapshot(cache, host, { sessionKey: "home" })?.messages).toEqual(
       replacement,
@@ -291,72 +255,49 @@ describe("session message cache", () => {
   });
 
   it("reuses retained message weights when snapshot metadata changes", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
     const toJSON = vi.fn(() => ({ role: "assistant", content: "retained" }));
     const message = { toJSON };
 
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: [message],
-        pagination: { hasMore: true, nextOffset: 1, totalMessages: 2 },
-        sessionId: "session-1",
-      },
-    );
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: [message],
-        pagination: { hasMore: false, totalMessages: 1 },
-        sessionId: "session-1",
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: [message],
+      pagination: { hasMore: true, nextOffset: 1, totalMessages: 2 },
+      sessionId: "session-1",
+    });
+    cacheHomeSnapshot(cache, host, {
+      messages: [message],
+      pagination: { hasMore: false, totalMessages: 1 },
+      sessionId: "session-1",
+    });
 
     expect(toJSON).toHaveBeenCalledOnce();
   });
 
   it("removes an empty identity-free snapshot after a cleared session reload", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
     cacheChatMessages(cache, host, { sessionKey: "home" }, ["stale"]);
 
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: [],
-        pagination: { hasMore: false },
-        sessionId: null,
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: [],
+      pagination: { hasMore: false },
+      sessionId: null,
+    });
 
     expect(readChatSessionSnapshot(cache, host, { sessionKey: "home" })).toBeNull();
   });
 
   it("caps an oversized snapshot at a raw transcript boundary", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
     const content = "x".repeat(4 * 1024 * 1024);
-    cacheChatSessionSnapshot(
-      cache,
-      host,
-      { sessionKey: "home" },
-      {
-        messages: [
-          { content, __openclaw: { seq: 1 } },
-          { content, projection: "sibling", __openclaw: { seq: 1 } },
-          { content, __openclaw: { seq: 2 } },
-        ],
-        pagination: { hasMore: false, totalMessages: 2 },
-        sessionId: "session-1",
-      },
-    );
+    cacheHomeSnapshot(cache, host, {
+      messages: [
+        { content, __openclaw: { seq: 1 } },
+        { content, projection: "sibling", __openclaw: { seq: 1 } },
+        { content, __openclaw: { seq: 2 } },
+      ],
+      pagination: { hasMore: false, totalMessages: 2 },
+      sessionId: "session-1",
+    });
 
     const snapshot = readChatSessionSnapshot(cache, host, { sessionKey: "home" });
     expect(snapshot?.messages).toHaveLength(1);
@@ -368,8 +309,7 @@ describe("session message cache", () => {
   });
 
   it("evicts whole least-recently-used snapshots when the global budget is exceeded", () => {
-    const host = createHost();
-    const cache: ChatMessageCache = new Map();
+    const { host, cache } = createCacheContext();
     const content = "x".repeat(9 * 1024 * 1024);
     for (const sessionKey of ["one", "two", "three"]) {
       cacheChatSessionSnapshot(

--- a/ui/src/pages/chat/stream-reconciliation.test.ts
+++ b/ui/src/pages/chat/stream-reconciliation.test.ts
@@ -18,6 +18,16 @@ const visibleStreamOptions = {
   persistCommentary: true,
 };
 
+function makeIdleStreamState<
+  T extends Omit<Partial<StreamReconciliationState>, "chatStream" | "chatStreamStartedAt">,
+>(overrides: T) {
+  return {
+    chatStream: null,
+    chatStreamStartedAt: null,
+    ...overrides,
+  } satisfies StreamReconciliationState;
+}
+
 function messageText(message: unknown): string | null {
   const content = (message as { content?: unknown }).content;
   if (!Array.isArray(content)) {
@@ -62,18 +72,13 @@ function createConcurrentToolStreamState() {
 
 describe("stream reconciliation", () => {
   it("materializes keyed preambles by timestamp instead of tool index", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [
         { text: "first preamble", ts: 2, itemId: "preamble-1" },
         { text: "second preamble", ts: 3, itemId: "preamble-2" },
       ],
       toolStreamOrder: ["call_1"],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-      toolStreamOrder: string[];
-    };
+    });
     const messages = [
       { role: "user", content: "latest ask", timestamp: 1 },
       { role: "toolResult", toolCallId: "call_1", content: "tool output", timestamp: 4 },
@@ -90,16 +95,12 @@ describe("stream reconciliation", () => {
   });
 
   it("materializes keyed preambles before later assistant messages", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [
         { text: "first preamble", ts: 2, itemId: "preamble-1" },
         { text: "second preamble", ts: 3, itemId: "preamble-2" },
       ],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-    };
+    });
     const messages = [
       { role: "user", content: "latest ask", timestamp: 1 },
       { role: "assistant", content: [{ type: "text", text: "final reply" }], timestamp: 4 },
@@ -116,17 +117,13 @@ describe("stream reconciliation", () => {
   });
 
   it("does not replay a keyed preamble across a same-run steer boundary", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [
         { text: "already visible", ts: 2, itemId: "preamble-1" },
         { text: "distinct item", ts: 4, itemId: "preamble-2" },
         { text: "already visible", ts: 5 },
       ],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId?: string }>;
-    };
+    });
     const messages = [
       { role: "user", content: "original ask", timestamp: 1 },
       {
@@ -157,17 +154,13 @@ describe("stream reconciliation", () => {
   });
 
   it("recomputes the unkeyed boundary after keyed insertions before a steer", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [
         { text: "first keyed", ts: 2, itemId: "preamble-1" },
         { text: "repeatable", ts: 3, itemId: "preamble-2" },
         { text: "repeatable", ts: 5 },
       ],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId?: string }>;
-    };
+    });
     const messages = [
       { role: "user", content: "original ask", timestamp: 1 },
       { role: "user", content: "steer this run", timestamp: 4 },
@@ -188,9 +181,7 @@ describe("stream reconciliation", () => {
   });
 
   it("does not prune keyed preambles by live tool index", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [
         { text: "keyed preamble", ts: 2, itemId: "preamble-1" },
         { text: "before tool", ts: 3, toolCallId: "call_1" },
@@ -198,17 +189,7 @@ describe("stream reconciliation", () => {
       chatToolMessages: [{ role: "toolResult", toolCallId: "call_1", content: "tool output" }],
       toolStreamById: new Map<string, unknown>([["call_1", {}]]),
       toolStreamOrder: ["call_1"],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{
-        text: string;
-        ts: number;
-        itemId?: string;
-        toolCallId?: string;
-      }>;
-      chatToolMessages: unknown[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-    };
+    });
 
     prunePersistedToolStreamMessages(state, new Set(["call_1"]));
 
@@ -280,16 +261,14 @@ describe("stream reconciliation", () => {
       toolCallId,
       content: [{ type: "toolcall", name: "read", arguments: { path: "notes.txt" } }],
     };
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatToolMessages: [liveMessage],
       chatStreamSegments: [{ text: "Reading notes", ts: 2, runId, toolCallId }],
       toolStreamById: new Map<string, unknown>([
         [identity, { runId, toolCallId, message: liveMessage }],
       ]),
       toolStreamOrder: [identity],
-    };
+    });
     const messages = [
       { role: "user", content: "Read the notes", timestamp: 1 },
       {
@@ -318,15 +297,13 @@ describe("stream reconciliation", () => {
     const unrelatedCallId = "transcript-message-42";
     const actualIdentity = buildToolStreamIdentity(runId, actualCallId);
     const unrelatedIdentity = buildToolStreamIdentity(runId, unrelatedCallId);
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       toolStreamOrder: [actualIdentity, unrelatedIdentity],
       toolStreamById: new Map<string, unknown>([
         [actualIdentity, { runId, toolCallId: actualCallId }],
         [unrelatedIdentity, { runId, toolCallId: unrelatedCallId }],
       ]),
-    };
+    });
     const messages = [
       { role: "user", content: "Run both tools", timestamp: 1 },
       {
@@ -363,9 +340,7 @@ describe("stream reconciliation", () => {
       { role: "assistant", content: "hello" },
       { role: "user", content: "hello" },
     ];
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatToolMessages: messages,
       toolStreamById: new Map<string, unknown>([
         ["call_1", {}],
@@ -375,12 +350,7 @@ describe("stream reconciliation", () => {
       ]),
       toolStreamOrder: ["call_1", "call_2", "call_3", "call_4"],
       chatStreamSegments: [],
-    } satisfies StreamReconciliationState & {
-      chatToolMessages: unknown[];
-      toolStreamById: Map<string, unknown>;
-      toolStreamOrder: string[];
-      chatStreamSegments: Array<never>;
-    };
+    });
 
     prunePersistedToolStreamMessages(state, new Set(["call_1", "call_2", "call_3", "call_4"]));
 
@@ -393,13 +363,9 @@ describe("stream reconciliation", () => {
   });
 
   it("keeps materialized keyed preambles before terminal messages that share their prefix", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [{ text: "before tool", ts: 2, itemId: "preamble-1" }],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-    };
+    });
     const messages = [{ role: "user", content: "latest ask", timestamp: 1 }];
 
     const materialized = materializeVisibleStreamState(messages, state, visibleStreamOptions);
@@ -417,13 +383,9 @@ describe("stream reconciliation", () => {
   });
 
   it("does not treat matching terminal text as a keyed preamble replacement", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [{ text: "before tool", ts: 2, itemId: "preamble-1" }],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-    };
+    });
     const terminalMessage = {
       role: "assistant",
       content: [{ type: "text", text: "before tool\nfinal answer" }],
@@ -446,13 +408,9 @@ describe("stream reconciliation", () => {
   });
 
   it("does not require transient keyed commentary to be present in history", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [{ text: "before tool", ts: 2, itemId: "preamble-1" }],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-    };
+    });
     const messages = [
       { role: "user", content: "latest ask", timestamp: 1 },
       { role: "assistant", content: [{ type: "text", text: "final answer" }], timestamp: 3 },
@@ -467,13 +425,9 @@ describe("stream reconciliation", () => {
   });
 
   it("keeps transient keyed commentary when history has no terminal assistant message", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [{ text: "before tool", ts: 2, itemId: "preamble-1" }],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-    };
+    });
     const messages = [{ role: "user", content: "latest ask", timestamp: 1 }];
 
     expect(
@@ -485,13 +439,9 @@ describe("stream reconciliation", () => {
   });
 
   it("replaces materialized tool stream segments with matching terminal messages", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [{ text: "before tool", ts: 2, toolCallId: "call_1" }],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; toolCallId: string }>;
-    };
+    });
     const messages = [{ role: "user", content: "latest ask", timestamp: 1 }];
 
     const materialized = materializeVisibleStreamState(messages, state, visibleStreamOptions);
@@ -505,16 +455,12 @@ describe("stream reconciliation", () => {
   });
 
   it("omits keyed commentary parts when persistCommentary is false (transient mode)", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [
         { text: "first preamble", ts: 2, itemId: "preamble-1" },
         { text: "second preamble", ts: 3, itemId: "preamble-2" },
       ],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-    };
+    });
     const messages = [
       { role: "user", content: "latest ask", timestamp: 1 },
       { role: "assistant", content: [{ type: "text", text: "final reply" }], timestamp: 4 },
@@ -547,13 +493,9 @@ describe("stream reconciliation", () => {
   });
 
   it("materializes keyed commentary parts when persistCommentary is true (persist mode)", () => {
-    const state = {
-      chatStream: null,
-      chatStreamStartedAt: null,
+    const state = makeIdleStreamState({
       chatStreamSegments: [{ text: "kept preamble", ts: 2, itemId: "preamble-1" }],
-    } satisfies StreamReconciliationState & {
-      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
-    };
+    });
     const messages = [
       { role: "user", content: "latest ask", timestamp: 1 },
       { role: "assistant", content: [{ type: "text", text: "final reply" }], timestamp: 4 },

--- a/ui/src/pages/chat/tool-stream.startup.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.startup.node.test.ts
@@ -1,24 +1,16 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { handleAgentEvent, type ToolStreamEntry } from "./tool-stream.ts";
+import { createHost } from "./tool-stream.test-helpers.ts";
+import { handleAgentEvent } from "./tool-stream.ts";
 
-type ToolStreamHost = Parameters<typeof handleAgentEvent>[0];
 type AgentEvent = NonNullable<Parameters<typeof handleAgentEvent>[1]>;
 
-function createHost(): ToolStreamHost {
-  return {
-    sessionKey: "main",
+function createStartupHost() {
+  return createHost({
     chatRunId: "run-1",
-    chatStream: null,
-    chatStreamStartedAt: null,
     chatRunStartup: { state: "status", runId: "run-1", phase: "starting_model" },
-    chatStreamSegments: [],
-    toolStreamById: new Map<string, ToolStreamEntry>(),
-    toolStreamOrder: [],
-    chatToolMessages: [],
     toolStreamSyncTimer: 1,
-    sessions: { setModelOverride: () => {} },
-  };
+  });
 }
 
 function toolStart(runId: string, toolCallId: string): AgentEvent {
@@ -34,7 +26,7 @@ function toolStart(runId: string, toolCallId: string): AgentEvent {
 
 describe("app-tool-stream startup status", () => {
   it("clears the active run status on the first matching tool start", () => {
-    const host = createHost();
+    const host = createStartupHost();
 
     handleAgentEvent(host, toolStart("run-1", "tool-1"));
 
@@ -42,7 +34,7 @@ describe("app-tool-stream startup status", () => {
   });
 
   it("keeps active status for a tool from another run", () => {
-    const host = createHost();
+    const host = createStartupHost();
 
     handleAgentEvent(host, toolStart("run-2", "tool-2"));
 

--- a/ui/src/pages/chat/tool-stream.usage.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.usage.node.test.ts
@@ -1,29 +1,9 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import {
-  handleAgentEvent,
-  resolveActiveRunOutputTokens,
-  type ToolStreamEntry,
-} from "./tool-stream.ts";
+import { createHost } from "./tool-stream.test-helpers.ts";
+import { handleAgentEvent, resolveActiveRunOutputTokens } from "./tool-stream.ts";
 
-type ToolStreamHost = Parameters<typeof handleAgentEvent>[0];
 type AgentEvent = NonNullable<Parameters<typeof handleAgentEvent>[1]>;
-
-function createHost(overrides?: Partial<ToolStreamHost>): ToolStreamHost {
-  return {
-    sessionKey: "main",
-    chatRunId: null,
-    chatStream: null,
-    chatStreamStartedAt: null,
-    chatStreamSegments: [],
-    toolStreamById: new Map<string, ToolStreamEntry>(),
-    toolStreamOrder: [],
-    chatToolMessages: [],
-    toolStreamSyncTimer: null,
-    sessions: { setModelOverride: () => undefined },
-    ...overrides,
-  };
-}
 
 function agentEvent(
   runId: string,


### PR DESCRIPTION
## What Problem This Solves

The chat UI test suites repeated large `ChatHost` literals, request mocks, and arrange scaffolding across many files. That duplication made behavior-neutral test maintenance noisy and allowed fixture setup to drift between suites.

## Why This Change Was Made

This refactor adopts the shared chat-host fixture where its defaults match the suite and replaces repeated arrange blocks with narrow local builders elsewhere. The original audit premise needed one correction: direct `makeChatHost` adoption fits `chat-avatar.test.ts` cleanly; history and state tests compose partial session fixtures, while specialized and narrow suites keep local builders so their exact defaults remain visible and unchanged. No production behavior or changelog changes are included.

## User Impact

There is no user-visible behavior change. Developers get smaller, more consistent chat tests with 2,026 fewer net test lines and unchanged titles and assertions.

## Evidence

- Mechanical title-delta check:
  - `node /tmp/worker-a-extract-chat-titles.mjs "$PWD" /tmp/worker-a-chat-titles-post-fix.json /tmp/worker-a-chat-titles-before.json`
  - PASS: `{files:15,lines:26704,titles:926}`; 926/926 titles matched, all 15 files had `matchedBaseline: true`, with zero ordered or duplicate-title mismatches.
- Focused Vitest, run strictly sequentially:
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-avatar.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-gateway.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-history.inflight.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-history.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-state.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs ui/src/pages/chat/chat-thread.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-background-tasks.test.ts`
  - `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/run-lifecycle.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/session-message-cache.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/stream-reconciliation.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/tool-stream.startup.node.test.ts`
  - `node scripts/run-vitest.mjs ui/src/pages/chat/tool-stream.usage.node.test.ts`
  - PASS: 975/975 tests.
- Formatting and lint:
  - `pnpm format ui/src/pages/chat/{chat-avatar.test.ts,chat-gateway.test.ts,chat-history.inflight.test.ts,chat-history.test.ts,chat-state.test.ts,chat-thread.test.ts,chat-view.test.ts,run-lifecycle.test.ts,session-message-cache.test.ts,stream-reconciliation.test.ts,tool-stream.startup.node.test.ts,tool-stream.usage.node.test.ts} ui/src/pages/chat/components/{chat-background-tasks.test.ts,chat-message.test.ts}` — PASS.
  - `node scripts/run-oxlint.mjs ui/src/pages/chat/{chat-avatar.test.ts,chat-gateway.test.ts,chat-history.inflight.test.ts,chat-history.test.ts,chat-state.test.ts,chat-thread.test.ts,chat-view.test.ts,run-lifecycle.test.ts,session-message-cache.test.ts,stream-reconciliation.test.ts,tool-stream.startup.node.test.ts,tool-stream.usage.node.test.ts} ui/src/pages/chat/components/{chat-background-tasks.test.ts,chat-message.test.ts}` — PASS.
  - `git diff --check origin/main...HEAD` — PASS.
- Changed-check gate:
  - Remote delegation from `node scripts/check-changed.mjs` was unavailable because Azure returned HTTP 403 `admin_required`.
  - `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — PASS locally across the constituent lanes.
- LOC: Production +0/-0; Tests +2430/-4456 (net -2026).
