### PR TITLE
test(msteams): cover occupied webhook port

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -1,5 +1,5 @@
 // Msteams tests cover monitor.lifecycle plugin behavior.
-import type { Server } from "node:http";
+import { createServer, type Server } from "node:http";
 import type { Request, Response } from "express";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
@@ -289,6 +289,42 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     const result = await task;
     if (!result.app) {
       throw new Error("expected Teams monitor app after startup abort");
+    }
+  });
+
+  it("rejects startup when the webhook port is already in use", async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen(0, resolve);
+    });
+
+    try {
+      const address = blocker.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected occupied TCP port");
+      }
+
+      const stores = createStores();
+      const task = monitorMSTeamsProvider({
+        cfg: createConfig(address.port),
+        runtime: createRuntime(),
+        conversationStore: stores.conversationStore,
+        pollStore: stores.pollStore,
+      });
+
+      await expect(task).rejects.toMatchObject({ code: "EADDRINUSE" });
+      const ingress = getMSTeamsIngressMockState().instances[0];
+      if (!ingress) {
+        throw new Error("expected Teams ingress");
+      }
+      expect(ingress.start).toHaveBeenCalledTimes(1);
+      expect(ingress.stop).toHaveBeenCalledTimes(1);
+      expect(keepHttpServerTaskAliveMock).not.toHaveBeenCalled();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((err) => (err ? reject(err) : resolve()));
+      });
     }
   });
 


### PR DESCRIPTION
Related: #120145
Related: #120117

## What Problem This Solves

Restores real boundary coverage for Microsoft Teams webhook startup when the configured port is already occupied. PR #120117 correctly removed a test that proved an invented Express mock contract, but the working Express 5.2.1 startup path no longer had a regression test.

## Why This Change Was Made

This AI-assisted test binds a real Node HTTP server to an ephemeral port using the same unspecified-host mode as production, starts the real Microsoft Teams monitor on that assigned port, and verifies the existing startup owner rejects with `EADDRINUSE`, starts then stops ingress exactly once, and never enters the HTTP keep-alive phase. The blocking server is always closed in `finally`.

No production, config, SDK, dependency, or public-contract code changes.

## User Impact

No runtime behavior changes. The test now protects the existing operator-visible startup failure path from regressing back to a silent or hanging listener failure.

## Evidence

- Real Express 5.2.1 dependency repro: occupied-port startup invoked the listen callback once with `EADDRINUSE`.
- Direct dependency inspection: Express 5.2.1 `lib/application.js` wraps the callback once, registers it on the server's startup `error` event, then delegates to `server.listen`; the installed Express types declare the callback as `(error?: Error) => void`.
- Exact occupied-port test: 20 independent runs passed.
- Full `monitor.lifecycle.test.ts` suite: 16/16 passed.
- Blacksmith Testbox changed gate passed, including extension-test typecheck, focused lint, formatting, dependency, boundary, dead-export, and policy guards: https://github.com/openclaw/openclaw/actions/runs/31150573037
- Exact-head PR CI passed with zero pending or failing checks.
- Max-P1 autoreview: clean, patch correct at 0.98 confidence.
- `git diff --check`: passed.

Production LOC: +0/-0. Test LOC: +37/-1.

<!--
Punchcard-Session: silver-willow-harbor-px
Punchcard-Receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaREJIODRNNERNOUcyVDhCUlY1R1Q3RwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl8zODZGRjVCMzQxQTI2NzQzQjJDREEzMEY0RAB3cmtfMDFLWkRBS0o2RVpEN1FYSEE4TUJURjQ3RzQAc2VzXzAxS1pEQUtNN1pWMFY0OVQ4VFZZRzE2TVY3AHNpbHZlci13aWxsb3ctaGFyYm9yLXB4AG9wZW5jbGF3L29wZW5jbGF3AAAxMjAxNTgAZmZhMzNjMjc3MWEzNzJmYTA4NGZlYzZhOTBlYWM3ZDM5Y2ZhNzI5ZTlmNmZmOWE1NDg0MDNiYzRmZTUzNzgwNABzaWduaW5nLXYxAE01Rm1yMWd1cmVYS2Y3eEJqdjFkM25RaklUWm8xOUR2YXZOQnFhTERTbHZ2UHY5a2ZzUW5FV1ltazdVNWtkYnFzM0tTSnRTQlpOYTN3N3IzUzJYaUJBADIwMjYtMDgtMDdUMDU6MzY6MDAuNjYwWgA.Hf06ux1oMSl-YL119XggxA0TMEm3eFrF9b64wNZrNo10HVOCKoW_OVdpjAMTOov2B2ld7zN0R44SOPfpUFyLAA
-->
