### PR TITLE
fix(gateway): preserve plugin icon 404 metadata on HEAD

### DIFF
--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -340,6 +340,7 @@ describe("Control UI plugin and catalog icon routes", () => {
       const response = await request(pathname, { method: "HEAD" });
 
       expect(response.status).toBe(404);
+      expect(response.headers.get("content-length")).toBe("9");
       expect((await response.arrayBuffer()).byteLength).toBe(0);
       expect(mocks.readRemoteMediaBuffer).not.toHaveBeenCalled();
     },

--- a/src/gateway/plugin-icon-http.ts
+++ b/src/gateway/plugin-icon-http.ts
@@ -19,6 +19,7 @@ import {
   CONTROL_UI_CATALOG_ICON_PATH_PREFIX,
   CONTROL_UI_PLUGIN_ICON_PATH_PREFIX,
 } from "./control-ui-contract.js";
+import { respondNotFound as sendNotFound } from "./control-ui-http-utils.js";
 import { sendMethodNotAllowed } from "./http-common.js";
 import { authorizeGatewayHttpRequestOrReply } from "./http-utils.js";
 
@@ -237,12 +238,6 @@ async function loadCatalogIcon(params: {
     pluginIconCache.delete(cacheKey);
   }
   return result;
-}
-
-function sendNotFound(res: ServerResponse): void {
-  res.statusCode = 404;
-  res.setHeader("content-type", "text/plain; charset=utf-8");
-  res.end("Not Found");
 }
 
 export function clearPluginIconCacheForTest(): void {


### PR DESCRIPTION
Related: #119822

## What Problem This Solves

Fixes an issue where Control UI plugin and catalog icon `HEAD` probes returned a 404 without the representation's byte length when an icon was unavailable. Clients could see the status and content type, but could not compare the missing response's metadata with `GET`.

## Why This Change Was Made

The icon handler now reuses the gateway's canonical plain-text `respondNotFound` helper instead of maintaining a second local 404 implementation. This keeps plugin and catalog icon misses aligned with the existing Control UI response contract without changing board routes, authentication, icon resolution, or successful image responses.

Production LOC: +1/-6 (net -5) | Tests: +1/-0

## User Impact

Plugin and catalog icon `HEAD` misses now return `Content-Length: 9`, matching the `Not Found` representation sent by `GET`, while the `HEAD` response remains bodyless.

## Evidence

- Actual handler over a loopback HTTP server:
  - `GET`: 404, `content-type: text/plain; charset=utf-8`, `content-length: 9`, 9-byte `Not Found` body.
  - `HEAD`: 404, the same content type and length, and a 0-byte body.
- Full focused file: `pnpm exec vitest run --config test/vitest/vitest.gateway-core.config.ts src/gateway/plugin-icon-http.test.ts` - 32/32 passed.
- Repeated regression matrix: plugin and catalog `HEAD` 404 cases passed 20 consecutive runs, 40 cases total.
- `pnpm format src/gateway/plugin-icon-http.ts src/gateway/plugin-icon-http.test.ts` - passed.
- `pnpm exec oxfmt --check src/gateway/plugin-icon-http.ts src/gateway/plugin-icon-http.test.ts` - passed.
- `git diff --check` - passed.

Punchcard-Session: cobalt-harbor-harbor-2b
