### PR TITLE
fix(cli): reject Infinity/NaN in config set/batch/patch values

### DIFF
--- a/src/cli/config-cli-input.test.ts
+++ b/src/cli/config-cli-input.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { readConfigPatchOperations } from "./config-cli-input.js";
+
+async function withPatchFile<T>(
+  contents: string,
+  run: (patchPath: string) => Promise<T>,
+): Promise<T> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-cli-input-"));
+  const patchPath = path.join(tempDir, "patch.json5");
+  fs.writeFileSync(patchPath, contents, "utf8");
+  try {
+    return await run(patchPath);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe("readConfigPatchOperations", () => {
+  it("rejects patch files containing non-finite numbers", async () => {
+    await withPatchFile('{ "channels": { "custom": { "timeout": 1e999 } } }', async (patchPath) => {
+      await expect(readConfigPatchOperations({ file: patchPath })).rejects.toThrow(
+        "Value must be a finite number",
+      );
+    });
+  });
+});

--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -24,6 +24,7 @@ import { formatCliCommand } from "./command-format.js";
 import {
   parseConfigSetPath,
   parseConfigSetValue,
+  rejectConfigNonFiniteNumbers,
   type PathSegment,
   toDotPath,
   validatePathSegments,
@@ -520,11 +521,14 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
       throw err;
     }
   }
+  let parsed: unknown;
   try {
-    return JSON5.parse(raw);
+    parsed = JSON5.parse(raw);
   } catch (err) {
     throw new Error(`Failed to parse ${sourceLabel} as JSON5: ${String(err)}`, { cause: err });
   }
+  rejectConfigNonFiniteNumbers(parsed);
+  return parsed;
 }
 
 function buildDeleteOperation(path: PathSegment[]): ConfigSetOperation {

--- a/src/cli/config-cli-input.ts
+++ b/src/cli/config-cli-input.ts
@@ -3,6 +3,7 @@ import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-c
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import JSON5 from "json5";
+import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
 import {
   coerceSecretRef,
   isValidEnvSecretRefId,
@@ -24,7 +25,6 @@ import { formatCliCommand } from "./command-format.js";
 import {
   parseConfigSetPath,
   parseConfigSetValue,
-  rejectConfigNonFiniteNumbers,
   type PathSegment,
   toDotPath,
   validatePathSegments,
@@ -233,7 +233,6 @@ function buildProviderFromBuilder(opts: ConfigSetOptions): SecretProviderConfig 
       ...(mode ? { mode } : {}),
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(maxBytes !== undefined ? { maxBytes } : {}),
-      ...(opts.providerAllowInsecurePath ? { allowInsecurePath: true } : {}),
     };
   } else {
     const command = opts.providerCommand?.trim();
@@ -255,8 +254,6 @@ function buildProviderFromBuilder(opts: ConfigSetOptions): SecretProviderConfig 
       ...(opts.providerTrustedDir?.length
         ? { trustedDirs: normalizeStringEntries(opts.providerTrustedDir) }
         : {}),
-      ...(opts.providerAllowInsecurePath ? { allowInsecurePath: true } : {}),
-      ...(opts.providerAllowSymlinkCommand ? { allowSymlinkCommand: true } : {}),
     };
   }
 

--- a/src/cli/config-cli-path.test.ts
+++ b/src/cli/config-cli-path.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseConfigSetValue } from "./config-cli-path.js";
+
+describe("parseConfigSetValue", () => {
+  it.each([
+    { raw: "42", expected: 42 },
+    { raw: "3.14", expected: 3.14 },
+    { raw: "-0", expected: -0 },
+    { raw: "true", expected: true },
+    { raw: "false", expected: false },
+    { raw: "null", expected: null },
+    { raw: "{a:1}", expected: { a: 1 } },
+    { raw: "[1,2]", expected: [1, 2] },
+  ])("parses $raw as expected", ({ raw, expected }) => {
+    expect(parseConfigSetValue(raw, false)).toEqual(expected);
+  });
+
+  it("falls back to the raw string when JSON5 parsing fails", () => {
+    expect(parseConfigSetValue("hello", false)).toBe("hello");
+  });
+
+  it.each([
+    { raw: "Infinity", label: "Infinity" },
+    { raw: "-Infinity", label: "negative Infinity" },
+    { raw: "NaN", label: "NaN" },
+    { raw: "1e999", label: "overflow exponent" },
+    { raw: "{timeout:1e999}", label: "object with overflow exponent" },
+    { raw: "[1e999]", label: "array with overflow exponent" },
+  ])("rejects $label in value mode", ({ raw }) => {
+    expect(() => parseConfigSetValue(raw, false)).toThrow("Value must be a finite number");
+  });
+
+  it("rejects overflow exponent in strict JSON mode with the finite-number error", () => {
+    expect(() => parseConfigSetValue("1e999", true)).toThrow("Value must be a finite number");
+  });
+
+  it.each([
+    { raw: "Infinity", label: "Infinity" },
+    { raw: "-Infinity", label: "negative Infinity" },
+    { raw: "NaN", label: "NaN" },
+  ])("rejects $label in strict JSON mode as invalid JSON", ({ raw }) => {
+    expect(() => parseConfigSetValue(raw, true)).toThrow();
+  });
+
+  it("still reports JSON parse errors in strict JSON mode", () => {
+    expect(() => parseConfigSetValue("not-json", true)).toThrow(
+      /(Unexpected token|Expected).*not-json/,
+    );
+  });
+});

--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -1,9 +1,12 @@
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import JSON5 from "json5";
+import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { parseConfigPathArrayIndex } from "../shared/path-array-index.js";
 import { formatCliCommand } from "./command-format.js";
 import { formatStrictJsonParseFailure } from "./error-format.js";
+
+export { rejectConfigNonFiniteNumbers };
 
 export type PathSegment = string;
 
@@ -155,26 +158,6 @@ export function parseConfigSetPath(path: string): string[] {
   }
   validatePathSegments(parsedPath);
   return parsedPath;
-}
-
-export function rejectConfigNonFiniteNumbers(value: unknown): void {
-  if (typeof value === "number") {
-    if (!Number.isFinite(value)) {
-      throw new Error(`Value must be a finite number, got ${String(value)}`);
-    }
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      rejectConfigNonFiniteNumbers(entry);
-    }
-    return;
-  }
-  if (isPlainRecord(value)) {
-    for (const entry of Object.values(value)) {
-      rejectConfigNonFiniteNumbers(entry);
-    }
-  }
 }
 
 export function parseConfigSetValue(raw: string, strictJson: boolean): unknown {

--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -6,8 +6,6 @@ import { parseConfigPathArrayIndex } from "../shared/path-array-index.js";
 import { formatCliCommand } from "./command-format.js";
 import { formatStrictJsonParseFailure } from "./error-format.js";
 
-export { rejectConfigNonFiniteNumbers };
-
 export type PathSegment = string;
 
 export type JsonSchemaRecord = {

--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -157,20 +157,46 @@ export function parseConfigSetPath(path: string): string[] {
   return parsedPath;
 }
 
+export function rejectConfigNonFiniteNumbers(value: unknown): void {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Value must be a finite number, got ${String(value)}`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      rejectConfigNonFiniteNumbers(entry);
+    }
+    return;
+  }
+  if (isPlainRecord(value)) {
+    for (const entry of Object.values(value)) {
+      rejectConfigNonFiniteNumbers(entry);
+    }
+  }
+}
+
 export function parseConfigSetValue(raw: string, strictJson: boolean): unknown {
   const trimmed = raw.trim();
   if (strictJson) {
+    let parsed: unknown;
     try {
-      return JSON.parse(trimmed);
+      parsed = JSON.parse(trimmed);
     } catch (err) {
       throw new Error(formatStrictJsonParseFailure({ value: raw, cause: err }), { cause: err });
     }
+    rejectConfigNonFiniteNumbers(parsed);
+    return parsed;
   }
+  let parsed: unknown;
   try {
-    return JSON5.parse(trimmed);
+    parsed = JSON5.parse(trimmed);
   } catch {
     return raw;
   }
+  rejectConfigNonFiniteNumbers(parsed);
+  return parsed;
 }
 
 export function validatePathSegments(path: PathSegment[]): void {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1765,6 +1765,8 @@ describe("config cli", () => {
       expect(helpText).toContain("Strict JSON parsing (error instead of");
       expect(helpText).toContain("--ref-provider");
       expect(helpText).toContain("--provider-source");
+      expect(helpText).not.toContain("--provider-allow-insecure-path");
+      expect(helpText).not.toContain("--provider-allow-symlink-command");
       expect(helpText).toContain("--batch-json");
       expect(helpText).toContain("--dry-run");
       expect(helpText).toContain("--allow-exec");
@@ -1943,6 +1945,27 @@ describe("config cli", () => {
         mode: "json",
       });
     });
+
+    it.each(["--provider-allow-insecure-path", "--provider-allow-symlink-command"])(
+      "rejects retired provider builder option %s",
+      async (option) => {
+        await expect(
+          runConfigCommand([
+            "config",
+            "set",
+            "secrets.providers.vaultfile",
+            "--provider-source",
+            "file",
+            "--provider-path",
+            "/tmp/vault.json",
+            option,
+          ]),
+        ).rejects.toThrow(`unknown option '${option}'`);
+
+        expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+        expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      },
+    );
 
     it("rejects exponent-style provider builder integer options", async () => {
       await expect(

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -476,16 +476,6 @@ export function registerConfigCli(program: Command) {
       collectOption,
       [] as string[],
     )
-    .option(
-      "--provider-allow-insecure-path",
-      "Provider builder (file|exec): bypass strict path permission checks",
-      false,
-    )
-    .option(
-      "--provider-allow-symlink-command",
-      "Provider builder (exec): allow command symlink path",
-      false,
-    )
     .option("--batch-json <json>", "Batch mode: JSON array of set operations")
     .option("--batch-file <path>", "Batch mode: read JSON array of set operations from file")
     .action(async (path: string | undefined, value: string | undefined, opts: ConfigSetOptions) => {

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseBatchSource } from "./config-set-input.js";
+import {
+  hasProviderBuilderOptions,
+  parseBatchSource,
+  type ConfigSetOptions,
+} from "./config-set-input.js";
 
 function withBatchFile<T>(prefix: string, contents: string, run: (batchPath: string) => T): T {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -17,6 +21,16 @@ function withBatchFile<T>(prefix: string, contents: string, run: (batchPath: str
 }
 
 describe("config set input parsing", () => {
+  it("does not treat retired provider bypass fields as builder options", () => {
+    const retired = {
+      providerAllowInsecurePath: true,
+      providerAllowSymlinkCommand: true,
+    } as ConfigSetOptions;
+
+    expect(hasProviderBuilderOptions(retired)).toBe(false);
+    expect(hasProviderBuilderOptions({ providerTrustedDir: ["/usr/local/bin"] })).toBe(true);
+  });
+
   it("returns null when no batch options are provided", () => {
     expect(parseBatchSource({})).toBeNull();
   });

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -146,4 +146,12 @@ describe("config set input parsing", () => {
       expect(parsed).toEqual([{ path: "gateway.port", value: 19000 }]);
     });
   });
+
+  it("rejects batch entries with non-finite numbers", () => {
+    expect(() =>
+      parseBatchSource({
+        batchJson: '[{"path":"channels.custom.timeout","value":1e999}]',
+      }),
+    ).toThrow("Value must be a finite number");
+  });
 });

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -7,6 +7,7 @@ import {
 import JSON5 from "json5";
 import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import { hasErrnoCode } from "../infra/errors.js";
+import { rejectConfigNonFiniteNumbers } from "./config-cli-path.js";
 
 export type ConfigSetOptions = {
   strictJson?: boolean;
@@ -104,11 +105,14 @@ export function hasProviderBuilderOptions(opts: ConfigSetOptions): boolean {
 }
 
 function parseJson5Raw(raw: string, label: string): unknown {
+  let parsed: unknown;
   try {
-    return JSON5.parse(raw);
+    parsed = JSON5.parse(raw);
   } catch (err) {
     throw new Error(`Failed to parse ${label}: ${String(err)}`, { cause: err });
   }
+  rejectConfigNonFiniteNumbers(parsed);
+  return parsed;
 }
 
 function parseBatchEntries(raw: string, sourceLabel: string): ConfigSetBatchEntry[] {

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -5,9 +5,9 @@ import {
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import JSON5 from "json5";
+import { rejectConfigNonFiniteNumbers } from "../config/io.read-helpers.js";
 import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import { hasErrnoCode } from "../infra/errors.js";
-import { rejectConfigNonFiniteNumbers } from "./config-cli-path.js";
 
 export type ConfigSetOptions = {
   strictJson?: boolean;
@@ -34,8 +34,6 @@ export type ConfigSetOptions = {
   providerEnv?: string[];
   providerPassEnv?: string[];
   providerTrustedDir?: string[];
-  providerAllowInsecurePath?: boolean;
-  providerAllowSymlinkCommand?: boolean;
   batchJson?: string;
   batchFile?: string;
 };
@@ -98,9 +96,7 @@ export function hasProviderBuilderOptions(opts: ConfigSetOptions): boolean {
     opts.providerJsonOnly ||
     opts.providerEnv?.length ||
     opts.providerPassEnv?.length ||
-    opts.providerTrustedDir?.length ||
-    opts.providerAllowInsecurePath ||
-    opts.providerAllowSymlinkCommand,
+    opts.providerTrustedDir?.length,
   );
 }
 

--- a/src/config/io.read-helpers.ts
+++ b/src/config/io.read-helpers.ts
@@ -81,6 +81,26 @@ export function resolveGatewayMode(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+export function rejectConfigNonFiniteNumbers(value: unknown): void {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Value must be a finite number, got ${String(value)}`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      rejectConfigNonFiniteNumbers(entry);
+    }
+    return;
+  }
+  if (isRecord(value)) {
+    for (const entry of Object.values(value)) {
+      rejectConfigNonFiniteNumbers(entry);
+    }
+  }
+}
+
 export function collectEnvRefPaths(
   value: unknown,
   pathLocal: string,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1666,6 +1666,25 @@ describe("config io write", () => {
     expect(persisted.plugins).toEqual({});
   });
 
+  itWithHome(
+    "rejects non-finite numbers before serializing the normal config writer",
+    async (home) => {
+      const { configPath } = await writeConfigFixture(home, {
+        plugins: { entries: { demo: { enabled: true } } },
+      });
+      const io = createFastConfigIO(home);
+      const originalRaw = await fs.readFile(configPath, "utf-8");
+
+      await expect(
+        io.writeConfigFile({
+          plugins: { entries: { demo: { enabled: true, config: { timeout: Infinity } } } },
+        }),
+      ).rejects.toThrow("Value must be a finite number, got Infinity");
+
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    },
+  );
+
   it("preserves escaped root literals before validating unrelated includes", async () => {
     mockLoadPluginManifestRegistry.mockReturnValue({
       diagnostics: [],

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -40,6 +40,7 @@ import {
   hashConfigRaw,
   hasConfigMeta,
   parseConfigJson5,
+  rejectConfigNonFiniteNumbers,
   resolveConfigSnapshotHash,
   resolveGatewayMode,
   restoreAuthoredTildePathsForWrite,
@@ -255,6 +256,7 @@ export async function writeConfigFileFromContext(
     options.lastTouchedVersionOverride,
     snapshot.exists ? snapshot.parsed : null,
   );
+  rejectConfigNonFiniteNumbers(stampedOutputConfig);
   const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
   const nextHash = hashConfigRaw(json);
   const previousHash = resolveConfigSnapshotHash(snapshot);

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -1284,6 +1284,43 @@ describe("config mutate helpers", () => {
     );
   });
 
+  it("rejects non-finite numbers before serializing single-file top-level include writes", async () => {
+    const home = await suiteRootTracker.make("include-non-finite");
+    const { configPath, pluginsPath } = await createPluginIncludeFixture(home);
+    const initialPluginsRaw = `${JSON.stringify({ entries: {} }, null, 2)}\n`;
+    await fs.writeFile(pluginsPath, initialPluginsRaw, "utf-8");
+    const snapshot = createSnapshot({
+      hash: "hash-include-non-finite",
+      path: configPath,
+      parsed: { plugins: { $include: "./config/plugins.json5" } },
+      sourceConfig: { plugins: { entries: {} } },
+    });
+
+    await expect(
+      replaceConfigFile({
+        baseHash: snapshot.hash,
+        snapshot,
+        writeOptions: {
+          expectedConfigPath: snapshot.path,
+          assertConfigPathForWrite: allowConfigPathWrite,
+          includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
+        },
+        nextConfig: {
+          plugins: {
+            entries: {
+              demo: { config: { timeout: Infinity } },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("Value must be a finite number, got Infinity");
+
+    await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+    await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(
+      `${JSON.stringify({ plugins: { $include: "./config/plugins.json5" } }, null, 2)}\n`,
+    );
+  });
+
   it("preflights single-file top-level include writes before persisting", async () => {
     const home = await suiteRootTracker.make("include-runtime-preflight");
     const { configPath, pluginsPath } = await createPluginIncludeFixture(home);

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -42,6 +42,7 @@ import {
   type ConfigWriteOptions,
   type ConfigWriteResult,
 } from "./io.js";
+import { rejectConfigNonFiniteNumbers } from "./io.read-helpers.js";
 import { warnIfJSON5CommentsWillBeStripped } from "./json5-comments.js";
 import { ConfigMutationConflictError } from "./mutation-conflict.js";
 import type { ConfigMutationBase } from "./mutation-types.js";
@@ -406,6 +407,7 @@ function snapshotProvesBrokenInclude(snapshot: ConfigFileSnapshot, includePath: 
 }
 
 function formatJsonFileValue(value: unknown): string {
+  rejectConfigNonFiniteNumbers(value);
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 


### PR DESCRIPTION
<!--
Related: gap finding `config-set-infinity-nan` (strategy C, confirmed)
-->

## What Problem This Solves

Fixes an issue where `openclaw config set <path> <value>` (and the equivalent `--batch-*` / `config patch` inputs) would silently accept `Infinity`, `-Infinity`, or `NaN` values and later write them as `null` to the config file. The CLI reported success, but the stored value was corrupted.

Example:
```bash
openclaw config set channels.custom.timeout 1e999
# "Updated channels.custom.timeout. No gateway restart needed."
# Config file contained: "timeout": null
```

## Why This Change Was Made

JSON5 and V8's JSON parser accept tokens like `Infinity`, `NaN`, and overflow exponents (`1e999`) as numeric values, but `JSON.stringify` converts them to `null`. The config write path never validated finiteness, so non-finite numbers could reach the file.

The fix introduces a small recursive guard, `rejectConfigNonFiniteNumbers()`, owned by the config IO layer and applied at every user-facing JSON5/JSON parse boundary for config mutations, plus both shared configuration serialization paths:

- `parseConfigSetValue()` — single-value `config set` and `--strict-json` mode
- `parseJson5Raw()` — `config set --batch-json` / `--batch-file`
- `readConfigPatchInput()` — `config patch --file` / `--stdin`
- `writeConfigFileFromContext()` — normal config file writer
- `formatJsonFileValue()` / `writeRootBoundJsonFile()` — single-file top-level include fast path

The guard rejects only `Infinity`, `-Infinity`, and `NaN`; ordinary finite numbers, strings, booleans, objects, and arrays continue to work exactly as before.

This revision also removes the accidentally restored retired provider-builder bypass options `--provider-allow-insecure-path` and `--provider-allow-symlink-command`, keeping them out of the provider-builder CLI path as they are on current `main`.

## User Impact

Users now get a clear error immediately when they try to set a non-finite numeric value, instead of a misleading success message followed by a corrupted config file. The retired provider-bypass flags remain unavailable through `config set` builder mode.

## Evidence

### Before fix

```bash
$ node -e "const JSON5 = require('json5'); console.log(JSON5.parse('1e999')); console.log(JSON.stringify(JSON5.parse('1e999')));"
Infinity
null
```

`openclaw config set channels.custom.timeout 1e999` wrote `null` to `openclaw.json` while printing "Updated ...".

### After fix

```bash
$ pnpm exec tsx -e "import { parseConfigSetValue } from './src/cli/config-cli-path.ts'; console.log(parseConfigSetValue('1e999', false));"
Error: Value must be a finite number, got Infinity

$ pnpm exec tsx -e "import { parseBatchSource } from './src/cli/config-set-input.ts'; console.log(parseBatchSource({ batchJson: '[{\"path\":\"x\",\"value\":1e999}]' }));"
Error: Value must be a finite number, got Infinity
```

### Tests

- `node scripts/run-vitest.mjs src/config/io.write-config.test.ts src/config/mutate.test.ts src/cli/config-cli.test.ts src/cli/config-cli-path.test.ts src/cli/config-set-input.test.ts src/cli/config-cli-input.test.ts` — 202 tests passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <11 files>` — 0 warnings/errors
- `pnpm format:check <11 files>` — passed
- `pnpm check:test-types` — passed (core/extensions/root tsgo lanes)

### CI proof: exact-head before/after

Proved this change at exact heads using the real `openclaw config set`, `config set --batch-json`, and `config patch --file` CLI against isolated config files. Also verifies retired provider-builder bypass options (`--provider-allow-insecure-path`, `--provider-allow-symlink-command`) are rejected.

- Before (main): `9aa24e8f`
- After (PR head): `538724c8`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/31352782783
- Artifact download: https://github.com/xialonglee/openclaw/actions/runs/31352782783/artifacts/9049571802

Key markers from the proof log:

```text
[proof] scene=config-set-scalar before exit=0 stored_value=null
[proof] scene=config-set-scalar before corruption=confirmed
[proof] scene=config-set-batch before exit=0 stored_value=null
[proof] scene=config-set-batch before corruption=confirmed
[proof] scene=config-patch before exit=0 stored_value=null
[proof] scene=config-patch before corruption=confirmed
Error: Value must be a finite number, got Infinity
[proof] scene=config-set-scalar after exit=1 stored_value=MISSING status=rejected
[proof] scene=config-set-batch after exit=1 stored_value=MISSING status=rejected
[proof] scene=config-patch after exit=1 stored_value=MISSING status=rejected
[proof] scene=error-message after status=found
OpenClaw does not recognize option "--provider-allow-insecure-path".
OpenClaw does not recognize option "--provider-allow-symlink-command".
[proof] scene=provider-retired-options after status=rejected insecure=1 symlink=1
```

The before run shows `1e999` being silently persisted as `null` for scalar, batch, and patch inputs. The after run shows all three modes plus retired provider options rejected before writing, leaving the config file unchanged.

