### PR TITLE
fix(release): repair 2026.6.35 validation backports

### DIFF
--- a/extensions/mattermost/src/mattermost/client.retry.test.ts
+++ b/extensions/mattermost/src/mattermost/client.retry.test.ts
@@ -100,13 +100,12 @@ describe("createMattermostDirectChannelWithRetry", () => {
     return run;
   }
 
+  function jsonResponse(body: unknown, status = 200): Response {
+    return Response.json(body, { status });
+  }
+
   it("succeeds on first attempt without retries", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 201,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ id: "dm-channel-123" }),
-    } as Response);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "dm-channel-123" }, 201));
 
     const client = createMockClient();
     const onRetry = vi.fn();
@@ -124,19 +123,8 @@ describe("createMattermostDirectChannelWithRetry", () => {
 
   it("retries on 429 rate limit error and succeeds", async () => {
     mockFetch
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 429,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ message: "Too many requests" }),
-        text: async () => "Too many requests",
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-456" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ message: "Too many requests" }, 429))
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-456" }, 201));
 
     const client = createMockClient();
     const onRetry = vi.fn();
@@ -157,21 +145,14 @@ describe("createMattermostDirectChannelWithRetry", () => {
     expect(retryCall?.[1]).toBeGreaterThanOrEqual(10);
     expect(retryCall?.[1]).toBeLessThanOrEqual(20);
     expect(retryCall?.[2]).toBeInstanceOf(Error);
-    expect((retryCall?.[2] as Error | undefined)?.message).toBe(
-      "Mattermost API 429 undefined: Too many requests",
-    );
+    expect((retryCall?.[2] as Error | undefined)?.message).toContain("Too many requests");
   });
 
   it("retries on port 443 connection errors (not misclassified as 4xx)", async () => {
     // This tests that port numbers like :443 don't trigger false 4xx classification
     mockFetch
       .mockRejectedValueOnce(new Error("connect ECONNRESET 104.18.32.10:443"))
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-port" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-port" }, 201));
 
     const client = createMockClient();
 
@@ -190,13 +171,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
   it("does not retry on 400 even if error message contains '429' text", async () => {
     // This tests that "429" in error detail doesn't trigger false rate-limit retry
     // e.g., "Invalid user ID: 4294967295" should NOT be retried
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 400,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ message: "Invalid user ID: 4294967295" }),
-      text: async () => "Invalid user ID: 4294967295",
-    } as Response);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Invalid user ID: 4294967295" }, 400));
 
     const client = createMockClient();
 
@@ -214,26 +189,9 @@ describe("createMattermostDirectChannelWithRetry", () => {
 
   it("retries on 5xx server errors", async () => {
     mockFetch
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 503,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ message: "Service unavailable" }),
-        text: async () => "Service unavailable",
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 502,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ message: "Bad gateway" }),
-        text: async () => "Bad gateway",
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-789" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ message: "Service unavailable" }, 503))
+      .mockResolvedValueOnce(jsonResponse({ message: "Bad gateway" }, 502))
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-789" }, 201));
 
     const client = createMockClient();
 
@@ -252,12 +210,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
     mockFetch
       .mockRejectedValueOnce(new Error("Network error: connection refused"))
       .mockRejectedValueOnce(new Error("ECONNRESET"))
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-abc" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-abc" }, 201));
 
     const client = createMockClient();
 
@@ -280,12 +233,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
           code: "ECONNREFUSED",
         }),
       )
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-fetch-failed" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-fetch-failed" }, 201));
 
     const client = createMockClient();
 
@@ -301,13 +249,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
   });
 
   it("does not retry on 4xx client errors (except 429)", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 400,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ message: "Bad request" }),
-      text: async () => "Bad request",
-    } as Response);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Bad request" }, 400));
 
     const client = createMockClient();
 
@@ -323,13 +265,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
   });
 
   it("does not retry on 404 not found", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ message: "User not found" }),
-      text: async () => "User not found",
-    } as Response);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "User not found" }, 404));
 
     const client = createMockClient();
 
@@ -345,13 +281,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
   });
 
   it("throws after exhausting all retries", async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 503,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ message: "Service unavailable" }),
-      text: async () => "Service unavailable",
-    } as Response);
+    mockFetch.mockImplementation(async () => jsonResponse({ message: "Service unavailable" }, 503));
 
     const client = createMockClient();
 
@@ -414,12 +344,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
       .spyOn(globalThis, "setTimeout")
       .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
     vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 201,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ id: "dm-channel-capped" }),
-    } as Response);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ id: "dm-channel-capped" }, 201));
 
     const client = createMockClient();
 
@@ -436,12 +361,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
     mockFetch
       .mockRejectedValueOnce(new Error("Mattermost API 503 Service Unavailable"))
       .mockRejectedValueOnce(new Error("Mattermost API 503 Service Unavailable"))
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-delay" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-delay" }, 201));
 
     const client = createMockClient();
 
@@ -472,12 +392,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
       .mockRejectedValueOnce(new Error("Mattermost API 503"))
       .mockRejectedValueOnce(new Error("Mattermost API 503"))
       .mockRejectedValueOnce(new Error("Mattermost API 503"))
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-max" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-max" }, 201));
 
     const client = createMockClient();
 
@@ -502,13 +417,9 @@ describe("createMattermostDirectChannelWithRetry", () => {
   it("does not retry on 4xx errors even if message contains retryable keywords", async () => {
     // This tests the fix for false positives where a 400 error with "timeout" in the message
     // would incorrectly be retried
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 400,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ message: "Request timeout: connection timed out" }),
-      text: async () => "Request timeout: connection timed out",
-    } as Response);
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ message: "Request timeout: connection timed out" }, 400),
+    );
 
     const client = createMockClient();
 
@@ -525,13 +436,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
   });
 
   it("does not retry on 403 Forbidden even with 'abort' in message", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-      headers: new Headers({ "content-type": "application/json" }),
-      json: async () => ({ message: "Request aborted: forbidden" }),
-      text: async () => "Request aborted: forbidden",
-    } as Response);
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Request aborted: forbidden" }, 403));
 
     const client = createMockClient();
 
@@ -550,12 +455,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
     let capturedSignal: AbortSignal | undefined;
     mockFetch.mockImplementationOnce((url, init) => {
       capturedSignal = init?.signal ?? undefined;
-      return Promise.resolve({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-signal" }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ id: "dm-channel-signal" }, 201));
     });
 
     const client = createMockClient();
@@ -573,12 +473,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
     // This tests the fix for the ordering bug: 503 with "upstream 404" should be retried
     mockFetch
       .mockRejectedValueOnce(new Error("Mattermost API 503: upstream returned 404 Not Found"))
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        headers: new Headers({ "content-type": "application/json" }),
-        json: async () => ({ id: "dm-channel-5xx-with-404" }),
-      } as Response);
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-channel-5xx-with-404" }, 201));
 
     const client = createMockClient();
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -54,16 +54,18 @@ type EmbedLockCall = [
   () => Promise<unknown>,
 ];
 
+type MockStream = EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+
 interface MockChild extends EventEmitter {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
+  stdout: MockStream;
+  stderr: MockStream;
   kill: (signal?: NodeJS.Signals) => void;
   closeWith: (code?: number | null) => void;
 }
 
 function createMockChild(params?: { autoClose?: boolean; closeDelayMs?: number }): MockChild {
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
+  const stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+  const stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
   const child: MockChild = Object.assign(new EventEmitter(), {
     stdout,
     stderr,

--- a/extensions/ollama/provider-discovery.test.ts
+++ b/extensions/ollama/provider-discovery.test.ts
@@ -103,16 +103,16 @@ describe("Ollama provider", () => {
 
   const createTagModel = (name: string) => ({ name, modified_at: "", size: 1, digest: "" });
 
-  const tagsResponse = (names: string[]) => ({
-    ok: true,
-    json: async () => ({ models: names.map((name) => createTagModel(name)) }),
-  });
+  const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
 
-  const notFoundJsonResponse = () => ({
-    ok: false,
-    status: 404,
-    json: async () => ({}),
-  });
+  const tagsResponse = (names: string[]) =>
+    jsonResponse({ models: names.map((name) => createTagModel(name)) });
+
+  const notFoundJsonResponse = () => jsonResponse({}, 404);
 
   const stubTagsFetch = (names: string[] = []) => {
     const fetchMock = vi.fn(async (input: unknown) => {
@@ -213,16 +213,10 @@ describe("Ollama provider", () => {
         const bodyText = typeof rawBody === "string" ? rawBody : "{}";
         const parsed = JSON.parse(bodyText) as { name?: string };
         if (parsed.name === "qwen3:32b") {
-          return {
-            ok: true,
-            json: async () => ({ model_info: { "qwen3.context_length": 131072 } }),
-          };
+          return jsonResponse({ model_info: { "qwen3.context_length": 131072 } });
         }
         if (parsed.name === "llama3.3:70b") {
-          return {
-            ok: true,
-            json: async () => ({ model_info: { "llama.context_length": 65536 } }),
-          };
+          return jsonResponse({ model_info: { "llama.context_length": 65536 } });
         }
       }
       return notFoundJsonResponse();
@@ -249,10 +243,7 @@ describe("Ollama provider", () => {
           return tagsResponse(["deepseek-r1:latest", "llama3.3:latest"]);
         }
         if (url.endsWith("/api/show")) {
-          return {
-            ok: true,
-            json: async () => ({ model_info: {} }),
-          };
+          return jsonResponse({ model_info: {} });
         }
         return notFoundJsonResponse();
       });
@@ -331,10 +322,7 @@ describe("Ollama provider", () => {
         return tagsResponse(["qwen3:32b"]);
       }
       if (url.endsWith("/api/show")) {
-        return {
-          ok: false,
-          status: 500,
-        };
+        return jsonResponse({}, 500);
       }
       return notFoundJsonResponse();
     });
@@ -359,15 +347,9 @@ describe("Ollama provider", () => {
     const fetchMock = vi.fn(async (input: unknown) => {
       const url = String(input);
       if (url.endsWith("/api/tags")) {
-        return {
-          ok: true,
-          json: async () => ({ models: manyModels }),
-        };
+        return jsonResponse({ models: manyModels });
       }
-      return {
-        ok: true,
-        json: async () => ({ model_info: { "llama.context_length": 65536 } }),
-      };
+      return jsonResponse({ model_info: { "llama.context_length": 65536 } });
     });
     vi.stubGlobal("fetch", withFetchPreconnect(fetchMock));
 

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
@@ -610,31 +610,32 @@ describe("discord live qa runtime", () => {
     }
   });
 
-  it("uses the Discord API helper timeout for identity probes", async () => {
-    const controller = new AbortController();
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+  it("aborts Discord identity probes after the API helper timeout", async () => {
+    vi.useFakeTimers();
     let signal: AbortSignal | undefined;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_input: string | URL | globalThis.Request, init?: RequestInit) => {
-        signal = init?.signal as AbortSignal | undefined;
-        return new Response(JSON.stringify({ id: "423456789012345678" }), {
-          status: 200,
-          headers: {
-            "content-type": "application/json",
-          },
-        });
-      }),
-    );
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_input: string | URL | globalThis.Request, init?: RequestInit) => {
+          signal = init?.signal as AbortSignal | undefined;
+          return new Promise<Response>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("request aborted")), {
+              once: true,
+            });
+          });
+        }),
+      );
 
-    await expect(testing.getCurrentDiscordUser("token")).resolves.toEqual({
-      id: "423456789012345678",
-    });
-    expect(timeoutSpy).toHaveBeenCalledWith(15_000);
-    expect(signal).toBe(controller.signal);
-    expect(signal?.aborted).toBe(false);
-    controller.abort();
-    expect(signal?.aborted).toBe(true);
+      const request = testing.getCurrentDiscordUser("token");
+      const rejection = expect(request).rejects.toBeInstanceOf(Error);
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(signal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await rejection;
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("retries Discord REST requests after a 429 rate limit", async () => {

--- a/qa/contracts/telegram-execution-evidence.json
+++ b/qa/contracts/telegram-execution-evidence.json
@@ -2,5 +2,5 @@
   "version": 1,
   "kind": "openclaw-release-telegram-execution-evidence",
   "mode": "legacy-direct-runner-v1",
-  "candidateVersion": "2026.6.34"
+  "candidateVersion": "2026.6.35"
 }

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -336,15 +336,15 @@ describe("manifest model id normalization", () => {
     setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
     deleteTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR");
 
-    const readFileSyncSpy = vi.spyOn(fs, "readFileSync");
+    const openSyncSpy = vi.spyOn(fs, "openSync");
 
     expect(listOpenClawPluginManifestMetadata(process.env)).toHaveLength(1);
     expect(listOpenClawPluginManifestMetadata(process.env)).toHaveLength(1);
 
-    const manifestReads = readFileSyncSpy.mock.calls.filter(
+    const manifestReads = openSyncSpy.mock.calls.filter(
       ([filePath]) => String(filePath) === manifestPath,
     );
     expect(manifestReads).toHaveLength(1);
-    readFileSyncSpy.mockRestore();
+    openSyncSpy.mockRestore();
   });
 });

--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -327,19 +327,38 @@ describe("buildTimeoutAbortSignal", () => {
     }
   });
 
-  it("does not log when a parent signal aborts first", async () => {
+  it("preserves the parent reason when a parent signal aborts first", async () => {
     const parent = new AbortController();
+    const reason = new Error("parent stopped");
     const { signal, cleanup } = buildTimeoutAbortSignal({
       timeoutMs: 25,
       signal: parent.signal,
       operation: "unit-test",
     });
 
-    parent.abort();
+    parent.abort(reason);
     await vi.advanceTimersByTimeAsync(25);
 
     expect(signal?.aborted).toBe(true);
-    expect(signal?.reason).not.toMatchObject({ name: "TimeoutError" });
+    expect(signal?.reason).toBe(reason);
+    expect(warn).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("preserves an already-aborted parent reason", () => {
+    const parent = new AbortController();
+    const reason = new Error("parent already stopped");
+    parent.abort(reason);
+
+    const { signal, cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: 25,
+      signal: parent.signal,
+      operation: "unit-test",
+    });
+
+    expect(signal?.aborted).toBe(true);
+    expect(signal?.reason).toBe(reason);
     expect(warn).not.toHaveBeenCalled();
 
     cleanup();

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -27,6 +27,11 @@ export function bindAbortRelay(controller: AbortController): () => void {
   return relayAbort.bind(controller);
 }
 
+/** Relays a parent abort while preserving its reason. */
+function relayAbortReason(this: AbortController, signal: AbortSignal) {
+  this.abort(signal.reason);
+}
+
 function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
   const trimmed = rawUrl?.trim();
   if (!trimmed) {
@@ -134,10 +139,10 @@ export function buildTimeoutAbortSignal(params: TimeoutAbortSignalParams): {
     );
   };
   scheduleTimeout();
-  const onAbort = bindAbortRelay(controller);
-  if (signal) {
+  const onAbort = signal ? relayAbortReason.bind(controller, signal) : undefined;
+  if (signal && onAbort) {
     if (signal.aborted) {
-      controller.abort();
+      controller.abort(signal.reason);
     } else {
       signal.addEventListener("abort", onAbort, { once: true });
     }
@@ -159,7 +164,7 @@ export function buildTimeoutAbortSignal(params: TimeoutAbortSignalParams): {
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
-      if (signal) {
+      if (signal && onAbort) {
         signal.removeEventListener("abort", onAbort);
       }
     },


### PR DESCRIPTION
## What Problem This Solves

The 2026.6.35 full-validation Plugin Prerelease child has deterministic failures from six backport/test-contract mismatches, and Telegram QA cannot select the candidate's attested legacy evidence mode.

## Why This Change Was Made

Preserves abort reasons through timeout relays, updates bounded-response and stream test doubles to their real runtime contracts, restores the bounded-manifest cache assertion, and aligns the shipped Telegram evidence contract with package version 2026.6.35.

## User Impact

Restores correct cancellation reason propagation and unblocks release validation. The remaining changes are test/evidence alignment only.

## Evidence

- Plugin Prerelease failure run: 31157720429.
- Exact failed paths were traced to the production/test contracts before patching.
- `git diff --check` passed.
- Structured autoreview (`--mode uncommitted`) returned clean with no accepted/actionable findings.
- Focused execution is pending GitHub CI: this isolated worktree lacks `node_modules`; Blacksmith Testbox and brokered Crabbox are unauthenticated in this session.

AI-assisted release-maintainer change.