### PR TITLE
fix(gateway): heal session list after projection rebuild

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -2,6 +2,7 @@ import type { SessionsListParams } from "../../../packages/gateway-protocol/src/
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import { isGatewayAdmin } from "../session-sharing.js";
+import { readSessionTitleProjectionUnavailableVersion } from "../session-transcript-title-reader.js";
 import type { SessionsListResult } from "../session-utils.types.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { readSessionsMutationVersion } from "./session-change-event.js";
@@ -10,6 +11,7 @@ import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js
 type SessionListFence = {
   agentRunIndexVersion: number;
   sessionsMutationVersion: number;
+  titleProjectionUnavailableVersion: number;
 };
 type SessionListOperation = SessionListFence & { promise: Promise<SessionsListResult> };
 type SessionListCompleted = SessionListFence & { expiresAt?: number; result: SessionsListResult };
@@ -26,13 +28,15 @@ function readSessionListFence(context: GatewayRequestContext): SessionListFence 
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
     sessionsMutationVersion: readSessionsMutationVersion(context),
+    titleProjectionUnavailableVersion: readSessionTitleProjectionUnavailableVersion(),
   };
 }
 
 function matchesSessionListFence(value: SessionListFence, fence: SessionListFence): boolean {
   return (
     value.agentRunIndexVersion === fence.agentRunIndexVersion &&
-    value.sessionsMutationVersion === fence.sessionsMutationVersion
+    value.sessionsMutationVersion === fence.sessionsMutationVersion &&
+    value.titleProjectionUnavailableVersion === fence.titleProjectionUnavailableVersion
   );
 }
 

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -6,12 +6,15 @@ import {
 } from "../../agents/subagent-registry.test-helpers.js";
 import {
   loadSessionEntry,
+  persistSessionTranscriptTurn,
   replaceSessionEntry,
   upsertSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { waitForSessionTranscriptIndexReconcile } from "../../config/sessions/session-transcript-reconcile.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { GatewaySessionRow } from "../session-utils.types.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
@@ -236,6 +239,53 @@ describe("sessions.list single-flight", () => {
 
       emitSessionsChanged(context, { reason: "test", sessionKey: "agent:main:active" });
       await listSessions({ client, context, request });
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not cache title rows degraded during projection rebuild", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const config = await seedSessions();
+      const sessionKey = "agent:main:active";
+      const sessionId = "main-active";
+      await persistSessionTranscriptTurn(
+        { agentId: "main", sessionId, sessionKey },
+        {
+          messages: [
+            { message: { role: "user", content: "active prompt" } },
+            { message: { role: "assistant", content: "active reply" } },
+          ],
+          touchSessionEntry: false,
+        },
+      );
+      const database = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
+      database.db
+        .prepare("UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?")
+        .run(sessionId);
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = {
+        agentId: "main",
+        archived: "all" as const,
+        includeDerivedTitles: true,
+        includeLastMessage: true,
+        limit: 100,
+      };
+
+      const degraded = await listSessions({ client, context, request });
+      const degradedRow = degraded.sessions.find((session) => session.key === sessionKey);
+      expect(degradedRow?.derivedTitle).not.toBe("active prompt");
+      expect(degradedRow?.lastMessagePreview).toBeUndefined();
+
+      await waitForSessionTranscriptIndexReconcile({ agentId: "main", env: state.env });
+      const healed = await listSessions({ client, context, request });
+      expect(healed.sessions.find((session) => session.key === sessionKey)).toMatchObject({
+        derivedTitle: "active prompt",
+        lastMessagePreview: "active reply",
+      });
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+
+      expect(await listSessions({ client, context, request })).toBe(healed);
       expect(loader.calls).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -458,36 +458,6 @@ describe("session transcript reader facade", () => {
     ]);
   });
 
-  test("degrades batch title fields per rebuilding projection and restores them afterward", async () => {
-    const healthyScope = await writeSqliteMessages("reader-title-batch-healthy", [
-      { role: "user", content: "healthy prompt" },
-      { role: "assistant", content: "healthy reply" },
-    ]);
-    const rebuildingScope = await writeSqliteMessages("reader-title-batch-rebuilding", [
-      { role: "user", content: "rebuilding prompt" },
-      { role: "assistant", content: "rebuilding reply" },
-    ]);
-    markProjectionNeedsRebuild(rebuildingScope.sessionId);
-
-    let fields: ReturnType<typeof readSessionTitleFieldsFromTranscriptBatch> | undefined;
-    try {
-      fields = readSessionTitleFieldsFromTranscriptBatch([healthyScope, rebuildingScope]);
-    } finally {
-      await waitForSessionTranscriptIndexReconcile({
-        agentId: "main",
-        path: path.join(tempDir, "openclaw-agent.sqlite"),
-      });
-    }
-    expect(fields).toEqual([
-      { firstUserMessage: "healthy prompt", lastMessagePreview: "healthy reply" },
-      { firstUserMessage: null, lastMessagePreview: null },
-    ]);
-    expect(readSessionTitleFieldsFromTranscript(rebuildingScope)).toEqual({
-      firstUserMessage: "rebuilding prompt",
-      lastMessagePreview: "rebuilding reply",
-    });
-  });
-
   test("degrades single title reads while the projection rebuilds", async () => {
     const scope = await writeSqliteMessages("reader-title-single-rebuilding", [
       { role: "user", content: "single prompt" },
@@ -508,6 +478,170 @@ describe("session transcript reader facade", () => {
       firstUserMessage: null,
       lastMessagePreview: null,
     });
+  });
+
+  test("isolates a rebuilding projection to one title row and heals on refresh", async () => {
+    const scopes: SessionTranscriptReadScope[] = [];
+    for (const label of ["first", "rebuilding", "last"]) {
+      scopes.push(
+        await writeSqliteMessages(`reader-title-${label}`, [
+          { role: "user", content: `${label} prompt` },
+          { role: "assistant", content: `${label} reply` },
+        ]),
+      );
+    }
+    const databasePath = path.join(tempDir, "openclaw-agent.sqlite");
+    openOpenClawAgentDatabase({ agentId: "main", path: databasePath })
+      .db.prepare(
+        "UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?",
+      )
+      .run("reader-title-rebuilding");
+
+    expect(readSessionTitleFieldsFromTranscriptBatch(scopes)).toEqual([
+      { firstUserMessage: "first prompt", lastMessagePreview: "first reply" },
+      { firstUserMessage: null, lastMessagePreview: null },
+      { firstUserMessage: "last prompt", lastMessagePreview: "last reply" },
+    ]);
+
+    await waitForSessionTranscriptIndexReconcile({ agentId: "main", path: databasePath });
+    expect(readSessionTitleFieldsFromTranscriptBatch(scopes)).toEqual([
+      { firstUserMessage: "first prompt", lastMessagePreview: "first reply" },
+      { firstUserMessage: "rebuilding prompt", lastMessagePreview: "rebuilding reply" },
+      { firstUserMessage: "last prompt", lastMessagePreview: "last reply" },
+    ]);
+  });
+
+  test.each(["watermarkBatch", "titleProbeBatch", "watermark", "messageEventPage"] as const)(
+    "degrades only the unavailable scope when %s throws",
+    async (faultSource) => {
+      const actual = await vi.importActual<typeof import("../config/sessions/session-accessor.js")>(
+        "../config/sessions/session-accessor.js",
+      );
+      const brokenSessionId = `reader-title-${faultSource}-broken`;
+      const scopes: SessionTranscriptReadScope[] = [];
+      for (const label of ["first", "broken", "last"]) {
+        scopes.push(
+          await writeSqliteMessages(`reader-title-${faultSource}-${label}`, [
+            { role: "user", content: `${label} prompt` },
+            { role: "assistant", content: `${label} reply` },
+          ]),
+        );
+      }
+      if (faultSource === "watermarkBatch") {
+        readSessionTitleFieldsFromTranscriptBatch(scopes);
+      }
+
+      const watermarkBatch = vi.mocked(sessionAccessor.readSessionTranscriptWatermarkBatch);
+      const titleProbeBatch = vi.mocked(sessionAccessor.readSessionTranscriptTitleProbeBatch);
+      const watermark = vi.mocked(sessionAccessor.readSessionTranscriptWatermark);
+      const messageEventPage = vi.mocked(sessionAccessor.readSessionTranscriptMessageEventPage);
+      const unavailable = () =>
+        new sessionAccessor.SessionTranscriptProjectionUnavailableError(brokenSessionId);
+      try {
+        if (faultSource === "watermarkBatch") {
+          watermarkBatch.mockImplementation((readScopes) => {
+            if (readScopes.some((scope) => scope.sessionId === brokenSessionId)) {
+              throw unavailable();
+            }
+            return actual.readSessionTranscriptWatermarkBatch(readScopes);
+          });
+          watermark.mockImplementation((scope) => {
+            if (scope.sessionId === brokenSessionId) {
+              throw unavailable();
+            }
+            return actual.readSessionTranscriptWatermark(scope);
+          });
+        } else if (faultSource === "titleProbeBatch") {
+          titleProbeBatch.mockImplementation((readScopes) => {
+            if (readScopes.some((scope) => scope.sessionId === brokenSessionId)) {
+              throw unavailable();
+            }
+            return actual.readSessionTranscriptTitleProbeBatch(readScopes);
+          });
+          messageEventPage.mockImplementation((scope, options) => {
+            if (scope.sessionId === brokenSessionId) {
+              throw unavailable();
+            }
+            return actual.readSessionTranscriptMessageEventPage(scope, options);
+          });
+        } else {
+          titleProbeBatch.mockImplementation((readScopes) =>
+            actual
+              .readSessionTranscriptTitleProbeBatch(readScopes)
+              .map((probe, index) =>
+                readScopes[index]?.sessionId === brokenSessionId ? undefined : probe,
+              ),
+          );
+          if (faultSource === "watermark") {
+            watermark.mockImplementation((scope) => {
+              if (scope.sessionId === brokenSessionId) {
+                throw unavailable();
+              }
+              return actual.readSessionTranscriptWatermark(scope);
+            });
+          } else {
+            messageEventPage.mockImplementation((scope, options) => {
+              if (scope.sessionId === brokenSessionId) {
+                throw unavailable();
+              }
+              return actual.readSessionTranscriptMessageEventPage(scope, options);
+            });
+          }
+        }
+
+        expect(readSessionTitleFieldsFromTranscriptBatch(scopes)).toEqual([
+          { firstUserMessage: "first prompt", lastMessagePreview: "first reply" },
+          { firstUserMessage: null, lastMessagePreview: null },
+          { firstUserMessage: "last prompt", lastMessagePreview: "last reply" },
+        ]);
+      } finally {
+        watermarkBatch.mockImplementation(actual.readSessionTranscriptWatermarkBatch);
+        titleProbeBatch.mockImplementation(actual.readSessionTranscriptTitleProbeBatch);
+        watermark.mockImplementation(actual.readSessionTranscriptWatermark);
+        messageEventPage.mockImplementation(actual.readSessionTranscriptMessageEventPage);
+      }
+    },
+  );
+
+  test("isolates a batch failure when separate scopes share a session id", async () => {
+    const actual = await vi.importActual<typeof import("../config/sessions/session-accessor.js")>(
+      "../config/sessions/session-accessor.js",
+    );
+    const sessionId = "reader-title-duplicate-session-id";
+    const scopes = [
+      { agentId: "main", sessionId, sessionKey: "agent:main:duplicate-title" },
+      { agentId: "work", sessionId, sessionKey: "agent:work:duplicate-title" },
+    ];
+    for (const [index, scope] of scopes.entries()) {
+      await persistSessionTranscriptTurn(scope, {
+        messages: [
+          { message: { role: "user", content: `prompt ${index}` } },
+          { message: { role: "assistant", content: `reply ${index}` } },
+        ],
+        touchSessionEntry: false,
+      });
+    }
+    const titleProbeBatch = vi.mocked(sessionAccessor.readSessionTranscriptTitleProbeBatch);
+    const messageEventPage = vi.mocked(sessionAccessor.readSessionTranscriptMessageEventPage);
+    try {
+      titleProbeBatch.mockImplementation(() => {
+        throw new sessionAccessor.SessionTranscriptProjectionUnavailableError(sessionId);
+      });
+      messageEventPage.mockImplementation((scope, options) => {
+        if (scope.agentId === "work") {
+          throw new sessionAccessor.SessionTranscriptProjectionUnavailableError(sessionId);
+        }
+        return actual.readSessionTranscriptMessageEventPage(scope, options);
+      });
+
+      expect(readSessionTitleFieldsFromTranscriptBatch(scopes)).toEqual([
+        { firstUserMessage: "prompt 0", lastMessagePreview: "reply 0" },
+        { firstUserMessage: null, lastMessagePreview: null },
+      ]);
+    } finally {
+      titleProbeBatch.mockImplementation(actual.readSessionTranscriptTitleProbeBatch);
+      messageEventPage.mockImplementation(actual.readSessionTranscriptMessageEventPage);
+    }
   });
 
   test("bounds title probe reads independently of transcript length", async () => {

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -491,11 +491,7 @@ describe("session transcript reader facade", () => {
       );
     }
     const databasePath = path.join(tempDir, "openclaw-agent.sqlite");
-    openOpenClawAgentDatabase({ agentId: "main", path: databasePath })
-      .db.prepare(
-        "UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?",
-      )
-      .run("reader-title-rebuilding");
+    markProjectionNeedsRebuild("reader-title-rebuilding");
 
     expect(readSessionTitleFieldsFromTranscriptBatch(scopes)).toEqual([
       { firstUserMessage: "first prompt", lastMessagePreview: "first reply" },

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -25,6 +25,18 @@ type SessionTitleFields = {
   lastMessagePreview: string | null;
 };
 
+const EMPTY_SESSION_TITLE_FIELDS: SessionTitleFields = {
+  firstUserMessage: null,
+  lastMessagePreview: null,
+};
+// Degraded nulls advance the sessions.list cache fence so the completed result cannot
+// outlive the projection rebuild that made those title fields temporarily unavailable.
+let sessionTitleProjectionUnavailableVersion = 0;
+
+export function readSessionTitleProjectionUnavailableVersion(): number {
+  return sessionTitleProjectionUnavailableVersion;
+}
+
 // Session-list title probes must not scale with transcript size. Read at most
 // this many active-path messages from either end, widening only once.
 const SQLITE_TITLE_PROBE_INITIAL_MESSAGES = 20;
@@ -155,7 +167,8 @@ function readSqliteTitleFields(
     }
     // Titles are optional list decoration: degrade only this session while its projection rebuilds.
     // Do not cache nulls, so the next list can restore titles after reconciliation.
-    return { firstUserMessage: null, lastMessagePreview: null };
+    sessionTitleProjectionUnavailableVersion += 1;
+    return { ...EMPTY_SESSION_TITLE_FIELDS };
   }
   const fieldsByVariant =
     cached?.generation === watermark.generation && cached.maxSeq === watermark.maxSeq
@@ -166,8 +179,23 @@ function readSqliteTitleFields(
   return { ...fields };
 }
 
+function readSqliteTitleFieldsOrEmpty(
+  target: ResolvedTranscriptReadTarget,
+  opts?: { includeInterSession?: boolean },
+): SessionTitleFields {
+  try {
+    return readSqliteTitleFields(target, opts);
+  } catch (error) {
+    if (!isSessionTranscriptProjectionUnavailableError(error)) {
+      throw error;
+    }
+    sessionTitleProjectionUnavailableVersion += 1;
+    return { ...EMPTY_SESSION_TITLE_FIELDS };
+  }
+}
+
 /** Batch-hydrates list title fields once per store, with canonical widening only for misses. */
-export function readSessionTitleFieldsFromTranscriptBatch(
+function readSessionTitleFieldsFromTranscriptBatchCurrent(
   scopes: readonly SessionTranscriptReadScope[],
   opts?: { includeInterSession?: boolean },
 ): SessionTitleFields[] {
@@ -229,7 +257,7 @@ export function readSessionTitleFieldsFromTranscriptBatch(
   for (const [probeIndex, miss] of misses.entries()) {
     const probe = probes[probeIndex];
     if (!probe) {
-      results.set(miss.index, readSqliteTitleFields(miss.target, opts));
+      results.set(miss.index, readSqliteTitleFieldsOrEmpty(miss.target, opts));
       continue;
     }
     const cached = sqliteTitleFieldCache.get(miss.cacheKey);
@@ -245,7 +273,7 @@ export function readSessionTitleFieldsFromTranscriptBatch(
     const firstUser = findFirstTitleUserMessage(probe.head, opts?.includeInterSession === true);
     const lastText = findLastMessageText(probe.tail);
     if (probe.totalMessages > SQLITE_TITLE_PROBE_INITIAL_MESSAGES && (!firstUser || !lastText)) {
-      results.set(miss.index, readSqliteTitleFields(miss.target, opts));
+      results.set(miss.index, readSqliteTitleFieldsOrEmpty(miss.target, opts));
       continue;
     }
     const fields = {
@@ -274,12 +302,29 @@ export function readSessionTitleFieldsFromTranscriptBatch(
   });
 }
 
+/** Batch-hydrates list title fields while isolating a rebuilding projection to its session. */
+export function readSessionTitleFieldsFromTranscriptBatch(
+  scopes: readonly SessionTranscriptReadScope[],
+  opts?: { includeInterSession?: boolean },
+): SessionTitleFields[] {
+  try {
+    return readSessionTitleFieldsFromTranscriptBatchCurrent(scopes, opts);
+  } catch (error) {
+    if (!isSessionTranscriptProjectionUnavailableError(error)) {
+      throw error;
+    }
+    return scopes.map((scope) =>
+      readSqliteTitleFieldsOrEmpty(resolveTranscriptReadTarget(scope), opts),
+    );
+  }
+}
+
 /** Reads title and preview text from a transcript through the reader seam. */
 export function readSessionTitleFieldsFromTranscript(
   scope: SessionTranscriptReadScope,
   opts?: { includeInterSession?: boolean },
 ): SessionTitleFields {
-  return readSqliteTitleFields(resolveTranscriptReadTarget(scope), opts);
+  return readSqliteTitleFieldsOrEmpty(resolveTranscriptReadTarget(scope), opts);
 }
 
 /** Reads title and preview text asynchronously through the reader seam. */
@@ -287,5 +332,5 @@ export async function readSessionTitleFieldsFromTranscriptAsync(
   scope: SessionTranscriptReadScope,
   opts?: { includeInterSession?: boolean },
 ): Promise<SessionTitleFields> {
-  return readSqliteTitleFields(resolveTranscriptReadTarget(scope), opts);
+  return readSqliteTitleFieldsOrEmpty(resolveTranscriptReadTarget(scope), opts);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where one session whose SQLite transcript projection was rebuilding caused every `sessions.list` RPC to fail with `UNAVAILABLE`, blanking the entire session sidebar for all connected web clients.

Live incident evidence: on 2026-08-06 in clawstudio, session `fade729d-eb57-45ba` caused 118 `sessions.list` `UNAVAILABLE` failures while its transcript projection rebuilt.

## Why This Change Was Made

After #120159 added per-page title degradation on `main` while this PR's first CI run was active, this branch was rebased onto that canonical implementation. It completes the owner boundary for watermark and batch title-read failures: `SessionTranscriptProjectionUnavailableError` remains a per-scope title miss, healthy rows survive even when session IDs collide, unrelated errors still propagate, and the normal watermark/title-probe batch path remains intact.

A monotonic title-degradation fence prevents the completed `sessions.list` cache from retaining temporary null fields after the projection rebuild. The next identical refresh reruns the projection and can cache the healed result. Message and history readers still surface the retryable unavailable response because the accessor layer is unchanged.

## User Impact

The session sidebar remains populated when one transcript projection is rebuilding. Only that session temporarily loses its derived title and last-message preview, and a subsequent refresh restores them after the already-scheduled rebuild completes. List latency does not wait for or retry the rebuild.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/session-transcript-readers.test.ts src/gateway/session-utils.perf.test.ts src/gateway/session-utils.test.ts src/gateway/server-methods/sessions-read-cache.test.ts`
  - 4 test files passed, 213 tests passed after rebasing onto current `main`.
  - Covers a real three-session stale projection, next-refresh healing, all requested title-read seams, duplicate session IDs across scopes, and completed-cache bypass/healing.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs`
  - Passed the final `core` and `coreTests` changed gate, including formatting, production/test typechecks, lint, dependency and Plugin SDK guards, database-first storage checks, and runtime import-cycle checks.
  - The normal wrapper first attempted Crabbox/Testbox delegation; provider readiness failed because managed broker authentication was unavailable, so trusted-source validation used the repository-documented local fallback.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - Codex `gpt-5.6-sol` high review completed cleanly with no accepted/actionable findings; TruffleHog preflight was clean.

AI-assisted change; implementation and proof were reviewed against the affected owner, callers, sibling read paths, cache lifecycle, and projection error contract.
