### PR TITLE
fix(reply): surface auth-profile cooldown failures in group chats

### DIFF
--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
-import { buildEmptyInteractiveReplyPayload } from "./agent-runner-failure-reply.js";
+import {
+  buildEmptyInteractiveReplyPayload,
+  buildExternalRunFailureReply,
+  resolveExternalRunFailureTextForConversation,
+} from "./agent-runner-failure-reply.js";
 
 const EMPTY_INTERACTIVE_REPLY_TEXT =
   "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.";
@@ -33,5 +37,50 @@ describe("buildEmptyInteractiveReplyPayload", () => {
         cfg: { agents: { defaults: { silentReply: { group: "disallow" } } } },
       }),
     ).toMatchObject({ text: EMPTY_INTERACTIVE_REPLY_TEXT, isError: true });
+  });
+});
+
+describe("auth profile cooldown failures", () => {
+  const cooldownMessage =
+    'Auth profile "openai:user@example.com" is temporarily unavailable for openai/gpt-5.6-sol.';
+
+  it("maps plain auth-cooldown errors to non-generic provider copy without the profile id", () => {
+    const reply = buildExternalRunFailureReply(
+      { message: cooldownMessage, error: new Error(cooldownMessage) },
+      { includeAuthProfileId: false, includeDetails: false, isHeartbeat: false },
+    );
+    expect(reply.isGenericRunnerFailure).toBe(false);
+    expect(reply.text).toContain("openai");
+    expect(reply.text).not.toContain("user@example.com");
+  });
+
+  it("stays visible in group conversations instead of resolving to a silent reply", () => {
+    const reply = buildExternalRunFailureReply(
+      { message: cooldownMessage, error: new Error(cooldownMessage) },
+      { includeAuthProfileId: false, includeDetails: false, isHeartbeat: false },
+    );
+    const resolved = resolveExternalRunFailureTextForConversation({
+      text: reply.text,
+      sessionCtx: {
+        SessionKey: "agent:main:telegram:group:-100123:topic:1",
+        Surface: "telegram",
+        Provider: "telegram",
+        ChatType: "group",
+      },
+      isGenericRunnerFailure: reply.isGenericRunnerFailure,
+    });
+    expect(resolved).not.toBe(SILENT_REPLY_TOKEN);
+    expect(resolved).toContain("openai");
+  });
+
+  it("also matches provider-only cooldown messages from route auth", () => {
+    const routeMessage =
+      'Auth profile "openai:user@example.com" is temporarily unavailable for openai.';
+    const reply = buildExternalRunFailureReply(
+      { message: routeMessage, error: new Error(routeMessage) },
+      { includeAuthProfileId: false, includeDetails: false, isHeartbeat: false },
+    );
+    expect(reply.isGenericRunnerFailure).toBe(false);
+    expect(reply.text).toContain("openai");
   });
 });

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -355,6 +355,25 @@ export function buildAuthProfileFailoverFailureText(error: unknown): string | nu
   });
 }
 
+// Runtime-plan auth preparation throws plain Errors, so cooldown failures arrive
+// without failover structure. Without this match they fall through to the generic
+// runner-failure copy, which group silent-reply policy suppresses entirely — the
+// turn fails with no visible outcome.
+const AUTH_PROFILE_TEMPORARILY_UNAVAILABLE_RE =
+  /\bAuth profile "[^"]+" is temporarily unavailable for ([\w.-]+)(?:\/[\w".-]+)?\.?/u;
+
+function buildAuthProfileCooldownFailureText(message: string): string | null {
+  const match = AUTH_PROFILE_TEMPORARILY_UNAVAILABLE_RE.exec(message);
+  if (!match?.[1]) {
+    return null;
+  }
+  return formatAuthProfileFailureMessage({
+    reason: "rate_limit",
+    provider: match[1],
+    allInCooldown: true,
+  });
+}
+
 function formatForwardedExternalRunFailureText(message: string): string {
   const sanitized = sanitizeUserFacingText(message, { errorContext: true })
     .trim()
@@ -419,6 +438,10 @@ export function buildExternalRunFailureReply(
   const authProfileFailoverFailure = buildAuthProfileFailoverFailureText(error);
   if (authProfileFailoverFailure) {
     return { text: authProfileFailoverFailure, isGenericRunnerFailure: false };
+  }
+  const authProfileCooldownFailure = buildAuthProfileCooldownFailureText(normalizedMessage);
+  if (authProfileCooldownFailure) {
+    return { text: authProfileCooldownFailure, isGenericRunnerFailure: false };
   }
   const cliMaxTurnsError = findCliMaxTurnsError(error);
   if (cliMaxTurnsError) {


### PR DESCRIPTION
Field report: a group-addressed turn on a live deployment failed with no visible outcome after the provider's auth profile entered cooldown (subscription usage limit). The inbound was received and dispatched; the log shows \`visible channel turn dispatched with no queued reply payloads\`.

## Root cause

\`prepareAgentRuntimeAuth\` throws plain \`Error\`s for cooldown profiles (\`src/agents/runtime-plan/prepare-auth.ts\`), so the failure loses failover structure. \`buildAuthProfileFailoverFailureText\` only matches structured \`FailoverError\`s, and \`isRateLimitErrorMessage\` does not match the cooldown wording — so the handler fell through to the **generic** runner-failure copy, which \`resolveExternalRunFailureTextForConversation\` converts to \`SILENT_REPLY_TOKEN\` in group conversations. Silent failure on an addressed turn.

## Fix

Match the cooldown message shape in \`buildExternalRunFailureReply\` and route it through the existing \`formatAuthProfileFailureMessage\` copy (\`rate_limit\`/\`allInCooldown\`), marked non-generic. Groups now see "\<provider\> is asking us to slow down. Please wait a moment before trying again." — no profile id (which contains an account email) is leaked.

## Proof

Regression tests fail on unmodified main:

```
× stays visible in group conversations instead of resolving to a silent reply
AssertionError: expected 'NO_REPLY' not to be 'NO_REPLY'
```

and pass on this branch (both message shapes: \`for <provider>/<model>.\` and \`for <provider>.\`). \`pnpm check\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)