### PR TITLE
fix(gateway): leave sessions without human-derived titles untitled

### DIFF
--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -681,6 +681,30 @@ test("sessions.list ignores hidden internal abortable runs", async () => {
   );
 });
 
+test("sessions.list leaves failed-first-turn dashboard sessions untitled instead of an id-prefix title", async () => {
+  const sessionKey = "agent:main:dashboard:fade729d-1111-2222-3333-444455556666";
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      "dashboard:fade729d-1111-2222-3333-444455556666": sessionStoreEntry("sess-dash-untitled"),
+    },
+  });
+  await seedSessionTranscript({
+    sessionId: "sess-dash-untitled",
+    sessionKey,
+    storePath,
+    messages: [{ role: "assistant", content: "The first turn failed before a user message." }],
+  });
+
+  const { respond } = await invokeSessionsList({
+    requestId: "req-sessions-list-untitled-dashboard",
+    params: { includeDerivedTitles: true },
+  });
+
+  const session = findSession(expectRespondPayload(respond), sessionKey);
+  expect(session.derivedTitle).toBeUndefined();
+});
+
 test("sessions.list yields before responding during bulk transcript hydration", async () => {
   const { storePath } = await createSessionStoreDir();
   const entries: Record<string, ReturnType<typeof sessionStoreEntry>> = {};

--- a/src/gateway/session-title-inbound-metadata.test.ts
+++ b/src/gateway/session-title-inbound-metadata.test.ts
@@ -74,10 +74,10 @@ describe("session titles with inbound Gateway metadata", () => {
     },
   );
 
-  test("falls back to the session id when the first message contains only metadata", () => {
+  test("does not derive a title when the first message contains only metadata", () => {
     const entry: SessionEntry = { sessionId: "abcd1234-rest-of-session", updatedAt: 0 };
 
-    expect(deriveSessionTitle(entry, senderMetadata)).toBe("abcd1234");
+    expect(deriveSessionTitle(entry, senderMetadata)).toBeUndefined();
   });
 
   test("preserves unmarked sender-like user text", () => {

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -27,16 +27,6 @@ import type { GatewaySessionRow } from "./session-utils.types.js";
 
 const DERIVED_TITLE_MAX_LEN = 60;
 
-function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
-  const prefix = sessionId.slice(0, 8);
-  if (updatedAt && updatedAt > 0) {
-    const d = new Date(updatedAt);
-    const date = d.toISOString().slice(0, 10);
-    return `${prefix} (${date})`;
-  }
-  return prefix;
-}
-
 function truncateTitle(text: string, maxLen: number): string {
   if (text.length <= maxLen) {
     return text;
@@ -83,10 +73,8 @@ export function deriveSessionTitle(
     return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
   }
 
-  if (entry.sessionId) {
-    return formatSessionIdPrefix(entry.sessionId, entry.updatedAt);
-  }
-
+  // Derived titles are human content only; UI/TUI/ACP own key-based fallbacks,
+  // which an id prefix here would mask.
   return undefined;
 }
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -3372,22 +3372,15 @@ describe("deriveSessionTitle", () => {
     expect(result.includes("  ")).toBe(false);
   });
 
-  test("falls back to sessionId prefix with date", () => {
+  test("leaves a failed dashboard thread untitled so the UI can render New thread", () => {
     const entry = {
       sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
       updatedAt: new Date("2024-03-15T10:30:00Z").getTime(),
     } as SessionEntry;
-    const result = deriveSessionTitle(entry);
-    expect(result).toBe("abcd1234 (2024-03-15)");
-  });
 
-  test("falls back to sessionId prefix without date when updatedAt missing", () => {
-    const entry = {
-      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
-      updatedAt: 0,
-    } as SessionEntry;
-    const result = deriveSessionTitle(entry);
-    expect(result).toBe("abcd1234");
+    expect(deriveSessionTitle(entry)).toBeUndefined();
+    expect(deriveSessionTitle(entry, "")).toBeUndefined();
+    expect(deriveSessionTitle(entry, "   ")).toBeUndefined();
   });
 
   test("trims whitespace from displayName", () => {

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -45,8 +45,15 @@ describe("resolveSessionDisplayName", () => {
   });
 
   it("falls back to a friendly name for dashboard sessions instead of the uuid key", () => {
+    const key = "agent:main:dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6d";
+
+    expect(resolveSessionDisplayName(key)).toBe("New thread");
     expect(
-      resolveSessionDisplayName("agent:main:dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6d"),
+      resolveSessionDisplayName(key, {
+        label: undefined,
+        displayName: undefined,
+        derivedTitle: undefined,
+      }),
     ).toBe("New thread");
   });
 


### PR DESCRIPTION
## What Problem This Solves

A new dashboard chat thread whose first turn failed (no label, no displayName, no subject, and no user message on the active transcript path) rendered a raw machine title like `fade729d (2026-08-07)` in the Control UI sidebar and session list. Observed live on claw.steipete.dev on 2026-08-06. The UI already has a proper "New thread" fallback for dashboard keys (`ui/src/lib/session-display.ts`), but it never rendered because the server's non-empty `derivedTitle` always wins in `resolveSessionDisplayName`.

## Why This Change Was Made

Root cause: `deriveSessionTitle` (`src/gateway/session-utils-core.ts`) fell back to an 8-hex session-id prefix plus date when nothing human-meaningful existed. That id-prefix fallback masked every consumer's own key-based fallback. Derived titles are human content only; when no label/displayName/subject/first-user-message exists, the function now returns `undefined` and each consumer's existing fallback owns the empty case:

- Control UI: dashboard keys render "New thread"; other kinds keep their per-kind fallbacks (`parseSessionKey`)
- TUI session picker: falls back to the formatted session key
- ACP translator/presentation: falls back through displayName → label → key
- `/name` suggestion, watched-sessions prompt, sessions_list tool, MCP channel projection: title simply omitted

No dashboard-specific special case was added to core; the fix is the generic removal of the id-prefix fallback (deleted `formatSessionIdPrefix`, net −12 production LOC).

## User Impact

Dashboard threads with a failed first turn now show "New thread" instead of an opaque hex/date string. No consumer surface regresses: every `derivedTitle` reader already tolerated `undefined`.

## Evidence

Live ephemeral-gateway proof (isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_WORKSPACE_DIR`, loopback port 49386, dashboard session seeded via `sessions.create` + assistant-only `chat.inject`, then `sessions.list includeDerivedTitles:true`):

```json
{
  "fixed": true,
  "sessionKey": "agent:main:dashboard:fade729d-1111-2222-3333-444455556666",
  "derivedTitle": null,
  "gatewayPort": 49386,
  "rawSessionRow": {
    "key": "agent:main:dashboard:fade729d-1111-2222-3333-444455556666",
    "label": null,
    "displayName": null,
    "derivedTitle": null
  },
  "notes": "sessions.list omitted label, displayName, and derivedTitle; assistant-only transcript present via lastMessagePreview; Control UI dashboard-key fallback renders New thread."
}
```

Tests (all green via `node scripts/run-vitest.mjs`):

- `src/gateway/session-utils.test.ts` (159) — regression test: failed dashboard thread stays untitled
- `src/gateway/server.sessions.list-changed.test.ts` (34) — new RPC-boundary regression test at the sessions.list seam
- `src/gateway/session-title-inbound-metadata.test.ts` (7) — metadata-only first message yields no title
- `ui/src/lib/session-display.test.ts` (14) — dashboard key + empty row resolves to "New thread"
- Consumer suites: `commands-name.test.ts`, `watched-sessions-prompt.test.ts`, `server.sessions.list-store-materialization.test.ts`

Codex autoreview (gpt-5.6-sol, high): clean, no accepted/actionable findings.
