### PR TITLE
fix(device-pair): log bootstrap token revoke and QR temp cleanup failures

### DIFF
--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -78,6 +78,7 @@ type RegisterPairOptions = {
   config?: OpenClawPluginApi["config"];
   runtime?: OpenClawPluginApi["runtime"];
   pluginConfig?: Record<string, unknown>;
+  logger?: OpenClawPluginApi["logger"];
 };
 
 const INTERNAL_PAIRING_SCOPES = ["operator.write", "operator.pairing"];
@@ -126,6 +127,7 @@ function createApi(
     },
     runtime: (params.runtime ?? {}) as OpenClawPluginApi["runtime"],
     registerCommand: params.registerCommand,
+    ...(params.logger ? { logger: params.logger } : {}),
   });
 }
 
@@ -442,6 +444,53 @@ describe("device-pair /pair qr", () => {
     expect(pluginApiMocks.issueDeviceBootstrapToken).toHaveBeenCalledTimes(2);
     expect(text).toContain("Pairing setup code generated.");
     expect(text).toContain("If this code leaks or you are done, run /pair cleanup");
+  });
+
+  it("logs a warning when bootstrap token revocation fails after QR delivery failure", async () => {
+    pluginApiMocks.issueDeviceBootstrapToken
+      .mockResolvedValueOnce({ token: "first-token", expiresAtMs: Date.now() + 10 * 60_000 })
+      .mockResolvedValueOnce({ token: "second-token", expiresAtMs: Date.now() + 10 * 60_000 });
+    pluginApiMocks.revokeDeviceBootstrapToken.mockRejectedValueOnce(new Error("revoke failed"));
+    const sendMessage = vi.fn().mockRejectedValue(new Error("upload failed"));
+    const warn = vi.fn();
+
+    requireText(
+      await runPair(
+        {
+          channel: "discord",
+          senderId: "123",
+          gatewayClientScopes: INTERNAL_SETUP_SCOPES,
+        },
+        {
+          runtime: createChannelRuntime("discord", sendMessage),
+          logger: { ...createTestPluginApi().logger, warn },
+        },
+      ),
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      "device-pair: failed to revoke bootstrap token (Error: revoke failed)",
+    );
+  });
+
+  it("logs a warning when bootstrap token revocation fails after webchat QR render failure", async () => {
+    pluginApiMocks.issueDeviceBootstrapToken
+      .mockResolvedValueOnce({ token: "first-token", expiresAtMs: Date.now() + 10 * 60_000 })
+      .mockResolvedValueOnce({ token: "second-token", expiresAtMs: Date.now() + 10 * 60_000 });
+    pluginApiMocks.renderQrPngDataUrl.mockRejectedValueOnce(new Error("render failed"));
+    pluginApiMocks.revokeDeviceBootstrapToken.mockRejectedValueOnce(new Error("revoke failed"));
+    const warn = vi.fn();
+
+    requireText(
+      await runPair(
+        { channel: "webchat", gatewayClientScopes: INTERNAL_SETUP_SCOPES },
+        { logger: { ...createTestPluginApi().logger, warn } },
+      ),
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      "device-pair: failed to revoke bootstrap token (Error: revoke failed)",
+    );
   });
 
   it("falls back to the setup code instead of ASCII when the channel cannot send media", async () => {

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -892,7 +892,13 @@ export default definePluginEntry({
               api.logger.warn?.(
                 `device-pair: QR image send failed channel=${channel}, falling back (${(err as Error)?.message ?? err})`,
               );
-              await revokeDeviceBootstrapToken({ token: payload.bootstrapToken }).catch(() => {});
+              await revokeDeviceBootstrapToken({ token: payload.bootstrapToken }).catch(
+                (revokeErr: unknown) => {
+                  api.logger.warn?.(
+                    `device-pair: failed to revoke bootstrap token (${String(revokeErr)})`,
+                  );
+                },
+              );
               payload = await issueSetupPayload({
                 url: urlResult.url,
                 urls: urlResult.urls,
@@ -902,7 +908,11 @@ export default definePluginEntry({
             } finally {
               if (qrFilePath) {
                 await rm(path.dirname(qrFilePath), { recursive: true, force: true }).catch(
-                  () => {},
+                  (cleanupErr: unknown) => {
+                    api.logger.warn?.(
+                      `device-pair: failed to remove QR temp directory (${String(cleanupErr)})`,
+                    );
+                  },
                 );
               }
             }
@@ -918,7 +928,13 @@ export default definePluginEntry({
               api.logger.warn?.(
                 `device-pair: webchat QR render failed, falling back (${(err as Error)?.message ?? err})`,
               );
-              await revokeDeviceBootstrapToken({ token: payload.bootstrapToken }).catch(() => {});
+              await revokeDeviceBootstrapToken({ token: payload.bootstrapToken }).catch(
+                (revokeErr: unknown) => {
+                  api.logger.warn?.(
+                    `device-pair: failed to revoke bootstrap token (${String(revokeErr)})`,
+                  );
+                },
+              );
               payload = await issueSetupPayload({
                 url: urlResult.url,
                 urls: urlResult.urls,


### PR DESCRIPTION
<!--
Related: gap finding device-pair-revoke-silent-failure
-->

## What Problem This Solves

Fixes an issue where operators using `/pair qr` would have bootstrap token revocation failures silently swallowed when QR delivery or rendering fails and the command falls back to a setup code. If `revokeDeviceBootstrapToken` failed, the old single-use bootstrap token remained valid until expiration with no recorded diagnostic.

## Why This Change Was Made

The QR fallback paths in `extensions/device-pair/index.ts` treated bootstrap token revocation and temporary QR directory cleanup as best-effort operations, but used empty `.catch(() => {})` handlers that hid failures from operators and logs. This change records a `warn` log for both failure modes so the issue is observable without blocking the setup-code fallback. Two regression tests verify the warning is emitted when revocation fails after QR delivery failure and after webchat QR render failure.

## User Impact

Operators and developers can now see in logs when a bootstrap token revocation or QR temp cleanup failed during `/pair qr` fallback, making it possible to detect and respond to stuck security state instead of relying on the 10-minute token TTL to eventually expire the token.

## Evidence

### Tests

```bash
node scripts/run-vitest.mjs extensions/device-pair/index.test.ts
```

Result: **67 passed** (2 new regression tests for revocation-failure logging).

### Type check

```bash
pnpm check:test-types
```

Result: passed.

### Lint

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json extensions/device-pair/index.ts extensions/device-pair/index.test.ts
```

Result: 0 warnings, 0 errors.

### Before fix

`extensions/device-pair/index.ts:895`, `:921`, and `:910` contained empty `.catch(() => {})` handlers:

```ts
await revokeDeviceBootstrapToken({ token: payload.bootstrapToken }).catch(() => {});
await rm(path.dirname(qrFilePath), { recursive: true, force: true }).catch(() => {});
```

A failed revocation produced no log output.

### After fix

Failed revocation and cleanup now emit structured warnings:

```ts
await revokeDeviceBootstrapToken({ token: payload.bootstrapToken }).catch(
  (revokeErr: unknown) => {
    api.logger.warn?.(
      `device-pair: failed to revoke bootstrap token (${String(revokeErr)})`,
    );
  },
);
```


### CI proof: device-pair revoke and QR cleanup warnings (with boundary run)

Proved this change at exact heads using a secretless GitHub Actions workflow that runs both an injected-runtime test and a boundary test (real plugin SDK channel runtime + real bootstrap-token state operations) against `main` (before) and the PR head (after). Proof markers are emitted directly to stdout in the job logs (independently readable via raw logs) and also archived in the artifact.

- Before (main): `f87d8bb7`
- After (PR head): `8da6a862`
- Proof branch: `xialonglee/openclaw@fix/gap-device-pair-revoke-silent-failure-proof`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/31372131532
- Raw job log: https://github.com/xialonglee/openclaw/actions/runs/31372131532/job/93403220986#step:7:1 (independently readable — contains `::group::Proof Summary` section with all markers)
- Artifact: https://github.com/xialonglee/openclaw/actions/runs/31372131532/artifacts/9056552361

#### Before fix (BEFORE_SHA: `f87d8bb7`)

All 6 scenes (3 injected-runtime + 3 boundary) show failures are silent (`warningEmitted=false`):

```
[proof] scene=qr-delivery-revoke-failure warningEmitted=false status=observed
[proof] scene=webchat-render-revoke-failure warningEmitted=false status=observed
[proof] scene=qr-temp-cleanup-failure warningEmitted=false rmCalled=true status=observed
[proof] scene=qr-delivery-revoke-failure boundary=true warningEmitted=false status=observed
[proof] scene=webchat-render-revoke-failure boundary=true warningEmitted=false status=observed
[proof] scene=qr-temp-cleanup-failure boundary=true warningEmitted=false rmCalled=true status=observed
[proof] before=revoke-and-cleanup-silent status=pass
```

#### After fix (AFTER_SHA: `8da6a862`)

All 6 scenes show failures are now warned (`warningEmitted=true`), setup-code fallback still completes:

```
[proof] scene=qr-delivery-revoke-failure warningEmitted=true status=observed
[proof] scene=webchat-render-revoke-failure warningEmitted=true status=observed
[proof] scene=qr-temp-cleanup-failure warningEmitted=true rmCalled=true status=observed
[proof] scene=qr-delivery-revoke-failure boundary=true warningEmitted=true status=observed
[proof] scene=webchat-render-revoke-failure boundary=true warningEmitted=true status=observed
[proof] scene=qr-temp-cleanup-failure boundary=true warningEmitted=true rmCalled=true status=observed
[proof] after=revoke-and-cleanup-warned status=pass
```

The workflow also runs the PR's regression tests (67 tests, `extensions/device-pair/index.test.ts`) at `AFTER_SHA` — all pass.


