### PR TITLE
fix(gateway): show New thread for empty dashboard sessions

### DIFF
--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -19,6 +19,7 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { isDashboardSessionKey } from "../sessions/session-key-utils.js";
 import {
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
@@ -90,10 +91,6 @@ function shouldInspectStoredSubagentEnvelope(sessionKey: string): boolean {
   // ACP session keys can represent resumed subagents only when their persisted
   // envelope carries subagent metadata or points back to a subagent parent.
   return isSubagentSessionKey(sessionKey) || isAcpSessionKey(sessionKey);
-}
-
-function isDashboardSessionKey(sessionKey: string): boolean {
-  return parseAgentSessionKey(sessionKey)?.rest.startsWith("dashboard:") === true;
 }
 
 function canInspectStoredSubagentEnvelope(

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -430,6 +430,8 @@ export function createSessionsListTool(opts?: {
               target.row.derivedTitle = deriveSessionTitle(
                 target.titleEntry,
                 fields.firstUserMessage,
+                undefined,
+                target.sessionKey,
               );
             }
             if (includeLastMessage && fields.lastMessagePreview) {

--- a/src/agents/watched-sessions-prompt.ts
+++ b/src/agents/watched-sessions-prompt.ts
@@ -77,7 +77,7 @@ export function prepareWatchedSessionsPrompt(params: {
     // Exact persisted-key probe: watch cursors store canonical keys, so the
     // alias-resolving loader's full-snapshot scan is wasted work here.
     const entry = loadExactSessionEntryReadOnly({ sessionKey: key, clone: false })?.entry;
-    const title = deriveSessionTitle(entry);
+    const title = deriveSessionTitle(entry, undefined, undefined, key);
     if (title) {
       row.title = truncateUtf16Safe(title, WATCHED_SESSION_TITLE_MAX_CHARS);
     }

--- a/src/auto-reply/reply/commands-name.ts
+++ b/src/auto-reply/reply/commands-name.ts
@@ -58,7 +58,12 @@ export const handleNameCommand: CommandHandler = defineAuthorizedTextCommand(
         params.sessionEntry;
       const current = normalizeOptionalString(entry?.label);
       const suggestionEntry = entry ? { ...entry, label: undefined } : undefined;
-      const suggestion = deriveSessionTitle(suggestionEntry);
+      const suggestion = deriveSessionTitle(
+        suggestionEntry,
+        undefined,
+        undefined,
+        params.sessionKey,
+      );
       const lines: string[] = [];
       lines.push(
         current ? `Current session name: ${current}` : "This session has no custom name yet.",

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -8,7 +8,7 @@ import { generateConversationLabelWithFallback } from "../auto-reply/reply/conve
 import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { isDashboardSessionKey } from "../sessions/session-key-utils.js";
 import { getOrCreatePromise } from "../shared/lazy-promise.js";
 
 type DashboardSessionTitleModelEntry = Pick<
@@ -41,10 +41,6 @@ export function hasExplicitSessionName(entry: SessionEntry | undefined): boolean
     entry?.groupChannel?.trim() ||
     entry?.space?.trim(),
   );
-}
-
-function isDashboardSessionKey(sessionKey: string): boolean {
-  return parseAgentSessionKey(sessionKey)?.rest.startsWith("dashboard:") === true;
 }
 
 export function isDashboardSessionTitleCandidate(params: {

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -681,30 +681,6 @@ test("sessions.list ignores hidden internal abortable runs", async () => {
   );
 });
 
-test("sessions.list leaves failed-first-turn dashboard sessions untitled instead of an id-prefix title", async () => {
-  const sessionKey = "agent:main:dashboard:fade729d-1111-2222-3333-444455556666";
-  const { storePath } = await createSessionStoreDir();
-  await writeSessionStore({
-    entries: {
-      "dashboard:fade729d-1111-2222-3333-444455556666": sessionStoreEntry("sess-dash-untitled"),
-    },
-  });
-  await seedSessionTranscript({
-    sessionId: "sess-dash-untitled",
-    sessionKey,
-    storePath,
-    messages: [{ role: "assistant", content: "The first turn failed before a user message." }],
-  });
-
-  const { respond } = await invokeSessionsList({
-    requestId: "req-sessions-list-untitled-dashboard",
-    params: { includeDerivedTitles: true },
-  });
-
-  const session = findSession(expectRespondPayload(respond), sessionKey);
-  expect(session.derivedTitle).toBeUndefined();
-});
-
 test("sessions.list yields before responding during bulk transcript hydration", async () => {
   const { storePath } = await createSessionStoreDir();
   const entries: Record<string, ReturnType<typeof sessionStoreEntry>> = {};
@@ -753,6 +729,31 @@ test("sessions.list yields before responding during bulk transcript hydration", 
     derivedTitle: "title 0",
     lastMessagePreview: "last 0",
   });
+});
+
+test("sessions.list omits a derived title for a failed empty dashboard thread", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      "dashboard:failed-turn": sessionStoreEntry("fade729d-failed-turn", {
+        updatedAt: new Date("2026-08-07T01:00:00Z").getTime(),
+      }),
+    },
+  });
+  await seedSessionTranscript({
+    sessionId: "fade729d-failed-turn",
+    sessionKey: "agent:main:dashboard:failed-turn",
+    storePath,
+    messages: [{ role: "assistant", content: "The first turn failed before user persistence." }],
+  });
+
+  const { respond } = await invokeSessionsList({
+    requestId: "req-sessions-list-empty-dashboard-title",
+    params: { includeDerivedTitles: true },
+  });
+
+  const session = findSession(expectRespondPayload(respond), "agent:main:dashboard:failed-turn");
+  expect(session.derivedTitle).toBeUndefined();
 });
 
 test("sessions.list does not block on slow model catalog discovery", async () => {

--- a/src/gateway/session-title-inbound-metadata.test.ts
+++ b/src/gateway/session-title-inbound-metadata.test.ts
@@ -74,10 +74,12 @@ describe("session titles with inbound Gateway metadata", () => {
     },
   );
 
-  test("does not derive a title when the first message contains only metadata", () => {
+  test("falls back to the session id when the first message contains only metadata", () => {
     const entry: SessionEntry = { sessionId: "abcd1234-rest-of-session", updatedAt: 0 };
 
-    expect(deriveSessionTitle(entry, senderMetadata)).toBeUndefined();
+    expect(
+      deriveSessionTitle(entry, senderMetadata, undefined, "agent:main:telegram:direct:42"),
+    ).toBe("abcd1234");
   });
 
   test("preserves unmarked sender-like user text", () => {

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -12,6 +12,7 @@ import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js"
 import { isTerminalSessionStatus, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { isDashboardSessionKey } from "../sessions/session-key-utils.js";
 import { resolveNonNegativeNumber } from "../shared/number-coercion.js";
 import { truncateUtf16Safe } from "../utils.js";
 import {
@@ -26,6 +27,16 @@ import {
 import type { GatewaySessionRow } from "./session-utils.types.js";
 
 const DERIVED_TITLE_MAX_LEN = 60;
+
+function formatSessionIdPrefix(sessionId: string, updatedAt?: number | null): string {
+  const prefix = sessionId.slice(0, 8);
+  if (updatedAt && updatedAt > 0) {
+    const d = new Date(updatedAt);
+    const date = d.toISOString().slice(0, 10);
+    return `${prefix} (${date})`;
+  }
+  return prefix;
+}
 
 function truncateTitle(text: string, maxLen: number): string {
   if (text.length <= maxLen) {
@@ -43,6 +54,7 @@ export function deriveSessionTitle(
   entry: SessionEntry | undefined,
   firstUserMessage?: string | null,
   externalDisplayName?: string | null,
+  sessionKey?: string,
 ): string | undefined {
   if (!entry) {
     return undefined;
@@ -73,8 +85,14 @@ export function deriveSessionTitle(
     return truncateTitle(normalized, DERIVED_TITLE_MAX_LEN);
   }
 
-  // Derived titles are human content only; UI/TUI/ACP own key-based fallbacks,
-  // which an id prefix here would mask.
+  if (sessionKey && isDashboardSessionKey(sessionKey)) {
+    return undefined;
+  }
+
+  if (entry.sessionId) {
+    return formatSessionIdPrefix(entry.sessionId, entry.updatedAt);
+  }
+
   return undefined;
 }
 

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -590,7 +590,12 @@ export async function listSessionsFromStoreAsync(
         );
         transcriptFieldIndex += 1;
         if (list.includeDerivedTitles) {
-          row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage, row.displayName);
+          row.derivedTitle = deriveSessionTitle(
+            entry,
+            fields.firstUserMessage,
+            row.displayName,
+            key,
+          );
         }
         if (list.includeLastMessage && fields.lastMessagePreview) {
           row.lastMessagePreview = fields.lastMessagePreview;

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -28,6 +28,7 @@ import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.j
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import { resolveActiveSessionAgentStatus } from "../sessions/session-agent-status.js";
+import { isDashboardSessionKey } from "../sessions/session-key-utils.js";
 import { resolveNonNegativeNumber } from "../shared/number-coercion.js";
 import { getUserProfileListItem } from "../state/user-profiles.js";
 import { projectSessionDeliveryFields } from "../utils/delivery-context.shared.js";
@@ -140,7 +141,7 @@ export function buildGatewaySessionRow(params: {
   const origin = deliveryFields.origin;
   const originLabel = origin?.label;
   const parsedAgent = parseAgentSessionKey(key);
-  const isDashboardSession = parsedAgent?.rest.startsWith("dashboard:") === true;
+  const isDashboardSession = isDashboardSessionKey(key);
   const isGroupSession = isGroupOrChannelDisplaySession(entry, parsed);
   // A user-assigned label is an explicit rename; it must win over stored
   // channel-derived display names or renames silently vanish on refresh.
@@ -371,7 +372,7 @@ export function buildGatewaySessionRow(params: {
       storePath,
     });
     if (params.includeDerivedTitles) {
-      derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage, displayName);
+      derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage, displayName, key);
     }
     if (params.includeLastMessage && fields.lastMessagePreview) {
       lastMessagePreview = fields.lastMessagePreview;

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -3372,15 +3372,54 @@ describe("deriveSessionTitle", () => {
     expect(result.includes("  ")).toBe(false);
   });
 
-  test("leaves a failed dashboard thread untitled so the UI can render New thread", () => {
+  test("falls back to sessionId prefix with date for non-dashboard sessions", () => {
     const entry = {
       sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
       updatedAt: new Date("2024-03-15T10:30:00Z").getTime(),
     } as SessionEntry;
+    const result = deriveSessionTitle(entry, undefined, undefined, "agent:main:telegram:direct:42");
+    expect(result).toBe("abcd1234 (2024-03-15)");
+  });
 
-    expect(deriveSessionTitle(entry)).toBeUndefined();
-    expect(deriveSessionTitle(entry, "")).toBeUndefined();
-    expect(deriveSessionTitle(entry, "   ")).toBeUndefined();
+  test("omits the sessionId fallback for an empty dashboard session", () => {
+    const entry = {
+      sessionId: "fade729d-5678-90ef-ghij-klmnopqrstuv",
+      updatedAt: new Date("2026-08-07T01:00:00Z").getTime(),
+    } as SessionEntry;
+
+    expect(
+      deriveSessionTitle(entry, undefined, undefined, "agent:main:dashboard:failed-turn"),
+    ).toBeUndefined();
+  });
+
+  test("uses the first user message for a dashboard session", () => {
+    const entry = {
+      sessionId: "fade729d-5678-90ef-ghij-klmnopqrstuv",
+      updatedAt: new Date("2026-08-07T01:00:00Z").getTime(),
+    } as SessionEntry;
+
+    expect(
+      deriveSessionTitle(
+        entry,
+        "Help me recover the failed turn",
+        undefined,
+        "agent:main:dashboard:failed-turn",
+      ),
+    ).toBe("Help me recover the failed turn");
+  });
+
+  test("falls back to sessionId prefix without date when updatedAt missing", () => {
+    const entry = {
+      sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
+      updatedAt: 0,
+    } as SessionEntry;
+    const result = deriveSessionTitle(
+      entry,
+      undefined,
+      undefined,
+      "agent:main:telegram:direct:42",
+    );
+    expect(result).toBe("abcd1234");
   });
 
   test("trims whitespace from displayName", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -3413,12 +3413,7 @@ describe("deriveSessionTitle", () => {
       sessionId: "abcd1234-5678-90ef-ghij-klmnopqrstuv",
       updatedAt: 0,
     } as SessionEntry;
-    const result = deriveSessionTitle(
-      entry,
-      undefined,
-      undefined,
-      "agent:main:telegram:direct:42",
-    );
+    const result = deriveSessionTitle(entry, undefined, undefined, "agent:main:telegram:direct:42");
     expect(result).toBe("abcd1234");
   });
 

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -278,6 +278,10 @@ export function parseAgentSessionKey(
   return { agentId, rest };
 }
 
+export function isDashboardSessionKey(sessionKey: string): boolean {
+  return parseAgentSessionKey(sessionKey)?.rest.startsWith("dashboard:") === true;
+}
+
 export function isCronRunSessionKey(sessionKey: string | undefined | null): boolean {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -55,6 +55,7 @@ describe("resolveSessionDisplayName", () => {
         derivedTitle: undefined,
       }),
     ).toBe("New thread");
+    expect(resolveSessionDisplayName(key, { derivedTitle: null })).toBe("New thread");
   });
 
   it("names unnamed work sessions after their checkout", () => {

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -103,7 +103,7 @@ function typedSessionPrefix(kind: SessionTypedKind): string {
 type SessionDisplayRow = {
   label?: string;
   displayName?: string;
-  derivedTitle?: string;
+  derivedTitle?: string | null;
 } & SessionWorktreeDisplayRow;
 
 type SessionDisplayOptions = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a new dashboard thread showed a raw session-id prefix and date when its first turn failed before any user message or explicit title was stored.

## Why This Change Was Made

Empty dashboard sessions now omit the server-derived id-prefix title so the web UI can use its existing friendly `New thread` fallback. Other session surfaces keep the existing id-prefix fallback, and title consumers continue to handle the optional value explicitly.

## User Impact

Users see `New thread` in the web sidebar for empty or failed dashboard threads instead of an opaque identifier such as `fade729d (2026-08-07)`. Dashboard threads with a user message and non-dashboard sessions retain their existing titles.

## Evidence

- Live incident observation: on claw.steipete.dev on 2026-08-06, after a failed first turn, the sidebar showed `fade729d (2026-08-07)`.
- Focused gateway tests: 196 passed across `src/gateway/session-utils.test.ts` and `src/gateway/server.sessions.list-changed.test.ts`.
- Focused UI tests: 14 passed in `ui/src/lib/session-display.test.ts`.
- Adjacent dashboard-title and title-consumer suites: 53 passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs`: passed across core, coreTests, and UI, including formatting, types, lint, and guards.
- `git diff --check`: passed.

The repaired browser behavior was not claimed as live proof because no preview deployment for this branch was available.
