### PR TITLE
feat: let plugins stop an agent run without discarding the session

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -402,11 +402,27 @@ two-party event loops that do not go through the shared inbound reply runner.
       limit: 10,
     });
 
+    // Stop whatever is running on a session, KEEPING the session + transcript
+    await api.runtime.subagent.abortSession({
+      sessionKey: "agent:main:subagent:search-helper",
+    });
+
     // Delete a session
     await api.runtime.subagent.deleteSession({
       sessionKey: "agent:main:subagent:search-helper",
     });
     ```
+
+    `abortSession` and `deleteSession` both end an in-flight run, and they are
+    not interchangeable. `abortSession` cancels the run and leaves the session
+    entry and its transcript in place, so the next message continues the same
+    conversation — this is what a user-facing "stop" control wants.
+    `deleteSession` discards the session itself, so the next message starts a
+    fresh one. Reach for `deleteSession` only when the conversation should end,
+    not merely the work.
+
+    Both are restricted to sessions your plugin owns: calling either on a
+    session created by another plugin is rejected.
 
     <Warning>
     Model overrides (`provider`/`model`) require operator opt-in via `plugins.entries.<id>.subagent.allowModelOverride: true` in config. Untrusted plugins can still run subagents, but override requests are rejected.

--- a/src/gateway/server-methods/sessions-abort.test.ts
+++ b/src/gateway/server-methods/sessions-abort.test.ts
@@ -99,6 +99,66 @@ test("sessions.abort aborts a pre-existing session after its agent is removed fr
   expect(activeRun.controller.signal.aborted).toBe(true);
 });
 
+test("sessions.abort refuses a plugin caller when the session has no stored owner row", async () => {
+  // The no-store active run above is a supported state, and the plugin path
+  // dispatches under a synthetic admin client that chat-abort authorizes without
+  // matching the controller owner. So "no row" must REJECT for a plugin caller —
+  // the shared ownership helper permits an absent entry, which is correct for
+  // delete/patch and a bypass here.
+  const agentId = "active-only";
+  const sessionKey = `agent:${agentId}:running`;
+  const runId = "run-no-row";
+  const activeRun = createActiveRun(sessionKey, { agentId });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+
+  const result = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey },
+    {
+      context: abortContext,
+      client: { internal: { pluginRuntimeOwnerId: "intruder" } } as never,
+    },
+  );
+
+  expect(result).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST" },
+  });
+  expect(result.error?.message).toContain("did not create it");
+  // The decisive assertion: the run was NOT cancelled.
+  expect(activeRun.controller.signal.aborted).toBe(false);
+});
+
+test("sessions.abort refuses a plugin caller whose id does not own the stored row", async () => {
+  const agentId = "owned";
+  const sessionKey = `agent:${agentId}:owned-run`;
+  const sessionId = "session-owned";
+  const runId = "run-owned";
+  const storePath = path.join(requireStateDir(), "agents", agentId, "sessions", "sessions.json");
+  await replaceSessionEntry(
+    { agentId, sessionKey, storePath },
+    { sessionId, updatedAt: 42, pluginOwnerId: "owner-plugin" } as never,
+  );
+  const activeRun = createActiveRun(sessionKey, { agentId, sessionId });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+
+  const result = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey },
+    {
+      context: abortContext,
+      client: { internal: { pluginRuntimeOwnerId: "intruder" } } as never,
+    },
+  );
+
+  expect(result).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+  expect(activeRun.controller.signal.aborted).toBe(false);
+});
+
 test("sessions.abort aborts an exact active run for an unconfigured agent without a store", async () => {
   const agentId = "active-only";
   const sessionKey = `agent:${agentId}:running`;

--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -235,6 +235,20 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
         ...(requestedGlobalAgentId ? { storeAgentId: requestedGlobalAgentId } : {}),
       });
     const sessionEntry = loadedSession?.entry;
+    // A plugin may abort only runs on sessions it owns. `sessions.delete` and the
+    // session mutations already assert this; without the same check here a
+    // plugin-scoped caller could cancel another plugin's in-flight work.
+    if (
+      rejectPluginRuntimeSessionOwnershipMismatch({
+        action: "abort",
+        client,
+        key: canonicalKey,
+        entry: sessionEntry,
+        respond,
+      })
+    ) {
+      return;
+    }
     const requestedKeyAliases =
       requestedKey &&
       requestedKey !== key &&

--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -238,9 +238,28 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
         ...(requestedGlobalAgentId ? { storeAgentId: requestedGlobalAgentId } : {}),
       });
     const sessionEntry = loadedSession?.entry;
-    // A plugin may abort only runs on sessions it owns. `sessions.delete` and the
-    // session mutations already assert this; without the same check here a
-    // plugin-scoped caller could cancel another plugin's in-flight work.
+    // A plugin may abort only runs on sessions it owns.
+    //
+    // The shared ownership helper treats an ABSENT entry as permissible, which is
+    // right for delete/patch (mutating a missing row is a no-op) and WRONG here:
+    // an active run can exist with no persisted row — see "aborts an exact active
+    // run for an unconfigured agent without a store" — and this path dispatches
+    // under a synthetic admin client, which chat-abort authorizes without
+    // matching the controller owner. So an absent row would let a plugin cancel a
+    // run it does not own. Require a row for plugin callers, then fall through to
+    // the shared owner comparison.
+    const pluginCallerId = normalizeOptionalString(client?.internal?.pluginRuntimeOwnerId);
+    if (pluginCallerId && !sessionEntry) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `Plugin "${pluginCallerId}" cannot abort session "${canonicalKey}" because it did not create it.`,
+        ),
+      );
+      return;
+    }
     if (
       rejectPluginRuntimeSessionOwnershipMismatch({
         action: "abort",

--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -31,7 +31,10 @@ import { resolveWorkerSessionTarget } from "../worker-environments/session-targe
 import { setGatewayDedupeEntry } from "./agent-job.js";
 import { handleChatAbortRequestWithLifecycle } from "./chat-abort-handler.js";
 import { emitSessionsChanged } from "./session-change-event.js";
-import { requireSessionKey } from "./sessions-shared.js";
+import {
+  rejectPluginRuntimeSessionOwnershipMismatch,
+  requireSessionKey,
+} from "./sessions-shared.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1889,6 +1889,41 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("memory-core");
   });
 
+  // A bare sessions.abort deliberately PRESERVES the followup and lane queues, so
+  // forwarding only { key } would cancel the active run and let queued work
+  // promote itself straight afterwards — the user presses Stop and the session
+  // starts talking again. The boundary is the dispatched payload, which is why
+  // this asserts on it rather than on the facade's return value: abortSession
+  // resolves to undefined either way, so the broken shape is invisible from the
+  // caller's side.
+  test("clears queued session work when a plugin aborts its session", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("fallback-plugin-abort-session"));
+
+    let abortParams: Record<string, unknown> | undefined;
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      abortParams = opts.req.params as Record<string, unknown>;
+      opts.respond(true, {});
+    });
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimePluginIdScope("memory-core", () =>
+        runtime.abortSession({ sessionKey: "dreaming-narrative-light-workspace-1" }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(abortParams).toMatchObject({
+      key: "dreaming-narrative-light-workspace-1",
+      clearQueued: true,
+    });
+    // Still no runId: the session is what was authorized, and pairing an owned
+    // key with a caller-supplied run id under synthetic admin is the bypass the
+    // ownership check exists to stop.
+    expect(abortParams).not.toHaveProperty("runId");
+    expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("memory-core");
+  });
+
   test("can select setup-runtime channel plugins for setup flows", () => {
     loadOpenClawPlugins.mockReturnValue(createRegistry([]));
     loadGatewayPluginsForTest({

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -510,9 +510,17 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       // Deliberately no runId: the session is what was authorized. Forwarding a
       // caller-supplied run id under the synthetic admin client would let a
       // plugin pair its own key with another plugin's run and cancel that.
+      //
+      // clearQueued is REQUIRED, not an optimisation. A bare `sessions.abort`
+      // deliberately preserves the followup and lane queues, which is right for
+      // a run-scoped cancel but wrong for the Stop this method advertises:
+      // cancelling the active run would let queued followup work promote itself
+      // immediately, so the user presses Stop, watches the run end, and sees the
+      // session start talking again. Clearing is scoped to this session's keys
+      // (see clearSessionQueues), so it cannot reach another plugin's queues.
       await dispatchGatewayMethodInProcess(
         "sessions.abort",
-        { key: params.sessionKey },
+        { key: params.sessionKey, clearQueued: true },
         pluginOwnedAbortOptions,
       );
     },

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -507,12 +507,12 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
               : {}),
           }
         : undefined;
+      // Deliberately no runId: the session is what was authorized. Forwarding a
+      // caller-supplied run id under the synthetic admin client would let a
+      // plugin pair its own key with another plugin's run and cancel that.
       await dispatchGatewayMethodInProcess(
         "sessions.abort",
-        {
-          key: params.sessionKey,
-          ...(params.runId ? { runId: params.runId } : {}),
-        },
+        { key: params.sessionKey },
         pluginOwnedAbortOptions,
       );
     },

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -490,6 +490,32 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         pluginOwnedCleanupOptions,
       );
     },
+    async abortSession(params) {
+      const scope = getPluginRuntimeGatewayRequestScope();
+      const pluginId =
+        typeof scope?.pluginId === "string" && scope.pluginId.trim()
+          ? scope.pluginId.trim()
+          : undefined;
+      const pluginOwnedAbortOptions = pluginId
+        ? {
+            pluginRuntimeOwnerId: pluginId,
+            ...(!hasAdminScope(scope?.client)
+              ? {
+                  forceSyntheticClient: true,
+                  syntheticScopes: [ADMIN_SCOPE],
+                }
+              : {}),
+          }
+        : undefined;
+      await dispatchGatewayMethodInProcess(
+        "sessions.abort",
+        {
+          key: params.sessionKey,
+          ...(params.runId ? { runId: params.runId } : {}),
+        },
+        pluginOwnedAbortOptions,
+      );
+    },
   };
 }
 

--- a/src/gateway/session-plugin-ownership.ts
+++ b/src/gateway/session-plugin-ownership.ts
@@ -6,7 +6,14 @@ import {
 } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../config/sessions.js";
 
-export type PluginSessionOwnershipAction = "adopt" | "delete" | "fork" | "link" | "patch" | "reset";
+export type PluginSessionOwnershipAction =
+  | "abort"
+  | "adopt"
+  | "delete"
+  | "fork"
+  | "link"
+  | "patch"
+  | "reset";
 
 /** Plugin callers may access an existing session only when they own its exact row. */
 export function resolvePluginSessionOwnershipError(params: {

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -999,6 +999,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       waitForRun: vi.fn(),
       getSessionMessages: vi.fn(),
       deleteSession: vi.fn(),
+      abortSession: vi.fn(),
     },
     sandbox: {
       resolveWorkspaceAuthority: vi.fn(),

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -48,6 +48,7 @@ function createDeferredGatewaySubagentRuntime(runtime: PluginRuntime): PluginRun
     waitForRun: (...args) => runtime.subagent.waitForRun(...args),
     getSessionMessages: (...args) => runtime.subagent.getSessionMessages(...args),
     deleteSession: (...args) => runtime.subagent.deleteSession(...args),
+    abortSession: (...args) => runtime.subagent.abortSession(...args),
   };
 }
 

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -874,6 +874,11 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
               assertStoredSessionEntryOwned({ action: "delete", sessionKey: params.sessionKey });
               await subagent.deleteSession(params);
             }),
+          abortSession: async (params) =>
+            await withPluginRuntimePluginIdScope(pluginId, async () => {
+              assertStoredSessionEntryOwned({ action: "abort", sessionKey: params.sessionKey });
+              await subagent.abortSession(params);
+            }),
         } satisfies PluginRuntime["subagent"];
       },
     });

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -500,6 +500,7 @@ describe("plugin registry runtime config scope", () => {
       waitForRun: vi.fn(async () => ({ status: "ok" as const })),
       getSessionMessages: vi.fn(async () => ({ messages: [] })),
       deleteSession: vi.fn(async () => {}),
+      abortSession: vi.fn(async () => {}),
     } satisfies PluginRuntime["subagent"];
     const runtime = createPluginRuntime({ subagent });
     const session = runtime.agent.session;
@@ -711,6 +712,9 @@ describe("plugin registry runtime config scope", () => {
     ).rejects.toThrow('owned by plugin "codex-owner"');
     await expect(
       otherApi.runtime.subagent.deleteSession({ sessionKey: reservedKey }),
+    ).rejects.toThrow('owned by plugin "codex-owner"');
+    await expect(
+      otherApi.runtime.subagent.abortSession({ sessionKey: reservedKey }),
     ).rejects.toThrow('owned by plugin "codex-owner"');
     await expect(
       otherApi.runtime.gateway.request("sessions.patch", {

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -716,6 +716,11 @@ describe("plugin registry runtime config scope", () => {
     await expect(
       otherApi.runtime.subagent.abortSession({ sessionKey: reservedKey }),
     ).rejects.toThrow('owned by plugin "codex-owner"');
+    // ...and the owner itself may abort it, so the guard rejects the foreign
+    // caller rather than the operation.
+    subagent.abortSession.mockClear();
+    await ownerApi.runtime.subagent.abortSession({ sessionKey: reservedKey });
+    expect(subagent.abortSession).toHaveBeenCalledWith({ sessionKey: reservedKey });
     await expect(
       otherApi.runtime.gateway.request("sessions.patch", {
         key: reservedKey,

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -727,6 +727,13 @@ describe("plugin registry runtime config scope", () => {
         archived: true,
       }),
     ).rejects.toThrow('owned by plugin "codex-owner"');
+    // Direct Gateway route, not just the subagent facade: the handler-side guard
+    // must reject a foreign session even when the caller reaches sessions.abort
+    // through runtime.gateway.request, so the facade is not the only thing
+    // standing between a plugin and another plugin's active run.
+    await expect(
+      otherApi.runtime.gateway.request("sessions.abort", { key: reservedKey }),
+    ).rejects.toThrow('owned by plugin "codex-owner"');
     await expect(
       otherApi.runtime.gateway.request("agent", {
         sessionId: reservedEntry.sessionId,

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -45,6 +45,7 @@ function createGatewaySubagentRuntime() {
     waitForRun: vi.fn(),
     getSessionMessages: vi.fn(),
     deleteSession: vi.fn(),
+    abortSession: vi.fn(),
   };
 }
 

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -179,6 +179,7 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
     waitForRun: unavailable,
     getSessionMessages: unavailable,
     deleteSession: unavailable,
+    abortSession: unavailable,
   };
 }
 

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -139,6 +139,11 @@ export type PluginRuntime = PluginRuntimeCore & {
      * transcript. `deleteSession` also stops a run, but it removes the session
      * entry, so the next message starts a fresh session and prior history
      * becomes unreachable.
+     *
+     * This is a full Stop for the session, not a run-scoped cancel: the
+     * session's queued followup and lane work is cleared too, so nothing
+     * promotes itself once the active run ends. Queue clearing is scoped to
+     * this session's own keys.
      */
     abortSession: (params: SubagentAbortSessionParams) => Promise<void>;
   };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -63,6 +63,17 @@ type SubagentGetSessionMessagesResult = {
   messages: unknown[];
 };
 
+/**
+ * Cancel any in-flight run on a session WITHOUT destroying the session or its
+ * transcript. Use this to STOP work; SubagentDeleteSessionParams discards the
+ * session entirely.
+ */
+type SubagentAbortSessionParams = {
+  sessionKey: string;
+  /** Abort only this run; omit to abort whatever is currently running. */
+  runId?: string;
+};
+
 type SubagentDeleteSessionParams = {
   sessionKey: string;
   deleteTranscript?: boolean;
@@ -125,6 +136,13 @@ export type PluginRuntime = PluginRuntimeCore & {
       params: SubagentGetSessionMessagesParams,
     ) => Promise<SubagentGetSessionMessagesResult>;
     deleteSession: (params: SubagentDeleteSessionParams) => Promise<void>;
+    /**
+     * Cancel the in-flight run on a session, KEEPING the session and its
+     * transcript. `deleteSession` also stops a run, but it removes the session
+     * entry, so the next message starts a fresh session and prior history
+     * becomes unreachable.
+     */
+    abortSession: (params: SubagentAbortSessionParams) => Promise<void>;
   };
   nodes: {
     list: (params?: RuntimeNodeListParams) => Promise<RuntimeNodeListResult>;

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -70,8 +70,6 @@ type SubagentGetSessionMessagesResult = {
  */
 type SubagentAbortSessionParams = {
   sessionKey: string;
-  /** Abort only this run; omit to abort whatever is currently running. */
-  runId?: string;
 };
 
 type SubagentDeleteSessionParams = {


### PR DESCRIPTION
Closes #120139

## What Problem This Solves

Plugin authors cannot stop an agent run without discarding the conversation it belongs to.

`PluginRuntime["subagent"]` exposes `run`, `waitForRun`, `getSessionMessages` and `deleteSession`. The only one of those that halts an in-flight run is `deleteSession`, and it is not a cancel — it removes the session store entry, so the next message on that session key opens a fresh session and the prior conversation is no longer referenced.

Any plugin that puts a Stop control in front of users therefore has to pick between stopping the work and keeping the conversation. There is no third option today.

The capability itself already exists: `sessions.abort` → `chat.abort` cancels through the run's `AbortController` and leaves the session entry and transcript untouched — it is what `/stop` and the control UI call. It is just not reachable from the plugin runtime, so first-party surfaces get a clean stop and plugin-built surfaces cannot.

## Why This Change Was Made

Adds `subagent.abortSession({ sessionKey })`, dispatched through `dispatchGatewayMethodInProcess("sessions.abort", …)` with the same `pluginRuntimeOwnerId` stamp `deleteSession` already carries, so it runs with plugin identity rather than requiring an admin client. Exposing it on the runtime facade — rather than having plugins reach the gateway directly — keeps ownership enforcement in the one place that applies it.

It also closes an asymmetry in the ownership model. `assertStoredSessionEntryOwned` and `rejectPluginRuntimeSessionOwnershipMismatch` already assert that a plugin may not `adopt | delete | fork | link | patch | reset` a session it does not own, but `sessions.abort` reads no ownership at all. Aborting another plugin's run is the same class of violation, so `"abort"` joins `PluginSessionOwnershipAction` and the existing guard is applied on the abort path — reusing the current helper rather than adding a parallel mechanism.

**The API deliberately takes no `runId`.** An earlier revision accepted one and forwarded it; because the facade authorizes the *session* and then dispatches under a synthetic admin client, a plugin could pair its own session key with another plugin's run id and cancel that foreign run. Rather than police a run id we never authorized, the parameter is gone: a plugin stops what is running on its own session, and nothing else.

Non-goals: `deleteSession` behavior is unchanged, and no new transport, endpoint or permission is introduced.

## User Impact

Plugin authors can offer a Stop that halts the current run and leaves the conversation intact, which is what users expect a Stop to do.

Operators running plugins from more than one owner in a single instance get abort covered by the same ownership rules as every other session mutation, instead of an unscoped cancel.

No behavior changes for existing plugins: `abortSession` is additive, and nothing that works today works differently.

## Evidence

**Type check** — `pnpm tsgo:core && pnpm tsgo:test:src`, Node 24: **0 errors**.

**Tests** — `src/plugins/registry.runtime-config.test.ts`, Node 24.19.0, `pnpm install --frozen-lockfile` clean:

```
 ✓  plugins  src/plugins/registry.runtime-config.test.ts (10 tests) 34ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

That file now exercises the **new facade path** in both directions:

- a foreign plugin calling `abortSession` on a session it does not own is rejected with `owned by plugin "codex-owner"`, and
- the owning plugin's call reaches the runtime — asserted with `expect(subagent.abortSession).toHaveBeenCalledWith({ sessionKey: reservedKey })`, so the guard rejects the *caller*, not the operation.

**Handler-level coverage** in `src/gateway/server-methods/sessions-abort.test.ts` (11/11), reaching the handler through `directSessionReq` with a plugin-scoped client:

- a plugin caller is refused when the session has **no stored owner row**, and
- a plugin caller is refused when the stored row belongs to someone else,

both asserting the run's `AbortController` was **not** aborted — not merely that the call errored.

Mutation-checked: removing the no-row guard makes the first test fail (1 failed / 10 passed); restoring it returns 11/11. The second passes either way by design, guarding the pre-existing helper behaviour.

*(An earlier revision cited a `runtime.gateway.request("sessions.abort", …)` assertion as handler proof. That was wrong — it is rejected before reaching the handler, so it proved less than claimed. The tests above replace that claim.)*

The subagent fixture is `satisfies PluginRuntime["subagent"]`, so the added method is type-checked at the fixture too, and the deferred adapter in `loader-runtime-load.ts` forwards it.

**After-fix behaviour through the facade**, on a plugin-owned streaming session, from a deployment running this patch. Persisted store entry (fields elided):

```json
key: agent:pencil-orchestrator:space:6a6b…ded6
{ "sessionId": "b9acba2f-…-530c12f06c40", "status": "done", "pluginOwnerId": "pencil-spaces" }
```

`pluginOwnerId` is what makes this the reviewed path: the session was created by a plugin, and Stop reached it via `runtime.subagent.abortSession({ sessionKey })`, not via an admin client. `stopReason` markers from that session id, one transcript file:

```
 13  2026-08-07T06:28:38.703Z  stopReason=stop
 16  2026-08-07T06:28:39.177Z  stopReason=aborted     <-- plugin Stop
 18  2026-08-07T15:32:27.186Z  stopReason=stop
 …
 58  2026-08-08T03:44:14.525Z  stopReason=stop
```

Line 16 is the abort; lines 18–58 are five later turns in the **same** file across 21 hours, the store entry still holding the same `sessionId`. Under `deleteSession` — previously the only way a plugin could stop a run — line 18 onward would have been a different session and everything above line 16 unreachable.

That deployment pins v2026.7.1, whose `SessionsAbortParamsSchema` is `additionalProperties: false`, so it cannot carry `clearQueued`; the queue behaviour is covered by the dispatch regression above, not by this trace.

**Queued work** — `src/gateway/server-plugins.test.ts`, "clears queued session work when a plugin aborts its session": asserts the dispatched payload carries `clearQueued: true` and no `runId`. It asserts the payload rather than the return value because `abortSession` resolves to `undefined` either way. Mutation-checked: reverting to `{ key: params.sessionKey }` fails it; restored, the four affected suites are 117/117.

**Underlying primitive** — `sessions.abort` measured against a live streaming run, confirming it stops the run while retaining the session and transcript (this is what motivated routing the facade at it):

```
                 before abort                     after abort
sessionId    63c40c44-…-1e4fe1ab58eb    →    63c40c44-…-1e4fe1ab58eb   unchanged
transcript   758,010 bytes / 82 lines   →    792,218 bytes / 101 lines  kept, appended
archives     —                          →    none created
run          streaming                  →    stopped (transcript frozen across 3 samples)
```

Scope: 12 files (source, tests, one doc).



