### PR TITLE
fix(release): refresh 2026.6.35 SDK API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-65d076e75378a41b99387e8e63688791b59fd0b8c32c8ba43ae1d73373db364c  plugin-sdk-api-baseline.json
-f7cbee9e03763aa559d8ac0f6c8e8bf8cfb2d23301eb66cf84df93360bc99c83  plugin-sdk-api-baseline.jsonl
+646ce7f675c0d9a0131efd50ea7a723bf939178a0f5e6dfef2692075cacf4c4a  plugin-sdk-api-baseline.json
+3cb24791192635813d140073899cc472ff1a65a05ca4646fb69e2633edbc2f07  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Resolves the 2026.6.35 npm preflight failure caused by an outdated generated Plugin SDK API baseline after the approved image-provider hardening backport.

## Why This Change Was Made

The release commit intentionally exports `resolveInlineImageJsonResponseMaxBytes` through the public Plugin SDK image-generation entrypoint. This refreshes only the tracked generated hashes for that exact API surface.

## User Impact

No runtime or package behavior changes. The release candidate can complete its npm preflight with an API baseline that matches the shipped SDK.

## Evidence

- Compared the generated manifests to the published 2026.6.34 baseline: exactly one public export was added.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `node --max-old-space-size=8192 scripts/plugin-sdk-surface-report.mjs --check`
- Fresh autoreview: no actionable findings.