### PR TITLE
fix(model-fallback): treat empty non-GPT completions as failed candidates (#120132)

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -222,6 +222,8 @@ export const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0nQAAAAASUVORK5CYII=";
 export const QA_REASONING_ONLY_RECOVERY_PROMPT_RE = /reasoning-only continuation qa check/i;
 export const QA_REASONING_ONLY_SIDE_EFFECT_PROMPT_RE = /reasoning-only after write safety check/i;
+export const QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT_RE =
+  /mixed reasoning blank fallback qa check/i;
 export const QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT_RE = /anthropic thinking error qa check/i;
 export const QA_THINKING_VISIBILITY_OFF_PROMPT_RE = /qa thinking visibility check off/i;
 export const QA_THINKING_VISIBILITY_MAX_PROMPT_RE = /qa thinking visibility check max/i;

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -7922,18 +7922,25 @@ Update and merge these partial structured summaries.`,
     );
   });
 
-  it("scripts mixed reasoning-plus-blank primary output and a visible fallback", async () => {
+  it.each([
+    { name: "default", primaryModel: "gpt-5.6-luna", fallbackModel: "gpt-5.6-luna-alt" },
+    {
+      name: "explicit",
+      primaryModel: "mock-empty-primary",
+      fallbackModel: "mock-visible-fallback",
+    },
+  ])("scripts mixed reasoning-plus-blank output for the $name model pair", async (models) => {
     const server = await startMockServer();
 
     const primary = await expectOpenAiNonStreamingResponsesJson(server, {
-      model: "mock-empty-primary",
+      model: models.primaryModel,
       input: [makeUserInput(QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT)],
     });
     expect(outputItems(primary).map((item) => item.type)).toEqual(["reasoning", "message"]);
     expect(outputText(primary, 1)).toBe(" ");
 
     const fallback = await expectOpenAiNonStreamingResponsesJson(server, {
-      model: "mock-visible-fallback",
+      model: models.fallbackModel,
       input: [makeUserInput(QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT)],
     });
     expect(outputText(fallback)).toBe("MODEL-FALLBACK-VISIBLE-OK");

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -18,6 +18,8 @@ const QA_REASONING_ONLY_RECOVERY_PROMPT =
   "Reasoning-only continuation QA check: read QA_KICKOFF_TASK.md, then answer with exactly REASONING-RECOVERED-OK.";
 const QA_REASONING_ONLY_SIDE_EFFECT_PROMPT =
   "Reasoning-only after write safety check: write reasoning-only-side-effect.txt, then answer with exactly SIDE-EFFECT-GUARD-OK.";
+const QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT =
+  "Mixed reasoning blank fallback QA check: recover through the alternate model.";
 const QA_THINKING_VISIBILITY_OFF_PROMPT =
   "QA thinking visibility check off: answer exactly THINKING-OFF-OK.";
 const QA_THINKING_VISIBILITY_MAX_PROMPT =
@@ -7918,6 +7920,23 @@ Update and merge these partial structured summaries.`,
     expect(String(requireRecord(requestLog[2], "debug request 2").allInputText)).toContain(
       QA_REASONING_ONLY_RETRY_INSTRUCTION,
     );
+  });
+
+  it("scripts mixed reasoning-plus-blank primary output and a visible fallback", async () => {
+    const server = await startMockServer();
+
+    const primary = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "mock-empty-primary",
+      input: [makeUserInput(QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT)],
+    });
+    expect(outputItems(primary).map((item) => item.type)).toEqual(["reasoning", "message"]);
+    expect(outputText(primary, 1)).toBe(" ");
+
+    const fallback = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "mock-visible-fallback",
+      input: [makeUserInput(QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT)],
+    });
+    expect(outputText(fallback)).toBe("MODEL-FALLBACK-VISIBLE-OK");
   });
 
   it("scripts the GPT-5.6 Luna thinking visibility switch prompts", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1338,7 +1338,9 @@ async function buildResponsesPayload(
     return buildAssistantEvents("BUG-SHOULD-NOT-AUTO-RETRY");
   }
   if (QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT_RE.test(allInputText)) {
-    if (model === "mock-visible-fallback") {
+    // The catalog's default mock alternate and the explicit proof model both
+    // recover, so the scenario exercises the same fallback path with or without flags.
+    if (model === "gpt-5.6-luna-alt" || model === "mock-visible-fallback") {
       return buildAssistantEvents("MODEL-FALLBACK-VISIBLE-OK");
     }
     return buildReasoningAndAssistantEvents({

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -32,6 +32,7 @@ import {
   TINY_PNG_BASE64,
   QA_REASONING_ONLY_RECOVERY_PROMPT_RE,
   QA_REASONING_ONLY_SIDE_EFFECT_PROMPT_RE,
+  QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT_RE,
   QA_ANTHROPIC_THINKING_ERROR_RECOVERY_PROMPT_RE,
   QA_THINKING_VISIBILITY_OFF_PROMPT_RE,
   QA_THINKING_VISIBILITY_MAX_PROMPT_RE,
@@ -786,9 +787,8 @@ async function buildResponsesPayload(
     compactionSummaryFaultMode?: MockCompactionSummaryFaultMode;
   } = {},
 ) {
-  const providerVariant = resolveProviderVariant(
-    typeof body.model === "string" ? body.model : undefined,
-  );
+  const model = typeof body.model === "string" ? body.model : "";
+  const providerVariant = resolveProviderVariant(model);
   const input = normalizeResponsesInput(body.input);
   const toolDeclarationBody = resolveCurrentToolDeclarationSurface(body, input);
   const prompt = extractLastUserText(input);
@@ -1336,6 +1336,15 @@ async function buildResponsesPayload(
       );
     }
     return buildAssistantEvents("BUG-SHOULD-NOT-AUTO-RETRY");
+  }
+  if (QA_MIXED_REASONING_BLANK_FALLBACK_PROMPT_RE.test(allInputText)) {
+    if (model === "mock-visible-fallback") {
+      return buildAssistantEvents("MODEL-FALLBACK-VISIBLE-OK");
+    }
+    return buildReasoningAndAssistantEvents({
+      reasoningId: `rs_mock_mixed_blank_${model.replaceAll(/[^a-z0-9]+/gi, "_")}`,
+      answerText: " ",
+    });
   }
   if (QA_THINKING_VISIBILITY_MAX_PROMPT_RE.test(prompt)) {
     return buildReasoningAndAssistantEvents({

--- a/qa/scenarios/runtime/mixed-reasoning-blank-model-fallback.yaml
+++ b/qa/scenarios/runtime/mixed-reasoning-blank-model-fallback.yaml
@@ -1,0 +1,115 @@
+title: Mixed reasoning-plus-blank model fallback
+
+scenario:
+  id: mixed-reasoning-blank-model-fallback
+  surface: runtime
+  coverage:
+    primary:
+      - agent-runtime.failure-recovery-empty-response-recovery
+      - channels.qa-channel-final-reply
+    secondary:
+      - agent-runtime.failure-recovery-retry-policy
+  objective: Verify a mixed reasoning-plus-whitespace completion advances non-GPT model fallback to one visible answer.
+  successCriteria:
+    - The scenario runs through qa-channel, the scenario-aware mock provider, and an ephemeral Gateway child.
+    - The primary non-GPT model returns one reasoning item plus one whitespace-only final-answer item.
+    - The fallback runner rejects that invisible completion and attempts the configured alternate model.
+    - The alternate model's exact marker reaches the channel exactly once.
+  docsRefs:
+    - docs/help/testing.md
+    - docs/channels/qa-channel.md
+  codeRefs:
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+    - src/agents/embedded-agent-runner/result-fallback-classifier.ts
+    - src/agents/model-fallback-runner.ts
+  execution:
+    kind: flow
+    providerMode: mock-openai
+    retryCount: 0
+    summary: Exercise mixed invisible output through mock provider, model fallback, ephemeral Gateway, and qa-channel delivery.
+    config:
+      requiredProviderMode: mock-openai
+      promptSnippet: Mixed reasoning blank fallback QA check
+      prompt: "Mixed reasoning blank fallback QA check: recover through the alternate model."
+      expectedReply: MODEL-FALLBACK-VISIBLE-OK
+
+flow:
+  steps:
+    - name: advances the invisible primary candidate and delivers the fallback
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message:
+              expr: "`expected provider mode ${config.requiredProviderMode}, got ${env.providerMode}`"
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: sessionKey
+          value:
+            expr: "`agent:qa:mixed-reasoning-blank:${randomUUID().slice(0, 8)}`"
+        - call: startAgentRun
+          saveAs: started
+          args:
+            - ref: env
+            - sessionKey:
+                ref: sessionKey
+              message:
+                expr: config.prompt
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, 45000)
+        - set: waited
+          value:
+            expr: "await env.gateway.call('agent.wait', { runId: started.runId, timeoutMs: liveTurnTimeoutMs(env, 45000) }, { timeoutMs: liveTurnTimeoutMs(env, 50000) })"
+        - assert:
+            expr: "['ok', 'completed', 'succeeded'].includes(String(waited?.status)) || (waited?.status === 'error' && String(waited?.error ?? '').trim().toLowerCase() === 'completed')"
+            message:
+              expr: "`agent.wait returned ${String(waited?.status ?? 'unknown')}: ${String(waited?.error ?? '')}`"
+        - call: waitForCondition
+          saveAs: outbound
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).find((message) => message.conversation.id === 'qa-operator')"
+            - expr: liveTurnTimeoutMs(env, 30000)
+            - 100
+        - call: sleep
+          args:
+            - 300
+        - set: scenarioOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).filter((message) => message.conversation.id === 'qa-operator')"
+        - set: scenarioRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+        - set: expectedModels
+          value:
+            expr: "[splitModelRef(env.primaryModel)?.model, splitModelRef(env.alternateModel)?.model]"
+        - set: primaryRequests
+          value:
+            expr: "scenarioRequests.filter((request) => request.model === expectedModels[0])"
+        - set: fallbackRequests
+          value:
+            expr: "scenarioRequests.filter((request) => request.model === expectedModels[1])"
+        - assert:
+            expr: "expectedModels.every((model) => typeof model === 'string' && model.length > 0) && primaryRequests.length > 0 && fallbackRequests.length === 1 && scenarioRequests.at(-1) === fallbackRequests[0] && scenarioRequests.every((request) => !request.plannedToolName)"
+            message:
+              expr: "`expected ordered mixed-output primary retries then one visible fallback ${JSON.stringify(expectedModels)}, saw ${JSON.stringify(scenarioRequests.map((request) => ({ model: request.model, tool: request.plannedToolName ?? null })))}`"
+        - assert:
+            expr: "scenarioOutbound.length === 1 && String(outbound.text ?? '') === config.expectedReply"
+            message:
+              expr: "`expected one visible fallback reply, saw ${JSON.stringify(scenarioOutbound.map((message) => String(message.text ?? '')))}`"
+        - set: verdict
+          value:
+            expr: "({ verdict: 'PASS', harness: 'qa-channel + qa-lab bus + ephemeral Gateway child + mock-openai', primaryOutput: 'reasoning item plus whitespace-only final answer', primaryModel: expectedModels[0], fallbackModel: expectedModels[1], primaryRequestCount: primaryRequests.length, fallbackRequestCount: fallbackRequests.length, attemptedModels: scenarioRequests.map((request) => request.model), visibleTerminalPayloads: scenarioOutbound.map((message) => String(message.text ?? '')), outboundCount: scenarioOutbound.length, silentDropPrevented: scenarioOutbound.length === 1, pass: primaryRequests.length > 0 && fallbackRequests.length === 1 && scenarioOutbound.length === 1 && String(outbound.text ?? '') === config.expectedReply })"
+        - assert:
+            expr: verdict.pass === true
+            message:
+              expr: "`mixed reasoning fallback verdict failed: ${JSON.stringify(verdict)}`"
+      detailsExpr: "JSON.stringify(verdict, null, 2)"

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -503,6 +503,51 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     });
   });
 
+  it("classifies mixed reasoning-plus-blank completions as fallback-worthy (#120148)", () => {
+    // A result such as [{ isReasoning: true, text: "thinking" }, { text: " " }]
+    // carries no user-visible reply: reasoning text is invisible to the shared
+    // visibility test, and the remaining payload is blank. Counting the
+    // reasoning text as visible would silently end the turn on visible
+    // channels.
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "zai",
+      model: "glm-5.2",
+      result: {
+        payloads: [{ isReasoning: true, text: "thinking about the answer" }, { text: "   " }],
+        meta: {
+          durationMs: 42,
+          finalAssistantRawText: "   ",
+          finalAssistantVisibleText: "   ",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: "zai/glm-5.2 ended without a visible assistant reply",
+      reason: "format",
+      code: "empty_result",
+    });
+  });
+
+  it("keeps mixed reasoning-plus-visible completions successful (#120148)", () => {
+    // The reasoning payload is invisible, but a sibling payload with visible
+    // text is a real reply, so the run must not be fallback-eligible.
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "zai",
+      model: "glm-5.2",
+      result: {
+        payloads: [{ isReasoning: true, text: "thinking" }, { text: "Here is the answer" }],
+        meta: {
+          durationMs: 42,
+          finalAssistantRawText: "Here is the answer",
+          finalAssistantVisibleText: "Here is the answer",
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("keeps deliberate silent replies successful for non-GPT models (#120132)", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "zai",

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -437,6 +437,89 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
+  it("classifies empty non-GPT completions as fallback-worthy (#120132)", () => {
+    // A tail model that survives the API call but returns an empty completion
+    // must not count as candidate_succeeded: that silently drops the turn on
+    // visible channels.
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "zai",
+      model: "glm-5.2",
+      result: {
+        payloads: [],
+        meta: {
+          durationMs: 42,
+          finalAssistantRawText: "",
+          finalAssistantVisibleText: "",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: "zai/glm-5.2 ended without a visible assistant reply",
+      reason: "format",
+      code: "empty_result",
+    });
+  });
+
+  it("classifies whitespace-only non-GPT completions as fallback-worthy (#120132)", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "zai",
+      model: "glm-5.2",
+      result: {
+        payloads: [{ text: "   " }],
+        meta: {
+          durationMs: 42,
+          finalAssistantRawText: "   ",
+          finalAssistantVisibleText: "   ",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: "zai/glm-5.2 ended without a visible assistant reply",
+      reason: "format",
+      code: "empty_result",
+    });
+  });
+
+  it("classifies reasoning-only non-GPT completions as fallback-worthy (#120132)", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "zai",
+      model: "glm-5.2",
+      result: {
+        payloads: [{ isReasoning: true, text: "thinking about the answer" }],
+        meta: {
+          durationMs: 42,
+          finalAssistantRawText: "",
+          finalAssistantVisibleText: "",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message: "zai/glm-5.2 ended with reasoning only",
+      reason: "format",
+      code: "reasoning_only_result",
+    });
+  });
+
+  it("keeps deliberate silent replies successful for non-GPT models (#120132)", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "zai",
+      model: "glm-5.2",
+      result: {
+        payloads: [],
+        meta: {
+          durationMs: 42,
+          finalAssistantRawText: "NO_REPLY",
+          finalAssistantVisibleText: "NO_REPLY",
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("keeps side-effecting incomplete tool turns out of fallback before harness classification", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "openai",

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -437,128 +437,83 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
-  it("classifies empty non-GPT completions as fallback-worthy (#120132)", () => {
-    // A tail model that survives the API call but returns an empty completion
-    // must not count as candidate_succeeded: that silently drops the turn on
-    // visible channels.
-    const result = classifyEmbeddedAgentRunResultForModelFallback({
-      provider: "zai",
-      model: "glm-5.2",
-      result: {
-        payloads: [],
-        meta: {
-          durationMs: 42,
-          finalAssistantRawText: "",
-          finalAssistantVisibleText: "",
-        },
-      },
-    });
-
-    expect(result).toEqual({
-      message: "zai/glm-5.2 ended without a visible assistant reply",
-      reason: "format",
+  it.each([
+    {
+      name: "empty",
+      payloads: [],
       code: "empty_result",
-    });
-  });
-
-  it("classifies whitespace-only non-GPT completions as fallback-worthy (#120132)", () => {
-    const result = classifyEmbeddedAgentRunResultForModelFallback({
-      provider: "zai",
-      model: "glm-5.2",
-      result: {
-        payloads: [{ text: "   " }],
-        meta: {
-          durationMs: 42,
-          finalAssistantRawText: "   ",
-          finalAssistantVisibleText: "   ",
-        },
-      },
-    });
-
-    expect(result).toEqual({
-      message: "zai/glm-5.2 ended without a visible assistant reply",
-      reason: "format",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "whitespace-only",
+      payloads: [{ text: "   " }],
       code: "empty_result",
-    });
-  });
-
-  it("classifies reasoning-only non-GPT completions as fallback-worthy (#120132)", () => {
-    const result = classifyEmbeddedAgentRunResultForModelFallback({
-      provider: "zai",
-      model: "glm-5.2",
-      result: {
-        payloads: [{ isReasoning: true, text: "thinking about the answer" }],
-        meta: {
-          durationMs: 42,
-          finalAssistantRawText: "",
-          finalAssistantVisibleText: "",
-        },
-      },
-    });
-
-    expect(result).toEqual({
-      message: "zai/glm-5.2 ended with reasoning only",
-      reason: "format",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "reasoning-only",
+      payloads: [{ isReasoning: true, text: "thinking about the answer" }],
       code: "reasoning_only_result",
-    });
-  });
-
-  it("classifies mixed reasoning-plus-blank completions as fallback-worthy (#120148)", () => {
-    // A result such as [{ isReasoning: true, text: "thinking" }, { text: " " }]
-    // carries no user-visible reply: reasoning text is invisible to the shared
-    // visibility test, and the remaining payload is blank. Counting the
-    // reasoning text as visible would silently end the turn on visible
-    // channels.
+      suffix: "with reasoning only",
+    },
+    {
+      name: "mixed reasoning-plus-blank",
+      payloads: [{ isReasoning: true, text: "thinking about the answer" }, { text: "   " }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "commentary-only",
+      payloads: [{ isCommentary: true, text: "progress only" }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "explicitly hidden",
+      payloads: [{ visible: false, text: "internal" }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "blank error",
+      payloads: [{ isError: true, text: " " }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+  ])("classifies $name non-GPT completions as fallback-worthy", ({ payloads, code, suffix }) => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "zai",
       model: "glm-5.2",
       result: {
-        payloads: [{ isReasoning: true, text: "thinking about the answer" }, { text: "   " }],
-        meta: {
-          durationMs: 42,
-          finalAssistantRawText: "   ",
-          finalAssistantVisibleText: "   ",
-        },
+        payloads,
+        meta: { durationMs: 42 },
       },
     });
 
     expect(result).toEqual({
-      message: "zai/glm-5.2 ended without a visible assistant reply",
+      message: `zai/glm-5.2 ended ${suffix}`,
       reason: "format",
-      code: "empty_result",
+      code,
     });
   });
 
-  it("keeps mixed reasoning-plus-visible completions successful (#120148)", () => {
-    // The reasoning payload is invisible, but a sibling payload with visible
-    // text is a real reply, so the run must not be fallback-eligible.
+  it.each([
+    {
+      name: "mixed reasoning-plus-visible text",
+      payloads: [{ isReasoning: true, text: "thinking" }, { text: "Here is the answer" }],
+    },
+    { name: "media-only", payloads: [{ mediaUrl: "https://example.test/result.png" }] },
+    {
+      name: "rich error",
+      payloads: [{ isError: true, mediaUrl: "https://example.test/error.png" }],
+    },
+  ])("keeps $name completions successful", ({ payloads }) => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "zai",
       model: "glm-5.2",
       result: {
-        payloads: [{ isReasoning: true, text: "thinking" }, { text: "Here is the answer" }],
-        meta: {
-          durationMs: 42,
-          finalAssistantRawText: "Here is the answer",
-          finalAssistantVisibleText: "Here is the answer",
-        },
-      },
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("keeps deliberate silent replies successful for non-GPT models (#120132)", () => {
-    const result = classifyEmbeddedAgentRunResultForModelFallback({
-      provider: "zai",
-      model: "glm-5.2",
-      result: {
-        payloads: [],
-        meta: {
-          durationMs: 42,
-          finalAssistantRawText: "NO_REPLY",
-          finalAssistantVisibleText: "NO_REPLY",
-        },
+        payloads,
+        meta: { durationMs: 42 },
       },
     });
 

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -5,7 +5,6 @@ import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../auto-reply/reply/agent-
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "../embedded-agent-helpers/types.js";
-import { isGpt5ModelId } from "../gpt5-prompt-overlay.js";
 import type { ModelFallbackResultClassification } from "../model-fallback-attempt.js";
 import {
   hasCommittedOutboundDeliveryEvidence,
@@ -270,12 +269,10 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     };
   }
 
-  if (!isGpt5ModelId(params.model)) {
-    return null;
-  }
-
-  // Legacy GPT-5 handling treats empty/reasoning-only payloads as fallback
-  // candidates, while deliberate silent replies remain successful terminal work.
+  // Empty completions and reasoning-only output are fallback candidates for
+  // every model: counting them as success silently drops the turn on visible
+  // channels (the user sees nothing). Deliberate silent replies remain
+  // successful terminal work.
   if (payloads.length === 0 && hasDeliberateSilentTerminalReply(params.result)) {
     return null;
   }
@@ -291,6 +288,21 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
       message: `${params.provider}/${params.model} ended with reasoning only`,
       reason: "format",
       code: "reasoning_only_result",
+    };
+  }
+  // A completion that returns only empty/whitespace text payloads is the same
+  // silent drop as no payloads at all.
+  if (
+    payloads.every(
+      (payload) =>
+        !hasNonTextVisiblePayloadContent(payload) &&
+        !(typeof payload?.text === "string" && payload.text.trim().length > 0),
+    )
+  ) {
+    return {
+      message: `${params.provider}/${params.model} ended without a visible assistant reply`,
+      reason: "format",
+      code: "empty_result",
     };
   }
 

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -80,17 +80,36 @@ export function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult)
   );
 }
 
+function hasDeliverableAssistantPayload(result: {
+  payloads?: unknown;
+  meta?: { finalAssistantVisibleText?: unknown };
+}): boolean {
+  const finalVisibleText = result.meta?.finalAssistantVisibleText;
+  const payloads = Array.isArray(result.payloads)
+    ? result.payloads.filter((payload) => {
+        if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+          return true;
+        }
+        const record = payload as { isCommentary?: unknown; visible?: unknown };
+        return record.isCommentary !== true && record.visible !== false;
+      })
+    : [];
+  return (
+    (typeof finalVisibleText === "string" &&
+      finalVisibleText.trim().length > 0 &&
+      !isSilentReplyPayloadText(finalVisibleText)) ||
+    hasVisibleAgentPayload(
+      { payloads },
+      { includeErrorPayloads: false, includeReasoningPayloads: false },
+    )
+  );
+}
+
 function hasNonTextVisiblePayloadContent(
   payload: NonNullable<EmbeddedAgentRunResult["payloads"]>[number],
 ): boolean {
-  const { text: _text, ...payloadWithoutText } = payload;
-  return hasVisibleAgentPayload(
-    { payloads: [payloadWithoutText] },
-    {
-      includeErrorPayloads: false,
-      includeReasoningPayloads: false,
-    },
-  );
+  const { isError: _isError, text: _text, ...payloadWithoutText } = payload;
+  return hasDeliverableAssistantPayload({ payloads: [payloadWithoutText] });
 }
 
 function classifyGenericExternalRunFailurePayload(params: {
@@ -215,19 +234,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
   if (genericExternalFailureClassification) {
     return genericExternalFailureClassification;
   }
-  if (
-    typeof params.result.meta.finalAssistantVisibleText === "string" &&
-    params.result.meta.finalAssistantVisibleText.trim().length > 0 &&
-    !isSilentReplyPayloadText(params.result.meta.finalAssistantVisibleText)
-  ) {
-    return null;
-  }
-  if (
-    hasVisibleAgentPayload(params.result, {
-      includeErrorPayloads: false,
-      includeReasoningPayloads: false,
-    })
-  ) {
+  if (hasDeliverableAssistantPayload(params.result)) {
     return null;
   }
   if (fallbackSafeIncompleteTurn) {
@@ -269,45 +276,33 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     };
   }
 
-  // Empty completions and reasoning-only output are fallback candidates for
-  // every model: counting them as success silently drops the turn on visible
-  // channels (the user sees nothing). Deliberate silent replies remain
-  // successful terminal work.
-  if (payloads.length === 0 && hasDeliberateSilentTerminalReply(params.result)) {
+  // Once the shared visibility owner finds no deliverable assistant payload,
+  // empty and reasoning-only output must advance fallback for every model.
+  if (hasDeliberateSilentTerminalReply(params.result)) {
     return null;
   }
-  if (payloads.length === 0) {
-    return {
-      message: `${params.provider}/${params.model} ended without a visible assistant reply`,
-      reason: "format",
-      code: "empty_result",
-    };
+  if (errorText.trim()) {
+    return null;
   }
-  if (payloads.every((payload) => payload.isReasoning === true)) {
+  if (
+    payloads.some((payload) => payload.isError === true && hasNonTextVisiblePayloadContent(payload))
+  ) {
+    return null;
+  }
+  const assistantPayloads = payloads.filter((payload) => payload.isError !== true);
+  if (
+    assistantPayloads.length > 0 &&
+    assistantPayloads.every((payload) => payload.isReasoning === true)
+  ) {
     return {
       message: `${params.provider}/${params.model} ended with reasoning only`,
       reason: "format",
       code: "reasoning_only_result",
     };
   }
-  // A completion that returns only empty/whitespace text payloads is the same
-  // silent drop as no payloads at all. Reasoning payloads are invisible to the
-  // shared visibility test, so their text must not make a mixed
-  // reasoning-plus-blank completion look like a visible reply.
-  const nonReasoningPayloads = payloads.filter((payload) => payload.isReasoning !== true);
-  if (
-    nonReasoningPayloads.every(
-      (payload) =>
-        !hasNonTextVisiblePayloadContent(payload) &&
-        !(typeof payload?.text === "string" && payload.text.trim().length > 0),
-    )
-  ) {
-    return {
-      message: `${params.provider}/${params.model} ended without a visible assistant reply`,
-      reason: "format",
-      code: "empty_result",
-    };
-  }
-
-  return null;
+  return {
+    message: `${params.provider}/${params.model} ended without a visible assistant reply`,
+    reason: "format",
+    code: "empty_result",
+  };
 }

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -291,9 +291,12 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     };
   }
   // A completion that returns only empty/whitespace text payloads is the same
-  // silent drop as no payloads at all.
+  // silent drop as no payloads at all. Reasoning payloads are invisible to the
+  // shared visibility test, so their text must not make a mixed
+  // reasoning-plus-blank completion look like a visible reply.
+  const nonReasoningPayloads = payloads.filter((payload) => payload.isReasoning !== true);
   if (
-    payloads.every(
+    nonReasoningPayloads.every(
       (payload) =>
         !hasNonTextVisiblePayloadContent(payload) &&
         !(typeof payload?.text === "string" && payload.text.trim().length > 0),

--- a/src/agents/outcome-fallback-runtime-contract.test.ts
+++ b/src/agents/outcome-fallback-runtime-contract.test.ts
@@ -60,12 +60,11 @@ describe("Outcome/fallback runtime contract - embedded runtime fallback classifi
     },
   );
 
-  it("advances to the configured fallback after a classified GPT-5 terminal result", async () => {
+  it("advances to the configured fallback after an invisible non-GPT terminal result", async () => {
+    const primaryProvider = "zai";
+    const primaryModel = "glm-5.2";
     const primary = createContractRunResult({
-      meta: {
-        durationMs: 1,
-        agentHarnessResultClassification: "empty",
-      },
+      payloads: [{ isReasoning: true, text: "thinking" }, { text: " " }],
     });
     const fallback = createContractRunResult({
       payloads: [{ text: "fallback ok" }],
@@ -75,8 +74,8 @@ describe("Outcome/fallback runtime contract - embedded runtime fallback classifi
 
     const result = await runWithModelFallback<ReturnType<typeof createContractRunResult>>({
       cfg: undefined,
-      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
-      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+      provider: primaryProvider,
+      model: primaryModel,
       fallbacksOverride: contractFallbackOverride,
       run,
       classifyResult: ({ provider, model, result: resultValue }) =>
@@ -97,8 +96,8 @@ describe("Outcome/fallback runtime contract - embedded runtime fallback classifi
       OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
       { isFinalFallbackAttempt: true },
     ]);
-    expect(result.attempts[0]?.provider).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider);
-    expect(result.attempts[0]?.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel);
+    expect(result.attempts[0]?.provider).toBe(primaryProvider);
+    expect(result.attempts[0]?.model).toBe(primaryModel);
     expect(result.attempts[0]?.reason).toBe("format");
     expect(result.attempts[0]?.code).toBe("empty_result");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes #120132. A model-fallback candidate that completed without a deliverable assistant payload could be accepted as `candidate_succeeded` for non-GPT model IDs. On a visible channel, the turn then ended with zero reply payloads: the user saw an acknowledgement reaction and no answer, error, or later fallback.

## Why This Change Was Made

The fallback classifier already knew how to reject empty and reasoning-only GPT results, but `src/agents/embedded-agent-runner/result-fallback-classifier.ts` returned `null` for every non-GPT model after recognized provider failures. `runFallbackAttempt` interprets `null` as success, and the fallback runner records `candidate_succeeded`.

This takeover rewrite removes that model gate and makes the classifier own one canonical deliverable-assistant-payload decision. It uses the shared visibility semantics while excluding reasoning, commentary-only progress, and explicitly hidden payloads. It preserves deliberate `NO_REPLY`, hook blocks, committed outbound effects, visible text/media/rich payloads, recognized provider errors, and unknown nonblank or rich error results.

Residual invisible outcomes now classify as:

- all assistant payloads reasoning-only: `reasoning_only_result`
- empty, whitespace-only, mixed reasoning plus whitespace, commentary-only, explicitly hidden, or blank-error output: `empty_result`

The incoming bespoke whitespace scans were removed. Product runtime is **+46/-36 (net +10)**, justified by moving the deliverability invariant into its owner boundary. QA and regression evidence is **+248/-12**. Earlier red-main fallout fixes landed independently and are absent from this branch.

## User Impact

Visible-channel turns no longer silently stop when a non-GPT fallback candidate returns no usable answer. OpenClaw exhausts the normal retry budget, advances to the configured alternate model, and delivers that model's visible response. Deliberate silent outcomes and already-committed work remain terminal successes.

## Provenance

This is a carried-forward model-scope gap, not a new August regression. The GPT-only behavior originated in #70743 (`40be5ad58187`, authored by @100yenadmin and merged by @steipete on April 24, 2026), was retained when `90cd9fce8594` moved the gate on April 26, and shipped in `v2026.4.24` and later releases, including the reporter's `v2026.7.1-2`.

## Evidence

Focused regression and fallback-owner proof on exact head `8a82e80fab635b6c931479c2e4d8ce9e7d857379`:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/outcome-fallback-runtime-contract.test.ts
Test Files 2 passed; Tests 41 passed

node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts --testNamePattern 'scripts mixed reasoning-plus-blank'
Test Files 1 passed; Tests 2 passed, 262 skipped

node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts
Test Files 1 passed; Tests 58 passed
```

Exact-head real-behavior proof through the catalog's default mock model pair, with no model override flags:

```text
OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 node scripts/tsdown-build.mjs
OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS=0 node scripts/runtime-postbuild.mjs
OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 node openclaw.mjs qa suite \
  --provider-mode mock-openai \
  --scenario mixed-reasoning-blank-model-fallback \
  --channel-driver qa-channel \
  --concurrency 1 \
  --output-dir .artifacts/qa-e2e/pr-120148-default-models
```

```json
{
  "counts": { "total": 1, "passed": 1, "failed": 0, "skipped": 0 },
  "run": {
    "providerMode": "mock-openai",
    "primaryModel": "mock-openai/gpt-5.6-luna",
    "alternateModel": "mock-openai/gpt-5.6-luna-alt",
    "channelDriver": "qa-channel",
    "channel": "qa-channel",
    "scenarioIds": ["mixed-reasoning-blank-model-fallback"]
  },
  "scenario": {
    "name": "Mixed reasoning-plus-blank model fallback",
    "status": "pass",
    "verdict": {
      "verdict": "PASS",
      "harness": "qa-channel + qa-lab bus + ephemeral Gateway child + mock-openai",
      "primaryOutput": "reasoning item plus whitespace-only final answer",
      "primaryModel": "gpt-5.6-luna",
      "fallbackModel": "gpt-5.6-luna-alt",
      "primaryRequestCount": 3,
      "fallbackRequestCount": 1,
      "attemptedModels": [
        "gpt-5.6-luna",
        "gpt-5.6-luna",
        "gpt-5.6-luna",
        "gpt-5.6-luna-alt"
      ],
      "visibleTerminalPayloads": ["MODEL-FALLBACK-VISIBLE-OK"],
      "outboundCount": 1,
      "silentDropPrevented": true,
      "pass": true
    }
  }
}
```

`git diff --check` and targeted `oxfmt --check` passed. Fresh exact-head structured Autoreview reported no accepted/actionable findings (`patch is correct`, confidence 0.98). Exact-head hosted PR CI and the native prepare Testbox remain the broad gates.

Exact-head non-GPT gate proof used the same qa-channel + ephemeral-Gateway scenario with an explicit non-GPT-shaped primary and recoverable alternate:

```text
OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 node openclaw.mjs qa suite \
  --provider-mode mock-openai \
  --scenario mixed-reasoning-blank-model-fallback \
  --channel-driver qa-channel \
  --model mock-openai/mock-empty-primary \
  --alt-model mock-openai/mock-visible-fallback \
  --concurrency 1 \
  --output-dir .artifacts/qa-e2e/pr-120148-non-gpt-models
```

```json
{
  "counts": { "total": 1, "passed": 1, "failed": 0, "skipped": 0 },
  "primaryModel": "mock-openai/mock-empty-primary",
  "alternateModel": "mock-openai/mock-visible-fallback",
  "attemptedModels": [
    "mock-empty-primary",
    "mock-empty-primary",
    "mock-empty-primary",
    "mock-visible-fallback"
  ],
  "visibleTerminalPayloads": ["MODEL-FALLBACK-VISIBLE-OK"],
  "outboundCount": 1,
  "silentDropPrevented": true,
  "pass": true
}
```

## Follow-up Boundary

Raw CLI directive-only text such as a reply-target tag is stripped later by reply normalization. Moving that downstream directive contract into the model-fallback classifier would cross a separate layering boundary, so it is intentionally not folded into this repair.

[AI-assisted]
