### PR TITLE
fix(slack): add verbose diagnostics to slash command menu model context resolution

### DIFF
--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -8,6 +8,8 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSlackSlashMocks, resetSlackSlashMocks } from "./slash.test-harness.js";
 
@@ -18,6 +20,28 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
   return {
     ...actual,
     loadPreparedModelCatalog: vi.fn(async () => []),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    logVerbose: vi.fn(),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/session-store-runtime")>(
+    "openclaw/plugin-sdk/session-store-runtime",
+  );
+  return {
+    ...actual,
+    getSessionEntry: vi.fn((params: Parameters<typeof actual.getSessionEntry>[0]) =>
+      actual.getSessionEntry(params),
+    ),
   };
 });
 
@@ -528,6 +552,8 @@ describe("Slack native command argument menus", () => {
 
   beforeEach(() => {
     harness.postEphemeral.mockClear();
+    vi.mocked(getSessionEntry).mockReset();
+    vi.mocked(logVerbose).mockClear();
   });
 
   it("delivers native /login block replies before the command finishes", async () => {
@@ -762,6 +788,41 @@ describe("Slack native command argument menus", () => {
       expect(values.includes("ultra")).toBe(includesUltra);
     },
   );
+
+  it("gracefully degrades the slash command menu when the session store throws", async () => {
+    const testHarness = createArgMenusHarness({
+      commands: { native: true, nativeSkills: false },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.6-luna" },
+          models: {
+            "openai/gpt-5.6-luna": { agentRuntime: { id: "openclaw" } },
+          },
+        },
+      },
+    });
+    await registerCommands(testHarness.ctx, testHarness.account);
+    const handler = requireHandler(testHarness.commands, "/think", "/think");
+
+    vi.mocked(getSessionEntry).mockImplementationOnce(() => {
+      throw new Error("session store corrupt");
+    });
+
+    const { respond } = await runCommandHandler(handler);
+
+    // Must not crash: the slash command should still dispatch normally
+    // even when model context resolution fails.
+    expect(respond).toHaveBeenCalledTimes(1);
+    const payload = firstCallPayload(respond, "response") as { blocks?: Array<{ type: string }> };
+    expect(payload.blocks?.some((block) => block.type === "actions")).toBe(true);
+    expect(logVerbose).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "slack: failed to resolve slash command menu model context for agent=main",
+      ),
+    );
+    expect(logVerbose).toHaveBeenCalledWith(expect.stringContaining("session store corrupt"));
+  });
 
   it("falls back to static menus when app.options() throws during registration", async () => {
     const testHarness = createArgMenusHarness();

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -135,7 +135,10 @@ function resolveSlackCommandMenuModelContext(params: {
         sessionEntry: entry,
       }),
     };
-  } catch {
+  } catch (err) {
+    logVerbose(
+      `slack: failed to resolve slash command menu model context for agent=${params.agentId}: ${formatErrorMessage(err)}`,
+    );
     return {};
   }
 }

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -9,6 +9,19 @@ import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
+
+const logVerboseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    logVerbose: logVerboseMock,
+  };
+});
+
 import {
   createDeferred,
   createTelegramGroupCommandContext,
@@ -704,6 +717,7 @@ function resetSessionMetaMocks() {
   sessionBindingMocks.resolveByConversation.mockReset().mockReturnValue(null);
   sessionBindingMocks.touch.mockReset();
   deliveryMocks.deliverReplies.mockClear().mockResolvedValue({ delivered: true });
+  logVerboseMock.mockClear();
 }
 
 describe("registerTelegramNativeCommands — session metadata", () => {
@@ -864,6 +878,45 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       label: "thinking menu",
     });
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("gracefully degrades the native command menu when the session store throws", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.6-luna": { agentRuntime: { id: "openclaw" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    sessionMocks.getSessionEntry.mockImplementationOnce(() => {
+      throw new Error("session store corrupt");
+    });
+
+    const { handler, sendMessage } = registerAndResolveCommandHandler({
+      commandName: "think",
+      cfg,
+      allowFrom: ["*"],
+    });
+    await handler(createTelegramPrivateCommandContext());
+
+    // Must not crash: the native command menu should still be sent
+    // even when model context resolution fails.
+    expectSendMessageCall({
+      sendMessage,
+      chatId: 100,
+      textIncludes: "Choose level for /think.",
+      requireReplyMarkup: true,
+      label: "fallback thinking menu",
+    });
+    expect(logVerboseMock).toHaveBeenCalledTimes(1);
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "telegram: failed to resolve native command menu model context for agent=main",
+      ),
+    );
+    expect(logVerboseMock).toHaveBeenCalledWith(expect.stringContaining("session store corrupt"));
   });
 
   it.each([

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -37,6 +37,7 @@ import type {
   TelegramGroupConfig,
   TelegramTopicConfig,
 } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
@@ -366,7 +367,10 @@ function resolveTelegramCommandMenuModelContext(params: {
         sessionEntry: entry,
       }),
     };
-  } catch {
+  } catch (err) {
+    logVerbose(
+      `telegram: failed to resolve native command menu model context for agent=${params.agentId}: ${formatErrorMessage(err)}`,
+    );
     return {};
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack slash commands (`/think` and others) could produce a
degraded or incomplete argument-choice menu with no diagnostic trace when the
session store is inaccessible (corruption, I/O error, or disk full). The bare
`catch {}` in `resolveSlackCommandMenuModelContext` silently returned `{}`,
losing the model context needed to build the correct menu choices.

The same failure mode existed in Telegram's native command menu resolver,
`resolveTelegramCommandMenuModelContext`, which also swallowed errors with a bare
`catch {}` and returned an empty context.

## Why This Change Was Made

Added a `logVerbose` diagnostic inside the previously-empty catch blocks so
operators can trace the failure to its source when slash command menus behave
unexpectedly. The graceful degradation behavior (return `{}` and continue) is
preserved; only the missing diagnostic surface is added.

This diagnostic is now applied to both the Slack interactive arg-menu fallback
path and the matching Telegram native-menu fallback path, addressing the
ClawSweeper P2 finding that the same session-store/model-resolution failure
remained silent in Telegram.

Cross-channel unification beyond these two channel-owned diagnostics is out of
scope for this change.

## User Impact

Operators and users can now diagnose silent failures during Slack slash command
menu resolution and Telegram native command menu resolution by enabling verbose
logging — previously the only clue was a degraded menu with no indication of why.

## Evidence

### Before fix

`resolveSlackCommandMenuModelContext` (`extensions/slack/src/monitor/slash.ts:138`)
had a bare `catch {}` that swallowed all errors from session-store and
model-resolution operations without any log or diagnostic:

```typescript
  } catch {
    return {};
  }
```

`resolveTelegramCommandMenuModelContext`
(`extensions/telegram/src/bot-native-commands.ts:369`) had the same bare
`catch {}`:

```typescript
  } catch {
    return {};
  }
```

No test covered either error path.

### After fix

Both catch blocks now emit a verbose-level diagnostic with agent id and error
details while keeping the graceful fallback.

Slack:

```typescript
  } catch (err) {
    logVerbose(
      `slack: failed to resolve slash command menu model context for agent=${params.agentId}: ${formatErrorMessage(err)}`,
    );
    return {};
  }
```

Telegram:

```typescript
  } catch (err) {
    logVerbose(
      `telegram: failed to resolve native command menu model context for agent=${params.agentId}: ${formatErrorMessage(err)}`,
    );
    return {};
  }
```

New Slack test `"gracefully degrades the slash command menu when the session store throws"`
verifies the slash command does not crash when session store access fails, a
valid menu response is still sent, and the verbose diagnostic records the
failure with the agent identifier and error message.

New Telegram test `"gracefully degrades the native command menu when the session store throws"`
verifies the native command menu does not crash when session store access fails,
a valid menu response is still sent, and the verbose diagnostic records the
failure with the agent identifier and error message.

### Revision notes

- Addressed ClawSweeper findings:
  - [P1] Typed the `getSessionEntry` mock delegate in `slash.test.ts` using
    `Parameters<typeof actual.getSessionEntry>[0]`.
  - [P2] Added a `logVerbose` spy and asserted the emitted diagnostic in Slack.
  - [P2] Added the equivalent redacted diagnostic and regression test in Telegram
    for `resolveTelegramCommandMenuModelContext`.
- Rebased onto current `openclaw/openclaw:main` (the upstream history was
  rewritten, so the branch was reset to `upstream/main` and the intended
  changes reapplied as a single commit).

### Validation

```bash
node scripts/run-vitest.mjs extensions/slack/src/monitor/slash.test.ts
node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.session-meta.test.ts
```

- **Tests**: 57/57 passed (`extensions/slack/src/monitor/slash.test.ts`)
- **Tests**: 55/55 passed (`extensions/telegram/src/bot-native-commands.session-meta.test.ts`)
- **Lint**: `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json extensions/telegram/src/bot-native-commands.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts extensions/slack/src/monitor/slash.test.ts extensions/slack/src/monitor/slash.ts` — 0 warnings, 0 errors
- **Format**: `./node_modules/.bin/oxfmt --check extensions/telegram/src/bot-native-commands.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts extensions/slack/src/monitor/slash.test.ts extensions/slack/src/monitor/slash.ts` — clean

> **Note:** `scripts/run-oxlint.mjs` currently fails on `upstream/main` with
> unrelated `plugin-sdk boundary dts` errors (`rejectSymlinks`), so the changed
> files were linted directly with `oxlint`.

### CI proof: Slack slash menu session-store failure diagnostic

Proved this change at exact heads using a focused runtime test that exercises
`resolveSlackCommandMenuModelContext` through the Slack `/think` slash-command
handler while the session store is forced to throw:

- Before (main): `cbe1319`
- After (PR head): `9e7dbef`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/31161744690
- Artifact download URL: https://github.com/xialonglee/openclaw/actions/runs/31161744690/artifacts/8987382034

The same proof test was run against both SHAs in an isolated
`OPENCLAW_STATE_DIR` with no secrets. Markers from the artifact log:

```
BEFORE: [proof] scene=slack-slash-menu-session-throw logVerboseCalled=false hasActionsBlock=true
AFTER:  [proof] scene=slack-slash-menu-session-throw logVerboseCalled=true hasActionsBlock=true logContainsAgent=true logContainsError=true
```

This shows the fix preserves the graceful fallback menu (`hasActionsBlock=true`)
while adding the verbose diagnostic (`logVerboseCalled=true`) that includes the
agent id and the thrown error message.
