### PR TITLE
fix(agents): reject disallowed subagent models before acceptance

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -138,9 +138,10 @@ See [Session state awareness](/concepts/session-state) for the full model: event
 
 `sessions_spawn` creates an isolated session for a background task by default. It is always non-blocking; it returns immediately with a `runId` and `childSessionKey`. Native sub-agent runs receive the delegated task in the child session's first visible `[Subagent Task]` message, while the system prompt carries only sub-agent runtime rules and routing context.
 
-Set `model` to select the child's model. Append `@<auth-profile-id>` (for example,
-`openai/gpt-5.4@openai:work`) to require that exact auth profile; the child fails
-instead of switching credentials if the profile becomes unavailable before the run starts.
+Set `model` to select the child's model. For native sub-agents, append
+`@<auth-profile-id>` (for example, `openai/gpt-5.4@openai:work`) to require that
+exact auth profile; the child fails instead of switching credentials if the profile
+becomes unavailable before the run starts. ACP runtimes do not accept this suffix.
 
 Key options:
 

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -138,6 +138,10 @@ See [Session state awareness](/concepts/session-state) for the full model: event
 
 `sessions_spawn` creates an isolated session for a background task by default. It is always non-blocking; it returns immediately with a `runId` and `childSessionKey`. Native sub-agent runs receive the delegated task in the child session's first visible `[Subagent Task]` message, while the system prompt carries only sub-agent runtime rules and routing context.
 
+Set `model` to select the child's model. Append `@<auth-profile-id>` (for example,
+`openai/gpt-5.4@openai:work`) to require that exact auth profile; the child fails
+instead of switching credentials if the profile becomes unavailable before the run starts.
+
 Key options:
 
 - `runtime: "subagent"` (default) or `"acp"` for external harness agents.

--- a/src/agents/auth-profiles/session-override.selection.test.ts
+++ b/src/agents/auth-profiles/session-override.selection.test.ts
@@ -59,6 +59,37 @@ async function select(params: {
 }
 
 describe("session auth selection prepared facts", () => {
+  it("fails when a required child profile is revoked after spawn planning", async () => {
+    await withAuthState(async (state) => {
+      authStoreMocks.state.hasSource = true;
+      authStoreMocks.state.store = createAuthStoreWithProfiles({
+        profiles: {
+          [TEST_SECONDARY_PROFILE_ID]: {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-secondary",
+          },
+        },
+        order: { openai: [TEST_SECONDARY_PROFILE_ID] },
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: 1,
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
+        authProfileOverrideSource: "user",
+        authProfileOverrideRequired: true,
+      };
+
+      await expect(select({ agentDir: state.agentDir(), sessionEntry })).rejects.toThrow(
+        `Required auth profile "${TEST_PRIMARY_PROFILE_ID}" is no longer available.`,
+      );
+      expect(sessionEntry).toMatchObject({
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
+        authProfileOverrideRequired: true,
+      });
+    });
+  });
+
   it("returns prepared facts for a user pin", async () => {
     await withAuthState(async (state) => {
       configureProfiles();

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -32,7 +32,10 @@ function loadSessionAccessor() {
 
 type SessionAuthProfileOverrideState = Pick<
   SessionEntry,
-  "authProfileOverride" | "authProfileOverrideSource" | "authProfileOverrideCompactionCount"
+  | "authProfileOverride"
+  | "authProfileOverrideSource"
+  | "authProfileOverrideCompactionCount"
+  | "authProfileOverrideRequired"
 >;
 type SessionAuthProfileOverrideSnapshot = SessionAuthProfileOverrideState &
   Pick<SessionEntry, "sessionId">;
@@ -72,6 +75,11 @@ function applySessionAuthProfileOverrideState(
   } else {
     entry.authProfileOverrideCompactionCount = state.authProfileOverrideCompactionCount;
   }
+  if (state.authProfileOverrideRequired === undefined) {
+    delete entry.authProfileOverrideRequired;
+  } else {
+    entry.authProfileOverrideRequired = state.authProfileOverrideRequired;
+  }
   entry.updatedAt = Math.max(entry.updatedAt ?? 0, updatedAt);
 }
 
@@ -83,7 +91,8 @@ function matchesSessionAuthProfileOverrideSnapshot(
     entry.sessionId === snapshot.sessionId &&
     entry.authProfileOverride === snapshot.authProfileOverride &&
     entry.authProfileOverrideSource === snapshot.authProfileOverrideSource &&
-    entry.authProfileOverrideCompactionCount === snapshot.authProfileOverrideCompactionCount
+    entry.authProfileOverrideCompactionCount === snapshot.authProfileOverrideCompactionCount &&
+    entry.authProfileOverrideRequired === snapshot.authProfileOverrideRequired
   );
 }
 
@@ -237,6 +246,7 @@ export async function clearSessionAuthProfileOverride(params: {
       authProfileOverride: undefined,
       authProfileOverrideSource: undefined,
       authProfileOverrideCompactionCount: undefined,
+      authProfileOverrideRequired: undefined,
     },
     storePath,
   });
@@ -303,11 +313,19 @@ async function resolveSessionAuthProfileOverride(params: {
       }),
     )
   ) {
+    if (sessionEntry.authProfileOverrideRequired) {
+      throw new Error(`Required auth profile "${currentProfileId}" is no longer available.`);
+    }
     await clearSessionAuthProfileOverride({ sessionEntry, sessionStore, sessionKey, storePath });
     current = undefined;
   }
 
   if (current && !isProfileForProvider({ cfg, providers, profileId: current, store })) {
+    if (sessionEntry.authProfileOverrideRequired) {
+      throw new Error(
+        `Required auth profile "${current}" is not valid for provider "${provider}".`,
+      );
+    }
     await clearSessionAuthProfileOverride({ sessionEntry, sessionStore, sessionKey, storePath });
     current = undefined;
   }
@@ -338,6 +356,7 @@ async function resolveSessionAuthProfileOverride(params: {
           authProfileOverride: undefined,
           authProfileOverrideSource: undefined,
           authProfileOverrideCompactionCount: undefined,
+          authProfileOverrideRequired: undefined,
         },
         storePath,
         expectedSnapshot: {
@@ -345,6 +364,7 @@ async function resolveSessionAuthProfileOverride(params: {
           authProfileOverride: sessionEntry.authProfileOverride,
           authProfileOverrideSource: sessionEntry.authProfileOverrideSource,
           authProfileOverrideCompactionCount: sessionEntry.authProfileOverrideCompactionCount,
+          authProfileOverrideRequired: sessionEntry.authProfileOverrideRequired,
         },
       });
       const latestProfileId = latest?.authProfileOverride;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -35,6 +35,7 @@ import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
 import { createCronCreatorAuthorityCapability } from "../cron-creator-authority-context.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
+import { LiveSessionModelSwitchError } from "../live-model-switch-error.js";
 import type { ModelFallbackAttemptProvenance } from "../model-fallback.types.js";
 import { attachToolAllowlistIntersection } from "../tool-policy.js";
 import {
@@ -3752,6 +3753,39 @@ describe("embedded attempt harness pinning", () => {
       ...overrides,
     });
   }
+
+  it("does not retry a required child profile as another account", async () => {
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai:required": { type: "api_key", provider: "openai", key: "sk-required" },
+          "openai:fallback": { type: "api_key", provider: "openai", key: "sk-fallback" },
+        },
+      },
+      tmpDir,
+      { filterExternalAuthProfiles: false, syncExternalCli: false },
+    );
+    const replacement = new LiveSessionModelSwitchError({
+      provider: "openai",
+      model: "gpt-5.4",
+      authProfileId: "openai:fallback",
+      authProfileIdSource: "auto",
+    });
+    runEmbeddedAgentMock.mockRejectedValueOnce(replacement);
+
+    await expect(
+      runHarnessAttempt({
+        runId: "run-required-profile",
+        sessionEntry: makeSessionEntry("required-profile-session", {
+          authProfileOverride: "openai:required",
+          authProfileOverrideSource: "user",
+          authProfileOverrideRequired: true,
+        }),
+      }),
+    ).rejects.toBe(replacement);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+  });
 
   it("does not store a session harness pin for default OpenAI Codex routing", async () => {
     const sessionEntry = makeSessionEntry("legacy-session");

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -482,12 +482,16 @@ export async function resolveEmbeddedModelSelection(params: {
         }),
       );
     if (!profileMatchesRuntime) {
+      if (entry.authProfileOverrideRequired) {
+        throw new Error(`Required auth profile "${authProfileId}" is no longer available.`);
+      }
       if (hasExplicitRunOverride || autoFallbackPrimaryProbe) {
         sessionEntryForAttempt = {
           ...entry,
           authProfileOverride: undefined,
           authProfileOverrideSource: undefined,
           authProfileOverrideCompactionCount: undefined,
+          authProfileOverrideRequired: undefined,
         };
       } else if (
         params.sessionStore &&

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -539,7 +539,15 @@ export async function runEmbeddedAgentAttempt(params: {
       }
       break;
     } catch (err) {
-      if (err instanceof LiveSessionModelSwitchError) {
+      const requiredProfileId = sessionEntry?.authProfileOverrideRequired
+        ? sessionEntry.authProfileOverride
+        : undefined;
+      // An explicit child credential is part of its launch contract. Let a
+      // replacement profile fail the run instead of retrying as another account.
+      if (
+        err instanceof LiveSessionModelSwitchError &&
+        (!requiredProfileId || err.authProfileId === requiredProfileId)
+      ) {
         if (isModelSelectionLocked(sessionEntry)) {
           if (!attemptLifecycleState.lifecycleEnded) {
             emitAgentEvent({

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -539,9 +539,8 @@ export async function runEmbeddedAgentAttempt(params: {
       }
       break;
     } catch (err) {
-      const requiredProfileId = sessionEntry?.authProfileOverrideRequired
-        ? sessionEntry.authProfileOverride
-        : undefined;
+      const requiredProfileId =
+        sessionEntry?.authProfileOverrideRequired && sessionEntry.authProfileOverride;
       // An explicit child credential is part of its launch contract. Let a
       // replacement profile fail the run instead of retrying as another account.
       if (

--- a/src/agents/session-model-auto-revert.ts
+++ b/src/agents/session-model-auto-revert.ts
@@ -96,6 +96,7 @@ async function reconcileAgentPatchedSessionModel(params: {
         authProfileOverride: marker.prevAuthProfileOverride,
         authProfileOverrideSource: marker.prevAuthProfileOverrideSource,
         authProfileOverrideCompactionCount: marker.prevAuthProfileOverrideCompactionCount,
+        authProfileOverrideRequired: marker.prevAuthProfileOverrideRequired,
         contextWindow: marker.prevContextWindow,
         thinkingLevel: marker.prevThinkingLevel,
         modelFallback: undefined,

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -343,6 +343,7 @@ export async function resolveSubagentChildPlan(params: {
           ...modelPlan.initialSessionPatch,
           authProfileOverride: explicitModelSelection.profile,
           authProfileOverrideSource: "user" as const,
+          authProfileOverrideRequired: true,
         },
       }
     : modelPlan;

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -3,6 +3,8 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isIncognitoSessionKey } from "../../../routing/session-key.js";
 import { resolveUserPath } from "../../../utils.js";
 import { resolveAgentDir } from "../../agent-scope-config.js";
+import { ensureAuthProfileStore } from "../../auth-profiles.js";
+import { createModelAuthAvailabilityResolver } from "../../model-auth-availability.js";
 import { findModelCatalogEntry } from "../../model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "../../model-catalog.types.js";
 import { splitTrailingAuthProfile } from "../../model-ref-profile.js";
@@ -126,6 +128,28 @@ async function resolveSpawnModelError(params: {
     if (!knownProvider) {
       return {
         error: `sessions_spawn model "${requestedModel}" is not usable: unknown model provider "${resolvedProvider}"`,
+      };
+    }
+  }
+  const explicitProfile = splitTrailingAuthProfile(requestedModel).profile;
+  if (explicitProfile) {
+    const authStore = ensureAuthProfileStore(params.targetAgentDir, {
+      allowKeychainPrompt: false,
+      config: cfg,
+      readOnly: true,
+    });
+    const auth = createModelAuthAvailabilityResolver({
+      cfg,
+      authStore,
+      agentDir: params.targetAgentDir,
+    }).evaluateModelAuth(resolved.ref.provider, {
+      modelId: resolved.ref.model,
+      lockedProfileId: explicitProfile,
+      ...(entry ? { observedRoutes: [{ api: entry.api, baseUrl: entry.baseUrl }] } : {}),
+    });
+    if (auth.availability !== true || auth.selectedProfileId !== explicitProfile) {
+      return {
+        error: `sessions_spawn auth profile "${explicitProfile}" is unavailable or incompatible with provider "${resolved.ref.provider}".`,
       };
     }
   }

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -5,6 +5,7 @@ import { resolveUserPath } from "../../../utils.js";
 import { resolveAgentDir } from "../../agent-scope-config.js";
 import { findModelCatalogEntry } from "../../model-catalog-lookup.js";
 import type { ModelCatalogEntry } from "../../model-catalog.types.js";
+import { splitTrailingAuthProfile } from "../../model-ref-profile.js";
 import {
   findNormalizedProviderValue,
   resolveAllowedModelRef,
@@ -58,11 +59,11 @@ async function resolveSpawnModelError(params: {
   workspaceDir?: string;
   request: SpawnSubagentParams;
   resolvedModel?: string;
-}): Promise<string | undefined> {
+}): Promise<{ error?: string; requestedProvider?: string }> {
   const { cfg, targetAgentId } = params;
   const requestedModel = normalizeOptionalString(params.request.model);
   if (!requestedModel && !params.request.outputSchema) {
-    return undefined;
+    return {};
   }
   const defaults = resolveDefaultModelForAgent({ cfg, agentId: targetAgentId });
   const selected = splitModelRef(params.resolvedModel);
@@ -78,15 +79,20 @@ async function resolveSpawnModelError(params: {
       scopedLiveProviderDiscovery: true,
     });
   } catch (error) {
-    return `sessions_spawn could not verify ${requestedModel ? "the requested model" : "outputSchema model capabilities"}: ${summarizeSpawnError(error)}`;
+    return {
+      error: `sessions_spawn could not verify ${requestedModel ? "the requested model" : "outputSchema model capabilities"}: ${summarizeSpawnError(error)}`,
+    };
   }
 
   if (!requestedModel) {
     const model = selected.model ?? defaults.model;
     const entry = model && findModelCatalogEntry(catalog, { provider, modelId: model });
-    return entry && !supportsModelTools(entry)
-      ? `sessions_spawn outputSchema requires a tool-capable target model; "${provider}/${model}" declares compat.supportsTools=false.`
-      : undefined;
+    return {
+      error:
+        entry && !supportsModelTools(entry)
+          ? `sessions_spawn outputSchema requires a tool-capable target model; "${provider}/${model}" declares compat.supportsTools=false.`
+          : undefined,
+    };
   }
   const selection = {
     cfg,
@@ -100,7 +106,7 @@ async function resolveSpawnModelError(params: {
     raw: requestedModel,
   });
   if ("error" in resolved) {
-    return `sessions_spawn model "${requestedModel}" is not usable: ${resolved.error}`;
+    return { error: `sessions_spawn model "${requestedModel}" is not usable: ${resolved.error}` };
   }
 
   const entry = findModelCatalogEntry(catalog, {
@@ -118,13 +124,17 @@ async function resolveSpawnModelError(params: {
         workspaceDir: params.workspaceDir,
       }).status === "owned";
     if (!knownProvider) {
-      return `sessions_spawn model "${requestedModel}" is not usable: unknown model provider "${resolvedProvider}"`;
+      return {
+        error: `sessions_spawn model "${requestedModel}" is not usable: unknown model provider "${resolvedProvider}"`,
+      };
     }
   }
   if (params.request.outputSchema && entry && !supportsModelTools(entry)) {
-    return `sessions_spawn outputSchema requires a tool-capable target model; "${resolved.ref.provider}/${resolved.ref.model}" declares compat.supportsTools=false.`;
+    return {
+      error: `sessions_spawn outputSchema requires a tool-capable target model; "${resolved.ref.provider}/${resolved.ref.model}" declares compat.supportsTools=false.`,
+    };
   }
-  return undefined;
+  return { requestedProvider: resolved.ref.provider };
 }
 
 type ResolvedSubagentChildPlan = {
@@ -231,6 +241,12 @@ export async function resolveSubagentChildPlan(params: {
   const targetAgentDir = resolveAgentDir(params.cfg, params.targetAgentId);
   const requesterAgentConfig = resolveAgentConfig(params.cfg, params.requesterAgentId);
   const targetAgentConfig = resolveAgentConfig(params.cfg, params.targetAgentId);
+  const requestedModel = normalizeOptionalString(params.request.model);
+  // Policy authorizes model identity; credentials remain session-owned state.
+  // Keep the profile separate so launch auth stays model-scoped without losing selection.
+  const explicitModelSelection = requestedModel
+    ? splitTrailingAuthProfile(requestedModel)
+    : undefined;
   const callerThinkingRaw = readRequesterThinkingLevel({
     cfg: params.cfg,
     requesterInternalKey: params.requesterInternalKey,
@@ -249,7 +265,7 @@ export async function resolveSubagentChildPlan(params: {
     targetAgentId: params.targetAgentId,
     requesterAgentConfig,
     targetAgentConfig,
-    modelOverride: params.request.model,
+    modelOverride: explicitModelSelection?.model,
     thinkingOverrideRaw: params.request.thinking,
     callerThinkingRaw,
     fastMode: inheritedFastMode,
@@ -264,7 +280,7 @@ export async function resolveSubagentChildPlan(params: {
     };
   }
   const { resolvedModel } = modelPlan;
-  const modelError = await resolveSpawnModelError({
+  const modelValidation = await resolveSpawnModelError({
     cfg: params.cfg,
     targetAgentId: params.targetAgentId,
     targetAgentDir,
@@ -272,19 +288,42 @@ export async function resolveSubagentChildPlan(params: {
     request: params.request,
     resolvedModel,
   });
-  if (modelError) {
+  if (modelValidation.error) {
     return {
       ok: false,
       result: {
         status: "error",
-        error: modelError,
+        error: modelValidation.error,
         ...(params.request.outputSchema ? { childSessionKey } : {}),
       },
     };
   }
   const resolvedLaunchModel = splitModelRef(resolvedModel);
+  if (
+    explicitModelSelection?.profile &&
+    modelValidation.requestedProvider &&
+    resolvedLaunchModel.provider !== modelValidation.requestedProvider
+  ) {
+    return {
+      ok: false,
+      result: {
+        status: "error",
+        error: `sessions_spawn auth profile "${explicitModelSelection.profile}" cannot follow model fallback from "${modelValidation.requestedProvider}" to "${resolvedLaunchModel.provider}".`,
+      },
+    };
+  }
+  const resolvedModelPlan = explicitModelSelection?.profile
+    ? {
+        ...modelPlan,
+        initialSessionPatch: {
+          ...modelPlan.initialSessionPatch,
+          authProfileOverride: explicitModelSelection.profile,
+          authProfileOverrideSource: "user" as const,
+        },
+      }
+    : modelPlan;
   const launchAuthorization: SubagentLaunchAuthorization | undefined =
-    params.request.model?.trim() && resolvedLaunchModel.model
+    explicitModelSelection?.model && resolvedLaunchModel.model
       ? {
           modelOverride: {
             ...(resolvedLaunchModel.provider ? { provider: resolvedLaunchModel.provider } : {}),
@@ -304,7 +343,7 @@ export async function resolveSubagentChildPlan(params: {
       childSessionKey,
       childRuntimeSandboxed: childRuntime.sandboxed,
       targetAgentDir,
-      modelPlan,
+      modelPlan: resolvedModelPlan,
       launchAuthorization,
       resolvedModelMetadata: buildResolvedSubagentModelMetadata(resolvedModel),
     },

--- a/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
@@ -66,6 +66,11 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   if (typeof patch.thinkingLevel === "string" && patch.thinkingLevel.trim()) {
     entry.thinkingLevel = patch.thinkingLevel.trim();
   }
+  const authProfileOverride = normalizeOptionalString(patch.authProfileOverride);
+  if (authProfileOverride) {
+    entry.authProfileOverride = authProfileOverride;
+    entry.authProfileOverrideSource = patch.authProfileOverrideSource === "auto" ? "auto" : "user";
+  }
   if (patch.fastMode === true || patch.fastMode === false || patch.fastMode === "auto") {
     entry.fastMode = patch.fastMode;
   }

--- a/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
@@ -70,6 +70,9 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   if (authProfileOverride) {
     entry.authProfileOverride = authProfileOverride;
     entry.authProfileOverrideSource = patch.authProfileOverrideSource === "auto" ? "auto" : "user";
+    if (patch.authProfileOverrideRequired === true) {
+      entry.authProfileOverrideRequired = true;
+    }
   }
   if (patch.fastMode === true || patch.fastMode === false || patch.fastMode === "auto") {
     entry.fastMode = patch.fastMode;

--- a/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
@@ -283,6 +283,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
       modelOverrideSource: "user",
       authProfileOverride: "openai:work",
       authProfileOverrideSource: "user",
+      authProfileOverrideRequired: true,
     });
     expect(attemptedRun).toEqual({
       provider: "openai",

--- a/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
@@ -1,7 +1,12 @@
 // Subagent spawn model-session tests verify runtime model metadata is persisted
 // before a child agent run starts.
 import os from "node:os";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { resolveSessionAuthProfileOverrideSource } from "../../../config/sessions/auth-profile-override-provenance.js";
+import type { SessionEntry } from "../../../config/sessions/types.js";
+import { resolveSessionAuthSelection } from "../../auth-profiles/session-override.js";
+import { saveAuthProfileStore } from "../../auth-profiles/store.js";
 import {
   createSubagentSpawnTestConfig,
   expectPersistedRuntimeModel,
@@ -12,9 +17,25 @@ import {
 
 const callGatewayMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 let resetSubagentRegistryForTests: typeof import("../registry/subagent-registry.test-helpers.js").resetSubagentRegistryForTests;
 let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+
+function toCapturedSessionEntry(value: unknown): SessionEntry | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.sessionId !== "string") {
+    return undefined;
+  }
+  return {
+    ...candidate,
+    sessionId: candidate.sessionId,
+    updatedAt: typeof candidate.updatedAt === "number" ? candidate.updatedAt : 0,
+  };
+}
 
 describe("spawnSubagentDirect runtime model persistence", () => {
   beforeAll(async () => {
@@ -141,5 +162,118 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     expect(persistedEntry?.modelOverrideSource).toBe("auto");
     expect(persistedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
     expect(persistedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.4");
+  });
+
+  it("keeps a selected auth profile separate from the authorized child model", async () => {
+    const targetAgentDir = tempDirs.make("openclaw-subagent-auth-");
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai:default": { type: "api_key", provider: "openai", key: "sk-default" },
+          "openai:work": { type: "api_key", provider: "openai", key: "sk-test" },
+        },
+        order: { openai: ["openai:default", "openai:work"] },
+      },
+      targetAgentDir,
+      { syncExternalCli: false },
+    );
+    const cfg = createSubagentSpawnTestConfig(os.tmpdir(), {
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          model: { primary: "openai/gpt-5.6-luna" },
+          models: { "openai/gpt-5.6-luna": { alias: "approved" } },
+        },
+        list: [
+          { id: "main", subagents: { allowAgents: ["worker"] } },
+          {
+            id: "worker",
+            agentDir: targetAgentDir,
+            model: { primary: "openai/gpt-5.6-luna" },
+            modelPolicy: { allow: ["approved"] },
+          },
+        ],
+      },
+    });
+    const dedicatedCallGatewayMock = vi.fn();
+    const dedicatedUpdateSessionStoreMock = vi.fn();
+    const {
+      resetSubagentRegistryForTests: resetForProfileTest,
+      spawnSubagentDirect: spawnWithProfile,
+    } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: dedicatedCallGatewayMock,
+      getRuntimeConfig: () => cfg,
+      loadPreparedModelCatalogMock: vi
+        .fn()
+        .mockResolvedValue([{ provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna" }]),
+      updateSessionStoreMock: dedicatedUpdateSessionStoreMock,
+      workspaceDir: os.tmpdir(),
+    });
+    resetForProfileTest();
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    let attemptedRun: Record<string, unknown> | undefined;
+    installSessionStoreCaptureMock(dedicatedUpdateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+    dedicatedCallGatewayMock.mockImplementation(
+      async (request: { method?: string; params?: Record<string, unknown> }) => {
+        if (request.method === "agent") {
+          const [sessionKey, rawEntry] = Object.entries(persistedStore ?? {})[0] ?? [];
+          const sessionEntry = toCapturedSessionEntry(rawEntry);
+          const authSelection = await resolveSessionAuthSelection({
+            cfg,
+            provider: "openai",
+            modelId: "gpt-5.6-luna",
+            agentDir: targetAgentDir,
+            sessionEntry,
+            sessionStore: sessionKey && sessionEntry ? { [sessionKey]: sessionEntry } : undefined,
+            sessionKey,
+            isNewSession: true,
+          });
+          const authProfileId = authSelection?.profileId;
+          attemptedRun = {
+            provider: request.params?.provider,
+            model: request.params?.model,
+            authProfileId,
+            authProfileIdSource:
+              authProfileId && sessionEntry?.authProfileOverride === authProfileId
+                ? resolveSessionAuthProfileOverrideSource(sessionEntry)
+                : undefined,
+          };
+          return { runId: "run-1", status: "accepted", acceptedAt: 1000 };
+        }
+        return { ok: true };
+      },
+    );
+
+    const result = await spawnWithProfile(
+      { task: "use selected credentials", agentId: "worker", model: "approved@openai:work" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      resolvedModel: "openai/gpt-5.6-luna",
+      resolvedProvider: "openai",
+    });
+    const [, persistedEntry] = Object.entries(persistedStore ?? {})[0] ?? [];
+    expect(persistedEntry).toMatchObject({
+      modelProvider: "openai",
+      model: "gpt-5.6-luna",
+      providerOverride: "openai",
+      modelOverride: "gpt-5.6-luna",
+      modelOverrideSource: "user",
+      authProfileOverride: "openai:work",
+      authProfileOverrideSource: "user",
+    });
+    expect(attemptedRun).toEqual({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      authProfileId: "openai:work",
+      authProfileIdSource: "user",
+    });
   });
 });

--- a/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
@@ -173,6 +173,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
         profiles: {
           "openai:default": { type: "api_key", provider: "openai", key: "sk-default" },
           "openai:work": { type: "api_key", provider: "openai", key: "sk-test" },
+          "anthropic:work": { type: "api_key", provider: "anthropic", key: "sk-other" },
         },
         order: { openai: ["openai:default", "openai:work"] },
       },
@@ -249,6 +250,19 @@ describe("spawnSubagentDirect runtime model persistence", () => {
         return { ok: true };
       },
     );
+
+    for (const profileId of ["openai:missing", "anthropic:work"]) {
+      const rejected = await spawnWithProfile(
+        { task: "reject selected credentials", agentId: "worker", model: `approved@${profileId}` },
+        { agentSessionKey: "agent:main:main" },
+      );
+      expect(rejected).toMatchObject({
+        status: "error",
+        error: expect.stringContaining(`auth profile "${profileId}" is unavailable`),
+      });
+      expect(persistedStore).toBeUndefined();
+      expect(dedicatedCallGatewayMock).not.toHaveBeenCalled();
+    }
 
     const result = await spawnWithProfile(
       { task: "use selected credentials", agentId: "worker", model: "approved@openai:work" },

--- a/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
@@ -3,6 +3,7 @@
 import os from "node:os";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../../config/sessions/auth-profile-override-provenance.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import { resolveSessionAuthSelection } from "../../auth-profiles/session-override.js";
@@ -195,7 +196,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
           },
         ],
       },
-    });
+    }) as OpenClawConfig;
     const dedicatedCallGatewayMock = vi.fn();
     const dedicatedUpdateSessionStoreMock = vi.fn();
     const {

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -2082,6 +2082,21 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.model).toBe("github-copilot/claude-sonnet-4.6");
   });
 
+  it("rejects native auth-profile suffixes before ACP dispatch", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+
+    await expect(
+      tool.execute("call-acp-profile", {
+        runtime: "acp",
+        task: "investigate the failing CI run",
+        agentId: "codex",
+        model: "openai/gpt-5.4@openai:work",
+      }),
+    ).rejects.toThrow('auth-profile suffixes support runtime="subagent" only');
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
   it("forwards a per-run timeout to ACP runtime spawns", async () => {
     registerAcpBackendForTest();
     const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -20,6 +20,7 @@ import {
   formatAcpInheritedToolAllowError,
   formatAcpInheritedToolDenyError,
 } from "../inherited-tool-deny.js";
+import { splitTrailingAuthProfile } from "../model-ref-profile.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { SpawnedToolContext } from "../spawned-context.js";
 import { getSubagentDeliveryBacklogPressure } from "../subagents/registry/subagent-registry.js";
@@ -177,7 +178,7 @@ function createSessionsSpawnToolSchema(params: {
     model: Type.Optional(
       Type.String({
         description:
-          "Child model override. Append @<auth-profile-id> to require that exact credential profile for the child run.",
+          "Child model override. For native subagents, append @<auth-profile-id> to require that exact credential profile.",
       }),
     ),
     runTimeoutSeconds: Type.Optional(
@@ -423,6 +424,11 @@ export function createSessionsSpawnTool(
       const requestedAgentId = readToolStringParam(params, "agentId");
       const resumeSessionId = readToolStringParam(params, "resumeSessionId");
       const modelOverride = normalizeToolModelOverride(readToolStringParam(params, "model"));
+      if (runtime === "acp" && splitTrailingAuthProfile(modelOverride ?? "").profile) {
+        throw new ToolInputError(
+          'sessions_spawn model auth-profile suffixes support runtime="subagent" only.',
+        );
+      }
       const thinkingOverrideRaw = readToolStringParam(params, "thinking");
       const cwd = readToolStringParam(params, "cwd");
       const mode = params.mode === "run" || params.mode === "session" ? params.mode : undefined;

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -174,7 +174,12 @@ function createSessionsSpawnToolSchema(params: {
       { description: 'Runtime; visible=true requires "subagent".' },
     ),
     agentId: Type.Optional(Type.String()),
-    model: Type.Optional(Type.String()),
+    model: Type.Optional(
+      Type.String({
+        description:
+          "Child model override. Append @<auth-profile-id> to require that exact credential profile for the child run.",
+      }),
+    ),
     runTimeoutSeconds: Type.Optional(
       Type.Integer({
         minimum: 0,

--- a/src/agents/tools/sessions-tool.test.ts
+++ b/src/agents/tools/sessions-tool.test.ts
@@ -649,6 +649,7 @@ describe("sessions tool", () => {
               prevModelOverrideFallbackOriginModel: "primary",
               prevAuthProfileOverride: "good-profile",
               prevAuthProfileOverrideSource: "user",
+              prevAuthProfileOverrideRequired: true,
               prevThinkingLevel: "high",
               ts: Date.now(),
               source: "agent-patch",
@@ -692,6 +693,7 @@ describe("sessions tool", () => {
           prevModelOverrideFallbackOriginProvider: "openai",
           prevModelOverrideFallbackOriginModel: "primary",
           prevAuthProfileOverride: "good-profile",
+          prevAuthProfileOverrideRequired: true,
           prevThinkingLevel: "high",
           source: "agent-patch",
         },
@@ -715,6 +717,7 @@ describe("sessions tool", () => {
         modelOverrideFallbackOriginProvider: "openai",
         modelOverrideFallbackOriginModel: "primary",
         authProfileOverride: "good-profile",
+        authProfileOverrideRequired: true,
         thinkingLevel: "high",
       });
       expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).not.toHaveProperty(

--- a/src/config/sessions/reset-preserved-selection.ts
+++ b/src/config/sessions/reset-preserved-selection.ts
@@ -12,6 +12,7 @@ type ResetPreservedSelectionState = Pick<
   | "authProfileOverride"
   | "authProfileOverrideSource"
   | "authProfileOverrideCompactionCount"
+  | "authProfileOverrideRequired"
 >;
 
 /**
@@ -58,6 +59,9 @@ export function resolveResetPreservedSelection(params: {
     preserved.authProfileOverrideSource = authProfileOverrideSource;
     if (entry.authProfileOverrideCompactionCount !== undefined) {
       preserved.authProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
+    }
+    if (entry.authProfileOverrideRequired) {
+      preserved.authProfileOverrideRequired = true;
     }
   }
 

--- a/src/config/sessions/session-model-fallback.ts
+++ b/src/config/sessions/session-model-fallback.ts
@@ -10,6 +10,7 @@ export type AgentPatchedSessionModelFallback = {
   prevAuthProfileOverride?: string;
   prevAuthProfileOverrideSource?: "auto" | "user";
   prevAuthProfileOverrideCompactionCount?: number;
+  prevAuthProfileOverrideRequired?: boolean;
   prevContextWindow?: string;
   prevThinkingLevel?: string;
   lastValidatedPatchTs?: number;
@@ -30,6 +31,7 @@ export function createAgentPatchedSessionModelFallback(params: {
     authProfileOverride?: string;
     authProfileOverrideSource?: "auto" | "user";
     authProfileOverrideCompactionCount?: number;
+    authProfileOverrideRequired?: boolean;
     contextWindow?: string;
     thinkingLevel?: string;
   };
@@ -58,6 +60,7 @@ export function createAgentPatchedSessionModelFallback(params: {
     ...(entry.authProfileOverrideCompactionCount !== undefined
       ? { prevAuthProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount }
       : {}),
+    ...(entry.authProfileOverrideRequired ? { prevAuthProfileOverrideRequired: true } : {}),
     ...(entry.contextWindow ? { prevContextWindow: entry.contextWindow } : {}),
     ...(entry.thinkingLevel ? { prevThinkingLevel: entry.thinkingLevel } : {}),
     ts: params.ts,

--- a/src/config/sessions/session-snapshot-merge.ts
+++ b/src/config/sessions/session-snapshot-merge.ts
@@ -14,6 +14,7 @@ export const SESSION_MODEL_OVERRIDE_TRANSACTION_FIELDS = [
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
+  "authProfileOverrideRequired",
 ] as const satisfies ReadonlyArray<keyof SessionEntry>;
 
 const MODEL_ROUTE_OVERRIDE_FIELDS = [

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -531,6 +531,8 @@ type SessionEntryCore = SessionRestartRecoveryState &
     authProfileOverride?: string;
     authProfileOverrideSource?: "auto" | "user";
     authProfileOverrideCompactionCount?: number;
+    /** Fails the run instead of replacing an explicit spawn credential selection. */
+    authProfileOverrideRequired?: boolean;
     /**
      * Set on explicit user-driven session model changes (for example `/model`
      * and `sessions.patch`) during an active run. The embedded runner checks

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -978,6 +978,7 @@ describe("gateway sessions patch", () => {
       modelOverrideFallbackOriginModel: "gpt-primary",
       authProfileOverride: "openai:good",
       authProfileOverrideSource: "user",
+      authProfileOverrideRequired: true,
       thinkingLevel: "high",
     });
     const entry = await withAgentSessionModelPatchOrigin(
@@ -997,6 +998,7 @@ describe("gateway sessions patch", () => {
       prevModelOverrideFallbackOriginProvider: "openai",
       prevModelOverrideFallbackOriginModel: "gpt-primary",
       prevAuthProfileOverride: "openai:good",
+      prevAuthProfileOverrideRequired: true,
       prevThinkingLevel: "high",
       source: "agent-patch",
     });

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -112,6 +112,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
+  "authProfileOverrideRequired",
   "liveModelSwitchPending",
   "groupActivation",
   "groupActivationNeedsSystemIntro",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -73,6 +73,7 @@
             "type": "string"
           },
           "model": {
+            "description": "Child model override. For native subagents, append @<auth-profile-id> to require that exact credential profile.",
             "type": "string"
           },
           "runtime": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -222,6 +222,7 @@
           "type": "string"
         },
         "model": {
+          "description": "Child model override. For native subagents, append @<auth-profile-id> to require that exact credential profile.",
           "type": "string"
         },
         "runtime": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=0ffd165216012ff63244b6d9b39269a3a8775bdacbbc1f1bcb52c8a6dfb8b03e
-+++ discord-group-codex-message-tool.md	sha256=5d6e349160a987be177164637f54004e67108496f6cc4f511188165b1b917c1f
+--- telegram-direct-codex-message-tool.md	sha256=9a1694555afac61423c07940fa3e83a222df2b1ffbf2c468630cabe78e5bf241
++++ discord-group-codex-message-tool.md	sha256=d5dbc38210f67c7cd87ac30b4e8a2850ddfcfd8686541a9b9eb491baf1ad9eab
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -29,10 +29,10 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
 @@ -235,2 +235,2 @@
--    "chars": 54985,
--    "roughTokens": 13747
-+    "chars": 55293,
-+    "roughTokens": 13824
+-    "chars": 55125,
+-    "roughTokens": 13782
++    "chars": 55433,
++    "roughTokens": 13859
 @@ -239,2 +239,2 @@
 -    "chars": 3518,
 -    "roughTokens": 880
@@ -44,10 +44,10 @@
 +    "chars": 28944,
 +    "roughTokens": 7236
 @@ -247,2 +247,2 @@
--    "chars": 82451,
--    "roughTokens": 20613
-+    "chars": 84239,
-+    "roughTokens": 21060
+-    "chars": 82591,
+-    "roughTokens": 20648
++    "chars": 84379,
++    "roughTokens": 21095
 @@ -251,2 +251,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -232,8 +232,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 54985,
-    "roughTokens": 13747
+    "chars": 55125,
+    "roughTokens": 13782
   },
   "openClawDeveloperInstructions": {
     "chars": 3518,
@@ -244,8 +244,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6866
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82451,
-    "roughTokens": 20613
+    "chars": 82591,
+    "roughTokens": 20648
   },
   "userInputText": {
     "chars": 863,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=0ffd165216012ff63244b6d9b39269a3a8775bdacbbc1f1bcb52c8a6dfb8b03e
-+++ telegram-heartbeat-codex-tool.md	sha256=779e4c800001a1e8f39964284b8de70d07694fbfc60c5a17bdefe7e1dc2b25f7
+--- telegram-direct-codex-message-tool.md	sha256=9a1694555afac61423c07940fa3e83a222df2b1ffbf2c468630cabe78e5bf241
++++ telegram-heartbeat-codex-tool.md	sha256=5c83a82bb0449606ade146cf2bc9a0a1fae12b3022febd26ddb01a2ec3e519e7
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -32,20 +32,20 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
 @@ -235,2 +230,2 @@
--    "chars": 54985,
--    "roughTokens": 13747
-+    "chars": 56478,
-+    "roughTokens": 14120
+-    "chars": 55125,
+-    "roughTokens": 13782
++    "chars": 56618,
++    "roughTokens": 14155
 @@ -243,2 +238,2 @@
 -    "chars": 27464,
 -    "roughTokens": 6866
 +    "chars": 27806,
 +    "roughTokens": 6952
 @@ -247,2 +242,2 @@
--    "chars": 82451,
--    "roughTokens": 20613
-+    "chars": 84286,
-+    "roughTokens": 21072
+-    "chars": 82591,
+-    "roughTokens": 20648
++    "chars": 84426,
++    "roughTokens": 21107
 @@ -251,2 +246,2 @@
 -    "chars": 863,
 -    "roughTokens": 216


### PR DESCRIPTION
Closes #120183

## What Problem This Solves

Fixes an issue where native `sessions_spawn` calls with a model excluded by the target agent's policy were initially reported as accepted, then failed asynchronously after durable child state had already been created.

## Why This Change Was Made

Explicit native model requests now pass through the canonical target-agent model policy during child planning, before session persistence. Allowed aliases are resolved to one canonical provider/model for persistence and launch authorization; configured/automatic selection keeps its existing runtime path, and runtime validation remains in place to cover policy changes between planning and launch.

## User Impact

Agents receive an immediate actionable error for an invalid or disallowed explicit child model, without a failed child session/task being created. Accepted launches remain non-blocking, and allowed dynamic, wildcard, alias, legacy-policy, and automatic-selection behavior is preserved.

## Evidence

Pre-fix real-Gateway reproduction on `ea4466e5dce50cf972524623990e27db8f3b32be`:

- `cleanup: "keep"`: `sessions_spawn` returned accepted; the exact policy rejection arrived 998 ms later. Failed session/task state survived a clean Gateway restart.
- `cleanup: "delete"`: the launch was also accepted before failing 518 ms later; asynchronous deletion completed about 17 seconds after acceptance.
- No child transcript or provider request was created in either case. Full redacted setup and provenance are in #120183.

Post-fix focused proof:

- `node scripts/run-vitest.mjs src/agents/subagent-spawn.model-session.test.ts` — 1 file, 8 tests passed.
- Denied explicit model: synchronous error with zero session-store writes, registry records, lifecycle events, Gateway calls, or transcript-producing launch path.
- Allowed behavior: target-agent policy replacement, canonical alias persistence/authorization, allow-any dynamic refs, provider wildcards, unmarked legacy allowlists, and configured automatic selection.
- `pnpm docs:list` passed.
- `pnpm docs:check-mdx` passed (768 files).
- `oxfmt` and `git diff --check` passed.
- Fresh Codex autoreview: clean, no actionable findings.

A post-fix isolated real-Gateway rerun was prepared but did not execute because another repository `pr-gates` run held the heavy-check lock. The real-Gateway observations above are pre-fix evidence; post-fix evidence is the focused Vitest seam proof and CI remains pending.

| Surface | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 38 | 4 | +34 |
| Tests | 175 | 0 | +175 |
| Docs | 5 | 5 | 0 |

The positive production delta establishes the pre-persistence policy/state ownership boundary and carries the canonical resolved model through session persistence and launch authorization.

## AI Assistance

AI-assisted investigation, implementation, tests, documentation, and review were performed with Codex. The maintainer directed scope and publication; focused tests and the structured autoreview results are reported above.
