### PR TITLE
fix(release): include Codex survivor companion

### DIFF
--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -98,6 +98,7 @@ const UPGRADE_SURVIVOR_SCENARIO_ALIASES = new Map([
   ["reported-issues", UPGRADE_SURVIVOR_SCENARIOS],
   ["far-reaching", UPGRADE_SURVIVOR_SCENARIOS],
 ]);
+const UPGRADE_SURVIVOR_LOCKSTEP_PLUGIN_PACKAGES = ["@openclaw/codex"];
 
 // Pre-protocol catalogs are content-addressed. Unknown legacy blocks fail
 // closed instead of requiring a dependency or reimplementing a JavaScript parser.
@@ -674,16 +675,18 @@ function configuredChannelIdsForLane(poolLane, scenario) {
 
 export function requiredPrepublishPluginPackagesForLanes(poolLanes) {
   const configuredChannelIds = new Set();
+  let requiresUpgradeSurvivorCompanions = false;
   for (const poolLane of poolLanes) {
     const scenario = upgradeSurvivorScenarioForLane(poolLane);
     if (!scenario) {
       continue;
     }
+    requiresUpgradeSurvivorCompanions = true;
     for (const channelId of configuredChannelIdsForLane(poolLane, scenario)) {
       configuredChannelIds.add(channelId);
     }
   }
-  return (officialExternalChannelCatalog.entries ?? [])
+  const channelPackages = (officialExternalChannelCatalog.entries ?? [])
     .filter((entry) => {
       const channelId = entry.openclaw?.channel?.id;
       const install = entry.openclaw?.install;
@@ -694,8 +697,11 @@ export function requiredPrepublishPluginPackagesForLanes(poolLanes) {
         install?.npmSpec === entry.name
       );
     })
-    .map((entry) => entry.name)
-    .toSorted((a, b) => a.localeCompare(b));
+    .map((entry) => entry.name);
+  return unique([
+    ...(requiresUpgradeSurvivorCompanions ? UPGRADE_SURVIVOR_LOCKSTEP_PLUGIN_PACKAGES : []),
+    ...channelPackages,
+  ]).toSorted((a, b) => a.localeCompare(b));
 }
 
 function buildPlanJson(params) {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1653,9 +1653,20 @@ describe("scripts/lib/docker-e2e-plan", () => {
   });
 
   it("derives prerelease npm companions from selected survivor recipes", () => {
-    const basePlan = planFor({ selectedLaneNames: ["published-upgrade-survivor"] });
-    expect(basePlan.requiredPrepublishPluginPackages).toEqual(["@openclaw/discord"]);
-    expect(basePlan.needs.prepublishPluginRegistry).toBe(true);
+    for (const laneName of [
+      "upgrade-survivor",
+      "published-upgrade-survivor",
+      "root-managed-vps-upgrade",
+      "update-restart-auth",
+      "update-migration",
+    ]) {
+      const plan = planFor({ selectedLaneNames: [laneName] });
+      expect(plan.requiredPrepublishPluginPackages).toEqual([
+        "@openclaw/codex",
+        "@openclaw/discord",
+      ]);
+      expect(plan.needs.prepublishPluginRegistry).toBe(true);
+    }
 
     const feishuPlan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
@@ -1663,21 +1674,19 @@ describe("scripts/lib/docker-e2e-plan", () => {
       upgradeSurvivorScenarios: "base feishu-channel",
     });
     expect(feishuPlan.requiredPrepublishPluginPackages).toEqual([
+      "@openclaw/codex",
       "@openclaw/discord",
       "@openclaw/feishu",
     ]);
-    expect(
-      planFor({ selectedLaneNames: ["root-managed-vps-upgrade"] }).requiredPrepublishPluginPackages,
-    ).toEqual(["@openclaw/discord"]);
-    expect(
-      planFor({ selectedLaneNames: ["update-migration"] }).requiredPrepublishPluginPackages,
-    ).toEqual(["@openclaw/discord"]);
     const legacyFeishuPlan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
       upgradeSurvivorBaselines: "2026.3.13",
       upgradeSurvivorScenarios: "feishu-channel",
     });
-    expect(legacyFeishuPlan.requiredPrepublishPluginPackages).toEqual(["@openclaw/discord"]);
+    expect(legacyFeishuPlan.requiredPrepublishPluginPackages).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+    ]);
     const selfUpgradeLane = findLaneByName("update-run-package-self-upgrade");
     expect(selfUpgradeLane).toBeDefined();
     expect(requiredPrepublishPluginPackagesForLanes([selfUpgradeLane!])).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where prerelease upgrade-survivor validation could build a package registry without the matching `@openclaw/codex` candidate, causing the frozen release candidate to install an older or unavailable runtime companion.

## Why This Change Was Made

Every lane carrying an `upgradeSurvivorScenario` now requests the explicit lockstep `@openclaw/codex` package in addition to companions derived from configured channels. The planner continues to use the existing scenario recipe and official channel catalog; it does not duplicate runtime inference or catalog schema.

## User Impact

Release maintainers can validate upgrade-survivor scenarios against a registry where OpenClaw, Codex, Discord, and scenario-specific channel packages stay on the same prerelease version.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-e2e-plan.test.ts`: 57/57 passed
- Trusted changed gate: https://github.com/openclaw/openclaw/actions/runs/31158382667
- Production LOC: +9/-3 (net +6); tests: +19/-10 (net +9)
- Frozen `272b3098c71af4143882e68e13193437ef605dd9` Package Acceptance: pending

AI-assisted: yes. No agent transcript is included.
