### PR TITLE
fix(ci): allow frozen-target scenario omissions in candidate prep

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -420,6 +420,7 @@ jobs:
       include_live_suites: false
       enable_prepublish_plugin_registry: true
       published_upgrade_survivor_scenarios: ${{ (inputs.run_release_soak || inputs.release_profile == 'stable' || inputs.release_profile == 'full') && 'reported-issues' || '' }}
+      allow_frozen_target_scenario_omissions: ${{ inputs.target_context_ref != '' }}
       allow_unreleased_changelog: ${{ inputs.allow_unreleased_changelog || (inputs.target_context_ref == '' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')) }}
       release_test_profile: ${{ inputs.release_profile }}
       shared_image_artifact_namespace: full-release

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2442,6 +2442,9 @@ describe("package artifact reuse", () => {
     expect(prepare.with?.published_upgrade_survivor_scenarios).toBe(
       "${{ (inputs.run_release_soak || inputs.release_profile == 'stable' || inputs.release_profile == 'full') && 'reported-issues' || '' }}",
     );
+    expect(prepare.with?.allow_frozen_target_scenario_omissions).toBe(
+      "${{ inputs.target_context_ref != '' }}",
+    );
     expect(pluginDispatch.run).toContain(
       'args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")',
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves a failure when Full Release Validation prepares a canonical frozen release target whose upgrade-survivor scenario catalog predates new trusted workflow scenarios.

## Why This Change Was Made

The trusted workflow already permits those known omissions when it dispatches release checks. Candidate preparation now receives the same trusted opt-in only when a canonical target context is supplied.

## User Impact

Release validation can prepare older supported release candidates without silently dropping scenarios or requiring a runtime backport solely for new validation fixtures.

## Evidence

- Reproduced against extended-stable 2026.6.35: three newer survivor scenarios were absent from the frozen target.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` (157 passed)
- `git diff --check`
- Fresh autoreview: no actionable findings.