### PR TITLE
fix: session list fails for everyone while one session's transcript projection rebuilds

### DIFF
--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -94,6 +94,17 @@ describe("session transcript reader facade", () => {
     return scope;
   }
 
+  function markProjectionNeedsRebuild(sessionId: string): void {
+    openOpenClawAgentDatabase({
+      agentId: "main",
+      path: path.join(tempDir, "openclaw-agent.sqlite"),
+    })
+      .db.prepare(
+        "UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?",
+      )
+      .run(sessionId);
+  }
+
   function extractReferenceText(message: unknown): string | null {
     if (!message || typeof message !== "object" || Array.isArray(message)) {
       return null;
@@ -447,6 +458,58 @@ describe("session transcript reader facade", () => {
     ]);
   });
 
+  test("degrades batch title fields per rebuilding projection and restores them afterward", async () => {
+    const healthyScope = await writeSqliteMessages("reader-title-batch-healthy", [
+      { role: "user", content: "healthy prompt" },
+      { role: "assistant", content: "healthy reply" },
+    ]);
+    const rebuildingScope = await writeSqliteMessages("reader-title-batch-rebuilding", [
+      { role: "user", content: "rebuilding prompt" },
+      { role: "assistant", content: "rebuilding reply" },
+    ]);
+    markProjectionNeedsRebuild(rebuildingScope.sessionId);
+
+    let fields: ReturnType<typeof readSessionTitleFieldsFromTranscriptBatch> | undefined;
+    try {
+      fields = readSessionTitleFieldsFromTranscriptBatch([healthyScope, rebuildingScope]);
+    } finally {
+      await waitForSessionTranscriptIndexReconcile({
+        agentId: "main",
+        path: path.join(tempDir, "openclaw-agent.sqlite"),
+      });
+    }
+    expect(fields).toEqual([
+      { firstUserMessage: "healthy prompt", lastMessagePreview: "healthy reply" },
+      { firstUserMessage: null, lastMessagePreview: null },
+    ]);
+    expect(readSessionTitleFieldsFromTranscript(rebuildingScope)).toEqual({
+      firstUserMessage: "rebuilding prompt",
+      lastMessagePreview: "rebuilding reply",
+    });
+  });
+
+  test("degrades single title reads while the projection rebuilds", async () => {
+    const scope = await writeSqliteMessages("reader-title-single-rebuilding", [
+      { role: "user", content: "single prompt" },
+      { role: "assistant", content: "single reply" },
+    ]);
+    markProjectionNeedsRebuild(scope.sessionId);
+
+    let fields: ReturnType<typeof readSessionTitleFieldsFromTranscript> | undefined;
+    try {
+      fields = readSessionTitleFieldsFromTranscript(scope);
+    } finally {
+      await waitForSessionTranscriptIndexReconcile({
+        agentId: "main",
+        path: path.join(tempDir, "openclaw-agent.sqlite"),
+      });
+    }
+    expect(fields).toEqual({
+      firstUserMessage: null,
+      lastMessagePreview: null,
+    });
+  });
+
   test("bounds title probe reads independently of transcript length", async () => {
     const probeReadCount = async (sessionId: string, messageCount: number) => {
       const scope = await writeSqliteMessages(
@@ -721,13 +784,7 @@ describe("session transcript reader facade", () => {
       ],
       touchSessionEntry: false,
     });
-    const database = openOpenClawAgentDatabase({
-      agentId: "main",
-      path: path.join(tempDir, "openclaw-agent.sqlite"),
-    });
-    database.db
-      .prepare("UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?")
-      .run(sessionId);
+    markProjectionNeedsRebuild(sessionId);
 
     await expect(readSessionMessageCountAsync(scope)).resolves.toBe(2);
   });

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -1,6 +1,7 @@
 // Session-list title reads: bounded transcript probes plus a watermark-validated
 // cache so list rendering never rescans transcripts that have not changed.
 import {
+  isSessionTranscriptProjectionUnavailableError,
   readSessionTranscriptMessageEventPage,
   readSessionTranscriptTitleProbeBatch,
   readSessionTranscriptWatermark,
@@ -105,47 +106,57 @@ function readSqliteTitleFields(
     setSqliteTitleFieldCache(cacheKey, cached);
     return { ...cachedFields };
   }
-  const tail = readSessionTranscriptMessageEventPage(scope, {
-    maxMessages: SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
-    offset: 0,
-  });
-  let lastText = findLastMessageText(tail.events);
-  if (!lastText && tail.totalMessages > SQLITE_TITLE_PROBE_INITIAL_MESSAGES) {
-    lastText = findLastMessageText(
-      readSqliteTitleProbeRange(
-        scope,
-        tail.totalMessages,
-        tail.totalMessages - SQLITE_TITLE_PROBE_MAX_MESSAGES,
-        tail.totalMessages - SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
-      ),
-    );
-  }
-
-  const head =
-    tail.totalMessages <= SQLITE_TITLE_PROBE_INITIAL_MESSAGES
-      ? tail.events
-      : readSqliteTitleProbeRange(
+  let fields: SessionTitleFields;
+  try {
+    const tail = readSessionTranscriptMessageEventPage(scope, {
+      maxMessages: SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
+      offset: 0,
+    });
+    let lastText = findLastMessageText(tail.events);
+    if (!lastText && tail.totalMessages > SQLITE_TITLE_PROBE_INITIAL_MESSAGES) {
+      lastText = findLastMessageText(
+        readSqliteTitleProbeRange(
           scope,
           tail.totalMessages,
-          0,
+          tail.totalMessages - SQLITE_TITLE_PROBE_MAX_MESSAGES,
+          tail.totalMessages - SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
+        ),
+      );
+    }
+
+    const head =
+      tail.totalMessages <= SQLITE_TITLE_PROBE_INITIAL_MESSAGES
+        ? tail.events
+        : readSqliteTitleProbeRange(
+            scope,
+            tail.totalMessages,
+            0,
+            SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
+          );
+    let firstUser = findFirstTitleUserMessage(head, opts?.includeInterSession === true);
+    if (!firstUser && tail.totalMessages > SQLITE_TITLE_PROBE_INITIAL_MESSAGES) {
+      firstUser = findFirstTitleUserMessage(
+        readSqliteTitleProbeRange(
+          scope,
+          tail.totalMessages,
           SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
-        );
-  let firstUser = findFirstTitleUserMessage(head, opts?.includeInterSession === true);
-  if (!firstUser && tail.totalMessages > SQLITE_TITLE_PROBE_INITIAL_MESSAGES) {
-    firstUser = findFirstTitleUserMessage(
-      readSqliteTitleProbeRange(
-        scope,
-        tail.totalMessages,
-        SQLITE_TITLE_PROBE_INITIAL_MESSAGES,
-        SQLITE_TITLE_PROBE_MAX_MESSAGES,
-      ),
-      opts?.includeInterSession === true,
-    );
+          SQLITE_TITLE_PROBE_MAX_MESSAGES,
+        ),
+        opts?.includeInterSession === true,
+      );
+    }
+    fields = {
+      firstUserMessage: firstUser ? extractMessageText(firstUser) : null,
+      lastMessagePreview: lastText,
+    };
+  } catch (error) {
+    if (!isSessionTranscriptProjectionUnavailableError(error)) {
+      throw error;
+    }
+    // Titles are optional list decoration: degrade only this session while its projection rebuilds.
+    // Do not cache nulls, so the next list can restore titles after reconciliation.
+    return { firstUserMessage: null, lastMessagePreview: null };
   }
-  const fields = {
-    firstUserMessage: firstUser ? extractMessageText(firstUser) : null,
-    lastMessagePreview: lastText,
-  };
   const fieldsByVariant =
     cached?.generation === watermark.generation && cached.maxSeq === watermark.maxSeq
       ? cached.fields


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the entire session sidebar would blank out for all connected clients whenever a single session's SQLite transcript projection was rebuilding. Observed live on clawstudio 2026-08-06 18:39: one session with a dirty transcript index (`needs_rebuild=1`) made every `sessions.list` call fail with UNAVAILABLE (`SessionTranscriptProjectionUnavailableError`) for ~10 seconds until the rebuild completed.

## Why This Change Was Made

`sessions.list` treats transcript-derived title fields (derived title, last-message preview) as optional row decoration, but the title reader was the one consumer of the projection gate with no per-scope catch. The batched title probe already skips rebuilding sessions correctly — but a skipped probe falls back to the per-session widening reader `readSqliteTitleFields`, which hits `withCurrentProjectionSnapshot` and throws. Nothing caught it, so one rebuilding session failed the whole batch and the whole list RPC. Every sibling consumer of the gate (chat-history-handler, sessions-messaging, sessions-history-http, session-transcript-readers, plugin-sdk transcript runtime) already catches this error per-scope.

The fix adds one canonical catch at the owner — inside `readSqliteTitleFields` in `src/gateway/session-transcript-title-reader.ts` — returning null title fields for the rebuilding session without caching them. That single catch covers the batch fallback, the batch widening path, and both single-row readers used by `buildGatewaySessionRow`. Nulls are intentionally not cached so titles return on the next list after the reconcile (which the throwing read already schedules). The throw semantics of `withCurrentProjectionSnapshot` are untouched: chat/history readers keep their retryable signal.

## User Impact

The session list always renders. A session whose transcript projection is rebuilding shows its fallback title (id-prefix/display name) with no last-message preview for one list cycle, then self-heals; every other session is unaffected. Previously the whole sidebar failed for every connected client.

## Evidence

- Regression tests in `src/gateway/session-transcript-readers.test.ts`: batch degrade (one rebuilding + one healthy scope → no throw, healthy fields intact, null fields for the rebuilding one), self-heal after `waitForSessionTranscriptIndexReconcile` (proves nulls are not cached), and single-read degrade. All 25 tests pass; `session-utils.perf.test.ts` (3/3) stays green.
- Live proof against a session-owned dev gateway (isolated `OPENCLAW_STATE_DIR`, port 19311): seeded two sessions, set `needs_rebuild=1` on one via SQLite, called `sessions.list` with `includeDerivedTitles`/`includeLastMessage`:
  - during rebuild: list succeeded, rebuilding session returned fallback title + `lastMessagePreview: null`, healthy session returned real title/preview
  - after reconcile: rebuilding session's real title and preview returned (`derivedTitle: "rebuilding live prompt"`, `lastMessagePreview: "rebuilding live reply"`)
- Production diff is one file (`session-transcript-title-reader.ts`, net +11 lines: try/catch + contract comment); tests net +57.
