### PR TITLE
fix(matrix): bind E2EE readiness to client generations

### DIFF
--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -155,8 +155,8 @@ describe("shared Matrix client generations", () => {
     expect(repeatedFirstLease.client).toBe(firstClient);
     expect(secondLease.client).toBe(secondClient);
     expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
-    expect(firstCrypto.prepare).toHaveBeenCalledTimes(1);
-    expect(secondCrypto.prepare).toHaveBeenCalledTimes(1);
+    expect(firstCrypto.prepare).not.toHaveBeenCalled();
+    expect(secondCrypto.prepare).not.toHaveBeenCalled();
 
     await firstLease.release();
     expect(firstClient.stopAndPersist).not.toHaveBeenCalled();
@@ -732,6 +732,25 @@ describe("shared Matrix client generations", () => {
     await Promise.resolve();
     const replacement = await acquireSharedMatrixClient({ auth, startClient: false });
     expect(replacement.client).toBe(replacementClient);
+    await replacement.release({ mode: "discard" });
+  });
+
+  it("retires and replaces a generation whose startup fails", async () => {
+    const cause = new Error("crypto startup failed");
+    const firstClient = createMockClient("first");
+    const replacementClient = createMockClient("replacement");
+    firstClient.start.mockRejectedValue(cause);
+    createMatrixClientMock
+      .mockResolvedValueOnce(firstClient)
+      .mockResolvedValueOnce(replacementClient);
+    const auth = authFor("main");
+
+    await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
+    const replacement = await acquireSharedMatrixClient({ auth });
+
+    expect(replacement.client).toBe(replacementClient);
+    expect(firstClient.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    expect(replacementClient.start).toHaveBeenCalledTimes(1);
     await replacement.release({ mode: "discard" });
   });
 

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -4,7 +4,6 @@ import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { CoreConfig } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
-import { LogService } from "../sdk/logger.js";
 import { awaitMatrixStartupWithAbort } from "../startup-abort.js";
 import { resolveMatrixAuth, resolveMatrixAuthContext } from "./config.js";
 import type { MatrixAuth } from "./types.js";
@@ -50,7 +49,6 @@ type SharedMatrixClientState = {
   client: MatrixClient;
   key: string;
   started: boolean;
-  cryptoReady: boolean;
   startPromise: Promise<void> | null;
   phase: SharedMatrixClientPhase;
   leases: Set<SharedMatrixClientLeaseState>;
@@ -74,6 +72,7 @@ type SharedMatrixClientParams = {
 
 const sharedClientStates = new Map<string, SharedMatrixClientState>();
 const sharedClientPromises = new Map<string, Promise<SharedMatrixClientState>>();
+const replaceAfterRetirement = new WeakSet<SharedMatrixClientState>();
 
 function buildSharedClientKey(auth: MatrixAuth): string {
   // Serialize the tuple as a whole: Matrix URLs and credentials may contain `|`,
@@ -113,7 +112,6 @@ async function createSharedMatrixClient(params: {
     client,
     key: buildSharedClientKey(params.auth),
     started: false,
-    cryptoReady: false,
     startPromise: null,
     phase: "open",
     leases: new Set(),
@@ -145,21 +143,21 @@ async function ensureSharedClientStarted(
   }
 
   const startPromise = (async () => {
-    if (state.auth.encryption && !state.cryptoReady) {
-      try {
-        const joinedRooms = await state.client.getJoinedRooms();
-        if (state.client.crypto) {
-          await state.client.crypto.prepare(joinedRooms);
-          state.cryptoReady = true;
-        }
-      } catch (err) {
-        LogService.warn("MatrixClientLite", "Failed to prepare crypto:", err);
-      }
+    if (state.phase !== "open" || sharedClientStates.get(state.key) !== state) {
+      throw new Error("Matrix client generation is retiring");
     }
-
     await awaitMatrixStartupWithAbort(state.client.start({ abortSignal }), abortSignal);
+    if (state.phase !== "open" || sharedClientStates.get(state.key) !== state) {
+      throw new Error("Matrix client generation retired during startup");
+    }
     state.started = true;
-  })();
+  })().catch((error: unknown) => {
+    if (state.phase === "open") {
+      state.poisonError = toRetirementError(error);
+      replaceAfterRetirement.add(state);
+    }
+    throw error;
+  });
   const guardedStart = startPromise.finally(() => {
     if (state.startPromise === guardedStart) {
       state.startPromise = null;
@@ -204,15 +202,27 @@ async function resolveOpenSharedMatrixClientState(
 
   while (true) {
     const existing = sharedClientStates.get(key);
+    if (existing?.poisonError && !replaceAfterRetirement.has(existing)) {
+      throw existing.poisonError;
+    }
+    if (existing?.poisonError && !existing.retirementPromise) {
+      void beginGenerationRetirement({ state: existing }).catch(() => undefined);
+    }
+    if (existing?.retirementPromise) {
+      try {
+        await awaitMatrixStartupWithAbort(existing.retirementPromise, params.abortSignal);
+      } catch (error) {
+        if (!replaceAfterRetirement.has(existing)) {
+          throw error;
+        }
+      }
+      continue;
+    }
     if (existing?.poisonError) {
       throw existing.poisonError;
     }
     if (existing?.phase === "open") {
       return existing;
-    }
-    if (existing?.retirementPromise) {
-      await awaitMatrixStartupWithAbort(existing.retirementPromise, params.abortSignal);
-      continue;
     }
 
     const pending = sharedClientPromises.get(key);
@@ -348,8 +358,9 @@ function beginGenerationRetirement(params: {
   }
   state.phase = "quiescing";
   state.retirementPromise = Promise.resolve().then(async () => {
+    const deadlineMs = Date.now() + 10_000;
     try {
-      await state.client.quiesceSync();
+      await state.client.quiesceSync({ deadlineMs });
       state.started = false;
       await state.client.drainPendingDecryptions("matrix monitor sync quiesce");
     } catch (error) {
@@ -375,6 +386,9 @@ function beginGenerationRetirement(params: {
         .drainPendingDecryptions("matrix poisoned client shutdown")
         .catch(() => undefined);
       state.client.stopWithoutPersist();
+      if (replaceAfterRetirement.has(state)) {
+        deleteSharedClientState(state);
+      }
       throw state.poisonError;
     }
 
@@ -391,11 +405,13 @@ function beginGenerationRetirement(params: {
     }
     try {
       if (state.releaseMode === "persist") {
-        await state.client.stopAndPersist();
+        await state.client.stopAndPersist({ deadlineMs });
       } else if (state.releaseMode === "discard") {
         state.client.stopWithoutPersist();
       } else {
-        await state.client.stopAndPersist().catch(() => state.client.stopWithoutPersist());
+        await state.client
+          .stopAndPersist({ deadlineMs })
+          .catch(() => state.client.stopWithoutPersist());
       }
     } finally {
       deleteSharedClientState(state);

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -72,7 +72,6 @@ type SharedMatrixClientParams = {
 
 const sharedClientStates = new Map<string, SharedMatrixClientState>();
 const sharedClientPromises = new Map<string, Promise<SharedMatrixClientState>>();
-const replaceAfterRetirement = new WeakSet<SharedMatrixClientState>();
 
 function buildSharedClientKey(auth: MatrixAuth): string {
   // Serialize the tuple as a whole: Matrix URLs and credentials may contain `|`,
@@ -154,7 +153,7 @@ async function ensureSharedClientStarted(
   })().catch((error: unknown) => {
     if (state.phase === "open") {
       state.poisonError = toRetirementError(error);
-      replaceAfterRetirement.add(state);
+      deleteSharedClientState(state);
     }
     throw error;
   });
@@ -202,27 +201,15 @@ async function resolveOpenSharedMatrixClientState(
 
   while (true) {
     const existing = sharedClientStates.get(key);
-    if (existing?.poisonError && !replaceAfterRetirement.has(existing)) {
-      throw existing.poisonError;
-    }
-    if (existing?.poisonError && !existing.retirementPromise) {
-      void beginGenerationRetirement({ state: existing }).catch(() => undefined);
-    }
-    if (existing?.retirementPromise) {
-      try {
-        await awaitMatrixStartupWithAbort(existing.retirementPromise, params.abortSignal);
-      } catch (error) {
-        if (!replaceAfterRetirement.has(existing)) {
-          throw error;
-        }
-      }
-      continue;
-    }
     if (existing?.poisonError) {
       throw existing.poisonError;
     }
     if (existing?.phase === "open") {
       return existing;
+    }
+    if (existing?.retirementPromise) {
+      await awaitMatrixStartupWithAbort(existing.retirementPromise, params.abortSignal);
+      continue;
     }
 
     const pending = sharedClientPromises.get(key);
@@ -386,9 +373,6 @@ function beginGenerationRetirement(params: {
         .drainPendingDecryptions("matrix poisoned client shutdown")
         .catch(() => undefined);
       state.client.stopWithoutPersist();
-      if (replaceAfterRetirement.has(state)) {
-        deleteSharedClientState(state);
-      }
       throw state.poisonError;
     }
 

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -564,6 +564,58 @@ describe("MatrixClient request hardening", () => {
     await expectAbortError(readiness);
   });
 
+  it("rejects terminal sync failure while an async readiness probe is pending", async () => {
+    const roomId = "!room:example.org";
+    const encryption = createDeferred<boolean>();
+    const isEncryptionEnabledInRoom = vi.fn(() => encryption.promise);
+    matrixJsClient.getRoom.mockReturnValue({
+      getMyMembership: () => "join",
+      hasEncryptionStateEvent: () => true,
+    });
+    matrixJsClient.getCrypto.mockReturnValue({ isEncryptionEnabledInRoom });
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      autoBootstrapCrypto: false,
+      encryption: true,
+    });
+    await client.start();
+
+    const readiness = client.waitForEncryptedRoomReady(roomId);
+    await vi.waitFor(() => expect(isEncryptionEnabledInRoom).toHaveBeenCalledTimes(1));
+    const failure = new Error("terminal sync failure");
+    matrixJsClient.emit("sync.unexpectedError", failure);
+    encryption.resolve(true);
+
+    await expect(readiness).rejects.toBe(failure);
+  });
+
+  it("times out readiness when the async probe never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const roomId = "!room:example.org";
+      const isEncryptionEnabledInRoom = vi.fn(() => new Promise<boolean>(() => {}));
+      matrixJsClient.getRoom.mockReturnValue({
+        getMyMembership: () => "join",
+        hasEncryptionStateEvent: () => true,
+      });
+      matrixJsClient.getCrypto.mockReturnValue({ isEncryptionEnabledInRoom });
+      const client = new MatrixClient("https://matrix.example.org", "token", {
+        autoBootstrapCrypto: false,
+        encryption: true,
+      });
+      await client.start();
+
+      const readiness = client.waitForEncryptedRoomReady(roomId, { timeoutMs: 100 });
+      const rejection = expect(readiness).rejects.toThrow(
+        `Matrix encrypted room ${roomId} did not become ready within 100ms`,
+      );
+      await vi.waitFor(() => expect(isEncryptionEnabledInRoom).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(100);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rechecks readiness when a newer sync arrives during the crypto check", async () => {
     const roomId = "!room:example.org";
     const firstCheck = createDeferred<boolean>();
@@ -1064,6 +1116,46 @@ describe("MatrixClient request hardening", () => {
     await expect(fetchFn("http://127.0.0.1/_matrix/client/v3/account/whoami")).rejects.toThrow(
       /private|blocked|not allowed/i,
     );
+  });
+
+  it("aborts an active upload through the matrix-js-sdk upload controller", async () => {
+    const uploadStarted = createDeferred<void>();
+    matrixJsClient.uploadContent.mockImplementation(
+      async (_file: unknown, opts?: { abortController?: AbortController }) =>
+        await new Promise<never>((_resolve, reject) => {
+          const signal = opts?.abortController?.signal;
+          if (!signal) {
+            reject(new Error("missing upload abort controller"));
+            return;
+          }
+          uploadStarted.resolve();
+          signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    const client = new MatrixClient("https://matrix.example.org", "token");
+    const abortController = new AbortController();
+    const upload = client.uploadContent(
+      Buffer.from("image"),
+      "application/octet-stream",
+      "image.bin",
+      abortController,
+    );
+
+    await uploadStarted.promise;
+    abortController.abort();
+
+    await expect(upload).rejects.toMatchObject({ name: "AbortError" });
+    expect(
+      (
+        matrixJsClient.uploadContent.mock.calls[0]?.[1] as
+          | { abortController?: AbortController }
+          | undefined
+      )?.abortController?.signal.aborted,
+    ).toBe(true);
   });
 
   it("prefers authenticated client media downloads", async () => {
@@ -2636,7 +2728,7 @@ describe("MatrixClient event bridge", () => {
 
     await expectAbortError(startup);
     expect(matrixJsClient.startClient).not.toHaveBeenCalled();
-    expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
+    expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(2);
   });
 
   it("replays outstanding invite rooms at startup", async () => {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -41,6 +41,16 @@ function expectRecordFields(record: Record<string, unknown>, fields: Record<stri
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
 async function expectAbortError(promise: Promise<unknown>) {
   const err = await promise.catch((caught: unknown) => caught);
   expect(err).toBeInstanceOf(Error);
@@ -275,6 +285,8 @@ type MatrixJsClientStub = {
   getRoom: ReturnType<typeof vi.fn>;
   getRooms: ReturnType<typeof vi.fn>;
   getCrypto: ReturnType<typeof vi.fn<() => unknown>>;
+  getSyncState: ReturnType<typeof vi.fn>;
+  getSyncStateData: ReturnType<typeof vi.fn>;
   decryptEventIfNeeded: ReturnType<typeof vi.fn>;
   relations: ReturnType<typeof vi.fn>;
   syncApi: SyncApi;
@@ -282,6 +294,16 @@ type MatrixJsClientStub = {
 
 function createMatrixJsClientStub(): MatrixJsClientStub {
   const client = new EventEmitter() as unknown as MatrixJsClientStub;
+  let syncState: string | null = null;
+  let syncStateData: unknown;
+  const emit = client.emit.bind(client);
+  client.emit = (eventName, ...args) => {
+    if (eventName === "sync") {
+      syncState = args[0] as string;
+      syncStateData = args[2];
+    }
+    return emit(eventName, ...args);
+  };
   client.classicSyncStop = vi.fn(() => {
     queueMicrotask(() => {
       client.emit("sync", SyncState.Stopped, SyncState.Syncing, undefined);
@@ -354,6 +376,8 @@ function createMatrixJsClientStub(): MatrixJsClientStub {
   client.getRoom = vi.fn(() => ({ hasEncryptionStateEvent: () => false }));
   client.getRooms = vi.fn(() => []);
   client.getCrypto = vi.fn(() => undefined);
+  client.getSyncState = vi.fn(() => syncState);
+  client.getSyncStateData = vi.fn(() => syncStateData);
   client.decryptEventIfNeeded = vi.fn(async () => {});
   client.relations = vi.fn(async () => ({
     originalEvent: null,
@@ -480,6 +504,94 @@ describe("MatrixClient request hardening", () => {
       "m.room.encrypted",
     );
     expect(matrixJsClient.getStateEvent).not.toHaveBeenCalled();
+  });
+
+  it("waits past cached PREPARED for live joined encrypted room readiness", async () => {
+    const roomId = "!room:example.org";
+    const joinedRooms = vi.spyOn(MatrixClient.prototype, "getJoinedRooms");
+    matrixJsClient.getRoom.mockReturnValue({
+      getMyMembership: () => "join",
+      hasEncryptionStateEvent: () => true,
+    });
+    matrixJsClient.getCrypto.mockReturnValue({
+      isEncryptionEnabledInRoom: vi.fn(async () => true),
+    });
+    matrixJsClient.startClient.mockImplementation(async () => {
+      queueMicrotask(() => {
+        matrixJsClient.emit("sync", SyncState.Prepared, null, { fromCache: true });
+      });
+    });
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      autoBootstrapCrypto: false,
+      encryption: true,
+    });
+    await client.start();
+
+    let ready = false;
+    const readiness = client.waitForEncryptedRoomReady(roomId, { timeoutMs: 1_000 }).then(() => {
+      ready = true;
+    });
+    await Promise.resolve();
+    expect(ready).toBe(false);
+
+    matrixJsClient.emit("sync", SyncState.Syncing, SyncState.Prepared, { fromCache: false });
+    await readiness;
+    expect(joinedRooms).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale-generation readiness after the client stops", async () => {
+    const roomId = "!room:example.org";
+    const encryption = createDeferred<boolean>();
+    const isEncryptionEnabledInRoom = vi.fn(() => encryption.promise);
+    matrixJsClient.getRoom.mockReturnValue({
+      getMyMembership: () => "join",
+      hasEncryptionStateEvent: () => true,
+    });
+    matrixJsClient.getCrypto.mockReturnValue({
+      isEncryptionEnabledInRoom,
+    });
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      autoBootstrapCrypto: false,
+      encryption: true,
+    });
+    await client.start();
+
+    const readiness = client.waitForEncryptedRoomReady(roomId);
+    await vi.waitFor(() => expect(isEncryptionEnabledInRoom).toHaveBeenCalledTimes(1));
+    client.stopWithoutPersist();
+    encryption.resolve(true);
+
+    await expectAbortError(readiness);
+  });
+
+  it("rechecks readiness when a newer sync arrives during the crypto check", async () => {
+    const roomId = "!room:example.org";
+    const firstCheck = createDeferred<boolean>();
+    const isEncryptionEnabledInRoom = vi
+      .fn()
+      .mockReturnValueOnce(firstCheck.promise)
+      .mockResolvedValue(true);
+    matrixJsClient.getRoom.mockReturnValue({
+      getMyMembership: () => "join",
+      hasEncryptionStateEvent: () => true,
+    });
+    matrixJsClient.getCrypto.mockReturnValue({ isEncryptionEnabledInRoom });
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      autoBootstrapCrypto: false,
+      encryption: true,
+    });
+    await client.start();
+
+    const readiness = client.waitForEncryptedRoomReady(roomId);
+    await vi.waitFor(() => expect(isEncryptionEnabledInRoom).toHaveBeenCalledTimes(1));
+    matrixJsClient.emit("sync", SyncState.Reconnecting, SyncState.Syncing, undefined);
+    firstCheck.resolve(true);
+    await Promise.resolve();
+    expect(isEncryptionEnabledInRoom).toHaveBeenCalledTimes(1);
+
+    matrixJsClient.emit("sync", SyncState.Syncing, SyncState.Reconnecting, { fromCache: false });
+    await readiness;
+    expect(isEncryptionEnabledInRoom).toHaveBeenCalledTimes(2);
   });
 
   it("preserves persisted encryption settings when the homeserver no longer exposes room state", async () => {
@@ -1409,6 +1521,37 @@ describe("MatrixClient request hardening", () => {
     }
   });
 
+  it("bounds crypto persistence with the shared shutdown deadline", async () => {
+    vi.useFakeTimers();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-sdk-deadline-"));
+    clearMatrixSyncApiForNeverStartedClient();
+    const databases = createDeferred<IDBDatabaseInfo[]>();
+    const databasesSpy = vi.spyOn(indexedDB, "databases").mockReturnValue(databases.promise);
+    try {
+      const client = new MatrixClient("https://matrix.example.org", "token", {
+        storageRootDir: tempDir,
+        idbSnapshotPath: path.join(tempDir, "crypto-idb-snapshot.json"),
+      });
+      const store = lastCreateClientOpts?.store as { markCleanShutdown: () => void } | undefined;
+      const markCleanSpy = vi.spyOn(store!, "markCleanShutdown");
+      const shutdown = client.stopAndPersist({ deadlineMs: Date.now() + 100 });
+      const rejection = expect(shutdown).rejects.toThrow(
+        "shutdown deadline expired while persisting crypto state",
+      );
+
+      await vi.waitFor(() => expect(databasesSpy).toHaveBeenCalled());
+      await vi.advanceTimersByTimeAsync(100);
+      await rejection;
+      databases.resolve([]);
+      await Promise.resolve();
+      expect(markCleanSpy).not.toHaveBeenCalled();
+    } finally {
+      databases.resolve([]);
+      databasesSpy.mockRestore();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to one non-persisting SDK stop when public stop persistence fails", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-sdk-stop-"));
     clearMatrixSyncApiForNeverStartedClient();
@@ -1490,7 +1633,7 @@ describe("MatrixClient request hardening", () => {
     await client.quiesceSync();
 
     expect(syncStop).toHaveBeenCalledTimes(1);
-    expect(matrixJsClient.stopClient).not.toHaveBeenCalled();
+    expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
   });
 
   it("times out classic sync quiesce without public stop and removes its waiter", async () => {
@@ -1511,7 +1654,7 @@ describe("MatrixClient request hardening", () => {
 
       const quiesce = client.quiesceSync();
       const rejection = expect(quiesce).rejects.toThrow(
-        "Matrix classic sync did not reach STOPPED within 5000ms",
+        "Matrix classic sync did not reach STOPPED before shutdown deadline",
       );
       await vi.advanceTimersByTimeAsync(5_000);
       await rejection;
@@ -2475,6 +2618,24 @@ describe("MatrixClient event bridge", () => {
       "Matrix client has been fully stopped and cannot be restarted; acquire a new shared client generation",
     );
     expect(matrixJsClient.startClient).toHaveBeenCalledTimes(1);
+    expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start sync after stop wins a delayed rust crypto initialization", async () => {
+    const cryptoInit = createDeferred<void>();
+    matrixJsClient.initRustCrypto.mockReturnValue(cryptoInit.promise);
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      autoBootstrapCrypto: false,
+      encryption: true,
+    });
+
+    const startup = client.start();
+    await vi.waitFor(() => expect(matrixJsClient.initRustCrypto).toHaveBeenCalledTimes(1));
+    client.stopWithoutPersist();
+    cryptoInit.resolve();
+
+    await expectAbortError(startup);
+    expect(matrixJsClient.startClient).not.toHaveBeenCalled();
     expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -10,6 +10,7 @@ import { VerificationMethod } from "matrix-js-sdk/lib/types.js";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { SsrFPolicy } from "../../runtime-api.js";
 import { SqliteBackedMatrixSyncStore } from "../client/file-sync-store.js";
 import { createMatrixJsSdkClientLogger } from "../client/logging.js";
@@ -380,50 +381,50 @@ export abstract class MatrixClientBase {
   protected async waitForSyncCondition(params: {
     abortSignal?: AbortSignal;
     check: () => boolean | Promise<boolean>;
-    generation: number;
     timeoutMessage: string;
     timeoutMs: number;
   }): Promise<void> {
+    const generation = this.lifecycleGeneration;
     let revision = 0;
     let pendingError: Error | undefined;
     let wake = () => {};
-    const onSync = () => {
+    const signal = () => {
       revision += 1;
       wake();
     };
     const reject = (error: unknown) => {
       pendingError = error instanceof Error ? error : new Error(String(error));
-      wake();
+      signal();
     };
     const onAbort = () => reject(createMatrixStartupAbortError());
     const timeout = setTimeout(() => reject(new Error(params.timeoutMessage)), params.timeoutMs);
     timeout.unref?.();
-    this.on("sync.state", onSync);
+    this.on("sync.state", signal);
     this.on("sync.unexpected_error", reject);
     this.on("lifecycle.invalidated", onAbort);
     params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    if (params.abortSignal?.aborted) onAbort();
     try {
+      const assertActive = () => {
+        if (pendingError) throw pendingError;
+        this.assertLifecycleGeneration(generation, params.abortSignal);
+      };
       while (true) {
-        this.assertLifecycleGeneration(params.generation, params.abortSignal);
-        if (pendingError) {
-          throw pendingError;
-        }
+        assertActive();
         const checkedRevision = revision;
-        if ((await params.check()) && checkedRevision === revision) {
-          this.assertLifecycleGeneration(params.generation, params.abortSignal);
-          return;
-        }
-        if (checkedRevision !== revision) {
-          continue;
-        }
-        await new Promise<void>((resolve) => {
+        const changed = new Promise<void>((resolve) => {
           wake = resolve;
+          if (checkedRevision !== revision) resolve();
         });
+        const ready = await Promise.race([params.check(), changed.then(() => false)]);
+        assertActive();
+        if (ready === true && checkedRevision === revision) return;
+        if (ready === false && checkedRevision === revision) await changed;
         wake = () => {};
       }
     } finally {
       clearTimeout(timeout);
-      this.off("sync.state", onSync);
+      this.off("sync.state", signal);
       this.off("sync.unexpected_error", reject);
       this.off("lifecycle.invalidated", onAbort);
       params.abortSignal?.removeEventListener("abort", onAbort);
@@ -431,14 +432,12 @@ export abstract class MatrixClientBase {
   }
 
   protected async waitForInitialSyncReady(params: {
-    generation: number;
     timeoutMs?: number;
     abortSignal?: AbortSignal;
   }): Promise<void> {
     const timeoutMs = params.timeoutMs ?? 30_000;
     await this.waitForSyncCondition({
       abortSignal: params.abortSignal,
-      generation: params.generation,
       check: () => {
         if (isMatrixReadySyncState(this.currentSyncState)) {
           return true;
@@ -473,34 +472,32 @@ export abstract class MatrixClientBase {
     }
 
     const generation = ++this.lifecycleGeneration;
+    const assertActive = () => this.assertLifecycleGeneration(generation, opts.abortSignal);
     try {
-      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      assertActive();
       await this.ensureCryptoSupportInitialized();
-      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      assertActive();
       this.registerBridge();
       await this.initializeCryptoIfNeeded(opts.abortSignal, generation);
-      this.assertLifecycleGeneration(generation, opts.abortSignal);
       await this.client.startClient({
         initialSyncLimit: this.initialSyncLimit,
         ...(this.syncFilter
           ? { filter: Filter.fromJson(this.selfUserId, "", this.syncFilter) }
           : {}),
       });
-      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      assertActive();
       await this.waitForInitialSyncReady({
-        generation,
         abortSignal: opts.abortSignal,
         timeoutMs: opts.readyTimeoutMs,
       });
-      this.assertLifecycleGeneration(generation, opts.abortSignal);
       if (opts.bootstrapCrypto && this.autoBootstrapCrypto) {
         await this.bootstrapCryptoIfNeeded(opts.abortSignal);
       }
-      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      assertActive();
       this.started = true;
       this.emitOutstandingInviteEvents();
       await this.refreshDmCache().catch(noop);
-      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      assertActive();
     } catch (error) {
       this.stopWithoutPersist();
       throw error;
@@ -583,28 +580,17 @@ export abstract class MatrixClientBase {
       return;
     }
     const deadlineMs = params.deadlineMs ?? Date.now() + 10_000;
-    const withinDeadline = async <T>(promise: Promise<T>, phase: string): Promise<T> => {
-      let timeout!: ReturnType<typeof setTimeout>;
-      try {
-        return await Promise.race([
-          promise,
-          new Promise<never>((_, reject) => {
-            timeout = setTimeout(
-              () => {
-                this.syncStore?.discardPendingSyncCursorPersistence();
-                reject(new Error(`Matrix client shutdown deadline expired while ${phase}`));
-              },
-              Math.max(0, deadlineMs - Date.now()),
-            );
-            timeout.unref?.();
-          }),
-        ]);
-      } finally {
-        clearTimeout(timeout);
-      }
-    };
+    const persistAbort = new AbortController();
+    const withinDeadline = <T>(promise: Promise<T>, phase: string) =>
+      withTimeout(promise, Math.max(1, deadlineMs - Date.now()), {
+        createError: () => {
+          this.syncStore?.discardPendingSyncCursorPersistence();
+          persistAbort.abort();
+          return new Error(`Matrix client shutdown deadline expired while ${phase}`);
+        },
+      });
     this.stopPersistPromise = (async () => {
-      await this.quiesceSync({ deadlineMs });
+      await withinDeadline(this.quiesceSync({ deadlineMs }), "quiescing sync");
       this.stopSdkClient();
       this.decryptBridge?.stop();
       const runtime =
@@ -615,6 +601,7 @@ export abstract class MatrixClientBase {
           snapshotPath: this.idbSnapshotPath,
           databasePrefix: this.cryptoDatabasePrefix,
           strict: true,
+          abortSignal: persistAbort.signal,
         }),
         "persisting crypto state",
       );
@@ -700,9 +687,13 @@ export abstract class MatrixClientBase {
     this.assertLifecycleGeneration(generation, abortSignal);
 
     try {
-      await this.client.initRustCrypto({
-        cryptoDatabasePrefix: this.cryptoDatabasePrefix,
-      });
+      try {
+        await this.client.initRustCrypto({
+          cryptoDatabasePrefix: this.cryptoDatabasePrefix,
+        });
+      } finally {
+        if (this.sdkStopped || generation !== this.lifecycleGeneration) this.client.stopClient();
+      }
       this.assertLifecycleGeneration(generation, abortSignal);
       this.cryptoInitialized = true;
 

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -147,6 +147,7 @@ export abstract class MatrixClientBase {
   protected transactionScopePromise: Promise<string> | null = null;
   private readonly messageWireDispatchGuards = new Map<string, MatrixMessageWireDispatchGuard>();
   private sdkStopped = false;
+  protected lifecycleGeneration = 0;
 
   readonly dms = {
     update: async (): Promise<boolean> => {
@@ -376,101 +377,84 @@ export abstract class MatrixClientBase {
     });
   }
 
-  protected async waitForInitialSyncReady(
-    params: {
-      timeoutMs?: number;
-      abortSignal?: AbortSignal;
-    } = {},
-  ): Promise<void> {
-    const timeoutMs = params.timeoutMs ?? 30_000;
-    if (isMatrixReadySyncState(this.currentSyncState)) {
-      return;
-    }
-    if (isMatrixAccessTokenInvalidatedError(this.currentSyncError)) {
-      throw this.currentSyncError instanceof Error
-        ? this.currentSyncError
-        : new Error("Matrix access token invalidated", { cause: this.currentSyncError });
-    }
-    if (isMatrixTerminalSyncState(this.currentSyncState)) {
-      throw new Error(`Matrix sync entered ${this.currentSyncState} during startup`);
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      const abortSignal = params.abortSignal;
-
-      const cleanup = () => {
-        this.off("sync.state", onSyncState);
-        this.off("sync.unexpected_error", onUnexpectedError);
-        abortSignal?.removeEventListener("abort", onAbort);
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = undefined;
+  protected async waitForSyncCondition(params: {
+    abortSignal?: AbortSignal;
+    check: () => boolean | Promise<boolean>;
+    generation: number;
+    timeoutMessage: string;
+    timeoutMs: number;
+  }): Promise<void> {
+    let revision = 0;
+    let pendingError: Error | undefined;
+    let wake = () => {};
+    const onSync = () => {
+      revision += 1;
+      wake();
+    };
+    const reject = (error: unknown) => {
+      pendingError = error instanceof Error ? error : new Error(String(error));
+      wake();
+    };
+    const onAbort = () => reject(createMatrixStartupAbortError());
+    const timeout = setTimeout(() => reject(new Error(params.timeoutMessage)), params.timeoutMs);
+    timeout.unref?.();
+    this.on("sync.state", onSync);
+    this.on("sync.unexpected_error", reject);
+    this.on("lifecycle.invalidated", onAbort);
+    params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      while (true) {
+        this.assertLifecycleGeneration(params.generation, params.abortSignal);
+        if (pendingError) {
+          throw pendingError;
         }
-      };
-
-      const settleResolve = () => {
-        if (settled) {
+        const checkedRevision = revision;
+        if ((await params.check()) && checkedRevision === revision) {
+          this.assertLifecycleGeneration(params.generation, params.abortSignal);
           return;
         }
-        settled = true;
-        cleanup();
-        resolve();
-      };
-
-      const settleReject = (error: Error) => {
-        if (settled) {
-          return;
+        if (checkedRevision !== revision) {
+          continue;
         }
-        settled = true;
-        cleanup();
-        reject(error);
-      };
-
-      const onSyncState = (state: MatrixSyncState, _prevState: string | null, error?: unknown) => {
-        if (isMatrixReadySyncState(state)) {
-          settleResolve();
-          return;
-        }
-        if (isMatrixAccessTokenInvalidatedError(error)) {
-          settleReject(
-            error instanceof Error ? error : new Error("Matrix access token invalidated"),
-          );
-          return;
-        }
-        if (isMatrixTerminalSyncState(state)) {
-          settleReject(
-            new Error(
-              error instanceof Error && error.message
-                ? error.message
-                : `Matrix sync entered ${state} during startup`,
-            ),
-          );
-        }
-      };
-
-      const onUnexpectedError = (error: Error) => {
-        settleReject(error);
-      };
-
-      const onAbort = () => {
-        settleReject(createMatrixStartupAbortError());
-      };
-
-      this.on("sync.state", onSyncState);
-      this.on("sync.unexpected_error", onUnexpectedError);
-      if (abortSignal?.aborted) {
-        onAbort();
-        return;
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+        wake = () => {};
       }
-      abortSignal?.addEventListener("abort", onAbort, { once: true });
-      timeoutId = setTimeout(() => {
-        settleReject(
-          new Error(`Matrix client did not reach a ready sync state within ${timeoutMs}ms`),
-        );
-      }, timeoutMs);
-      timeoutId.unref?.();
+    } finally {
+      clearTimeout(timeout);
+      this.off("sync.state", onSync);
+      this.off("sync.unexpected_error", reject);
+      this.off("lifecycle.invalidated", onAbort);
+      params.abortSignal?.removeEventListener("abort", onAbort);
+    }
+  }
+
+  protected async waitForInitialSyncReady(params: {
+    generation: number;
+    timeoutMs?: number;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
+    const timeoutMs = params.timeoutMs ?? 30_000;
+    await this.waitForSyncCondition({
+      abortSignal: params.abortSignal,
+      generation: params.generation,
+      check: () => {
+        if (isMatrixReadySyncState(this.currentSyncState)) {
+          return true;
+        }
+        if (isMatrixAccessTokenInvalidatedError(this.currentSyncError)) {
+          throw this.currentSyncError instanceof Error
+            ? this.currentSyncError
+            : new Error("Matrix access token invalidated", { cause: this.currentSyncError });
+        }
+        if (isMatrixTerminalSyncState(this.currentSyncState)) {
+          throw new Error(`Matrix sync entered ${this.currentSyncState} during startup`);
+        }
+        return false;
+      },
+      timeoutMessage: `Matrix client did not reach a ready sync state within ${timeoutMs}ms`,
+      timeoutMs,
     });
   }
 
@@ -488,28 +472,39 @@ export abstract class MatrixClientBase {
       );
     }
 
-    throwIfMatrixStartupAborted(opts.abortSignal);
-    await this.ensureCryptoSupportInitialized();
-    throwIfMatrixStartupAborted(opts.abortSignal);
-    this.registerBridge();
-    await this.initializeCryptoIfNeeded(opts.abortSignal);
-
-    await this.client.startClient({
-      initialSyncLimit: this.initialSyncLimit,
-      ...(this.syncFilter ? { filter: Filter.fromJson(this.selfUserId, "", this.syncFilter) } : {}),
-    });
-    await this.waitForInitialSyncReady({
-      abortSignal: opts.abortSignal,
-      timeoutMs: opts.readyTimeoutMs,
-    });
-    throwIfMatrixStartupAborted(opts.abortSignal);
-    if (opts.bootstrapCrypto && this.autoBootstrapCrypto) {
-      await this.bootstrapCryptoIfNeeded(opts.abortSignal);
+    const generation = ++this.lifecycleGeneration;
+    try {
+      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      await this.ensureCryptoSupportInitialized();
+      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      this.registerBridge();
+      await this.initializeCryptoIfNeeded(opts.abortSignal, generation);
+      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      await this.client.startClient({
+        initialSyncLimit: this.initialSyncLimit,
+        ...(this.syncFilter
+          ? { filter: Filter.fromJson(this.selfUserId, "", this.syncFilter) }
+          : {}),
+      });
+      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      await this.waitForInitialSyncReady({
+        generation,
+        abortSignal: opts.abortSignal,
+        timeoutMs: opts.readyTimeoutMs,
+      });
+      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      if (opts.bootstrapCrypto && this.autoBootstrapCrypto) {
+        await this.bootstrapCryptoIfNeeded(opts.abortSignal);
+      }
+      this.assertLifecycleGeneration(generation, opts.abortSignal);
+      this.started = true;
+      this.emitOutstandingInviteEvents();
+      await this.refreshDmCache().catch(noop);
+      this.assertLifecycleGeneration(generation, opts.abortSignal);
+    } catch (error) {
+      this.stopWithoutPersist();
+      throw error;
     }
-    throwIfMatrixStartupAborted(opts.abortSignal);
-    this.started = true;
-    this.emitOutstandingInviteEvents();
-    await this.refreshDmCache().catch(noop);
   }
 
   async prepareForOneOff(): Promise<void> {
@@ -552,14 +547,17 @@ export abstract class MatrixClientBase {
     }
     this.currentSyncState = null;
     this.currentSyncError = undefined;
+    this.lifecycleGeneration += 1;
+    this.emitter.emit("lifecycle.invalidated");
     this.client.stopClient();
     this.sdkStopped = true;
     this.started = false;
   }
 
-  async quiesceSync(): Promise<void> {
+  async quiesceSync(params: { deadlineMs?: number } = {}): Promise<void> {
     await quiesceMatrixClientSync({
       client: this.client,
+      deadlineMs: params.deadlineMs,
       emitter: this.emitter,
       markStopped: () => {
         this.started = false;
@@ -579,23 +577,49 @@ export abstract class MatrixClientBase {
       .catch(noop);
   }
 
-  async stopAndPersist(): Promise<void> {
+  async stopAndPersist(params: { deadlineMs?: number } = {}): Promise<void> {
     if (this.stopPersistPromise) {
       await this.stopPersistPromise;
       return;
     }
+    const deadlineMs = params.deadlineMs ?? Date.now() + 10_000;
+    const withinDeadline = async <T>(promise: Promise<T>, phase: string): Promise<T> => {
+      let timeout!: ReturnType<typeof setTimeout>;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
+              () => {
+                this.syncStore?.discardPendingSyncCursorPersistence();
+                reject(new Error(`Matrix client shutdown deadline expired while ${phase}`));
+              },
+              Math.max(0, deadlineMs - Date.now()),
+            );
+            timeout.unref?.();
+          }),
+        ]);
+      } finally {
+        clearTimeout(timeout);
+      }
+    };
     this.stopPersistPromise = (async () => {
-      await this.quiesceSync();
+      await this.quiesceSync({ deadlineMs });
       this.stopSdkClient();
       this.decryptBridge?.stop();
-      const runtime = loadedMatrixCryptoRuntime ?? (await loadMatrixCryptoRuntime());
-      await runtime.persistIdbToDisk({
-        snapshotPath: this.idbSnapshotPath,
-        databasePrefix: this.cryptoDatabasePrefix,
-        strict: true,
-      });
+      const runtime =
+        loadedMatrixCryptoRuntime ??
+        (await withinDeadline(loadMatrixCryptoRuntime(), "loading crypto persistence"));
+      await withinDeadline(
+        runtime.persistIdbToDisk({
+          snapshotPath: this.idbSnapshotPath,
+          databasePrefix: this.cryptoDatabasePrefix,
+          strict: true,
+        }),
+        "persisting crypto state",
+      );
       this.syncStore?.markCleanShutdown();
-      await this.syncStore?.flush();
+      await withinDeadline(this.syncStore?.flush() ?? Promise.resolve(), "flushing sync state");
     })();
     await this.stopPersistPromise;
   }
@@ -660,30 +684,34 @@ export abstract class MatrixClientBase {
     this.cryptoBootstrapped = true;
   }
 
-  protected async initializeCryptoIfNeeded(abortSignal?: AbortSignal): Promise<void> {
+  protected async initializeCryptoIfNeeded(
+    abortSignal?: AbortSignal,
+    generation = this.lifecycleGeneration,
+  ): Promise<void> {
     if (!this.encryptionEnabled || this.cryptoInitialized) {
       return;
     }
     throwIfMatrixStartupAborted(abortSignal);
     const { persistIdbToDisk, restoreIdbFromDisk } = await loadMatrixCryptoRuntime();
+    this.assertLifecycleGeneration(generation, abortSignal);
 
     // Restore persisted IndexedDB crypto store before initializing WASM crypto.
     await restoreIdbFromDisk(this.idbSnapshotPath);
-    throwIfMatrixStartupAborted(abortSignal);
+    this.assertLifecycleGeneration(generation, abortSignal);
 
     try {
       await this.client.initRustCrypto({
         cryptoDatabasePrefix: this.cryptoDatabasePrefix,
       });
+      this.assertLifecycleGeneration(generation, abortSignal);
       this.cryptoInitialized = true;
-      throwIfMatrixStartupAborted(abortSignal);
 
       // Persist the crypto store after successful init (captures fresh keys on first run).
       await persistIdbToDisk({
         snapshotPath: this.idbSnapshotPath,
         databasePrefix: this.cryptoDatabasePrefix,
       });
-      throwIfMatrixStartupAborted(abortSignal);
+      this.assertLifecycleGeneration(generation, abortSignal);
 
       // Periodically persist to capture new Olm sessions and room keys.
       this.idbPersistTimer = setInterval(() => {
@@ -694,7 +722,15 @@ export abstract class MatrixClientBase {
       }, MATRIX_IDB_PERSIST_INTERVAL_MS);
       this.idbPersistTimer.unref?.();
     } catch (err) {
+      this.assertLifecycleGeneration(generation, abortSignal);
       LogService.warn("MatrixClientLite", "Failed to initialize rust crypto:", err);
+    }
+  }
+
+  protected assertLifecycleGeneration(generation: number, abortSignal?: AbortSignal): void {
+    throwIfMatrixStartupAborted(abortSignal);
+    if (this.sdkStopped || generation !== this.lifecycleGeneration) {
+      throw createMatrixStartupAbortError();
     }
   }
 }

--- a/extensions/matrix/src/matrix/sdk/client-core.ts
+++ b/extensions/matrix/src/matrix/sdk/client-core.ts
@@ -32,6 +32,30 @@ function isUnsupportedAuthenticatedMediaEndpointError(err: unknown): boolean {
 }
 
 export abstract class MatrixClientCore extends MatrixClientBase {
+  async waitForEncryptedRoomReady(
+    roomId: string,
+    params: { abortSignal?: AbortSignal; timeoutMs?: number } = {},
+  ): Promise<void> {
+    const generation = this.lifecycleGeneration;
+    await this.waitForSyncCondition({
+      abortSignal: params.abortSignal,
+      generation,
+      check: async () => {
+        const state = this.client.getSyncState();
+        const room = this.client.getRoom(roomId);
+        return Boolean(
+          this.client.getSyncStateData()?.fromCache !== true &&
+          (state === "PREPARED" || state === "SYNCING") &&
+          room?.getMyMembership() === "join" &&
+          room.hasEncryptionStateEvent() &&
+          (await this.client.getCrypto()?.isEncryptionEnabledInRoom(roomId)),
+        );
+      },
+      timeoutMessage: `Matrix encrypted room ${roomId} did not become ready within ${params.timeoutMs ?? 30_000}ms`,
+      timeoutMs: params.timeoutMs ?? 30_000,
+    });
+  }
+
   async getUserId(): Promise<string> {
     const fromClient = this.client.getUserId();
     if (fromClient) {

--- a/extensions/matrix/src/matrix/sdk/client-core.ts
+++ b/extensions/matrix/src/matrix/sdk/client-core.ts
@@ -36,19 +36,17 @@ export abstract class MatrixClientCore extends MatrixClientBase {
     roomId: string,
     params: { abortSignal?: AbortSignal; timeoutMs?: number } = {},
   ): Promise<void> {
-    const generation = this.lifecycleGeneration;
     await this.waitForSyncCondition({
       abortSignal: params.abortSignal,
-      generation,
       check: async () => {
         const state = this.client.getSyncState();
         const room = this.client.getRoom(roomId);
-        return Boolean(
+        return (
           this.client.getSyncStateData()?.fromCache !== true &&
           (state === "PREPARED" || state === "SYNCING") &&
           room?.getMyMembership() === "join" &&
           room.hasEncryptionStateEvent() &&
-          (await this.client.getCrypto()?.isEncryptionEnabledInRoom(roomId)),
+          (await this.client.getCrypto()?.isEncryptionEnabledInRoom(roomId)) === true
         );
       },
       timeoutMessage: `Matrix encrypted room ${roomId} did not become ready within ${params.timeoutMs ?? 30_000}ms`,
@@ -444,11 +442,17 @@ export abstract class MatrixClientCore extends MatrixClientBase {
     return await request(legacyEndpoint);
   }
 
-  async uploadContent(file: Buffer, contentType?: string, filename?: string): Promise<string> {
+  async uploadContent(
+    file: Buffer,
+    contentType?: string,
+    filename?: string,
+    abortController?: AbortController,
+  ): Promise<string> {
     const uploaded = await this.client.uploadContent(new Uint8Array(file), {
       type: contentType || "application/octet-stream",
       name: filename,
       includeFilename: Boolean(filename),
+      abortController,
     });
     return uploaded.content_uri;
   }

--- a/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts
+++ b/extensions/matrix/src/matrix/sdk/client-sync-quiesce.ts
@@ -22,6 +22,7 @@ function assertMatrixJsSdkSyncVersion(): void {
 
 export async function quiesceMatrixClientSync(params: {
   client: MatrixJsClient;
+  deadlineMs?: number;
   emitter: EventEmitter;
   markStopped: () => void;
   started: boolean;
@@ -30,6 +31,7 @@ export async function quiesceMatrixClientSync(params: {
     "discardPendingSyncCursorPersistence" | "freezeSyncCursorPersistence"
   >;
 }): Promise<void> {
+  const deadlineMs = params.deadlineMs ?? Date.now() + MATRIX_SYNC_QUIESCE_TIMEOUT_MS;
   await params.syncStore?.freezeSyncCursorPersistence();
   try {
     assertMatrixJsSdkSyncVersion();
@@ -77,10 +79,11 @@ export async function quiesceMatrixClientSync(params: {
         settle();
       }
     };
+    const remainingMs = Math.max(0, deadlineMs - Date.now());
     const timeout = setTimeout(() => {
       params.syncStore?.discardPendingSyncCursorPersistence();
-      settle(new Error(`Matrix classic sync did not reach STOPPED within 5000ms`));
-    }, MATRIX_SYNC_QUIESCE_TIMEOUT_MS);
+      settle(new Error(`Matrix classic sync did not reach STOPPED before shutdown deadline`));
+    }, remainingMs);
     timeout.unref?.();
 
     params.emitter.on("sync.state", onSyncState);

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
@@ -183,4 +183,34 @@ describe("Matrix IndexedDB persistence", () => {
       databasesSpy.mockRestore();
     }
   });
+
+  it("does not commit a snapshot after persistence is aborted", async () => {
+    const snapshotPath = path.join(tmpDir, "crypto-idb-snapshot.json");
+    await seedDatabase({
+      name: cryptoDatabaseName,
+      storeName: "sessions",
+      records: [{ key: "room-1", value: { session: "late" } }],
+    });
+    const databaseList = await indexedDB.databases();
+    const pending = Promise.withResolvers<IDBDatabaseInfo[]>();
+    const databasesSpy = vi.spyOn(indexedDB, "databases").mockReturnValueOnce(pending.promise);
+    const abortController = new AbortController();
+    try {
+      const persist = persistIdbToDisk({
+        snapshotPath,
+        databasePrefix: DATABASE_PREFIX,
+        strict: true,
+        abortSignal: abortController.signal,
+      });
+      await vi.waitFor(() => expect(databasesSpy).toHaveBeenCalledTimes(1));
+      abortController.abort();
+      pending.resolve(databaseList);
+
+      await expect(persist).rejects.toMatchObject({ name: "AbortError" });
+      expect(readMatrixIdbSnapshotJson(tmpDir)).toBeNull();
+    } finally {
+      pending.resolve(databaseList);
+      databasesSpy.mockRestore();
+    }
+  });
 });

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -307,10 +307,12 @@ export async function persistIdbToDisk(params?: {
   snapshotPath?: string;
   databasePrefix?: string;
   strict?: boolean;
+  abortSignal?: AbortSignal;
 }): Promise<void> {
   const snapshotPath = params?.snapshotPath ?? resolveDefaultIdbSnapshotPath();
   let callbackStarted = false;
   try {
+    params?.abortSignal?.throwIfAborted();
     fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
     // withFileLock is acquire-or-throw; it never skips the callback on contention.
     const persistedCount = await withFileLock(
@@ -330,6 +332,7 @@ export async function persistIdbToDisk(params?: {
         }
         throwIfLegacySnapshotNeedsDoctor(snapshotPath, storedSnapshotJson);
         const snapshot = await dumpIndexedDatabases(params?.databasePrefix);
+        params?.abortSignal?.throwIfAborted();
         if (snapshot.length === 0) {
           return 0;
         }

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { inheritMatrixQaReplacementRelation, type MatrixQaObservedEvent } from "./events.js";
 
 export type MatrixQaE2eeActorId = "driver" | "observer" | `driver-${string}` | `cli-${string}`;
@@ -14,42 +15,14 @@ async function withMatrixQaE2eeTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
   message: string,
-  onTimeout?: () => Promise<void>,
+  onTimeout?: () => void,
 ): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  let timedOut = false;
-  const result = new Promise<T>((resolve, reject) => {
-    promise.then(
-      (value) => {
-        if (!timedOut) {
-          resolve(value);
-        }
-      },
-      (error: unknown) => {
-        if (!timedOut) {
-          reject(error);
-        }
-      },
-    );
-    timer = setTimeout(() => {
-      timedOut = true;
-      const finish = () => reject(new Error(message));
-      const cleanup = onTimeout?.();
-      if (cleanup) {
-        void cleanup.then(finish, finish);
-      } else {
-        finish();
-      }
-    }, timeoutMs);
-    timer.unref();
-  });
-
+  const timeoutError = new Error(message);
   try {
-    return await result;
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
+    return await withTimeout(promise, timeoutMs, { createError: () => timeoutError });
+  } catch (error) {
+    if (error === timeoutError) onTimeout?.();
+    throw error;
   }
 }
 
@@ -83,9 +56,7 @@ export function createMatrixQaE2eeClientLifecycle(params: {
     stopPromise = (async () => {
       const deadline = Date.now() + params.shutdownTimeoutMs;
       params.detachListeners();
-      for (const controller of activeOperations.values()) {
-        controller.abort();
-      }
+      activeOperations.forEach((controller) => controller.abort());
       if (activeOperations.size > 0) {
         const graceMs = Math.min(1_000, Math.max(0, deadline - Date.now()));
         await withMatrixQaE2eeTimeout(
@@ -103,11 +74,7 @@ export function createMatrixQaE2eeClientLifecycle(params: {
       ).catch((error: unknown) => {
         failShutdown("draining pending Matrix decryptions", error);
       });
-      await withMatrixQaE2eeTimeout(
-        params.stopAndPersist({ deadlineMs: deadline }),
-        Math.max(0, deadline - Date.now()),
-        "Matrix persistence did not settle before shutdown",
-      ).catch((error: unknown) => {
+      await params.stopAndPersist({ deadlineMs: deadline }).catch((error: unknown) => {
         failShutdown("persisting Matrix state", error);
       });
     })();
@@ -116,7 +83,7 @@ export function createMatrixQaE2eeClientLifecycle(params: {
 
   const runMatrixQaE2eeClientOperation = async <T>(operation: {
     label: string;
-    run: (abortSignal: AbortSignal) => Promise<T>;
+    run: (abortController: AbortController) => Promise<T>;
     timeoutMs: number;
   }): Promise<T> => {
     if (shutdownStarted) {
@@ -125,7 +92,7 @@ export function createMatrixQaE2eeClientLifecycle(params: {
       );
     }
     const controller = new AbortController();
-    const active = operation.run(controller.signal);
+    const active = operation.run(controller);
     activeOperations.set(active, controller);
     void active.finally(() => activeOperations.delete(active)).catch(() => undefined);
 
@@ -133,9 +100,9 @@ export function createMatrixQaE2eeClientLifecycle(params: {
       active,
       operation.timeoutMs,
       `${operation.label} timed out after ${operation.timeoutMs}ms`,
-      async () => {
+      () => {
         controller.abort();
-        await stop().catch(() => undefined);
+        void stop().catch(() => undefined);
       },
     );
   };

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
@@ -14,19 +14,38 @@ async function withMatrixQaE2eeTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
   message: string,
-  onTimeout?: () => void,
+  onTimeout?: () => Promise<void>,
 ): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
+  let timedOut = false;
+  const result = new Promise<T>((resolve, reject) => {
+    promise.then(
+      (value) => {
+        if (!timedOut) {
+          resolve(value);
+        }
+      },
+      (error: unknown) => {
+        if (!timedOut) {
+          reject(error);
+        }
+      },
+    );
     timer = setTimeout(() => {
-      onTimeout?.();
-      reject(new Error(message));
+      timedOut = true;
+      const finish = () => reject(new Error(message));
+      const cleanup = onTimeout?.();
+      if (cleanup) {
+        void cleanup.then(finish, finish);
+      } else {
+        finish();
+      }
     }, timeoutMs);
     timer.unref();
   });
 
   try {
-    return await Promise.race([promise, timeout]);
+    return await result;
   } finally {
     if (timer) {
       clearTimeout(timer);
@@ -38,10 +57,10 @@ export function createMatrixQaE2eeClientLifecycle(params: {
   detachListeners: () => void;
   drainPendingDecryptions: () => Promise<void>;
   shutdownTimeoutMs: number;
-  stopAndPersist: () => Promise<void>;
+  stopAndPersist: (params: { deadlineMs: number }) => Promise<void>;
   stopWithoutPersist: () => void;
 }) {
-  const activeOperations = new Set<Promise<unknown>>();
+  const activeOperations = new Map<Promise<unknown>, AbortController>();
   let shutdownStarted = false;
   let stopPromise: Promise<void> | undefined;
 
@@ -64,10 +83,13 @@ export function createMatrixQaE2eeClientLifecycle(params: {
     stopPromise = (async () => {
       const deadline = Date.now() + params.shutdownTimeoutMs;
       params.detachListeners();
+      for (const controller of activeOperations.values()) {
+        controller.abort();
+      }
       if (activeOperations.size > 0) {
         const graceMs = Math.min(1_000, Math.max(0, deadline - Date.now()));
         await withMatrixQaE2eeTimeout(
-          Promise.allSettled(activeOperations),
+          Promise.allSettled(activeOperations.keys()),
           graceMs,
           "active Matrix SDK operations did not settle before shutdown",
         ).catch((error: unknown) => {
@@ -81,14 +103,20 @@ export function createMatrixQaE2eeClientLifecycle(params: {
       ).catch((error: unknown) => {
         failShutdown("draining pending Matrix decryptions", error);
       });
-      await params.stopAndPersist();
+      await withMatrixQaE2eeTimeout(
+        params.stopAndPersist({ deadlineMs: deadline }),
+        Math.max(0, deadline - Date.now()),
+        "Matrix persistence did not settle before shutdown",
+      ).catch((error: unknown) => {
+        failShutdown("persisting Matrix state", error);
+      });
     })();
     return stopPromise;
   };
 
   const runMatrixQaE2eeClientOperation = async <T>(operation: {
     label: string;
-    run: () => Promise<T>;
+    run: (abortSignal: AbortSignal) => Promise<T>;
     timeoutMs: number;
   }): Promise<T> => {
     if (shutdownStarted) {
@@ -96,15 +124,19 @@ export function createMatrixQaE2eeClientLifecycle(params: {
         `Matrix E2EE client shutdown has started; cannot start ${operation.label}. Retry the QA scenario with a fresh client.`,
       );
     }
-    const active = operation.run();
-    activeOperations.add(active);
+    const controller = new AbortController();
+    const active = operation.run(controller.signal);
+    activeOperations.set(active, controller);
     void active.finally(() => activeOperations.delete(active)).catch(() => undefined);
 
     return withMatrixQaE2eeTimeout(
       active,
       operation.timeoutMs,
       `${operation.label} timed out after ${operation.timeoutMs}ms`,
-      () => void stop().catch(() => undefined),
+      async () => {
+        controller.abort();
+        await stop().catch(() => undefined);
+      },
     );
   };
 

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
@@ -19,9 +19,18 @@ const testing = {
   prepareMatrixQaE2eeStorage,
 };
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("matrix qa e2ee client storage", () => {
   function createLifecycleFixture(options?: {
     drain?: () => Promise<void>;
+    persist?: () => Promise<void>;
     shutdownTimeoutMs?: number;
   }) {
     const calls: string[] = [];
@@ -34,6 +43,7 @@ describe("matrix qa e2ee client storage", () => {
       shutdownTimeoutMs: options?.shutdownTimeoutMs ?? 500,
       stopAndPersist: vi.fn(async () => {
         calls.push("stop-and-persist");
+        await options?.persist?.();
       }),
       stopWithoutPersist: vi.fn(() => calls.push("stop-and-discard")),
     });
@@ -47,7 +57,6 @@ describe("matrix qa e2ee client storage", () => {
 
     expect(calls).toEqual(["detach", "drain", "stop-and-persist"]);
   });
-
   it("shares one stop promise across concurrent and repeated shutdown requests", async () => {
     const { calls, lifecycle } = createLifecycleFixture();
 
@@ -168,11 +177,59 @@ describe("matrix qa e2ee client storage", () => {
       );
 
       await vi.advanceTimersByTimeAsync(50);
-
-      await rejection;
       expect(calls).toEqual(["operation", "detach"]);
       await vi.advanceTimersByTimeAsync(100);
+      await rejection;
       expect(calls).toEqual(["operation", "detach", "stop-and-discard"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts the tracked encrypt and upload operation before timeout settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const { calls, lifecycle } = createLifecycleFixture();
+      const encrypt = createDeferred<void>();
+      const operation = lifecycle.runOperation({
+        label: "Matrix E2EE image send",
+        timeoutMs: 50,
+        run: async (abortSignal) => {
+          calls.push("encrypt");
+          await encrypt.promise;
+          abortSignal.throwIfAborted();
+          calls.push("upload");
+        },
+      });
+      const rejection = expect(operation).rejects.toThrow(
+        "Matrix E2EE image send timed out after 50ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(calls).toEqual(["encrypt", "detach"]);
+      encrypt.resolve();
+      await rejection;
+      expect(calls).toEqual(["encrypt", "detach", "drain", "stop-and-persist"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds persistence with the same shutdown deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const { calls, lifecycle } = createLifecycleFixture({
+        persist: () => new Promise<void>(() => {}),
+        shutdownTimeoutMs: 100,
+      });
+      const stop = lifecycle.stop();
+      const rejection = expect(stop).rejects.toThrow(
+        "shutdown failed while persisting Matrix state",
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+      await rejection;
+      expect(calls).toEqual(["detach", "drain", "stop-and-persist", "stop-and-discard"]);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
@@ -30,7 +30,7 @@ function createDeferred<T>() {
 describe("matrix qa e2ee client storage", () => {
   function createLifecycleFixture(options?: {
     drain?: () => Promise<void>;
-    persist?: () => Promise<void>;
+    persist?: (deadlineMs: number) => Promise<void>;
     shutdownTimeoutMs?: number;
   }) {
     const calls: string[] = [];
@@ -41,9 +41,9 @@ describe("matrix qa e2ee client storage", () => {
         await options?.drain?.();
       }),
       shutdownTimeoutMs: options?.shutdownTimeoutMs ?? 500,
-      stopAndPersist: vi.fn(async () => {
+      stopAndPersist: vi.fn(async ({ deadlineMs }) => {
         calls.push("stop-and-persist");
-        await options?.persist?.();
+        await options?.persist?.(deadlineMs);
       }),
       stopWithoutPersist: vi.fn(() => calls.push("stop-and-discard")),
     });
@@ -186,53 +186,55 @@ describe("matrix qa e2ee client storage", () => {
     }
   });
 
-  it("aborts the tracked encrypt and upload operation before timeout settles", async () => {
+  it("aborts an active upload operation when its timeout expires", async () => {
     vi.useFakeTimers();
     try {
       const { calls, lifecycle } = createLifecycleFixture();
-      const encrypt = createDeferred<void>();
       const operation = lifecycle.runOperation({
         label: "Matrix E2EE image send",
         timeoutMs: 50,
-        run: async (abortSignal) => {
-          calls.push("encrypt");
-          await encrypt.promise;
-          abortSignal.throwIfAborted();
-          calls.push("upload");
-        },
+        run: ({ signal }) =>
+          new Promise<void>((_resolve, reject) => {
+            calls.push("upload");
+            signal.addEventListener(
+              "abort",
+              () => {
+                calls.push("upload-abort");
+                reject(new DOMException("Aborted", "AbortError"));
+              },
+              { once: true },
+            );
+          }),
       });
       const rejection = expect(operation).rejects.toThrow(
         "Matrix E2EE image send timed out after 50ms",
       );
 
       await vi.advanceTimersByTimeAsync(50);
-      expect(calls).toEqual(["encrypt", "detach"]);
-      encrypt.resolve();
       await rejection;
-      expect(calls).toEqual(["encrypt", "detach", "drain", "stop-and-persist"]);
+      await vi.waitFor(() => {
+        expect(calls).toEqual(["upload", "upload-abort", "detach", "drain", "stop-and-persist"]);
+      });
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("bounds persistence with the same shutdown deadline", async () => {
-    vi.useFakeTimers();
-    try {
-      const { calls, lifecycle } = createLifecycleFixture({
-        persist: () => new Promise<void>(() => {}),
-        shutdownTimeoutMs: 100,
-      });
-      const stop = lifecycle.stop();
-      const rejection = expect(stop).rejects.toThrow(
-        "shutdown failed while persisting Matrix state",
-      );
+  it("passes the shared shutdown deadline to the persistence owner", async () => {
+    let persistenceDeadline = 0;
+    const { calls, lifecycle } = createLifecycleFixture({
+      persist: async (deadlineMs) => {
+        persistenceDeadline = deadlineMs;
+      },
+      shutdownTimeoutMs: 100,
+    });
+    const startedAt = Date.now();
 
-      await vi.advanceTimersByTimeAsync(100);
-      await rejection;
-      expect(calls).toEqual(["detach", "drain", "stop-and-persist", "stop-and-discard"]);
-    } finally {
-      vi.useRealTimers();
-    }
+    await lifecycle.stop();
+
+    expect(persistenceDeadline).toBeGreaterThanOrEqual(startedAt);
+    expect(persistenceDeadline).toBeLessThanOrEqual(startedAt + 100);
+    expect(calls).toEqual(["detach", "drain", "stop-and-persist"]);
   });
 
   it("observes a tracked operation that rejects after shutdown has discarded state", async () => {

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.ts
@@ -343,7 +343,7 @@ export async function createMatrixQaE2eeScenarioClient(
     },
     drainPendingDecryptions: () => client.drainPendingDecryptions(),
     shutdownTimeoutMs,
-    stopAndPersist: () => client.stopAndPersist(),
+    stopAndPersist: ({ deadlineMs }) => client.stopAndPersist({ deadlineMs }),
     stopWithoutPersist: () => client.stopWithoutPersist(),
   });
 
@@ -398,7 +398,7 @@ export async function createMatrixQaE2eeScenarioClient(
     }
     return client.crypto;
   };
-  const runClientOperation = <T>(label: string, run: () => Promise<T>) =>
+  const runClientOperation = <T>(label: string, run: (abortSignal: AbortSignal) => Promise<T>) =>
     lifecycle.runOperation({
       label,
       run,
@@ -465,28 +465,46 @@ export async function createMatrixQaE2eeScenarioClient(
       return await requireCrypto().scanVerificationQr(id, qrDataBase64);
     },
     async sendTextMessage(opts) {
-      return await runClientOperation("Matrix E2EE text send", () =>
-        client.sendMessage(opts.roomId, buildMatrixQaMessageContent(opts) as MessageEventContent),
-      );
+      return await runClientOperation("Matrix E2EE text send", async (abortSignal) => {
+        await client.waitForEncryptedRoomReady(opts.roomId, {
+          abortSignal,
+          timeoutMs: params.timeoutMs,
+        });
+        return await client.sendMessage(
+          opts.roomId,
+          buildMatrixQaMessageContent(opts) as MessageEventContent,
+        );
+      });
     },
     async sendNoticeMessage(opts) {
-      return await runClientOperation("Matrix E2EE notice send", () =>
-        client.sendMessage(opts.roomId, {
+      return await runClientOperation("Matrix E2EE notice send", async (abortSignal) => {
+        await client.waitForEncryptedRoomReady(opts.roomId, {
+          abortSignal,
+          timeoutMs: params.timeoutMs,
+        });
+        return await client.sendMessage(opts.roomId, {
           ...buildMatrixQaMessageContent(opts),
           msgtype: "m.notice",
-        } as MessageEventContent),
-      );
+        } as MessageEventContent);
+      });
     },
     async sendImageMessage(opts) {
-      const encrypted = await requireCrypto().encryptMedia(opts.buffer);
-      const contentUri = await client.uploadContent(
-        encrypted.buffer,
-        opts.contentType,
-        opts.fileName,
-      );
-      const file: EncryptedFile = { url: contentUri, ...encrypted.file };
-      return await runClientOperation("Matrix E2EE image send", () =>
-        client.sendMessage(opts.roomId, {
+      return await runClientOperation("Matrix E2EE image send", async (abortSignal) => {
+        await client.waitForEncryptedRoomReady(opts.roomId, {
+          abortSignal,
+          timeoutMs: params.timeoutMs,
+        });
+        abortSignal.throwIfAborted();
+        const encrypted = await requireCrypto().encryptMedia(opts.buffer);
+        abortSignal.throwIfAborted();
+        const contentUri = await client.uploadContent(
+          encrypted.buffer,
+          opts.contentType,
+          opts.fileName,
+        );
+        abortSignal.throwIfAborted();
+        const file: EncryptedFile = { url: contentUri, ...encrypted.file };
+        return await client.sendMessage(opts.roomId, {
           ...buildMatrixQaMessageContent({
             body: opts.body,
             mentionUserIds: opts.mentionUserIds,
@@ -498,8 +516,8 @@ export async function createMatrixQaE2eeScenarioClient(
             size: opts.buffer.byteLength,
           },
           msgtype: "m.image",
-        } as MessageEventContent),
-      );
+        } as MessageEventContent);
+      });
     },
     async startVerification(id, method) {
       return await requireCrypto().startVerification(id, method);

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.ts
@@ -398,11 +398,22 @@ export async function createMatrixQaE2eeScenarioClient(
     }
     return client.crypto;
   };
-  const runClientOperation = <T>(label: string, run: (abortSignal: AbortSignal) => Promise<T>) =>
+  const runClientOperation = <T>(
+    label: string,
+    run: (abortController: AbortController) => Promise<T>,
+  ) =>
     lifecycle.runOperation({
       label,
       run,
       timeoutMs: params.timeoutMs,
+    });
+  const sendReadyMessage = (label: string, roomId: string, content: MessageEventContent) =>
+    runClientOperation(label, async ({ signal }) => {
+      await client.waitForEncryptedRoomReady(roomId, {
+        abortSignal: signal,
+        timeoutMs: params.timeoutMs,
+      });
+      return client.sendMessage(roomId, content);
     });
 
   return {
@@ -465,44 +476,35 @@ export async function createMatrixQaE2eeScenarioClient(
       return await requireCrypto().scanVerificationQr(id, qrDataBase64);
     },
     async sendTextMessage(opts) {
-      return await runClientOperation("Matrix E2EE text send", async (abortSignal) => {
-        await client.waitForEncryptedRoomReady(opts.roomId, {
-          abortSignal,
-          timeoutMs: params.timeoutMs,
-        });
-        return await client.sendMessage(
-          opts.roomId,
-          buildMatrixQaMessageContent(opts) as MessageEventContent,
-        );
-      });
+      return await sendReadyMessage(
+        "Matrix E2EE text send",
+        opts.roomId,
+        buildMatrixQaMessageContent(opts) as MessageEventContent,
+      );
     },
     async sendNoticeMessage(opts) {
-      return await runClientOperation("Matrix E2EE notice send", async (abortSignal) => {
-        await client.waitForEncryptedRoomReady(opts.roomId, {
-          abortSignal,
-          timeoutMs: params.timeoutMs,
-        });
-        return await client.sendMessage(opts.roomId, {
-          ...buildMatrixQaMessageContent(opts),
-          msgtype: "m.notice",
-        } as MessageEventContent);
-      });
+      return await sendReadyMessage("Matrix E2EE notice send", opts.roomId, {
+        ...buildMatrixQaMessageContent(opts),
+        msgtype: "m.notice",
+      } as MessageEventContent);
     },
     async sendImageMessage(opts) {
-      return await runClientOperation("Matrix E2EE image send", async (abortSignal) => {
+      return await runClientOperation("Matrix E2EE image send", async (abortController) => {
+        const { signal } = abortController;
         await client.waitForEncryptedRoomReady(opts.roomId, {
-          abortSignal,
+          abortSignal: signal,
           timeoutMs: params.timeoutMs,
         });
-        abortSignal.throwIfAborted();
+        signal.throwIfAborted();
         const encrypted = await requireCrypto().encryptMedia(opts.buffer);
-        abortSignal.throwIfAborted();
+        signal.throwIfAborted();
         const contentUri = await client.uploadContent(
           encrypted.buffer,
           opts.contentType,
           opts.fileName,
+          abortController,
         );
-        abortSignal.throwIfAborted();
+        signal.throwIfAborted();
         const file: EncryptedFile = { url: contentUri, ...encrypted.file };
         return await client.sendMessage(opts.roomId, {
           ...buildMatrixQaMessageContent({


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/119920

## What Problem This Solves

Fixes four Matrix E2EE lifecycle races in the split from #119920:

- readiness probes could outlive terminal sync/generation changes, lose a wake, or hang past timeout;
- Rust crypto could finish initializing after terminal stop and leave its newly assigned backend running;
- QA image timeout cancellation did not reach matrix-js-sdk's active upload;
- shutdown could return at its deadline while IndexedDB persistence later committed a snapshot.

This remains limited to Matrix generation/readiness, upload cancellation, persistence shutdown, and the QA E2EE lifecycle that owns those operations. It does not add scenario configuration, room setup, CLI/gateway, Docker, recording, release, or live evidence changes.

## Why This Change Was Made

The canonical owners now enforce the lifecycle:

- `extensions/matrix/src/matrix/sdk/client-base.ts:381-432` races each async readiness probe against sync/error/abort changes and rechecks captured generation ownership before accepting success.
- `extensions/matrix/src/matrix/sdk/client-base.ts:680-718` re-stops matrix-js-sdk if delayed Rust crypto initialization settles after the OpenClaw generation stopped.
- `extensions/matrix/src/matrix/sdk/client-core.ts:445-457` passes the QA operation's `AbortController` into matrix-js-sdk's upload contract; `extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.ts:491-522` keeps readiness, encryption, upload, and dispatch in one tracked operation. Cancellation can abort an active upload; once message dispatch starts, its send promise remains authoritative and timeout reports unknown completion rather than a false aborted-send result.
- `extensions/matrix/src/matrix/sdk/client-base.ts:577-612` propagates one absolute shutdown deadline and abort signal to persistence; `extensions/matrix/src/matrix/sdk/idb-persistence.ts:305-344` checks cancellation again immediately before the snapshot write, preventing a late commit after shutdown returns.

The repair also removes duplicate lifecycle policy: failed shared generations are deleted at the startup producer, QA uses the plugin SDK timeout primitive, and one generation-aware readiness loop owns both startup and encrypted-room readiness.

## Direct Dependency Evidence

Personally inspected installed matrix-js-sdk 41.9.0 source and declarations:

- `matrix-js-sdk/src/sync.ts:80-97,821-855,887-929`: `ERROR` may recover, cached `PREPARED` is marked `fromCache`, live sync emits readiness after processing, and sync persistence occurs before/after those transitions.
- `matrix-js-sdk/src/client.ts:1470-1542,1564-1576`: startup is async; `stopClient()` stops the current crypto backend and is idempotent once client polling is stopped.
- `matrix-js-sdk/src/client.ts:1993-2048`: Rust crypto assigns `cryptoBackend` only after asynchronous import/initialization, so an earlier stop cannot clean the late backend.
- `matrix-js-sdk/src/http-api/interface.ts:192-215`, `src/http-api/index.ts:55-165`, `src/http-api/fetch.ts:257-305`: upload cancellation is owned by `UploadOpts.abortController`, which drives both XHR and fetch cancellation.
- `matrix-js-sdk/lib/client.d.ts:949-958,1160-1176,2763-2769`: declarations confirm async start/init, synchronous stop, and the upload options contract.

## Provenance

- Reviewed head `95bac4d76966d78e92711336c68ab761593db1b7` introduced the readiness wait, generation checks, QA operation cancellation, and shutdown deadline paths where findings 1, 3, and 4 manifested.
- The upload gap combined that head's QA abort signal with the older wrapper from `5402ef192d5`, which did not expose matrix-js-sdk's upload controller.
- Delayed crypto cleanup is the interaction between the async init path from `5402ef192d5`, shared generation retirement from https://github.com/openclaw/openclaw/pull/119570 (`a3419d4a4b4c894b47a9273181735d091f4d502f`), and the new generation checks at `95bac4d`.
- Related history checked: https://github.com/openclaw/openclaw/pull/110968 (`56915896bc8e5f98ed6d5ac068bd5ff3f926204f`) for bounded QA sends and https://github.com/openclaw/openclaw/pull/117390 (`39cc0a3199f5444a95e2a7756440792c73cd19ed`) for Matrix replacement-event observation.

## User Impact

Matrix E2EE QA sends now wait on the current live generation, active image uploads are actually abortable, terminal stop cleans crypto even when initialization completes late, and shutdown cannot produce a post-deadline snapshot commit.

## Evidence

- Exact pushed head: `089056737bd173a02afe129b9b27142fbf587c38`.
- Focused Matrix shared/SDK/persistence tests: 3 files, 174 passed.
- Focused QA E2EE lifecycle tests: 1 file, 14 passed.
- Added regressions for a never-settling readiness probe, terminal failure during a pending probe, late crypto init after stop, abort during active upload, and persistence resolving after deadline cancellation without a late snapshot commit.
- Targeted `oxfmt`: clean on all 9 repair files.
- `git diff --check`: clean.
- Autoreview: clean; no accepted/actionable findings, patch-correct score 0.98, TruffleHog clean.
- Whole non-test production delta from the PR parent: `+272/-192`, net `+80`.
- Whole test delta from the PR parent: `+369/-8`, net `+361`.
- Targeted oxlint could not start because the package-boundary declaration preflight fails outside this diff at `packages/terminal-core/src/ansi.ts:194` with `TS2554`.
- The changed classifier was stopped because its automatic AWS Crabbox route conflicted with the explicit no-Crabbox boundary; the owned lease was released and no remote result is claimed.

Remaining proof: independent exact-head re-review, hosted CI, and any parent-assigned live Matrix/Crabbox evidence. This PR remains draft.

Punchcard-Session: calm-orchard-workshop-fw
