### PR TITLE
feat(plugin-sdk): expose subagent.abortSession scoped by plugin ownership (#120139)

### DIFF
--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -268,6 +268,31 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
     });
     const abortSessionKey =
       canonicalKey === "global" && requestedGlobalAgentId ? "global" : resolvedAbortSessionKey;
+    // A runId can redirect the abort target to a session that differs from
+    // the requested key (resolveAbortSessionKey prefers the active run's
+    // session key). The requested-key guard above only authorizes the key
+    // the caller submitted; a plugin could pair its own key with a foreign
+    // active runId and cancel another plugin's run under synthetic admin
+    // dispatch. Authorize the run-resolved target as well.
+    const pluginRuntimeOwnerId = normalizeOptionalString(client?.internal?.pluginRuntimeOwnerId);
+    if (pluginRuntimeOwnerId && abortSessionKey !== canonicalKey) {
+      const resolvedAbortCanonicalKey = resolveSessionStoreKey({
+        cfg,
+        sessionKey: abortSessionKey,
+        ...(requestedGlobalAgentId ? { storeAgentId: requestedGlobalAgentId } : {}),
+      });
+      if (resolvedAbortCanonicalKey !== canonicalKey) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `Plugin "${pluginRuntimeOwnerId}" cannot abort session "${abortSessionKey}" because it did not create it.`,
+          ),
+        );
+        return;
+      }
+    }
     const abortAgentId =
       abortSessionKey === "global" ? (requestedGlobalAgentId ?? activeRunAgentId) : undefined;
     // Capture run kinds before the abort because abortChatRunById deletes entries

--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -31,7 +31,10 @@ import { resolveWorkerSessionTarget } from "../worker-environments/session-targe
 import { setGatewayDedupeEntry } from "./agent-job.js";
 import { handleChatAbortRequestWithLifecycle } from "./chat-abort-handler.js";
 import { emitSessionsChanged } from "./session-change-event.js";
-import { requireSessionKey } from "./sessions-shared.js";
+import {
+  rejectPluginRuntimeSessionOwnershipMismatch,
+  requireSessionKey,
+} from "./sessions-shared.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -235,6 +238,21 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
         ...(requestedGlobalAgentId ? { storeAgentId: requestedGlobalAgentId } : {}),
       });
     const sessionEntry = loadedSession?.entry;
+    // Aborting another plugin's run is the same class of violation as deleting
+    // its session: the abort path must not become an unscoped, instance-wide
+    // cancel for plugin callers. Non-plugin clients and owner-matching plugins
+    // pass through unchanged.
+    if (
+      rejectPluginRuntimeSessionOwnershipMismatch({
+        action: "abort",
+        client,
+        key: canonicalKey,
+        entry: sessionEntry,
+        respond,
+      })
+    ) {
+      return;
+    }
     const requestedKeyAliases =
       requestedKey &&
       requestedKey !== key &&

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -254,6 +254,13 @@ function getLastDispatchedParams(): Record<string, unknown> | undefined {
   return call?.req?.params as Record<string, unknown> | undefined;
 }
 
+function getLastDispatchedMethod(): string | undefined {
+  const call = getLastMockFirstArg(handleGatewayRequest, "gateway request") as
+    | HandleGatewayRequestOptions
+    | undefined;
+  return call?.req?.method;
+}
+
 function getRequiredLastDispatchedParams(): Record<string, unknown> {
   return requireRecord(getLastDispatchedParams(), "dispatched params");
 }
@@ -1882,6 +1889,62 @@ describe("loadGatewayPlugins", () => {
             deleteTranscript: true,
           }),
         ),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.admin"]);
+    expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("memory-core");
+  });
+
+  test("abortSession dispatches sessions.abort with key and runId under the plugin identity", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("plugin-abort-session"));
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimePluginIdScope("memory-core", () =>
+        runtime.abortSession({
+          sessionKey: "agent:main:subagent:abort-me",
+          runId: "run-abort-1",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(getLastDispatchedMethod()).toBe("sessions.abort");
+    const params = getRequiredLastDispatchedParams();
+    expect(params.key).toBe("agent:main:subagent:abort-me");
+    expect(params.runId).toBe("run-abort-1");
+    expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("memory-core");
+  });
+
+  test("abortSession omits runId when not provided", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("plugin-abort-session-no-run"));
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimePluginIdScope("memory-core", () =>
+        runtime.abortSession({
+          sessionKey: "agent:main:subagent:abort-all",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(getLastDispatchedMethod()).toBe("sessions.abort");
+    expect(getLastDispatchedParams()).not.toHaveProperty("runId");
+    expect(getRequiredLastDispatchedParams().key).toBe("agent:main:subagent:abort-all");
+  });
+
+  test("abortSession uses owner-scoped synthetic admin for plugin-owned stops", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("plugin-abort-synthetic-admin"));
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimePluginIdScope("memory-core", () =>
+        runtime.abortSession({
+          sessionKey: "dreaming-narrative-light-workspace-1",
+        }),
       ),
     ).resolves.toBeUndefined();
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -52,6 +52,7 @@ import {
   resolvePluginSubagentRequestedModelRef,
 } from "./server-plugin-subagent-runtime.js";
 import { projectGatewayRuntimeNodes } from "./server-plugins-node-runtime.js";
+import { resolvePluginOwnedCleanupOptions } from "./session-plugin-ownership.js";
 import {
   cancelSubagentCompletionToolHandoff,
   registerSubagentCompletionToolHandoff,
@@ -466,54 +467,24 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
     getSessionMessages,
     async deleteSession(params) {
       const scope = getPluginRuntimeGatewayRequestScope();
-      const pluginId =
-        typeof scope?.pluginId === "string" && scope.pluginId.trim()
-          ? scope.pluginId.trim()
-          : undefined;
-      const pluginOwnedCleanupOptions = pluginId
-        ? {
-            pluginRuntimeOwnerId: pluginId,
-            ...(!hasAdminScope(scope?.client)
-              ? {
-                  forceSyntheticClient: true,
-                  syntheticScopes: [ADMIN_SCOPE],
-                }
-              : {}),
-          }
-        : undefined;
       await dispatchGatewayMethodInProcess(
         "sessions.delete",
         {
           key: params.sessionKey,
           deleteTranscript: params.deleteTranscript ?? true,
         },
-        pluginOwnedCleanupOptions,
+        resolvePluginOwnedCleanupOptions(scope),
       );
     },
     async abortSession(params) {
       const scope = getPluginRuntimeGatewayRequestScope();
-      const pluginId =
-        typeof scope?.pluginId === "string" && scope.pluginId.trim()
-          ? scope.pluginId.trim()
-          : undefined;
-      const pluginOwnedCleanupOptions = pluginId
-        ? {
-            pluginRuntimeOwnerId: pluginId,
-            ...(!hasAdminScope(scope?.client)
-              ? {
-                  forceSyntheticClient: true,
-                  syntheticScopes: [ADMIN_SCOPE],
-                }
-              : {}),
-          }
-        : undefined;
       await dispatchGatewayMethodInProcess(
         "sessions.abort",
         {
           key: params.sessionKey,
           ...(params.runId && { runId: params.runId }),
         },
-        pluginOwnedCleanupOptions,
+        resolvePluginOwnedCleanupOptions(scope),
       );
     },
   };

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -490,6 +490,32 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         pluginOwnedCleanupOptions,
       );
     },
+    async abortSession(params) {
+      const scope = getPluginRuntimeGatewayRequestScope();
+      const pluginId =
+        typeof scope?.pluginId === "string" && scope.pluginId.trim()
+          ? scope.pluginId.trim()
+          : undefined;
+      const pluginOwnedCleanupOptions = pluginId
+        ? {
+            pluginRuntimeOwnerId: pluginId,
+            ...(!hasAdminScope(scope?.client)
+              ? {
+                  forceSyntheticClient: true,
+                  syntheticScopes: [ADMIN_SCOPE],
+                }
+              : {}),
+          }
+        : undefined;
+      await dispatchGatewayMethodInProcess(
+        "sessions.abort",
+        {
+          key: params.sessionKey,
+          ...(params.runId && { runId: params.runId }),
+        },
+        pluginOwnedCleanupOptions,
+      );
+    },
   };
 }
 

--- a/src/gateway/server.sessions.plugin-ownership.test.ts
+++ b/src/gateway/server.sessions.plugin-ownership.test.ts
@@ -284,3 +284,57 @@ test("sessions.delete protects the archived session generation from a replacemen
     sessionId: "replacement-plugin-session",
   });
 });
+
+test.each([
+  {
+    name: "another plugin's session",
+    key: "agent:main:dreaming-narrative-foreign",
+    entry: sessionStoreEntry("foreign-plugin-session", { pluginOwnerId: "other-plugin" }),
+  },
+  {
+    name: "an operator-owned session",
+    key: "agent:main:dashboard:operator-owned",
+    entry: sessionStoreEntry("operator-owned-session"),
+  },
+])("sessions.abort prevents a plugin from aborting $name", async ({ key, entry }) => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({ entries: { [key]: entry } });
+  const pluginClient = {
+    connect: { scopes: ["operator.write"] },
+    internal: { pluginRuntimeOwnerId: "memory-core" },
+  } as never;
+
+  const abort = await directSessionReq("sessions.abort", { key }, { client: pluginClient });
+
+  expect(abort.ok).toBe(false);
+  expect(abort.error).toMatchObject({
+    code: "INVALID_REQUEST",
+    message: `Plugin "memory-core" cannot abort session "${key}" because it did not create it.`,
+  });
+});
+
+test("sessions.abort allows a plugin to abort its own session", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:dreaming-narrative-owned";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry("owned-plugin-session", { pluginOwnerId: "memory-core" }),
+    },
+  });
+  const pluginClient = {
+    connect: { scopes: ["operator.write"] },
+    internal: { pluginRuntimeOwnerId: "memory-core" },
+  } as never;
+
+  const abort = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey },
+    { client: pluginClient },
+  );
+
+  expect(abort.ok, JSON.stringify(abort.error)).toBe(true);
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    pluginOwnerId: "memory-core",
+    sessionId: "owned-plugin-session",
+  });
+});

--- a/src/gateway/server.sessions.plugin-ownership.test.ts
+++ b/src/gateway/server.sessions.plugin-ownership.test.ts
@@ -344,7 +344,7 @@ test("sessions.abort allows a plugin to abort its own session", async () => {
 });
 
 test("sessions.abort rejects a plugin aborting a foreign active run via its own key + foreign runId", async () => {
-  const { storePath } = await createSessionStoreDir();
+  await createSessionStoreDir();
   const ownedKey = "agent:main:dreaming-narrative-owned";
   const foreignKey = "agent:main:dreaming-narrative-foreign";
   const runId = "run-foreign-active";
@@ -381,7 +381,7 @@ test("sessions.abort rejects a plugin aborting a foreign active run via its own 
 });
 
 test("sessions.abort allows a plugin to abort its own active run by runId", async () => {
-  const { storePath } = await createSessionStoreDir();
+  await createSessionStoreDir();
   const sessionKey = "agent:main:dreaming-narrative-owned";
   const runId = "run-own-active";
   await writeSessionStore({

--- a/src/gateway/server.sessions.plugin-ownership.test.ts
+++ b/src/gateway/server.sessions.plugin-ownership.test.ts
@@ -5,6 +5,10 @@ import {
   replaceSessionEntrySync,
 } from "../config/sessions/session-accessor.js";
 import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
+import {
+  createActiveRun,
+  createChatAbortContext,
+} from "./server-methods/chat.abort.test-helpers.js";
 import { writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
@@ -337,4 +341,77 @@ test("sessions.abort allows a plugin to abort its own session", async () => {
     pluginOwnerId: "memory-core",
     sessionId: "owned-plugin-session",
   });
+});
+
+test("sessions.abort rejects a plugin aborting a foreign active run via its own key + foreign runId", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const ownedKey = "agent:main:dreaming-narrative-owned";
+  const foreignKey = "agent:main:dreaming-narrative-foreign";
+  const runId = "run-foreign-active";
+  await writeSessionStore({
+    entries: {
+      [ownedKey]: sessionStoreEntry("owned-plugin-session", { pluginOwnerId: "memory-core" }),
+      [foreignKey]: sessionStoreEntry("foreign-plugin-session", { pluginOwnerId: "other-plugin" }),
+    },
+  });
+  const activeRun = createActiveRun(foreignKey, {
+    agentId: "main",
+    sessionId: "foreign-plugin-session",
+  });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+  const pluginClient = {
+    connect: { scopes: ["operator.admin"] },
+    internal: { pluginRuntimeOwnerId: "memory-core" },
+  } as never;
+
+  const abort = await directSessionReq(
+    "sessions.abort",
+    { key: ownedKey, runId },
+    { context: abortContext, client: pluginClient },
+  );
+
+  expect(abort.ok).toBe(false);
+  expect(abort.error).toMatchObject({
+    code: "INVALID_REQUEST",
+    message: `Plugin "memory-core" cannot abort session "${foreignKey}" because it did not create it.`,
+  });
+  expect(activeRun.controller.signal.aborted).toBe(false);
+});
+
+test("sessions.abort allows a plugin to abort its own active run by runId", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:dreaming-narrative-owned";
+  const runId = "run-own-active";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry("owned-plugin-session", { pluginOwnerId: "memory-core" }),
+    },
+  });
+  const activeRun = createActiveRun(sessionKey, {
+    agentId: "main",
+    sessionId: "owned-plugin-session",
+  });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+  const pluginClient = {
+    connect: { scopes: ["operator.admin"] },
+    internal: { pluginRuntimeOwnerId: "memory-core" },
+  } as never;
+
+  const abort = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey, runId },
+    { context: abortContext, client: pluginClient },
+  );
+
+  expect(abort.ok, JSON.stringify(abort.error)).toBe(true);
+  expect(abort.payload).toMatchObject({
+    ok: true,
+    abortedRunId: runId,
+    status: "aborted",
+  });
+  expect(activeRun.controller.signal.aborted).toBe(true);
 });

--- a/src/gateway/server.sessions.plugin-ownership.test.ts
+++ b/src/gateway/server.sessions.plugin-ownership.test.ts
@@ -297,7 +297,7 @@ test.each([
     entry: sessionStoreEntry("operator-owned-session"),
   },
 ])("sessions.abort prevents a plugin from aborting $name", async ({ key, entry }) => {
-  const { storePath } = await createSessionStoreDir();
+  await createSessionStoreDir();
   await writeSessionStore({ entries: { [key]: entry } });
   const pluginClient = {
     connect: { scopes: ["operator.write"] },

--- a/src/gateway/session-plugin-ownership.ts
+++ b/src/gateway/session-plugin-ownership.ts
@@ -46,7 +46,7 @@ export function resolvePluginSessionOwnershipError(params: {
 export function resolvePluginOwnedCleanupOptions(
   params:
     | {
-        client?: { connect?: { scopes?: readonly string[] } };
+        client?: { connect?: { scopes?: readonly string[] } } | null;
         pluginId?: string;
       }
     | undefined,

--- a/src/gateway/session-plugin-ownership.ts
+++ b/src/gateway/session-plugin-ownership.ts
@@ -6,7 +6,14 @@ import {
 } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../config/sessions.js";
 
-export type PluginSessionOwnershipAction = "adopt" | "delete" | "fork" | "link" | "patch" | "reset";
+export type PluginSessionOwnershipAction =
+  | "abort"
+  | "adopt"
+  | "delete"
+  | "fork"
+  | "link"
+  | "patch"
+  | "reset";
 
 /** Plugin callers may access an existing session only when they own its exact row. */
 export function resolvePluginSessionOwnershipError(params: {

--- a/src/gateway/session-plugin-ownership.ts
+++ b/src/gateway/session-plugin-ownership.ts
@@ -5,6 +5,7 @@ import {
   type ErrorShape,
 } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { ADMIN_SCOPE } from "./method-scopes.js";
 
 export type PluginSessionOwnershipAction =
   | "abort"
@@ -34,4 +35,35 @@ export function resolvePluginSessionOwnershipError(params: {
     ErrorCodes.INVALID_REQUEST,
     `Plugin "${pluginOwnerId}" cannot ${params.action} session "${params.key}" because it did not create it.`,
   );
+}
+
+/**
+ * Resolves the gateway dispatch options that scope a session mutation to the
+ * owning plugin. Non-plugin callers (no plugin id) pass through unchanged;
+ * plugin callers without an admin-scoped client get a synthetic admin client
+ * so the ownership-bound method accepts the owner-scoped request.
+ */
+export function resolvePluginOwnedCleanupOptions(
+  params:
+    | {
+        client?: { connect?: { scopes?: readonly string[] } };
+        pluginId?: string;
+      }
+    | undefined,
+):
+  | { pluginRuntimeOwnerId: string; forceSyntheticClient?: boolean; syntheticScopes?: string[] }
+  | undefined {
+  const pluginId = normalizeOptionalString(params?.pluginId);
+  if (!pluginId) {
+    return undefined;
+  }
+  const scopes = Array.isArray(params?.client?.connect?.scopes)
+    ? params?.client?.connect?.scopes
+    : [];
+  return {
+    pluginRuntimeOwnerId: pluginId,
+    ...(scopes.includes(ADMIN_SCOPE)
+      ? {}
+      : { forceSyntheticClient: true, syntheticScopes: [ADMIN_SCOPE] }),
+  };
 }

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -999,6 +999,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       waitForRun: vi.fn(),
       getSessionMessages: vi.fn(),
       deleteSession: vi.fn(),
+      abortSession: vi.fn(),
     },
     sandbox: {
       resolveWorkspaceAuthority: vi.fn(),

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -48,6 +48,7 @@ function createDeferredGatewaySubagentRuntime(runtime: PluginRuntime): PluginRun
     waitForRun: (...args) => runtime.subagent.waitForRun(...args),
     getSessionMessages: (...args) => runtime.subagent.getSessionMessages(...args),
     deleteSession: (...args) => runtime.subagent.deleteSession(...args),
+    abortSession: (...args) => runtime.subagent.abortSession(...args),
   };
 }
 

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -874,6 +874,11 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
               assertStoredSessionEntryOwned({ action: "delete", sessionKey: params.sessionKey });
               await subagent.deleteSession(params);
             }),
+          abortSession: async (params) =>
+            await withPluginRuntimePluginIdScope(pluginId, async () => {
+              assertStoredSessionEntryOwned({ action: "abort", sessionKey: params.sessionKey });
+              await subagent.abortSession(params);
+            }),
         } satisfies PluginRuntime["subagent"];
       },
     });

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -500,6 +500,7 @@ describe("plugin registry runtime config scope", () => {
       waitForRun: vi.fn(async () => ({ status: "ok" as const })),
       getSessionMessages: vi.fn(async () => ({ messages: [] })),
       deleteSession: vi.fn(async () => {}),
+      abortSession: vi.fn(async () => {}),
     } satisfies PluginRuntime["subagent"];
     const runtime = createPluginRuntime({ subagent });
     const session = runtime.agent.session;

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -45,6 +45,7 @@ function createGatewaySubagentRuntime() {
     waitForRun: vi.fn(),
     getSessionMessages: vi.fn(),
     deleteSession: vi.fn(),
+    abortSession: vi.fn(),
   };
 }
 

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -179,6 +179,7 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
     waitForRun: unavailable,
     getSessionMessages: unavailable,
     deleteSession: unavailable,
+    abortSession: unavailable,
   };
 }
 

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -68,6 +68,12 @@ type SubagentDeleteSessionParams = {
   deleteTranscript?: boolean;
 };
 
+type SubagentAbortSessionParams = {
+  sessionKey: string;
+  /** Abort only this run; omit to abort whatever is currently running. */
+  runId?: string;
+};
+
 type RuntimeNodeListParams = {
   connected?: boolean;
 };
@@ -125,6 +131,8 @@ export type PluginRuntime = PluginRuntimeCore & {
       params: SubagentGetSessionMessagesParams,
     ) => Promise<SubagentGetSessionMessagesResult>;
     deleteSession: (params: SubagentDeleteSessionParams) => Promise<void>;
+    /** Stop an in-flight run without destroying the session entry or transcript. */
+    abortSession: (params: SubagentAbortSessionParams) => Promise<void>;
   };
   nodes: {
     list: (params?: RuntimeNodeListParams) => Promise<RuntimeNodeListResult>;


### PR DESCRIPTION
## What Problem This Solves

The plugin runtime has no way to stop an in-flight agent run without destroying the session. `subagent.deleteSession` is the only lever, and it discards the session store entry as a side effect. Plugins that surface a "Stop" affordance (button, slash command, timeout, admin kill-switch) must choose between stopping the work and losing the session, or keeping the session with no way to stop the work.

The capability already exists in the gateway — `sessions.abort` → `chat.abort` cancels the run through its `AbortController` and leaves the session entry and transcript untouched (what `/stop` and the control UI use). It is simply not reachable from a plugin. Separately, `sessions.abort` never inspects `pluginRuntimeOwnerId`, so a plugin-facing abort would currently be an unscoped, instance-wide cancel.

## Why

First-party surfaces get a clean stop; plugin-built surfaces cannot. And because the ownership guard (`assertStoredSessionEntryOwned` / `rejectPluginRuntimeSessionOwnershipMismatch`) covers `adopt | delete | fork | link | patch | reset` but not abort, exposing the method without scoping it would hand every plugin an instance-wide cancel — a real problem for instances running plugins for more than one tenant.

## User Impact

- Plugin authors can now call `subagent.abortSession({ sessionKey, runId? })` to stop an in-flight run while keeping the session entry and transcript intact.
- Aborts are scoped by plugin ownership: a plugin cannot abort a session another plugin created (same class of violation as deleting it). Non-plugin clients and owner-matching plugins are unaffected.
- The new method is dispatched exactly like `deleteSession`, carrying the same plugin identity (`pluginRuntimeOwnerId`) and synthetic-admin scoping for owner-scoped stops.
- A plugin cannot pair its own session key with a foreign active `runId` to cancel another plugin's run: the run-resolved target is re-authorized against the caller's canonical key before aborting.

## Evidence

### Boundary repair (ClawSweeper P1: authorize the run-resolved session before aborting)

`src/gateway/server-methods/sessions-abort.ts` now re-checks the resolved abort target: when a `runId` redirects the abort to a session whose canonical key differs from the caller's authorized key, plugin callers are rejected with the standard ownership error. This closes the cross-plugin cancellation bypass where a plugin submitted its owned key with another plugin's active runId and synthetic admin dispatch cancelled the foreign run.

### Local runs (Node v24.15.0)

```text
$ ./node_modules/.bin/vitest run src/gateway/server.sessions.plugin-ownership.test.ts
✓ sessions.abort prevents a plugin from aborting 'another plugin\'s session'
✓ sessions.abort allows a plugin to abort its own active run by runId
✓ sessions.abort rejects a plugin aborting a foreign active run via its own key + foreign runId
Test Files  1 passed (1)
     Tests  13 passed (13)

$ ./node_modules/.bin/vitest run src/gateway/server-methods/sessions-abort.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)
```

The two new regression tests prove both sides of the boundary:

```text
sessions.abort rejects a plugin aborting a foreign active run via its own key + foreign runId
  → error: Plugin "memory-core" cannot abort session "agent:main:dreaming-narrative-foreign" because it did not create it.
  → activeRun.controller.signal.aborted === false

sessions.abort allows a plugin to abort its own active run by runId
  → payload: { ok: true, abortedRunId: "run-own-active", status: "aborted" }
  → activeRun.controller.signal.aborted === true
```

### Code shape

- `src/plugins/runtime/types.ts`: added `SubagentAbortSessionParams` + `abortSession` on `PluginRuntime["subagent"]`.
- `src/gateway/server-plugins.ts`: `abortSession` dispatches `sessions.abort` with `key` + optional `runId`, mirroring `deleteSession`'s plugin-owned options.
- `src/gateway/session-plugin-ownership.ts`: `"abort"` joined `PluginSessionOwnershipAction`.
- `src/gateway/server-methods/sessions-abort.ts`: applies `rejectPluginRuntimeSessionOwnershipMismatch({ action: "abort", ... })` before aborting, plus the run-resolved target re-authorization above.
- `src/plugins/registry-runtime.ts` / `loader-runtime-load.ts` / `runtime/index.ts`: proxied/unavailable runtimes updated; `plugin-runtime-mock.ts` and runtime-config test fixtures updated.

[AI-assisted]
