### PR TITLE
fix(release): accept verified prerelease plugin companions

### DIFF
--- a/scripts/prepublish-plugin-registry-artifact.mjs
+++ b/scripts/prepublish-plugin-registry-artifact.mjs
@@ -133,11 +133,12 @@ export function validatePrepublishPluginRegistryArtifact(params) {
     throw new Error("prepublish plugin registry version differs from the root package candidate");
   }
   const requiredPackages = normalizeRequiredPackages(params.requiredPackages);
-  if (
-    JSON.stringify(manifest.packages.map((entry) => entry.name)) !==
-    JSON.stringify(requiredPackages)
-  ) {
-    throw new Error("prepublish plugin registry package set differs from the Docker plan");
+  const manifestPackageNames = new Set(manifest.packages.map((entry) => entry.name));
+  const missingRequiredPackage = requiredPackages.find((name) => !manifestPackageNames.has(name));
+  if (missingRequiredPackage) {
+    throw new Error(
+      `prepublish plugin registry is missing Docker-plan package ${missingRequiredPackage}`,
+    );
   }
   const expectedFiles = new Set([
     PREPUBLISH_PLUGIN_REGISTRY_MANIFEST,

--- a/test/scripts/prepublish-plugin-registry-artifact.test.ts
+++ b/test/scripts/prepublish-plugin-registry-artifact.test.ts
@@ -81,6 +81,27 @@ function firstPackage(paths: ReturnType<typeof fixture>) {
   return entry;
 }
 
+function addCompanionPackage(paths: ReturnType<typeof fixture>) {
+  const name = "@openclaw/feishu";
+  const tarball = "openclaw-feishu-2026.8.1-beta.1.tgz";
+  const archiveRoot = path.join(path.dirname(paths.artifactDir), "feishu-package");
+  const packageRoot = path.join(archiveRoot, "package");
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify({ name, version: VERSION })}\n`,
+  );
+  const tarballPath = path.join(paths.artifactDir, tarball);
+  execFileSync("tar", ["-czf", tarballPath, "-C", archiveRoot, "package"]);
+  paths.manifest.packages.push({
+    name,
+    version: VERSION,
+    tarball,
+    sha256: sha256(tarballPath),
+  });
+  paths.writeManifest();
+}
+
 function cliFixture() {
   const repoRoot = mkdtempSync(path.join(tmpdir(), "openclaw-prepublish-plugin-cli-"));
   tempDirs.push(repoRoot);
@@ -159,6 +180,16 @@ describe("prepublish plugin registry artifact", () => {
         validatePrepublishPluginRegistryArtifact({ ...common, [field]: undefined }),
       ).toThrow(field);
     }
+  });
+
+  it("accepts immutable companion packages beyond the selected Docker plan", () => {
+    const paths = fixture();
+    addCompanionPackage(paths);
+
+    expect(validate(paths).manifest.packages.map((entry) => entry.name)).toEqual([
+      "@openclaw/discord",
+      "@openclaw/feishu",
+    ]);
   });
 
   it("refuses to create an artifact from tracked changes under the same HEAD", () => {
@@ -275,7 +306,7 @@ describe("prepublish plugin registry artifact", () => {
 
     const required = fixture();
     expect(() => validate(required, { requiredPackages: ["@openclaw/feishu"] })).toThrow(
-      "package set differs",
+      "missing Docker-plan package",
     );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation creates one immutable prerelease plugin registry for multiple release children. A child that requires only `@openclaw/discord` rejects the shared registry when it also contains the verified `@openclaw/feishu` companion.

## Why This Change Was Made

The registry is already bound to its source SHA, candidate version, manifest digest, tarball hashes, and package identities. Require every package needed by the current Docker plan, while permitting verified companions needed by sibling release children.

## User Impact

Unblocks shared release-candidate validation without weakening package identity or integrity checks.

## Evidence

- Failed release job: 92801555441 (`prepublish plugin registry package set differs from the Docker plan`).
- Direct Node proof created a two-package immutable registry and validated the one-package child requirement.
- `git diff --check` passed.
- Structured autoreview (`--mode uncommitted`) returned clean with no accepted/actionable findings.
- Focused Vitest execution is pending GitHub CI because this isolated worktree lacks `node_modules`; Blacksmith Testbox and brokered Crabbox are unauthenticated in this session.

AI-assisted release-maintainer change.