### PR TITLE
fix: update js-yaml omap resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7165,8 +7165,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jscpd-darwin-arm64@5.0.12:
@@ -13413,7 +13413,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14428,7 +14428,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers installing the current dependency graph would receive `js-yaml@4.3.0`, which is affected by the High-severity quadratic-complexity advisory GHSA-5p4m-2wfm-xmqj when resolving hostile `!!omap` YAML. No related open issue or PR was found.

## Why This Change Was Made

The pnpm lockfile now resolves the existing transitive js-yaml 4.x dependency to 4.3.1, the minimum fixed release. This is a lockfile-only remediation; it does not add a direct dependency or change application code.

## User Impact

Fresh installs no longer include the affected js-yaml release. There is no intended user-visible behavior change.

## Evidence

- `CI=true corepack pnpm install --frozen-lockfile --lockfile-only --ignore-scripts` passed across all 175 workspaces with pnpm 11.15.1
- the repository lockfile resolves only `js-yaml@4.3.1` after the patch
- the repository supply-chain policy verified all 1,611 lock entries during frozen installation
- `git diff --check` passed
- full build/check/test suites were not run locally; exact-head fork CI is the remaining proof boundary

AI-assisted: yes. I reviewed the four-line lockfile resolution change and understand that it preserves the existing 4.x dependency contract while replacing the affected tarball and integrity metadata.