### PR TITLE
refactor(test): compress repetitive fixtures in mega-tests, batch 2

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -135,12 +135,136 @@ function completedCommand(id: string, command: string): CodexServerNotification 
   });
 }
 
+type AttemptOptions = NonNullable<Parameters<typeof runCodexAppServerAttempt>[1]>;
+type TestParams = ReturnType<typeof createTestParams>;
+
+function makeTestParams(overrides: Partial<TestParams> = {}): TestParams {
+  return { ...createTestParams(), ...overrides };
+}
+
+function makeDynamicToolCallRequest(
+  overrides: {
+    id?: string;
+    params?: Partial<{
+      threadId: string;
+      turnId: string;
+      callId: string;
+      namespace: string | null;
+      tool: string;
+      arguments: JsonObject;
+    }>;
+  } = {},
+) {
+  const { params, ...requestOverrides } = overrides;
+  return {
+    id: "request-tool-1",
+    method: "item/tool/call",
+    ...requestOverrides,
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "message",
+      arguments: { action: "send", text: "already sent" },
+      ...params,
+    },
+  };
+}
+
+function makeAgentMessageDelta(
+  overrides: Partial<{
+    threadId: string;
+    turnId: string;
+    itemId: string;
+    delta: string;
+  }> = {},
+): CodexServerNotification {
+  return {
+    method: "item/agentMessage/delta",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "msg-partial-1",
+      delta: "Still writing",
+      ...overrides,
+    },
+  };
+}
+
+function makeRawAssistant(
+  overrides: Partial<{
+    id: string;
+    phase: "commentary" | "final_answer";
+    text: string;
+  }> = {},
+): CodexServerNotification {
+  const { text = "Done.", ...itemOverrides } = overrides;
+  return rawItemCompleted({
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text }],
+    ...itemOverrides,
+  });
+}
+
+function makeRecoveryAttemptOptions(overrides: AttemptOptions = {}): AttemptOptions {
+  return {
+    turnAssistantCompletionIdleTimeoutMs: 10,
+    turnTerminalIdleTimeoutMs: 500,
+    ...overrides,
+  };
+}
+
+async function expectTurnInterrupted(
+  harness: ReturnType<typeof createStartedThreadHarness>,
+): Promise<void> {
+  await vi.waitFor(
+    () =>
+      expect(harness.request).toHaveBeenCalledWith(
+        "turn/interrupt",
+        { threadId: "thread-1", turnId: "turn-1" },
+        { timeoutMs: 5_000 },
+      ),
+    { interval: 1 },
+  );
+}
+
+function makeMediaProjectionGate() {
+  let releaseProjection!: () => void;
+  let markProjectionStarted!: () => void;
+  const projectionGate = new Promise<void>((resolve) => {
+    releaseProjection = resolve;
+  });
+  const projectionStarted = new Promise<void>((resolve) => {
+    markProjectionStarted = resolve;
+  });
+  vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async () => {
+    markProjectionStarted();
+    await projectionGate;
+    throw new Error("expected projection gate");
+  });
+  return { projectionStarted, releaseProjection };
+}
+
+function expectSuccessfulAttempt(result: EmbeddedRunAttemptResult): void {
+  expect(readAttemptTerminal(result).aborted).toBe(false);
+  expect(readAttemptTerminal(result).timedOut).toBe(false);
+  expect(readAttemptTerminal(result).promptError).toBeNull();
+}
+
+function expectTimedOutAttempt(result: EmbeddedRunAttemptResult): void {
+  expect(readAttemptTerminal(result).aborted).toBe(true);
+  expect(readAttemptTerminal(result).timedOut).toBe(true);
+  expect(readAttemptTerminal(result).promptError).toBe(
+    "codex app-server turn idle timed out waiting for turn/completed",
+  );
+}
+
 async function runTurnWatchTimeoutScenario(notifications: CodexServerNotification[]) {
   const harness = createStartedThreadHarness();
   const onRunAgentEvent = vi.fn();
-  const params = createTestParams();
-  params.timeoutMs = 100;
-  params.onAgentEvent = onRunAgentEvent;
+  const params = makeTestParams({ timeoutMs: 100, onAgentEvent: onRunAgentEvent });
   const run = runCodexAppServerAttempt(params, {
     turnCompletionIdleTimeoutMs: 500,
     turnAssistantCompletionIdleTimeoutMs: 1_000,
@@ -155,7 +279,9 @@ async function runTurnWatchTimeoutScenario(notifications: CodexServerNotificatio
 
 async function runClientCloseScenario(notifications: CodexServerNotification[]) {
   const harness = createStartedThreadHarness();
-  const run = runCodexAppServerAttempt(createTestParams(), { turnTerminalIdleTimeoutMs: 60_000 });
+  const run = runCodexAppServerAttempt(createTestParams(), {
+    turnTerminalIdleTimeoutMs: 60_000,
+  });
   await harness.waitForMethod("turn/start");
   for (const notification of notifications) {
     await harness.notify(notification);
@@ -240,8 +366,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   ])("$name", async ({ runTimeoutOverrideMs, expectedTerminalIdleTimeoutMs }) => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 48 * 60 * 60_000;
+    const params = makeTestParams({ timeoutMs: 48 * 60 * 60_000 });
     params.runTimeoutOverrideMs = runTimeoutOverrideMs;
     const run = runCodexAppServerAttempt(params);
 
@@ -268,8 +393,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("releases the session when Codex never completes after a dynamic tool response", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 5 } },
@@ -278,18 +402,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     // The keyed router only accepts turn-scoped requests once the turn is bound.
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as {
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
       contentItems?: Array<{ text?: string; type?: string }>;
       success?: boolean;
     };
@@ -300,31 +413,15 @@ describe("runCodexAppServerAttempt turn watches", () => {
     );
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    expectTimedOutAttempt(result);
+    await expectTurnInterrupted(harness);
     await expect(readCodexAppServerBinding(params.sessionFile)).resolves.toBeUndefined();
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
   });
 
   it("marks Codex completion-idle timeouts after completed items as replay-invalid", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 5 } },
@@ -354,8 +451,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("keeps partial assistant deltas on the timeout path", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 5 } },
@@ -363,15 +459,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       turnTerminalIdleTimeoutMs: 60_000,
     });
     await harness.waitForMethod("turn/start");
-    await harness.notify({
-      method: "item/agentMessage/delta",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "msg-partial-1",
-        delta: "Still writing",
-      },
-    });
+    await harness.notify(makeAgentMessageDelta());
 
     const result = await run;
 
@@ -391,8 +479,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("preserves raw image-generation media when Codex never sends turn completion", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
     vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempDir, "state"));
 
     const run = runCodexAppServerAttempt(params, {
@@ -476,8 +563,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("uses the terminal dead-client outcome for silent terminal timeouts", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 500,
@@ -574,11 +660,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("preserves a rewritten completed assistant after its id-less raw echo", async () => {
     const { result } = await runTurnWatchTimeoutScenario([
       completedAssistant("msg-1", "Contributor-rewritten answer."),
-      rawItemCompleted({
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Original model answer." }],
-      }),
+      makeRawAssistant({ text: "Original model answer." }),
     ]);
 
     expect(projectAttemptResult(result)).toMatchObject({
@@ -593,11 +675,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("uses an id-less raw echo when the typed completion is blank", async () => {
     const { result } = await runTurnWatchTimeoutScenario([
       completedAssistant("msg-1", " "),
-      rawItemCompleted({
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Raw fallback answer." }],
-      }),
+      makeRawAssistant({ text: "Raw fallback answer." }),
     ]);
 
     expect(projectAttemptResult(result)).toMatchObject({
@@ -620,11 +698,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       }),
     ]);
 
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     expect(result.assistantTexts).toEqual(["I will run a tool."]);
     expect(result.codexAppServerFailure?.turnWatchTimeoutKind).toBe("progress");
   });
@@ -732,16 +806,11 @@ describe("runCodexAppServerAttempt turn watches", () => {
           addRequestHandler: () => () => undefined,
         }) as never,
     );
-    const params = createTestParams();
-    params.timeoutMs = 250;
+    const params = makeTestParams({ timeoutMs: 250 });
 
     const result = await runCodexAppServerAttempt(params);
 
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     expect(request).toHaveBeenCalledWith(
       "turn/interrupt",
       {
@@ -771,8 +840,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const progressIntervalMs = 50;
     const progressPhaseMs = attemptIdleTimeoutMs + 200;
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = attemptIdleTimeoutMs;
+    const params = makeTestParams({ timeoutMs: attemptIdleTimeoutMs });
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
 
@@ -799,11 +867,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
       });
       sentProgressNotifications += 1;
       await harness.notify(
-        rawItemCompleted({
-          type: "message",
+        makeRawAssistant({
           id: `raw-progress-${sentProgressNotifications}`,
-          role: "assistant",
-          content: [{ type: "output_text", text: "Still working." }],
+          text: "Still working.",
         }),
       );
       progressPhaseElapsedMs = Date.now() - progressStartedAt;
@@ -835,8 +901,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("does not count non-turn app-server requests as turn attempt progress", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const params = createTestParams();
-    params.timeoutMs = 100;
+    const params = makeTestParams({ timeoutMs: 100 });
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
 
@@ -864,11 +929,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     const warnCall = warn.mock.calls.find(
       ([message]) => message === "codex app-server turn idle timed out waiting for progress",
     );
@@ -895,8 +956,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
         chatgptPlanType: null,
       };
     });
-    const params = createTestParams();
-    params.timeoutMs = 100;
+    const params = makeTestParams({ timeoutMs: 100 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 500,
@@ -926,11 +986,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     resolveRefresh?.();
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     const warnCall = warn.mock.calls.find(
       ([message]) => message === "codex app-server turn idle timed out waiting for progress",
     );
@@ -952,8 +1008,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       content: null,
       _meta: null,
     });
-    const params = createTestParams();
-    params.timeoutMs = 10_000;
+    const params = makeTestParams({ timeoutMs: 10_000 });
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
 
@@ -1026,8 +1081,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     vi.spyOn(elicitationBridge, "handleCodexAppServerElicitationRequest").mockImplementation(
       async () => await bridgePromise,
     );
-    const params = createTestParams();
-    params.timeoutMs = 500;
+    const params = makeTestParams({ timeoutMs: 500 });
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
 
@@ -1185,8 +1239,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const preRequestIdleMs = 500;
     const pendingHoldMs = 700;
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = attemptIdleTimeoutMs;
+    const params = makeTestParams({ timeoutMs: attemptIdleTimeoutMs });
     params.onBlockReply = vi.fn();
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
@@ -1264,8 +1317,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("does not count mismatched turn-scoped requests as turn attempt progress", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const params = createTestParams();
-    params.timeoutMs = 100;
+    const params = makeTestParams({ timeoutMs: 100 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 500,
@@ -1311,11 +1363,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     const warnCall = warn.mock.calls.find(
       ([message]) => message === "codex app-server turn idle timed out waiting for progress",
     );
@@ -1330,8 +1378,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("does not count account rate-limit updates as turn completion activity", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 5,
@@ -1340,27 +1387,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
     await harness.notify(rateLimitsUpdated(Math.ceil(Date.now() / 1000) + 120));
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     const warnCall = warn.mock.calls.find(
       ([message]) =>
         message === "codex app-server turn idle timed out waiting for completion" ||
@@ -1400,8 +1434,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     async ({ completion, expectedReason, expectedItemType }) => {
       const harness = createStartedThreadHarness();
       const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-      const params = createTestParams();
-      params.timeoutMs = 60_000;
+      const params = makeTestParams({ timeoutMs: 60_000 });
 
       let settled = false;
       const run = runCodexAppServerAttempt(params, {
@@ -1413,18 +1446,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
       });
       await harness.waitForMethod("turn/start");
 
-      const toolResult = (await harness.handleServerRequest({
-        id: "request-tool-1",
-        method: "item/tool/call",
-        params: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-1",
-          namespace: null,
-          tool: "message",
-          arguments: { action: "send", text: "already sent" },
-        },
-      })) as { success?: boolean };
+      const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+        success?: boolean;
+      };
       expect(toolResult.success).toBe(false);
       await harness.notify(completion);
 
@@ -1467,8 +1491,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("keeps waiting when Codex emits a raw assistant item after a dynamic tool response", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 5,
@@ -1477,26 +1500,12 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
     await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-status-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "I'm writing the report now." }],
-      }),
+      makeRawAssistant({ id: "raw-status-1", text: "I'm writing the report now." }),
     );
     await new Promise((resolve) => {
       setTimeout(resolve, 20);
@@ -1506,9 +1515,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     await harness.notify(turnCompleted({ id: "turn-1", status: "completed" }));
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
@@ -1531,18 +1538,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
 
     await new Promise((resolve) => {
@@ -1554,9 +1552,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     await harness.notify(turnCompleted({ id: "turn-1", status: "completed" }));
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
   });
 
   it("keeps waiting after native tool completion before final synthesis", async () => {
@@ -1602,9 +1598,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
   });
 
   it("preserves post-tool budget for native tool completion buffered during turn start", async () => {
@@ -1676,15 +1670,12 @@ describe("runCodexAppServerAttempt turn watches", () => {
     await notify(turnCompleted({ id: "turn-1", status: "completed" }));
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
   });
 
   it("times out post-tool raw assistant progress after the post-tool timeout", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 50,
@@ -1694,53 +1685,23 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
     await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-status-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "I'm writing the report now." }],
-      }),
+      makeRawAssistant({ id: "raw-status-1", text: "I'm writing the report now." }),
     );
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    expectTimedOutAttempt(result);
+    await expectTurnInterrupted(harness);
   });
 
   it("uses configured post-tool raw assistant completion timeout instead of assistant release timeout", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
@@ -1753,26 +1714,12 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
     await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-status-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "I'm writing the report now." }],
-      }),
+      makeRawAssistant({ id: "raw-status-1", text: "I'm writing the report now." }),
     );
 
     await new Promise((resolve) => {
@@ -1781,23 +1728,8 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(settled).toBe(false);
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    expectTimedOutAttempt(result);
+    await expectTurnInterrupted(harness);
     const completionWarnCall = warn.mock.calls.find(
       ([message]) => message === "codex app-server turn idle timed out waiting for completion",
     );
@@ -1819,8 +1751,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("uses the post-tool timeout for commentary raw assistant progress", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
@@ -1833,26 +1764,15 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
     await harness.notify(
-      rawItemCompleted({
-        type: "message",
+      makeRawAssistant({
         id: "raw-status-1",
-        role: "assistant",
         phase: "commentary",
-        content: [{ type: "output_text", text: "I'm editing app.js now." }],
+        text: "I'm editing app.js now.",
       }),
     );
 
@@ -1888,25 +1808,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    });
+    await harness.handleServerRequest(makeDynamicToolCallRequest());
     await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-status-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "I'm writing a large patch now." }],
-      }),
+      makeRawAssistant({ id: "raw-status-1", text: "I'm writing a large patch now." }),
     );
 
     await new Promise((resolve) => {
@@ -1946,8 +1850,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("times out post-native-tool raw assistant progress after the post-tool timeout", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 100,
@@ -1971,39 +1874,18 @@ describe("runCodexAppServerAttempt turn watches", () => {
       }),
     );
     await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-status-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "I'm summarizing command output." }],
-      }),
+      makeRawAssistant({ id: "raw-status-1", text: "I'm summarizing command output." }),
     );
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    expectTimedOutAttempt(result);
+    await expectTurnInterrupted(harness);
   });
 
   it("logs raw assistant item context when the terminal watchdog fires", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 5,
@@ -2012,34 +1894,16 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
     await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-status-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "I'm writing the report now." }],
-      }),
+      makeRawAssistant({ id: "raw-status-1", text: "I'm writing the report now." }),
     );
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     const terminalWarnCall = warn.mock.calls.find(
       ([message]) => message === "codex app-server turn idle timed out waiting for terminal event",
     );
@@ -2075,8 +1939,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("uses the post-tool timeout after raw reasoning completes", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 5,
@@ -2086,18 +1949,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const toolResult = (await harness.handleServerRequest({
-      id: "request-tool-1",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-1",
-        namespace: null,
-        tool: "message",
-        arguments: { action: "send", text: "already sent" },
-      },
-    })) as { success?: boolean };
+    const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+      success?: boolean;
+    };
     expect(toolResult.success).toBe(false);
     // Post-tool reasoning can precede the final reply; keep the longer
     // post-tool guard armed instead of falling back to the generic completion
@@ -2111,11 +1965,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     );
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
+    expectTimedOutAttempt(result);
     const completionWarnCall = warn.mock.calls.find(
       ([message]) => message === "codex app-server turn idle timed out waiting for completion",
     );
@@ -2158,8 +2008,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     async ({ method, progressParams }) => {
       const harness = createStartedThreadHarness();
       const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-      const params = createTestParams();
-      params.timeoutMs = 60_000;
+      const params = makeTestParams({ timeoutMs: 60_000 });
 
       const run = runCodexAppServerAttempt(params, {
         turnCompletionIdleTimeoutMs: 20,
@@ -2169,18 +2018,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
       });
       await harness.waitForMethod("turn/start");
 
-      const toolResult = (await harness.handleServerRequest({
-        id: "request-tool-1",
-        method: "item/tool/call",
-        params: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-1",
-          namespace: null,
-          tool: "message",
-          arguments: { action: "send", text: "already sent" },
-        },
-      })) as { success?: boolean };
+      const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+        success?: boolean;
+      };
       expect(toolResult.success).toBe(false);
       await harness.notify(
         itemNotification("item/started", { id: "reasoning-1", type: "reasoning" }),
@@ -2196,11 +2036,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       });
 
       const result = await run;
-      expect(readAttemptTerminal(result).aborted).toBe(true);
-      expect(readAttemptTerminal(result).timedOut).toBe(true);
-      expect(readAttemptTerminal(result).promptError).toBe(
-        "codex app-server turn idle timed out waiting for turn/completed",
-      );
+      expectTimedOutAttempt(result);
       const completionWarnCall = warn.mock.calls.find(
         ([message]) => message === "codex app-server turn idle timed out waiting for completion",
       );
@@ -2221,37 +2057,20 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("releases the session when Codex accepts a turn but never sends progress", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
 
     const run = runCodexAppServerAttempt(params, { turnCompletionIdleTimeoutMs: 5 });
     await harness.waitForMethod("turn/start");
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(true);
-    expect(readAttemptTerminal(result).timedOut).toBe(true);
-    expect(readAttemptTerminal(result).promptError).toBe(
-      "codex app-server turn idle timed out waiting for turn/completed",
-    );
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    expectTimedOutAttempt(result);
+    await expectTurnInterrupted(harness);
     expect(queueActiveRunMessageForTest("session-1", "after silent turn")).toBe(false);
   });
 
   it("keeps waiting after reasoning completes before a visible message call", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
     params.sourceReplyDeliveryMode = "message_tool_only";
 
     let settled = false;
@@ -2276,16 +2095,13 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
   it("keeps waiting after reasoning and its raw mirror complete before a visible message call", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 60_000;
+    const params = makeTestParams({ timeoutMs: 60_000 });
     params.sourceReplyDeliveryMode = "message_tool_only";
 
     let settled = false;
@@ -2311,16 +2127,13 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
   it("keeps waiting after raw reasoning completes before automatic assistant reply", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 80;
+    const params = makeTestParams({ timeoutMs: 80 });
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
@@ -2339,16 +2152,13 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
   it("keeps waiting after commentary assistant progress before automatic final reply", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 80;
+    const params = makeTestParams({ timeoutMs: 80 });
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
@@ -2382,9 +2192,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
@@ -2392,8 +2200,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const harness = createStartedThreadHarness();
     const onRunAgentEvent = vi.fn();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
     params.onAgentEvent = onRunAgentEvent;
 
     const run = runCodexAppServerAttempt(params, { turnCompletionIdleTimeoutMs: 15 });
@@ -2437,18 +2244,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
         },
       },
     });
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    await expectTurnInterrupted(harness);
     expect(warn).toHaveBeenCalledWith(
       "codex app-server client retired after timed-out turn",
       expect.objectContaining({
@@ -2516,8 +2312,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("merges rate-limit updates into the client cache at receive time", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 1_000;
+    const params = makeTestParams({ timeoutMs: 1_000 });
 
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
@@ -2537,8 +2332,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("does not idle-timeout when terminal completion queues behind projection", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 120;
+    const params = makeTestParams({ timeoutMs: 120 });
     const turnStartProgressEvents: DiagnosticEventPayload[] = [];
     const stopDiagnostics = onInternalDiagnosticEvent((event) => {
       if (event.type === "run.progress" && event.reason === "codex_app_server:turn:start") {
@@ -2596,9 +2390,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     releaseProjection();
     await queuedTerminal;
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
   });
 
   it.each([
@@ -2613,15 +2405,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       name: "a real completed agent message omits text",
       attemptOptions: { turnAssistantCompletionIdleTimeoutMs: 5 },
       notifications: [
-        {
-          method: "item/agentMessage/delta",
-          params: {
-            threadId: "thread-1",
-            turnId: "turn-1",
-            itemId: "msg-final-1",
-            delta: "Done.",
-          },
-        },
+        makeAgentMessageDelta({ itemId: "msg-final-1", delta: "Done." }),
         completedAssistant("msg-final-1"),
       ],
     },
@@ -2629,15 +2413,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       name: "bookkeeping follows a completed assistant",
       attemptOptions: { turnAssistantCompletionIdleTimeoutMs: 5 },
       notifications: [
-        {
-          method: "item/agentMessage/delta",
-          params: {
-            threadId: "thread-1",
-            turnId: "turn-1",
-            itemId: "msg-final-1",
-            delta: "Done.",
-          },
-        },
+        makeAgentMessageDelta({ itemId: "msg-final-1", delta: "Done." }),
         completedAssistant("msg-final-1"),
         {
           method: "turn/plan/updated",
@@ -2647,8 +2423,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     },
   ])("releases the session when $name", async ({ attemptOptions, notifications }) => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
     const run = runCodexAppServerAttempt(params, attemptOptions);
     await harness.waitForMethod("turn/start");
     for (const notification of notifications) {
@@ -2662,15 +2437,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       promptError: null,
       assistantTexts: ["Done."],
     });
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          { threadId: "thread-1", turnId: "turn-1" },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    await expectTurnInterrupted(harness);
   });
 
   it.each([
@@ -2692,12 +2459,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     },
     {
       name: "raw commentary before turn completion",
-      commentary: rawItemCompleted({
-        type: "message",
+      commentary: makeRawAssistant({
         id: "raw-commentary-1",
-        role: "assistant",
         phase: "commentary",
-        content: [{ type: "output_text", text: "I am checking the workspace." }],
+        text: "I am checking the workspace.",
       }) satisfies CodexServerNotification,
       completion: turnCompleted({
         id: "turn-1",
@@ -2707,8 +2472,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     },
   ])("does not release $name", async ({ commentary, completion, expectedAssistantTexts }) => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
     const run = runCodexAppServerAttempt(params, { turnAssistantCompletionIdleTimeoutMs: 5 });
     await harness.waitForMethod("turn/start");
     await harness.notify(commentary);
@@ -2729,8 +2493,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("releases the session after a raw assistant response item without turn completion", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 5,
@@ -2738,14 +2501,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       turnTerminalIdleTimeoutMs: 500,
     });
     await harness.waitForMethod("turn/start");
-    await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        id: "raw-final-1",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Done." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ id: "raw-final-1" }));
 
     const result = await run;
     expect({
@@ -2759,31 +2515,16 @@ describe("runCodexAppServerAttempt turn watches", () => {
       promptError: null,
       assistantTexts: ["Done."],
     });
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    await expectTurnInterrupted(harness);
   });
 
   it.each(["stop", "subagentStop"] as const)(
     "waits for an active %s hook before recovering a completed assistant",
     async (eventName) => {
       const harness = createStartedThreadHarness();
-      const params = createTestParams();
-      params.timeoutMs = 200;
+      const params = makeTestParams({ timeoutMs: 200 });
 
-      const run = runCodexAppServerAttempt(params, {
-        turnAssistantCompletionIdleTimeoutMs: 10,
-        turnTerminalIdleTimeoutMs: 500,
-      });
+      const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
       await harness.waitForMethod("turn/start");
       await harness.notify(completedAssistant("msg-final-1", "Done."));
       await harness.notify(finalizationHookNotification("hook/started", "running", eventName));
@@ -2811,27 +2552,11 @@ describe("runCodexAppServerAttempt turn watches", () => {
   );
 
   it("keeps recovery suspended when a finalization hook queues behind an assistant", async () => {
-    let releaseProjection!: () => void;
-    let markProjectionStarted!: () => void;
-    const projectionGate = new Promise<void>((resolve) => {
-      releaseProjection = resolve;
-    });
-    const projectionStarted = new Promise<void>((resolve) => {
-      markProjectionStarted = resolve;
-    });
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async () => {
-      markProjectionStarted();
-      await projectionGate;
-      throw new Error("expected projection gate");
-    });
+    const { projectionStarted, releaseProjection } = makeMediaProjectionGate();
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
     const pendingProjection = harness.notify(
       rawItemCompleted({
@@ -2864,22 +2589,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("rearms recovery after queued assistant projection outlives the receive-time watch", async () => {
-    let releaseProjection!: () => void;
-    let markProjectionStarted!: () => void;
-    const projectionGate = new Promise<void>((resolve) => {
-      releaseProjection = resolve;
-    });
-    const projectionStarted = new Promise<void>((resolve) => {
-      markProjectionStarted = resolve;
-    });
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async () => {
-      markProjectionStarted();
-      await projectionGate;
-      throw new Error("expected projection gate");
-    });
+    const { projectionStarted, releaseProjection } = makeMediaProjectionGate();
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       turnAssistantCompletionIdleTimeoutMs: 5,
@@ -2916,14 +2628,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("does not rearm recovery for an assistant superseded during finalization", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     let settled = false;
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    }).finally(() => {
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions()).finally(() => {
       settled = true;
     });
     await harness.waitForMethod("turn/start");
@@ -2955,26 +2663,16 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("does not recover a delayed raw echo after later work starts", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     let settled = false;
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    }).finally(() => {
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions()).finally(() => {
       settled = true;
     });
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-final-1", "Stale answer."));
     await harness.notify(startedCommand("cmd-later-1", "echo later"));
-    await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Stale answer." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ text: "Stale answer." }));
     await harness.notify(completedCommand("cmd-later-1", "echo later"));
     await new Promise((resolve) => {
       setTimeout(resolve, 25);
@@ -3000,35 +2698,18 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("does not revive a superseded assistant from an unpaired raw echo", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     let settled = false;
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    }).finally(() => {
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions()).finally(() => {
       settled = true;
     });
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-final-1", "Stale answer."));
-    await harness.notify({
-      method: "item/agentMessage/delta",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "msg-partial-2",
-        delta: "Newer partial answer.",
-      },
-    });
     await harness.notify(
-      rawItemCompleted({
-        id: "raw-final-1",
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Stale answer." }],
-      }),
+      makeAgentMessageDelta({ itemId: "msg-partial-2", delta: "Newer partial answer." }),
     );
+    await harness.notify(makeRawAssistant({ id: "raw-final-1", text: "Stale answer." }));
     await new Promise((resolve) => {
       setTimeout(resolve, 25);
     });
@@ -3053,23 +2734,12 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("treats a differently identified raw assistant as newer output", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-final-1", "Earlier answer."));
-    await harness.notify(
-      rawItemCompleted({
-        id: "raw-final-2",
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Newer raw answer." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ id: "raw-final-2", text: "Newer raw answer." }));
 
     await expect(run.then(projectAttemptResult)).resolves.toMatchObject({
       aborted: false,
@@ -3081,24 +2751,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("treats an id-less raw assistant after later completed work as newer output", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-pre-tool", "I will check."));
     await harness.notify(startedCommand("cmd-later-1", "echo checked"));
     await harness.notify(completedCommand("cmd-later-1", "echo checked"));
-    await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Checked successfully." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ text: "Checked successfully." }));
 
     await expect(run.then(projectAttemptResult)).resolves.toMatchObject({
       aborted: false,
@@ -3110,13 +2770,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("keeps recovery valid through raw output for an earlier active item", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
     await harness.notify(
       itemNotification("item/started", {
@@ -3152,28 +2808,18 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("does not rearm recovery after a newer assistant starts streaming", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     let settled = false;
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    }).finally(() => {
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions()).finally(() => {
       settled = true;
     });
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-final-1", "Stale answer."));
     await harness.notify(finalizationHookNotification("hook/started", "running"));
-    await harness.notify({
-      method: "item/agentMessage/delta",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "msg-partial-2",
-        delta: "Newer partial answer.",
-      },
-    });
+    await harness.notify(
+      makeAgentMessageDelta({ itemId: "msg-partial-2", delta: "Newer partial answer." }),
+    );
     await harness.notify(finalizationHookNotification("hook/completed", "completed"));
     await new Promise((resolve) => {
       setTimeout(resolve, 25);
@@ -3214,13 +2860,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
     },
   ])("honors a stopped finalization override when hooks complete $name", async (scenario) => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-final-1", "Accepted answer."));
     await harness.notify(
@@ -3245,22 +2887,11 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("recovers an accepted raw-only assistant after finalization hooks", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
-    await harness.notify(
-      rawItemCompleted({
-        id: "raw-final-1",
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Accepted raw answer." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ id: "raw-final-1", text: "Accepted raw answer." }));
     await harness.notify(finalizationHookNotification("hook/started", "running"));
     await harness.notify(finalizationHookNotification("hook/completed", "completed"));
 
@@ -3274,32 +2905,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("recovers a revised raw-only assistant after finalization rejection", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
-    await harness.notify(
-      rawItemCompleted({
-        id: "raw-final-1",
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Rejected raw answer." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ id: "raw-final-1", text: "Rejected raw answer." }));
     await harness.notify(finalizationHookNotification("hook/started", "running"));
     await harness.notify(finalizationHookNotification("hook/completed", "blocked"));
-    await harness.notify(
-      rawItemCompleted({
-        id: "raw-final-2",
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Revised raw answer." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ id: "raw-final-2", text: "Revised raw answer." }));
 
     await expect(run.then(projectAttemptResult)).resolves.toMatchObject({
       aborted: false,
@@ -3311,24 +2924,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("does not recover an assistant rejected by a Stop hook", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
-    const run = runCodexAppServerAttempt(params, {
-      turnAssistantCompletionIdleTimeoutMs: 10,
-      turnTerminalIdleTimeoutMs: 500,
-    });
+    const run = runCodexAppServerAttempt(params, makeRecoveryAttemptOptions());
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-final-1", " "));
     await harness.notify(finalizationHookNotification("hook/started", "running"));
     await harness.notify(finalizationHookNotification("hook/completed", "blocked"));
-    await harness.notify(
-      rawItemCompleted({
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "Rejected answer." }],
-      }),
-    );
+    await harness.notify(makeRawAssistant({ text: "Rejected answer." }));
     await new Promise((resolve) => {
       setTimeout(resolve, 25);
     });
@@ -3349,24 +2952,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("keeps upstream cancellation aborted when it races with timeout recovery", async () => {
-    let releaseProjection!: () => void;
-    let markProjectionStarted!: () => void;
-    const projectionGate = new Promise<void>((resolve) => {
-      releaseProjection = resolve;
-    });
-    const projectionStarted = new Promise<void>((resolve) => {
-      markProjectionStarted = resolve;
-    });
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async () => {
-      markProjectionStarted();
-      await projectionGate;
-      throw new Error("expected projection gate");
-    });
+    const { projectionStarted, releaseProjection } = makeMediaProjectionGate();
     const harness = createStartedThreadHarness();
     const abortController = new AbortController();
-    const params = createTestParams();
-    params.abortSignal = abortController.signal;
-    params.timeoutMs = 200;
+    const params = makeTestParams({ abortSignal: abortController.signal, timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       turnAssistantCompletionIdleTimeoutMs: 5,
@@ -3402,22 +2991,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("waits for interrupted turn completion after a queued native abort marker", async () => {
-    let releaseProjection!: () => void;
-    let markProjectionStarted!: () => void;
-    const projectionGate = new Promise<void>((resolve) => {
-      releaseProjection = resolve;
-    });
-    const projectionStarted = new Promise<void>((resolve) => {
-      markProjectionStarted = resolve;
-    });
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async () => {
-      markProjectionStarted();
-      await projectionGate;
-      throw new Error("expected projection gate");
-    });
+    const { projectionStarted, releaseProjection } = makeMediaProjectionGate();
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       turnAssistantCompletionIdleTimeoutMs: 5,
@@ -3477,8 +3053,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("keeps waiting when a current-turn item is still active", async () => {
     const harness = createStartedThreadHarness();
-    const params = createTestParams();
-    params.timeoutMs = 200;
+    const params = makeTestParams({ timeoutMs: 200 });
 
     const run = runCodexAppServerAttempt(params, {
       turnAssistantCompletionIdleTimeoutMs: 5,
@@ -3574,18 +3149,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       timedOut: true,
       promptError: "codex app-server turn idle timed out waiting for turn/completed",
     });
-    await vi.waitFor(
-      () =>
-        expect(harness.request).toHaveBeenCalledWith(
-          "turn/interrupt",
-          {
-            threadId: "thread-1",
-            turnId: "turn-1",
-          },
-          { timeoutMs: 5_000 },
-        ),
-      { interval: 1 },
-    );
+    await expectTurnInterrupted(harness);
   });
 
   it("releases completion and native hook relay state after marker plus interrupted completion", async () => {
@@ -3660,9 +3224,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     await harness.notify(turnCompleted({ id: "turn-1", status: "interrupted", items: [] }));
 
     const result = await run;
-    expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(readAttemptTerminal(result).timedOut).toBe(false);
-    expect(readAttemptTerminal(result).promptError).toBeNull();
+    expectSuccessfulAttempt(result);
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
     await expect(
       invokeNativeHookRelay({
@@ -3684,9 +3246,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const harness = createStartedThreadHarness();
     const abortController = new AbortController();
     const onRunAgentEvent = vi.fn();
-    const params = createTestParams();
-    params.abortSignal = abortController.signal;
-    params.onAgentEvent = onRunAgentEvent;
+    const params = makeTestParams({
+      abortSignal: abortController.signal,
+      onAgentEvent: onRunAgentEvent,
+    });
     const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 60_000 });
 
     await harness.waitForMethod("turn/start");
@@ -3708,9 +3271,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const harness = createStartedThreadHarness();
     const abortController = new AbortController();
     const onRunAgentEvent = vi.fn();
-    const params = createTestParams();
-    params.abortSignal = abortController.signal;
-    params.onAgentEvent = onRunAgentEvent;
+    const params = makeTestParams({
+      abortSignal: abortController.signal,
+      onAgentEvent: onRunAgentEvent,
+    });
     const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 60_000 });
 
     await harness.waitForMethod("turn/start");
@@ -3767,20 +3331,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("delivers completed assistant output when the client closes before turn completion", async () => {
-    const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createTestParams(), { turnTerminalIdleTimeoutMs: 60_000 });
-
-    await harness.waitForMethod("turn/start");
-    await harness.notify(
+    const result = await runClientCloseScenario([
       itemNotification("item/completed", {
         type: "agentMessage",
         id: "msg-final-1",
         text: "Done before restart.",
       }),
-    );
-    harness.close();
+    ]);
 
-    const result = await run;
     expect(readAttemptTerminal(result).promptError).toBeNull();
     expect(readAttemptTerminal(result).aborted).toBe(false);
     expect(readAttemptTerminal(result).timedOut).toBe(false);
@@ -3789,22 +3347,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("keeps partial assistant output as a client-close failure", async () => {
-    const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createTestParams(), { turnTerminalIdleTimeoutMs: 60_000 });
-
-    await harness.waitForMethod("turn/start");
-    await harness.notify({
-      method: "item/agentMessage/delta",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "msg-partial-1",
-        delta: "Still writing",
-      },
-    });
-    harness.close();
-
-    const result = await run;
+    const result = await runClientCloseScenario([makeAgentMessageDelta()]);
     expect(readAttemptTerminal(result).promptError).toBe(
       "codex app-server client closed before turn completed",
     );
@@ -3820,29 +3363,15 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("keeps a later partial assistant output as a client-close failure after an earlier completed message", async () => {
-    const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createTestParams(), { turnTerminalIdleTimeoutMs: 60_000 });
-
-    await harness.waitForMethod("turn/start");
-    await harness.notify(
+    const result = await runClientCloseScenario([
       itemNotification("item/completed", {
         type: "agentMessage",
         id: "msg-completed-1",
         text: "Earlier complete reply.",
       }),
-    );
-    await harness.notify({
-      method: "item/agentMessage/delta",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "msg-partial-2",
-        delta: "Later partial reply",
-      },
-    });
-    harness.close();
+      makeAgentMessageDelta({ itemId: "msg-partial-2", delta: "Later partial reply" }),
+    ]);
 
-    const result = await run;
     expect(readAttemptTerminal(result).promptError).toBe(
       "codex app-server client closed before turn completed",
     );
@@ -3924,27 +3453,19 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("keeps completed assistant output as a client-close failure while another item is active", async () => {
-    const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(createTestParams(), { turnTerminalIdleTimeoutMs: 60_000 });
-
-    await harness.waitForMethod("turn/start");
-    await harness.notify(
+    const result = await runClientCloseScenario([
       itemNotification("item/started", {
         type: "commandExecution",
         id: "cmd-active-1",
         status: "inProgress",
       }),
-    );
-    await harness.notify(
       itemNotification("item/completed", {
         type: "agentMessage",
         id: "msg-final-1",
         text: "Done before restart.",
       }),
-    );
-    harness.close();
+    ]);
 
-    const result = await run;
     expect(readAttemptTerminal(result).promptError).toBe(
       "codex app-server client closed before turn completed",
     );
@@ -3977,8 +3498,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
   it("does not treat a user prompt containing the interrupted marker as terminal", async () => {
     const harness = createStartedThreadHarness();
     const markerPrompt = "<turn_aborted>\narbitrary prompt prose\n</turn_aborted>";
-    const params = createTestParams();
-    params.prompt = markerPrompt;
+    const params = makeTestParams({ prompt: markerPrompt });
     const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 60_000 });
     let resolved = false;
     void run.then(() => {

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -433,16 +433,59 @@ describe("DiscordVoiceManager", () => {
       runtime: createRuntime(),
     });
 
-  const createAgentProxyManager = (clientOverride?: ReturnType<typeof createClient>) =>
-    createManager(
+  type DiscordConfig = ConstructorParameters<
+    typeof managerModule.DiscordVoiceManager
+  >[0]["discordConfig"];
+  type VoiceConfig = NonNullable<DiscordConfig["voice"]>;
+  type AgentProxyConfigOverrides = Omit<Partial<DiscordConfig>, "voice"> & {
+    voice?: Partial<VoiceConfig>;
+  };
+
+  const makeVoiceConfig = (
+    voice: Partial<VoiceConfig> = {},
+    overrides: Omit<Partial<DiscordConfig>, "voice"> = {},
+  ): DiscordConfig => ({
+    ...overrides,
+    voice: { enabled: true, mode: "stt-tts", ...voice },
+  });
+
+  const makeAgentProxyConfig = (overrides: AgentProxyConfigOverrides = {}): DiscordConfig => {
+    const { voice, ...discord } = overrides;
+    return makeVoiceConfig(
       {
-        groupPolicy: "open",
-        voice: {
-          enabled: true,
-          mode: "agent-proxy",
-          realtime: { provider: "openai" },
-        },
+        mode: "agent-proxy",
+        ...voice,
+        realtime: { provider: "openai", ...voice?.realtime },
       },
+      { groupPolicy: "open", ...discord },
+    );
+  };
+
+  const makeBidiConfig = (overrides: AgentProxyConfigOverrides = {}): DiscordConfig => {
+    const { voice, ...discord } = overrides;
+    return makeVoiceConfig(
+      {
+        mode: "bidi",
+        ...voice,
+        realtime: { provider: "openai", ...voice?.realtime },
+      },
+      { groupPolicy: "open", ...discord },
+    );
+  };
+
+  const createAgentProxyManager = (
+    clientOverride?: ReturnType<typeof createClient>,
+    overrides?: AgentProxyConfigOverrides,
+    cfgOverride?: ConstructorParameters<typeof managerModule.DiscordVoiceManager>[0]["cfg"],
+  ) => createManager(makeAgentProxyConfig(overrides), clientOverride, cfgOverride);
+
+  const createFollowManager = (
+    voice: Partial<VoiceConfig> = {},
+    clientOverride?: ReturnType<typeof createClient>,
+    overrides: Omit<Partial<DiscordConfig>, "voice"> = {},
+  ) =>
+    createManager(
+      makeVoiceConfig({ followUsers: ["u-owner"], ...voice }, overrides),
       clientOverride,
     );
 
@@ -496,16 +539,9 @@ describe("DiscordVoiceManager", () => {
   };
 
   const createWakeNameFixture = async (agentName = "Molty") => {
-    const manager = createManager(
-      {
-        groupPolicy: "open",
-        voice: {
-          enabled: true,
-          mode: "agent-proxy",
-          realtime: { provider: "openai", consultPolicy: "auto", requireWakeName: true },
-        },
-      },
+    const manager = createAgentProxyManager(
       undefined,
+      { voice: { realtime: { consultPolicy: "auto", requireWakeName: true } } },
       { agents: { list: [{ id: "agent-1", identity: { name: agentName } }] } },
     );
     await manager.join({ guildId: "g1", channelId: "1001" });
@@ -573,6 +609,30 @@ describe("DiscordVoiceManager", () => {
       )[0],
       "realtime bridge params",
     ) as TestRealtimeBridgeParams;
+
+  const joinManagerFixture = async (
+    manager: InstanceType<typeof managerModule.DiscordVoiceManager>,
+  ) => {
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    return {
+      bridgeParams: lastRealtimeBridgeParams(),
+      entry: getSessionEntry(manager),
+      manager,
+      player: getLastAudioPlayer(),
+    };
+  };
+
+  const createJoinedAgentProxyFixture = async (
+    overrides: {
+      client?: ReturnType<typeof createClient>;
+      config?: AgentProxyConfigOverrides;
+      cfg?: ConstructorParameters<typeof managerModule.DiscordVoiceManager>[0]["cfg"];
+    } = {},
+  ) =>
+    joinManagerFixture(createAgentProxyManager(overrides.client, overrides.config, overrides.cfg));
+
+  const createJoinedBidiFixture = async (config: AgentProxyConfigOverrides = {}) =>
+    joinManagerFixture(createManager(makeBidiConfig(config)));
 
   const lastAudioResourceInput = () =>
     lastMockCall(createAudioResourceMock as unknown as MockCallSource, "audio resource")[0];
@@ -690,6 +750,20 @@ describe("DiscordVoiceManager", () => {
     return { dave, gateway };
   };
 
+  const makePoisonedDaveConnections = (additionalConnections = 0) => {
+    const firstConnection = createConnectionMock();
+    const secondConnection = createConnectionMock();
+    installFailingDaveSession(firstConnection, "native");
+    installFailingDaveSession(secondConnection, "key-package");
+    const connections = [
+      firstConnection,
+      secondConnection,
+      ...Array.from({ length: additionalConnections }, createConnectionMock),
+    ];
+    connections.forEach((connection) => joinVoiceChannelMock.mockReturnValueOnce(connection));
+    return { firstConnection, secondConnection };
+  };
+
   it("rejects joins when Discord voice config is absent", async () => {
     const manager = createManager({});
 
@@ -745,6 +819,17 @@ describe("DiscordVoiceManager", () => {
       ...(member ? { member } : {}),
     } as never);
   };
+
+  const handleSpeakingStart = async (
+    manager: InstanceType<typeof managerModule.DiscordVoiceManager>,
+    entry: unknown,
+    userId: string,
+  ) =>
+    await (
+      manager as unknown as {
+        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
+      }
+    ).handleSpeakingStart(entry, userId);
 
   it("keeps the new session when an old disconnected handler fires", async () => {
     const oldConnection = createConnectionMock();
@@ -1021,19 +1106,9 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("keeps realtime playback alive when transcripts attaches to an existing voice session", async () => {
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "openai", consultPolicy: "auto" },
-      },
+    const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture({
+      config: { voice: { realtime: { consultPolicy: "auto" } } },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const player = getLastAudioPlayer();
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(24_000));
     const stopCallsBeforeTranscripts = player.stop.mock.calls.length;
@@ -1138,13 +1213,12 @@ describe("DiscordVoiceManager", () => {
 
   it("suppresses repeated autoJoin attempts after fatal realtime startup failures", async () => {
     realtimeSessionMock.connect.mockRejectedValueOnce(new Error("Incorrect API key provided"));
-    const manager = createManager({
-      voice: {
-        enabled: true,
+    const manager = createManager(
+      makeVoiceConfig({
         mode: "agent-proxy",
         autoJoin: [{ guildId: "g1", channelId: "1001" }],
-      },
-    });
+      }),
+    );
 
     await manager.autoJoin();
     await manager.autoJoin();
@@ -1155,13 +1229,9 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("rejects joins outside configured allowed voice channels", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        allowedChannels: [{ guildId: "g1", channelId: "1001" }],
-      },
-    });
+    const manager = createManager(
+      makeVoiceConfig({ allowedChannels: [{ guildId: "g1", channelId: "1001" }] }),
+    );
 
     const result = await manager.join({ guildId: "g1", channelId: "1002" });
 
@@ -1173,13 +1243,9 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("allows joins inside configured allowed voice channels", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        allowedChannels: [{ guildId: "g1", channelId: "1001" }],
-      },
-    });
+    const manager = createManager(
+      makeVoiceConfig({ allowedChannels: [{ guildId: "g1", channelId: "1001" }] }),
+    );
 
     const result = await manager.join({ guildId: "g1", channelId: "1001" });
 
@@ -1448,16 +1514,8 @@ describe("DiscordVoiceManager", () => {
     enqueueSystemEventMock.mockClear();
     const entry = getSessionEntry(manager);
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u-raced-first");
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u-raced-second");
+    await handleSpeakingStart(manager, entry, "u-raced-first");
+    await handleSpeakingStart(manager, entry, "u-raced-second");
     await manager.handleVoiceStateUpdate({
       guild_id: "g1",
       user_id: "u-raced-second",
@@ -1538,17 +1596,12 @@ describe("DiscordVoiceManager", () => {
           resolveMember = resolve;
         }),
     );
-    const manager = createManager(
+    const manager = createFollowManager(
       {
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          allowedChannels: [
-            { guildId: "g1", channelId: "1001" },
-            { guildId: "g1", channelId: "1002" },
-          ],
-          followUsers: ["u-owner"],
-        },
+        allowedChannels: [
+          { guildId: "g1", channelId: "1001" },
+          { guildId: "g1", channelId: "1002" },
+        ],
       },
       client,
     );
@@ -1605,13 +1658,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("follows configured users into voice channels", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["discord:u-owner"],
-      },
-    });
+    const manager = createFollowManager({ followUsers: ["discord:u-owner"] });
 
     await updateVoiceState(manager, "u-owner", "1001");
 
@@ -1620,14 +1667,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("does not follow configured users when followUsersEnabled is false", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsersEnabled: false,
-        followUsers: ["u-owner"],
-      },
-    });
+    const manager = createFollowManager({ followUsersEnabled: false });
 
     await updateVoiceState(manager, "u-owner", "1001");
 
@@ -1642,17 +1682,7 @@ describe("DiscordVoiceManager", () => {
       user_id: "bot-user",
       channel_id: "1001",
     });
-    const manager = createManager(
-      {
-        guilds: { g1: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: ["u-owner"],
-        },
-      },
-      client,
-    );
+    const manager = createFollowManager({}, client, { guilds: { g1: {} } });
     manager.setBotUserId("bot-user");
 
     await manager.autoJoin();
@@ -1667,13 +1697,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("moves with configured followed users", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-      },
-    });
+    const manager = createFollowManager();
 
     await updateVoiceState(manager, "u-owner", "1001");
     await updateVoiceState(manager, "u-owner", "1002");
@@ -1683,13 +1707,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("preserves follow ownership when a bot voice move rebuilds the session", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-      },
-    });
+    const manager = createFollowManager();
     manager.setBotUserId("bot-user");
 
     await updateVoiceState(manager, "u-owner", "1001");
@@ -1701,13 +1719,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("leaves when a followed user disconnects", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-      },
-    });
+    const manager = createFollowManager();
 
     await updateVoiceState(manager, "u-owner", "1001");
     await updateVoiceState(manager, "u-owner", null);
@@ -1716,16 +1728,12 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("hands off to another followed user when the active followed user disconnects", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        allowedChannels: [
-          { guildId: "g1", channelId: "1001" },
-          { guildId: "g1", channelId: "1002" },
-        ],
-        followUsers: ["u-owner", "u-backup"],
-      },
+    const manager = createFollowManager({
+      allowedChannels: [
+        { guildId: "g1", channelId: "1001" },
+        { guildId: "g1", channelId: "1002" },
+      ],
+      followUsers: ["u-owner", "u-backup"],
     });
 
     await updateVoiceState(manager, "u-backup", "1002");
@@ -1753,17 +1761,13 @@ describe("DiscordVoiceManager", () => {
         type: ChannelType.GuildVoice,
       };
     });
-    const manager = createManager(
+    const manager = createFollowManager(
       {
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          allowedChannels: [
-            { guildId: "g1", channelId: "1001" },
-            { guildId: "g1", channelId: "1002" },
-          ],
-          followUsers: ["u-owner", "u-backup"],
-        },
+        allowedChannels: [
+          { guildId: "g1", channelId: "1001" },
+          { guildId: "g1", channelId: "1002" },
+        ],
+        followUsers: ["u-owner", "u-backup"],
       },
       client,
     );
@@ -1776,13 +1780,8 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("does not follow configured users into disallowed channels", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-        allowedChannels: [{ guildId: "g1", channelId: "1001" }],
-      },
+    const manager = createFollowManager({
+      allowedChannels: [{ guildId: "g1", channelId: "1001" }],
     });
 
     await updateVoiceState(manager, "u-owner", "1002");
@@ -1797,17 +1796,9 @@ describe("DiscordVoiceManager", () => {
     const guilds = Object.fromEntries(
       Array.from({ length: 10 }, (_, index) => [`g${index + 1}`, {}]),
     );
-    const manager = createManager(
-      {
-        guilds,
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: ["u1", "u2", "u3", "u4", "u5"],
-        },
-      },
-      client,
-    );
+    const manager = createFollowManager({ followUsers: ["u1", "u2", "u3", "u4", "u5"] }, client, {
+      guilds,
+    });
     manager.setBotUserId("bot-user");
 
     await manager.autoJoin();
@@ -1818,17 +1809,7 @@ describe("DiscordVoiceManager", () => {
 
   it("keeps followed voice state when reconciliation hits a transient REST failure", async () => {
     const client = createClient();
-    const manager = createManager(
-      {
-        guilds: { g1: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: ["u-owner"],
-        },
-      },
-      client,
-    );
+    const manager = createFollowManager({}, client, { guilds: { g1: {} } });
 
     await updateVoiceState(manager, "u-owner", "1001");
     client.rest.get.mockRejectedValue(new Error("Discord API failed (500): fetch failed"));
@@ -1849,17 +1830,7 @@ describe("DiscordVoiceManager", () => {
           resolveVoiceState = resolve;
         }),
     );
-    const manager = createManager(
-      {
-        guilds: { g1: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: ["u-owner"],
-        },
-      },
-      client,
-    );
+    const manager = createFollowManager({}, client, { guilds: { g1: {} } });
 
     const autoJoinPromise = manager.autoJoin();
     await vi.waitFor(() => {
@@ -1881,16 +1852,10 @@ describe("DiscordVoiceManager", () => {
       }
       throw new Error("Unknown Voice State");
     });
-    const manager = createManager(
-      {
-        guilds: { g1: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: Array.from({ length: 40 }, (_, index) => `u${index + 1}`),
-        },
-      },
+    const manager = createFollowManager(
+      { followUsers: Array.from({ length: 40 }, (_, index) => `u${index + 1}`) },
       client,
+      { guilds: { g1: {} } },
     );
     manager.setBotUserId("bot-user");
 
@@ -1921,16 +1886,10 @@ describe("DiscordVoiceManager", () => {
       }
       throw new Error("Unknown Voice State");
     });
-    const manager = createManager(
-      {
-        guilds: { g1: {}, g2: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: Array.from({ length: 40 }, (_, index) => `u${index + 1}`),
-        },
-      },
+    const manager = createFollowManager(
+      { followUsers: Array.from({ length: 40 }, (_, index) => `u${index + 1}`) },
       client,
+      { guilds: { g1: {}, g2: {} } },
     );
     manager.setBotUserId("bot-user");
 
@@ -1961,16 +1920,10 @@ describe("DiscordVoiceManager", () => {
       }
       throw new Error("Unknown Voice State");
     });
-    const manager = createManager(
-      {
-        guilds: { g1: {}, g2: {}, g3: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: Array.from({ length: 10 }, (_, index) => `u${index + 1}`),
-        },
-      },
+    const manager = createFollowManager(
+      { followUsers: Array.from({ length: 10 }, (_, index) => `u${index + 1}`) },
       client,
+      { guilds: { g1: {}, g2: {}, g3: {} } },
     );
     manager.setBotUserId("bot-user");
 
@@ -1991,13 +1944,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("treats an empty allowed voice channel list as deny-all", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        allowedChannels: [],
-      },
-    });
+    const manager = createManager(makeVoiceConfig({ allowedChannels: [] }));
 
     const result = await manager.join({ guildId: "g1", channelId: "1001" });
 
@@ -2006,14 +1953,12 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("leaves and rejoins the configured target when Discord moves the bot outside allowed voice channels", async () => {
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
+    const manager = createManager(
+      makeVoiceConfig({
         autoJoin: [{ guildId: "g1", channelId: "1001" }],
         allowedChannels: [{ guildId: "g1", channelId: "1001" }],
-      },
-    });
+      }),
+    );
     manager.setBotUserId("bot-user");
     await manager.join({ guildId: "g1", channelId: "1001" });
 
@@ -2082,11 +2027,7 @@ describe("DiscordVoiceManager", () => {
     const entry = getSessionEntry(manager);
     player.state.status = "playing";
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u1");
+    await handleSpeakingStart(manager, entry, "u1");
 
     expect(player.stop).not.toHaveBeenCalled();
     expect(connection.receiver.subscribe).not.toHaveBeenCalled();
@@ -2095,14 +2036,10 @@ describe("DiscordVoiceManager", () => {
   it("allows configured realtime barge-in when provider input interruption is disabled", async () => {
     const connection = createConnectionMock();
     joinVoiceChannelMock.mockReturnValueOnce(connection);
-    const manager = createManager({
-      groupPolicy: "open",
+    const { bridgeParams, entry, manager, player } = await createJoinedBidiFixture({
       allowFrom: ["discord:u1"],
       voice: {
-        enabled: true,
-        mode: "bidi",
         realtime: {
-          provider: "openai",
           bargeIn: true,
           providers: {
             openai: {
@@ -2112,20 +2049,10 @@ describe("DiscordVoiceManager", () => {
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const player = getLastAudioPlayer();
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
     player.state.status = "playing";
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u1");
+    await handleSpeakingStart(manager, entry, "u1");
 
     expect(realtimeSessionMock.handleBargeIn).toHaveBeenCalled();
     expect(player.stop).not.toHaveBeenCalled();
@@ -2141,14 +2068,10 @@ describe("DiscordVoiceManager", () => {
   it("interrupts realtime playback when an already-active speaker keeps talking", async () => {
     const connection = createConnectionMock();
     joinVoiceChannelMock.mockReturnValueOnce(connection);
-    const manager = createManager({
-      groupPolicy: "open",
+    const { bridgeParams, entry, player } = await createJoinedBidiFixture({
       allowFrom: ["discord:u1"],
       voice: {
-        enabled: true,
-        mode: "bidi",
         realtime: {
-          provider: "openai",
           bargeIn: true,
           providers: {
             openai: {
@@ -2158,12 +2081,6 @@ describe("DiscordVoiceManager", () => {
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
-    const player = getLastAudioPlayer();
     const turn = entry.realtime?.beginSpeakerTurn(
       { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
       "u1",
@@ -2186,14 +2103,10 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("does not interrupt realtime provider state when local playback is already idle", async () => {
-    const manager = createManager({
-      groupPolicy: "open",
+    const { entry, player } = await createJoinedBidiFixture({
       allowFrom: ["discord:u1"],
       voice: {
-        enabled: true,
-        mode: "bidi",
         realtime: {
-          provider: "openai",
           bargeIn: true,
           providers: {
             openai: {
@@ -2203,11 +2116,6 @@ describe("DiscordVoiceManager", () => {
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const entry = getSessionEntry(manager);
-    const player = getLastAudioPlayer();
     const turn = entry.realtime?.beginSpeakerTurn(
       { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
       "u1",
@@ -2221,14 +2129,10 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("sends trailing realtime silence when a speaker turn closes", async () => {
-    const manager = createManager({
-      groupPolicy: "open",
+    const { entry } = await createJoinedBidiFixture({
       allowFrom: ["discord:u1"],
       voice: {
-        enabled: true,
-        mode: "bidi",
         realtime: {
-          provider: "openai",
           providers: {
             openai: {
               silenceDurationMs: 450,
@@ -2237,10 +2141,6 @@ describe("DiscordVoiceManager", () => {
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const entry = getSessionEntry(manager);
     const turn = entry.realtime?.beginSpeakerTurn(
       { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
       "u1",
@@ -2259,14 +2159,10 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("clamps configured realtime trailing silence before allocating audio", async () => {
-    const manager = createManager({
-      groupPolicy: "open",
+    const { entry } = await createJoinedBidiFixture({
       allowFrom: ["discord:u1"],
       voice: {
-        enabled: true,
-        mode: "bidi",
         realtime: {
-          provider: "openai",
           providers: {
             openai: {
               silenceDurationMs: 60_000,
@@ -2275,10 +2171,6 @@ describe("DiscordVoiceManager", () => {
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const entry = getSessionEntry(manager);
     const turn = entry.realtime?.beginSpeakerTurn(
       { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
       "u1",
@@ -2298,30 +2190,13 @@ describe("DiscordVoiceManager", () => {
   it("ignores realtime capture during playback when barge-in is disabled", async () => {
     const connection = createConnectionMock();
     joinVoiceChannelMock.mockReturnValueOnce(connection);
-    const manager = createManager({
-      groupPolicy: "open",
+    const { entry, manager, player } = await createJoinedBidiFixture({
       allowFrom: ["discord:u1"],
-      voice: {
-        enabled: true,
-        mode: "bidi",
-        realtime: {
-          provider: "openai",
-          bargeIn: false,
-        },
-      },
+      voice: { realtime: { bargeIn: false } },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const player = getLastAudioPlayer();
-    const entry = getSessionEntry(manager);
     player.state.status = "playing";
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u1");
+    await handleSpeakingStart(manager, entry, "u1");
 
     expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();
     expect(player.stop).not.toHaveBeenCalled();
@@ -2576,9 +2451,7 @@ describe("DiscordVoiceManager", () => {
   it("closes realtime sessions when disconnected recovery destroys the connection", async () => {
     const connection = createConnectionMock();
     joinVoiceChannelMock.mockReturnValueOnce(connection);
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
+    const { manager } = await createJoinedAgentProxyFixture();
 
     entersStateMock.mockClear();
     entersStateMock.mockRejectedValueOnce(new Error("still disconnected"));
@@ -2596,9 +2469,7 @@ describe("DiscordVoiceManager", () => {
   it("closes realtime sessions when Discord destroys the connection", async () => {
     const connection = createConnectionMock();
     joinVoiceChannelMock.mockReturnValueOnce(connection);
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
+    const { manager } = await createJoinedAgentProxyFixture();
 
     const destroyed = connection.handlers.get("destroyed");
     expect(destroyed).toBeTypeOf("function");
@@ -2701,10 +2572,7 @@ describe("DiscordVoiceManager", () => {
       show: true,
       suppress: false,
     });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams } = await createJoinedAgentProxyFixture();
 
     void bridgeParams?.onToolCall?.(
       {
@@ -2737,10 +2605,7 @@ describe("DiscordVoiceManager", () => {
       acceptResult = resolve;
     });
     realtimeSessionMock.submitToolResult.mockImplementationOnce(() => accepted);
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams } = await createJoinedAgentProxyFixture();
 
     const handled = bridgeParams?.onToolCall?.(
       {
@@ -2769,10 +2634,7 @@ describe("DiscordVoiceManager", () => {
 
   it("does not retry a rejected control result submission as a tool error", async () => {
     realtimeSessionMock.submitToolResult.mockRejectedValueOnce(new Error("result delivery failed"));
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams } = await createJoinedAgentProxyFixture();
 
     const handled = bridgeParams?.onToolCall?.(
       {
@@ -2792,10 +2654,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("rejects malformed realtime consult tool calls without crashing Discord voice", async () => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams } = await createJoinedAgentProxyFixture();
 
     expect(() =>
       bridgeParams?.onToolCall?.(
@@ -2816,10 +2675,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("does not require speaker context for internal exact-speech consults", async () => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams } = await createJoinedAgentProxyFixture();
 
     void bridgeParams?.onToolCall?.(
       {
@@ -2989,19 +2845,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("prebuffers realtime output before starting Discord playback", async () => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const player = getLastAudioPlayer();
-    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
-      | {
-          audioSink?: {
-            sendAudio: (audio: Buffer) => void;
-          };
-          onEvent?: (event: { direction: "server"; type: string }) => void;
-        }
-      | undefined;
+    const { bridgeParams, player } = await createJoinedAgentProxyFixture();
 
     for (let index = 0; index < 49; index += 1) {
       bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
@@ -3018,13 +2862,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("cancels realtime output when Discord playback backpressures", async () => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const player = getLastAudioPlayer();
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
 
     for (let index = 0; index < 50; index += 1) {
       bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
@@ -3071,13 +2909,7 @@ describe("DiscordVoiceManager", () => {
       },
     ],
   ] as const)("does not let a deferred backpressure cancel cross %s", async (_label, terminal) => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const player = getLastAudioPlayer();
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
 
     for (let index = 0; index < 50; index += 1) {
       bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
@@ -3113,19 +2945,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("discards prebuffered realtime output when the response is cancelled", async () => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-
-    const player = getLastAudioPlayer();
-    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
-      | {
-          audioSink?: {
-            sendAudio: (audio: Buffer) => void;
-          };
-          onEvent?: (event: { detail?: string; direction: "server"; type: string }) => void;
-        }
-      | undefined;
+    const { bridgeParams, player } = await createJoinedAgentProxyFixture();
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
     bridgeParams?.onEvent?.({ direction: "server", type: "response.cancelled" });
@@ -3147,21 +2967,22 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("applies Discord realtime model and voice overrides during provider auto-selection", async () => {
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: {
-          model: "gpt-realtime-2",
-          speakerVoiceId: "cedar",
-          minBargeInAudioEndMs: 500,
-          providers: {
-            openai: { model: "provider-default", voice: "marin" },
+    const manager = createManager(
+      makeVoiceConfig(
+        {
+          mode: "agent-proxy",
+          realtime: {
+            model: "gpt-realtime-2",
+            speakerVoiceId: "cedar",
+            minBargeInAudioEndMs: 500,
+            providers: {
+              openai: { model: "provider-default", voice: "marin" },
+            },
           },
         },
-      },
-    });
+        { groupPolicy: "open" },
+      ),
+    );
 
     const result = await manager.join({ guildId: "g1", channelId: "1001" });
 
@@ -3188,24 +3009,15 @@ describe("DiscordVoiceManager", () => {
 
   it("keeps agent-proxy realtime transcripts on the audio turn speaker context", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "non-owner answer" }] });
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "openai", debounceMs: 1 },
-      },
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+      config: { voice: { realtime: { debounceMs: 1 } } },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     const nonOwnerTurn = entry?.realtime?.beginSpeakerTurn(
       { extraSystemPrompt: undefined, senderIsOwner: false, speakerLabel: "Guest" },
       "u-guest",
     );
     nonOwnerTurn?.sendInputAudio(Buffer.alloc(8));
 
-    const bridgeParams = lastRealtimeBridgeParams();
     await flushRealtimeForcedConsultTimers(() => {
       bridgeParams?.onTranscript?.("user", "non-owner question", true);
       const ownerTurn = entry?.realtime?.beginSpeakerTurn(
@@ -3232,11 +3044,7 @@ describe("DiscordVoiceManager", () => {
       show: true,
       suppress: false,
     });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const player = getLastAudioPlayer();
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, player } = await createJoinedAgentProxyFixture();
 
     bridgeParams?.onTranscript?.("user", "cancel that", true);
 
@@ -3286,10 +3094,7 @@ describe("DiscordVoiceManager", () => {
         show: true,
         suppress: false,
       });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams } = await createJoinedAgentProxyFixture();
     bridgeParams?.onTranscript?.("user", "cancel that", true);
     await vi.waitFor(() => expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledTimes(1));
 
@@ -3328,18 +3133,9 @@ describe("DiscordVoiceManager", () => {
         }),
       )
       .mockResolvedValueOnce({ payloads: [{ text: "fresh talkback" }] });
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "openai", debounceMs: 1, toolPolicy: "none" },
-      },
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+      config: { voice: { realtime: { debounceMs: 1, toolPolicy: "none" } } },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "old question");
     await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledTimes(1));
@@ -3360,12 +3156,8 @@ describe("DiscordVoiceManager", () => {
 
   it("preserves realtime forced consults when no active run accepts steering", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "normal answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
     beginSpeakerTurn(entry);
-    const bridgeParams = lastRealtimeBridgeParams();
 
     await emitFinalRealtimeUserTranscript(bridgeParams, "normal question");
 
@@ -3395,16 +3187,9 @@ describe("DiscordVoiceManager", () => {
     };
     let voiceStates: Array<Record<string, unknown>> = [ownerState, agentState, helperBotState];
     configureVoiceStateGateway(client, () => voiceStates);
-    const manager = createManager(
-      {
-        groupPolicy: "open",
-        voice: {
-          enabled: true,
-          mode: "agent-proxy",
-          realtime: { provider: "openai", consultPolicy: "auto" },
-        },
-      },
+    const manager = createAgentProxyManager(
       client,
+      { voice: { realtime: { consultPolicy: "auto" } } },
       {
         agents: {
           list: [{ id: "agent-1", identity: { name: "Molty" } }],
@@ -3412,14 +3197,9 @@ describe("DiscordVoiceManager", () => {
       },
     );
     manager.setBotUserId("bot-user");
-
     await manager.join({ guildId: "g1", channelId: "1001" });
     const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams() as {
-      autoRespondToAudio?: boolean;
-      interruptResponseOnInputAudio?: boolean;
-      onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
-    };
+    const bridgeParams = lastRealtimeBridgeParams();
     const beginOwnerTurn = () => {
       beginSpeakerTurn(entry);
     };
@@ -3560,12 +3340,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "second answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const player = getLastAudioPlayer();
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "first question");
@@ -3597,12 +3372,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "second answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const player = getLastAudioPlayer();
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "first question");
@@ -3631,12 +3401,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "second answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const player = getLastAudioPlayer();
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "first question");
@@ -3670,11 +3435,7 @@ describe("DiscordVoiceManager", () => {
         }),
       )
       .mockResolvedValueOnce({ payloads: [{ text: "fresh answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
     beginSpeakerTurn(entry);
     const oldSubmission = bridgeParams?.onToolCall?.(
       {
@@ -3713,16 +3474,9 @@ describe("DiscordVoiceManager", () => {
   it("treats a bare wake name as an activation for the next realtime transcript", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "follow-up answer" }] });
     const onUtterance = vi.fn();
-    const manager = createManager(
-      {
-        groupPolicy: "open",
-        voice: {
-          enabled: true,
-          mode: "agent-proxy",
-          realtime: { provider: "openai", consultPolicy: "auto", requireWakeName: true },
-        },
-      },
+    const manager = createAgentProxyManager(
       undefined,
+      { voice: { realtime: { consultPolicy: "auto", requireWakeName: true } } },
       {
         agents: {
           list: [{ id: "agent-1", identity: { name: "Molty" } }],
@@ -3859,17 +3613,13 @@ describe("DiscordVoiceManager", () => {
       provider: { id: "google" },
       providerConfig: { model: "gemini-live", voice: "default" },
     });
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "google", consultPolicy: "auto", requireWakeName: true },
+    const { bridgeParams } = await createJoinedAgentProxyFixture({
+      config: {
+        voice: {
+          realtime: { provider: "google", consultPolicy: "auto", requireWakeName: true },
+        },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const bridgeParams = lastRealtimeBridgeParams();
 
     expect(bridgeParams?.autoRespondToAudio).toBe(true);
     expect(bridgeParams?.interruptResponseOnInputAudio).toBe(true);
@@ -3877,24 +3627,18 @@ describe("DiscordVoiceManager", () => {
 
   it("uses configured wake names before realtime agent-proxy consults", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "configured wake answer" }] });
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: {
-          provider: "openai",
-          consultPolicy: "auto",
-          requireWakeName: true,
-          wakeNames: ["Claw", "Claw Bot", "Okay Google"],
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+      config: {
+        voice: {
+          realtime: {
+            consultPolicy: "auto",
+            requireWakeName: true,
+            wakeNames: ["Claw", "Claw Bot", "Okay Google"],
+          },
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     beginSpeakerTurn(entry);
-    const bridgeParams = lastRealtimeBridgeParams();
 
     await emitFinalRealtimeUserTranscript(bridgeParams, "Claw Bot, ship it");
 
@@ -3913,24 +3657,18 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("does not accept configured realtime wake names longer than two words", async () => {
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: {
-          provider: "openai",
-          consultPolicy: "auto",
-          requireWakeName: true,
-          wakeNames: ["Claw Bot Helper"],
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+      config: {
+        voice: {
+          realtime: {
+            consultPolicy: "auto",
+            requireWakeName: true,
+            wakeNames: ["Claw Bot Helper"],
+          },
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     beginSpeakerTurn(entry);
-    const bridgeParams = lastRealtimeBridgeParams();
 
     await emitFinalRealtimeUserTranscript(bridgeParams, "Claw Bot Helper, ship it");
 
@@ -3952,12 +3690,8 @@ describe("DiscordVoiceManager", () => {
       show: true,
       suppress: false,
     });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
     beginSpeakerTurn(entry);
-    const bridgeParams = lastRealtimeBridgeParams();
 
     await emitFinalRealtimeUserTranscript(bridgeParams, "how is it going");
 
@@ -3973,11 +3707,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "guest answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "owner answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry, { senderIsOwner: false });
 
@@ -3998,11 +3728,7 @@ describe("DiscordVoiceManager", () => {
 
   it("skips incomplete and non-actionable forced agent-proxy transcripts", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "valid answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
 
@@ -4021,11 +3747,7 @@ describe("DiscordVoiceManager", () => {
 
   it("keeps forced agent-proxy fallback diagnostics out of agent prompts", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "Could you repeat that?" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "What?");
@@ -4059,14 +3781,10 @@ describe("DiscordVoiceManager", () => {
             resolveThird = resolve;
           }),
       );
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const player = getLastAudioPlayer() as {
+    const { bridgeParams, entry, player: rawPlayer } = await createJoinedAgentProxyFixture();
+    const player = rawPlayer as {
       on: ReturnType<typeof vi.fn>;
     };
-    const bridgeParams = lastRealtimeBridgeParams();
 
     beginSpeakerTurn(entry);
     beginSpeakerTurn(entry);
@@ -4128,16 +3846,12 @@ describe("DiscordVoiceManager", () => {
         type: ChannelType.GuildVoice,
       };
     });
-    const manager = createAgentProxyManager(client);
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
+    const { bridgeParams, entry, manager } = await createJoinedAgentProxyFixture({ client });
     const realtime = entry.realtime as unknown as {
       enqueueExactSpeechMessage: (text: string) => void;
     };
     const connection = (entry as unknown as { connection: { destroy: ReturnType<typeof vi.fn> } })
       .connection;
-    const bridgeParams = lastRealtimeBridgeParams();
     const accepted = "😀".repeat(8 * 1024);
     expect(accepted.length).toBe(16 * 1024);
     expect(Buffer.byteLength(accepted, "utf8")).toBe(32 * 1024);
@@ -4174,10 +3888,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("terminates realtime voice when retained exact speech exceeds the message budget", async () => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
+    const { entry, manager } = await createJoinedAgentProxyFixture();
     const realtime = entry.realtime as unknown as {
       enqueueExactSpeechMessage: (text: string) => void;
     };
@@ -4203,12 +3914,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "second answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const player = getLastAudioPlayer();
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "first question");
@@ -4244,18 +3950,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "second answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const player = getLastAudioPlayer();
-    const bridgeParams = createRealtimeVoiceBridgeSessionMock.mock.calls.at(-1)?.[0] as
-      | {
-          audioSink?: { sendAudio: (audio: Buffer) => void };
-          onEvent?: (event: { detail?: string; direction: "server"; type: string }) => void;
-          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
-        }
-      | undefined;
+    const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "first question");
@@ -4278,11 +3973,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "owner answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "guest fallback answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry, { senderIsOwner: false });
 
@@ -4315,11 +4006,7 @@ describe("DiscordVoiceManager", () => {
 
   it("reuses forced agent-proxy answers for late matching consult tool calls", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "forced answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "late question");
@@ -4372,10 +4059,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("terminally satisfies a late native call for a cancelled forced consult", async () => {
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
     const realtime = entry.realtime as unknown as {
       harness: RealtimeVoiceSessionHarness;
     };
@@ -4385,7 +4069,6 @@ describe("DiscordVoiceManager", () => {
     }
     realtime.harness.forcedConsults.markStarted(cancelled);
     realtime.harness.forcedConsults.markCancelled(cancelled);
-    const bridgeParams = lastRealtimeBridgeParams();
 
     await bridgeParams?.onToolCall?.(
       {
@@ -4415,11 +4098,7 @@ describe("DiscordVoiceManager", () => {
         resolveAgentTurn = resolve;
       }),
     );
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "late question");
     realtimeSessionMock.bridge.supportsToolResultSuppression = false;
@@ -4475,11 +4154,7 @@ describe("DiscordVoiceManager", () => {
         rejectAgentTurn = reject;
       }),
     );
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "late question");
@@ -4513,11 +4188,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "forced answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "guest answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     await emitFinalRealtimeUserTranscript(bridgeParams, "late question");
@@ -4555,11 +4226,7 @@ describe("DiscordVoiceManager", () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "old direct answer" }] })
       .mockResolvedValueOnce({ payloads: [{ text: "new forced answer" }] });
-    const manager = createAgentProxyManager();
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
-    const bridgeParams = lastRealtimeBridgeParams();
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
 
     beginSpeakerTurn(entry);
     void bridgeParams?.onToolCall?.(
@@ -4609,22 +4276,13 @@ describe("DiscordVoiceManager", () => {
 
   it("expires closed agent-proxy turns before later speaker audio", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "guest answer" }] });
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "openai", debounceMs: 1 },
-      },
+    const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+      config: { voice: { realtime: { debounceMs: 1 } } },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     const ownerTurn = beginSpeakerTurn(entry);
     ownerTurn?.close();
     beginSpeakerTurn(entry, { senderIsOwner: false });
 
-    const bridgeParams = lastRealtimeBridgeParams();
     await emitFinalRealtimeUserTranscript(bridgeParams, "guest question");
 
     expectUserMessageIncludes("guest answer");
@@ -4632,14 +4290,10 @@ describe("DiscordVoiceManager", () => {
 
   it("starts Discord realtime voice in bidi mode with the consult tool", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "consult answer" }] });
-    const manager = createManager({
-      groupPolicy: "open",
+    const { bridgeParams, entry } = await createJoinedBidiFixture({
       voice: {
-        enabled: true,
-        mode: "bidi",
         model: "openai/gpt-5.5",
         realtime: {
-          provider: "openai",
           model: "gpt-realtime-2",
           speakerVoice: "cedar",
           toolPolicy: "safe-read-only",
@@ -4653,16 +4307,12 @@ describe("DiscordVoiceManager", () => {
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     const ownerTurn = entry?.realtime?.beginSpeakerTurn(
       { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
       "u-owner",
     );
     ownerTurn?.sendInputAudio(Buffer.alloc(8));
 
-    const bridgeParams = lastRealtimeBridgeParams();
     expect(bridgeParams?.autoRespondToAudio).toBe(true);
     expect(bridgeParams?.interruptResponseOnInputAudio).toBe(false);
     expect(bridgeParams?.instructions).toContain("Call openclaw_agent_consult");
@@ -4703,19 +4353,9 @@ describe("DiscordVoiceManager", () => {
     resolveRealtimeBootstrapContextInstructionsMock.mockResolvedValue(
       "OpenClaw realtime voice profile context:\n\n### IDENTITY.md\nName: Wilfred",
     );
-    const manager = createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "bidi",
-        realtime: {
-          provider: "openai",
-          consultPolicy: "always",
-        },
-      },
+    const { bridgeParams } = await createJoinedBidiFixture({
+      voice: { realtime: { consultPolicy: "always" } },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
 
     expect(resolveRealtimeBootstrapContextInstructionsMock).toHaveBeenCalledWith({
       config: {},
@@ -4724,7 +4364,6 @@ describe("DiscordVoiceManager", () => {
       files: undefined,
       warn: expect.any(Function),
     });
-    const bridgeParams = lastRealtimeBridgeParams();
     expect(bridgeParams?.instructions).toContain("OpenClaw realtime voice profile context");
     expect(bridgeParams?.instructions).toContain("Name: Wilfred");
     expect(bridgeParams?.instructions).toContain("short natural backchannel");
@@ -4745,30 +4384,20 @@ describe("DiscordVoiceManager", () => {
       };
     });
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "maintainer answer" }] });
-    const manager = createManager({
-      groupPolicy: "open",
+    const { bridgeParams, entry } = await createJoinedBidiFixture({
       voice: {
-        enabled: true,
-        mode: "bidi",
         agentSession: {
           mode: "target",
           target: "channel:maintainers",
         },
-        realtime: {
-          provider: "openai",
-          consultPolicy: "always",
-        },
+        realtime: { consultPolicy: "always" },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     expect(entry.voiceSessionKey).toBe("agent:main:discord:channel:1001");
     expect(entry.route?.sessionKey).toBe("agent:main:discord:channel:maintainers");
 
     beginSpeakerTurn(entry);
 
-    const bridgeParams = lastRealtimeBridgeParams();
     void bridgeParams?.onToolCall?.(
       {
         itemId: "item-1",
@@ -4789,21 +4418,14 @@ describe("DiscordVoiceManager", () => {
 
   it("keeps bidi realtime consults on the audio turn speaker context", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "guest consult answer" }] });
-    const manager = createManager({
-      groupPolicy: "open",
+    const { bridgeParams, entry } = await createJoinedBidiFixture({
       voice: {
-        enabled: true,
-        mode: "bidi",
         realtime: {
-          provider: "openai",
           toolPolicy: "safe-read-only",
           consultPolicy: "always",
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     const nonOwnerTurn = entry?.realtime?.beginSpeakerTurn(
       { extraSystemPrompt: undefined, senderIsOwner: false, speakerLabel: "Guest" },
       "u-guest",
@@ -4815,7 +4437,6 @@ describe("DiscordVoiceManager", () => {
     );
     ownerTurn?.sendInputAudio(Buffer.alloc(8));
 
-    const bridgeParams = lastRealtimeBridgeParams();
     void bridgeParams?.onToolCall?.(
       {
         itemId: "item-guest",
@@ -4841,26 +4462,18 @@ describe("DiscordVoiceManager", () => {
 
   it("expires closed bidi turns before later speaker consults", async () => {
     agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "guest consult answer" }] });
-    const manager = createManager({
-      groupPolicy: "open",
+    const { bridgeParams, entry } = await createJoinedBidiFixture({
       voice: {
-        enabled: true,
-        mode: "bidi",
         realtime: {
-          provider: "openai",
           toolPolicy: "safe-read-only",
           consultPolicy: "always",
         },
       },
     });
-
-    await manager.join({ guildId: "g1", channelId: "1001" });
-    const entry = getSessionEntry(manager);
     const ownerTurn = beginSpeakerTurn(entry);
     ownerTurn?.close();
     beginSpeakerTurn(entry, { senderIsOwner: false });
 
-    const bridgeParams = lastRealtimeBridgeParams();
     void bridgeParams?.onToolCall?.(
       {
         itemId: "item-guest",
@@ -4930,11 +4543,7 @@ describe("DiscordVoiceManager", () => {
     expect(entry.player.state.status).toBe("idle");
     entry.player.state.status = "playing";
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u-denied");
+    await handleSpeakingStart(manager, entry, "u-denied");
 
     expect(connection.receiver.subscribe).not.toHaveBeenCalled();
     expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();
@@ -5195,11 +4804,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("disconnects after repeated poisoned DAVE sessions without a reconnect loop", async () => {
-    const firstConnection = createConnectionMock();
-    const secondConnection = createConnectionMock();
-    installFailingDaveSession(firstConnection, "native");
-    installFailingDaveSession(secondConnection, "key-package");
-    joinVoiceChannelMock.mockReturnValueOnce(firstConnection).mockReturnValueOnce(secondConnection);
+    const { firstConnection, secondConnection } = makePoisonedDaveConnections();
     const manager = createManager();
 
     await manager.join({ guildId: "g1", channelId: "1001" });
@@ -5219,31 +4824,14 @@ describe("DiscordVoiceManager", () => {
   it("suppresses followed-user reconciliation until the poisoned-DAVE cooldown expires", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-    const firstConnection = createConnectionMock();
-    const secondConnection = createConnectionMock();
-    installFailingDaveSession(firstConnection, "native");
-    installFailingDaveSession(secondConnection, "key-package");
-    joinVoiceChannelMock
-      .mockReturnValueOnce(firstConnection)
-      .mockReturnValueOnce(secondConnection)
-      .mockReturnValueOnce(createConnectionMock());
+    makePoisonedDaveConnections(1);
     const client = createClient();
     client.rest.get.mockResolvedValue({
       guild_id: "g1",
       user_id: "u-owner",
       channel_id: "1001",
     });
-    const manager = createManager(
-      {
-        guilds: { g1: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: ["u-owner"],
-        },
-      },
-      client,
-    );
+    const manager = createFollowManager({}, client, { guilds: { g1: {} } });
 
     try {
       await manager.autoJoin();
@@ -5271,18 +4859,8 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("suppresses repeated same-channel voice-state updates during a DAVE cooldown", async () => {
-    const firstConnection = createConnectionMock();
-    const secondConnection = createConnectionMock();
-    installFailingDaveSession(firstConnection, "native");
-    installFailingDaveSession(secondConnection, "key-package");
-    joinVoiceChannelMock.mockReturnValueOnce(firstConnection).mockReturnValueOnce(secondConnection);
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-      },
-    });
+    makePoisonedDaveConnections();
+    const manager = createFollowManager();
 
     await updateVoiceState(manager, "u-owner", "1001");
     emitDecryptFailure(manager);
@@ -5308,21 +4886,8 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("still follows real user movement to another channel during a DAVE cooldown", async () => {
-    const firstConnection = createConnectionMock();
-    const secondConnection = createConnectionMock();
-    installFailingDaveSession(firstConnection, "native");
-    installFailingDaveSession(secondConnection, "key-package");
-    joinVoiceChannelMock
-      .mockReturnValueOnce(firstConnection)
-      .mockReturnValueOnce(secondConnection)
-      .mockReturnValueOnce(createConnectionMock());
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-      },
-    });
+    makePoisonedDaveConnections(1);
+    const manager = createFollowManager();
 
     await updateVoiceState(manager, "u-owner", "1001");
     emitDecryptFailure(manager);
@@ -5337,21 +4902,8 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("follows a user who leaves and rejoins the same channel during a DAVE cooldown", async () => {
-    const firstConnection = createConnectionMock();
-    const secondConnection = createConnectionMock();
-    installFailingDaveSession(firstConnection, "native");
-    installFailingDaveSession(secondConnection, "key-package");
-    joinVoiceChannelMock
-      .mockReturnValueOnce(firstConnection)
-      .mockReturnValueOnce(secondConnection)
-      .mockReturnValueOnce(createConnectionMock());
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-      },
-    });
+    makePoisonedDaveConnections(1);
+    const manager = createFollowManager();
 
     await updateVoiceState(manager, "u-owner", "1001");
     emitDecryptFailure(manager);
@@ -5368,31 +4920,14 @@ describe("DiscordVoiceManager", () => {
   it("reconciles a followed-user move to another channel during a DAVE cooldown", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-    const firstConnection = createConnectionMock();
-    const secondConnection = createConnectionMock();
-    installFailingDaveSession(firstConnection, "native");
-    installFailingDaveSession(secondConnection, "key-package");
-    joinVoiceChannelMock
-      .mockReturnValueOnce(firstConnection)
-      .mockReturnValueOnce(secondConnection)
-      .mockReturnValueOnce(createConnectionMock());
+    makePoisonedDaveConnections(1);
     const client = createClient();
     client.rest.get.mockResolvedValue({
       guild_id: "g1",
       user_id: "u-owner",
       channel_id: "1001",
     });
-    const manager = createManager(
-      {
-        guilds: { g1: {} },
-        voice: {
-          enabled: true,
-          mode: "stt-tts",
-          followUsers: ["u-owner"],
-        },
-      },
-      client,
-    );
+    const manager = createFollowManager({}, client, { guilds: { g1: {} } });
 
     try {
       await manager.autoJoin();
@@ -5416,14 +4951,7 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("allows explicit manual joins during a poisoned-DAVE cooldown", async () => {
-    const firstConnection = createConnectionMock();
-    const secondConnection = createConnectionMock();
-    installFailingDaveSession(firstConnection, "native");
-    installFailingDaveSession(secondConnection, "key-package");
-    joinVoiceChannelMock
-      .mockReturnValueOnce(firstConnection)
-      .mockReturnValueOnce(secondConnection)
-      .mockReturnValueOnce(createConnectionMock());
+    makePoisonedDaveConnections(1);
     const manager = createManager();
 
     await manager.join({ guildId: "g1", channelId: "1001" });
@@ -5555,13 +5083,7 @@ describe("DiscordVoiceManager", () => {
     joinVoiceChannelMock
       .mockReturnValueOnce(connection)
       .mockReturnValueOnce(createConnectionMock());
-    const manager = createManager({
-      voice: {
-        enabled: true,
-        mode: "stt-tts",
-        followUsers: ["u-owner"],
-      },
-    });
+    const manager = createFollowManager();
 
     await updateVoiceState(manager, "u-owner", "1001");
 
@@ -5590,14 +5112,8 @@ describe("DiscordVoiceManager", () => {
         params.onChunk(Buffer.alloc(8));
       },
     );
-    const manager = createManager({
-      groupPolicy: "open",
+    const manager = createAgentProxyManager(undefined, {
       allowFrom: ["discord:u-speaker"],
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "openai" },
-      },
     });
 
     await manager.join({ guildId: "g1", channelId: "1001" });
@@ -5615,11 +5131,7 @@ describe("DiscordVoiceManager", () => {
     };
     connection.receiver.subscribe.mockReturnValueOnce(stream);
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u-speaker");
+    await handleSpeakingStart(manager, entry, "u-speaker");
 
     expect(decodeOpusStreamChunksMock).toHaveBeenCalledTimes(1);
     expect(entry.receiveRecovery.decryptFailureCount).toBe(0);
@@ -5650,14 +5162,8 @@ describe("DiscordVoiceManager", () => {
         errorListener?.(err);
       },
     );
-    const manager = createManager({
-      groupPolicy: "open",
+    const manager = createAgentProxyManager(undefined, {
       allowFrom: ["discord:u-speaker"],
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "openai" },
-      },
     });
 
     await manager.join({ guildId: "g1", channelId: "1001" });
@@ -5671,11 +5177,7 @@ describe("DiscordVoiceManager", () => {
     };
     connection.receiver.subscribe.mockReturnValueOnce(stream);
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u-speaker");
+    await handleSpeakingStart(manager, entry, "u-speaker");
 
     const errorListener = stream.on.mock.calls.find(([event]) => event === "error")?.[1];
     expect(errorListener).toBeTypeOf("function");
@@ -5700,11 +5202,9 @@ describe("DiscordVoiceManager", () => {
         return Buffer.alloc(8);
       },
     );
-    const manager = createManager({
-      groupPolicy: "open",
-      allowFrom: ["discord:u-speaker"],
-      voice: { enabled: true, mode: "stt-tts" },
-    });
+    const manager = createManager(
+      makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+    );
 
     await manager.join({ guildId: "g1", channelId: "1001" });
     const entry = getSessionEntry(manager);
@@ -5717,11 +5217,7 @@ describe("DiscordVoiceManager", () => {
     };
     connection.receiver.subscribe.mockReturnValueOnce(stream);
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u-speaker");
+    await handleSpeakingStart(manager, entry, "u-speaker");
 
     expect(transcribeAudioFileMock).not.toHaveBeenCalled();
     expect(entry.receiveRecovery.decryptFailureCount).toBe(1);
@@ -5745,11 +5241,9 @@ describe("DiscordVoiceManager", () => {
         return Buffer.alloc(48_000);
       },
     );
-    const manager = createManager({
-      groupPolicy: "open",
-      allowFrom: ["discord:u-speaker"],
-      voice: { enabled: true, mode: "stt-tts" },
-    });
+    const manager = createManager(
+      makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+    );
 
     await manager.join({ guildId: "g1", channelId: "1001" });
     const entry = getSessionEntry(manager);
@@ -5762,11 +5256,7 @@ describe("DiscordVoiceManager", () => {
     };
     connection.receiver.subscribe.mockReturnValueOnce(stream);
 
-    await (
-      manager as unknown as {
-        handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-      }
-    ).handleSpeakingStart(entry, "u-speaker");
+    await handleSpeakingStart(manager, entry, "u-speaker");
     await entry.processingQueue;
 
     expect(transcribeAudioFileMock).toHaveBeenCalledTimes(1);
@@ -5808,11 +5298,7 @@ describe("DiscordVoiceManager", () => {
       };
       connection.receiver.subscribe.mockReturnValueOnce(secondStream);
 
-      await (
-        manager as unknown as {
-          handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-        }
-      ).handleSpeakingStart(entry, "u1");
+      await handleSpeakingStart(manager, entry, "u1");
 
       const subscribeCall = lastMockCall(
         connection.receiver.subscribe as unknown as MockCallSource,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -279,14 +279,48 @@ const SUBAGENT_ANNOUNCE_EMBEDDED_DELIVERY_CASES: readonly SubagentAnnounceDelive
   },
 ];
 
-const runAgentAttempt = (
-  params: Omit<RunAgentAttemptParams, "lifecycleGeneration"> &
-    Partial<Pick<RunAgentAttemptParams, "lifecycleGeneration">>,
-) =>
+const runAgentAttempt = (params: RunAgentAttemptOverrides) =>
   runAgentAttemptImpl({
-    ...params,
+    ...makeRunAgentAttemptParams(params),
     lifecycleGeneration: params.lifecycleGeneration ?? "test-generation",
   });
+
+type RunAgentAttemptOverrides = Omit<
+  Partial<RunAgentAttemptParams>,
+  "agentDir" | "opts" | "runContext" | "sessionEntry" | "sessionKey" | "workspaceDir"
+> &
+  Pick<RunAgentAttemptParams, "agentDir" | "sessionEntry" | "sessionKey" | "workspaceDir"> & {
+    opts?: Partial<RunAgentAttemptParams["opts"]>;
+    runContext?: Partial<RunAgentAttemptParams["runContext"]>;
+  };
+
+function makeRunAgentAttemptParams(overrides: RunAgentAttemptOverrides): RunAgentAttemptParams {
+  const provider = overrides.providerOverride ?? "openai";
+  return {
+    providerOverride: provider,
+    originalProvider: provider,
+    modelOverride: "gpt-5.4",
+    cfg: {} as OpenClawConfig,
+    sessionId: overrides.sessionEntry.sessionId,
+    sessionAgentId: "main",
+    sessionFile: path.join(overrides.workspaceDir, "session.jsonl"),
+    body: "continue",
+    isFallbackRetry: false,
+    resolvedThinkLevel: "medium",
+    timeoutMs: 1_000,
+    runId: `run-${overrides.sessionEntry.sessionId}`,
+    spawnedBy: undefined,
+    messageChannel: undefined,
+    skillsSnapshot: undefined,
+    resolvedVerboseLevel: undefined,
+    onAgentEvent: vi.fn(),
+    authProfileProvider: provider,
+    sessionHasHistory: false,
+    ...overrides,
+    opts: { ...overrides.opts } as RunAgentAttemptParams["opts"],
+    runContext: { ...overrides.runContext } as RunAgentAttemptParams["runContext"],
+  };
+}
 
 const runCliAgentMock = vi.hoisted(() => vi.fn());
 const runEmbeddedAgentMock = vi.hoisted(() => vi.fn());
@@ -409,6 +443,10 @@ function makeCliResult(text: string): EmbeddedAgentRunResult {
       },
     },
   };
+}
+
+function makeSessionEntry(sessionId: string, overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return { sessionId, updatedAt: Date.now(), ...overrides };
 }
 
 async function persistCliTranscriptEntry(
@@ -577,34 +615,25 @@ describe("CLI attempt execution", () => {
       configuredAuthProfileId: overrides?.configuredAuthProfileId,
       cfg: overrides?.config ?? ({ session: { store: storePath } } as OpenClawConfig),
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
       sessionFile: path.join(tmpDir, `${runId}.jsonl`),
       workspaceDir: tmpDir,
       body: overrides?.body ?? "stream gate",
       transcriptBody: overrides?.transcriptBody,
       isFallbackRetry: overrides?.isFallbackRetry ?? false,
       fallbackRuntimeState: overrides?.fallbackRuntimeState,
-      resolvedThinkLevel: "medium",
       timeoutMs: overrides?.timeoutMs ?? 1_000,
       runTimeoutOverrideMs: overrides?.runTimeoutOverrideMs,
       runId,
       opts: {
         message: "stream gate",
         ...overrides?.opts,
-      } as RunAgentAttemptParams["opts"],
-      runContext: {} as RunAgentAttemptParams["runContext"],
-      spawnedBy: undefined,
+      },
       messageChannel: "telegram",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
       agentDir,
-      onAgentEvent: vi.fn(),
       authProfileProvider: providerOverride,
       sessionStore,
       storePath,
-      sessionHasHistory: false,
       userTurnTranscriptRecorder: overrides?.userTurnTranscriptRecorder,
     });
 
@@ -647,6 +676,12 @@ describe("CLI attempt execution", () => {
     for (const [sessionKey, entry] of Object.entries(sessionStore)) {
       await replaceSessionEntry({ sessionKey, storePath }, entry);
     }
+  }
+
+  function runStoredAttempt(
+    overrides: Omit<RunAgentAttemptOverrides, "agentDir" | "storePath" | "workspaceDir">,
+  ) {
+    return runAgentAttempt({ workspaceDir: tmpDir, agentDir, storePath, ...overrides });
   }
 
   function createSubagentAnnounceSessionStore(
@@ -778,44 +813,23 @@ describe("CLI attempt execution", () => {
   }) {
     await runAgentAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
-      cfg: {} as OpenClawConfig,
       sessionEntry: params.sessionEntry,
-      sessionId: params.sessionEntry.sessionId,
       sessionKey: params.sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       cwd: params.cwd,
       body: params.body,
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: params.runId,
-      opts: {
-        onExecutionStarted: params.onExecutionStarted,
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
+      opts: { onExecutionStarted: params.onExecutionStarted },
       agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore: params.sessionStore,
       storePath,
-      sessionHasHistory: false,
     });
   }
 
   it("forwards execution admission callbacks to the CLI runtime", async () => {
     const sessionKey = "agent:main:direct:cli-execution-started";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-cli-execution-started",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-cli-execution-started");
     const sessionStore = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     const onExecutionStarted = vi.fn();
@@ -835,11 +849,9 @@ describe("CLI attempt execution", () => {
 
   it("forwards authoritative group type to CLI runs with opaque session keys", async () => {
     const sessionKey = "agent:main:opaque:binding";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-cli-opaque-group",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("session-cli-opaque-group", {
       chatType: "group",
-    };
+    });
     const sessionStore = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("shared"));
@@ -943,34 +955,12 @@ describe("CLI attempt execution", () => {
       return makeCliResult("hello from cli");
     });
 
-    await runAgentAttempt({
-      providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
-      modelOverride: "opus",
-      cfg: {} as OpenClawConfig,
+    await runClaudeCliAttempt({
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "retry this",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-cli-expired",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
+      body: "retry this",
+      runId: "run-cli-expired",
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -1342,30 +1332,13 @@ describe("CLI attempt execution", () => {
     // would only give callers a false sense that stale state was repaired.
     await runAgentAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       body: "storeless retry path",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-storeless-cli",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
       agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -1608,44 +1581,21 @@ describe("CLI attempt execution", () => {
 
   it("passes session-bound OpenAI Codex auth profile to codex-cli aliases", async () => {
     const sessionKey = "agent:main:direct:codex-cli-auth-alias";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-codex",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("openclaw-session-codex", {
       authProfileOverride: "openai:work",
       authProfileOverrideSource: "user",
-    };
+    });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("codex cli response"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "codex-cli",
-      originalProvider: "codex-cli",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-codex-cli-auth-alias",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
       authProfileProvider: "openai",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -1654,10 +1604,7 @@ describe("CLI attempt execution", () => {
 
   it("skips auto auth-profile resolution for CLI-owned transport", async () => {
     const sessionKey = "agent:main:direct:codex-cli-owned-transport";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-codex-owned",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-codex-owned");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     const cfg: OpenClawConfig = {
       agents: {
@@ -1670,34 +1617,14 @@ describe("CLI attempt execution", () => {
     await fs.writeFile(path.join(tmpDir, "auth-profiles.json"), "{", "utf-8");
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("codex cli response"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "codex-cli",
-      originalProvider: "codex-cli",
-      modelOverride: "gpt-5.4",
       cfg,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-codex-cli-owned-transport-auth-skip",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
       authProfileProvider: "openai-codex",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -1706,10 +1633,7 @@ describe("CLI attempt execution", () => {
 
   it("selects a google-gemini-cli auth profile for canonical Google models routed through Gemini CLI", async () => {
     const sessionKey = "agent:main:direct:gemini-cli-auth-bridge";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-gemini",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-gemini");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -1730,9 +1654,8 @@ describe("CLI attempt execution", () => {
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli response"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "google",
-      originalProvider: "google",
       modelOverride: "gemini-3.1-pro-preview",
       cfg: {
         auth: {
@@ -1751,28 +1674,9 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-gemini-cli-auth-bridge",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "google",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -1782,12 +1686,10 @@ describe("CLI attempt execution", () => {
 
   it("forwards pinned canonical Google API-key profiles to Google models routed through Gemini CLI", async () => {
     const sessionKey = "agent:main:direct:gemini-cli-google-api-key";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-gemini-api-key",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("openclaw-session-gemini-api-key", {
       authProfileOverride: "google:api-key",
       authProfileOverrideSource: "user",
-    };
+    });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -1805,9 +1707,8 @@ describe("CLI attempt execution", () => {
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli api-key response"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "google",
-      originalProvider: "google",
       modelOverride: "gemini-3.1-pro-preview",
       cfg: {
         agents: {
@@ -1821,28 +1722,9 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-gemini-cli-google-api-key",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "google",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -1852,12 +1734,10 @@ describe("CLI attempt execution", () => {
 
   it("rejects incompatible pinned profiles before selecting another CLI identity", async () => {
     const sessionKey = "agent:main:direct:gemini-cli-incompatible-auth";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-gemini-incompatible-auth",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("openclaw-session-gemini-incompatible-auth", {
       authProfileOverride: "vercel-ai-gateway:default",
       authProfileOverrideSource: "user",
-    };
+    });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -1874,9 +1754,8 @@ describe("CLI attempt execution", () => {
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     expect(() =>
-      runAgentAttempt({
+      runStoredAttempt({
         providerOverride: "google",
-        originalProvider: "google",
         modelOverride: "gemini-3.1-pro-preview",
         cfg: {
           agents: {
@@ -1890,28 +1769,9 @@ describe("CLI attempt execution", () => {
           },
         } as OpenClawConfig,
         sessionEntry,
-        sessionId: sessionEntry.sessionId,
         sessionKey,
-        sessionAgentId: "main",
-        sessionFile: path.join(tmpDir, "session.jsonl"),
-        workspaceDir: tmpDir,
-        body: "continue",
-        isFallbackRetry: false,
-        resolvedThinkLevel: "medium",
-        timeoutMs: 1_000,
         runId: "run-gemini-cli-incompatible-auth",
-        opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-        runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-        spawnedBy: undefined,
-        messageChannel: undefined,
-        skillsSnapshot: undefined,
-        resolvedVerboseLevel: undefined,
-        agentDir,
-        onAgentEvent: vi.fn(),
-        authProfileProvider: "google",
         sessionStore,
-        storePath,
-        sessionHasHistory: false,
       }),
     ).toThrow(/cannot use auth profile "vercel-ai-gateway:default"/);
 
@@ -1920,12 +1780,10 @@ describe("CLI attempt execution", () => {
 
   it("ignores stale auto-selected profiles when resolving Gemini CLI auth order", async () => {
     const sessionKey = "agent:main:direct:gemini-cli-stale-auto-auth";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-gemini-stale-auto-auth",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("openclaw-session-gemini-stale-auto-auth", {
       authProfileOverride: "openai:work",
       authProfileOverrideSource: "auto",
-    };
+    });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -1950,9 +1808,8 @@ describe("CLI attempt execution", () => {
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli api-key response"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "google",
-      originalProvider: "google",
       modelOverride: "gemini-3.1-pro-preview",
       cfg: {
         auth: {
@@ -1971,28 +1828,9 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-gemini-cli-stale-auto-auth",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "google",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -2002,10 +1840,7 @@ describe("CLI attempt execution", () => {
 
   it("selects canonical Google API-key auth order for Google models routed through Gemini CLI", async () => {
     const sessionKey = "agent:main:direct:gemini-cli-google-api-key-order";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-gemini-api-key-order",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-gemini-api-key-order");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -2023,9 +1858,8 @@ describe("CLI attempt execution", () => {
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli api-key response"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "google",
-      originalProvider: "google",
       modelOverride: "gemini-3.1-pro-preview",
       cfg: {
         auth: {
@@ -2044,28 +1878,9 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-gemini-cli-google-api-key-order",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "google",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -2229,11 +2044,7 @@ describe("CLI attempt execution", () => {
   it("mirrors only the CLI reply when the shared recorder already persisted the user turn", async () => {
     const sessionKey = "agent:main:direct:cli-recorder-owned-user";
     const sessionFile = path.join(tmpDir, "session-cli-recorder-owned-user.jsonl");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-cli-recorder-owned-user",
-      sessionFile,
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-cli-recorder-owned-user", { sessionFile });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     await appendTranscriptMessage(
@@ -2280,10 +2091,7 @@ describe("CLI attempt execution", () => {
 
   it("does not gap-fill an assistant already owned by the runtime", async () => {
     const sessionKey = "agent:main:direct:runtime-owned-assistant";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-runtime-owned-assistant",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-runtime-owned-assistant");
     await appendTranscriptMessage(
       { agentId: "main", sessionId: sessionEntry.sessionId, sessionKey, storePath },
       {
@@ -2326,10 +2134,7 @@ describe("CLI attempt execution", () => {
 
   it("holds the session-key lease for the embedded assistant gap-fill", async () => {
     const sessionKey = "agent:main:direct:gap-fill-lease";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-gap-fill-lease",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-gap-fill-lease");
     await writeSessionStoreSeed({ [sessionKey]: sessionEntry });
     const release = vi.fn();
     sessionWriteLockMocks.acquireSessionWriteLock.mockResolvedValueOnce({ release });
@@ -2360,11 +2165,7 @@ describe("CLI attempt execution", () => {
   it("persists a media-only ACP user turn when the reply is empty", async () => {
     const sessionKey = "agent:main:direct:acp-media-only";
     const sessionFile = path.join(tmpDir, "session-acp-media-only.jsonl");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-acp-media-only",
-      sessionFile,
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-acp-media-only", { sessionFile });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
 
@@ -2442,10 +2243,7 @@ describe("CLI attempt execution", () => {
 
   it("embedded assistant gap-fill skips user mirror and dedupes identical assistant tails", async () => {
     const sessionKey = "agent:main:subagent:embedded-gap-fill";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-embedded-gap-fill",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-embedded-gap-fill");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
 
@@ -2505,10 +2303,7 @@ describe("CLI attempt execution", () => {
 
   it("embedded assistant gap-fill skips trailing openclaw.cache-ttl custom entries (regression for #83427)", async () => {
     const sessionKey = "agent:main:subagent:embedded-gap-fill-cache-ttl";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-embedded-gap-fill-cache-ttl",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-embedded-gap-fill-cache-ttl");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
 
@@ -2575,10 +2370,7 @@ describe("CLI attempt execution", () => {
 
   it("embedded assistant gap-fill appends repeated replies after a user tail", async () => {
     const sessionKey = "agent:main:subagent:embedded-repeated-reply";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-embedded-repeated-reply",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-embedded-repeated-reply");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
 
@@ -2646,10 +2438,7 @@ describe("CLI attempt execution", () => {
 
   it("persists the transcript body instead of runtime-only CLI prompt context", async () => {
     const sessionKey = "agent:main:subagent:cli-transcript-clean";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session-cli-transcript-clean",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("session-cli-transcript-clean");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
 
@@ -2687,33 +2476,19 @@ describe("CLI attempt execution", () => {
 
   it("forwards separate user trigger, channel, and provider context to CLI runs", async () => {
     const sessionKey = "agent:main:direct:claude-channel-context";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-channel",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-channel");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("channel aware"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "route this",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-cli-channel-context",
-      opts: {
-        messageProvider: "discord-voice",
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      opts: { messageProvider: "discord-voice" },
       runContext: {
         currentChannelId: "channel:voice-room",
         chatId: "voice-room",
@@ -2722,17 +2497,9 @@ describe("CLI attempt execution", () => {
           chat: { id: "voice-room" },
         },
         senderId: "sender-voice",
-      } as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      },
       messageChannel: "discord",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -2752,44 +2519,21 @@ describe("CLI attempt execution", () => {
 
   it("forwards message-tool-only policy and requires explicit subagent targets", async () => {
     const sessionKey = "agent:main:subagent:claude-message-policy";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-cli-message-policy",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-cli-message-policy");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("sent"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "route this",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-cli-message-policy",
-      opts: {
-        sourceReplyDeliveryMode: "message_tool_only",
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      opts: { sourceReplyDeliveryMode: "message_tool_only" },
       messageChannel: "discord",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runCliAgentMock, {
@@ -2800,17 +2544,13 @@ describe("CLI attempt execution", () => {
 
   it("does not pass auth-order profiles to CLI backends that do not stage them", async () => {
     const sessionKey = "agent:main:direct:claude-auth-order";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-claude-auth-order",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-claude-auth-order");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("ambient claude cli"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
       cfg: {
         auth: {
@@ -2820,28 +2560,10 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "use ambient cli auth",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-claude-auth-order",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -2850,10 +2572,7 @@ describe("CLI attempt execution", () => {
 
   it("does not pass auth-order profiles to configured CLI runtimes that do not stage them", async () => {
     const sessionKey = "agent:main:direct:anthropic-claude-runtime-auth-order";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-anthropic-claude-runtime-auth-order",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-anthropic-claude-runtime-auth-order");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -2871,9 +2590,8 @@ describe("CLI attempt execution", () => {
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("configured claude cli"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "anthropic",
-      originalProvider: "anthropic",
       modelOverride: "claude-opus-4-7",
       cfg: {
         auth: {
@@ -2890,15 +2608,8 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "use ambient cli auth",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-configured-claude-auth-order",
       opts: {
         messageProvider: "discord",
@@ -2909,22 +2620,14 @@ describe("CLI attempt execution", () => {
           fullAccessAvailable: false,
           fullAccessBlockedReason: "runtime",
         },
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      },
       runContext: {
         groupId: "group-a",
         groupChannel: "ops",
         groupSpace: "guild-a",
-      } as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      },
       spawnedBy: "agent:main:discord:channel:parent",
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "anthropic",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -2950,44 +2653,21 @@ describe("CLI attempt execution", () => {
 
   it("forwards runtime toolsAllow into CLI attempts so the CLI harness can fail closed", async () => {
     const sessionKey = "agent:main:direct:claude-tools-allow";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-cli-tools-allow",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-cli-tools-allow");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("restricted cli"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "route this",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-cli-tools-allow",
-      opts: {
-        toolsAllow: ["read", "web_search"],
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      opts: { toolsAllow: ["read", "web_search"] },
       messageChannel: "discord",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runCliAgentMock, {
@@ -3012,10 +2692,7 @@ describe("CLI attempt execution", () => {
       expectedToolsAllow,
     }) => {
       const sessionKey = "agent:main:direct:claude-announce";
-      const sessionEntry: SessionEntry = {
-        sessionId: "openclaw-session-cli-announce",
-        updatedAt: Date.now(),
-      };
+      const sessionEntry = makeSessionEntry("openclaw-session-cli-announce");
       const sessionStore = createSubagentAnnounceSessionStore(sessionKey, sessionEntry, {
         inheritedToolAllow,
         inheritedToolDeny,
@@ -3023,9 +2700,8 @@ describe("CLI attempt execution", () => {
       await writeSessionStoreSeed(sessionStore);
       runCliAgentMock.mockResolvedValueOnce(makeCliResult("completion announce"));
 
-      await runAgentAttempt({
+      await runStoredAttempt({
         providerOverride: "claude-cli",
-        originalProvider: "claude-cli",
         modelOverride: "opus",
         cfg: {
           session: { store: storePath },
@@ -3033,15 +2709,8 @@ describe("CLI attempt execution", () => {
           ...(sandboxMode ? { agents: { defaults: { sandbox: { mode: sandboxMode } } } } : {}),
         },
         sessionEntry,
-        sessionId: sessionEntry.sessionId,
         sessionKey,
-        sessionAgentId: "main",
-        sessionFile: path.join(tmpDir, "session.jsonl"),
-        workspaceDir: tmpDir,
         body: "A background task finished. Process the completion update now.",
-        isFallbackRetry: false,
-        resolvedThinkLevel: "medium",
-        timeoutMs: 1_000,
         runId: "run-cli-announce",
         opts: createSubagentAnnounceHandoffOptions({
           sourceReplyDeliveryMode,
@@ -3053,18 +2722,9 @@ describe("CLI attempt execution", () => {
           requireExplicitMessageTarget,
           runtimeToolsAllow,
           trustedInternalHandoff,
-        }) as Parameters<typeof runAgentAttempt>[0]["opts"],
-        runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-        spawnedBy: undefined,
+        }),
         messageChannel: "telegram",
-        skillsSnapshot: undefined,
-        resolvedVerboseLevel: undefined,
-        agentDir,
-        onAgentEvent: vi.fn(),
-        authProfileProvider: "claude-cli",
         sessionStore,
-        storePath,
-        sessionHasHistory: false,
       });
 
       expectMockArgFields(runCliAgentMock, {
@@ -3141,10 +2801,7 @@ describe("CLI attempt execution", () => {
   it("keeps trusted CLI completion handoffs tool-free when inherited policy is restricted", async () => {
     const sessionKey = "agent:main:direct:claude-trusted-announce";
     const childSessionKey = "agent:openclaw:subagent:child";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-cli-trusted-announce",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-cli-trusted-announce");
     const sessionStore: Record<string, SessionEntry> = {
       [sessionKey]: sessionEntry,
       [childSessionKey]: {
@@ -3161,21 +2818,13 @@ describe("CLI attempt execution", () => {
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("trusted announce"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
       cfg: { session: { store: storePath } } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "A background task finished. Process the completion update now.",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-cli-trusted-announce",
       opts: {
         trustedInternalHandoff: {
@@ -3207,18 +2856,9 @@ describe("CLI attempt execution", () => {
             replyInstruction: "Relay this completion.",
           },
         ],
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      },
       messageChannel: "telegram",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runCliAgentMock, {
@@ -3233,10 +2873,7 @@ describe("CLI attempt execution", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-06-05T15:30:00Z"));
     const sessionKey = "agent:main:direct:claude-timestamp";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-cli-timestamp",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-cli-timestamp");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("timestamped cli"));
@@ -3251,35 +2888,17 @@ describe("CLI attempt execution", () => {
         storePath,
       }),
     });
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "opus",
       cfg: { agents: { defaults: { userTimezone: "UTC" } } } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "what time is it?",
       transcriptBody: "canonical timestamp question",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-cli-timestamp",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
       messageChannel: "discord",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
       userTurnTranscriptRecorder,
     });
 
@@ -3294,10 +2913,7 @@ describe("CLI attempt execution", () => {
 
   it("routes canonical Anthropic models through the configured Claude CLI runtime", async () => {
     const sessionKey = "agent:main:direct:canonical-claude-cli";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-canonical-cli",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-canonical-cli");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("canonical cli"));
@@ -3305,9 +2921,8 @@ describe("CLI attempt execution", () => {
     const images = [{ type: "image" as const, data: "aGVsbG8=", mimeType: "image/png" }];
     const imageOrder = ["inline" as const];
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "anthropic",
-      originalProvider: "anthropic",
       modelOverride: "claude-opus-4-7",
       cfg: {
         agents: {
@@ -3319,28 +2934,13 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "route this",
       isFallbackRetry: true,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-canonical-claude-cli",
-      opts: { images, imageOrder } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      opts: { images, imageOrder },
       messageChannel: "telegram",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "anthropic",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
       fallbackRuntimeState,
     });
 
@@ -3365,17 +2965,13 @@ describe("CLI attempt execution", () => {
 
   it("routes provider-qualified Anthropic shorthand through the configured Claude CLI runtime", async () => {
     const sessionKey = "agent:main:direct:shorthand-claude-cli";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-shorthand-cli",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-shorthand-cli");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("shorthand cli"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "anthropic",
-      originalProvider: "anthropic",
       modelOverride: "opus-4.7",
       cfg: {
         agents: {
@@ -3387,28 +2983,11 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "route this",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-shorthand-claude-cli",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
       messageChannel: "telegram",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "anthropic",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
@@ -3420,10 +2999,7 @@ describe("CLI attempt execution", () => {
 
   it("routes canonical OpenAI models through the configured embedded Codex runtime", async () => {
     const sessionKey = "agent:main:direct:canonical-codex-cli";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-canonical-codex-cli",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-canonical-codex-cli");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runEmbeddedAgentMock.mockResolvedValueOnce({
@@ -3435,10 +3011,7 @@ describe("CLI attempt execution", () => {
       },
     });
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
+    await runStoredAttempt({
       cfg: {
         agents: {
           defaults: {
@@ -3449,17 +3022,9 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "route this",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-canonical-codex-cli",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
       runContext: {
         chatId: "chat-embedded",
         channelContext: {
@@ -3467,17 +3032,9 @@ describe("CLI attempt execution", () => {
           chat: { id: "chat-embedded" },
         },
         senderId: "sender-embedded",
-      } as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      },
       messageChannel: "telegram",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).not.toHaveBeenCalled();
@@ -3815,12 +3372,10 @@ describe("CLI attempt execution", () => {
 
   it("forwards selected auth profiles through metadata-scoped provider aliases", async () => {
     const sessionKey = "agent:main:direct:metadata-auth-alias";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-metadata-auth-alias",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("openclaw-session-metadata-auth-alias", {
       authProfileOverride: "openai:work",
       authProfileOverrideSource: "user",
-    };
+    });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -3842,33 +3397,14 @@ describe("CLI attempt execution", () => {
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "fixture",
-      originalProvider: "fixture",
       modelOverride: "fixture-model",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "use selected auth",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-metadata-auth-alias",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "fixture",
       sessionStore,
-      storePath,
       pluginsEnabled: true,
       metadataSnapshot: {
         plugins: [
@@ -3879,7 +3415,6 @@ describe("CLI attempt execution", () => {
           },
         ],
       } as never,
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runEmbeddedAgentMock, {
@@ -3893,12 +3428,10 @@ describe("CLI attempt execution", () => {
   it("forwards user-pinned OpenAI API-key backup profiles to Codex harness runs", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const sessionKey = "agent:main:direct:openai-chatgpt-api-key";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-openai-chatgpt-api-key",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("openclaw-session-openai-chatgpt-api-key", {
       authProfileOverride: "openai:backup",
       authProfileOverrideSource: "user",
-    };
+    });
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     saveAuthProfileStore(
       {
@@ -3926,34 +3459,12 @@ describe("CLI attempt execution", () => {
     } satisfies EmbeddedAgentRunResult);
 
     try {
-      await runAgentAttempt({
-        providerOverride: "openai",
-        originalProvider: "openai",
-        modelOverride: "gpt-5.4",
-        cfg: {} as OpenClawConfig,
+      await runStoredAttempt({
         sessionEntry,
-        sessionId: sessionEntry.sessionId,
         sessionKey,
-        sessionAgentId: "main",
-        sessionFile: path.join(tmpDir, "session.jsonl"),
-        workspaceDir: tmpDir,
         body: "use backup auth",
-        isFallbackRetry: false,
-        resolvedThinkLevel: "medium",
-        timeoutMs: 1_000,
         runId: "run-openai-chatgpt-api-key-backup",
-        opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-        runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-        spawnedBy: undefined,
-        messageChannel: undefined,
-        skillsSnapshot: undefined,
-        resolvedVerboseLevel: undefined,
-        agentDir,
-        onAgentEvent: vi.fn(),
-        authProfileProvider: "openai",
         sessionStore,
-        storePath,
-        sessionHasHistory: false,
       });
     } finally {
       clearAgentHarnesses();
@@ -3969,20 +3480,16 @@ describe("CLI attempt execution", () => {
 
   it("keeps one-shot model runs on the raw embedded provider path", async () => {
     const sessionKey = "agent:main:direct:model-run-raw";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-model-run-raw",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-model-run-raw");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-7",
-      originalProvider: "anthropic",
       cfg: {
         agents: {
           defaults: {
@@ -3991,15 +3498,8 @@ describe("CLI attempt execution", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "raw prompt",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-model-run-raw",
       opts: {
         modelRun: true,
@@ -4010,17 +3510,9 @@ describe("CLI attempt execution", () => {
           sourceSessionKey: "agent:main:discord:source",
           sourceTool: "sessions_send",
         },
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      },
       messageChannel: "discord",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "anthropic",
       sessionStore,
-      storePath,
       sessionHasHistory: true,
     });
 
@@ -4041,10 +3533,7 @@ describe("CLI attempt execution", () => {
 
   it("forwards trusted elevated defaults to embedded agent runs", async () => {
     const sessionKey = "agent:main:telegram:direct:123";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-elevated-followup",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-elevated-followup");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     const bashElevated = {
       enabled: true,
@@ -4056,36 +3545,14 @@ describe("CLI attempt execution", () => {
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
+    await runStoredAttempt({
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "follow up after approved exec",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-elevated-followup",
-      opts: {
-        bashElevated,
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
+      opts: { bashElevated },
       messageChannel: "telegram",
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runEmbeddedAgentMock, {
@@ -4097,45 +3564,23 @@ describe("CLI attempt execution", () => {
 
   it("forwards one-shot CLI cleanup to CLI providers", async () => {
     const sessionKey = "agent:main:direct:cleanup-claude-cli";
-    const sessionEntry: SessionEntry = {
-      sessionId: "openclaw-session-cleanup-cli",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("openclaw-session-cleanup-cli");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("cleanup cli"));
 
-    await runAgentAttempt({
+    await runStoredAttempt({
       providerOverride: "claude-cli",
-      originalProvider: "claude-cli",
       modelOverride: "claude-opus-4-7",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
       sessionKey,
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "cleanup",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-cleanup-claude-cli",
       opts: {
         cleanupBundleMcpOnRunEnd: true,
         cleanupCliLiveSessionOnRunEnd: true,
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "claude-cli",
+      },
       sessionStore,
-      storePath,
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runCliAgentMock, {
@@ -4191,40 +3636,26 @@ describe("embedded attempt harness pinning", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  function runHarnessAttempt(
+    overrides: Omit<RunAgentAttemptOverrides, "agentDir" | "sessionKey" | "workspaceDir">,
+  ) {
+    return runAgentAttempt({
+      sessionKey: "agent:main:main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      ...overrides,
+    });
+  }
+
   it("does not store a session harness pin for default OpenAI Codex routing", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "legacy-session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("legacy-session");
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
+    await runHarnessAttempt({
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-legacy-runtime-pin",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
       sessionHasHistory: true,
     });
 
@@ -4232,9 +3663,7 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("keeps a catalog-adopted Codex harness pinned for direct command attempts", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "mixed-provider-session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("mixed-provider-session", {
       agentHarnessId: "codex",
       modelSelectionLocked: true,
       pluginExtensions: {
@@ -4245,14 +3674,13 @@ describe("embedded attempt harness pinning", () => {
           },
         },
       },
-    };
+    });
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
+    await runHarnessAttempt({
       providerOverride: "anthropic",
-      originalProvider: "anthropic",
       modelOverride: "claude-opus-4-7",
       cfg: {
         agents: {
@@ -4265,25 +3693,8 @@ describe("embedded attempt harness pinning", () => {
       } as OpenClawConfig,
       sessionEntry,
       agentHarnessRuntimeOverride: "codex",
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "switch to minimax",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-mixed-provider-auto-runtime",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "anthropic",
       sessionHasHistory: true,
     });
 
@@ -4298,40 +3709,19 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("ignores stale session Codex harness pins on non-OpenAI model switches", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "mixed-provider-session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("mixed-provider-session", {
       agentHarnessId: "codex",
-    };
+    });
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
+    await runHarnessAttempt({
       providerOverride: "minimax",
-      originalProvider: "minimax",
       modelOverride: "minimax-m2.7",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "switch to minimax",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-mixed-provider-auto-runtime",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "minimax",
       sessionHasHistory: true,
     });
 
@@ -4339,40 +3729,16 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("does not leak a persisted CLI harness alias across providers", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "legacy-cli-pin",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("legacy-cli-pin", {
       agentHarnessId: "claude-cli",
-    };
+    });
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
+    await runHarnessAttempt({
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-provider-incompatible-cli-pin",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
       sessionHasHistory: true,
     });
 
@@ -4386,60 +3752,29 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("forwards runtime toolsAllow into embedded attempts", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "tools-allow-session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("tools-allow-session");
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
+    await runHarnessAttempt({
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "read only",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-tools-allow",
-      opts: {
-        toolsAllow: ["read", "web_search"],
-      } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionHasHistory: false,
+      opts: { toolsAllow: ["read", "web_search"] },
     });
 
     expectMockArgFields(runEmbeddedAgentMock, { toolsAllow: ["read", "web_search"] });
   });
 
   it("lets provider/model runtime policy choose Codex without storing a session harness pin", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "codex-history-session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("codex-history-session");
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
+    await runHarnessAttempt({
       providerOverride: "codex",
-      originalProvider: "codex",
-      modelOverride: "gpt-5.4",
       cfg: {
         models: {
           providers: {
@@ -4452,25 +3787,7 @@ describe("embedded attempt harness pinning", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-codex-no-runtime-pin",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "codex",
       sessionHasHistory: true,
     });
 
@@ -4479,10 +3796,7 @@ describe("embedded attempt harness pinning", () => {
 
   it("auto-forwards OpenAI Codex auth profiles to default Codex harness runs", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
-    const sessionEntry: SessionEntry = {
-      sessionId: "codex-auth-session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("codex-auth-session");
     saveAuthProfileStore(
       {
         version: 1,
@@ -4511,31 +3825,9 @@ describe("embedded attempt harness pinning", () => {
     });
 
     try {
-      await runAgentAttempt({
-        providerOverride: "openai",
-        originalProvider: "openai",
-        modelOverride: "gpt-5.4",
-        cfg: {} as OpenClawConfig,
+      await runHarnessAttempt({
         sessionEntry,
-        sessionId: sessionEntry.sessionId,
-        sessionKey: "agent:main:main",
-        sessionAgentId: "main",
-        sessionFile: path.join(tmpDir, "session.jsonl"),
-        workspaceDir: tmpDir,
-        body: "continue",
-        isFallbackRetry: false,
-        resolvedThinkLevel: "medium",
-        timeoutMs: 1_000,
         runId: "run-codex-auto-auth-profile",
-        opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-        runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-        spawnedBy: undefined,
-        messageChannel: undefined,
-        skillsSnapshot: undefined,
-        resolvedVerboseLevel: undefined,
-        agentDir: tmpDir,
-        onAgentEvent: vi.fn(),
-        authProfileProvider: "openai",
         sessionHasHistory: true,
       });
     } finally {
@@ -4550,81 +3842,32 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("pins a fresh OpenAI session to the Codex harness by default", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "fresh-session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("fresh-session");
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
+    await runHarnessAttempt({
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "start",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-fresh-no-pin",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runEmbeddedAgentMock, { agentHarnessId: undefined });
   });
 
   it("honors a resolved persisted OpenClaw harness", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "stale-agent-session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("stale-agent-session", {
       agentHarnessId: "openclaw",
-    };
+    });
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
+    await runHarnessAttempt({
       sessionEntry,
       agentHarnessRuntimeOverride: "openclaw",
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-stale-openai-runtime-pin",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
       sessionHasHistory: true,
     });
 
@@ -4636,42 +3879,20 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("honors an explicit OpenClaw session runtime override", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "explicit-openclaw-session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("explicit-openclaw-session", {
       agentRuntimeOverride: "openclaw",
       agentHarnessId: "codex",
-    };
+    });
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
+    await runHarnessAttempt({
       modelOverride: "gpt-5.6-luna",
-      cfg: {} as OpenClawConfig,
       sessionEntry,
       agentHarnessRuntimeOverride: "openclaw",
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
       resolvedThinkLevel: "ultra",
-      timeoutMs: 1_000,
       runId: "run-explicit-openclaw-runtime",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
       sessionHasHistory: true,
     });
 
@@ -4685,20 +3906,15 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("routes explicit OpenAI native runs with legacy Codex OAuth through OpenClaw", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "explicit-agent-codex-oauth-session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry("explicit-agent-codex-oauth-session", {
       authProfileOverride: "openai:work",
       authProfileOverrideSource: "user",
-    };
+    });
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
+    await runHarnessAttempt({
       cfg: {
         models: {
           providers: {
@@ -4711,26 +3927,7 @@ describe("embedded attempt harness pinning", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-openai-agent-codex-oauth",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionHasHistory: false,
     });
 
     expectMockArgFields(runEmbeddedAgentMock, {
@@ -4744,18 +3941,13 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("does not pass CLI runtime aliases as embedded harness ids for fallback providers", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "fallback-session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry("fallback-session");
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedAgentRunResult);
 
-    await runAgentAttempt({
-      providerOverride: "openai",
+    await runHarnessAttempt({
       originalProvider: "claude-cli",
-      modelOverride: "gpt-5.4",
       cfg: {
         agents: {
           defaults: {
@@ -4764,26 +3956,9 @@ describe("embedded attempt harness pinning", () => {
         },
       } as OpenClawConfig,
       sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
       body: "fallback",
       isFallbackRetry: true,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
       runId: "run-openai-fallback-with-cli-runtime",
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionHasHistory: false,
     });
 
     expect(runCliAgentMock).not.toHaveBeenCalled();

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -280,19 +280,19 @@ const SUBAGENT_ANNOUNCE_EMBEDDED_DELIVERY_CASES: readonly SubagentAnnounceDelive
 ];
 
 const runAgentAttempt = (params: RunAgentAttemptOverrides) =>
-  runAgentAttemptImpl({
-    ...makeRunAgentAttemptParams(params),
-    lifecycleGeneration: params.lifecycleGeneration ?? "test-generation",
-  });
+  runAgentAttemptImpl(makeRunAgentAttemptParams(params));
 
 type RunAgentAttemptOverrides = Omit<
   Partial<RunAgentAttemptParams>,
   "agentDir" | "opts" | "runContext" | "sessionEntry" | "sessionKey" | "workspaceDir"
-> &
-  Pick<RunAgentAttemptParams, "agentDir" | "sessionEntry" | "sessionKey" | "workspaceDir"> & {
-    opts?: Partial<RunAgentAttemptParams["opts"]>;
-    runContext?: Partial<RunAgentAttemptParams["runContext"]>;
-  };
+> & {
+  agentDir: RunAgentAttemptParams["agentDir"];
+  sessionEntry: NonNullable<RunAgentAttemptParams["sessionEntry"]>;
+  sessionKey: NonNullable<RunAgentAttemptParams["sessionKey"]>;
+  workspaceDir: RunAgentAttemptParams["workspaceDir"];
+  opts?: Partial<RunAgentAttemptParams["opts"]>;
+  runContext?: Partial<RunAgentAttemptParams["runContext"]>;
+};
 
 function makeRunAgentAttemptParams(overrides: RunAgentAttemptOverrides): RunAgentAttemptParams {
   const provider = overrides.providerOverride ?? "openai";
@@ -317,6 +317,7 @@ function makeRunAgentAttemptParams(overrides: RunAgentAttemptOverrides): RunAgen
     authProfileProvider: provider,
     sessionHasHistory: false,
     ...overrides,
+    lifecycleGeneration: overrides.lifecycleGeneration ?? "test-generation",
     opts: { ...overrides.opts } as RunAgentAttemptParams["opts"],
     runContext: { ...overrides.runContext } as RunAgentAttemptParams["runContext"],
   };

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -49,6 +49,8 @@ const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
 const runEmbeddedAgent = runIncompleteTurnOwnerHarness;
 
 type LastAssistant = NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+type AttemptOverrides = Parameters<typeof makeAttemptResult>[0];
+type RunParams = Parameters<typeof runEmbeddedAgent>[0];
 type LastAssistantFixture = Omit<LastAssistant, "content" | "stopReason" | "usage"> & {
   content: Array<Record<string, unknown>>;
   stopReason: LastAssistant["stopReason"] | "end_turn";
@@ -74,6 +76,100 @@ function resolveIncompleteTurnPayloadText(
   // Most helper tests exercise internal abort behavior; external aborts opt in
   // explicitly through params.
   return resolveIncompleteTurnPayloadTextCore({ externalAbort: false, ...params });
+}
+
+function makeBaseRunParams(runId: string, overrides: Partial<RunParams> = {}): RunParams {
+  return { ...overflowBaseRunParams, runId, ...overrides };
+}
+
+function makeRunParams(runId: string, overrides: Partial<RunParams> = {}): RunParams {
+  return {
+    ...overflowBaseRunParams,
+    provider: "openai",
+    model: "gpt-5.5",
+    runId,
+    ...overrides,
+  };
+}
+
+function makeIncompleteTurnParams(
+  attemptOverrides: AttemptOverrides = {},
+  overrides: Partial<Omit<Parameters<typeof resolveIncompleteTurnPayloadText>[0], "attempt">> = {},
+): Parameters<typeof resolveIncompleteTurnPayloadText>[0] {
+  return {
+    payloadCount: 0,
+    aborted: false,
+    timedOut: false,
+    attempt: makeAttemptResult(attemptOverrides),
+    ...overrides,
+  };
+}
+
+function makeReasoningRetryParams(
+  attemptOverrides: AttemptOverrides = {},
+  overrides: Partial<
+    Omit<Parameters<typeof resolveReasoningOnlyRetryInstruction>[0], "attempt">
+  > = {},
+): Parameters<typeof resolveReasoningOnlyRetryInstruction>[0] {
+  return {
+    provider: "openai",
+    modelId: "gpt-5.4",
+    aborted: false,
+    timedOut: false,
+    attempt: makeAttemptResult(attemptOverrides),
+    ...overrides,
+  };
+}
+
+function makeEmptyResponseRetryParams(
+  attemptOverrides: AttemptOverrides = {},
+  overrides: Partial<
+    Omit<Parameters<typeof resolveEmptyResponseRetryInstruction>[0], "attempt">
+  > = {},
+): Parameters<typeof resolveEmptyResponseRetryInstruction>[0] {
+  return {
+    provider: "openai",
+    modelId: "gpt-5.4",
+    payloadCount: 0,
+    aborted: false,
+    timedOut: false,
+    attempt: makeAttemptResult(attemptOverrides),
+    ...overrides,
+  };
+}
+
+function makeSettledContinuationParams(
+  attemptOverrides: AttemptOverrides = {},
+  overrides: Partial<
+    Omit<Parameters<typeof resolveSettledToolTerminalContinuationInstruction>[0], "attempt">
+  > = {},
+): Parameters<typeof resolveSettledToolTerminalContinuationInstruction>[0] {
+  return {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    modelApi: "openai-chatgpt-responses",
+    payloadCount: 0,
+    aborted: false,
+    timedOut: false,
+    attempt: makeAttemptResult(attemptOverrides),
+    ...overrides,
+  };
+}
+
+function makeSilentReplyParams(
+  attempt: EmbeddedRunAttemptResult,
+  overrides: Partial<
+    Omit<Parameters<typeof shouldTreatEmptyAssistantReplyAsSilent>[0], "attempt">
+  > = {},
+): Parameters<typeof shouldTreatEmptyAssistantReplyAsSilent>[0] {
+  return {
+    allowEmptyAssistantReplyAsSilent: true,
+    payloadCount: 0,
+    aborted: false,
+    timedOut: false,
+    attempt,
+    ...overrides,
+  };
 }
 
 describe("runEmbeddedAgent incomplete-turn safety", () => {
@@ -135,10 +231,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      runId: "run-tool-summary-failure-count",
-    });
+    const result = await runEmbeddedAgent(makeBaseRunParams("run-tool-summary-failure-count"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.meta?.toolSummary).toEqual({
@@ -157,10 +250,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      runId: "run-before-agent-run-hook-block",
-    });
+    const result = await runEmbeddedAgent(makeBaseRunParams("run-before-agent-run-hook-block"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toEqual([{ text: "Blocked by before-run policy.", isError: true }]);
@@ -193,12 +283,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-4.1",
-      runId: "run-incomplete-turn-messaging-warning",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-incomplete-turn-messaging-warning", { model: "gpt-4.1" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(mockedClassifyFailoverReason).toHaveBeenCalledTimes(1);
@@ -220,12 +307,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-internal-abort-tool-use-incomplete",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-internal-abort-tool-use-incomplete"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toEqual([
@@ -255,11 +337,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       });
     });
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      runId: "run-caller-timeout",
-      abortSignal: controller.signal,
-    });
+    const result = await runEmbeddedAgent(
+      makeBaseRunParams("run-caller-timeout", { abortSignal: controller.signal }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.at(-1)?.text).toContain("timed out");
@@ -294,11 +374,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       });
     });
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      runId: "run-caller-abort",
-      abortSignal: controller.signal,
-    });
+    const result = await runEmbeddedAgent(
+      makeBaseRunParams("run-caller-abort", { abortSignal: controller.signal }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toBeUndefined();
@@ -326,10 +404,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      runId: "run-canonical-assistant-abort",
-    });
+    const result = await runEmbeddedAgent(makeBaseRunParams("run-canonical-assistant-abort"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.meta?.aborted).toBe(true);
@@ -415,13 +490,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      trigger: "cron",
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-cron-no-reply-empty-final",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-cron-no-reply-empty-final", { trigger: "cron", model: "gpt-5.4" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
@@ -457,12 +528,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       });
     });
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-structured-terminal-presentation",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-structured-terminal-presentation", { model: "gpt-5.4" }),
+    );
 
     expect(result.payloads).toEqual([
       {
@@ -511,12 +579,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       });
     });
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-read-only-cron-terminal-presentation",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-read-only-cron-terminal-presentation", { model: "gpt-5.4" }),
+    );
 
     expect(result.payloads).toEqual([
       {
@@ -569,12 +634,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-preserved-terminal-presentation",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-preserved-terminal-presentation", { model: "gpt-5.4" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toEqual([
@@ -624,12 +686,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       });
     });
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-stale-terminal-presentation",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-stale-terminal-presentation", { model: "gpt-5.4" }),
+    );
 
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
@@ -670,12 +729,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       });
     });
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-side-effect-terminal-presentation",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-side-effect-terminal-presentation", { model: "gpt-5.4" }),
+    );
 
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
@@ -698,12 +754,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-prompt-timeout-final-assistant-recovered",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-prompt-timeout-final-assistant-recovered"),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toEqual([{ text: finalText }]);
@@ -734,12 +787,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-prompt-timeout-stale-assistant",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-prompt-timeout-stale-assistant"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.some((payload) => payload.text?.includes("timed out"))).toBe(true);
@@ -764,12 +812,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-success-stale-transcript-assistant",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-success-stale-transcript-assistant"));
 
     expect(result.payloads).toEqual([{ text: "Current run reply." }]);
     expect(result.meta.finalAssistantVisibleText).toBe("Current run reply.");
@@ -800,12 +843,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-yielded-assistant-classification",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-yielded-assistant-classification"));
 
     expect(result.meta).toMatchObject({ livenessState: "paused", yielded: true });
     expect(mockedBuildEmbeddedRunPayloads).toHaveBeenCalledWith(
@@ -828,12 +866,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-prompt-timeout-no-assistant-texts",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-prompt-timeout-no-assistant-texts"));
 
     expect(result.payloads).toEqual([{ text: finalText }]);
   });
@@ -855,12 +888,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-prompt-timeout-final-assistant-media",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-prompt-timeout-final-assistant-media"),
+    );
 
     expect(result.payloads).toEqual([
       {
@@ -894,12 +924,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-prompt-timeout-latest-partial",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-prompt-timeout-latest-partial"));
 
     expect(result.payloads).toEqual([{ text: completedText }, { text: finalText }]);
   });
@@ -938,12 +963,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-same-model-rate-limit-trace",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-same-model-rate-limit-trace"));
 
     expect(mockedSleepWithAbort).toHaveBeenCalledWith(30_000, undefined);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
@@ -995,12 +1015,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-reasoning-only-continuation",
-    });
+    await runEmbeddedAgent(makeRunParams("run-reasoning-only-continuation", { model: "gpt-5.4" }));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
@@ -1075,12 +1090,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       .mockReturnValueOnce([])
       .mockReturnValueOnce([{ text: "Write completed. Here is the final answer." }]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-tool-use-terminal-continuation",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-tool-use-terminal-continuation"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.text).toBe("Write completed. Here is the final answer.");
@@ -1182,13 +1192,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       .mockReturnValueOnce([{ text: "⚠️ 🛠️ Exec failed", isError: true }])
       .mockReturnValueOnce([{ text: failureText }]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      ...runPolicy,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: `run-settled-failed-tool-${runPolicy.trigger}`,
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams(`run-settled-failed-tool-${runPolicy.trigger}`, runPolicy),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.text).toBe(failureText);
@@ -1240,12 +1246,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     );
     mockedBuildEmbeddedRunPayloads.mockReturnValueOnce([visibleError]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-structured-failed-tool-payload",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-structured-failed-tool-payload"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
     expect(result.payloads?.[0]).toMatchObject(visibleError);
@@ -1283,12 +1284,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       );
     mockedBuildEmbeddedRunPayloads.mockReturnValue([warning]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-failed-tool-finalization-fallback",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-failed-tool-finalization-fallback"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]).toEqual(warning);
@@ -1325,13 +1321,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         });
       });
 
-      const result = await runEmbeddedAgent({
-        ...overflowBaseRunParams,
-        provider: "openai",
-        model: "gpt-5.5",
-        agentHarnessId: "legacy",
-        runId: "run-tool-use-no-finalization-capability",
-      });
+      const result = await runEmbeddedAgent(
+        makeRunParams("run-tool-use-no-finalization-capability", { agentHarnessId: "legacy" }),
+      );
 
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
       expect(result.payloads?.[0]).toMatchObject({ isError: true });
@@ -1372,14 +1364,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       .mockReturnValueOnce([])
       .mockReturnValueOnce([{ text: "Write completed. Here is the final answer." }]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      trigger: "cron",
-      terminalReplyExpectation: "required",
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-empty-stop-settled-tool-continuation",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-empty-stop-settled-tool-continuation", {
+        trigger: "cron",
+        terminalReplyExpectation: "required",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.text).toBe("Write completed. Here is the final answer.");
@@ -1415,14 +1405,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
     mockedBuildEmbeddedRunPayloads.mockReturnValue([]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      trigger: runPolicy.trigger,
-      terminalReplyExpectation: runPolicy.terminalReplyExpectation,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-optional-empty-stop-settled-tool",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-optional-empty-stop-settled-tool", {
+        trigger: runPolicy.trigger,
+        terminalReplyExpectation: runPolicy.terminalReplyExpectation,
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]).toMatchObject({ isError: true });
@@ -1451,13 +1439,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     );
     mockedBuildEmbeddedRunPayloads.mockReturnValue([]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-empty-stop-settled-tool-continuation-exhausted",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-empty-stop-settled-tool-continuation-exhausted", {
+        allowEmptyAssistantReplyAsSilent: true,
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]).toMatchObject({ isError: true });
@@ -1518,12 +1504,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       .mockResolvedValueOnce(makeAttemptResult(finalAttempt));
     mockedBuildEmbeddedRunPayloads.mockReturnValue([]);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-settled-finalizer-sticky-operation",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-settled-finalizer-sticky-operation"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]).toMatchObject({ isError: true });
@@ -1552,12 +1533,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-tool-use-terminal-continuation-exhausted",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-tool-use-terminal-continuation-exhausted"),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.isError).toBe(true);
@@ -1583,12 +1561,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-tool-use-terminal-never-started",
-    });
+    await runEmbeddedAgent(makeRunParams("run-tool-use-terminal-never-started"));
 
     for (let call = 0; call < mockedRunEmbeddedAttempt.mock.calls.length; call += 1) {
       expect(runAttemptCall(call).prompt).not.toContain(
@@ -1620,12 +1593,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-tool-use-terminal-stale-prior-result",
-    });
+    await runEmbeddedAgent(makeRunParams("run-tool-use-terminal-stale-prior-result"));
 
     for (let call = 0; call < mockedRunEmbeddedAttempt.mock.calls.length; call += 1) {
       expect(runAttemptCall(call).prompt).not.toContain(
@@ -1658,12 +1626,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-tool-use-terminal-partial-dispatch",
-    });
+    await runEmbeddedAgent(makeRunParams("run-tool-use-terminal-partial-dispatch"));
 
     for (let call = 0; call < mockedRunEmbeddedAttempt.mock.calls.length; call += 1) {
       expect(runAttemptCall(call).prompt).not.toContain(
@@ -1700,13 +1663,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-reasoning-only-silent",
-    });
+    await runEmbeddedAgent(
+      makeRunParams("run-reasoning-only-silent", { allowEmptyAssistantReplyAsSilent: true }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(runAttemptCall(1).prompt).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
@@ -1743,12 +1702,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       makeAttemptResult({ assistantTexts: ["Visible answer."] }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-reasoning-continuation-missing-assistant",
-    });
+    await runEmbeddedAgent(
+      makeRunParams("run-reasoning-continuation-missing-assistant", { model: "gpt-5.4" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
     expect(runAttemptCall(1)).toMatchObject({
@@ -1783,12 +1739,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-reasoning-only-after-side-effects",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-reasoning-only-after-side-effects", { model: "gpt-5.4" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toBeUndefined();
@@ -1825,12 +1778,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-reasoning-only-assistant-error",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-reasoning-only-assistant-error", { model: "gpt-5.4" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
@@ -1859,12 +1809,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "anthropic",
-      model: "sonnet-4.6",
-      runId: "run-reasoning-only-provider-mismatch",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-reasoning-only-provider-mismatch", {
+        provider: "anthropic",
+        model: "sonnet-4.6",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
@@ -1915,12 +1865,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "kimi",
-      model: "kimi-for-coding",
-      runId: "run-kimi-anthropic-reasoning-only-continuation",
-    });
+    await runEmbeddedAgent(
+      makeRunParams("run-kimi-anthropic-reasoning-only-continuation", {
+        provider: "kimi",
+        model: "kimi-for-coding",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
@@ -1952,12 +1902,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-empty-response-continuation",
-    });
+    await runEmbeddedAgent(makeRunParams("run-empty-response-continuation", { model: "gpt-5.4" }));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
@@ -1991,12 +1936,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-missing-assistant-retry",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-missing-assistant-retry"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(runAttemptCall(1).prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
@@ -2028,12 +1968,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-missing-assistant-same-prompt-retry",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-missing-assistant-same-prompt-retry"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     // The same-prompt replay must not append the inbound user message a second time.
@@ -2080,30 +2015,28 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       makeAttemptResult({ assistantTexts: ["Recovered answer."] }),
     );
 
-    const runPromise = runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-missing-assistant-delayed-persistence",
-      userTurnTranscriptRecorder: {
-        message: persistedMessage,
-        resolveMessage: vi.fn(async () => persistedMessage),
-        markRuntimePersistencePending: vi.fn((pending) => {
-          pendingPersistence = pending;
-        }),
-        markRuntimePersisted: vi.fn(),
-        markBlocked: vi.fn(),
-        hasPersisted: vi.fn(() => false),
-        isBlocked: vi.fn(() => false),
-        hasRuntimePersistencePending: vi.fn(() => pendingPersistence !== undefined),
-        waitForRuntimePersistence: vi.fn(async () => {
-          await pendingPersistence;
-        }),
-        persistApproved,
-        persistBlocked: vi.fn(async () => undefined),
-        persistFallback: vi.fn(async () => undefined),
-      },
-    });
+    const runPromise = runEmbeddedAgent(
+      makeRunParams("run-missing-assistant-delayed-persistence", {
+        userTurnTranscriptRecorder: {
+          message: persistedMessage,
+          resolveMessage: vi.fn(async () => persistedMessage),
+          markRuntimePersistencePending: vi.fn((pending) => {
+            pendingPersistence = pending;
+          }),
+          markRuntimePersisted: vi.fn(),
+          markBlocked: vi.fn(),
+          hasPersisted: vi.fn(() => false),
+          isBlocked: vi.fn(() => false),
+          hasRuntimePersistencePending: vi.fn(() => pendingPersistence !== undefined),
+          waitForRuntimePersistence: vi.fn(async () => {
+            await pendingPersistence;
+          }),
+          persistApproved,
+          persistBlocked: vi.fn(async () => undefined),
+          persistFallback: vi.fn(async () => undefined),
+        },
+      }),
+    );
 
     await vi.waitFor(() => {
       expect(persistApproved).toHaveBeenCalledOnce();
@@ -2143,12 +2076,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-missing-assistant-unpersisted-retry",
-    });
+    await runEmbeddedAgent(makeRunParams("run-missing-assistant-unpersisted-retry"));
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(runAttemptCall(1).suppressNextUserMessagePersistence).toBe(false);
@@ -2190,12 +2118,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "anthropic",
-      model: "claude-opus-4.7",
-      runId: "run-empty-zero-usage-claude-continuation",
-    });
+    await runEmbeddedAgent(
+      makeRunParams("run-empty-zero-usage-claude-continuation", {
+        provider: "anthropic",
+        model: "claude-opus-4.7",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
@@ -2254,12 +2182,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "llamacpp",
-      model: "qwen3.6-27b",
-      runId: "run-empty-openai-compatible-stop-continuation",
-    });
+    await runEmbeddedAgent(
+      makeRunParams("run-empty-openai-compatible-stop-continuation", {
+        provider: "llamacpp",
+        model: "qwen3.6-27b",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
@@ -2318,12 +2246,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "sub2api",
-      model: "claude-opus-4-7",
-      runId: "run-empty-anthropic-compatible-stop-continuation",
-    });
+    await runEmbeddedAgent(
+      makeRunParams("run-empty-anthropic-compatible-stop-continuation", {
+        provider: "sub2api",
+        model: "claude-opus-4-7",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
@@ -2344,12 +2272,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-empty-response-exhausted",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-empty-response-exhausted", { model: "gpt-5.4" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.isError).toBe(true);
@@ -2379,13 +2304,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      reasoningLevel: "on",
-      runId: "run-reasoning-only-exhausted",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-reasoning-only-exhausted", {
+        model: "gpt-5.4",
+        reasoningLevel: "on",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
     expect(result.payloads?.[0]?.isError).toBe(true);
@@ -2433,13 +2357,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
     mockedRunEmbeddedAttempt.mockImplementation(reasoningOnlyAttempt);
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      reasoningLevel: "on",
-      runId: "run-reasoning-terminal-presentation",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-reasoning-terminal-presentation", {
+        model: "gpt-5.4",
+        reasoningLevel: "on",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
     expect(result.payloads).toEqual([
@@ -2526,22 +2449,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       stopReason: "toolUse",
       content: [{ type: "tool_use", id: "tool_1", name: "bash", input: {} }],
     });
-    const instruction = resolveSettledToolTerminalContinuationInstruction({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      payloadCount: 0,
-      aborted,
-      timedOut,
-      promptError,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        toolMetas: [{ toolName: "bash" }],
-        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-        lastAssistant: toolUseAssistant,
-        currentAttemptAssistant: toolUseAssistant,
-      }),
-    });
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams(
+        {
+          assistantTexts: [],
+          toolMetas: [{ toolName: "bash" }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          lastAssistant: toolUseAssistant,
+          currentAttemptAssistant: toolUseAssistant,
+        },
+        { aborted, timedOut, promptError },
+      ),
+    );
 
     expect(instruction).toBeNull();
   });
@@ -2562,14 +2481,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           { type: "toolCall", id: "tool_failed", name: "exec", arguments: {} },
         ],
       });
-      const instruction = resolveSettledToolTerminalContinuationInstruction({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-chatgpt-responses",
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: makeAttemptResult({
+      const instruction = resolveSettledToolTerminalContinuationInstruction(
+        makeSettledContinuationParams({
           assistantTexts: [],
           toolMetas: [{ toolName: "read" }, { toolName: "exec", isError: true }],
           itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
@@ -2582,7 +2495,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           currentAttemptAssistant: toolUseAssistant,
           lastToolError,
         }),
-      });
+      );
 
       expect(instruction).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
       expect(instruction).toContain(
@@ -2607,14 +2520,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       stopReason: "toolUse",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
     });
-    const instruction = resolveSettledToolTerminalContinuationInstruction({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams({
         assistantTexts: [],
         toolMetas: [{ toolName: resultToolName, isError: true }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
@@ -2631,7 +2538,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         currentAttemptAssistant: toolUseAssistant,
         lastToolError: { toolName: lastErrorToolName, error: "post-processing error" },
       }),
-    });
+    );
 
     expect(instruction).toBeNull();
   });
@@ -2644,14 +2551,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         { type: "toolCall", id: "tool_2", name: "exec", arguments: {} },
       ],
     });
-    const instruction = resolveSettledToolTerminalContinuationInstruction({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams({
         assistantTexts: [],
         toolMetas: [{ toolName: "exec", isError: true }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
@@ -2663,7 +2564,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         currentAttemptAssistant: toolUseAssistant,
         lastToolError: { toolName: "exec", error: "post-processing error" },
       }),
-    });
+    );
 
     expect(instruction).toBeNull();
   });
@@ -2698,14 +2599,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       stopReason: "toolUse",
       content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
     });
-    const instruction = resolveSettledToolTerminalContinuationInstruction({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams({
         assistantTexts: [],
         toolMetas: [{ toolName: "exec", isError: true }],
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
@@ -2718,7 +2613,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         lastToolError: { toolName: "exec", error: "post-processing error" },
         ...attemptOverrides,
       }),
-    });
+    );
 
     expect(instruction).toBeNull();
   });
@@ -2750,22 +2645,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       isError,
     }) => {
       const emptyStopAssistant = makeLastAssistant();
-      const instruction = resolveSettledToolTerminalContinuationInstruction({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-chatgpt-responses",
-        allowEmptyStopContinuation,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: makeAttemptResult({
-          assistantTexts: [],
-          toolMetas: [{ toolName: "write", asyncStarted, isError }],
-          itemLifecycle: { startedCount, completedCount, activeCount },
-          lastAssistant: emptyStopAssistant,
-          currentAttemptAssistant: emptyStopAssistant,
-        }),
-      });
+      const instruction = resolveSettledToolTerminalContinuationInstruction(
+        makeSettledContinuationParams(
+          {
+            assistantTexts: [],
+            toolMetas: [{ toolName: "write", asyncStarted, isError }],
+            itemLifecycle: { startedCount, completedCount, activeCount },
+            lastAssistant: emptyStopAssistant,
+            currentAttemptAssistant: emptyStopAssistant,
+          },
+          { allowEmptyStopContinuation },
+        ),
+      );
 
       expect(instruction).toBeNull();
     },
@@ -2773,69 +2664,65 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("does not use a stale prior-turn empty stop to prove a settled continuation", () => {
     const staleEmptyStopAssistant = makeLastAssistant();
-    const instruction = resolveSettledToolTerminalContinuationInstruction({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      allowEmptyStopContinuation: true,
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        toolMetas: [{ toolName: "write" }],
-        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-        lastAssistant: staleEmptyStopAssistant,
-        currentAttemptAssistant: undefined,
-      }),
-    });
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams(
+        {
+          assistantTexts: [],
+          toolMetas: [{ toolName: "write" }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          lastAssistant: staleEmptyStopAssistant,
+          currentAttemptAssistant: undefined,
+        },
+        { allowEmptyStopContinuation: true },
+      ),
+    );
 
     expect(instruction).toBeNull();
   });
 
   it("does not flag stale lastAssistant=toolUse when currentAttemptAssistant=stop exists (#80918)", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Analysis...", "Here is the final answer after update_plan."],
-        toolMetas: [{ toolName: "update_plan" }],
-        lastAssistant: makeLastAssistant({
-          stopReason: "toolUse",
-          content: [
-            { type: "text", text: "Analysis..." },
-            { type: "tool_use", id: "tool_1", name: "update_plan", input: {} },
-          ],
-        }),
-        currentAttemptAssistant: makeLastAssistant({
-          content: [{ type: "text", text: "Here is the final answer after update_plan." }],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Analysis...", "Here is the final answer after update_plan."],
+          toolMetas: [{ toolName: "update_plan" }],
+          lastAssistant: makeLastAssistant({
+            stopReason: "toolUse",
+            content: [
+              { type: "text", text: "Analysis..." },
+              { type: "tool_use", id: "tool_1", name: "update_plan", input: {} },
+            ],
+          }),
+          currentAttemptAssistant: makeLastAssistant({
+            content: [{ type: "text", text: "Here is the final answer after update_plan." }],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("still flags incomplete-turn when currentAttemptAssistant is absent and lastAssistant=toolUse (#76477 regression)", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Let me update the file..."],
-        toolMetas: [{ toolName: "write" }],
-        lastAssistant: makeLastAssistant({
-          stopReason: "toolUse",
-          model: "gpt-5.4",
-          content: [
-            { type: "text", text: "Let me update the file..." },
-            { type: "tool_use", id: "tool_1", name: "write", input: {} },
-          ],
-        }),
-        currentAttemptAssistant: undefined,
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Let me update the file..."],
+          toolMetas: [{ toolName: "write" }],
+          lastAssistant: makeLastAssistant({
+            stopReason: "toolUse",
+            model: "gpt-5.4",
+            content: [
+              { type: "text", text: "Let me update the file..." },
+              { type: "tool_use", id: "tool_1", name: "write", input: {} },
+            ],
+          }),
+          currentAttemptAssistant: undefined,
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
   });
@@ -2942,34 +2829,31 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     // text alone must not suppress the incomplete-turn guard. The model
     // expected to continue after tool results but the post-tool response was
     // never produced.
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Initial analysis of the codebase..."],
-        toolMetas: [{ toolName: "read", meta: "path=src/index.ts" }],
-        lastAssistant: makeLastAssistant({
-          stopReason: "toolUse",
-          provider: "anthropic",
-          model: "sonnet-4.6",
-          content: [
-            { type: "text", text: "Initial analysis of the codebase..." },
-            { type: "tool_use", id: "tool_1", name: "read", input: { path: "src/index.ts" } },
-          ],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Initial analysis of the codebase..."],
+          toolMetas: [{ toolName: "read", meta: "path=src/index.ts" }],
+          lastAssistant: makeLastAssistant({
+            stopReason: "toolUse",
+            provider: "anthropic",
+            model: "sonnet-4.6",
+            content: [
+              { type: "text", text: "Initial analysis of the codebase..." },
+              { type: "tool_use", id: "tool_1", name: "read", input: { path: "src/index.ts" } },
+            ],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
   });
 
   it("does not surface incomplete-turn error while an async media task is running", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         toolMetas: [
           {
@@ -2991,29 +2875,29 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           ],
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("surfaces tool-use terminal with pre-tool text and side effects as replay-unsafe (#76477)", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Let me update the file..."],
-        toolMetas: [{ toolName: "write" }],
-        lastAssistant: makeLastAssistant({
-          stopReason: "toolUse",
-          model: "gpt-5.4",
-          content: [
-            { type: "text", text: "Let me update the file..." },
-            { type: "tool_use", id: "tool_1", name: "write", input: {} },
-          ],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Let me update the file..."],
+          toolMetas: [{ toolName: "write" }],
+          lastAssistant: makeLastAssistant({
+            stopReason: "toolUse",
+            model: "gpt-5.4",
+            content: [
+              { type: "text", text: "Let me update the file..." },
+              { type: "tool_use", id: "tool_1", name: "write", input: {} },
+            ],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toContain("verify before retrying");
   });
@@ -3021,21 +2905,21 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("does not flag a completed tool-use turn with end_turn as incomplete (#76477)", () => {
     // When the model successfully produces post-tool text, lastAssistant has
     // stopReason=end_turn. The incomplete-turn guard should not fire.
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Initial analysis...", "Here is the final answer."],
-        toolMetas: [{ toolName: "read" }],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "anthropic",
-          model: "sonnet-4.6",
-          content: [{ type: "text", text: "Here is the final answer." }],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Initial analysis...", "Here is the final answer."],
+          toolMetas: [{ toolName: "read" }],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "anthropic",
+            model: "sonnet-4.6",
+            content: [{ type: "text", text: "Here is the final answer." }],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
@@ -3044,24 +2928,24 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     // Regression: unsigned thinking payloads increment payloadCount but carry no
     // user-visible content. The visible-text guard must not suppress incomplete-turn
     // detection when the model produced only a thinking block and no answer. (#89787)
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          model: "qwen3.6-35b-a3b",
-          content: [
-            {
-              type: "thinking",
-              thinking: "let me plan the tool calls I need to make...",
-              // no signature — unsigned thinking block
-            },
-          ],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            model: "qwen3.6-35b-a3b",
+            content: [
+              {
+                type: "thinking",
+                thinking: "let me plan the tool calls I need to make...",
+                // no signature — unsigned thinking block
+              },
+            ],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
   });
@@ -3069,24 +2953,24 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("does not surface a stall when unsigned thinking accompanies visible text (payloadCount=1)", () => {
     // When the model emits both a thinking block and a visible text answer, the turn
     // succeeded and no stall should be surfaced even though thinking is unsigned.
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Here is the answer to your question."],
-        lastAssistant: makeLastAssistant({
-          model: "qwen3.6-35b-a3b",
-          content: [
-            {
-              type: "thinking",
-              thinking: "let me answer this...",
-            },
-            { type: "text", text: "Here is the answer to your question." },
-          ],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Here is the answer to your question."],
+          lastAssistant: makeLastAssistant({
+            model: "qwen3.6-35b-a3b",
+            content: [
+              {
+                type: "thinking",
+                thinking: "let me answer this...",
+              },
+              { type: "text", text: "Here is the answer to your question." },
+            ],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
@@ -3109,12 +2993,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "anthropic",
-      model: "sonnet-4.6",
-      runId: "run-tool-use-dropped-final-text",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-tool-use-dropped-final-text", {
+        provider: "anthropic",
+        model: "sonnet-4.6",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
@@ -3142,12 +3026,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-current-assistant-after-tool-use",
-    });
+    const result = await runEmbeddedAgent(makeRunParams("run-current-assistant-after-tool-use"));
 
     expect(result.payloads).toEqual([{ text: finalText }]);
     expect(mockedBuildEmbeddedRunPayloads).toHaveBeenCalledWith(
@@ -3186,12 +3065,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("detects reasoning-only GPT turns from signed thinking blocks", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams({
         assistantTexts: [],
         lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
@@ -3205,317 +3080,296 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           ],
         }),
       }),
-    });
+    );
 
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("detects reasoning-only Gemini turns from signed thinking blocks", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "google",
-      modelId: "gemini-2.5-pro",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "google",
-          model: "gemini-2.5-pro",
-          content: [
-            {
-              type: "thinking",
-              thinking: "internal reasoning",
-              thinkingSignature: JSON.stringify({ id: "gemini_rs_helper", type: "reasoning" }),
-            },
-          ],
-        }),
-      }),
-    });
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "google",
+            model: "gemini-2.5-pro",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+                thinkingSignature: JSON.stringify({ id: "gemini_rs_helper", type: "reasoning" }),
+              },
+            ],
+          }),
+        },
+        { provider: "google", modelId: "gemini-2.5-pro" },
+      ),
+    );
 
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("retries signed reasoning-only Bedrock Converse turns with a visible-answer continuation", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "amazon-bedrock",
-      modelId: "openai.gpt-oss-120b-1:0",
-      modelApi: "bedrock-converse-stream",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            provider: "amazon-bedrock",
+            model: "openai.gpt-oss-120b-1:0",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+                thinkingSignature: "bedrock-reasoning-signature",
+              },
+            ],
+          }),
+        },
+        {
           provider: "amazon-bedrock",
-          model: "openai.gpt-oss-120b-1:0",
-          content: [
-            {
-              type: "thinking",
-              thinking: "internal reasoning",
-              thinkingSignature: "bedrock-reasoning-signature",
-            },
-          ],
-        }),
-      }),
-    });
+          modelId: "openai.gpt-oss-120b-1:0",
+          modelApi: "bedrock-converse-stream",
+        },
+      ),
+    );
 
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("retries signed reasoning-only Ollama turns with a visible-answer continuation instruction", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "ollama",
-          model: "gemma4:31b",
-          content: [
-            {
-              type: "thinking",
-              thinking: "internal reasoning",
-              thinkingSignature: JSON.stringify({ id: "ollama_rs_helper", type: "reasoning" }),
-            },
-          ],
-        }),
-      }),
-    });
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "ollama",
+            model: "gemma4:31b",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+                thinkingSignature: JSON.stringify({ id: "ollama_rs_helper", type: "reasoning" }),
+              },
+            ],
+          }),
+        },
+        { provider: "ollama", modelId: "gemma4:31b" },
+      ),
+    );
 
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("retries unsigned thinking-only turns via the reasoning-only path (openai-completions)", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "qwen3.6-35b-a3b",
-      modelApi: "openai-completions",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          model: "qwen3.6-35b-a3b",
-          content: [
-            {
-              type: "thinking",
-              thinking: "let me plan the tool calls I need to make...",
-            },
-          ],
-        }),
-      }),
-    });
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            model: "qwen3.6-35b-a3b",
+            content: [
+              {
+                type: "thinking",
+                thinking: "let me plan the tool calls I need to make...",
+              },
+            ],
+          }),
+        },
+        { modelId: "qwen3.6-35b-a3b", modelApi: "openai-completions" },
+      ),
+    );
 
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("retries unsigned thinking-only Ollama turns via the reasoning-only path", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "ollama",
-          model: "gemma4:31b",
-          content: [
-            {
-              type: "thinking",
-              thinking: "internal reasoning",
-            },
-          ],
-        }),
-      }),
-    });
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "ollama",
+            model: "gemma4:31b",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+              },
+            ],
+          }),
+        },
+        { provider: "ollama", modelId: "gemma4:31b" },
+      ),
+    );
 
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("retries unsigned-thinking Ollama turns via the empty-response path", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "ollama",
-          model: "gemma4:31b",
-          content: [
-            {
-              type: "thinking",
-              thinking: "internal reasoning",
-            },
-          ],
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "ollama",
+            model: "gemma4:31b",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+              },
+            ],
+          }),
+        },
+        { provider: "ollama", modelId: "gemma4:31b" },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("retries generic empty Ollama turns without visible text", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "ollama",
-          model: "gemma4:31b",
-          content: [{ type: "text", text: "" }],
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "ollama",
+            model: "gemma4:31b",
+            content: [{ type: "text", text: "" }],
+          }),
+        },
+        { provider: "ollama", modelId: "gemma4:31b" },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("retries empty Ollama stop turns when nonzero output tokens were generated", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "ollama",
-      modelId: "minimax-m2.7:cloud",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          provider: "ollama",
-          model: "minimax-m2.7:cloud",
-          usage: { input: 100, output: 6, totalTokens: 106 },
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            provider: "ollama",
+            model: "minimax-m2.7:cloud",
+            usage: { input: 100, output: 6, totalTokens: 106 },
+          }),
+        },
+        { provider: "ollama", modelId: "minimax-m2.7:cloud" },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("does not retry empty turns after an accepted sessions_spawn delivery", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        acceptedSessionSpawns: [
-          {
-            runId: "run-child",
-            childSessionKey: "agent:claude:subagent:child",
-          },
-        ],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "ollama",
-          model: "gemma4:31b",
-          content: [{ type: "text", text: "" }],
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          acceptedSessionSpawns: [
+            {
+              runId: "run-child",
+              childSessionKey: "agent:claude:subagent:child",
+            },
+          ],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "ollama",
+            model: "gemma4:31b",
+            content: [{ type: "text", text: "" }],
+          }),
+        },
+        { provider: "ollama", modelId: "gemma4:31b" },
+      ),
+    );
 
     expect(retryInstruction).toBeNull();
   });
 
   it("retries empty openai-chatgpt-responses turns with non-zero output tokens (#85364)", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          usage: { input: 24794, output: 111, cacheRead: 4608, totalTokens: 29513 },
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            usage: { input: 24794, output: 111, cacheRead: 4608, totalTokens: 29513 },
+          }),
+        },
+        { modelId: "gpt-5.5", modelApi: "openai-chatgpt-responses" },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("retries empty openai-responses turns without visible text", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          usage: { input: 5000, output: 200, totalTokens: 5200 },
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            usage: { input: 5000, output: 200, totalTokens: 5200 },
+          }),
+        },
+        { modelId: "gpt-5.5", modelApi: "openai-responses" },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("retries generic empty OpenAI-compatible turns from custom endpoints", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "llama-cpp-local",
-      modelId: "qwen3.6-27b",
-      modelApi: "openai-completions",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            provider: "llama-cpp-local",
+            model: "qwen3.6-27b",
+            usage: { input: 950, output: 103, totalTokens: 1053 },
+          }),
+        },
+        {
           provider: "llama-cpp-local",
-          model: "qwen3.6-27b",
-          usage: { input: 950, output: 103, totalTokens: 1053 },
-        }),
-      }),
-    });
+          modelId: "qwen3.6-27b",
+          modelApi: "openai-completions",
+        },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("does not retry clean zero-token Ollama stop turns", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "ollama",
-      modelId: "glm-5.1:cloud",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          provider: "ollama",
-          model: "glm-5.1:cloud",
-          usage: { input: 100, output: 0, totalTokens: 100 },
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            provider: "ollama",
+            model: "glm-5.1:cloud",
+            usage: { input: 100, output: 0, totalTokens: 100 },
+          }),
+        },
+        { provider: "ollama", modelId: "glm-5.1:cloud" },
+      ),
+    );
 
     expect(retryInstruction).toBeNull();
   });
 
   it("treats exact NO_REPLY as a deliberate silent assistant reply", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: ["NO_REPLY"],
         lastAssistant: makeLastAssistant({
           model: "gpt-5.4",
@@ -3530,17 +3384,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           ],
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("suppresses the incomplete-turn warning after committed messaging text delivery", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered through the message tool."],
@@ -3549,17 +3400,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           model: "kimi-k2.6:cloud",
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("suppresses the incomplete-turn warning after committed messaging delivery before end_turn", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered through the message tool."],
@@ -3576,17 +3424,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           ],
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("suppresses the incomplete-turn warning after committed media-only messaging delivery", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         didSendViaMessagingTool: false,
         messagingToolSentMediaUrls: ["file:///tmp/render.png"],
@@ -3595,17 +3440,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           model: "gpt-5.4",
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("suppresses the incomplete-turn warning after committed messaging delivery even when the provider errored", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered before the provider error."],
@@ -3616,7 +3458,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           errorMessage: "provider failed after delivery",
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
@@ -3638,12 +3480,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     };
 
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult(attemptWithAcceptedSpawn),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(attemptWithAcceptedSpawn),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
@@ -3668,12 +3507,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-timeout-after-accepted-spawn",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-timeout-after-accepted-spawn", { model: "gpt-5.4" }),
+    );
 
     expect(result.payloads).toEqual([
       {
@@ -3696,22 +3532,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     };
 
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult(attemptWithMalformedSpawn),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(attemptWithMalformedSpawn),
+    );
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
   });
 
   it("still surfaces the incomplete-turn warning when no messaging delivery was committed", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         didSendViaMessagingTool: true,
         lastAssistant: makeLastAssistant({
@@ -3721,7 +3551,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           errorMessage: "provider failed mid-turn",
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toContain("verify before retrying");
   });
@@ -3754,50 +3584,38 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(true);
   });
 
-  it("treats committed messaging text as replay-invalid side effect metadata", () => {
-    expect(
-      buildAttemptReplayMetadata({
-        toolMetas: [],
-        didSendViaMessagingTool: false,
-        messagingToolSentTexts: ["Delivered through the message tool."],
-        messagingToolSentMediaUrls: [],
-      }),
-    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
-  });
-
-  it("treats async-started background tools as replay-invalid side effects", () => {
-    expect(
-      buildAttemptReplayMetadata({
-        toolMetas: [{ toolName: "image_generate", asyncStarted: true }],
-        didSendViaMessagingTool: false,
-        messagingToolSentTexts: [],
-        messagingToolSentMediaUrls: [],
-      }),
-    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
-  });
-
-  it("treats committed messaging media as replay-invalid side effect metadata", () => {
-    expect(
-      buildAttemptReplayMetadata({
-        toolMetas: [],
-        didSendViaMessagingTool: false,
-        messagingToolSentTexts: [],
-        messagingToolSentMediaUrls: ["file:///tmp/render.png"],
-      }),
-    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
-  });
-
-  it("treats committed messaging targets as replay-invalid side effect metadata", () => {
-    expect(
-      buildAttemptReplayMetadata({
-        toolMetas: [],
-        didSendViaMessagingTool: false,
-        messagingToolSentTexts: [],
-        messagingToolSentMediaUrls: [],
+  for (const { name, overrides } of [
+    {
+      name: "treats committed messaging text as replay-invalid side effect metadata",
+      overrides: { messagingToolSentTexts: ["Delivered through the message tool."] },
+    },
+    {
+      name: "treats async-started background tools as replay-invalid side effects",
+      overrides: { toolMetas: [{ toolName: "image_generate", asyncStarted: true }] },
+    },
+    {
+      name: "treats committed messaging media as replay-invalid side effect metadata",
+      overrides: { messagingToolSentMediaUrls: ["file:///tmp/render.png"] },
+    },
+    {
+      name: "treats committed messaging targets as replay-invalid side effect metadata",
+      overrides: {
         messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel-1" }],
-      }),
-    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
-  });
+      },
+    },
+  ]) {
+    it(name, () => {
+      expect(
+        buildAttemptReplayMetadata({
+          toolMetas: [],
+          didSendViaMessagingTool: false,
+          messagingToolSentTexts: [],
+          messagingToolSentMediaUrls: [],
+          ...overrides,
+        }),
+      ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+    });
+  }
 
   it("treats accepted sessions_spawn as replay-invalid outbound delivery", () => {
     const acceptedSessionSpawns = [
@@ -3834,11 +3652,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("leaves committed delivery plus tool errors to the tool-error payload path", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         didSendViaMessagingTool: true,
         messagingToolSentTexts: ["Delivered through the message tool."],
@@ -3852,18 +3667,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           model: "gpt-5.4",
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("does not retry reasoning-only GPT turns after side effects", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams({
         assistantTexts: [],
         didSendViaMessagingTool: true,
         lastAssistant: makeLastAssistant({
@@ -3878,19 +3689,15 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           ],
         }),
       }),
-    });
+    );
 
     expect(retryInstruction).toBeNull();
     expect(DEFAULT_REASONING_ONLY_RETRY_LIMIT).toBe(2);
   });
 
   it("does not retry reasoning-only GPT turns when the assistant ended in error", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams({
         assistantTexts: [],
         lastAssistant: makeLastAssistant({
           stopReason: "error",
@@ -3904,18 +3711,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           ],
         }),
       }),
-    });
+    );
 
     expect(retryInstruction).toBeNull();
   });
 
   it("does not retry reasoning-only GPT turns when visible assistant text already exists", () => {
-    const retryInstruction = resolveReasoningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const retryInstruction = resolveReasoningOnlyRetryInstruction(
+      makeReasoningRetryParams({
         assistantTexts: ["Visible answer."],
         lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
@@ -3933,129 +3736,129 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           ],
         }),
       }),
-    });
+    );
 
     expect(retryInstruction).toBeNull();
   });
 
   it("surfaces incomplete-turn text for errored signed-thinking-only turns with payloads", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          stopReason: "error",
-          provider: "anthropic",
-          model: "claude-opus-4-8",
-          content: [
-            {
-              type: "thinking",
-              thinking: "internal reasoning before provider error",
-              thinkingSignature: JSON.stringify({ id: "rs_error_payload", type: "reasoning" }),
-            },
-          ],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            stopReason: "error",
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning before provider error",
+                thinkingSignature: JSON.stringify({ id: "rs_error_payload", type: "reasoning" }),
+              },
+            ],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
   });
 
   it("surfaces incomplete-turn text for token-limited partial answers", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Partial answer"],
-        lastAssistant: makeLastAssistant({
-          stopReason: "length",
-          provider: "ollama",
-          model: "qwen3.5",
-          content: [{ type: "text", text: "Partial answer" }],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Partial answer"],
+          lastAssistant: makeLastAssistant({
+            stopReason: "length",
+            provider: "ollama",
+            model: "qwen3.5",
+            content: [{ type: "text", text: "Partial answer" }],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
   });
 
   it("keeps complete visible stop turns successful", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Complete answer"],
-        lastAssistant: makeLastAssistant({
-          provider: "ollama",
-          model: "qwen3.5",
-          content: [{ type: "text", text: "Complete answer" }],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Complete answer"],
+          lastAssistant: makeLastAssistant({
+            provider: "ollama",
+            model: "qwen3.5",
+            content: [{ type: "text", text: "Complete answer" }],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("preserves terminal tool media on token-limited turns", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Partial answer"],
-        toolMediaUrls: ["file:///tmp/render.png"],
-        lastAssistant: makeLastAssistant({
-          stopReason: "length",
-          provider: "ollama",
-          model: "qwen3.5",
-          content: [{ type: "text", text: "Partial answer" }],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Partial answer"],
+          toolMediaUrls: ["file:///tmp/render.png"],
+          lastAssistant: makeLastAssistant({
+            stopReason: "length",
+            provider: "ollama",
+            model: "qwen3.5",
+            content: [{ type: "text", text: "Partial answer" }],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("preserves tool media already delivered through block replies", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Partial answer"],
-        hasToolMediaBlockReply: true,
-        lastAssistant: makeLastAssistant({
-          stopReason: "length",
-          provider: "ollama",
-          model: "qwen3.5",
-          content: [{ type: "text", text: "Partial answer" }],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Partial answer"],
+          hasToolMediaBlockReply: true,
+          lastAssistant: makeLastAssistant({
+            stopReason: "length",
+            provider: "ollama",
+            model: "qwen3.5",
+            content: [{ type: "text", text: "Partial answer" }],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
 
   it("preserves successful cron progress on token-limited turns", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Partial answer"],
-        successfulCronAdds: 1,
-        lastAssistant: makeLastAssistant({
-          stopReason: "length",
-          provider: "ollama",
-          model: "qwen3.5",
-          content: [{ type: "text", text: "Partial answer" }],
-        }),
-      }),
-    });
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams(
+        {
+          assistantTexts: ["Partial answer"],
+          successfulCronAdds: 1,
+          lastAssistant: makeLastAssistant({
+            stopReason: "length",
+            provider: "ollama",
+            model: "qwen3.5",
+            content: [{ type: "text", text: "Partial answer" }],
+          }),
+        },
+        { payloadCount: 1 },
+      ),
+    );
 
     expect(incompleteTurnText).toBeNull();
   });
@@ -4082,30 +3885,30 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   ] satisfies Array<[string, Partial<EmbeddedRunAttemptResult>]>)(
     "does not replace terminal %s with an incomplete-turn warning",
     (_label, attemptState) => {
-      const incompleteTurnText = resolveIncompleteTurnPayloadText({
-        payloadCount: 1,
-        aborted: false,
-        timedOut: false,
-        attempt: makeAttemptResult({
-          assistantTexts: [],
-          ...attemptState,
-          lastAssistant: makeLastAssistant({
-            stopReason: "error",
-            provider: "anthropic",
-            model: "claude-opus-4-8",
-            content: [
-              {
-                type: "thinking",
-                thinking: "internal reasoning before provider error",
-                thinkingSignature: JSON.stringify({
-                  id: "rs_terminal_payload",
-                  type: "reasoning",
-                }),
-              },
-            ],
-          }),
-        }),
-      });
+      const incompleteTurnText = resolveIncompleteTurnPayloadText(
+        makeIncompleteTurnParams(
+          {
+            assistantTexts: [],
+            ...attemptState,
+            lastAssistant: makeLastAssistant({
+              stopReason: "error",
+              provider: "anthropic",
+              model: "claude-opus-4-8",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "internal reasoning before provider error",
+                  thinkingSignature: JSON.stringify({
+                    id: "rs_terminal_payload",
+                    type: "reasoning",
+                  }),
+                },
+              ],
+            }),
+          },
+          { payloadCount: 1 },
+        ),
+      );
 
       expect(incompleteTurnText).toBeNull();
     },
@@ -4247,34 +4050,26 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   );
 
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "llamacpp",
-      modelId: "qwen3.6-27b",
-      modelApi: "openai-completions",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          provider: "llamacpp",
-          model: "qwen3.6-27b",
-          usage: { input: 512, output: 103, totalTokens: 615 },
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            provider: "llamacpp",
+            model: "qwen3.6-27b",
+            usage: { input: 512, output: 103, totalTokens: 615 },
+          }),
+        },
+        { provider: "llamacpp", modelId: "qwen3.6-27b", modelApi: "openai-completions" },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("detects generic empty GPT turns without visible text", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams({
         assistantTexts: [],
         lastAssistant: makeLastAssistant({
           stopReason: "end_turn",
@@ -4282,18 +4077,15 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           content: [{ type: "text", text: "" }],
         }),
       }),
-    });
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     expect(DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
   });
 
   it("surfaces empty Codex app-server replies after successful sparse bash output", () => {
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const incompleteTurnText = resolveIncompleteTurnPayloadText(
+      makeIncompleteTurnParams({
         assistantTexts: [],
         toolMetas: [{ toolName: "bash", meta: "exit=0" }],
         messagesSnapshot: [
@@ -4310,30 +4102,31 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           content: [{ type: "text", text: "" }],
         }),
       }),
-    });
+    );
 
     expect(incompleteTurnText).toContain("couldn't generate a response");
     expect(incompleteTurnText).toContain("verify before retrying");
   });
 
   it("retries generic empty Bedrock Converse turns without visible text", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "amazon-bedrock",
-      modelId: "openai.gpt-oss-120b-1:0",
-      modelApi: "bedrock-converse-stream",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            provider: "amazon-bedrock",
+            model: "openai.gpt-oss-120b-1:0",
+            content: [{ type: "text", text: "" }],
+            usage: { input: 950, output: 103, totalTokens: 1053 },
+          }),
+        },
+        {
           provider: "amazon-bedrock",
-          model: "openai.gpt-oss-120b-1:0",
-          content: [{ type: "text", text: "" }],
-          usage: { input: 950, output: 103, totalTokens: 1053 },
-        }),
-      }),
-    });
+          modelId: "openai.gpt-oss-120b-1:0",
+          modelApi: "bedrock-converse-stream",
+        },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
@@ -4346,33 +4139,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     });
 
+    expect(shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(attempt))).toBe(false);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
-    ).toBe(false);
-    expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        terminalReplyExpectation: "optional",
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(attempt, { terminalReplyExpectation: "optional" }),
+      ),
     ).toBe(true);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: false,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(attempt, { allowEmptyAssistantReplyAsSilent: false }),
+      ),
     ).toBe(false);
   });
 
@@ -4391,33 +4167,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     });
 
+    expect(shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(attempt))).toBe(false);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
-    ).toBe(false);
-    expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        terminalReplyExpectation: "optional",
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(attempt, { terminalReplyExpectation: "optional" }),
+      ),
     ).toBe(true);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: false,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(attempt, { allowEmptyAssistantReplyAsSilent: false }),
+      ),
     ).toBe(false);
   });
 
@@ -4429,23 +4188,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     });
 
+    expect(shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(attempt))).toBe(true);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
-    ).toBe(true);
-    expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: false,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(attempt, { allowEmptyAssistantReplyAsSilent: false }),
+      ),
     ).toBe(false);
   });
 
@@ -4458,15 +4205,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     });
 
-    expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt,
-      }),
-    ).toBe(true);
+    expect(shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(attempt))).toBe(true);
   });
 
   it("does not treat error or side-effect empty turns as silent", () => {
@@ -4501,41 +4240,15 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     });
 
+    expect(shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(errorAttempt))).toBe(false);
+    expect(shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(silentErrorAttempt))).toBe(
+      false,
+    );
+    expect(shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(sideEffectAttempt))).toBe(
+      false,
+    );
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: errorAttempt,
-      }),
-    ).toBe(false);
-    expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: silentErrorAttempt,
-      }),
-    ).toBe(false);
-    expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: sideEffectAttempt,
-      }),
-    ).toBe(false);
-    expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: postToolEmptyAttempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(postToolEmptyAttempt)),
     ).toBe(false);
   });
 
@@ -4558,13 +4271,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-empty-assistant-silent",
-    });
+    await runEmbeddedAgent(
+      makeRunParams("run-empty-assistant-silent", { allowEmptyAssistantReplyAsSilent: true }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(runAttemptCall(1).prompt).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
@@ -4589,13 +4298,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-exact-silent-assistant-reply",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-exact-silent-assistant-reply", {
+        allowEmptyAssistantReplyAsSilent: true,
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     const onlyCall = runAttemptCall(0);
@@ -4655,13 +4362,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      provider: "stepfun",
-      model: "step-router-v1",
-      runId: "run-post-tool-openai-compatible-empty-stop",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-post-tool-openai-compatible-empty-stop", {
+        allowEmptyAssistantReplyAsSilent: true,
+        provider: "stepfun",
+        model: "step-router-v1",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
@@ -4700,13 +4407,13 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      provider: "stepfun",
-      model: "step-router-v1",
-      runId: "run-post-tool-exact-silent-retry",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-post-tool-exact-silent-retry", {
+        allowEmptyAssistantReplyAsSilent: true,
+        provider: "stepfun",
+        model: "step-router-v1",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     const onlyCall = runAttemptCall(0);
@@ -4731,34 +4438,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        terminalReplyExpectation: "optional",
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: sideEffectToolAttempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(sideEffectToolAttempt, { terminalReplyExpectation: "optional" }),
+      ),
     ).toBe(true);
     // A required or unspecified terminal reply keeps the ambiguous-failure path.
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        terminalReplyExpectation: "required",
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: sideEffectToolAttempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(sideEffectToolAttempt, { terminalReplyExpectation: "required" }),
+      ),
     ).toBe(false);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: sideEffectToolAttempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(makeSilentReplyParams(sideEffectToolAttempt)),
     ).toBe(false);
   });
 
@@ -4780,34 +4471,22 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        terminalReplyExpectation: "optional",
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: toolErrorAttempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(toolErrorAttempt, { terminalReplyExpectation: "optional" }),
+      ),
     ).toBe(false);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        terminalReplyExpectation: "optional",
-        payloadCount: 0,
-        aborted: false,
-        timedOut: false,
-        attempt: errorStopAttempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(errorStopAttempt, { terminalReplyExpectation: "optional" }),
+      ),
     ).toBe(false);
     expect(
-      shouldTreatEmptyAssistantReplyAsSilent({
-        allowEmptyAssistantReplyAsSilent: true,
-        terminalReplyExpectation: "optional",
-        payloadCount: 0,
-        aborted: true,
-        timedOut: false,
-        attempt: errorStopAttempt,
-      }),
+      shouldTreatEmptyAssistantReplyAsSilent(
+        makeSilentReplyParams(errorStopAttempt, {
+          terminalReplyExpectation: "optional",
+          aborted: true,
+        }),
+      ),
     ).toBe(false);
   });
 
@@ -4824,14 +4503,12 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      terminalReplyExpectation: "optional",
-      provider: "openai",
-      model: "gpt-5.5",
-      runId: "run-reply-optional-post-tool-silent",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-reply-optional-post-tool-silent", {
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expectNoWarnMessageWith("incomplete turn detected");
@@ -4853,12 +4530,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-empty-assistant-error",
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-empty-assistant-error", { model: "gpt-5.4" }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.isError).toBe(true);
@@ -4866,34 +4540,27 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("detects generic empty Gemini turns without visible text", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "google-vertex",
-      modelId: "google/gemini-3.1-flash",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [],
-        lastAssistant: makeLastAssistant({
-          stopReason: "end_turn",
-          provider: "google-vertex",
-          model: "gemini-3.1-flash",
-          content: [{ type: "text", text: "" }],
-        }),
-      }),
-    });
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams(
+        {
+          assistantTexts: [],
+          lastAssistant: makeLastAssistant({
+            stopReason: "end_turn",
+            provider: "google-vertex",
+            model: "gemini-3.1-flash",
+            content: [{ type: "text", text: "" }],
+          }),
+        },
+        { provider: "google-vertex", modelId: "google/gemini-3.1-flash" },
+      ),
+    );
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("does not retry generic empty GPT turns after side effects", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      payloadCount: 0,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
+    const retryInstruction = resolveEmptyResponseRetryInstruction(
+      makeEmptyResponseRetryParams({
         assistantTexts: [],
         didSendViaMessagingTool: true,
         lastAssistant: makeLastAssistant({
@@ -4902,7 +4569,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           content: [{ type: "text", text: "" }],
         }),
       }),
-    });
+    );
 
     expect(retryInstruction).toBeNull();
   });
@@ -4934,19 +4601,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      prompt:
-        "made a bunch of improvements to the student's source code (openclaw) this weekend, along with a few other maintainers. hopefully he will be more proactive now",
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-visible-prose-no-classifier",
-      config: {
-        agents: {
-          list: [{ id: "main" }],
-        },
-      } as OpenClawConfig,
-    });
+    const result = await runEmbeddedAgent(
+      makeRunParams("run-visible-prose-no-classifier", {
+        prompt:
+          "made a bunch of improvements to the student's source code (openclaw) this weekend, along with a few other maintainers. hopefully he will be more proactive now",
+        model: "gpt-5.4",
+        config: {
+          agents: {
+            list: [{ id: "main" }],
+          },
+        } as OpenClawConfig,
+      }),
+    );
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toBeUndefined();

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -268,7 +268,7 @@ function makeUserMessage(content = "do the thing", overrides: Record<string, unk
   return { role: "user", content, ...overrides };
 }
 
-function makeToolResultMessage(content = "done", overrides: Record<string, unknown> = {}) {
+function makeToolResultMessage(content: unknown = "done", overrides: Record<string, unknown> = {}) {
   return { role: "toolResult", content, ...overrides };
 }
 

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -239,6 +239,98 @@ function mainSessionStore(
   return createSessionStore(mainSessionEntry(overrides), sessionKey);
 }
 
+async function makeMainSessionFixture(
+  overrides: SessionEntryFixture & { agentId?: string; sessionKey?: string } = {},
+): Promise<{ sessionsDir: string; storePath: string; sessionKey: string }> {
+  const { agentId = "main", sessionKey = "agent:main:main", ...entry } = overrides;
+  const sessionsDir = await makeSessionsDir(agentId);
+  await writeMainSession({ sessionsDir, sessionKey, ...entry });
+  return {
+    sessionsDir,
+    storePath: path.join(sessionsDir, "sessions.json"),
+    sessionKey,
+  };
+}
+
+function makePendingFinalDelivery(
+  text = "interrupted response",
+  overrides: Partial<NonNullable<SessionEntry["pendingFinalDelivery"]>> = {},
+): NonNullable<SessionEntry["pendingFinalDelivery"]> {
+  return {
+    kind: "replayable",
+    text,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeUserMessage(content = "do the thing", overrides: Record<string, unknown> = {}) {
+  return { role: "user", content, ...overrides };
+}
+
+function makeToolResultMessage(content = "done", overrides: Record<string, unknown> = {}) {
+  return { role: "toolResult", content, ...overrides };
+}
+
+function makeAssistantTextMessage(text: string, overrides: Record<string, unknown> = {}) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    ...overrides,
+  };
+}
+
+function makeMessageToolCall(
+  toolCallId = "message-call-1",
+  message = "delivered answer",
+  overrides: Record<string, unknown> = {},
+) {
+  return createAssistantToolCallMessage([
+    {
+      type: "toolCall",
+      id: toolCallId,
+      name: "message",
+      arguments: { action: "send", message },
+      ...overrides,
+    },
+  ]);
+}
+
+function makeMessageToolResult(
+  toolCallId = "message-call-1",
+  overrides: Record<string, unknown> = {},
+) {
+  return makeToolResultMessage([{ type: "text", text: "sent" }], {
+    toolCallId,
+    toolName: "message",
+    isError: false,
+    ...overrides,
+  });
+}
+
+function makeMessageDeliveryTranscript({
+  beforeCall = [],
+  content = "do the thing",
+  message = "delivered answer",
+  sourceRunId = "discord-message-1",
+  toolCallId = "message-call-1",
+  tail = [],
+}: {
+  beforeCall?: readonly unknown[];
+  content?: string;
+  message?: string;
+  sourceRunId?: string;
+  toolCallId?: string;
+  tail?: readonly unknown[];
+} = {}) {
+  return [
+    makeUserMessage(content, { idempotencyKey: sourceRunId }),
+    ...beforeCall,
+    makeMessageToolCall(toolCallId, message),
+    ...tail,
+  ];
+}
+
 function deliveredReceiptEntry(
   toolCallId = "message-call-1",
   sourceRunId = "discord-message-1",
@@ -251,6 +343,29 @@ function deliveredReceiptEntry(
     restartRecoveryDeliverySourceRunId: sourceRunId,
     restartRecoveryDeliveryContext: discordDeliveryContext,
   };
+}
+
+function makeDeliveredReceiptFixture(
+  toolCallId = "message-call-1",
+  sourceRunId = "discord-message-1",
+  overrides: SessionEntryFixture = {},
+) {
+  return makeMainSessionFixture({
+    sessionKey: "agent:main:discord:direct:123",
+    ...deliveredReceiptEntry(toolCallId, sourceRunId),
+    ...overrides,
+  });
+}
+
+function makeAdmittedControlUiFixture(overrides: SessionEntryFixture = {}) {
+  return makeMainSessionFixture({
+    restartRecoveryBeforeAgentReplyState: "admitted",
+    restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
+    restartRecoveryDeliveryRunId: "control-ui-run",
+    restartRecoveryDeliverySourceRunId: "control-ui-run",
+    restartRecoverySourceIngress: "control-ui",
+    ...overrides,
+  });
 }
 
 async function writeMainSession({
@@ -302,9 +417,9 @@ async function writeMainSessionTranscript(
 
 async function writeCompletedToolTranscript(sessionsDir: string): Promise<void> {
   await writeTranscript(sessionsDir, "main-session", [
-    { role: "user", content: "run the tool" },
+    makeUserMessage("run the tool"),
     { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
-    { role: "toolResult", content: "done" },
+    makeToolResultMessage(),
   ]);
 }
 
@@ -1044,21 +1159,19 @@ describe("main-session-restart-recovery", () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     process.env.OPENCLAW_STATE_DIR = tmpDir;
 
-    await writeStore(sessionsDir, {
-      "agent:main:discord:direct:123": {
-        ...runningSessionEntry("main-session"),
-        abortedLastRun: true,
-        deliveryContext: {
-          channel: "discord",
-          to: "discord:dm:stale",
-          accountId: "old",
-        },
-        restartRecoveryDeliveryContext: {
-          channel: "discord",
-          to: "discord:dm:123",
-          accountId: "main",
-          threadId: 123,
-        },
+    await writeMainSession({
+      sessionsDir,
+      sessionKey: "agent:main:discord:direct:123",
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:dm:stale",
+        accountId: "old",
+      },
+      restartRecoveryDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        threadId: 123,
       },
     });
     await writeCompletedToolTranscript(sessionsDir);
@@ -1141,21 +1254,16 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("reuses a transcript-only claim without inferring historical session routes", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeStore(sessionsDir, {
-      "agent:main:discord:direct:123": {
-        ...runningSessionEntry("main-session"),
-        abortedLastRun: true,
-        restartRecoveryDeliveryRunId: "control-ui-run",
-        restartRecoveryDeliverySourceRunId: "control-ui-run",
-        restartRecoverySourceIngress: "internal",
-        restartRecoverySourceReplyDeliveryMode: "message_tool_only",
-        deliveryContext: {
-          channel: "discord",
-          to: "discord:dm:stale",
-          accountId: "old",
-        },
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
+      sessionKey: "agent:main:discord:direct:123",
+      restartRecoveryDeliveryRunId: "control-ui-run",
+      restartRecoveryDeliverySourceRunId: "control-ui-run",
+      restartRecoverySourceIngress: "internal",
+      restartRecoverySourceReplyDeliveryMode: "message_tool_only",
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:dm:stale",
+        accountId: "old",
       },
     });
     await writeCompletedToolTranscript(sessionsDir);
@@ -1202,10 +1310,7 @@ describe("main-session-restart-recovery", () => {
   );
 
   it("retains one stable transcript-only claim across ambiguous dispatch rejection", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "control-ui-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
     });
@@ -1272,10 +1377,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("does not propagate a retained recovery token after collection is disabled", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "control-ui-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
     });
@@ -1576,10 +1678,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("settles a reused recovery RPC whose accepted cache already completed", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "recovery-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
     });
@@ -1616,10 +1715,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("does not settle a cached terminal response after a foreground owner wins admission", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "recovery-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
     });
@@ -1654,10 +1750,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("settles a reused recovery RPC after its dispatch wait times out", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "recovery-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
     });
@@ -1688,16 +1781,12 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("does not deliver restart recovery when session send policy denies sends", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, {
-      "agent:main:discord:direct:123": {
-        ...runningSessionEntry("main-session"),
-        abortedLastRun: true,
-        restartRecoveryDeliveryContext: {
-          channel: "discord",
-          to: "discord:dm:123",
-          accountId: "main",
-        },
+    const { sessionsDir } = await makeMainSessionFixture({
+      sessionKey: "agent:main:discord:direct:123",
+      restartRecoveryDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
       },
     });
     await writeCompletedToolTranscript(sessionsDir);
@@ -1801,15 +1890,12 @@ describe("main-session-restart-recovery", () => {
     await writeMainSession({
       sessionsDir,
       sessionKey,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "hook reply",
-        createdAt: Date.now(),
+      pendingFinalDelivery: makePendingFinalDelivery("hook reply", {
         context: {
           channel: "discord",
           to: "discord:dm:123",
         },
-      },
+      }),
       restartRecoveryBeforeAgentReplyState: "handled-reply",
       restartRecoveryForceSafeTools: true,
     });
@@ -1843,11 +1929,9 @@ describe("main-session-restart-recovery", () => {
         { role: "assistant", content: [{ type: "text", text: "Safe work finished." }] },
       ],
       {
-        pendingFinalDelivery: {
-          kind: "replayable",
-          text: "Safe work finished.",
+        pendingFinalDelivery: makePendingFinalDelivery("Safe work finished.", {
           createdAt: Date.now() - 5_000,
-        },
+        }),
       },
     );
 
@@ -1902,11 +1986,9 @@ describe("main-session-restart-recovery", () => {
       "agent:main:main": {
         ...runningSessionEntry("missing-transcript-session"),
         abortedLastRun: true,
-        pendingFinalDelivery: {
-          kind: "replayable",
-          text: "The durable final answer.",
+        pendingFinalDelivery: makePendingFinalDelivery("The durable final answer.", {
           createdAt: Date.now() - 5_000,
-        },
+        }),
       },
     });
 
@@ -1922,11 +2004,9 @@ describe("main-session-restart-recovery", () => {
         { role: "assistant", content: "assistant final was already captured" },
       ],
       {
-        pendingFinalDelivery: {
-          kind: "replayable",
-          text: "assistant final was already captured",
+        pendingFinalDelivery: makePendingFinalDelivery("assistant final was already captured", {
           createdAt: Date.now() - 5_000,
-        },
+        }),
       },
     );
 
@@ -2383,11 +2463,7 @@ describe("main-session-restart-recovery", () => {
     const sessionsDir = await makeSessionsDir();
     await writeMainSession({
       sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
 
     vi.useFakeTimers();
@@ -2414,15 +2490,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("cancels an immediate startup recovery before its queued attempt can claim a session", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+    const { storePath } = await makeMainSessionFixture({
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
@@ -2523,16 +2592,9 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("stops without waiting for an unresolved startup release", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
     const releaseStartup = createDeferred();
-    await writeMainSession({
-      sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+    const { storePath } = await makeMainSessionFixture({
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
@@ -2554,15 +2616,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fences an in-flight startup recovery before its durable session claim", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+    const { storePath } = await makeMainSessionFixture({
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
 
     const originalApply = sessionAccessor.applySessionEntryReplacements;
@@ -2618,14 +2673,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("joins an in-flight startup dispatch before stopping its recovery owner", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeMainSession({
-      sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+    await makeMainSessionFixture({
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
 
     const dispatchEntered = createDeferred();
@@ -2665,15 +2714,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fences an ambiguous terminal probe when its startup recovery owner stops", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+    const { storePath } = await makeMainSessionFixture({
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
 
     const probeEntered = createDeferred();
@@ -2742,11 +2784,7 @@ describe("main-session-restart-recovery", () => {
     const sessionsDir = await makeSessionsDir();
     await writeMainSession({
       sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
     const firstDispatch = createDeferred();
     const secondDispatch = createDeferred();
@@ -2826,11 +2864,7 @@ describe("main-session-restart-recovery", () => {
     const sessionsDir = await makeSessionsDir();
     await writeMainSession({
       sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
 
     const suspensionRef: {
@@ -2984,10 +3018,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("retries a failed exact owner-release recovery with bounded backoff", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "control-ui-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
     });
@@ -3015,19 +3046,14 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("tombstones exhausted recovery with replacement-session instructions", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeStore(sessionsDir, {
-      "agent:main:discord:direct:123": {
-        ...runningSessionEntry("main-session"),
-        abortedLastRun: true,
-        mainRestartRecovery: {
-          cycleId: "cycle-exhausted",
-          revision: 1,
-          chargedAttempts: 3,
-        },
-        restartRecoveryDeliveryContext: discordDeliveryContext,
+    const { storePath } = await makeMainSessionFixture({
+      sessionKey: "agent:main:discord:direct:123",
+      mainRestartRecovery: {
+        cycleId: "cycle-exhausted",
+        revision: 1,
+        chargedAttempts: 3,
       },
+      restartRecoveryDeliveryContext: discordDeliveryContext,
     });
 
     await expectRecovery({ recovered: 0, failed: 0, skipped: 1 });
@@ -3049,12 +3075,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("rejects foreground takeover while tombstoning exhausted recovery", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:main";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
       mainRestartRecovery: {
         cycleId: "cycle-exhausted",
         revision: 1,
@@ -3108,12 +3129,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("retries tombstoning after a transcript metadata conflict", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:main";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
       mainRestartRecovery: {
         cycleId: "cycle-exhausted",
         revision: 1,
@@ -3140,10 +3156,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("tombstones when the final owner-release retry consumes the last charge", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       mainRestartRecovery: {
         cycleId: "cycle-final-attempt",
         revision: 1,
@@ -3175,20 +3188,13 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("tombstones when the final startup retry consumes the last charge", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { storePath } = await makeMainSessionFixture({
       mainRestartRecovery: {
         cycleId: "cycle-final-startup-attempt",
         revision: 1,
         chargedAttempts: 2,
       },
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "interrupted response",
-        createdAt: Date.now(),
-      },
+      pendingFinalDelivery: makePendingFinalDelivery(),
     });
     vi.mocked(callGateway)
       .mockImplementationOnce(async () => {
@@ -3232,10 +3238,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed when message-tool-only authority cannot be reconstructed", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "recovery-main",
       restartRecoverySourceIngress: "channel",
       restartRecoverySourceReplyDeliveryMode: "message_tool_only",
@@ -3272,10 +3275,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("does not restore channel authority from a generic session route", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       channel: "discord",
       lastTo: "discord:dm:fallback",
       restartRecoveryDeliveryRunId: "recovery-main",
@@ -3309,10 +3309,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("dispatches an abandoned durable claim through its owning Gateway instance", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "recovery-main",
       restartRecoveryDeliverySourceRunId: "source-main",
     });
@@ -3499,14 +3496,7 @@ describe("main-session-restart-recovery", () => {
     });
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "do the thing", idempotencyKey: "discord-message-1" },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-1",
-          name: "message",
-          arguments: { action: "send", message: "delivered answer" },
-        },
-      ]),
+      makeMessageToolCall(),
       {
         role: "assistant",
         content: [{ type: "text", text: "delivered answer" }],
@@ -3632,23 +3622,9 @@ describe("main-session-restart-recovery", () => {
     expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
   });
   it("resumes a Control UI turn after proving the current runtime is hookless", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const sessionKey = "agent:main:main";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      restartRecoveryBeforeAgentReplyState: "admitted",
-      restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
-      restartRecoveryDeliveryRunId: "control-ui-run",
-      restartRecoveryDeliverySourceRunId: "control-ui-run",
-      restartRecoverySourceIngress: "control-ui",
-    });
+    const { sessionsDir, sessionKey } = await makeAdmittedControlUiFixture();
     await writeTranscript(sessionsDir, "main-session", [
-      {
-        role: "user",
-        content: "do the thing",
-        idempotencyKey: "control-ui-run:user",
-      },
+      makeUserMessage("do the thing", { idempotencyKey: "control-ui-run:user" }),
     ]);
 
     runtimePluginMocks.findRestartRecoveryUnsafeReplyHook.mockImplementationOnce(() => {
@@ -3674,25 +3650,10 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed when the restart recovery registry handle is unavailable", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:main";
     runtimePluginMocks.loadAgentRuntimePluginRegistryHandle.mockReturnValue(undefined);
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      restartRecoveryBeforeAgentReplyState: "admitted",
-      restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
-      restartRecoveryDeliveryRunId: "control-ui-run",
-      restartRecoveryDeliverySourceRunId: "control-ui-run",
-      restartRecoverySourceIngress: "control-ui",
-    });
+    const { sessionsDir, storePath, sessionKey } = await makeAdmittedControlUiFixture();
     await writeTranscript(sessionsDir, "main-session", [
-      {
-        role: "user",
-        content: "do the thing",
-        idempotencyKey: "control-ui-run:user",
-      },
+      makeUserMessage("do the thing", { idempotencyKey: "control-ui-run:user" }),
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 }, {});
@@ -3703,25 +3664,10 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails a pre-hook Control UI recovery when a runtime hook is active", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:main";
     runtimePluginMocks.findRestartRecoveryUnsafeReplyHook.mockReturnValue("before_agent_reply");
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      restartRecoveryBeforeAgentReplyState: "admitted",
-      restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
-      restartRecoveryDeliveryRunId: "control-ui-run",
-      restartRecoveryDeliverySourceRunId: "control-ui-run",
-      restartRecoverySourceIngress: "control-ui",
-    });
+    const { sessionsDir, storePath, sessionKey } = await makeAdmittedControlUiFixture();
     await writeTranscript(sessionsDir, "main-session", [
-      {
-        role: "user",
-        content: "do the thing",
-        idempotencyKey: "control-ui-run:user",
-      },
+      makeUserMessage("do the thing", { idempotencyKey: "control-ui-run:user" }),
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 }, {});
@@ -3734,24 +3680,15 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("keeps an adopted Control UI turn behind the unsafe hook gate", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:main";
     runtimePluginMocks.findRestartRecoveryUnsafeReplyHook.mockReturnValue("before_message_write");
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
       restartRecoveryBeforeAgentReplyState: "continue",
       restartRecoveryDeliveryRunId: "control-ui-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
       restartRecoverySourceIngress: "control-ui",
     });
     await writeTranscript(sessionsDir, "main-session", [
-      {
-        role: "user",
-        content: "do the thing",
-        idempotencyKey: "control-ui-run:user",
-      },
+      makeUserMessage("do the thing", { idempotencyKey: "control-ui-run:user" }),
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 }, {});
@@ -3762,12 +3699,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed while a terminal provider outcome remains unknown", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
+      sessionKey: "agent:main:discord:direct:123",
       restartRecoveryBeforeAgentReplyState: "continue",
       restartRecoveryDeliveryReceiptState: "terminal-pending",
       restartRecoveryDeliveryToolCallId: "message-call-1",
@@ -3790,25 +3723,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("completes from a durable terminal provider receipt without replaying", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      ...deliveredReceiptEntry(),
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing", idempotencyKey: "discord-message-1" },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-1",
-          name: "message",
-          arguments: { action: "send", message: "delivered answer" },
-        },
-      ]),
-    ]);
+    const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture();
+    await writeTranscript(sessionsDir, "main-session", makeMessageDeliveryTranscript());
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
 
@@ -3833,34 +3749,21 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("reconciles a receipt delivered during a restart-recovery continuation", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
+    const { sessionsDir, storePath, sessionKey } =
+      await makeDeliveredReceiptFixture("message-call-recovered");
+    await writeTranscript(
       sessionsDir,
-      sessionKey,
-      ...deliveredReceiptEntry("message-call-recovered", "discord-message-1"),
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing", idempotencyKey: "discord-message-1" },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "starting" }],
-      },
-      {
-        role: "user",
-        content: "[System] continue after restart",
-        idempotencyKey: "recovery-1:user",
-      },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-recovered",
-          name: "message",
-          arguments: { action: "send", message: "delivered answer" },
-        },
-      ]),
-    ]);
+      "main-session",
+      makeMessageDeliveryTranscript({
+        toolCallId: "message-call-recovered",
+        beforeCall: [
+          makeAssistantTextMessage("starting"),
+          makeUserMessage("[System] continue after restart", {
+            idempotencyKey: "recovery-1:user",
+          }),
+        ],
+      }),
+    );
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
 
@@ -3902,33 +3805,21 @@ describe("main-session-restart-recovery", () => {
   ] as const)(
     "reconciles a delivered terminal receipt through $label",
     async ({ content, expected, expectedStatus, gatewayCalls, recoveredResult }) => {
-      const sessionsDir = await makeSessionsDir();
-      const storePath = path.join(sessionsDir, "sessions.json");
-      const sessionKey = "agent:main:discord:direct:123";
-      await writeStore(sessionsDir, {
-        [sessionKey]: {
-          ...runningSessionEntry("main-session"),
-          abortedLastRun: true,
-          ...deliveredReceiptEntry(),
-        },
-      });
-      await writeTranscript(sessionsDir, "main-session", [
-        { role: "user", content: "do the thing", idempotencyKey: "discord-message-1" },
-        createAssistantToolCallMessage([
-          {
-            type: "toolCall",
-            id: "message-call-1",
-            name: "message",
-            arguments: { action: "send", message: "delivered answer" },
-          },
-        ]),
-        {
-          role: "assistant",
-          content,
-          stopReason: "aborted",
-          errorMessage: "Request was aborted",
-        },
-      ]);
+      const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture();
+      await writeTranscript(
+        sessionsDir,
+        "main-session",
+        makeMessageDeliveryTranscript({
+          tail: [
+            {
+              role: "assistant",
+              content,
+              stopReason: "aborted",
+              errorMessage: "Request was aborted",
+            },
+          ],
+        }),
+      );
 
       await expect(recoverRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual(
         expected,
@@ -3955,33 +3846,21 @@ describe("main-session-restart-recovery", () => {
   ] as const)(
     "fails closed on an existing %s result instead of duplicating it",
     async (_label, existingResult) => {
-      const sessionsDir = await makeSessionsDir();
-      const storePath = path.join(sessionsDir, "sessions.json");
-      const sessionKey = "agent:main:discord:direct:123";
-      await writeStore(sessionsDir, {
-        [sessionKey]: {
-          ...runningSessionEntry("main-session"),
-          abortedLastRun: true,
-          ...deliveredReceiptEntry(),
-        },
-      });
-      await writeTranscript(sessionsDir, "main-session", [
-        { role: "user", content: "do the thing", idempotencyKey: "discord-message-1" },
-        createAssistantToolCallMessage([
-          {
-            type: "toolCall",
-            id: "message-call-1",
-            name: "message",
-            arguments: { action: "send", message: "delivered answer" },
-          },
-        ]),
-        {
-          role: "toolResult",
-          toolCallId: "message-call-1",
-          content: [{ type: "text", text: "transport reported failure" }],
-          ...existingResult,
-        },
-      ]);
+      const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture();
+      await writeTranscript(
+        sessionsDir,
+        "main-session",
+        makeMessageDeliveryTranscript({
+          tail: [
+            {
+              role: "toolResult",
+              toolCallId: "message-call-1",
+              content: [{ type: "text", text: "transport reported failure" }],
+              ...existingResult,
+            },
+          ],
+        }),
+      );
 
       await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
@@ -4007,16 +3886,9 @@ describe("main-session-restart-recovery", () => {
   );
 
   it("fails a delivered receipt without its owning message tool call", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      ...deliveredReceiptEntry(),
-    });
+    const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture();
     await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing", idempotencyKey: "discord-message-1" },
+      makeUserMessage("do the thing", { idempotencyKey: "discord-message-1" }),
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
@@ -4036,24 +3908,11 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails a delivered receipt that lacks its durable source turn", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      ...deliveredReceiptEntry("message-call-1", "discord-message-missing"),
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-1",
-          name: "message",
-          arguments: { action: "send", message: "delivered answer" },
-        },
-      ]),
-    ]);
+    const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture(
+      "message-call-1",
+      "discord-message-missing",
+    );
+    await writeTranscript(sessionsDir, "main-session", [makeMessageToolCall()]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
 
@@ -4067,57 +3926,23 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed instead of appending a recovered result after later turns", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    const recoveryEntry: SessionEntry = {
-      sessionId: "main-session",
-      updatedAt: Date.now() - 10_000,
-      status: "running",
-      abortedLastRun: true,
-      ...deliveredReceiptEntry("message-call-reused", "discord-message-current"),
-    };
-    await writeStore(sessionsDir, {
-      [sessionKey]: recoveryEntry,
-    });
+    const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture(
+      "message-call-reused",
+      "discord-message-current",
+    );
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "old turn", idempotencyKey: "discord-message-old" },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-reused",
-          name: "message",
-          arguments: { action: "send", message: "old answer" },
-        },
-      ]),
+      makeMessageToolCall("message-call-reused", "old answer"),
       {
         role: "toolResult",
         toolCallId: "message-call-reused",
         toolName: "message",
         content: [{ type: "text", text: "old sent" }],
       },
-      {
-        role: "user",
-        content: "current turn",
-        idempotencyKey: "discord-message-current",
-      },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-reused",
-          name: "message",
-          arguments: { action: "send", message: "current answer" },
-        },
-      ]),
+      makeUserMessage("current turn", { idempotencyKey: "discord-message-current" }),
+      makeMessageToolCall("message-call-reused", "current answer"),
       { role: "user", content: "later turn", idempotencyKey: "discord-message-later" },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-reused",
-          name: "message",
-          arguments: { action: "send", message: "later answer" },
-        },
-      ]),
+      makeMessageToolCall("message-call-reused", "later answer"),
       {
         role: "toolResult",
         toolCallId: "message-call-reused",
@@ -4149,31 +3974,14 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed when an existing successful result belongs to an earlier turn", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      ...deliveredReceiptEntry("message-call-current", "discord-message-current"),
-    });
+    const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture(
+      "message-call-current",
+      "discord-message-current",
+    );
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "current turn", idempotencyKey: "discord-message-current" },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-current",
-          name: "message",
-          arguments: { action: "send", message: "current answer" },
-        },
-      ]),
-      {
-        role: "toolResult",
-        toolCallId: "message-call-current",
-        toolName: "message",
-        isError: false,
-        content: [{ type: "text", text: "sent" }],
-      },
+      makeMessageToolCall("message-call-current", "current answer"),
+      makeMessageToolResult("message-call-current"),
       { role: "user", content: "later turn", idempotencyKey: "discord-message-later" },
     ]);
 
@@ -4193,31 +4001,14 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed when a successful message result is followed by unfinished tool work", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      ...deliveredReceiptEntry("message-call-current", "discord-message-current"),
-    });
+    const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture(
+      "message-call-current",
+      "discord-message-current",
+    );
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "current turn", idempotencyKey: "discord-message-current" },
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "message-call-current",
-          name: "message",
-          arguments: { action: "send", message: "current answer" },
-        },
-      ]),
-      {
-        role: "toolResult",
-        toolCallId: "message-call-current",
-        toolName: "message",
-        isError: false,
-        content: [{ type: "text", text: "sent" }],
-      },
+      makeMessageToolCall("message-call-current", "current answer"),
+      makeMessageToolResult("message-call-current"),
       {
         role: "assistant",
         content: [{ type: "toolCall", id: "pending-write", name: "write", arguments: {} }],
@@ -4241,14 +4032,10 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed when a delivered message shares an assistant event with unfinished tool work", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
-      ...deliveredReceiptEntry("message-call-current", "discord-message-current"),
-    });
+    const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture(
+      "message-call-current",
+      "discord-message-current",
+    );
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "current turn", idempotencyKey: "discord-message-current" },
       createAssistantToolCallMessage([
@@ -4260,13 +4047,7 @@ describe("main-session-restart-recovery", () => {
         },
         { type: "toolCall", id: "pending-write", name: "write", arguments: {} },
       ]),
-      {
-        role: "toolResult",
-        toolCallId: "message-call-current",
-        toolName: "message",
-        isError: false,
-        content: [{ type: "text", text: "sent" }],
-      },
+      makeMessageToolResult("message-call-current"),
     ]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
@@ -4302,39 +4083,23 @@ describe("main-session-restart-recovery", () => {
   ] as const)(
     "reconciles a successful message result followed by $label",
     async ({ finalText, expected, expectedStatus, gatewayCalls }) => {
-      const sessionsDir = await makeSessionsDir();
-      const storePath = path.join(sessionsDir, "sessions.json");
-      const sessionKey = "agent:main:discord:direct:123";
-      await writeStore(sessionsDir, {
-        [sessionKey]: {
-          ...runningSessionEntry("main-session"),
-          abortedLastRun: true,
-          ...deliveredReceiptEntry("message-call-current", "discord-message-current"),
-        },
-      });
-      await writeTranscript(sessionsDir, "main-session", [
-        { role: "user", content: "current turn", idempotencyKey: "discord-message-current" },
-        createAssistantToolCallMessage([
-          {
-            type: "toolCall",
-            id: "message-call-current",
-            name: "message",
-            arguments: { action: "send", message: "delivered answer" },
-          },
-        ]),
-        {
-          role: "toolResult",
+      const { sessionsDir, storePath, sessionKey } = await makeDeliveredReceiptFixture(
+        "message-call-current",
+        "discord-message-current",
+      );
+      await writeTranscript(
+        sessionsDir,
+        "main-session",
+        makeMessageDeliveryTranscript({
+          content: "current turn",
+          sourceRunId: "discord-message-current",
           toolCallId: "message-call-current",
-          toolName: "message",
-          isError: false,
-          content: [{ type: "text", text: "sent" }],
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: finalText }],
-          stopReason: "stop",
-        },
-      ]);
+          tail: [
+            makeMessageToolResult("message-call-current"),
+            makeAssistantTextMessage(finalText, { stopReason: "stop" }),
+          ],
+        }),
+      );
 
       await expect(recoverRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual(
         expected,
@@ -4346,12 +4111,8 @@ describe("main-session-restart-recovery", () => {
   );
 
   it("completes a checkpointed silent before_agent_reply result without dispatch", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
+      sessionKey: "agent:main:discord:direct:123",
       restartRecoveryBeforeAgentReplyState: "handled-silent",
       restartRecoveryDeliveryRunId: "recovery-1",
       restartRecoveryDeliverySourceRunId: "discord-message-1",
@@ -4372,12 +4133,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("matches a checkpointed Control UI hook to its run-keyed user turn", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:main";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
       restartRecoveryBeforeAgentReplyState: "handled-silent",
       restartRecoveryDeliveryRunId: "control-ui-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
@@ -4397,12 +4153,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("does not let a silent checkpoint complete over a later user turn", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:discord:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
+      sessionKey: "agent:main:discord:direct:123",
       restartRecoveryBeforeAgentReplyState: "handled-silent",
       restartRecoveryDeliveryRunId: "recovery-1",
       restartRecoveryDeliverySourceRunId: "discord-message-1",
@@ -4420,12 +4172,8 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails closed for a source-less silent before_agent_reply checkpoint", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:custom:direct:123";
-    await writeMainSession({
-      sessionsDir,
-      sessionKey,
+    const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
+      sessionKey: "agent:main:custom:direct:123",
       restartRecoveryBeforeAgentReplyState: "handled-silent",
       restartRecoveryDeliveryRunId: "recovery-1",
       restartRecoveryDeliveryContext: discordDeliveryContext,
@@ -4444,18 +4192,12 @@ describe("main-session-restart-recovery", () => {
   it.each(["pending", "handled-reply", "handled-unrecoverable"] as const)(
     "fails closed for a %s before_agent_reply checkpoint without a recoverable result",
     async (restartRecoveryBeforeAgentReplyState) => {
-      const sessionsDir = await makeSessionsDir();
-      const storePath = path.join(sessionsDir, "sessions.json");
-      const sessionKey = "agent:main:discord:direct:123";
-      await writeStore(sessionsDir, {
-        [sessionKey]: {
-          ...runningSessionEntry("main-session"),
-          abortedLastRun: true,
-          restartRecoveryBeforeAgentReplyState,
-          restartRecoveryDeliveryRunId: "recovery-1",
-          restartRecoveryDeliverySourceRunId: "discord-message-1",
-          restartRecoveryDeliveryContext: discordDeliveryContext,
-        },
+      const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
+        sessionKey: "agent:main:discord:direct:123",
+        restartRecoveryBeforeAgentReplyState,
+        restartRecoveryDeliveryRunId: "recovery-1",
+        restartRecoveryDeliverySourceRunId: "discord-message-1",
+        restartRecoveryDeliveryContext: discordDeliveryContext,
       });
       await writeTranscript(sessionsDir, "main-session", [
         { role: "user", content: "do the thing", idempotencyKey: "discord-message-1" },
@@ -4505,19 +4247,11 @@ describe("main-session-restart-recovery", () => {
   it.each([
     [
       "completed assistant output",
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "finished answer" }],
-        stopReason: "stop",
-      },
+      makeAssistantTextMessage("finished answer", { stopReason: "stop" }),
     ],
     [
       "errored assistant output",
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "provider failed" }],
-        stopReason: "error",
-      },
+      makeAssistantTextMessage("provider failed", { stopReason: "error" }),
     ],
     [
       "an errored tail carrying a non-restart abort code",
@@ -4558,21 +4292,15 @@ describe("main-session-restart-recovery", () => {
   it.each([
     [
       "no abort string",
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "partial answer" }],
-        stopReason: "aborted",
-      },
+      makeAssistantTextMessage("partial answer", { stopReason: "aborted" }),
       false,
     ],
     [
       "a worker abort string",
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "" }],
+      makeAssistantTextMessage("", {
         stopReason: "aborted",
         errorMessage: "Worker inference aborted.",
-      },
+      }),
       false,
     ],
     [
@@ -4604,10 +4332,7 @@ describe("main-session-restart-recovery", () => {
   );
 
   it("keeps an unresumable Control UI notice in history despite a stale external route", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "control-ui-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
       lastChannel: "whatsapp",
@@ -4702,10 +4427,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("keeps an unresumable Control UI claim recoverable until its notice is durable", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    await writeMainSession({
-      sessionsDir,
+    const { sessionsDir, storePath } = await makeMainSessionFixture({
       restartRecoveryDeliveryRunId: "control-ui-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
     });
@@ -5221,12 +4943,10 @@ describe("main-session-restart-recovery", () => {
   it("resumes a partial streamed answer interrupted by a restart", async () => {
     await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Here is the first half of the answer" }],
+      makeAssistantTextMessage("Here is the first half of the answer", {
         stopReason: "aborted",
         errorMessage: "This operation was aborted",
-      },
+      }),
     ]);
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -297,6 +297,12 @@ describe("subagent registry seam flow", () => {
   > &
     Pick<RunningTaskParams, "task"> &
     Partial<Omit<RunningTaskParams, "runId" | "childSessionKey" | "startedAt" | "task">>;
+  type QueuedRunOverrides = Pick<SubagentRunRecordOverrides, "runId" | "createdAt" | "groupId"> &
+    Partial<
+      Omit<SubagentRunRecordOverrides, "runId" | "createdAt" | "groupId" | "queuedLaunch">
+    > & {
+      queuedLaunch?: Partial<NonNullable<SubagentRunRecord["queuedLaunch"]>>;
+    };
   type SuspendedDeliveryRunOverrides = Pick<SubagentRunRecordOverrides, "runId"> &
     Required<
       Pick<
@@ -352,6 +358,34 @@ describe("subagent registry seam flow", () => {
     lastEventAt: overrides.startedAt,
     ...overrides,
   });
+  const makeQueuedRun = ({
+    queuedLaunch: queuedLaunchOverrides,
+    ...overrides
+  }: QueuedRunOverrides): SubagentRunRecord => {
+    const childSessionKey = overrides.childSessionKey ?? `agent:main:subagent:${overrides.runId}`;
+    const requesterSessionKey = overrides.requesterSessionKey ?? "agent:main:main";
+    return createSubagentRunRecord({
+      childSessionKey,
+      requesterSessionKey,
+      requesterDisplayKey: "main",
+      task: overrides.runId,
+      cleanup: "keep",
+      collect: true,
+      execution: { status: "queued" },
+      completion: { required: false },
+      ...overrides,
+      queuedLaunch: {
+        request: {
+          sessionKey: childSessionKey,
+          idempotencyKey: overrides.runId,
+        },
+        timeoutMs: 1_000,
+        schedulerGroupKey: JSON.stringify([requesterSessionKey, overrides.groupId]),
+        maxConcurrent: 1,
+        ...queuedLaunchOverrides,
+      },
+    });
+  };
   const makeSuspendedDeliveryRun = ({
     delivery: deliveryOverrides,
     ...overrides
@@ -382,6 +416,14 @@ describe("subagent registry seam flow", () => {
   let mod: RegistryHarness;
   const findRequesterRun = (runId: string) =>
     mod.listSubagentRunsForRequester("agent:main:main").find((entry) => entry.runId === runId);
+  const mockPendingAgentWait = () =>
+    mockGatewayMethods(mocks.callGateway, { "agent.wait": { status: "pending" } });
+  const mockSingleCollectorConcurrency = () =>
+    mocks.getRuntimeConfig.mockReturnValue({
+      tools: { swarm: { enabled: true, maxConcurrent: 1 } },
+      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+      session: { mainKey: "main", scope: "per-sender" as const },
+    });
   const getLifecycleHandler = () => {
     const handler = mocks.onAgentEvent.mock.calls.at(-1)?.[0] as unknown as
       | ((event: {
@@ -947,9 +989,7 @@ describe("subagent registry seam flow", () => {
 
   it("tracks missing-entry lifecycle result refresh until capture and persistence settle", async () => {
     const childSessionKey = "agent:main:subagent:refresh-admission";
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     mod.registerSubagentRun({
       runId: "run-refresh-admission-old",
       childSessionKey,
@@ -1040,9 +1080,7 @@ describe("subagent registry seam flow", () => {
       });
       return null;
     });
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     const runId = "run-kill-tail-admission";
     mod.registerSubagentRun({
       runId,
@@ -1263,31 +1301,16 @@ describe("subagent registry seam flow", () => {
     }) => {
       params.runs.set(
         "run-queued-kill-intent",
-        createSubagentRunRecord({
+        makeQueuedRun({
           runId: "run-queued-kill-intent",
           childSessionKey: "agent:main:subagent:queued-kill-intent",
-          requesterSessionKey: "agent:main:main",
-          requesterDisplayKey: "main",
           task: "do not relaunch",
-          cleanup: "keep",
-          collect: true,
           groupId: "kill-intent",
           createdAt: now,
-          execution: { status: "queued" },
-          completion: { required: false },
           killIntent: {
             requestedAt: now + 1,
             reason: "killed",
             sessionId: "session-queued-kill-intent",
-          },
-          queuedLaunch: {
-            request: {
-              sessionKey: "agent:main:subagent:queued-kill-intent",
-              idempotencyKey: "run-queued-kill-intent",
-            },
-            timeoutMs: 1_000,
-            schedulerGroupKey: '["agent:main:main","kill-intent"]',
-            maxConcurrent: 1,
           },
         }),
       );
@@ -1305,38 +1328,29 @@ describe("subagent registry seam flow", () => {
 
   it("rehydrates persisted collector FIFO queues after admission reopens", async () => {
     const now = Date.now();
-    mocks.getRuntimeConfig.mockReturnValue({
-      tools: { swarm: { enabled: true, maxConcurrent: 1 } },
-      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
-      session: { mainKey: "main", scope: "per-sender" as const },
-    });
-    const makeQueuedRun = (runId: string, createdAt: number) => ({
-      runId,
-      childSessionKey: `agent:main:subagent:${runId}`,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: runId,
-      cleanup: "keep" as const,
-      collect: true,
+    mockSingleCollectorConcurrency();
+    const queuedRunOverrides = {
       groupId: "logical-group",
-      createdAt,
-      execution: { status: "queued" as const },
-      completion: { required: false },
       queuedLaunch: {
-        request: { sessionKey: `agent:main:subagent:${runId}`, idempotencyKey: runId },
-        authorization: {
-          modelOverride: { provider: "openai", model: "gpt-5.4" },
-        },
-        timeoutMs: 1_000,
-        schedulerGroupKey: '["agent:main:main","logical-group"]',
+        authorization: { modelOverride: { provider: "openai", model: "gpt-5.4" } },
         maxConcurrent: 2,
       },
-    });
+    };
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;
     }) => {
-      params.runs.set("run-queued-one", makeQueuedRun("run-queued-one", now));
-      params.runs.set("run-queued-two", makeQueuedRun("run-queued-two", now + 1));
+      params.runs.set(
+        "run-queued-one",
+        makeQueuedRun({ ...queuedRunOverrides, runId: "run-queued-one", createdAt: now }),
+      );
+      params.runs.set(
+        "run-queued-two",
+        makeQueuedRun({
+          ...queuedRunOverrides,
+          runId: "run-queued-two",
+          createdAt: now + 1,
+        }),
+      );
       return 2;
     }) as never);
     mocks.loadSessionStore.mockReturnValue({
@@ -1519,35 +1533,22 @@ describe("subagent registry seam flow", () => {
   it("holds a restored FIFO slot until an accepted collector is confirmed stopped", async () => {
     vi.useRealTimers();
     const now = Date.now();
-    mocks.getRuntimeConfig.mockReturnValue({
-      tools: { swarm: { enabled: true, maxConcurrent: 1 } },
-      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
-      session: { mainKey: "main", scope: "per-sender" as const },
-    });
-    const makeQueuedRun = (runId: string, createdAt: number) => ({
-      runId,
-      childSessionKey: `agent:main:subagent:${runId}`,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: runId,
-      cleanup: "keep" as const,
-      collect: true,
-      groupId: "restore-stop",
-      createdAt,
-      execution: { status: "queued" as const },
-      completion: { required: false },
-      queuedLaunch: {
-        request: { sessionKey: `agent:main:subagent:${runId}`, idempotencyKey: runId },
-        timeoutMs: 1_000,
-        schedulerGroupKey: '["agent:main:main","restore-stop"]',
-        maxConcurrent: 1,
-      },
-    });
+    mockSingleCollectorConcurrency();
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;
     }) => {
-      params.runs.set("run-restored-stop-one", makeQueuedRun("run-restored-stop-one", now));
-      params.runs.set("run-restored-stop-two", makeQueuedRun("run-restored-stop-two", now + 1));
+      params.runs.set(
+        "run-restored-stop-one",
+        makeQueuedRun({ runId: "run-restored-stop-one", groupId: "restore-stop", createdAt: now }),
+      );
+      params.runs.set(
+        "run-restored-stop-two",
+        makeQueuedRun({
+          runId: "run-restored-stop-two",
+          groupId: "restore-stop",
+          createdAt: now + 1,
+        }),
+      );
       return 2;
     }) as never);
     mocks.loadSessionStore.mockReturnValue({
@@ -1611,35 +1612,26 @@ describe("subagent registry seam flow", () => {
   it("holds a restored FIFO slot while an indeterminate launch session is deleted", async () => {
     vi.useRealTimers();
     const now = Date.now();
-    mocks.getRuntimeConfig.mockReturnValue({
-      tools: { swarm: { enabled: true, maxConcurrent: 1 } },
-      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
-      session: { mainKey: "main", scope: "per-sender" as const },
-    });
-    const makeQueuedRun = (runId: string, createdAt: number) => ({
-      runId,
-      childSessionKey: `agent:main:subagent:${runId}`,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: runId,
-      cleanup: "keep" as const,
-      collect: true,
-      groupId: "restore-delete",
-      createdAt,
-      execution: { status: "queued" as const },
-      completion: { required: false },
-      queuedLaunch: {
-        request: { sessionKey: `agent:main:subagent:${runId}`, idempotencyKey: runId },
-        timeoutMs: 1_000,
-        schedulerGroupKey: '["agent:main:main","restore-delete"]',
-        maxConcurrent: 1,
-      },
-    });
+    mockSingleCollectorConcurrency();
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;
     }) => {
-      params.runs.set("run-restored-delete-one", makeQueuedRun("run-restored-delete-one", now));
-      params.runs.set("run-restored-delete-two", makeQueuedRun("run-restored-delete-two", now + 1));
+      params.runs.set(
+        "run-restored-delete-one",
+        makeQueuedRun({
+          runId: "run-restored-delete-one",
+          groupId: "restore-delete",
+          createdAt: now,
+        }),
+      );
+      params.runs.set(
+        "run-restored-delete-two",
+        makeQueuedRun({
+          runId: "run-restored-delete-two",
+          groupId: "restore-delete",
+          createdAt: now + 1,
+        }),
+      );
       return 2;
     }) as never);
     mocks.loadSessionStore.mockReturnValue({
@@ -1683,37 +1675,25 @@ describe("subagent registry seam flow", () => {
   it("releases restored FIFO ownership when lifecycle rotates during failure persistence", async () => {
     vi.useRealTimers();
     const now = Date.now();
-    mocks.getRuntimeConfig.mockReturnValue({
-      tools: { swarm: { enabled: true, maxConcurrent: 1 } },
-      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
-      session: { mainKey: "main", scope: "per-sender" as const },
-    });
-    const makeQueuedRun = (runId: string, createdAt: number) => ({
-      runId,
-      childSessionKey: `agent:main:subagent:${runId}`,
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: runId,
-      cleanup: "keep" as const,
-      collect: true,
-      groupId: "restore-lifecycle-rotation",
-      createdAt,
-      execution: { status: "queued" as const },
-      completion: { required: false },
-      queuedLaunch: {
-        request: { sessionKey: `agent:main:subagent:${runId}`, idempotencyKey: runId },
-        timeoutMs: 1_000,
-        schedulerGroupKey: '["agent:main:main","restore-lifecycle-rotation"]',
-        maxConcurrent: 1,
-      },
-    });
+    mockSingleCollectorConcurrency();
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;
     }) => {
-      params.runs.set("run-restored-rotation-one", makeQueuedRun("run-restored-rotation-one", now));
+      params.runs.set(
+        "run-restored-rotation-one",
+        makeQueuedRun({
+          runId: "run-restored-rotation-one",
+          groupId: "restore-lifecycle-rotation",
+          createdAt: now,
+        }),
+      );
       params.runs.set(
         "run-restored-rotation-two",
-        makeQueuedRun("run-restored-rotation-two", now + 1),
+        makeQueuedRun({
+          runId: "run-restored-rotation-two",
+          groupId: "restore-lifecycle-rotation",
+          createdAt: now + 1,
+        }),
       );
       return 2;
     }) as never);
@@ -1777,21 +1757,15 @@ describe("subagent registry seam flow", () => {
     }) => {
       params.runs.set(
         "run-queued-failure",
-        createSubagentRunRecord({
+        makeQueuedRun({
           runId: "run-queued-failure",
           childSessionKey: "agent:main:subagent:queued-failure",
           swarmRequesterSessionKey: "agent:main:main",
           task: "fail restored launch",
-          collect: true,
           groupId: "restore-failure",
           createdAt: now,
-          execution: { status: "queued" },
-          completion: { required: false },
           queuedLaunch: {
             request: { sessionKey: "agent:main:subagent:queued-failure" },
-            timeoutMs: 1_000,
-            schedulerGroupKey: '["agent:main:main","restore-failure"]',
-            maxConcurrent: 1,
           },
         }),
       );
@@ -1856,21 +1830,15 @@ describe("subagent registry seam flow", () => {
     }) => {
       params.runs.set(
         "run-queued-cleanup-retry",
-        createSubagentRunRecord({
+        makeQueuedRun({
           runId: "run-queued-cleanup-retry",
           childSessionKey: "agent:main:subagent:queued-cleanup-retry",
           swarmRequesterSessionKey: "agent:main:main",
           task: "retry failed cleanup",
-          collect: true,
           groupId: "restore-cleanup-retry",
           createdAt: now,
-          execution: { status: "queued" },
-          completion: { required: false },
           queuedLaunch: {
             request: { sessionKey: "agent:main:subagent:queued-cleanup-retry" },
-            timeoutMs: 1_000,
-            schedulerGroupKey: '["agent:main:main","restore-cleanup-retry"]',
-            maxConcurrent: 1,
           },
         }),
       );
@@ -1947,22 +1915,18 @@ describe("subagent registry seam flow", () => {
 
   it("rolls back a queued collector failure when persistence fails", () => {
     const runId = "run-queued-persist-failure";
-    mod.addSubagentRunForTests({
-      runId,
-      childSessionKey: "agent:main:subagent:queued-persist-failure",
-      task: "remain queued after sqlite failure",
-      collect: true,
-      groupId: "persist-failure",
-      createdAt: Date.now(),
-      execution: { status: "queued" },
-      completion: { required: false },
-      queuedLaunch: {
-        request: { sessionKey: "agent:main:subagent:queued-persist-failure" },
-        timeoutMs: 1_000,
-        schedulerGroupKey: '["agent:main:main","persist-failure"]',
-        maxConcurrent: 1,
-      },
-    });
+    mod.addSubagentRunForTests(
+      makeQueuedRun({
+        runId,
+        childSessionKey: "agent:main:subagent:queued-persist-failure",
+        task: "remain queued after sqlite failure",
+        groupId: "persist-failure",
+        createdAt: Date.now(),
+        queuedLaunch: {
+          request: { sessionKey: "agent:main:subagent:queued-persist-failure" },
+        },
+      }),
+    );
     mocks.persistSubagentRunsToDiskOrThrow.mockImplementationOnce(() => {
       throw new Error("sqlite busy");
     });
@@ -2342,9 +2306,7 @@ describe("subagent registry seam flow", () => {
 
   it("converts first lifecycle success after the explicit run deadline into timeout", async () => {
     const startedAt = Date.now();
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
 
     mod.registerSubagentRun({
       runId: "run-lifecycle-success-after-deadline",
@@ -2387,9 +2349,7 @@ describe("subagent registry seam flow", () => {
     const createdAt = Date.parse("2026-03-24T11:59:00Z");
     const observedStartedAt = createdAt + 10_000;
     vi.setSystemTime(createdAt);
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
 
     mod.registerSubagentRun({
       runId: "run-lifecycle-observed-start",
@@ -2485,9 +2445,7 @@ describe("subagent registry seam flow", () => {
 
   it("refreshes unpublished timeout delivery payloads after lifecycle correction", async () => {
     const createdAt = Date.parse("2026-03-24T11:59:00Z");
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     mocks.runSubagentAnnounceFlow.mockResolvedValueOnce(false);
     mod.registerSubagentRun({
       runId: "run-refresh-pending-timeout-payload",
@@ -2608,9 +2566,7 @@ describe("subagent registry seam flow", () => {
 
   it("caps lifecycle timeout events to the explicit run deadline", async () => {
     const startedAt = Date.now();
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
 
     mod.registerSubagentRun({
       runId: "run-lifecycle-timeout-after-deadline",
@@ -3320,9 +3276,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("ignores a late yield lifecycle event after the paused run is killed", async () => {
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     const runId = "run-yield-killed-before-late-event";
     const childSessionKey = "agent:main:subagent:yield-killed-before-late-event";
     mod.registerSubagentRun({
@@ -3370,9 +3324,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("accepts an authoritative late yield after non-kill cleanup started", async () => {
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     const runId = "run-yield-after-success-cleanup";
     mod.registerSubagentRun({
       runId,
@@ -3417,9 +3369,7 @@ describe("subagent registry seam flow", () => {
     // subagent's yield terminal can arrive carrying yielded plus aborted (or
     // stopReason="aborted"). The event handler must still pause the run, not
     // settle it `cancelled` and deliver a false notice to the requester.
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
 
     const cases = [
       { runId: "run-yield-stopreason-aborted", extra: { stopReason: "aborted" } },
@@ -3461,9 +3411,7 @@ describe("subagent registry seam flow", () => {
   it("cancels a pending grace timer when a yield follows an intermediate aborted terminal (#92448)", async () => {
     // An earlier aborted terminal schedules a deferred kill grace timer; a
     // following yield must clear it, or it fires and settles the now-paused run.
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
 
     mod.registerSubagentRun({
       runId: "run-yield-after-pending-timeout",
@@ -3500,9 +3448,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("cancels a pending timeout grace timer when the run is explicitly killed", async () => {
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     const runId = "run-killed-after-pending-timeout";
     mod.registerSubagentRun({
       runId,
@@ -3717,9 +3663,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("reconciles stale active runs from persisted terminal session state during sweep", async () => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     const persistedStartedAt = Date.parse("2026-03-24T11:58:00Z");
     const persistedEndedAt = persistedStartedAt + 111;
     mocks.loadSessionStore.mockReturnValue(
@@ -4501,9 +4445,7 @@ describe("subagent registry seam flow", () => {
   it("retires a superseded tombstone after its newer generation is released", async () => {
     const killedAt = Date.now() - 5 * 60_000;
     const childSessionKey = "agent:main:subagent:released-successor";
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     mod.addSubagentRunForTests(
       makeKilledRun(killedAt, {
         runId: "run-released-successor-old",
@@ -4696,9 +4638,7 @@ describe("subagent registry seam flow", () => {
 
   it("does not restore session-write ownership after a successor is released", async () => {
     const childSessionKey = "agent:main:subagent:released-timing-owner";
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     mocks.loadSessionStore.mockReturnValue({
       [childSessionKey]: { sessionId: "sess-released-timing-owner", updatedAt: 1 },
     });
@@ -4831,9 +4771,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("uses session-store start time when sweeping stale explicit-timeout runs", async () => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     const createdAt = Date.parse("2026-03-24T11:59:00Z");
     const sessionStartedAt = createdAt + 10_000;
     const sessionEndedAt = createdAt + 65_000;
@@ -4874,9 +4812,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("keeps restart-aborted runs active while recovery dependencies are unavailable", async () => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     mocks.loadSessionStore.mockReturnValue(
       createSessionStore({
         updatedAt: 333,
@@ -5024,9 +4960,7 @@ describe("subagent registry seam flow", () => {
     { name: "running", queued: false },
     { name: "queued", queued: true },
   ])("persists a $name registration exactly once", ({ queued }) => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
 
     const runId = `run-single-persist-${queued ? "queued" : "running"}`;
     mod.registerSubagentRun({
@@ -5063,9 +4997,7 @@ describe("subagent registry seam flow", () => {
     mocks.persistSubagentRunsToDiskOrThrow.mockImplementationOnce((runs) => {
       persistedEntry = structuredClone(runs.get(runId));
     });
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     const defaultRuntime = getDetachedTaskLifecycleRuntime();
     const createMutatingTaskRun = vi.fn(
       (taskParams: Parameters<typeof defaultRuntime.createQueuedTaskRun>[0]) => {
@@ -5102,9 +5034,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("retains an already-running replacement when its durable write fails", () => {
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     mod.registerSubagentRun({
       runId: "run-replacement-persist-old",
       childSessionKey: "agent:main:subagent:replacement-persist",
@@ -5166,9 +5096,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("rolls back a killed tombstone when its durable registry write fails", () => {
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) =>
-      request.method === "agent.wait" ? { status: "pending" } : {},
-    );
+    mockPendingAgentWait();
     const runId = "run-kill-persist-failure";
     mod.registerSubagentRun({
       runId,
@@ -5234,9 +5162,7 @@ describe("subagent registry seam flow", () => {
   ] as const)(
     "announces $livenessState lifecycle end events as errors instead of success",
     async ({ livenessState, runId, task, error }) => {
-      mockGatewayMethods(mocks.callGateway, {
-        "agent.wait": { status: "pending" },
-      });
+      mockPendingAgentWait();
 
       mod.registerSubagentRun({
         runId,
@@ -5322,9 +5248,7 @@ describe("subagent registry seam flow", () => {
       verifiesAnnouncement: false,
     },
   ])("$name", async ({ runId, task, phase, event, verifiesAnnouncement }) => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     mod.registerSubagentRun({ runId, task, expectsCompletionMessage: true });
 
     const lifecycleHandler = getLifecycleHandler();
@@ -5382,9 +5306,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("finishes canonical killed cleanup when its best-effort hook fails", async () => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     mocks.getGlobalHookRunner.mockReturnValue({
       hasHooks: (hookName: string) => hookName === "subagent_ended",
       runSubagentEnded: vi.fn().mockRejectedValueOnce(new Error("ended hook unavailable")),
@@ -5476,9 +5398,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("suppresses stale timeout announces when the same child run later finishes successfully", async () => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
 
     mod.registerSubagentRun({
       runId: "run-timeout-then-ok",
@@ -5814,9 +5734,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("defers the killed hook until the provisional result reconciles", async () => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     const endedHookRunner = {
       hasHooks: (hookName: string) => hookName === "subagent_ended",
       runSubagentEnded: mocks.runSubagentEnded,
@@ -5966,9 +5884,7 @@ describe("subagent registry seam flow", () => {
   });
 
   it("emits only the canonical completion hook when completion beats a provisional kill", async () => {
-    mockGatewayMethods(mocks.callGateway, {
-      "agent.wait": { status: "pending" },
-    });
+    mockPendingAgentWait();
     mocks.getGlobalHookRunner.mockReturnValue({
       hasHooks: (hookName: string) => hookName === "subagent_ended",
       runSubagentEnded: mocks.runSubagentEnded,

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -88,8 +88,8 @@ function acceptedSubmit(runId: string, draftText: string | null = "pending"): Tu
   return { phase: "accepted", runId, draftText };
 }
 
-describe("tui-event-handlers: handleAgentEvent", () => {
-  const makeState = (overrides?: Partial<TuiStateAccess>): TuiStateAccess => ({
+function makeTuiState(overrides: Partial<TuiStateAccess> = {}): TuiStateAccess {
+  return {
     agentDefaultId: "main",
     sessionMainKey: "agent:main:main",
     sessionScope: "global",
@@ -97,7 +97,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     currentAgentId: "main",
     currentSessionKey: "agent:main:main",
     currentSessionId: "session-1",
-    activeChatRunId: "run-1",
+    activeChatRunId: null,
     pendingSubmit: null,
     historyLoaded: true,
     sessionInfo: { verboseLevel: "on" },
@@ -111,7 +111,65 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     statusTimeout: null,
     lastCtrlCAt: 0,
     ...overrides,
+  };
+}
+
+type ChatEventOverrides = Partial<ChatEvent> & { stopReason?: unknown };
+
+function makeChatEvent(state: TuiStateAccess, overrides: ChatEventOverrides = {}): ChatEvent {
+  return {
+    runId: "run-1",
+    sessionKey: state.currentSessionKey,
+    state: "delta",
+    ...overrides,
+  };
+}
+
+function makeFinalChatEvent(
+  state: TuiStateAccess,
+  runId: string,
+  overrides: ChatEventOverrides = {},
+): ChatEvent {
+  return makeChatEvent(state, {
+    runId,
+    state: "final",
+    message: { content: [{ type: "text", text: "done" }] },
+    ...overrides,
   });
+}
+
+function makeAgentEvent(overrides: Partial<AgentEvent> = {}): AgentEvent {
+  return {
+    runId: "run-1",
+    stream: "lifecycle",
+    data: { phase: "start" },
+    ...overrides,
+  };
+}
+
+function makeSessionChangedEvent(
+  state: TuiStateAccess,
+  overrides: Partial<SessionChangedEvent> = {},
+): SessionChangedEvent {
+  return {
+    sessionKey: state.currentSessionKey,
+    ...overrides,
+  };
+}
+
+function makeSessionMessageEvent(
+  state: TuiStateAccess,
+  overrides: Partial<SessionMessageEvent> = {},
+): SessionMessageEvent {
+  return {
+    sessionKey: state.currentSessionKey,
+    ...overrides,
+  };
+}
+
+describe("tui-event-handlers: handleAgentEvent", () => {
+  const makeState = (overrides?: Partial<TuiStateAccess>): TuiStateAccess =>
+    makeTuiState({ activeChatRunId: "run-1", ...overrides });
 
   const makeContext = (state: TuiStateAccess) => {
     const chatLog = createMockChatLog();
@@ -165,7 +223,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     const state = makeState(params?.state);
     const context = makeContext(state);
     const chatLog = (params?.chatLog ?? context.chatLog) as MockChatLog & HandlerChatLog;
-    const handlers = createEventHandlers({
+    const rawHandlers = createEventHandlers({
       chatLog,
       btw: (params?.btw ?? context.btw) as MockBtwPresenter & HandlerBtwPresenter,
       tui: context.tui,
@@ -182,6 +240,17 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       forgetLocalBtwRunId: context.forgetLocalBtwRunId,
       clearLocalBtwRunIds: context.clearLocalBtwRunIds,
     });
+    const handlers = {
+      ...rawHandlers,
+      handleChatEvent: (event: ChatEventOverrides) =>
+        rawHandlers.handleChatEvent(makeChatEvent(state, event)),
+      handleAgentEvent: (event: Partial<AgentEvent>) =>
+        rawHandlers.handleAgentEvent(makeAgentEvent(event)),
+      handleSessionsChangedEvent: (event: Partial<SessionChangedEvent> = {}) =>
+        rawHandlers.handleSessionsChangedEvent(makeSessionChangedEvent(state, event)),
+      handleSessionMessageEvent: (event: Partial<SessionMessageEvent> = {}) =>
+        rawHandlers.handleSessionMessageEvent(makeSessionMessageEvent(state, event)),
+    };
     return {
       ...context,
       state,
@@ -238,8 +307,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       runId: "run-work",
       sessionKey: "global",
       agentId: "work",
-      stream: "lifecycle",
-      data: { phase: "start" },
     });
 
     state.currentAgentId = "main";
@@ -266,8 +333,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     reconnectStreamingWatchdog(null);
     handleChatEvent({
       runId: "run-stale",
-      sessionKey: "agent:main:main",
-      state: "delta",
       message: { role: "assistant", content: "late stale output" },
     });
 
@@ -281,7 +346,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: { currentSessionId: "session-xyz", activeChatRunId: "run-123" },
     });
 
-    const evt: AgentEvent = {
+    const evt = makeAgentEvent({
       runId: "run-123",
       stream: "tool",
       data: {
@@ -290,7 +355,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         name: "exec",
         args: { command: "echo hi" },
       },
-    };
+    });
 
     handleAgentEvent(evt);
 
@@ -308,11 +373,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: { activeChatRunId: "run-1" },
     });
 
-    const evt: AgentEvent = {
+    const evt = makeAgentEvent({
       runId: "run-2",
       stream: "tool",
       data: { phase: "start", toolCallId: "tc1", name: "exec" },
-    };
+    });
 
     handleAgentEvent(evt);
 
@@ -328,11 +393,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       chatLog,
     });
 
-    const evt: AgentEvent = {
+    const evt = makeAgentEvent({
       runId: "run-9",
-      stream: "lifecycle",
-      data: { phase: "start" },
-    };
+    });
 
     handleAgentEvent(evt);
 
@@ -347,9 +410,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-bridge",
-      stream: "lifecycle",
       sessionKey: state.currentSessionKey,
-      data: { phase: "start" },
     });
 
     expect(setActivityStatus).toHaveBeenCalledWith("running");
@@ -364,9 +425,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-other",
-      stream: "lifecycle",
       sessionKey: "agent:other:other",
-      data: { phase: "start" },
     });
 
     expect(setActivityStatus).not.toHaveBeenCalled();
@@ -381,19 +440,15 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-bridge",
-      stream: "lifecycle",
       sessionKey: state.currentSessionKey,
-      data: { phase: "start" },
     });
     handleAgentEvent({
       runId: "run-bridge",
-      stream: "lifecycle",
       sessionKey: state.currentSessionKey,
       data: { phase: "finishing" },
     });
     handleAgentEvent({
       runId: "run-bridge",
-      stream: "lifecycle",
       sessionKey: state.currentSessionKey,
       data: { phase: "end" },
     });
@@ -411,13 +466,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-bridge",
-      stream: "lifecycle",
       sessionKey: state.currentSessionKey,
-      data: { phase: "start" },
     });
     handleChatEvent({
       runId: "run-user",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "done" }], stopReason: "stop" },
     });
@@ -446,7 +498,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId: "run-provider-error",
-        sessionKey: state.currentSessionKey,
         state: "final",
         ...(topLevelStopReason ? { stopReason: topLevelStopReason } : {}),
         message: {
@@ -475,7 +526,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-error",
-      stream: "lifecycle",
       data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
     });
 
@@ -510,25 +560,22 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-aborted-partial",
-      sessionKey: state.currentSessionKey,
       seq: 1,
-      state: "delta",
       message: {
         role: "assistant",
         content: [{ type: "text", text: "Already visible" }],
       },
-    } satisfies ChatEvent);
+    });
 
     handleChatEvent({
       runId: "run-aborted-partial",
-      sessionKey: state.currentSessionKey,
       seq: 2,
       state: "aborted",
       message: {
         role: "assistant",
         content: [{ type: "text", text: "Already visible and the throttled tail" }],
       },
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.updateAssistant).toHaveBeenCalledWith("Already visible", "run-aborted-partial");
     expect(chatLog.finalizeAssistant).toHaveBeenCalledExactlyOnceWith(
@@ -551,19 +598,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-aborted-stream",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: {
         role: "assistant",
         content: [{ type: "text", text: "Keep the streamed partial" }],
       },
-    } satisfies ChatEvent);
+    });
 
     handleChatEvent({
       runId: "run-aborted-stream",
-      sessionKey: state.currentSessionKey,
       state: "aborted",
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledExactlyOnceWith(
       "Keep the streamed partial",
@@ -586,18 +630,15 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     if (streamText !== undefined) {
       handleChatEvent({
         runId: "run-aborted-literal",
-        sessionKey: state.currentSessionKey,
-        state: "delta",
         message: {
           role: "assistant",
           content: [{ type: "text", text: streamText }],
         },
-      } satisfies ChatEvent);
+      });
     }
 
     handleChatEvent({
       runId: "run-aborted-literal",
-      sessionKey: state.currentSessionKey,
       state: "aborted",
       ...(finalText === undefined
         ? {}
@@ -607,7 +648,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
               content: [{ type: "text", text: finalText }],
             },
           }),
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledExactlyOnceWith(
       "(no output)",
@@ -643,10 +684,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-aborted-empty",
-      sessionKey: state.currentSessionKey,
       state: "aborted",
       message,
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
     expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("run aborted");
@@ -655,13 +695,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("appends the tool-error summary to the abort line when present", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-validation-loop" },
     });
 
     handleChatEvent({
       runId: "run-validation-loop",
-      sessionKey: state.currentSessionKey,
       state: "aborted",
       errorMessage: "edit tool validation failed: edits: must have required properties edits",
     });
@@ -672,13 +711,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("sanitizes untrusted abort diagnostics before rendering", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-hostile" },
     });
 
     handleChatEvent({
       runId: "run-hostile",
-      sessionKey: state.currentSessionKey,
       state: "aborted",
       errorMessage: "edit failed\u001b[31m\nsecret",
     });
@@ -687,14 +725,13 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("keeps truncated abort diagnostics on a UTF-16 boundary", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-emoji" },
     });
 
     const prefix = `${"word ".repeat(31)}abc`;
     handleChatEvent({
       runId: "run-emoji",
-      sessionKey: state.currentSessionKey,
       state: "aborted",
       errorMessage: `${prefix}🚀tail`,
     });
@@ -703,13 +740,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("falls back to a bare abort line when there is no summary", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-plain" },
     });
 
     handleChatEvent({
       runId: "run-plain",
-      sessionKey: state.currentSessionKey,
       state: "aborted",
     });
 
@@ -724,14 +760,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-error",
-      stream: "lifecycle",
       data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
     });
     vi.advanceTimersByTime(15_000);
 
     handleChatEvent({
       runId: "run-error",
-      sessionKey: state.currentSessionKey,
       state: "error",
       errorMessage: "provider exploded",
     });
@@ -751,13 +785,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-retry",
-      stream: "lifecycle",
       data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
     });
 
     handleAgentEvent({
       runId: "run-retry",
-      stream: "lifecycle",
       data: { phase: "start", startedAt: Date.now() },
     });
 
@@ -776,7 +808,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-retryable",
-      stream: "lifecycle",
       data: { phase: "error", error: "primary model timed out" },
     });
 
@@ -799,7 +830,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-fallback",
-      stream: "lifecycle",
       data: {
         phase: "fallback_step",
         fallbackStepFinalOutcome: "next_fallback",
@@ -828,7 +858,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-pending",
-      stream: "lifecycle",
       data: {
         phase: "fallback_step",
         fallbackStepFinalOutcome: "succeeded",
@@ -854,7 +883,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-pending",
-      stream: "lifecycle",
       data: { phase: "finishing" },
     });
 
@@ -875,8 +903,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-remote",
-      stream: "lifecycle",
-      data: { phase: "start" },
     });
 
     expect(state.activeChatRunId).toBeNull();
@@ -895,16 +921,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-pending",
-      stream: "lifecycle",
-      data: { phase: "start" },
     });
 
-    handleChatEvent({
-      runId: "run-pending",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-pending"));
 
     expect(state.pendingSubmit).toBeNull();
     expect(isLocalRunId("run-pending")).toBe(false);
@@ -924,12 +943,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     noteLocalRunId("run-pending");
     state.currentSessionKey = "agent:main:restored";
 
-    handleChatEvent({
-      runId: "run-pending",
-      sessionKey: "agent:main:restored",
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(
+      makeFinalChatEvent(state, "run-pending", { sessionKey: "agent:main:restored" }),
+    );
 
     expect(state.pendingSubmit).toBeNull();
     expect(isLocalRunId("run-pending")).toBe(false);
@@ -944,18 +960,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         state: { activeChatRunId: null },
       });
 
-    handleChatEvent({
-      runId: "run-final",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-final"));
     setActivityStatus.mockClear();
     tui.requestRender.mockClear();
 
     handleAgentEvent({
       runId: "run-final",
-      stream: "lifecycle",
       data: { phase: "finishing" },
     });
 
@@ -967,7 +977,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-final",
-      stream: "lifecycle",
       data: { phase: "end" },
     });
 
@@ -987,7 +996,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-local",
-      stream: "lifecycle",
       data: { phase: "finishing" },
     });
     setActivityStatus.mockClear();
@@ -995,19 +1003,13 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-local",
-      stream: "lifecycle",
       data: { phase: "end" },
     });
 
     expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
     expect(tui.requestRender).toHaveBeenCalledWith(true);
 
-    handleChatEvent({
-      runId: "run-local",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-local"));
 
     expect(setActivityStatus).toHaveBeenCalledWith("idle");
   });
@@ -1019,7 +1021,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-9",
-      stream: "lifecycle",
       data: { phase: "end" },
     });
 
@@ -1034,14 +1035,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-old",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "old done" }] },
     });
     handleChatEvent({
       runId: "run-new",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "new running" },
     });
     setActivityStatus.mockClear();
@@ -1049,12 +1047,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-old",
-      stream: "lifecycle",
       data: { phase: "finishing" },
     });
     handleAgentEvent({
       runId: "run-old",
-      stream: "lifecycle",
       data: { phase: "end" },
     });
 
@@ -1073,7 +1069,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-other",
-      stream: "lifecycle",
       data: { phase: "fallback_step", fallbackStepToModel: "openrouter/other-model" },
     });
 
@@ -1087,22 +1082,20 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: { activeChatRunId: null },
     });
 
-    const chatEvt: ChatEvent = {
+    const chatEvt = makeChatEvent(state, {
       runId: "run-42",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
-    };
+    });
 
     handleChatEvent(chatEvt);
 
     expect(state.activeChatRunId).toBe("run-42");
 
-    const agentEvt: AgentEvent = {
+    const agentEvt = makeAgentEvent({
       runId: "run-42",
       stream: "tool",
       data: { phase: "start", toolCallId: "tc1", name: "exec" },
-    };
+    });
 
     handleAgentEvent(agentEvt);
 
@@ -1120,7 +1113,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     handleChatEvent({
       runId: "run-alias",
       sessionKey: "main",
-      state: "delta",
       message: { content: "hello" },
     });
 
@@ -1136,46 +1128,36 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-first",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "first live response" }] },
-    } satisfies ChatEvent);
+    });
     handleAgentEvent({
       runId: "run-second",
       sessionKey: state.currentSessionKey,
-      stream: "lifecycle",
-      data: { phase: "start" },
-    } satisfies AgentEvent);
+    });
     handleChatEvent({
       runId: "run-second",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "second live response" }] },
-    } satisfies ChatEvent);
+    });
 
     for (let index = 0; index < 500; index += 1) {
       handleChatEvent({
         runId: `run-orphan-${index}`,
-        sessionKey: state.currentSessionKey,
-        state: "delta",
         message: { content: [{ type: "text", text: `orphan ${index}` }] },
-      } satisfies ChatEvent);
+      });
     }
 
     expect(state.activeChatRunId).toBe("run-first");
     handleChatEvent({
       runId: "run-second",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
     expect(state.activeChatRunId).toBe("run-first");
     handleChatEvent({
       runId: "run-first",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("second live response", "run-second");
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("first live response", "run-first");
@@ -1197,52 +1179,39 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-first",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "first live response" }] },
-    } satisfies ChatEvent);
+    });
     handleAgentEvent({
       runId: "run-second",
       sessionKey: state.currentSessionKey,
-      stream: "lifecycle",
-      data: { phase: "start" },
-    } satisfies AgentEvent);
+    });
     handleChatEvent({
       runId: "run-second",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "second live response" }] },
-    } satisfies ChatEvent);
+    });
 
     for (let index = 0; index < 500; index += 1) {
       handleChatEvent({
         runId: `run-orphan-${index}`,
-        sessionKey: state.currentSessionKey,
-        state: "delta",
         message: { content: [{ type: "text", text: `orphan ${index}` }] },
-      } satisfies ChatEvent);
+      });
     }
 
-    handleSessionMessageEvent({
-      sessionKey: state.currentSessionKey,
-      updatedAt: 200,
-    } satisfies SessionMessageEvent);
+    handleSessionMessageEvent(makeSessionMessageEvent(state, { updatedAt: 200 }));
     expect(loadHistory).not.toHaveBeenCalled();
 
     handleChatEvent({
       runId: "run-first",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
     expect(state.activeChatRunId).toBe("run-second");
 
     handleChatEvent({
       runId: "run-second",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("first live response", "run-first");
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("second live response", "run-second");
@@ -1251,29 +1220,24 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     for (const runId of ["run-first", "run-second"]) {
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         runId,
         phase: "end",
-      } satisfies SessionChangedEvent);
+      });
     }
     expect(loadHistory).toHaveBeenCalledTimes(1);
 
     const displayedDeltaCount = chatLog.updateAssistant.mock.calls.length;
     handleChatEvent({
       runId: "run-orphan-499",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "late orphan" }] },
-    } satisfies ChatEvent);
+    });
     expect(state.activeChatRunId).toBeNull();
     expect(chatLog.updateAssistant).toHaveBeenCalledTimes(displayedDeltaCount);
 
     handleChatEvent({
       runId: "run-never-seen-orphan",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "untracked late orphan" }] },
-    } satisfies ChatEvent);
+    });
     expect(state.activeChatRunId).toBeNull();
     expect(chatLog.updateAssistant).toHaveBeenCalledTimes(displayedDeltaCount);
   });
@@ -1285,38 +1249,30 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     handleAgentEvent({
       runId: "run-confirmed",
       sessionKey: state.currentSessionKey,
-      stream: "lifecycle",
-      data: { phase: "start" },
-    } satisfies AgentEvent);
+    });
     handleChatEvent({
       runId: "run-confirmed",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "confirmed response" }] },
-    } satisfies ChatEvent);
+    });
     handleChatEvent({
       runId: "run-without-lifecycle",
-      sessionKey: state.currentSessionKey,
       seq: 1,
-      state: "delta",
       message: { content: [{ type: "text", text: "older peer response" }] },
-    } satisfies ChatEvent);
+    });
 
     handleChatEvent({
       runId: "run-confirmed",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
     expect(state.activeChatRunId).toBe("run-without-lifecycle");
 
     handleChatEvent({
       runId: "run-without-lifecycle",
-      sessionKey: state.currentSessionKey,
       seq: 2,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
       "older peer response",
@@ -1332,52 +1288,40 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-first",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "first live response" }] },
-    } satisfies ChatEvent);
+    });
     handleAgentEvent({
       runId: "run-confirmed",
       sessionKey: state.currentSessionKey,
-      stream: "lifecycle",
-      data: { phase: "start" },
-    } satisfies AgentEvent);
+    });
     handleChatEvent({
       runId: "run-confirmed",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "confirmed response" }] },
-    } satisfies ChatEvent);
+    });
     handleChatEvent({
       runId: "run-without-lifecycle",
-      sessionKey: state.currentSessionKey,
       seq: 1,
-      state: "delta",
       message: { content: [{ type: "text", text: "older peer response" }] },
-    } satisfies ChatEvent);
+    });
     handleChatEvent({
       runId: "run-orphan",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: [{ type: "text", text: "unconfirmed orphan" }] },
-    } satisfies ChatEvent);
+    });
 
     handleChatEvent({
       runId: "run-first",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
     expect(["run-confirmed", "run-without-lifecycle"]).toContain(state.activeChatRunId);
 
     for (const runId of ["run-confirmed", "run-without-lifecycle"]) {
       handleChatEvent({
         runId,
-        sessionKey: state.currentSessionKey,
         ...(runId === "run-without-lifecycle" ? { seq: 2 } : {}),
         state: "final",
         message: { role: "assistant", content: [] },
-      } satisfies ChatEvent);
+      });
     }
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
@@ -1424,15 +1368,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       handleChatEvent({
         runId: "run-other-session",
         sessionKey: otherSessionKey,
-        state: "delta",
         message: { content: "message from another conversation" },
-      } satisfies ChatEvent);
+      });
       handleAgentEvent({
         runId: "run-other-lifecycle",
         sessionKey: otherSessionKey,
-        stream: "lifecycle",
-        data: { phase: "start" },
-      } satisfies AgentEvent);
+      });
       handleBtwEvent({
         kind: "btw",
         runId: "run-other-btw",
@@ -1445,13 +1386,13 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         reason: "reset",
         sessionId: "other-session",
         updatedAt: 200,
-      } satisfies SessionChangedEvent);
+      });
       handleSessionMessageEvent({
         sessionKey: otherSessionKey,
         agentId: "main",
         sessionId: "other-session",
         updatedAt: 200,
-      } satisfies SessionMessageEvent);
+      });
 
       expect(chatLog.updateAssistant).not.toHaveBeenCalled();
       expect(btw.showResult).not.toHaveBeenCalled();
@@ -1508,9 +1449,8 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-btw",
-      sessionKey: state.currentSessionKey,
       state: "final",
-    } satisfies ChatEvent);
+    });
 
     expect(loadHistory).not.toHaveBeenCalled();
     expect(btw.showResult).toHaveBeenCalledWith({
@@ -1547,9 +1487,8 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-btw",
-      sessionKey: state.currentSessionKey,
       state: "final",
-    } satisfies ChatEvent);
+    });
 
     expect(state.activeChatRunId).toBeNull();
     expect(state.activityStatus).toBe("idle");
@@ -1574,7 +1513,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     handleChatEvent({
       runId: "run-other-agent",
       sessionKey: "agent:beta:main",
-      state: "delta",
       message: { content: "should be ignored" },
     });
 
@@ -1593,15 +1531,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-main-global",
-      sessionKey: "global",
       agentId: "main",
-      state: "delta",
       message: { content: "wrong agent" },
     });
     handleChatEvent({
       runId: "run-legacy-default-global",
-      sessionKey: "global",
-      state: "delta",
       message: { content: "legacy default" },
     });
 
@@ -1636,8 +1570,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-old",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
     });
 
@@ -1678,12 +1610,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       refreshSessionInfo,
     });
 
-    handleChatEvent({
-      runId: "run-old",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-old"));
     noteLocalRunId("run-local");
     state.activeChatRunId = "run-stale";
     state.pendingSubmit = acceptedSubmit("run-pending");
@@ -1700,7 +1627,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       reason: "reset",
       sessionId: "session-after",
       updatedAt: 200,
-    } satisfies SessionChangedEvent);
+    });
 
     expect(state.activeChatRunId).toBeNull();
     expect(state.pendingSubmit).toBeNull();
@@ -1731,11 +1658,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     handleSessionsChangedEvent({
-      sessionKey: state.currentSessionKey,
       agentId: state.currentAgentId,
       sessionId: "session-1",
       phase: "message",
-    } satisfies SessionChangedEvent);
+    });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
     expect(state.activeChatRunId).toBeNull();
@@ -1754,11 +1680,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
 
     handleSessionsChangedEvent({
-      sessionKey: state.currentSessionKey,
       agentId: state.currentAgentId,
       sessionId: "session-1",
       phase: "message",
-    } satisfies SessionChangedEvent);
+    });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
     expect(state.activeChatRunId).toBe("run-active");
@@ -1775,11 +1700,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     handleSessionsChangedEvent({
-      sessionKey: state.currentSessionKey,
       agentId: state.currentAgentId,
       sessionId: "session-other",
       phase: "message",
-    } satisfies SessionChangedEvent);
+    });
 
     expect(loadHistory).not.toHaveBeenCalled();
     expect(state.currentSessionId).toBe("session-current");
@@ -1802,7 +1726,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       agentId: "main",
       sessionId: "session-work",
       phase: "message",
-    } satisfies SessionChangedEvent);
+    });
 
     expect(loadHistory).not.toHaveBeenCalled();
     expect(state.activeChatRunId).toBe("run-active");
@@ -1820,7 +1744,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     handleSessionsChangedEvent({
-      sessionKey: state.currentSessionKey,
       agentId: state.currentAgentId,
       sessionId: "session-1",
       phase: "message",
@@ -1840,7 +1763,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     handleSessionsChangedEvent({
       sessionKey: "agent:other:main",
       reason: "reset",
-    } satisfies SessionChangedEvent);
+    });
 
     expect(state.activeChatRunId).toBe("run-current");
     expect(state.activityStatus).toBe("streaming");
@@ -1866,7 +1789,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       reason: "reset",
       sessionId: "session-other-agent",
       updatedAt: 300,
-    } satisfies SessionChangedEvent);
+    });
 
     expect(state.activeChatRunId).toBe("run-current");
     expect(state.activityStatus).toBe("streaming");
@@ -1880,12 +1803,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: { activeChatRunId: null },
     });
 
-    handleChatEvent({
-      runId: "run-final",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-final"));
 
     handleAgentEvent({
       runId: "run-final",
@@ -1903,15 +1821,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("ignores lifecycle updates for non-active runs in the same session", () => {
-    const { state, tui, setActivityStatus, handleChatEvent, handleAgentEvent } =
-      createHandlersHarness({
-        state: { activeChatRunId: "run-active" },
-      });
+    const { tui, setActivityStatus, handleChatEvent, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-active" },
+    });
 
     handleChatEvent({
       runId: "run-other",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
     });
     setActivityStatus.mockClear();
@@ -1919,7 +1834,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleAgentEvent({
       runId: "run-other",
-      stream: "lifecycle",
       data: { phase: "end" },
     });
 
@@ -1995,7 +1909,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     // yet, causing the just-rendered message to vanish.
     handleChatEvent({
       runId: "run-external",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "assistant reply" }] },
     });
@@ -2021,13 +1934,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("finalizes an attachment-only assistant reply instead of dropping it", () => {
-    const { state, chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
+    const { chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
 
     handleChatEvent({
       runId: "run-external-image",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: {
         role: "assistant",
@@ -2055,7 +1967,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId: `run-${type}`,
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { role: "assistant", content: [{ type, text: "One visible reply." }] },
       });
@@ -2077,16 +1988,15 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       runId: "run-streamed-final",
       sessionKey,
       seq: 1,
-      state: "delta",
       message: { role: "assistant", content: "Assembled streamed reply." },
-    } satisfies ChatEvent);
+    });
     handleChatEvent({
       runId: "run-streamed-final",
       sessionKey,
       seq: 2,
       state: "final",
       message: { role: "assistant", content: [] },
-    } satisfies ChatEvent);
+    });
 
     reduceTuiSessionProjection(state, {
       type: "snapshotLoaded",
@@ -2101,7 +2011,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("reloads history on final when external run has no message", () => {
-    const { state, chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
+    const { chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
 
@@ -2109,7 +2019,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     // with server state since there is no local content to preserve.
     handleChatEvent({
       runId: "run-external-empty",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
 
@@ -2118,13 +2027,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("forces render when a command final only adds system text", () => {
-    const { state, chatLog, tui, handleChatEvent } = createHandlersHarness({
+    const { chatLog, tui, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-command" },
     });
 
     handleChatEvent({
       runId: "run-command",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: {
         command: true,
@@ -2144,12 +2052,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
     noteLocalRunId("run-gateway");
 
-    handleChatEvent({
-      runId: "run-gateway",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-gateway"));
 
     expect(state.pendingSubmit).toBeNull();
     expect(state.activeChatRunId).toBeNull();
@@ -2175,8 +2078,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-gateway",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "working" },
     });
 
@@ -2190,12 +2091,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: { activeChatRunId: null, pendingSubmit: sendingSubmit("run-pending") },
     });
 
-    handleChatEvent({
-      runId: "run-unknown",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-unknown"));
 
     expect(state.pendingSubmit).toEqual(sendingSubmit("run-pending"));
     expect(state.activeChatRunId).toBeNull();
@@ -2211,12 +2107,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       },
     });
 
-    handleChatEvent({
-      runId: "run-pending",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-pending"));
 
     expect(state.pendingSubmit).toBeNull();
     expect(state.activeChatRunId).toBe("run-active");
@@ -2237,7 +2128,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-other",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "other done" }] },
     });
@@ -2246,12 +2136,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(isLocalRunId("run-other")).toBe(false);
     expect(loadHistory).not.toHaveBeenCalled();
 
-    handleChatEvent({
-      runId: "run-pending",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-pending"));
 
     expect(state.pendingSubmit).toBeNull();
     expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("done", "run-pending");
@@ -2271,7 +2156,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-active",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "active done" }] },
     });
@@ -2292,12 +2176,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
     noteLocalRunId("run-early-final");
 
-    handleChatEvent({
-      runId: "run-early-final",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-early-final"));
 
     expect(state.pendingSubmit).toBeNull();
     expect(state.activeChatRunId).toBe("run-active");
@@ -2316,8 +2195,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-pending",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hi" },
     });
 
@@ -2333,8 +2210,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-active",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: localContent },
     });
 
@@ -2350,7 +2225,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-other",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "other final" }] },
     });
@@ -2361,8 +2235,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-active",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "continued" },
     });
 
@@ -2374,12 +2246,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: { activeChatRunId: "run-stale", activityStatus: "streaming" },
     });
 
-    handleChatEvent({
-      runId: "run-orphan",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-orphan"));
 
     expect(state.activeChatRunId).toBeNull();
     expect(setActivityStatus).toHaveBeenCalledWith("idle");
@@ -2390,23 +2257,15 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state: { activeChatRunId: null, activityStatus: "streaming" },
     });
 
-    handleChatEvent({
-      runId: "run-finalized",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-finalized"));
 
     noteLocalBtwRunId("run-btw-error");
     handleChatEvent({
       runId: "run-btw-error",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "background status update" },
     });
     handleChatEvent({
       runId: "run-btw-error",
-      sessionKey: state.currentSessionKey,
       state: "error",
       errorMessage: "background failure",
     });
@@ -2415,12 +2274,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(state.activityStatus).toBe("streaming");
     setActivityStatus.mockClear();
 
-    handleChatEvent({
-      runId: "run-finalized",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-finalized"));
 
     expect(state.activeChatRunId).toBeNull();
     expect(state.activityStatus).toBe("idle");
@@ -2442,7 +2296,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-local-empty",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
 
@@ -2459,7 +2312,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-orphan-error",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "failed" }], stopReason: "error" },
     });
@@ -2483,7 +2335,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId,
-        sessionKey: state.currentSessionKey,
         state: terminalState,
         errorMessage: terminalState === "error" ? "boom" : undefined,
       });
@@ -2501,7 +2352,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-other",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "other final" }] },
     });
@@ -2520,7 +2370,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-other",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [] },
     });
@@ -2532,13 +2381,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("renders final error text when chat final has no content but includes event errorMessage", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
 
     handleChatEvent({
       runId: "run-error-envelope",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [] },
       errorMessage: '401 {"error":{"message":"Missing scopes: model.request"}}',
@@ -2552,13 +2400,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("renders malformed streaming fragment text when chat final only has event errorMessage", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
 
     handleChatEvent({
       runId: "run-malformed-final",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [] },
       errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
@@ -2571,13 +2418,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("renders malformed streaming fragment text for chat error events without reloading", () => {
-    const { state, chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
+    const { chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
 
     handleChatEvent({
       runId: "run-malformed-error",
-      sessionKey: state.currentSessionKey,
       state: "error",
       errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
     });
@@ -2594,19 +2440,15 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
     handleChatEvent({
       runId: "run-other",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "still running" },
     });
     noteLocalRunId("run-local-empty");
     handleChatEvent({
       runId: "run-local-empty",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
     handleChatEvent({
       runId: "run-error",
-      sessionKey: state.currentSessionKey,
       state: "error",
       errorMessage: "provider exploded",
     });
@@ -2614,12 +2456,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(state.activeChatRunId).toBe("run-other");
     expect(loadHistory).not.toHaveBeenCalled();
 
-    handleChatEvent({
-      runId: "run-other",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-other"));
 
     await vi.waitFor(() => expect(chatLog.addSystem).toHaveBeenCalledTimes(2));
     expect(loadHistory).toHaveBeenCalledTimes(1);
@@ -2637,7 +2474,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-auth-error",
-      sessionKey: "agent:main:main",
       state: "error",
       errorMessage:
         "Authentication failed with an HTML 403 response from the provider. Re-authenticate and verify your provider account access.",
@@ -2661,7 +2497,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-xai-spending-limit",
-      sessionKey: "agent:main:main",
       state: "error",
       errorMessage: backendError,
     });
@@ -2676,7 +2511,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: {
         role: "assistant",
@@ -2685,7 +2519,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
     handleChatEvent({
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
       state: "error",
       errorMessage: "raw provider failure",
     });
@@ -2705,16 +2538,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [{ type: "text", text: "Delivered once." }] },
     });
-    const error = {
+    const error = makeChatEvent(state, {
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
-      state: "error" as const,
+      state: "error",
       errorMessage: "late provider failure",
-    };
+    });
 
     handleChatEvent(error);
     handleChatEvent(error);
@@ -2734,22 +2565,19 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [{ type: "text", text: "Delivered once." }] },
     });
     handleChatEvent({
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
       state: "error",
       errorMessage: "  \t  ",
     });
-    const error = {
+    const error = makeChatEvent(state, {
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
-      state: "error" as const,
+      state: "error",
       errorMessage: "  actionable provider failure  ",
-    };
+    });
 
     handleChatEvent(error);
     handleChatEvent(error);
@@ -2791,18 +2619,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         content: [{ type: "text", text: "Visible automatic final reply." }],
         ...(finalMetadata ? { __openclaw: finalMetadata } : {}),
       };
-      const sourceEvent = {
+      const sourceEvent = makeChatEvent(state, {
         runId: "run-message-tool",
-        sessionKey: state.currentSessionKey,
-        state: "final" as const,
+        state: "final",
         message: sourceReply,
-      };
-      const finalEvent = {
+      });
+      const finalEvent = makeChatEvent(state, {
         runId: "run-message-tool",
-        sessionKey: state.currentSessionKey,
-        state: "final" as const,
+        state: "final",
         message: automaticReply,
-      };
+      });
 
       handleChatEvent(sourceEvent);
       handleChatEvent(finalEvent);
@@ -2830,21 +2656,17 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-completed",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { role: "assistant", content: [{ type: "text", text: "Delivered once." }] },
     });
     handleChatEvent({
       runId: "run-newer",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "Newer response" },
     });
     setActivityStatus.mockClear();
 
     handleChatEvent({
       runId: "run-completed",
-      sessionKey: state.currentSessionKey,
       state: "error",
       errorMessage: "late provider failure",
     });
@@ -2864,12 +2686,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-abort-replay" },
     });
-    const aborted = {
+    const aborted = makeChatEvent(state, {
       runId: "run-abort-replay",
-      sessionKey: state.currentSessionKey,
-      state: "aborted" as const,
+      state: "aborted",
       errorMessage: "cancelled by user",
-    };
+    });
 
     handleChatEvent(aborted);
     handleChatEvent(aborted);
@@ -2889,7 +2710,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-abort-late-final",
-      sessionKey: state.currentSessionKey,
       seq: 1,
       state: "aborted",
       errorMessage: "cancelled by user",
@@ -2897,7 +2717,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
     handleChatEvent({
       runId: "run-abort-late-final",
-      sessionKey: state.currentSessionKey,
       seq: 2,
       state: "final",
       message,
@@ -2929,13 +2748,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId,
-        sessionKey: state.currentSessionKey,
         seq: 1,
         ...terminal,
       });
       handleChatEvent({
         runId,
-        sessionKey: state.currentSessionKey,
         seq: 2,
         state: "final",
         message: { role: "assistant", content: [{ type: "text", text: "Recovered reply." }] },
@@ -2947,14 +2764,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   );
 
   it("drops streaming assistant when chat final has no message", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
 
     handleChatEvent({
       runId: "run-silent",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
     });
     chatLog.dropAssistant.mockClear();
@@ -2962,7 +2777,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-silent",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
 
@@ -2971,13 +2785,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("renders a late displayable final after an earlier empty final for the same run", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+    const { chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-source-reply" },
     });
 
     handleChatEvent({
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
     chatLog.dropAssistant.mockClear();
@@ -2985,7 +2798,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-source-reply",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: {
         role: "assistant",
@@ -3001,13 +2813,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("ignores duplicate empty final envelopes after a run already finalized empty", () => {
-    const { state, chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
+    const { chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-empty-replay" },
     });
 
     handleChatEvent({
       runId: "run-empty-replay",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
     chatLog.dropAssistant.mockClear();
@@ -3016,7 +2827,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-empty-replay",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: {
         role: "assistant",
@@ -3030,7 +2840,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("reloads history when a local run ends without a displayable final message", () => {
-    const { state, loadHistory, noteLocalRunId, tui, handleChatEvent } = createHandlersHarness({
+    const { loadHistory, noteLocalRunId, tui, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-local-silent" },
     });
 
@@ -3038,7 +2848,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-local-silent",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
 
@@ -3056,7 +2865,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     handleChatEvent({
       runId: "run-local-empty",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
 
@@ -3072,17 +2880,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     noteLocalRunId("run-local-empty");
     handleChatEvent({
       runId: "run-local-empty",
-      sessionKey: state.currentSessionKey,
       state: "final",
     });
 
     noteLocalRunId("run-main");
-    handleChatEvent({
-      runId: "run-main",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-      message: { content: [{ type: "text", text: "done" }] },
-    });
+    handleChatEvent(makeFinalChatEvent(state, "run-main"));
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
   });
@@ -3116,7 +2918,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
 
       handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
         ...(initialSessionId === null ? { sessionId: "first-persisted-session" } : {}),
         ...envelope,
         message: {
@@ -3124,7 +2925,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
           content: [{ type: "text", text: "Canonical cross-client prompt." }],
           ...(metadata ? { __openclaw: metadata } : {}),
         },
-      } satisfies SessionMessageEvent);
+      });
 
       expect(chatLog.addLiveUser).toHaveBeenCalledExactlyOnceWith(
         "Canonical cross-client prompt.",
@@ -3152,7 +2953,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       const { state, chatLog, handleSessionMessageEvent } = createHandlersHarness();
 
       handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
         messageId: "native-or-provider-local-id",
         messageSeq: 99,
         message: {
@@ -3164,7 +2964,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
             ...(persistedSequence === null ? {} : { seq: persistedSequence }),
           },
         },
-      } satisfies SessionMessageEvent);
+      });
 
       expect(state.sessionProjection?.entries ?? []).toHaveLength(expectedEntries);
       expect(chatLog.addLiveUser).toHaveBeenCalledTimes(expectedEntries);
@@ -3182,13 +2982,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         handleChatEvent({
           runId,
           seq: 1,
-          sessionKey: state.currentSessionKey,
-          state: "delta",
           message: { content: [{ type: "text", text: "Already streaming." }] },
-        } satisfies ChatEvent);
+        });
 
         handleSessionMessageEvent({
-          sessionKey: state.currentSessionKey,
           ...(includeMessageMetadata ? {} : { clientRunId: runId }),
           messageId: "shared-session-user",
           messageSeq: 1,
@@ -3205,7 +3002,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
             content: [{ type: "text", text: "Sent from the other client." }],
             role: "user",
           },
-        } satisfies SessionMessageEvent);
+        });
 
         expect(chatLog.addLiveUser).toHaveBeenCalledWith("Sent from the other client.", {
           messageId: "shared-session-user",
@@ -3226,10 +3023,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
 
       handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
         sessionId: "session-after",
         updatedAt: 200,
-      } satisfies SessionMessageEvent);
+      });
 
       expect(state.currentSessionId).toBe("session-after");
       expect(state.sessionInfo.updatedAt).toBe(200);
@@ -3262,7 +3058,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         agentId: "main",
         sessionId: "session-default-agent",
         updatedAt: 200,
-      } satisfies SessionMessageEvent);
+      });
 
       expect(state.currentSessionId).toBe("session-work");
       expect(state.sessionInfo.updatedAt).toBe(100);
@@ -3282,7 +3078,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       handleSessionMessageEvent({
         sessionKey: "main",
         sessionId: "session-default-agent",
-      } satisfies SessionMessageEvent);
+      });
 
       expect(state.currentSessionId).toBe("session-work");
       expect(loadHistory).not.toHaveBeenCalled();
@@ -3304,7 +3100,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         agentId: "work",
         sessionId: "other-session",
         updatedAt: 200,
-      } satisfies SessionMessageEvent);
+      });
 
       expect(state.currentSessionId).toBe("session-before");
       expect(state.sessionInfo.updatedAt).toBe(100);
@@ -3322,10 +3118,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
 
       handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
         sessionId: "session-stale",
         updatedAt: 100,
-      } satisfies SessionMessageEvent);
+      });
 
       expect(state.currentSessionId).toBe("session-current");
       expect(state.sessionInfo.updatedAt).toBe(200);
@@ -3346,13 +3141,13 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       handleSessionMessageEvent({
         sessionKey: "global",
         agentId: "main",
-      } satisfies SessionMessageEvent);
+      });
       expect(loadHistory).not.toHaveBeenCalled();
 
       handleSessionMessageEvent({
         sessionKey: "global",
         agentId: "work",
-      } satisfies SessionMessageEvent);
+      });
       expect(loadHistory).toHaveBeenCalledTimes(1);
     });
 
@@ -3370,9 +3165,8 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       for (let index = 0; index < 250; index += 1) {
         handleSessionMessageEvent({
-          sessionKey: state.currentSessionKey,
           updatedAt: index,
-        } satisfies SessionMessageEvent);
+        });
       }
 
       expect(loadHistory).toHaveBeenCalledTimes(1);
@@ -3392,12 +3186,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         handleSessionMessageEvent,
       } = createHandlersHarness({ state: { activeChatRunId: "run-active" } });
 
-      handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
-      } satisfies SessionMessageEvent);
+      handleSessionMessageEvent(makeSessionMessageEvent(state));
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "keep this visible" }] },
       });
@@ -3405,17 +3196,13 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("keep this visible", "run-active");
       expect(loadHistory).not.toHaveBeenCalled();
 
-      handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
-        updatedAt: 200,
-      } satisfies SessionMessageEvent);
+      handleSessionMessageEvent(makeSessionMessageEvent(state, { updatedAt: 200 }));
       expect(loadHistory).not.toHaveBeenCalled();
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         runId: "run-active",
         phase: "end",
-      } satisfies SessionChangedEvent);
+      });
 
       expect(loadHistory).toHaveBeenCalledTimes(1);
     });
@@ -3432,15 +3219,12 @@ describe("tui-event-handlers: handleAgentEvent", () => {
           handleSessionMessageEvent,
         } = createHandlersHarness({ state: { activeChatRunId: "run-client-visible" } });
 
-        handleSessionMessageEvent({
-          sessionKey: state.currentSessionKey,
-        } satisfies SessionMessageEvent);
+        handleSessionMessageEvent(makeSessionMessageEvent(state));
         handleChatEvent({
           runId: "run-client-visible",
-          sessionKey: state.currentSessionKey,
           state: "final",
           message: { content: [{ type: "text", text: "keep the aliased reply visible" }] },
-        } satisfies ChatEvent);
+        });
 
         expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
           "keep the aliased reply visible",
@@ -3449,11 +3233,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         expect(loadHistory).not.toHaveBeenCalled();
 
         handleSessionsChangedEvent({
-          sessionKey: state.currentSessionKey,
           runId: "run-internal-agent",
           clientRunId: "run-client-visible",
           phase,
-        } satisfies SessionChangedEvent);
+        });
 
         expect(loadHistory).toHaveBeenCalledTimes(1);
       },
@@ -3469,19 +3252,15 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         handleSessionMessageEvent,
       } = createHandlersHarness({ state: { activeChatRunId: "run-active" } });
 
-      handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
-      } satisfies SessionMessageEvent);
+      handleSessionMessageEvent(makeSessionMessageEvent(state));
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         runId: "run-active",
         phase: "end",
-      } satisfies SessionChangedEvent);
+      });
       expect(loadHistory).not.toHaveBeenCalled();
 
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "keep this visible" }] },
       });
@@ -3502,7 +3281,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "keep this visible" }] },
       });
@@ -3510,17 +3288,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("keep this visible", "run-active");
       expect(loadHistory).not.toHaveBeenCalled();
 
-      handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
-      } satisfies SessionMessageEvent);
+      handleSessionMessageEvent(makeSessionMessageEvent(state));
 
       expect(loadHistory).not.toHaveBeenCalled();
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         runId: "run-active",
         phase: "end",
-      } satisfies SessionChangedEvent);
+      });
 
       expect(loadHistory).toHaveBeenCalledTimes(1);
     });
@@ -3543,38 +3318,31 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         for (const runId of ["run-first", "run-second"]) {
           handleChatEvent({
             runId,
-            sessionKey: state.currentSessionKey,
             state: "final",
             message: { content: [{ type: "text", text: `${runId} visible response` }] },
-          } satisfies ChatEvent);
+          });
         }
 
         expect(chatLog.finalizeAssistant).toHaveBeenCalledTimes(2);
-        handleSessionMessageEvent({
-          sessionKey: state.currentSessionKey,
-          updatedAt: 200,
-        } satisfies SessionMessageEvent);
+        handleSessionMessageEvent(makeSessionMessageEvent(state, { updatedAt: 200 }));
         expect(loadHistory).not.toHaveBeenCalled();
 
         handleSessionsChangedEvent({
-          sessionKey: state.currentSessionKey,
           runId: firstPersistedRunId,
           phase: "end",
-        } satisfies SessionChangedEvent);
+        });
         expect(loadHistory).not.toHaveBeenCalled();
 
         handleSessionsChangedEvent({
-          sessionKey: state.currentSessionKey,
           runId: secondPersistedRunId,
           phase: "end",
-        } satisfies SessionChangedEvent);
+        });
         expect(loadHistory).toHaveBeenCalledTimes(1);
       },
     );
 
     it("coalesces external updates until every concurrently displayed final is persisted", () => {
       const {
-        state,
         loadHistory,
         handleChatEvent,
         handleSessionsChangedEvent,
@@ -3584,33 +3352,29 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       for (const runId of ["run-first", "run-second", "run-third"]) {
         handleChatEvent({
           runId,
-          sessionKey: state.currentSessionKey,
           state: "final",
           message: { content: [{ type: "text", text: `${runId} visible response` }] },
-        } satisfies ChatEvent);
+        });
       }
 
       for (let index = 0; index < 250; index += 1) {
         handleSessionMessageEvent({
-          sessionKey: state.currentSessionKey,
           updatedAt: index,
-        } satisfies SessionMessageEvent);
+        });
       }
 
       for (const runId of ["run-third", "run-first"]) {
         handleSessionsChangedEvent({
-          sessionKey: state.currentSessionKey,
           runId,
           phase: "end",
-        } satisfies SessionChangedEvent);
+        });
         expect(loadHistory).not.toHaveBeenCalled();
       }
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         runId: "run-second",
         phase: "end",
-      } satisfies SessionChangedEvent);
+      });
       expect(loadHistory).toHaveBeenCalledTimes(1);
     });
 
@@ -3620,9 +3384,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
           state: { activeChatRunId: null, pendingSubmit: sendingSubmit("run-pending") },
         });
 
-      handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
-      } satisfies SessionMessageEvent);
+      handleSessionMessageEvent(makeSessionMessageEvent(state));
       expect(loadHistory).not.toHaveBeenCalled();
 
       state.pendingSubmit = null;
@@ -3644,21 +3406,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         state: { activeChatRunId: null, pendingSubmit: sendingSubmit("run-pending") },
       });
 
-      handleSessionMessageEvent({
-        sessionKey: state.currentSessionKey,
-      } satisfies SessionMessageEvent);
+      handleSessionMessageEvent(makeSessionMessageEvent(state));
       expect(loadHistory).not.toHaveBeenCalled();
 
       state.pendingSubmit = acceptedSubmit("run-pending");
       handleAgentEvent({
         runId: "run-pending",
         sessionKey: state.currentSessionKey,
-        stream: "lifecycle",
-        data: { phase: "start" },
-      } satisfies AgentEvent);
+      });
       handleChatEvent({
         runId: "run-pending",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "keep accepted output visible" }] },
       });
@@ -3670,10 +3427,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       expect(loadHistory).not.toHaveBeenCalled();
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         runId: "run-pending",
         phase: "end",
-      } satisfies SessionChangedEvent);
+      });
 
       expect(loadHistory).toHaveBeenCalledTimes(1);
     });
@@ -3687,8 +3443,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     ) => {
       handleChatEvent({
         runId,
-        sessionKey: state.currentSessionKey,
-        state: "delta",
         message: { content: [{ type: "text", text: "typing" }] },
       });
     };
@@ -3701,11 +3455,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       sessionId = state.currentSessionId,
     ) => {
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         reason: "new",
         sessionId: sessionId ?? undefined,
         updatedAt: 200,
-      } satisfies SessionChangedEvent);
+      });
     };
 
     const finishPersistence = (
@@ -3716,10 +3469,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       runId: string,
     ) => {
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         phase: "end",
         runId,
-      } satisfies SessionChangedEvent);
+      });
     };
 
     const deferNextHistoryLoad = (loadHistory: MockFn) => {
@@ -3744,7 +3496,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "reply" }] },
       });
@@ -3757,7 +3508,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "reply" }] },
       });
@@ -3775,7 +3525,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "history-owned" }] },
       });
@@ -3796,7 +3545,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       finishPersistence(state, handleSessionsChangedEvent, "run-active");
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "fallback reply" }] },
       });
@@ -3828,7 +3576,6 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
       handleChatEvent({
         runId: "run-active",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "late fallback" }] },
       });
@@ -3838,12 +3585,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     it("uses an already-observed persistence barrier for a recently finalized run", async () => {
       const { state, chatLog, loadHistory, handleChatEvent, handleSessionsChangedEvent } =
         createHandlersHarness({ state: { activeChatRunId: "run-done" } });
-      handleChatEvent({
-        runId: "run-done",
-        sessionKey: state.currentSessionKey,
-        state: "final",
-        message: { content: [{ type: "text", text: "done" }] },
-      });
+      handleChatEvent(makeFinalChatEvent(state, "run-done"));
       finishPersistence(state, handleSessionsChangedEvent, "run-done");
       loadHistory.mockClear();
 
@@ -3856,24 +3598,14 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
       const { state, chatLog, loadHistory, handleChatEvent, handleSessionsChangedEvent } =
         createHandlersHarness({ state: { activeChatRunId: "run-done" } });
-      handleChatEvent({
-        runId: "run-done",
-        sessionKey: state.currentSessionKey,
-        state: "final",
-        message: { content: [{ type: "text", text: "done" }] },
-      });
+      handleChatEvent(makeFinalChatEvent(state, "run-done"));
       finishPersistence(state, handleSessionsChangedEvent, "run-done");
       loadHistory.mockClear();
       now.mockReturnValue(12_000);
 
       changeSession(state, handleSessionsChangedEvent);
       await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
-      handleChatEvent({
-        runId: "run-done",
-        sessionKey: state.currentSessionKey,
-        state: "final",
-        message: { content: [{ type: "text", text: "done" }] },
-      });
+      handleChatEvent(makeFinalChatEvent(state, "run-done"));
 
       expect(chatLog.finalizeAssistant).toHaveBeenCalledTimes(1);
       now.mockRestore();
@@ -3928,10 +3660,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       });
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         reason: "reset",
         sessionId: state.currentSessionId ?? undefined,
-      } satisfies SessionChangedEvent);
+      });
 
       await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
       expect(state.activeChatRunId).toBe("run-reset");
@@ -3941,27 +3672,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     it("preserves finalized-run dedupe after reset history reload", async () => {
       const { state, chatLog, loadHistory, handleChatEvent, handleSessionsChangedEvent } =
         createHandlersHarness({ state: { activeChatRunId: "run-reset" } });
-      handleChatEvent({
-        runId: "run-reset",
-        sessionKey: state.currentSessionKey,
-        state: "final",
-        message: { content: [{ type: "text", text: "done" }] },
-      });
+      handleChatEvent(makeFinalChatEvent(state, "run-reset"));
       chatLog.finalizeAssistant.mockClear();
       loadHistory.mockClear();
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         reason: "reset",
         sessionId: state.currentSessionId ?? undefined,
-      } satisfies SessionChangedEvent);
-      await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
-      handleChatEvent({
-        runId: "run-reset",
-        sessionKey: state.currentSessionKey,
-        state: "final",
-        message: { content: [{ type: "text", text: "done" }] },
       });
+      await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
+      handleChatEvent(makeFinalChatEvent(state, "run-reset"));
 
       expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
     });
@@ -3970,27 +3690,16 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       const { state, chatLog, loadHistory, handleChatEvent, handleSessionsChangedEvent } =
         createHandlersHarness({ state: { activeChatRunId: "run-reset" } });
       const resolveHistory = deferNextHistoryLoad(loadHistory);
-      handleChatEvent({
-        runId: "run-reset",
-        sessionKey: state.currentSessionKey,
-        state: "final",
-        message: { content: [{ type: "text", text: "done" }] },
-      });
+      handleChatEvent(makeFinalChatEvent(state, "run-reset"));
       chatLog.finalizeAssistant.mockClear();
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         reason: "reset",
         sessionId: state.currentSessionId ?? undefined,
-      } satisfies SessionChangedEvent);
+      });
       resolveHistory(false);
       await Promise.resolve();
-      handleChatEvent({
-        runId: "run-reset",
-        sessionKey: state.currentSessionKey,
-        state: "final",
-        message: { content: [{ type: "text", text: "done" }] },
-      });
+      handleChatEvent(makeFinalChatEvent(state, "run-reset"));
 
       expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
     });
@@ -4003,13 +3712,11 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       loadHistory.mockClear();
 
       handleSessionsChangedEvent({
-        sessionKey: state.currentSessionKey,
         reason: "reset",
         sessionId: state.currentSessionId ?? undefined,
-      } satisfies SessionChangedEvent);
+      });
       handleChatEvent({
         runId: "run-reset",
-        sessionKey: state.currentSessionKey,
         state: "final",
         message: { content: [{ type: "text", text: "stale after reset" }] },
       });
@@ -4033,32 +3740,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
     vi.useRealTimers();
   });
 
-  const makeState = (overrides?: Partial<TuiStateAccess>): TuiStateAccess => ({
-    agentDefaultId: "main",
-    sessionMainKey: "agent:main:main",
-    sessionScope: "global",
-    agents: [],
-    currentAgentId: "main",
-    currentSessionKey: "agent:main:main",
-    currentSessionId: "session-1",
-    activeChatRunId: null,
-    pendingSubmit: null,
-    historyLoaded: true,
-    sessionInfo: { verboseLevel: "on" },
-    initialSessionApplied: true,
-    isConnected: true,
-    autoMessageSent: false,
-    toolsExpanded: false,
-    showThinking: false,
-    connectionStatus: "connected",
-    activityStatus: "idle",
-    statusTimeout: null,
-    lastCtrlCAt: 0,
-    ...overrides,
-  });
-
   const createHarness = (options?: { streamingWatchdogMs?: number }) => {
-    const state = makeState();
+    const state = makeTuiState();
     const chatLog = createMockChatLog();
     const btw = createMockBtwPresenter();
     const tui = { requestRender: vi.fn() } as unknown as MockTui & HandlerTui;
@@ -4068,7 +3751,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     const noteLocalRunId = (runId: string) => {
       localRunIds.add(runId);
     };
-    const handlers = createEventHandlers({
+    const rawHandlers = createEventHandlers({
       chatLog,
       btw,
       tui,
@@ -4080,6 +3763,13 @@ describe("tui-event-handlers: streaming watchdog", () => {
       forgetLocalRunId: localRunIds.delete.bind(localRunIds),
       streamingWatchdogMs: options?.streamingWatchdogMs,
     });
+    const handlers = {
+      ...rawHandlers,
+      handleChatEvent: (event: ChatEventOverrides) =>
+        rawHandlers.handleChatEvent(makeChatEvent(state, event)),
+      handleAgentEvent: (event: Partial<AgentEvent>) =>
+        rawHandlers.handleAgentEvent(makeAgentEvent(event)),
+    };
     return { state, chatLog, tui, setActivityStatus, loadHistory, noteLocalRunId, handlers };
   };
 
@@ -4090,10 +3780,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-stuck",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
-    } satisfies ChatEvent);
+    });
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
     expect(state.activeChatRunId).toBe("run-stuck");
@@ -4114,17 +3802,14 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-stuck",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
-    } satisfies ChatEvent);
+    });
 
     noteLocalRunId("run-local-empty");
     handlers.handleChatEvent({
       runId: "run-local-empty",
-      sessionKey: state.currentSessionKey,
       state: "final",
-    } satisfies ChatEvent);
+    });
 
     expect(loadHistory).not.toHaveBeenCalled();
 
@@ -4144,19 +3829,15 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-flow",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "first" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(3_000);
 
     handlers.handleChatEvent({
       runId: "run-flow",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "second" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(3_000);
 
@@ -4179,10 +3860,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-tools",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "first" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(3_000);
 
@@ -4190,7 +3869,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
       runId: "run-tools",
       stream: "tool",
       data: { phase: "start", toolCallId: "tool-1", name: "read" },
-    } satisfies AgentEvent);
+    });
 
     vi.advanceTimersByTime(3_000);
 
@@ -4212,10 +3891,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-reconnect",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
-    } satisfies ChatEvent);
+    });
 
     handlers.pauseStreamingWatchdog();
     vi.advanceTimersByTime(10_000);
@@ -4238,23 +3915,20 @@ describe("tui-event-handlers: streaming watchdog", () => {
   });
 
   it("reloads history only once when reconnect recovery and deferred history refresh overlap", () => {
-    const { state, loadHistory, noteLocalRunId, handlers } = createHarness({
+    const { loadHistory, noteLocalRunId, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
 
     handlers.handleChatEvent({
       runId: "run-reconnect",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
-    } satisfies ChatEvent);
+    });
 
     noteLocalRunId("run-local-empty");
     handlers.handleChatEvent({
       runId: "run-local-empty",
-      sessionKey: state.currentSessionKey,
       state: "final",
-    } satisfies ChatEvent);
+    });
 
     handlers.pauseStreamingWatchdog();
     handlers.reconnectStreamingWatchdog();
@@ -4288,19 +3962,16 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-lifecycle-only",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hello" },
-    } satisfies ChatEvent);
+    });
 
     handlers.pauseStreamingWatchdog();
     handlers.reconnectStreamingWatchdog();
 
     handlers.handleAgentEvent({
       runId: "run-lifecycle-only",
-      stream: "lifecycle",
       data: { phase: "end" },
-    } satisfies AgentEvent);
+    });
 
     vi.advanceTimersByTime(5_001);
 
@@ -4319,16 +3990,13 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-normal",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hi" },
-    } satisfies ChatEvent);
+    });
     handlers.handleChatEvent({
       runId: "run-normal",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "done" }], stopReason: "stop" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(10_000);
 
@@ -4347,10 +4015,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-no-watchdog",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hi" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(60_000);
 
@@ -4368,10 +4034,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-old",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "old" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(5_001);
     expect(state.activeChatRunId).toBe("run-old");
@@ -4379,20 +4043,16 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     handlers.handleChatEvent({
       runId: "run-new",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "new" },
-    } satisfies ChatEvent);
+    });
     expect(state.activeChatRunId).toBe("run-old");
 
     vi.advanceTimersByTime(3_000);
 
     handlers.handleChatEvent({
       runId: "run-old",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "old again" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(2_001);
 
@@ -4404,16 +4064,14 @@ describe("tui-event-handlers: streaming watchdog", () => {
   });
 
   it("dispose clears a pending watchdog without firing it", () => {
-    const { setActivityStatus, chatLog, handlers, state } = createHarness({
+    const { setActivityStatus, chatLog, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
 
     handlers.handleChatEvent({
       runId: "run-dispose",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "hi" },
-    } satisfies ChatEvent);
+    });
 
     handlers.dispose?.();
     vi.advanceTimersByTime(10_000);
@@ -4423,26 +4081,22 @@ describe("tui-event-handlers: streaming watchdog", () => {
   });
 
   it("dismisses the watchdog notice when a delta arrives after the watchdog fires", () => {
-    const { state, chatLog, handlers } = createHarness({
+    const { chatLog, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
 
     handlers.handleChatEvent({
       runId: "run-late",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "starting" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(5_001);
     expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-late", expectedTimeoutMessage);
 
     handlers.handleChatEvent({
       runId: "run-late",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "actually here" },
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-late");
 
@@ -4450,26 +4104,23 @@ describe("tui-event-handlers: streaming watchdog", () => {
   });
 
   it("dismisses the watchdog notice when the final arrives after the watchdog fires", () => {
-    const { state, chatLog, handlers } = createHarness({
+    const { chatLog, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
 
     handlers.handleChatEvent({
       runId: "run-final-late",
-      sessionKey: state.currentSessionKey,
-      state: "delta",
       message: { content: "starting" },
-    } satisfies ChatEvent);
+    });
 
     vi.advanceTimersByTime(5_001);
     expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-final-late", expectedTimeoutMessage);
 
     handlers.handleChatEvent({
       runId: "run-final-late",
-      sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "done" }], stopReason: "stop" },
-    } satisfies ChatEvent);
+    });
 
     expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-final-late");
 

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -146,7 +146,7 @@ function createConfirmationClient(failTaskId?: string) {
 let host: object;
 let state: ReturnType<typeof getWorkboardState>;
 
-function openEditDraft(card: WorkboardCard, status = "running") {
+function openEditDraft(card: WorkboardCard, status: WorkboardCard["status"] = "running") {
   state.draftOpen = true;
   state.editingCardId = card.id;
   state.draftTitle = card.title;

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -68,6 +68,18 @@ const sampleSession = createGatewaySession();
 const sampleTaskSessionKey = "subagent:workboard-default-card-1";
 const sampleTask = createWorkboardTask();
 
+function makeCard(overrides: Partial<WorkboardCard> = {}) {
+  return { ...sampleCard, ...overrides } satisfies WorkboardCard;
+}
+
+function makeSession(overrides: Partial<GatewaySessionRow> = {}) {
+  return { ...sampleSession, ...overrides } satisfies GatewaySessionRow;
+}
+
+function makeTask(overrides: Partial<WorkboardTaskSummary> = {}) {
+  return { ...sampleTask, ...overrides } satisfies WorkboardTaskSummary;
+}
+
 function listResult(cards: unknown[] = [sampleCard], statuses: string[] = ["todo", "done"]) {
   return { cards, statuses };
 }
@@ -133,6 +145,48 @@ function createConfirmationClient(failTaskId?: string) {
 
 let host: object;
 let state: ReturnType<typeof getWorkboardState>;
+
+function openEditDraft(card: WorkboardCard, status = "running") {
+  state.draftOpen = true;
+  state.editingCardId = card.id;
+  state.draftTitle = card.title;
+  state.draftNotes = card.notes ?? "";
+  state.draftStatus = status;
+  state.draftPriority = card.priority;
+  state.draftLabels = card.labels.join(", ");
+  state.draftAgentId = card.agentId ?? "";
+  state.draftSessionKey = card.sessionKey ?? "";
+}
+
+function makeMovedCard(card: WorkboardCard, overrides: Partial<WorkboardCard> = {}) {
+  return {
+    ...card,
+    status: "running",
+    updatedAt: 2,
+    events: [
+      {
+        id: "move-1",
+        kind: "moved",
+        at: 2,
+        fromStatus: "todo",
+        toStatus: "running",
+      },
+    ],
+    ...overrides,
+  } satisfies WorkboardCard;
+}
+
+function makeCommentedCard(
+  card: WorkboardCard,
+  body: string,
+  overrides: Partial<WorkboardCard> = {},
+) {
+  return {
+    ...card,
+    metadata: { comments: [{ id: "comment-1", body, createdAt: 2 }] },
+    ...overrides,
+  } satisfies WorkboardCard;
+}
 
 function loadBoard(
   client: WorkboardTestClient,
@@ -274,8 +328,8 @@ describe("workboard controller", () => {
     it("isolates state and loads between hosts", async () => {
       const firstHost = {};
       const secondHost = {};
-      const firstCard = { ...sampleCard, title: "First host" };
-      const secondCard = { ...sampleCard, title: "Second host" };
+      const firstCard = makeCard({ title: "First host" });
+      const secondCard = makeCard({ title: "Second host" });
       const firstClient = createClient({
         "workboard.cards.list": listResult([firstCard], ["todo", "done"]),
       });
@@ -355,7 +409,7 @@ describe("workboard controller", () => {
 
     it("rejects an invalidated generation after its replacement loads", async () => {
       const staleList = createDeferred<unknown>();
-      const currentCard = { ...sampleCard, title: "Current generation" };
+      const currentCard = makeCard({ title: "Current generation" });
       const client = createSequencedClient({
         "workboard.cards.list": [staleList.promise, listResult([currentCard])],
       });
@@ -366,7 +420,7 @@ describe("workboard controller", () => {
       await loadBoard(client);
 
       staleList.resolve({
-        cards: [{ ...sampleCard, title: "Stale generation" }],
+        cards: [makeCard({ title: "Stale generation" })],
         statuses: ["todo", "done"],
       });
       await staleLoad;
@@ -376,8 +430,8 @@ describe("workboard controller", () => {
     });
 
     it("tracks lifecycle writes until a same-host reload can proceed", async () => {
-      const linkedCard = { ...sampleCard, sessionKey: sampleSession.key };
-      const updatedCard = { ...linkedCard, status: "running" as const };
+      const linkedCard = makeCard({ sessionKey: sampleSession.key });
+      const updatedCard = makeCard({ ...linkedCard, status: "running" });
       const lifecycleWrite = createDeferred<{ card: WorkboardCard }>();
       state.loaded = true;
       state.cards = [linkedCard];
@@ -460,11 +514,10 @@ describe("workboard controller", () => {
   });
 
   it("links loaded cards to matching Gateway tasks", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient({
       "workboard.cards.list": listResult([linked], ["todo", "done"]),
       "tasks.list": { tasks: [sampleTask] },
@@ -481,12 +534,11 @@ describe("workboard controller", () => {
   });
 
   it("preserves matching task links when full task enrichment fails", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       status: "running",
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     state.tasksByCardId.set(sampleCard.id, sampleTask);
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -508,12 +560,11 @@ describe("workboard controller", () => {
   });
 
   it("confirms persisted task ids before marking paginated omissions missing", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return listResult([linked], ["todo", "done"]);
@@ -538,12 +589,11 @@ describe("workboard controller", () => {
   });
 
   it("keeps paginated task omissions unresolved when exact lookup finds the task", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient({
       "workboard.cards.list": listResult([linked], ["todo", "done"]),
       "tasks.list": { tasks: [] },
@@ -559,13 +609,12 @@ describe("workboard controller", () => {
   });
 
   it("defers lifecycle sync when exact task confirmation fails", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       status: "running",
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return listResult([linked], ["todo", "running", "done"]);
@@ -591,13 +640,12 @@ describe("workboard controller", () => {
   });
 
   it("preserves cached task summaries when full exact confirmation partially fails", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       status: "running",
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     state.tasksByCardId.set(linked.id, sampleTask);
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -621,18 +669,20 @@ describe("workboard controller", () => {
   });
 
   it("keeps linked-poll task failures sticky until a full refresh succeeds", async () => {
-    const cards = Array.from({ length: 33 }, (_, index) => ({
-      ...sampleCard,
-      id: `card-${index}`,
-      status: "running" as const,
-      taskId: `task-${index}`,
-    }));
-    const tasks = cards.map((card, index) => ({
-      ...sampleTask,
-      id: card.taskId,
-      taskId: card.taskId,
-      runId: `run-${index}`,
-    }));
+    const cards = Array.from({ length: 33 }, (_, index) =>
+      makeCard({
+        id: `card-${index}`,
+        status: "running",
+        taskId: `task-${index}`,
+      }),
+    );
+    const tasks = cards.map((card, index) =>
+      makeTask({
+        id: card.taskId,
+        taskId: card.taskId,
+        runId: `run-${index}`,
+      }),
+    );
     state.tasksByCardId = new Map(
       cards.map((card, index) => [
         card.id,
@@ -698,13 +748,12 @@ describe("workboard controller", () => {
   });
 
   it("reuses exact-confirmed full-load tasks for the next lifecycle sync", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       status: "running",
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient({
       "workboard.cards.list": listResult([linked], ["todo", "running", "done"]),
       "tasks.list": { tasks: [] },
@@ -723,18 +772,16 @@ describe("workboard controller", () => {
   });
 
   it("keeps a canonical task link over a newer loose session match", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: sampleTask.runId,
-    } satisfies WorkboardCard;
-    const unrelated = {
-      ...sampleTask,
+    });
+    const unrelated = makeTask({
       id: "task-unrelated",
       taskId: "task-unrelated",
       updatedAt: 10,
-    };
+    });
     const client = createClient({
       "workboard.cards.list": listResult([linked], ["todo", "done"]),
       "tasks.list": { tasks: [sampleTask, unrelated] },
@@ -878,7 +925,7 @@ describe("workboard controller", () => {
   });
 
   it("keeps refreshed cards when task enrichment fails", async () => {
-    const refreshedCard = { ...sampleCard, title: "Refreshed card" };
+    const refreshedCard = makeCard({ title: "Refreshed card" });
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return listResult([refreshedCard], ["todo", "done"]);
@@ -898,12 +945,11 @@ describe("workboard controller", () => {
   });
 
   it("defers task-backed lifecycle sync until a later load enrichment succeeds", async () => {
-    const linkedCard = {
-      ...sampleCard,
+    const linkedCard = makeCard({
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const requestUpdate = vi.fn();
     let tasksAvailable = false;
     const client = createClient((method) => {
@@ -938,11 +984,10 @@ describe("workboard controller", () => {
   });
 
   it("keeps prepared task summaries when bounded poll enrichment fails", async () => {
-    const linkedCard = {
-      ...sampleCard,
+    const linkedCard = makeCard({
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     state.tasksByCardId.set(sampleCard.id, sampleTask);
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -962,13 +1007,12 @@ describe("workboard controller", () => {
   });
 
   it("tracks terminal task links after authoritative task pruning", async () => {
-    const linkedCard = {
-      ...sampleCard,
+    const linkedCard = makeCard({
       taskId: sampleTask.taskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
-    state.tasksByCardId.set(sampleCard.id, { ...sampleTask, status: "completed" });
+    });
+    state.tasksByCardId.set(sampleCard.id, makeTask({ status: "completed" }));
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return listResult([linkedCard], ["todo", "done"]);
@@ -1009,28 +1053,25 @@ describe("workboard controller", () => {
   });
 
   it("refreshes live state through the read path without write methods", async () => {
-    const linkedCard = {
-      ...sampleCard,
+    const linkedCard = makeCard({
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
-    const completedTask = { ...sampleTask, status: "completed" as const };
+    });
+    const completedTask = makeTask({ status: "completed" });
     const olderSessionKey = "subagent:workboard-default-card-2";
-    const olderCard = {
-      ...sampleCard,
+    const olderCard = makeCard({
       id: "card-2",
       title: "Older running card",
       sessionKey: olderSessionKey,
       runId: "run-2",
-    };
-    const olderTask = {
-      ...sampleTask,
+    });
+    const olderTask = makeTask({
       id: "task-2",
       taskId: "task-2",
       childSessionKey: olderSessionKey,
       runId: "run-2",
       updatedAt: 1,
-    };
+    });
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
         return { cards: [linkedCard, olderCard], statuses: ["todo", "done"] };
@@ -1062,19 +1103,17 @@ describe("workboard controller", () => {
   });
 
   it("polls a canonical replacement task instead of a stale session-matched task", async () => {
-    const replacementCard = {
-      ...sampleCard,
+    const replacementCard = makeCard({
       sessionKey: sampleTaskSessionKey,
       runId: "run-2",
       taskId: "task-2",
-    } satisfies WorkboardCard;
-    const replacementTask = {
-      ...sampleTask,
+    });
+    const replacementTask = makeTask({
       id: "task-2",
       taskId: "task-2",
       runId: "run-2",
       updatedAt: 3,
-    };
+    });
     state.tasksByCardId.set(sampleCard.id, sampleTask);
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
@@ -1098,18 +1137,16 @@ describe("workboard controller", () => {
   });
 
   it("rotates bounded linked-task polling batches", async () => {
-    state.cards = Array.from({ length: 40 }, (_, index) => ({
-      ...sampleCard,
-      id: `card-${index}`,
-      taskId: `task-${index}`,
-    }));
+    state.cards = Array.from({ length: 40 }, (_, index) =>
+      makeCard({ id: `card-${index}`, taskId: `task-${index}` }),
+    );
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
         return listResult(state.cards, ["todo", "done"]);
       }
       if (method === "tasks.get") {
         const taskId = (params as { taskId: string }).taskId;
-        return { task: { ...sampleTask, id: taskId, taskId } };
+        return { task: makeTask({ id: taskId, taskId }) };
       }
       return {};
     });
@@ -1130,17 +1167,14 @@ describe("workboard controller", () => {
   });
 
   it("requires a full lifecycle refresh after a partial bounded task poll", async () => {
-    const cards = Array.from({ length: 33 }, (_, index) => ({
-      ...sampleCard,
-      id: `card-${index}`,
-      status: "running" as const,
-      taskId: `task-${index}`,
-    }));
-    const tasks = cards.map((card) => ({
-      ...sampleTask,
-      id: card.taskId,
-      taskId: card.taskId,
-    }));
+    const cards = Array.from({ length: 33 }, (_, index) =>
+      makeCard({
+        id: `card-${index}`,
+        status: "running",
+        taskId: `task-${index}`,
+      }),
+    );
+    const tasks = cards.map((card) => makeTask({ id: card.taskId, taskId: card.taskId }));
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
         return { cards, statuses: ["todo", "running", "done"] };
@@ -1166,13 +1200,14 @@ describe("workboard controller", () => {
   });
 
   it("rediscovers a bounded batch of running task links during polls", async () => {
-    const cards = Array.from({ length: 6 }, (_, index) => ({
-      ...sampleCard,
-      id: `card-${index}`,
-      status: "running" as const,
-      sessionKey: `agent:worker-${index}:subagent:workboard-default-card-${index}`,
-      runId: `run-${index}`,
-    }));
+    const cards = Array.from({ length: 6 }, (_, index) =>
+      makeCard({
+        id: `card-${index}`,
+        status: "running",
+        sessionKey: `agent:worker-${index}:subagent:workboard-default-card-${index}`,
+        runId: `run-${index}`,
+      }),
+    );
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
         return { cards, statuses: ["todo", "running", "done"] };
@@ -1182,13 +1217,12 @@ describe("workboard controller", () => {
         const index = sessionKey.at(-1);
         return {
           tasks: [
-            {
-              ...sampleTask,
+            makeTask({
               id: `task-${index}`,
               taskId: `task-${index}`,
               childSessionKey: sessionKey,
               runId: `run-${index}`,
-            },
+            }),
           ],
         };
       }
@@ -1212,19 +1246,18 @@ describe("workboard controller", () => {
   });
 
   it("rediscovers default-agent task links from an unfiltered bounded page", async () => {
-    const linkedCard = {
-      ...sampleCard,
+    const linkedCard = makeCard({
       status: "running",
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return listResult([linkedCard], ["todo", "running", "done"]);
       }
       if (method === "tasks.list") {
         return {
-          tasks: [{ ...sampleTask, childSessionKey: `agent:main:${sampleTaskSessionKey}` }],
+          tasks: [makeTask({ childSessionKey: `agent:main:${sampleTaskSessionKey}` })],
         };
       }
       return {};
@@ -1239,19 +1272,17 @@ describe("workboard controller", () => {
   it("preserves discovered replacements across consecutive polls", async () => {
     const missingTaskId = "task-pruned-from-ledger";
     const replacementTaskId = "task-replacement";
-    const replacementTask = {
-      ...sampleTask,
+    const replacementTask = makeTask({
       id: replacementTaskId,
       taskId: replacementTaskId,
       childSessionKey: `agent:main:${sampleTaskSessionKey}`,
-    };
-    const linkedCard = {
-      ...sampleCard,
+    });
+    const linkedCard = makeCard({
       status: "running",
       taskId: missingTaskId,
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     state.missingTaskIds = new Set([missingTaskId]);
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
@@ -1293,19 +1324,18 @@ describe("workboard controller", () => {
   });
 
   it("cycles default-agent task discovery through bounded task pages", async () => {
-    const linkedCard = {
-      ...sampleCard,
+    const linkedCard = makeCard({
       status: "running",
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
         return listResult([linkedCard], ["todo", "running", "done"]);
       }
       if (method === "tasks.list") {
         return (params as { cursor?: string }).cursor === "500"
-          ? { tasks: [{ ...sampleTask, childSessionKey: `agent:main:${sampleTaskSessionKey}` }] }
+          ? { tasks: [makeTask({ childSessionKey: `agent:main:${sampleTaskSessionKey}` })] }
           : { tasks: [], nextCursor: "500" };
       }
       return {};
@@ -1325,12 +1355,11 @@ describe("workboard controller", () => {
   });
 
   it("restarts default-agent task discovery after a terminal page", async () => {
-    const linkedCard = {
-      ...sampleCard,
+    const linkedCard = makeCard({
       status: "running",
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
         return listResult([linkedCard], ["todo", "running", "done"]);
@@ -1360,8 +1389,8 @@ describe("workboard controller", () => {
     { name: "an edit draft opens", title: "Edit target", interaction: "edit" },
   ] as const)("discards an in-flight poll when $name", async ({ title, interaction }) => {
     const listedCards = createDeferred<unknown>();
-    const initialCard = { ...sampleCard, title };
-    const refreshedCard = { ...sampleCard, title: "Server refresh" };
+    const initialCard = makeCard({ title });
+    const refreshedCard = makeCard({ title: "Server refresh" });
     state.cards = [initialCard];
     state.loaded = true;
     const client = createClient((method) => {
@@ -1497,7 +1526,7 @@ describe("workboard controller", () => {
   it("keeps concurrent card writes busy until each write finishes", async () => {
     const first = createDeferred<unknown>();
     const second = createDeferred<unknown>();
-    const secondCard = { ...sampleCard, id: "card-2", title: "Second card" };
+    const secondCard = makeCard({ id: "card-2", title: "Second card" });
     const client = createClient((method, params) => {
       if (method === "workboard.cards.move") {
         return (params as { id: string }).id === sampleCard.id ? first.promise : second.promise;
@@ -1534,7 +1563,7 @@ describe("workboard controller", () => {
       ),
     ).toHaveLength(1);
 
-    first.resolve({ card: { ...sampleCard, status: "review" } });
+    first.resolve({ card: makeCard({ status: "review" }) });
     getWorkboardState(host).draggedCardId = secondCard.id;
     await firstMove;
 
@@ -1573,7 +1602,7 @@ describe("workboard controller", () => {
 
   it("clears stale task summaries when dispatch task refresh fails", async () => {
     state.tasksByCardId.set("card-1", sampleTask);
-    const dispatchedCard = { ...sampleCard, status: "ready" as const };
+    const dispatchedCard = makeCard({ status: "ready" });
     const client = createClient((method) => {
       if (method === "workboard.cards.dispatch") {
         return {
@@ -1646,8 +1675,8 @@ describe("workboard controller", () => {
 
   it("does not let an older refresh overwrite cards listed after dispatch", async () => {
     const refreshList = createDeferred<unknown>();
-    const staleCard = { ...sampleCard, title: "Stale refresh card" };
-    const dispatchedCard = { ...sampleCard, title: "Dispatched card" };
+    const staleCard = makeCard({ title: "Stale refresh card" });
+    const dispatchedCard = makeCard({ title: "Dispatched card" });
     const client = createSequencedClient({
       "workboard.cards.list": [refreshList.promise, listResult([dispatchedCard])],
       "workboard.cards.dispatch": [
@@ -1679,8 +1708,8 @@ describe("workboard controller", () => {
 
   it("does not let an older refresh overwrite a card move", async () => {
     const refreshList = createDeferred<unknown>();
-    const staleCard = { ...sampleCard, status: "ready" as const, title: "Stale ready card" };
-    const movedCard = { ...sampleCard, status: "review" as const, title: "Moved card" };
+    const staleCard = makeCard({ status: "ready", title: "Stale ready card" });
+    const movedCard = makeCard({ status: "review", title: "Moved card" });
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return refreshList.promise;
@@ -1711,8 +1740,8 @@ describe("workboard controller", () => {
   it("allows automatic reload after an initial load is invalidated by a write", async () => {
     const initialList = createDeferred<unknown>();
     const reloadedList = createDeferred<unknown>();
-    const movedCard = { ...sampleCard, title: "Moved during initial load" };
-    const reloadedCard = { ...sampleCard, title: "Reloaded canonical card" };
+    const movedCard = makeCard({ title: "Moved during initial load" });
+    const reloadedCard = makeCard({ title: "Reloaded canonical card" });
     const client = createSequencedClient({
       "workboard.cards.list": [initialList.promise, reloadedList.promise],
       "workboard.cards.move": [{ card: movedCard }],
@@ -1776,7 +1805,7 @@ describe("workboard controller", () => {
     });
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.comment", expect.anything());
 
-    saveResponse.resolve({ card: { ...sampleCard, title: "Saved title" } });
+    saveResponse.resolve({ card: makeCard({ title: "Saved title" }) });
     await save;
     expect(state.draftSaving).toBe(false);
     expect(state.loading).toBe(false);
@@ -1784,7 +1813,7 @@ describe("workboard controller", () => {
 
   it("queues a forced full refresh behind an in-flight bounded poll load", async () => {
     const pollList = createDeferred<unknown>();
-    const forcedCard = { ...sampleCard, title: "Forced full refresh" };
+    const forcedCard = makeCard({ title: "Forced full refresh" });
     const client = createSequencedClient({
       "workboard.cards.list": [pollList.promise, listResult([forcedCard])],
       "tasks.list": [{ tasks: [] }],
@@ -1804,8 +1833,8 @@ describe("workboard controller", () => {
 
   it("preserves a stronger forced refresh behind another queued forced refresh", async () => {
     const initialList = createDeferred<unknown>();
-    const weakerCard = { ...sampleCard, title: "Weaker queued refresh" };
-    const strongerCard = { ...sampleCard, title: "Stronger queued refresh" };
+    const weakerCard = makeCard({ title: "Weaker queued refresh" });
+    const strongerCard = makeCard({ title: "Stronger queued refresh" });
     const client = createSequencedClient({
       "workboard.cards.list": [
         initialList.promise,
@@ -1850,7 +1879,7 @@ describe("workboard controller", () => {
   });
 
   it("reloads a previously loaded board after lifecycle teardown", async () => {
-    const reopenedCard = { ...sampleCard, title: "Reopened board" };
+    const reopenedCard = makeCard({ title: "Reopened board" });
     const client = createSequencedClient({
       "workboard.cards.list": [listResult(), listResult([reopenedCard])],
     });
@@ -1876,7 +1905,7 @@ describe("workboard controller", () => {
     const editState = getWorkboardState(editHost);
     const editClient = createClient({
       "workboard.cards.list": {
-        cards: [{ ...sampleCard, title: "Canonical title" }],
+        cards: [makeCard({ title: "Canonical title" })],
         statuses: ["todo", "done"],
       },
       "tasks.list": { tasks: [] },
@@ -1990,7 +2019,7 @@ describe("workboard controller", () => {
   it("does not attach a stale forced refresh to a reopened board load", async () => {
     const staleList = createDeferred<unknown>();
     const reopenedList = createDeferred<unknown>();
-    const reopenedCard = { ...sampleCard, title: "Reopened board" };
+    const reopenedCard = makeCard({ title: "Reopened board" });
     const client = createSequencedClient({
       "workboard.cards.list": [staleList.promise, reopenedList.promise],
     });
@@ -2013,7 +2042,7 @@ describe("workboard controller", () => {
 
   it("detaches a stalled initial load during lifecycle teardown", async () => {
     const initialList = createDeferred<unknown>();
-    const reopenedCard = { ...sampleCard, title: "Reopened board" };
+    const reopenedCard = makeCard({ title: "Reopened board" });
     const client = createSequencedClient({
       "workboard.cards.list": [initialList.promise, listResult([reopenedCard])],
     });
@@ -2058,8 +2087,8 @@ describe("workboard controller", () => {
 
   it("does not mark a load successful when task enrichment is invalidated by a write", async () => {
     const taskList = createDeferred<unknown>();
-    const movedCard = { ...sampleCard, title: "Moved during task enrichment" };
-    const reloadedCard = { ...sampleCard, title: "Reloaded after task invalidation" };
+    const movedCard = makeCard({ title: "Moved during task enrichment" });
+    const reloadedCard = makeCard({ title: "Reloaded after task invalidation" });
     const client = createSequencedClient({
       "workboard.cards.list": [listResult(), listResult([reloadedCard])],
       "tasks.list": [taskList.promise, { tasks: [] }],
@@ -2088,11 +2117,10 @@ describe("workboard controller", () => {
   });
 
   it("links cards from paginated Gateway task results", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient((method, params) => {
       if (method === "workboard.cards.list") {
         return listResult([linked], ["todo", "done"]);
@@ -2117,20 +2145,17 @@ describe("workboard controller", () => {
   });
 
   it("summarizes parent dependency readiness from loaded cards", () => {
-    const parentDone = {
-      ...sampleCard,
+    const parentDone = makeCard({
       id: "parent-done",
       title: "Done parent",
       status: "done",
-    } satisfies WorkboardCard;
-    const parentTodo = {
-      ...sampleCard,
+    });
+    const parentTodo = makeCard({
       id: "parent-todo",
       title: "Todo parent",
       status: "todo",
-    } satisfies WorkboardCard;
-    const child = {
-      ...sampleCard,
+    });
+    const child = makeCard({
       id: "child-1",
       metadata: {
         links: [
@@ -2139,7 +2164,7 @@ describe("workboard controller", () => {
           { id: "link-3", type: "parent", targetCardId: "missing-parent", createdAt: 1 },
         ],
       },
-    } satisfies WorkboardCard;
+    });
 
     const dependencies = getWorkboardDependencyState(child, [parentDone, parentTodo, child]);
 
@@ -2161,41 +2186,37 @@ describe("workboard controller", () => {
       id: "running",
       status: "running",
     });
-    const blocked = { ...sampleCard, id: "blocked", status: "blocked" } satisfies WorkboardCard;
-    const ready = { ...sampleCard, id: "ready", status: "ready" } satisfies WorkboardCard;
-    const missingProof = { ...sampleCard, id: "done", status: "done" } satisfies WorkboardCard;
-    const artifactProof = {
-      ...sampleCard,
+    const blocked = makeCard({ id: "blocked", status: "blocked" });
+    const ready = makeCard({ id: "ready", status: "ready" });
+    const missingProof = makeCard({ id: "done", status: "done" });
+    const artifactProof = makeCard({
       id: "artifact-proof",
       status: "done",
       metadata: { artifacts: [{ id: "artifact-1", createdAt: 1, label: "log" }] },
-    } satisfies WorkboardCard;
-    const failed = {
-      ...sampleCard,
+    });
+    const failed = makeCard({
       id: "failed",
       metadata: {
         failureCount: 2,
         attempts: [{ id: "attempt-1", status: "blocked", startedAt: 1 }],
         stale: { detectedAt: 2, reason: "old" },
       },
-    } satisfies WorkboardCard;
-    const recovered = {
-      ...sampleCard,
+    });
+    const recovered = makeCard({
       id: "recovered",
       metadata: {
         failureCount: 0,
         attempts: [{ id: "attempt-1", status: "failed", startedAt: 1 }],
       },
-    } satisfies WorkboardCard;
+    });
     const tasksByCardId = new Map<string, WorkboardTaskSummary>([
       [
         "ready",
-        {
-          ...sampleTask,
+        makeTask({
           taskId: "task-ready",
           id: "task-ready",
           status: "timed_out",
-        },
+        }),
       ],
     ]);
 
@@ -2216,8 +2237,7 @@ describe("workboard controller", () => {
   });
 
   it("does not count a terminal linked task already recorded as a failed attempt", () => {
-    const represented = {
-      ...sampleCard,
+    const represented = makeCard({
       id: "represented",
       metadata: {
         failureCount: 1,
@@ -2231,9 +2251,8 @@ describe("workboard controller", () => {
           },
         ],
       },
-    } satisfies WorkboardCard;
-    const unrepresented = {
-      ...sampleCard,
+    });
+    const unrepresented = makeCard({
       id: "unrepresented",
       metadata: {
         failureCount: 1,
@@ -2247,10 +2266,10 @@ describe("workboard controller", () => {
           },
         ],
       },
-    } satisfies WorkboardCard;
+    });
     const tasksByCardId = new Map<string, WorkboardTaskSummary>([
-      ["represented", { ...sampleTask, status: "failed" }],
-      ["unrepresented", { ...sampleTask, status: "failed" }],
+      ["represented", makeTask({ status: "failed" })],
+      ["unrepresented", makeTask({ status: "failed" })],
     ]);
 
     expect(
@@ -2263,8 +2282,7 @@ describe("workboard controller", () => {
   });
 
   it("matches failed attempts by session when only one record has a run id", () => {
-    const taskRunOnly = {
-      ...sampleCard,
+    const taskRunOnly = makeCard({
       id: "task-run-only",
       metadata: {
         failureCount: 1,
@@ -2277,9 +2295,8 @@ describe("workboard controller", () => {
           },
         ],
       },
-    } satisfies WorkboardCard;
-    const attemptRunOnly = {
-      ...sampleCard,
+    });
+    const attemptRunOnly = makeCard({
       id: "attempt-run-only",
       metadata: {
         failureCount: 1,
@@ -2293,10 +2310,10 @@ describe("workboard controller", () => {
           },
         ],
       },
-    } satisfies WorkboardCard;
+    });
     const tasksByCardId = new Map<string, WorkboardTaskSummary>([
-      ["task-run-only", { ...sampleTask, status: "failed" }],
-      ["attempt-run-only", { ...sampleTask, status: "failed", runId: undefined }],
+      ["task-run-only", makeTask({ status: "failed" })],
+      ["attempt-run-only", makeTask({ status: "failed", runId: undefined })],
     ]);
 
     expect(
@@ -2309,8 +2326,7 @@ describe("workboard controller", () => {
   });
 
   it("matches failed attempts to canonical default-agent task sessions", () => {
-    const card = {
-      ...sampleCard,
+    const card = makeCard({
       metadata: {
         failureCount: 1,
         attempts: [
@@ -2322,15 +2338,14 @@ describe("workboard controller", () => {
           },
         ],
       },
-    } satisfies WorkboardCard;
+    });
     const tasksByCardId = new Map<string, WorkboardTaskSummary>([
       [
         card.id,
-        {
-          ...sampleTask,
+        makeTask({
           status: "failed",
           childSessionKey: `agent:main:${sampleTaskSessionKey}`,
-        },
+        }),
       ],
     ]);
 
@@ -2347,18 +2362,17 @@ describe("workboard controller", () => {
     vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
     const now = Date.now();
     const cards = [
-      { ...sampleCard, id: "default-agent" },
-      { ...sampleCard, id: "assigned", agentId: "agent-1" },
-      { ...sampleCard, id: "ready", status: "ready" },
-      { ...sampleCard, id: "review", status: "review" },
-      { ...sampleCard, id: "done", status: "done", completedAt: now - 60_000 },
-      {
-        ...sampleCard,
+      makeCard({ id: "default-agent" }),
+      makeCard({ id: "assigned", agentId: "agent-1" }),
+      makeCard({ id: "ready", status: "ready" }),
+      makeCard({ id: "review", status: "review" }),
+      makeCard({ id: "done", status: "done", completedAt: now - 60_000 }),
+      makeCard({
         id: "old-done",
         status: "done",
         completedAt: now - 10 * 24 * 60 * 60 * 1000,
-      },
-    ] satisfies WorkboardCard[];
+      }),
+    ];
 
     expect(
       filterWorkboardCardsForPreset({
@@ -2396,20 +2410,18 @@ describe("workboard controller", () => {
   });
 
   it("links unassigned default-agent tasks with canonicalized session keys", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient({
       "workboard.cards.list": listResult([linked], ["todo", "done"]),
       "tasks.list": {
         tasks: [
-          {
-            ...sampleTask,
+          makeTask({
             childSessionKey: `agent:main:${sampleTaskSessionKey}`,
             runId: "run-1",
-          },
+          }),
         ],
       },
     });
@@ -2420,20 +2432,18 @@ describe("workboard controller", () => {
   });
 
   it("does not relink a loaded card to a stale task from another session", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       sessionKey: "agent:main:dashboard:new",
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient({
       "workboard.cards.list": listResult([linked], ["todo", "done"]),
       "tasks.list": {
         tasks: [
-          {
-            ...sampleTask,
+          makeTask({
             childSessionKey: sampleTaskSessionKey,
             runId: "run-1",
-          },
+          }),
         ],
       },
     });
@@ -2586,12 +2596,11 @@ describe("workboard controller", () => {
     state.draftTitle = "Write tests";
     state.draftNotes = "Cover the happy path";
     state.draftSessionKey = "agent:main:dashboard:1";
-    const created = {
-      ...sampleCard,
+    const created = makeCard({
       id: "card-2",
       title: "Write tests",
       sessionKey: "agent:main:dashboard:1",
-    };
+    });
     const client = createClient({ "workboard.cards.create": { card: created } });
 
     await saveDraft(client);
@@ -2614,12 +2623,11 @@ describe("workboard controller", () => {
     state.boardFilter = "ops";
     state.boards = [{ id: "ops", total: 0, active: 0, archived: 0, byStatus: {} }];
     state.draftTitle = "Investigate operations alert";
-    const created = {
-      ...sampleCard,
+    const created = makeCard({
       id: "card-ops",
       title: "Investigate operations alert",
       metadata: { automation: { boardId: "ops" } },
-    } satisfies WorkboardCard;
+    });
     const client = createClient({ "workboard.cards.create": { card: created } });
 
     await saveDraft(client);
@@ -2643,12 +2651,11 @@ describe("workboard controller", () => {
   it("creates template-backed cards through the save action", async () => {
     state.draftTitle = "Fix: flaky worker";
     state.draftTemplateId = "bugfix";
-    const created = {
-      ...sampleCard,
+    const created = makeCard({
       id: "card-2",
       title: "Fix: flaky worker",
       metadata: { templateId: "bugfix" },
-    } satisfies WorkboardCard;
+    });
     const client = createClient({ "workboard.cards.create": { card: created } });
 
     await saveDraft(client);
@@ -2670,29 +2677,8 @@ describe("workboard controller", () => {
       execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
     });
     setLoadedCard(linked);
-    state.draftOpen = true;
-    state.editingCardId = linked.id;
-    state.draftTitle = linked.title;
-    state.draftNotes = linked.notes ?? "";
-    state.draftStatus = "running";
-    state.draftPriority = linked.priority;
-    state.draftLabels = linked.labels.join(", ");
-    state.draftAgentId = linked.agentId ?? "";
-    state.draftSessionKey = linked.sessionKey ?? "";
-    const saved = {
-      ...linked,
-      status: "running",
-      updatedAt: 2,
-      events: [
-        {
-          id: "move-1",
-          kind: "moved",
-          at: 2,
-          fromStatus: "todo",
-          toStatus: "running",
-        },
-      ],
-    } satisfies WorkboardCard;
+    openEditDraft(linked);
+    const saved = makeMovedCard(linked);
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
         return { card: saved };
@@ -2702,7 +2688,7 @@ describe("workboard controller", () => {
 
     await saveDraft(client);
     await syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 1 }),
     ]);
 
     expect(client.request).toHaveBeenCalledTimes(3);
@@ -2722,12 +2708,12 @@ describe("workboard controller", () => {
   it("does not start lifecycle writes while dispatch is active", async () => {
     state.loaded = true;
     state.dispatching = true;
-    state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
+    state.cards = [makeCard({ sessionKey: sampleSession.key })];
     const client = createClient({
-      "workboard.cards.update": { card: { ...sampleCard, status: "running" } },
+      "workboard.cards.update": { card: makeCard({ status: "running" }) },
     });
 
-    await syncLifecycle(client, [{ ...sampleSession, status: "running", hasActiveRun: true }]);
+    await syncLifecycle(client, [makeSession({ status: "running", hasActiveRun: true })]);
 
     expect(client.request).not.toHaveBeenCalled();
   });
@@ -2744,7 +2730,7 @@ describe("workboard controller", () => {
     const client = createClient({});
 
     await syncLifecycle(client, [
-      { ...sampleSession, status: "done", hasActiveRun: false, updatedAt: 20 },
+      makeSession({ status: "done", hasActiveRun: false, updatedAt: 20 }),
     ]);
 
     expect(client.request).not.toHaveBeenCalled();
@@ -2767,13 +2753,13 @@ describe("workboard controller", () => {
       sessionKey: sampleSession.key,
     });
     state.cards = [archived, active];
-    const updated = { ...active, status: "review" as const };
+    const updated = makeCard({ ...active, status: "review" });
     const client = createClient((method) =>
       method === "workboard.cards.update" ? { card: updated } : {},
     );
 
     await syncLifecycle(client, [
-      { ...sampleSession, status: "done", hasActiveRun: false, updatedAt: 20 },
+      makeSession({ status: "done", hasActiveRun: false, updatedAt: 20 }),
     ]);
 
     expect(client.request).toHaveBeenCalledOnce();
@@ -2788,7 +2774,7 @@ describe("workboard controller", () => {
     "does not start lifecycle writes while a card is %s",
     async (interaction) => {
       state.loaded = true;
-      state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
+      state.cards = [makeCard({ sessionKey: sampleSession.key })];
       if (interaction === "editing") {
         state.draftOpen = true;
         state.editingCardId = sampleCard.id;
@@ -2796,10 +2782,10 @@ describe("workboard controller", () => {
         state.draggedCardId = sampleCard.id;
       }
       const client = createClient({
-        "workboard.cards.update": { card: { ...sampleCard, status: "running" } },
+        "workboard.cards.update": { card: makeCard({ status: "running" }) },
       });
 
-      await syncLifecycle(client, [{ ...sampleSession, status: "running", hasActiveRun: true }]);
+      await syncLifecycle(client, [makeSession({ status: "running", hasActiveRun: true })]);
 
       expect(client.request).not.toHaveBeenCalled();
     },
@@ -2807,21 +2793,21 @@ describe("workboard controller", () => {
 
   it("does not start lifecycle writes while a canonical refresh is loading", async () => {
     state.loaded = true;
-    state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
+    state.cards = [makeCard({ sessionKey: sampleSession.key })];
     const loadResponse = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return loadResponse.promise;
       }
       if (method === "workboard.cards.update") {
-        return { card: { ...sampleCard, status: "running" } };
+        return { card: makeCard({ status: "running" }) };
       }
       return {};
     });
 
     const loading = loadBoard(client);
     await Promise.resolve();
-    await syncLifecycle(client, [{ ...sampleSession, status: "running", hasActiveRun: true }]);
+    await syncLifecycle(client, [makeSession({ status: "running", hasActiveRun: true })]);
 
     expect(client.request).toHaveBeenCalledTimes(1);
     expect(client.request).toHaveBeenCalledWith("workboard.cards.list", {});
@@ -2835,29 +2821,8 @@ describe("workboard controller", () => {
       execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
     });
     setLoadedCard(linked);
-    state.draftOpen = true;
-    state.editingCardId = linked.id;
-    state.draftTitle = linked.title;
-    state.draftNotes = linked.notes ?? "";
-    state.draftStatus = "running";
-    state.draftPriority = linked.priority;
-    state.draftLabels = linked.labels.join(", ");
-    state.draftAgentId = linked.agentId ?? "";
-    state.draftSessionKey = linked.sessionKey ?? "";
-    const saved = {
-      ...linked,
-      status: "running",
-      updatedAt: 2,
-      events: [
-        {
-          id: "move-1",
-          kind: "moved",
-          at: 2,
-          fromStatus: "todo",
-          toStatus: "running",
-        },
-      ],
-    } satisfies WorkboardCard;
+    openEditDraft(linked);
+    const saved = makeMovedCard(linked);
     const saveResponse = createDeferred<{ card: WorkboardCard }>();
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
@@ -2869,7 +2834,7 @@ describe("workboard controller", () => {
     const saving = saveDraft(client);
     await Promise.resolve();
     await syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 1 }),
     ]);
 
     expect(client.request).toHaveBeenCalledOnce();
@@ -2882,12 +2847,7 @@ describe("workboard controller", () => {
     state.cards = [sampleCard];
     state.detailCardId = sampleCard.id;
     state.detailCommentBody = "Need one more proof run.";
-    const updated = {
-      ...sampleCard,
-      metadata: {
-        comments: [{ id: "comment-1", body: "Need one more proof run.", createdAt: 2 }],
-      },
-    } satisfies WorkboardCard;
+    const updated = makeCommentedCard(sampleCard, "Need one more proof run.");
     const client = createClient({ "workboard.cards.comment": { card: updated } });
 
     await commentCard(client, {
@@ -2905,12 +2865,11 @@ describe("workboard controller", () => {
   });
 
   it("captures existing sessions as linked workboard cards", async () => {
-    const session = {
-      ...sampleSession,
+    const session = makeSession({
       label: "Fix login",
       status: "done",
       hasActiveRun: false,
-    } as const;
+    });
     const created = createSessionCard({
       title: "Fix login",
       status: "review",
@@ -3101,7 +3060,7 @@ describe("workboard controller", () => {
 
   it("does not start duplicate capture requests while a session is in flight", async () => {
     state.capturingSessionKeys.add(sampleSession.key);
-    const existing = { ...sampleCard, sessionKey: sampleSession.key };
+    const existing = makeCard({ sessionKey: sampleSession.key });
     state.cards = [existing];
     const client = createClient({});
 
@@ -3113,10 +3072,10 @@ describe("workboard controller", () => {
 
   it("captures different sessions concurrently", async () => {
     state.loaded = true;
-    const firstSession = { ...sampleSession, key: "agent:main:dashboard:first" };
-    const secondSession = { ...sampleSession, key: "agent:main:dashboard:second" };
-    const firstCard = { ...sampleCard, id: "card-first", sessionKey: firstSession.key };
-    const secondCard = { ...sampleCard, id: "card-second", sessionKey: secondSession.key };
+    const firstSession = makeSession({ key: "agent:main:dashboard:first" });
+    const secondSession = makeSession({ key: "agent:main:dashboard:second" });
+    const firstCard = makeCard({ id: "card-first", sessionKey: firstSession.key });
+    const secondCard = makeCard({ id: "card-second", sessionKey: secondSession.key });
     const firstCreate = createDeferred<unknown>();
     const client = createClient((method, params) => {
       if (method === "chat.history") {
@@ -3155,7 +3114,7 @@ describe("workboard controller", () => {
   it("does not duplicate same-session captures waiting on the initial load", async () => {
     const list = createDeferred<unknown>();
     const create = createDeferred<unknown>();
-    const created = { ...sampleCard, sessionKey: sampleSession.key };
+    const created = makeCard({ sessionKey: sampleSession.key });
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return list.promise;
@@ -3215,7 +3174,7 @@ describe("workboard controller", () => {
 
   it("waits for an in-flight Workboard load before capturing a session", async () => {
     const list = createDeferred<unknown>();
-    const created = { ...sampleCard, sessionKey: sampleSession.key };
+    const created = makeCard({ sessionKey: sampleSession.key });
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return list.promise;
@@ -3243,15 +3202,11 @@ describe("workboard controller", () => {
 
   it("waits for retained lifecycle writes before capturing after teardown", async () => {
     const lifecycleCard = createSessionCard();
-    const capturedSession = {
-      ...sampleSession,
-      key: "agent:main:dashboard:capture",
-    };
-    const capturedCard = {
-      ...sampleCard,
+    const capturedSession = makeSession({ key: "agent:main:dashboard:capture" });
+    const capturedCard = makeCard({
       id: "captured-card",
       sessionKey: capturedSession.key,
-    };
+    });
     const lifecycleUpdate = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
@@ -3312,12 +3267,12 @@ describe("workboard controller", () => {
         };
       }
       if (method === "workboard.cards.create") {
-        return { card: { ...sampleCard, title: `${titlePrefix}...` } };
+        return { card: makeCard({ title: `${titlePrefix}...` }) };
       }
       return {};
     });
 
-    await captureSession(client, { ...sampleSession, label: `${titlePrefix}😀tail` });
+    await captureSession(client, makeSession({ label: `${titlePrefix}😀tail` }));
 
     expect(client.request).toHaveBeenNthCalledWith(
       3,
@@ -3382,11 +3337,11 @@ describe("workboard controller", () => {
     const client = createClient({
       agent: { sessionKey: sampleTaskSessionKey, runId: "run-1" },
       "tasks.list": { tasks: [sampleTask] },
-      "workboard.cards.update": { card: { ...sampleCard, title, status: "running" } },
+      "workboard.cards.update": { card: makeCard({ title, status: "running" }) },
     });
 
     await startCard(client, {
-      card: { ...sampleCard, title },
+      card: makeCard({ title }),
     });
 
     expect(client.request).toHaveBeenNthCalledWith(
@@ -3400,11 +3355,10 @@ describe("workboard controller", () => {
 
   it("starts reassigned cards with the current task session key", async () => {
     const expectedSessionKey = "agent:codex-main:subagent:workboard-default-card-1";
-    const staleLinked = {
-      ...sampleCard,
+    const staleLinked = makeCard({
       agentId: "codex-main",
       sessionKey: "agent:old-agent:dashboard:stale",
-    } satisfies WorkboardCard;
+    });
     const running = {
       ...staleLinked,
       status: "running",
@@ -3415,7 +3369,7 @@ describe("workboard controller", () => {
     const client = createClient({
       agent: { sessionKey: expectedSessionKey, runId: "run-1" },
       "tasks.list": {
-        tasks: [{ ...sampleTask, childSessionKey: expectedSessionKey }],
+        tasks: [makeTask({ childSessionKey: expectedSessionKey })],
       },
       "workboard.cards.update": { card: running },
     });
@@ -3439,7 +3393,7 @@ describe("workboard controller", () => {
   // canonicalizes it: "Codex-Main" and "codex-main" name one session, not two.
   it("canonicalizes a card's agent id in the worker session key", async () => {
     const expectedSessionKey = "agent:codex-main:subagent:workboard-default-card-1";
-    const mixedCase = { ...sampleCard, agentId: "Codex-Main" } satisfies WorkboardCard;
+    const mixedCase = makeCard({ agentId: "Codex-Main" });
     const running = {
       ...mixedCase,
       status: "running",
@@ -3491,12 +3445,11 @@ describe("workboard controller", () => {
 
   it("keeps a successfully started run when task lookup stays unavailable", async () => {
     vi.useFakeTimers();
-    const running = {
-      ...sampleCard,
+    const running = makeCard({
       status: "running",
       sessionKey: sampleTaskSessionKey,
       runId: "run-1",
-    } satisfies WorkboardCard;
+    });
     const client = createClient((method) => {
       if (method === "agent") {
         return { sessionKey: sampleTaskSessionKey, runId: "run-1" };
@@ -3527,15 +3480,14 @@ describe("workboard controller", () => {
   });
 
   it("lets the gateway decide starts when cached parent dependencies are stale", async () => {
-    const parent = { ...sampleCard, id: "parent-1", title: "Parent", status: "running" };
-    const child: WorkboardCard = {
-      ...sampleCard,
+    const parent = makeCard({ id: "parent-1", title: "Parent", status: "running" });
+    const child = makeCard({
       id: "child-1",
       title: "Child",
       metadata: {
         links: [{ id: "link-1", type: "parent", targetCardId: parent.id, createdAt: 1 }],
       },
-    };
+    });
     const running = {
       ...child,
       status: "running",
@@ -3598,7 +3550,7 @@ describe("workboard controller", () => {
   });
 
   it("rolls back the running preflight when task run creation fails", async () => {
-    const running = { ...sampleCard, status: "running" } satisfies WorkboardCard;
+    const running = makeCard({ status: "running" });
     const client = createSequencedClient({
       "workboard.cards.update": [{ card: running }, { card: sampleCard }],
       agent: [new Error("gateway disconnected")],
@@ -3628,7 +3580,7 @@ describe("workboard controller", () => {
   });
 
   it("rolls back the running preflight when final session link update fails", async () => {
-    const running = { ...sampleCard, status: "running" } satisfies WorkboardCard;
+    const running = makeCard({ status: "running" });
     const client = createSequencedClient({
       "workboard.cards.update": [
         { card: running },
@@ -3663,12 +3615,11 @@ describe("workboard controller", () => {
   });
 
   it("does not start a card before its scheduled time", async () => {
-    const scheduled = {
-      ...sampleCard,
+    const scheduled = makeCard({
       id: "scheduled-1",
       status: "scheduled",
       metadata: { automation: { scheduledAt: Date.now() + 60_000 } },
-    } satisfies WorkboardCard;
+    });
     const client = createClient({
       "workboard.cards.list": listResult([scheduled], ["scheduled", "running", "done"]),
     });
@@ -3685,13 +3636,12 @@ describe("workboard controller", () => {
       "Scheduled cards cannot start before their scheduled time.",
     );
 
-    const manualScheduled = {
-      ...sampleCard,
+    const manualScheduled = makeCard({
       id: "scheduled-2",
       status: "scheduled",
       metadata: { automation: { scheduledAt: Date.now() + 60_000 } },
-    } satisfies WorkboardCard;
-    const manualLinked = {
+    });
+    const manualLinked = makeCard({
       ...manualScheduled,
       status: "todo",
       metadata: {},
@@ -3702,7 +3652,7 @@ describe("workboard controller", () => {
         status: "idle",
         sessionKey: "agent:main:dashboard:manual",
       }),
-    } satisfies WorkboardCard;
+    });
     const manualClient = createClient({
       "sessions.create": { key: "agent:main:dashboard:manual" },
       "workboard.cards.update": { card: manualLinked },
@@ -3726,16 +3676,15 @@ describe("workboard controller", () => {
       }),
     );
 
-    const readyWithSchedule = {
-      ...sampleCard,
+    const readyWithSchedule = makeCard({
       id: "scheduled-2b",
       status: "ready",
       metadata: { automation: { scheduledAt: Date.now() + 60_000 } },
-    } satisfies WorkboardCard;
+    });
     const readyManualClient = createClient({
       "sessions.create": { key: "agent:main:dashboard:ready-manual" },
       "workboard.cards.update": {
-        card: { ...readyWithSchedule, sessionKey: "agent:main:dashboard:ready-manual" },
+        card: makeCard({ ...readyWithSchedule, sessionKey: "agent:main:dashboard:ready-manual" }),
       },
     });
     await startCard(readyManualClient, {
@@ -3751,18 +3700,18 @@ describe("workboard controller", () => {
       }),
     );
 
-    const dueScheduled = {
+    const dueScheduled = makeCard({
       ...scheduled,
       id: "scheduled-3",
       metadata: { automation: { scheduledAt: Date.now() - 60_000 } },
-    } satisfies WorkboardCard;
-    const dueRunning = {
+    });
+    const dueRunning = makeCard({
       ...dueScheduled,
       status: "running",
       sessionKey: "subagent:workboard-default-scheduled-3",
       runId: "run-due",
       taskId: "task-due",
-    } satisfies WorkboardCard;
+    });
     const dueClient = createClient((method) => {
       if (method === "workboard.cards.list") {
         return listResult([dueScheduled], ["scheduled", "running", "done"]);
@@ -3776,13 +3725,12 @@ describe("workboard controller", () => {
       if (method === "tasks.list") {
         return {
           tasks: [
-            {
-              ...sampleTask,
+            makeTask({
               id: "task-due",
               taskId: "task-due",
               childSessionKey: "subagent:workboard-default-scheduled-3",
               runId: "run-due",
-            },
+            }),
           ],
         };
       }
@@ -3820,7 +3768,7 @@ describe("workboard controller", () => {
       }),
     });
     const client = createSequencedClient({
-      "workboard.cards.update": [{ card: { ...sampleCard, status: "running" } }, { card: running }],
+      "workboard.cards.update": [{ card: makeCard({ status: "running" }) }, { card: running }],
       agent: [{ sessionKey: sampleTaskSessionKey, runId: "run-1" }],
       "tasks.list": [{ tasks: [sampleTask] }],
     });
@@ -3868,8 +3816,7 @@ describe("workboard controller", () => {
   it("resets execution start time when retrying a card run", async () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1234);
     try {
-      const previous = {
-        ...sampleCard,
+      const previous = makeCard({
         execution: {
           id: "card-1:codex",
           kind: "agent-session",
@@ -3882,18 +3829,17 @@ describe("workboard controller", () => {
           startedAt: 10,
           updatedAt: 20,
         },
-      } satisfies WorkboardCard;
+      });
       const client = createClient({
         agent: { sessionKey: "agent:main:dashboard:1", runId: "run-2" },
         "tasks.list": {
           tasks: [
-            {
-              ...sampleTask,
+            makeTask({
               taskId: "task-2",
               id: "task-2",
               childSessionKey: "agent:main:dashboard:1",
               runId: "run-2",
-            },
+            }),
           ],
         },
         "workboard.cards.update": { card: previous },
@@ -4035,10 +3981,7 @@ describe("workboard controller", () => {
           runError: { message: "provider unavailable" },
         },
       ],
-      "workboard.cards.update": [
-        { card: { ...sampleCard, status: "running" } },
-        { card: sampleCard },
-      ],
+      "workboard.cards.update": [{ card: makeCard({ status: "running" }) }, { card: sampleCard }],
     });
 
     const sessionKey = await startSampleCard(client);
@@ -4054,7 +3997,7 @@ describe("workboard controller", () => {
   });
 
   it("moves cards through the plugin gateway method", async () => {
-    const moved = { ...sampleCard, status: "blocked", position: 2000 };
+    const moved = makeCard({ status: "blocked", position: 2000 });
     const client = createClient({ "workboard.cards.move": { card: moved } });
 
     await moveCard(client, {
@@ -4074,21 +4017,7 @@ describe("workboard controller", () => {
       sessionKey: sampleSession.key,
       execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
     });
-    const moved = {
-      ...linked,
-      status: "running",
-      position: 2000,
-      updatedAt: 2,
-      events: [
-        {
-          id: "move-1",
-          kind: "moved",
-          at: 2,
-          fromStatus: "todo",
-          toStatus: "running",
-        },
-      ],
-    } satisfies WorkboardCard;
+    const moved = makeMovedCard(linked, { position: 2000 });
     setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "workboard.cards.move") {
@@ -4106,7 +4035,7 @@ describe("workboard controller", () => {
       position: 2000,
     });
     await syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 1 }),
     ]);
 
     expect(client.request).toHaveBeenCalledTimes(3);
@@ -4129,21 +4058,7 @@ describe("workboard controller", () => {
       sessionKey: sampleSession.key,
       execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
     });
-    const moved = {
-      ...linked,
-      status: "running",
-      position: 2000,
-      updatedAt: 2,
-      events: [
-        {
-          id: "move-1",
-          kind: "moved",
-          at: 2,
-          fromStatus: "todo",
-          toStatus: "running",
-        },
-      ],
-    } satisfies WorkboardCard;
+    const moved = makeMovedCard(linked, { position: 2000 });
     setLoadedCard(linked);
     const moveResponse = createDeferred<{ card: WorkboardCard }>();
     const client = createClient((method) => {
@@ -4160,7 +4075,7 @@ describe("workboard controller", () => {
     });
     await Promise.resolve();
     await syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 1 }),
     ]);
 
     expect(client.request).toHaveBeenCalledOnce();
@@ -4170,22 +4085,8 @@ describe("workboard controller", () => {
   });
 
   it("ignores stale lifecycle responses when dragged status changes while sync is in flight", async () => {
-    const linked = { ...sampleCard, sessionKey: sampleSession.key } satisfies WorkboardCard;
-    const moved = {
-      ...linked,
-      status: "running",
-      position: 2000,
-      updatedAt: 2,
-      events: [
-        {
-          id: "move-1",
-          kind: "moved",
-          at: 2,
-          fromStatus: "todo",
-          toStatus: "running",
-        },
-      ],
-    } satisfies WorkboardCard;
+    const linked = makeCard({ sessionKey: sampleSession.key });
+    const moved = makeMovedCard(linked, { position: 2000 });
     const staleLifecycleCard = {
       ...linked,
       status: "review",
@@ -4205,7 +4106,7 @@ describe("workboard controller", () => {
     });
 
     const syncing = syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 1 }),
     ]);
     await Promise.resolve();
     await moveCard(client, {
@@ -4232,14 +4133,8 @@ describe("workboard controller", () => {
   });
 
   it("ignores lifecycle responses after a newer comment write", async () => {
-    const linked = { ...sampleCard, sessionKey: sampleSession.key } satisfies WorkboardCard;
-    const commented = {
-      ...linked,
-      updatedAt: 2,
-      metadata: {
-        comments: [{ id: "comment-1", body: "Keep this", createdAt: 2 }],
-      },
-    } satisfies WorkboardCard;
+    const linked = makeCard({ sessionKey: sampleSession.key });
+    const commented = makeCommentedCard(linked, "Keep this", { updatedAt: 2 });
     const lifecycleResponse = createDeferred<{ card: WorkboardCard }>();
     setLoadedCard(linked);
     const client = createClient((method) => {
@@ -4253,7 +4148,7 @@ describe("workboard controller", () => {
     });
 
     const syncing = syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 1 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 1 }),
     ]);
     await Promise.resolve();
     await commentCard(client, {
@@ -4271,21 +4166,7 @@ describe("workboard controller", () => {
       sessionKey: sampleSession.key,
       execution: createWorkboardExecution({ sessionKey: sampleSession.key }),
     });
-    const moved = {
-      ...linked,
-      status: "running",
-      position: 2000,
-      updatedAt: 2,
-      events: [
-        {
-          id: "move-1",
-          kind: "moved",
-          at: 2,
-          fromStatus: "todo",
-          toStatus: "running",
-        },
-      ],
-    } satisfies WorkboardCard;
+    const moved = makeMovedCard(linked, { position: 2000 });
     const staleLifecycleCard = {
       ...linked,
       status: "review",
@@ -4309,7 +4190,7 @@ describe("workboard controller", () => {
     });
 
     const syncing = syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: null },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: null }),
     ]);
     await Promise.resolve();
     await moveCard(client, {
@@ -4356,7 +4237,7 @@ describe("workboard controller", () => {
     });
 
     await syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 3 }),
     ]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -4394,7 +4275,7 @@ describe("workboard controller", () => {
     });
 
     await syncLifecycle(client, [
-      { ...sampleSession, hasActiveRun: false, status: "done", updatedAt: 3 },
+      makeSession({ hasActiveRun: false, status: "done", updatedAt: 3 }),
     ]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -4411,20 +4292,18 @@ describe("workboard controller", () => {
   });
 
   it("removes stale dependency links from local cards after delete", async () => {
-    const parent: WorkboardCard = {
-      ...sampleCard,
+    const parent = makeCard({
       id: "parent-1",
       title: "Parent",
       status: "done",
-    };
-    const child: WorkboardCard = {
-      ...sampleCard,
+    });
+    const child = makeCard({
       id: "child-1",
       title: "Child",
       metadata: {
         links: [{ id: "link-1", type: "parent", targetCardId: parent.id, createdAt: 1 }],
       },
-    };
+    });
     const client = createClient((method) => {
       if (method === "workboard.cards.delete") {
         return { deleted: true };
@@ -4550,19 +4429,19 @@ describe("workboard controller", () => {
   it("syncs linked card status from session lifecycle without overriding manual review", async () => {
     state.loaded = true;
     state.cards = [
-      { ...sampleCard, sessionKey: sampleSession.key },
-      { ...sampleCard, id: "card-review", status: "review", sessionKey: "session-review" },
+      makeCard({ sessionKey: sampleSession.key }),
+      makeCard({ id: "card-review", status: "review", sessionKey: "session-review" }),
     ];
     const client = createClient((method) => {
       if (method === "workboard.cards.update") {
-        return { card: { ...sampleCard, status: "running", sessionKey: sampleSession.key } };
+        return { card: makeCard({ status: "running", sessionKey: sampleSession.key }) };
       }
       return {};
     });
 
     await syncLifecycle(client, [
       sampleSession,
-      { ...sampleSession, key: "session-review", status: "failed", hasActiveRun: false },
+      makeSession({ key: "session-review", status: "failed", hasActiveRun: false }),
     ]);
 
     expect(client.request).toHaveBeenCalledOnce();
@@ -4590,17 +4469,16 @@ describe("workboard controller", () => {
     ];
     const client = createClient({
       "workboard.cards.update": {
-        card: { ...sampleCard, status: "review", sessionKey: sampleSession.key },
+        card: makeCard({ status: "review", sessionKey: sampleSession.key }),
       },
     });
 
     await syncLifecycle(client, [
-      {
-        ...sampleSession,
+      makeSession({
         status: "done",
         hasActiveRun: false,
         updatedAt: 1000,
-      },
+      }),
     ]);
 
     expect(client.request).toHaveBeenCalledOnce();
@@ -4611,20 +4489,19 @@ describe("workboard controller", () => {
 
   it("does not sync linked card status from sessions without lifecycle provenance", async () => {
     state.loaded = true;
-    state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
+    state.cards = [makeCard({ sessionKey: sampleSession.key })];
     const client = createClient({
       "workboard.cards.update": {
-        card: { ...sampleCard, status: "review", sessionKey: sampleSession.key },
+        card: makeCard({ status: "review", sessionKey: sampleSession.key }),
       },
     });
 
     await syncLifecycle(client, [
-      {
-        ...sampleSession,
+      makeSession({
         status: "done",
         hasActiveRun: false,
         updatedAt: null,
-      },
+      }),
     ]);
 
     expect(client.request).not.toHaveBeenCalled();
@@ -4634,7 +4511,7 @@ describe("workboard controller", () => {
   it("refreshes task lifecycle before syncing task-backed cards", async () => {
     const { card: linked } = createLifecycleHarness(host);
     const client = createClient({
-      "tasks.list": { tasks: [{ ...sampleTask, status: "completed" }] },
+      "tasks.list": { tasks: [makeTask({ status: "completed" })] },
       "workboard.cards.update": {
         card: { ...linked, status: "review" },
       },
@@ -4673,7 +4550,7 @@ describe("workboard controller", () => {
       expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     });
     stopWorkboardLifecycleRefresh(host);
-    taskList.resolve({ tasks: [{ ...sampleTask, status: "completed" }] });
+    taskList.resolve({ tasks: [makeTask({ status: "completed" })] });
     await sync;
 
     expect(client.request).not.toHaveBeenCalledWith("workboard.cards.update", expect.anything());
@@ -4681,8 +4558,8 @@ describe("workboard controller", () => {
   });
 
   it("cancels remaining lifecycle card writes when refresh stops", async () => {
-    const first = { ...sampleCard, id: "card-1", sessionKey: "session-1" };
-    const second = { ...sampleCard, id: "card-2", sessionKey: "session-2" };
+    const first = makeCard({ id: "card-1", sessionKey: "session-1" });
+    const second = makeCard({ id: "card-2", sessionKey: "session-2" });
     const firstUpdate = createDeferred<{ card: WorkboardCard }>();
     state.loaded = true;
     state.cards = [first, second];
@@ -4699,10 +4576,7 @@ describe("workboard controller", () => {
       }
       return {};
     });
-    const sessions = [
-      { ...sampleSession, key: "session-1" },
-      { ...sampleSession, key: "session-2" },
-    ];
+    const sessions = [makeSession({ key: "session-1" }), makeSession({ key: "session-2" })];
 
     const syncing = syncWorkboardLifecycle({ host, client: client as never, sessions });
     await waitForFast(() => {
@@ -4752,12 +4626,8 @@ describe("workboard controller", () => {
 
   it("requests a fresh lifecycle sync after a shared task refresh is invalidated by a write", async () => {
     const { card: linked } = createLifecycleHarness(host);
-    const commented = {
-      ...linked,
-      updatedAt: 2,
-      metadata: { comments: [{ id: "comment-1", body: "Keep this", createdAt: 2 }] },
-    } satisfies WorkboardCard;
-    const completedTask = { ...sampleTask, status: "completed" as const, updatedAt: 3 };
+    const commented = makeCommentedCard(linked, "Keep this", { updatedAt: 2 });
+    const completedTask = makeTask({ status: "completed", updatedAt: 3 });
     const firstTaskList = createDeferred<unknown>();
     const client = createSequencedClient({
       "tasks.list": [firstTaskList.promise, { tasks: [completedTask] }],
@@ -4797,12 +4667,11 @@ describe("workboard controller", () => {
   it("authoritatively refreshes running linked cards without task ids before lifecycle sync", async () => {
     state.loaded = true;
     state.cards = [
-      {
-        ...sampleCard,
+      makeCard({
         status: "running",
         sessionKey: sampleTaskSessionKey,
         runId: "run-1",
-      },
+      }),
     ];
     const client = createClient({
       "tasks.list": { tasks: [] },
@@ -4831,7 +4700,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncLifecycle(client, [{ ...sampleSession, status: "done", hasActiveRun: false }]);
+    await syncLifecycle(client, [makeSession({ status: "done", hasActiveRun: false })]);
 
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -4860,7 +4729,7 @@ describe("workboard controller", () => {
       return {};
     });
 
-    await syncLifecycle(client, [{ ...sampleSession, status: "done", hasActiveRun: false }]);
+    await syncLifecycle(client, [makeSession({ status: "done", hasActiveRun: false })]);
 
     expect(client.request).not.toHaveBeenCalledWith("tasks.list", expect.anything());
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -4897,7 +4766,7 @@ describe("workboard controller", () => {
       card: { runId: "run-stale" },
       task: null,
     });
-    const confirmedTask = { ...sampleTask, runId: taskRunId };
+    const confirmedTask = makeTask({ runId: taskRunId });
     const client = createClient({
       "tasks.list": { tasks: [] },
       "tasks.get": { task: confirmedTask },
@@ -5059,11 +4928,10 @@ describe("workboard controller", () => {
   });
 
   it("requests a render after lifecycle refresh marks a task missing", async () => {
-    const linked = {
-      ...sampleCard,
+    const linked = makeCard({
       status: "ready",
       taskId: sampleTask.taskId,
-    } satisfies WorkboardCard;
+    });
     setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "tasks.list") {
@@ -5103,7 +4971,7 @@ describe("workboard controller", () => {
   it("refreshes prepared task lifecycle state after its freshness window", async () => {
     vi.useFakeTimers();
     const { card: linked } = createLifecycleHarness(host, { prepared: true });
-    const completedTask = { ...sampleTask, status: "completed" as const };
+    const completedTask = makeTask({ status: "completed" });
     const client = createClient({
       "tasks.list": { tasks: [completedTask] },
       "workboard.cards.update": { card: { ...linked, status: "review" } },
@@ -5178,7 +5046,7 @@ describe("workboard controller", () => {
     const syncing = syncLifecycle(client, []);
     await Promise.resolve();
     state.dispatching = true;
-    taskList.resolve({ tasks: [{ ...sampleTask, status: "completed" }] });
+    taskList.resolve({ tasks: [makeTask({ status: "completed" })] });
     await syncing;
 
     expect(client.request).toHaveBeenCalledOnce();
@@ -5187,11 +5055,7 @@ describe("workboard controller", () => {
 
   it("does not apply lifecycle task refresh after a newer card write", async () => {
     const { card: linked } = createLifecycleHarness(host);
-    const commented = {
-      ...linked,
-      updatedAt: 2,
-      metadata: { comments: [{ id: "comment-1", body: "Keep this", createdAt: 2 }] },
-    } satisfies WorkboardCard;
+    const commented = makeCommentedCard(linked, "Keep this", { updatedAt: 2 });
     const taskList = createDeferred<unknown>();
     const client = createClient((method) => {
       if (method === "tasks.list") {
@@ -5209,7 +5073,7 @@ describe("workboard controller", () => {
       cardId: linked.id,
       body: "Keep this",
     });
-    taskList.resolve({ tasks: [{ ...sampleTask, status: "completed" }] });
+    taskList.resolve({ tasks: [makeTask({ status: "completed" })] });
     await syncing;
 
     expect(state.cards[0]?.metadata?.comments?.[0]?.body).toBe("Keep this");
@@ -5241,9 +5105,7 @@ describe("workboard controller", () => {
       },
     });
 
-    await syncLifecycle(client, [
-      { ...sampleSession, updatedAt: staleUpdatedAt, hasActiveRun: false },
-    ]);
+    await syncLifecycle(client, [makeSession({ updatedAt: staleUpdatedAt, hasActiveRun: false })]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
       id: "card-1",
@@ -5273,7 +5135,7 @@ describe("workboard controller", () => {
       },
     });
 
-    await syncLifecycle(client, [{ ...sampleSession, updatedAt: Date.now(), hasActiveRun: true }]);
+    await syncLifecycle(client, [makeSession({ updatedAt: Date.now(), hasActiveRun: true })]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
       id: "card-1",
@@ -5305,12 +5167,11 @@ describe("workboard controller", () => {
     });
 
     await syncLifecycle(client, [
-      {
-        ...sampleSession,
+      makeSession({
         status: "running",
         updatedAt: 3,
         hasActiveRun: true,
-      },
+      }),
     ]);
 
     expect(client.request).toHaveBeenCalledWith("workboard.cards.update", {
@@ -5326,9 +5187,7 @@ describe("workboard controller", () => {
     setLoadedCard(linked);
     const client = createClient({ "workboard.cards.update": { card: linked } });
 
-    await syncLifecycle(client, [
-      { ...sampleSession, updatedAt: staleUpdatedAt, hasActiveRun: false },
-    ]);
+    await syncLifecycle(client, [makeSession({ updatedAt: staleUpdatedAt, hasActiveRun: false })]);
 
     expect(client.request).toHaveBeenCalledOnce();
     expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
@@ -5353,7 +5212,7 @@ describe("workboard controller", () => {
 
   it("skips lifecycle writeback for read-only workboard clients", async () => {
     state.loaded = true;
-    state.cards = [{ ...sampleCard, sessionKey: sampleSession.key }];
+    state.cards = [makeCard({ sessionKey: sampleSession.key })];
     const client = createClient(() => {
       throw new Error("write denied");
     });
@@ -5388,12 +5247,11 @@ describe("workboard controller", () => {
       status: "running",
       updatedAt: 1000,
     });
-    const completedSession = {
-      ...sampleSession,
+    const completedSession = makeSession({
       hasActiveRun: false,
       status: "done",
       updatedAt: 2000,
-    } as const;
+    });
     setLoadedCard(linked);
     const client = createClient({
       "workboard.cards.update": {
@@ -5414,12 +5272,11 @@ describe("workboard controller", () => {
       status: "running",
       updatedAt: 1000,
     });
-    const completedSession = {
-      ...sampleSession,
+    const completedSession = makeSession({
       hasActiveRun: false,
       status: "done",
       updatedAt: 2000,
-    } as const;
+    });
     setLoadedCard(linked);
     const client = createClient((method) => {
       if (method === "tasks.list") {
@@ -5442,7 +5299,7 @@ describe("workboard controller", () => {
   });
 
   it("stops linked sessions and marks cards blocked", async () => {
-    const linked = { ...sampleCard, sessionKey: sampleSession.key, runId: "run-1" };
+    const linked = makeCard({ sessionKey: sampleSession.key, runId: "run-1" });
     const blocked = { ...linked, status: "blocked" };
     const client = createClient({
       "chat.abort": { aborted: true, runIds: ["run-1"] },
@@ -5517,11 +5374,10 @@ describe("workboard controller", () => {
 
   it("cancels a tracked replacement instead of its confirmed-missing task link", async () => {
     const missingTaskId = "task-pruned-from-ledger";
-    const replacementTask = {
-      ...sampleTask,
+    const replacementTask = makeTask({
       id: "task-replacement",
       taskId: "task-replacement",
-    };
+    });
     const linked = createLinkedCard({ status: sampleCard.status, taskId: missingTaskId });
     const blocked = { ...linked, status: "blocked" };
     state.cards = [linked];
@@ -5725,7 +5581,7 @@ describe("workboard controller", () => {
   });
 
   it("cancels active task-only cards from the local task map", async () => {
-    const blocked = { ...sampleCard, status: "blocked" };
+    const blocked = makeCard({ status: "blocked" });
     state.cards = [sampleCard];
     state.tasksByCardId.set("card-1", sampleTask);
     const client = createClient({
@@ -5750,10 +5606,9 @@ describe("workboard controller", () => {
   });
 
   it("archives cards through the plugin gateway method", async () => {
-    const archived = {
-      ...sampleCard,
+    const archived = makeCard({
       metadata: { archivedAt: 20 },
-    } satisfies WorkboardCard;
+    });
     const client = createClient({ "workboard.cards.archive": { card: archived } });
 
     await archiveCard(client, "card-1");
@@ -5766,7 +5621,7 @@ describe("workboard controller", () => {
   });
 
   it("falls back to the active session abort when the stored run id is stale", async () => {
-    const linked = { ...sampleCard, sessionKey: sampleSession.key, runId: "old-run" };
+    const linked = makeCard({ sessionKey: sampleSession.key, runId: "old-run" });
     const blocked = { ...linked, status: "blocked" };
     const client = createSequencedClient(
       {
@@ -5795,7 +5650,7 @@ describe("workboard controller", () => {
   });
 
   it("leaves cards unchanged when stop does not abort an active run", async () => {
-    const linked = { ...sampleCard, sessionKey: sampleSession.key, runId: "stale-run" };
+    const linked = makeCard({ sessionKey: sampleSession.key, runId: "stale-run" });
     state.cards = [linked];
     const client = createClient({
       "chat.abort": { aborted: false, runIds: [] },


### PR DESCRIPTION
## What Problem This Solves

An audit found large test files with substantial within-file fixture repetition. This batch targets the top eight eligible `*.test.ts` files at least 1,500 LOC outside `ui/src/pages/chat/**` and the coordinator's sibling-owned paths. The selected files contained 1,654–2,012 repeated eligible lines apiece under the audit-compatible `sum(frequency - 1)` metric.

## Why This Change Was Made

The tests repeated large parameter objects, event envelopes, session records, controller state, and notification fixtures. This change introduces local defaults-first, overrides-last `make*` builders at each owning test boundary and consolidates exact shared assertion/setup shapes. No production code, shared support module, baseline, snapshot, test title, assertion contract, or test ordering changed.

The eight files were committed independently. The final test-only diff removes 3,010 net LOC while retaining the same focused test inventory.

## User Impact

None. This is a behavior-neutral test-maintenance refactor. It makes future test additions smaller and keeps scenario-specific differences visible at call sites.

## Evidence

Mechanical title-delta collection before and after editing was identical for every file:

- incomplete-turn: 342 collected routed entries (JSON exact-name comparison)
- Discord voice E2E: 194
- restart recovery: 314 routed entries
- CLI attempt execution: 232 routed entries
- subagent registry: 286 routed entries
- Workboard: 187
- TUI event handlers: 168
- Codex turn watches: 94

Focused Vitest proof, serialized in this worktree:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
# 171 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts extensions/discord/src/voice/manager.e2e.test.ts
# 194 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts
# 157 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts
# 116 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts
# 143 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs ui/src/lib/workboard/index.test.ts
# 187 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts
# 168 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
# 94 passed
```

Static proof:

```text
pnpm format <all eight paths>
# passed

node scripts/run-oxlint.mjs <all eight paths>
# passed

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed
# passed: guards, format, dead exports, UI i18n, core/extension test typecheck, core/extension lint

git diff --check
# passed

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
# clean: no accepted/actionable findings (full two-pass diff, then one-pass type-fix follow-up)
```

The first delegated `node scripts/check-changed.mjs` attempt reached Daytona run `run_e646765dfd13` after Blacksmith readiness failed, but exited without naming a failed lane and with empty stderr. Its persisted logs contained only passing guards. The trusted-source local fallback above is the final green gate.

Codex notification fixture shapes were checked against current upstream protocol definitions in `codex-rs/app-server-protocol/src/protocol/v2/item.rs` (`ItemCompletedNotification`, `RawResponseItemCompletedNotification`, and `AgentMessageDeltaNotification`), `protocol/v2/turn.rs` (`TurnCompletedNotification`), and the app-server dynamic-tool request documentation.

Production-vs-test numstat against `origin/main`:

```text
production: +0 / -0
 tests:     +2837 / -5847
 net test:  -3010 LOC
```
