### PR TITLE
fix(telegram): log error notification send failure instead of silent catch

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts
@@ -6,7 +6,7 @@ import {
   resolveInboundDebounceMs,
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramHandlerMessageRuntime } from "./bot-handlers.message.runtime.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
@@ -207,7 +207,7 @@ export function createTelegramInboundDebounceRuntime(
             threadId != null ? { message_thread_id: threadId } : undefined,
           )
           .catch((sendError: unknown) => {
-            logVerbose(`telegram: error fallback send failed: ${String(sendError)}`);
+            runtime.error?.(danger(`telegram: error fallback send failed: ${String(sendError)}`));
           });
       }
     },

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -1,6 +1,5 @@
 // Telegram tests cover bot message plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
@@ -877,7 +876,7 @@ describe("telegram bot message processor", () => {
     expect(runtimeError).toHaveBeenCalledWith(
       "telegram message processing failed: Error: dispatch exploded",
     );
-    expect(logVerbose).toHaveBeenCalledWith(
+    expect(runtimeError).toHaveBeenLastCalledWith(
       "telegram: error fallback send failed: Error: blocked by user",
     );
   });

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover bot message plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
@@ -855,7 +856,7 @@ describe("telegram bot message processor", () => {
     );
   });
 
-  it("swallows fallback delivery failures after dispatch throws", async () => {
+  it("logs the send failure when error fallback delivery also fails", async () => {
     const sendMessage = vi.fn().mockRejectedValue(new Error("blocked by user"));
     const { processMessage, runtimeError, dispatchError } = createDispatchFailureHarness(
       {
@@ -875,6 +876,9 @@ describe("telegram bot message processor", () => {
     );
     expect(runtimeError).toHaveBeenCalledWith(
       "telegram message processing failed: Error: dispatch exploded",
+    );
+    expect(logVerbose).toHaveBeenCalledWith(
+      "telegram: error fallback send failed: Error: blocked by user",
     );
   });
 });

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -323,7 +323,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               buildTelegramThreadParams(context.threadSpec),
             );
           } catch (sendError: unknown) {
-            logVerbose(`telegram: error fallback send failed: ${String(sendError)}`);
+            runtime.error?.(danger(`telegram: error fallback send failed: ${String(sendError)}`));
           }
         }
         const result: TelegramMessageProcessingResult = {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -322,7 +322,9 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               "Something went wrong while processing your request. Please try again.",
               buildTelegramThreadParams(context.threadSpec),
             );
-          } catch {}
+          } catch (sendError: unknown) {
+            logVerbose(`telegram: error fallback send failed: ${String(sendError)}`);
+          }
         }
         const result: TelegramMessageProcessingResult = {
           kind: "failed-retryable",


### PR DESCRIPTION
Relates to gap finding: `telegram-silent-fallback` (strategy A, evidence level A)

## What Problem This Solves

Fixes an issue where Telegram users who trigger a processing failure would
see nothing at all when the bot's "Something went wrong" error notification
also cannot be delivered (rate limit, bot kicked, network issue).

The error fallback `sendMessage` failure was silently swallowed by an
empty `catch {}`, leaving no record that the user was left in a dead-end
with no visible reply and no error indication — violating the
Product Doctrine invariant that every action must end in a visible
outcome or a recorded, intentional non-outcome.

## Why This Change Was Made

ClawSweeper review pointed out that the initial `logVerbose` diagnostic is
gated off under normal operator logging, so the silent dead-end would remain
unobservable by default. Both the message-processor fallback catch and the
identical debounce-handler fallback catch now route the secondary send
failure through the existing `runtime.error` path, matching the pattern used
by adjacent Telegram delivery failures
(`bot-message-dispatch-reply.ts:512`).

The primary processing error continues to be logged at `runtime.error`
level; this change ensures the secondary send-failure is recorded as a
normal diagnostic so operators can detect and investigate silent dead-ends
without enabling verbose/debug logging.

## User Impact

Operators now have an ungated diagnostic log line when the bot's error
notification could not be sent to a user, making it possible to detect and
investigate silent failure cases under default logging settings.

## Evidence

### Before fix

```
// Empty catch silently discards the send failure
} catch {}
```

The existing test `"swallows fallback delivery failures after dispatch throws"`
verified only that the original error was logged, but the secondary
`sendMessage` failure was untraceable.

### After fix

```typescript
} catch (sendError: unknown) {
  runtime.error?.(
    danger(`telegram: error fallback send failed: ${String(sendError)}`),
  );
}
```

Test verification (`extensions/telegram/src/bot-message.test.ts`):

```
 ✓ logs the send failure when error fallback delivery also fails
```

Focused test run:

```bash
node scripts/run-vitest.mjs extensions/telegram/src/bot-message.test.ts
```

```
Test Files  1 passed (1)
     Tests  25 passed (25)
```

Lint/format check:

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  extensions/telegram/src/bot-message.ts \
  extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts \
  extensions/telegram/src/bot-message.test.ts
node_modules/.bin/oxfmt --check \
  extensions/telegram/src/bot-message.ts \
  extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts \
  extensions/telegram/src/bot-message.test.ts
```

```
Found 0 warnings and 0 errors.
All matched files use the correct format.
```

```diff
 extensions/telegram/src/bot-handlers.inbound-debounce.runtime.ts | 4 ++--
 extensions/telegram/src/bot-message.test.ts                      | 3 +--
 extensions/telegram/src/bot-message.ts                           | 2 +-
 3 files changed, 4 insertions(+), 5 deletions(-)
```

### CI proof: Telegram error fallback send failure

Proved the behavior change at exact heads using a boundary test that
exercises the real `createTelegramMessageProcessor`, makes `dispatchTelegramMessage`
reject, makes the fallback `sendMessage` reject, and records whether the
secondary send failure reaches `runtime.error` under default logging.

- Before (main): `a6b20789`
- After (PR head): `c6a91016`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/31357849175
- Artifact download URL: https://github.com/xialonglee/openclaw/actions/runs/31357849175/artifacts/9051332542

Key markers from the proof log:

```
=== BEFORE proof: fallback send failure is silent ===
[proof] scene=telegram-error-fallback-send-failure logged=false status=observed
[proof] before=fallback-send-silent status=pass

=== AFTER proof: fallback send failure is logged ===
[proof] scene=telegram-error-fallback-send-failure logged=true status=observed
[proof] after=fallback-send-logged status=pass
```

The same boundary test fails to observe the send failure on the base main
commit and observes it on the PR head, confirming the fix routes the
secondary send failure through the normal `runtime.error` diagnostic.