### PR TITLE
fix(subagents): wake the parent when a follow-up finishes a yielded child

### DIFF
--- a/config/knip.all-exports.config.ts
+++ b/config/knip.all-exports.config.ts
@@ -93,10 +93,11 @@ const workspaces = Object.fromEntries(
           ? [".agents/skills/**/scripts/**/*.{js,mjs,cjs,ts,mts,cts}!", ...ROOT_TEST_ENTRY_GLOBS]
           : [
               TEST_ENTRY_GLOB,
-              // QA Lab loads this plugin fixture by path during the Gateway E2E.
-              ...(workspace === "extensions/qa-lab"
-                ? ["test-fixtures/current-requester-subagent-plugin/index.js!"]
-                : []),
+              // QA Lab loads these plugin fixtures by path during the Gateway
+              // E2E, so nothing imports their entry files. Matched as a group:
+              // a per-fixture list silently rots into a knip failure the next
+              // time a scenario needs its own fixture plugin.
+              ...(workspace === "extensions/qa-lab" ? ["test-fixtures/*/index.js!"] : []),
             ]),
       ],
       project:

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -301,7 +301,7 @@ A sub-agent can also yield on its own behalf to wait for external work, such
 as a remote job or a long-running task it does not drive itself. That pauses
 the child run instead of completing it, so the requester receives no
 completion event yet and keeps waiting. A plugin can then continue that same run
-by calling `runtime.subagent.run` with the paused `sessionKey`, instead of
+by calling `api.runtime.subagent.run` with the paused `sessionKey`, instead of
 starting a sibling. The requester is announced once such a follow-up finishes
 normally; a follow-up that yields again leaves the run paused and the requester
 waiting.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -306,9 +306,11 @@ starting a sibling. The requester is announced once such a follow-up finishes
 normally; a follow-up that yields again leaves the run paused and the requester
 waiting.
 
-Continuation is specific to the plugin runtime API above. Follow-ups that reach
-the paused session by other routes are not tracked as sub-agent runs, so they
-neither continue the paused run nor announce its requester.
+Automatic continuation is specific to the plugin runtime API above. Ordinary
+follow-ups through routes not tracked as sub-agent runs neither continue the
+paused run nor announce its requester. Explicit `subagents` steering is
+different: it deliberately replaces the yielded run and continues the same
+child session.
 
 Among plugin runtime follow-ups, continuation applies to those that use default
 delivery. A follow-up that supplies its own requester or completion-delivery

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -306,6 +306,11 @@ with the same `sessionKey` — it continues that same run rather than starting a
 sibling. The requester is announced once such a follow-up finishes normally;
 a follow-up that yields again leaves the run paused and the requester waiting.
 
+Continuation applies to follow-ups that use default delivery. A follow-up that
+supplies its own requester or completion-delivery context is asking for its own
+audience, so it runs as a separate sibling and delivers there instead. The
+paused run stays resumable, and a later default follow-up still continues it.
+
 When active children exist, OpenClaw injects a compact runtime-generated
 `Active Subagents` prompt block into normal turns so the requester can see
 the current child sessions, run ids, statuses, labels, tasks, and

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -297,6 +297,15 @@ it. Some minimal or custom tool profiles may expose `sessions_spawn` and
 `subagents` without exposing `sessions_yield`; in that case, do not invent
 a polling loop just to wait for completion.
 
+A sub-agent can also yield on its own behalf to wait for external work, such
+as a remote job or a long-running task it does not drive itself. That pauses
+the child run instead of completing it, so the requester receives no
+completion event yet and keeps waiting. When a later follow-up targets the
+paused child session — for example a plugin calling `runtime.subagent.run`
+with the same `sessionKey` — it continues that same run rather than starting a
+sibling. The requester is announced once such a follow-up finishes normally;
+a follow-up that yields again leaves the run paused and the requester waiting.
+
 When active children exist, OpenClaw injects a compact runtime-generated
 `Active Subagents` prompt block into normal turns so the requester can see
 the current child sessions, run ids, statuses, labels, tasks, and

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -300,16 +300,21 @@ a polling loop just to wait for completion.
 A sub-agent can also yield on its own behalf to wait for external work, such
 as a remote job or a long-running task it does not drive itself. That pauses
 the child run instead of completing it, so the requester receives no
-completion event yet and keeps waiting. When a later follow-up targets the
-paused child session — for example a plugin calling `runtime.subagent.run`
-with the same `sessionKey` — it continues that same run rather than starting a
-sibling. The requester is announced once such a follow-up finishes normally;
-a follow-up that yields again leaves the run paused and the requester waiting.
+completion event yet and keeps waiting. A plugin can then continue that same run
+by calling `runtime.subagent.run` with the paused `sessionKey`, instead of
+starting a sibling. The requester is announced once such a follow-up finishes
+normally; a follow-up that yields again leaves the run paused and the requester
+waiting.
 
-Continuation applies to follow-ups that use default delivery. A follow-up that
-supplies its own requester or completion-delivery context is asking for its own
-audience, so it runs as a separate sibling and delivers there instead. The
-paused run stays resumable, and a later default follow-up still continues it.
+Continuation is specific to the plugin runtime API above. Follow-ups that reach
+the paused session by other routes are not tracked as sub-agent runs, so they
+neither continue the paused run nor announce its requester.
+
+Among plugin runtime follow-ups, continuation applies to those that use default
+delivery. A follow-up that supplies its own requester or completion-delivery
+context is asking for its own audience, so it runs as a separate sibling and
+delivers there instead. The paused run stays resumable, and a later default
+follow-up still continues it.
 
 When active children exist, OpenClaw injects a compact runtime-generated
 `Active Subagents` prompt block into normal turns so the requester can see

--- a/extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts
+++ b/extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts
@@ -1,0 +1,151 @@
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { startQaGatewayChild } from "./gateway-child.js";
+import { QA_SUBAGENT_SELF_YIELD_MARKER } from "./providers/mock-openai/mock-openai-contracts.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+
+const PLUGIN_ID = "qa-self-yield-followup-subagent";
+const TRIGGER = "qa self yield follow-up";
+const REQUESTER_CONVERSATION = { id: "requester-user", kind: "direct" as const };
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const PLUGIN_DIR = path.join(
+  REPO_ROOT,
+  "extensions/qa-lab/test-fixtures/self-yield-followup-subagent-plugin",
+);
+
+function withFixturePlugin(config: OpenClawConfig): OpenClawConfig {
+  return {
+    ...config,
+    plugins: {
+      ...config.plugins,
+      enabled: true,
+      allow: [...new Set([...(config.plugins?.allow ?? []), PLUGIN_ID])],
+      load: {
+        ...config.plugins?.load,
+        paths: [...new Set([...(config.plugins?.load?.paths ?? []), PLUGIN_DIR])],
+      },
+      entries: {
+        ...config.plugins?.entries,
+        [PLUGIN_ID]: { enabled: true },
+      },
+    },
+  };
+}
+
+describe("plugin subagent sessions_yield follow-up", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      await cleanup();
+    }
+  });
+
+  it("announces to the original requester only after the follow-up run ends", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+
+    const gateway = await startQaGatewayChild({
+      repoRoot: REPO_ROOT,
+      useRepoCli: true,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+      mutateConfig: withFixturePlugin,
+    });
+    cleanups.push(() => gateway.stop());
+    await transport.waitReady({ gateway });
+
+    const outboundStartIndex = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound").length;
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: REQUESTER_CONVERSATION,
+      senderId: REQUESTER_CONVERSATION.id,
+      text: TRIGGER,
+    });
+
+    const failureContext = (error: unknown) =>
+      new Error(
+        [
+          error instanceof Error ? error.message : String(error),
+          `bus=${JSON.stringify(state.getSnapshot())}`,
+          `gateway=${gateway.logs()}`,
+        ].join("\n"),
+        { cause: error },
+      );
+
+    try {
+      const spawn = await transport.waitForOutbound({
+        conversation: REQUESTER_CONVERSATION,
+        sinceIndex: outboundStartIndex,
+        textIncludes: "QA-SELF-YIELD-SPAWNED",
+        timeoutMs: 30_000,
+      });
+
+      // Anchor the quiet window on the spawn acknowledgement itself rather than a
+      // snapshot taken afterwards, so an announce arriving between the two is
+      // still observed instead of being skipped as already-seen traffic.
+      const outboundAfterSpawn =
+        state
+          .getSnapshot()
+          .messages.filter((message) => message.direction === "outbound")
+          .findIndex((message) => message.id === spawn.id) + 1;
+      // The child pauses itself here. The requester must stay parked: an announce
+      // now would report a run that has produced no result yet, which is the
+      // silent-wrong-outcome this flow exists to prevent.
+      await transport.waitForNoOutbound({
+        sinceIndex: outboundAfterSpawn,
+        quietMs: 15_000,
+      });
+
+      const [, kickoffRunId, childSessionKey] = spawn.text.split(" ");
+      expect(childSessionKey).toBeTruthy();
+
+      const followUpResponse = await fetch(`${gateway.baseUrl}/qa/self-yield/follow-up`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${gateway.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ sessionKey: childSessionKey }),
+      });
+      expect(followUpResponse.status).toBe(200);
+      const followUp = (await followUpResponse.json()) as { runId: string };
+      // Adoption retires the paused run in favour of the follow-up, so the two
+      // runs are distinct gateway ids over one continued unit of work.
+      expect(followUp.runId).not.toBe(kickoffRunId);
+
+      const completion = await transport.waitForOutbound({
+        conversation: REQUESTER_CONVERSATION,
+        sinceIndex: outboundStartIndex,
+        textIncludes: QA_SUBAGENT_SELF_YIELD_MARKER,
+        timeoutMs: 90_000,
+      });
+      expect(completion.accountId).toBe("default");
+    } catch (error) {
+      throw failureContext(error);
+    }
+
+    const outbound = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound");
+    // Exactly one announce for the whole continued run: the paused kickoff must
+    // not announce separately, and the follow-up must not announce twice.
+    expect(
+      outbound.filter((message) => message.text.includes(QA_SUBAGENT_SELF_YIELD_MARKER)),
+    ).toHaveLength(1);
+  }, 180_000);
+});

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -284,6 +284,12 @@ export const QA_WHATSAPP_REPLY_TO_BOT_TRIGGER_MARKER_RE =
 export const QA_WHATSAPP_BATCHED_FINAL_MARKER_RE = /\bWHATSAPP_QA_BATCHED_FINAL_([A-Z0-9]+)\b/u;
 export const QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE = /subagent direct fallback qa check/i;
 export const QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE = /subagent direct fallback worker/i;
+// A subagent that yields on its own behalf, then finishes on a later follow-up
+// dispatched to the same paused child session. The worker regex must not match
+// the follow-up text, so the two turns carry deliberately disjoint wording: the
+// kickoff yields, and only the follow-up may finish.
+export const QA_SUBAGENT_SELF_YIELD_WORKER_RE = /subagent self yield qa worker/i;
+export const QA_SUBAGENT_SELF_YIELD_FOLLOW_UP_RE = /subagent self yield qa remote job finished/i;
 export const QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE =
   /subagent terminal reply qa check:\s*(visible|silent|empty|restart|fallback)/i;
 export const QA_SUBAGENT_TERMINAL_MATRIX_WORKER_RE =
@@ -312,6 +318,7 @@ export function isStrandedFinalRetryFailureRequest(allInputText: string): boolea
   );
 }
 export const QA_SUBAGENT_DIRECT_FALLBACK_MARKER = "QA-SUBAGENT-DIRECT-FALLBACK-OK";
+export const QA_SUBAGENT_SELF_YIELD_MARKER = "QA-SUBAGENT-SELF-YIELD-FOLLOW-UP-OK";
 export const QA_SUBAGENT_TERMINAL_MARKERS = {
   visible: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",
   empty: "QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -67,12 +67,15 @@ import {
   QA_WHATSAPP_AGENT_MESSAGE_ACTION_UPLOAD_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE,
+  QA_SUBAGENT_SELF_YIELD_FOLLOW_UP_RE,
+  QA_SUBAGENT_SELF_YIELD_WORKER_RE,
   QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE,
   QA_SUBAGENT_TERMINAL_MATRIX_WORKER_RE,
   buildStrandedFinalRecoveryText,
   buildStrandedFinalRetryFailureText,
   isStrandedFinalRetryFailureRequest,
   QA_SUBAGENT_DIRECT_FALLBACK_MARKER,
+  QA_SUBAGENT_SELF_YIELD_MARKER,
   QA_SUBAGENT_TERMINAL_MARKERS,
   QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
   QA_NATIVE_STOP_DELAY_PROMPT_RE,
@@ -1136,6 +1139,18 @@ async function buildResponsesPayload(
   }
   if (QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE.test(prompt)) {
     return buildAssistantEvents(QA_SUBAGENT_DIRECT_FALLBACK_MARKER);
+  }
+  // A child that pauses itself and finishes only when a later follow-up arrives
+  // on the same session. Both turns are matched on the current prompt so the
+  // yielded kickoff, still present in the shared transcript, cannot make the
+  // follow-up turn yield a second time.
+  if (QA_SUBAGENT_SELF_YIELD_FOLLOW_UP_RE.test(prompt)) {
+    return buildAssistantEvents(QA_SUBAGENT_SELF_YIELD_MARKER);
+  }
+  if (QA_SUBAGENT_SELF_YIELD_WORKER_RE.test(prompt) && canCallSessionsYield) {
+    return buildToolCallEventsWithArgs("sessions_yield", {
+      message: "Waiting for the remote job to report back.",
+    });
   }
   const terminalCompletionCase = extractLastMatchingUserTurn(
     input,

--- a/extensions/qa-lab/test-fixtures/self-yield-followup-subagent-plugin/index.js
+++ b/extensions/qa-lab/test-fixtures/self-yield-followup-subagent-plugin/index.js
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+
+const TRIGGER = "qa self yield follow-up";
+const FOLLOW_UP_MESSAGE =
+  "Subagent self yield qa remote job finished. Reply with only the exact marker.";
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeJson(res, statusCode, body) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(`${JSON.stringify(body)}\n`);
+}
+
+export default {
+  id: "qa-self-yield-followup-subagent",
+  register(api) {
+    api.on("before_dispatch", async (event) => {
+      if (!event.content.toLowerCase().includes(TRIGGER)) {
+        return undefined;
+      }
+      // The kickoff reports its session key so the follow-up can target the same
+      // paused session. Adoption is keyed on that session; a fresh key would
+      // register an unrelated run instead of continuing this one.
+      const childSessionKey = `agent:qa:subagent:qa-self-yield-${randomUUID()}`;
+      let result;
+      try {
+        result = await api.runtime.subagent.run({
+          sessionKey: childSessionKey,
+          message: "Subagent self yield qa worker: pause until the remote job reports back.",
+          deliver: false,
+          // Binds the requester to the operator turn that triggered this hook, so
+          // the announce this scenario waits for has a real audience to reach.
+          completionDelivery: "current-requester",
+        });
+      } catch (error) {
+        return {
+          handled: true,
+          text: `QA-SELF-YIELD-ERROR ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+      return {
+        handled: true,
+        text: `QA-SELF-YIELD-SPAWNED ${result.runId} ${childSessionKey}`,
+      };
+    });
+
+    api.registerHttpRoute({
+      path: "/qa/self-yield/follow-up",
+      auth: "gateway",
+      match: "exact",
+      gatewayRuntimeScopeSurface: "trusted-operator",
+      async handler(req, res) {
+        // Hook and route handlers do not share a closure instance here, so the
+        // caller supplies the paused session key the kickoff reported.
+        const childSessionKey = (await readJsonBody(req))?.sessionKey;
+        if (!childSessionKey) {
+          writeJson(res, 409, { ok: false, error: "no kickoff session" });
+          return true;
+        }
+        try {
+          // Default delivery on purpose: a follow-up that named its own requester
+          // would opt into its own audience and run as a sibling, which is the
+          // path this proof must not take.
+          const result = await api.runtime.subagent.run({
+            sessionKey: childSessionKey,
+            message: FOLLOW_UP_MESSAGE,
+            deliver: false,
+          });
+          writeJson(res, 200, { ok: true, runId: result.runId });
+        } catch (error) {
+          writeJson(res, 500, {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        return true;
+      },
+    });
+  },
+};

--- a/extensions/qa-lab/test-fixtures/self-yield-followup-subagent-plugin/openclaw.plugin.json
+++ b/extensions/qa-lab/test-fixtures/self-yield-followup-subagent-plugin/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "qa-self-yield-followup-subagent",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/src/agents/subagent-control.test.ts
+++ b/src/agents/subagent-control.test.ts
@@ -2016,7 +2016,7 @@ describe("killControlledSubagentRun", () => {
         nextRunId: recoveryRunId,
         expected: source,
         restartRecovery: receipt,
-        requirePersistence: true,
+        persistenceFailure: "return-false",
       }),
     ).toBe(true);
     addSubagentRunForTests({

--- a/src/agents/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagent-registry-lifecycle-delivery.ts
@@ -345,6 +345,13 @@ export function createSubagentRegistryLifecycleDelivery(
       if (typeof entry.cleanupCompletedAt === "number") {
         continue;
       }
+      // A paused row's result was deliberately cleared when it yielded; the text
+      // now in its session belongs to whatever turn runs next, not to the paused
+      // work. Refreezing it here would announce a stranger's output as this run's
+      // completion once the row finally settles.
+      if (entry.pauseReason === "sessions_yield") {
+        continue;
+      }
       out.push(entry);
     }
     return out;

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -1470,6 +1470,24 @@ describe("subagent registry lifecycle hardening", () => {
     });
   });
 
+  it("skips frozen-result refill for a sessions_yield-paused run", async () => {
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+      endedAt: 4_000,
+      pauseReason: "sessions_yield",
+    });
+    const captureSubagentCompletionReply = vi.fn(async () => "text from the next turn");
+    const controller = createLifecycleController({ entry, captureSubagentCompletionReply });
+
+    expect(await controller.refreshFrozenResultFromSession(entry.childSessionKey)).toBe(false);
+
+    // The yield cleared this row's result on purpose. Whatever the session holds
+    // now belongs to the turn that runs next, so refreezing it would announce a
+    // stranger's output as the paused run's completion.
+    expect(captureSubagentCompletionReply).not.toHaveBeenCalled();
+    expect(entry.completion?.resultText).toBeUndefined();
+  });
+
   it("keeps success canonical while a killed callback waits behind reply capture", async () => {
     const entry = createRunEntry({ expectsCompletionMessage: true });
     let releaseCapture: ((value: string) => void) | undefined;

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -326,10 +326,18 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
   };
 }
 
-/** Returns the latest-generation run for a child session. */
+/**
+ * Returns the latest-generation run for a child session.
+ *
+ * `matches` narrows the candidates before the generation comparison, so callers
+ * that own a specific row class (a paused continuation target, say) select the
+ * newest row of that class rather than the newest row overall. Without it a
+ * sibling registered at a higher generation hides the row the caller owns.
+ */
 export function getLatestSubagentRunByChildSessionKeyFromRuns(
   runs: Map<string, SubagentRunRecord> | Iterable<SubagentRunRecord>,
   childSessionKey: string,
+  matches?: (entry: SubagentRunRecord) => boolean,
 ): SubagentRunRecord | undefined {
   const key = childSessionKey.trim();
   if (!key) {
@@ -338,6 +346,9 @@ export function getLatestSubagentRunByChildSessionKeyFromRuns(
   let latest: SubagentRunRecord | undefined;
   for (const entry of runs instanceof Map ? runs.values() : runs) {
     if (entry.childSessionKey !== key) {
+      continue;
+    }
+    if (matches && !matches(entry)) {
       continue;
     }
     if (!latest || compareSubagentRunGeneration(entry, latest) > 0) {

--- a/src/agents/subagent-registry-read.ts
+++ b/src/agents/subagent-registry-read.ts
@@ -123,15 +123,25 @@ export function getLatestSubagentRunByChildSessionKey(
   );
 }
 
-/** Returns the authoritative process-local run for mutation ownership checks. */
+/**
+ * Returns the authoritative process-local run for mutation ownership checks.
+ *
+ * `matches` restricts the search to a row class the caller owns; see
+ * `getLatestSubagentRunByChildSessionKeyFromRuns`.
+ */
 export function getLatestLiveSubagentRunByChildSessionKey(
   childSessionKey: string,
+  matches?: (entry: SubagentRunRecord) => boolean,
 ): SubagentRunRecord | null {
   const key = childSessionKey.trim();
   if (!key) {
     return null;
   }
   return (
-    getLatestSubagentRunByChildSessionKeyFromRuns(getSubagentRunsForChildSession(key), key) ?? null
+    getLatestSubagentRunByChildSessionKeyFromRuns(
+      getSubagentRunsForChildSession(key),
+      key,
+      matches,
+    ) ?? null
   );
 }

--- a/src/agents/subagent-registry-restart-recovery.test.ts
+++ b/src/agents/subagent-registry-restart-recovery.test.ts
@@ -256,7 +256,7 @@ describe("subagent registry restart recovery", () => {
         nextRunId: expect.stringMatching(/^subagent-recovery:[a-f0-9]{64}$/),
         expected: entry,
         task: "finish the restart-safe task",
-        requirePersistence: true,
+        persistenceFailure: "return-false",
       }),
     );
     expect(replaceRun.mock.calls[0]?.[0].restartRecovery).toMatchObject({
@@ -782,7 +782,7 @@ describe("subagent registry restart recovery", () => {
         previousRunId: entry.runId,
         nextRunId: "subagent-recovery:accepted",
         restartRecovery: expect.objectContaining({ phase: "accepted" }),
-        requirePersistence: true,
+        persistenceFailure: "return-false",
       }),
     );
     expect(dispatchAgent).not.toHaveBeenCalled();

--- a/src/agents/subagent-registry-restart-recovery.ts
+++ b/src/agents/subagent-registry-restart-recovery.ts
@@ -115,7 +115,7 @@ async function reconcileAcceptedRecovery(params: {
           }),
           task: params.entry.task,
           restartRecovery: params.receipt,
-          requirePersistence: true,
+          persistenceFailure: "return-false",
         });
     } catch {}
     if (!remapped) {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -684,7 +684,7 @@ export function createSubagentRunManager(params: {
     task?: string;
     restartRecovery?: SubagentRestartRecoveryReceipt;
     lifecycleGeneration?: string;
-    requirePersistence?: boolean;
+    persistenceFailure?: "return-false" | "throw";
   }) => {
     const previousRunId = replaceParams.previousRunId.trim();
     const nextRunId = replaceParams.nextRunId.trim();
@@ -838,7 +838,7 @@ export function createSubagentRunManager(params: {
       params.persistOrThrow(...changedRunIds);
     } catch (error) {
       if (
-        replaceParams.requirePersistence === true ||
+        replaceParams.persistenceFailure !== undefined ||
         replaceParams.lifecycleGeneration !== undefined
       ) {
         restoreKillReconciliationSnapshots(killReconciliationSnapshots);
@@ -849,6 +849,9 @@ export function createSubagentRunManager(params: {
           previousRunId,
           nextRunId,
         });
+        if (replaceParams.persistenceFailure === "throw") {
+          throw error;
+        }
         return false;
       }
       // The gateway has already started nextRunId. Keep its in-memory owner

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -52,6 +52,7 @@ import {
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type {
+  RequesterSettleWakeState,
   SubagentCompletionRequest,
   SubagentProgressOrigin,
   SubagentRestartRecoveryReceipt,
@@ -673,6 +674,12 @@ export function createSubagentRunManager(params: {
     runTimeoutSeconds?: number;
     allowEndedSource?: boolean;
     preserveFrozenResultFallback?: boolean;
+    // A follow-up that continues a paused run inherits the original requester's
+    // wake credential. An operator steer intentionally drops it: the operator is
+    // already the live audience, so re-arming would wake a requester that is no
+    // longer waiting. Without this the yielded parent loses its only wake path
+    // and its settle batch defers with nothing recording why.
+    preserveRequesterSettleWake?: boolean;
     transcriptTarget?: AgentRunSessionTarget;
     task?: string;
     restartRecovery?: SubagentRestartRecoveryReceipt;
@@ -747,6 +754,25 @@ export function createSubagentRunManager(params: {
       typeof replaceParams.task === "string" && replaceParams.task.length > 0
         ? replaceParams.task
         : source.task;
+    // The frozen batch is addressed by runId. Adoption retires the previous id,
+    // so an unmapped membership list would drop this row from its own batch and
+    // let the wave complete without ever waking the requester.
+    const sourceRequesterSettleWake = replaceParams.preserveRequesterSettleWake
+      ? source.requesterSettleWake
+      : undefined;
+    const inheritedRequesterSettleWake: RequesterSettleWakeState | undefined =
+      sourceRequesterSettleWake
+        ? {
+            ...sourceRequesterSettleWake,
+            ...(sourceRequesterSettleWake.batchRunIds
+              ? {
+                  batchRunIds: sourceRequesterSettleWake.batchRunIds
+                    .map((runId) => (runId === previousRunId ? nextRunId : runId))
+                    .toSorted(),
+                }
+              : {}),
+          }
+        : undefined;
     const next: SubagentRunRecord = normalizeSubagentRunState({
       ...source,
       runId: nextRunId,
@@ -765,7 +791,7 @@ export function createSubagentRunManager(params: {
       browserCleanupDispatchedAt: undefined,
       deleteCleanupDispatchedAt: undefined,
       wakeOnDescendantSettle: undefined,
-      requesterSettleWake: undefined,
+      requesterSettleWake: inheritedRequesterSettleWake,
       execution: {
         status: "running",
         startedAt: now,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -3273,6 +3273,145 @@ describe("subagent registry seam flow", () => {
     expect(replacement?.runId).toBe("run-yield-continuation");
     expect(replacement?.pauseReason).toBeUndefined();
     expect(replacement?.execution.endedAt).toBeUndefined();
+    // The operator is the live audience for a steer, so the requester wake
+    // credential is intentionally dropped rather than re-armed.
+    expect(replacement?.requesterSettleWake).toBeUndefined();
+  });
+
+  describe("sessions_yield follow-up adoption", () => {
+    const CHILD_SESSION_KEY = "agent:main:subagent:yield-followup";
+    const PAUSED_RUN_ID = "run-yield-followup-paused";
+    const FOLLOW_UP_RUN_ID = "run-yield-followup-continued";
+    const SIBLING_RUN_ID = "run-yield-followup-sibling";
+
+    /**
+     * Drives a child run to the paused state a `sessions_yield` produces, then
+     * arms the wake credential that `settleRequesterTurnAfterSessionSpawns`
+     * writes when the parent yields behind its own spawn batch.
+     */
+    const arrangePausedChildWithYieldedRequester = async () => {
+      mockGatewayMethods(mocks.callGateway, {
+        "agent.wait": {
+          status: "ok",
+          startedAt: 111,
+          endedAt: 222,
+          stopReason: "end_turn",
+          livenessState: "paused",
+          yielded: true,
+        },
+      });
+      mod.registerSubagentRun({
+        runId: PAUSED_RUN_ID,
+        childSessionKey: CHILD_SESSION_KEY,
+        task: "wait for the remote job",
+      });
+      const paused = await waitForFast(() => {
+        const run = expectDefined(findRequesterRun(PAUSED_RUN_ID), "paused subagent run");
+        expect(run.pauseReason).toBe("sessions_yield");
+        return run;
+      });
+      paused.requesterSettleWake = {
+        status: "pending",
+        attemptCount: 0,
+        requesterYieldBatch: true,
+        afterRequesterYield: true,
+        rearmGeneration: 1,
+        batchRunIds: [SIBLING_RUN_ID, PAUSED_RUN_ID].toSorted(),
+      };
+      expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      return paused;
+    };
+
+    it("announces to the original requester once the adopted follow-up ends normally", async () => {
+      await arrangePausedChildWithYieldedRequester();
+
+      mockGatewayMethods(mocks.callGateway, {
+        "agent.wait": {
+          status: "ok",
+          startedAt: 333,
+          endedAt: 444,
+          stopReason: "end_turn",
+        },
+      });
+      expect(
+        mod.adoptPausedSubagentRunForFollowUp({
+          childSessionKey: CHILD_SESSION_KEY,
+          runId: FOLLOW_UP_RUN_ID,
+          task: "the remote job finished",
+        }),
+      ).toBe(true);
+
+      expect(findRequesterRun(PAUSED_RUN_ID)).toBeUndefined();
+      const adopted = expectDefined(findRequesterRun(FOLLOW_UP_RUN_ID), "adopted follow-up run");
+      // Adoption continues the same unit of work: the requester identity that
+      // spawned the paused run must survive, or the announce lands on the
+      // child's own session instead of the waiting parent.
+      expect(adopted.requesterSessionKey).toBe("agent:main:main");
+      expect(adopted.task).toBe("the remote job finished");
+      expect(adopted.pauseReason).toBeUndefined();
+      // The frozen batch is addressed by runId, so the retired id must be
+      // remapped or this row drops out of the batch it still gates.
+      expect(adopted.requesterSettleWake?.batchRunIds).toEqual(
+        [SIBLING_RUN_ID, FOLLOW_UP_RUN_ID].toSorted(),
+      );
+      expect(adopted.requesterSettleWake).toMatchObject({
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+      });
+
+      await waitForFast(() => {
+        expect(
+          expectDefined(findRequesterRun(FOLLOW_UP_RUN_ID), "adopted follow-up run").execution
+            .endedAt,
+        ).toBe(444);
+        expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalled();
+      });
+    });
+
+    it("stays paused without announcing when the adopted follow-up yields again", async () => {
+      await arrangePausedChildWithYieldedRequester();
+
+      expect(
+        mod.adoptPausedSubagentRunForFollowUp({
+          childSessionKey: CHILD_SESSION_KEY,
+          runId: FOLLOW_UP_RUN_ID,
+          task: "still waiting on the remote job",
+        }),
+      ).toBe(true);
+
+      await waitForFast(() => {
+        const adopted = expectDefined(findRequesterRun(FOLLOW_UP_RUN_ID), "adopted follow-up run");
+        expect(adopted.pauseReason).toBe("sessions_yield");
+      });
+      expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      // A yielded row is still unsettled work, so the parent's batch keeps
+      // deferring instead of waking on a run that has not produced a result.
+      expect(mod.countPendingDescendantRuns("agent:main:main")).toBe(1);
+    });
+
+    it("declines adoption when the session has no paused run", async () => {
+      mockPendingAgentWait();
+      mod.registerSubagentRun({
+        runId: PAUSED_RUN_ID,
+        childSessionKey: CHILD_SESSION_KEY,
+        task: "still running",
+      });
+      await waitForFast(() => {
+        expect(
+          expectDefined(findRequesterRun(PAUSED_RUN_ID), "paused subagent run").execution.status,
+        ).toBe("running");
+      });
+
+      expect(
+        mod.adoptPausedSubagentRunForFollowUp({
+          childSessionKey: CHILD_SESSION_KEY,
+          runId: FOLLOW_UP_RUN_ID,
+          task: "concurrent work",
+        }),
+      ).toBe(false);
+      expect(findRequesterRun(PAUSED_RUN_ID)).toBeDefined();
+      expect(findRequesterRun(FOLLOW_UP_RUN_ID)).toBeUndefined();
+    });
   });
 
   it("ignores a late yield lifecycle event after the paused run is killed", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -3388,30 +3388,6 @@ describe("subagent registry seam flow", () => {
       // deferring instead of waking on a run that has not produced a result.
       expect(mod.countPendingDescendantRuns("agent:main:main")).toBe(1);
     });
-
-    it("declines adoption when the session has no paused run", async () => {
-      mockPendingAgentWait();
-      mod.registerSubagentRun({
-        runId: PAUSED_RUN_ID,
-        childSessionKey: CHILD_SESSION_KEY,
-        task: "still running",
-      });
-      await waitForFast(() => {
-        expect(
-          expectDefined(findRequesterRun(PAUSED_RUN_ID), "paused subagent run").execution.status,
-        ).toBe("running");
-      });
-
-      expect(
-        mod.adoptPausedSubagentRunForFollowUp({
-          childSessionKey: CHILD_SESSION_KEY,
-          runId: FOLLOW_UP_RUN_ID,
-          task: "concurrent work",
-        }),
-      ).toBe(false);
-      expect(findRequesterRun(PAUSED_RUN_ID)).toBeDefined();
-      expect(findRequesterRun(FOLLOW_UP_RUN_ID)).toBeUndefined();
-    });
   });
 
   it("ignores a late yield lifecycle event after the paused run is killed", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -497,8 +497,15 @@ export function adoptPausedSubagentRunForFollowUp(params: {
   if (!childSessionKey || !runId) {
     return false;
   }
-  const paused = getLatestLiveSubagentRunByChildSessionKey(childSessionKey);
-  if (!paused || paused.pauseReason !== "sessions_yield") {
+  // Select the newest paused row rather than the newest row overall: a
+  // requester-bound follow-up stays a sibling at a higher generation, and
+  // matching on generation alone would let that sibling hide the paused owner
+  // and park its requester for good.
+  const paused = getLatestLiveSubagentRunByChildSessionKey(
+    childSessionKey,
+    (entry) => entry.pauseReason === "sessions_yield",
+  );
+  if (!paused) {
     return false;
   }
   return subagentRunManager.replaceSubagentRunAfterSteer({

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -518,6 +518,10 @@ export function adoptPausedSubagentRunForFollowUp(params: {
     // The original requester is idle behind its own yield, so its wake credential
     // is the only path back to it once this follow-up settles.
     preserveRequesterSettleWake: true,
+    // Gateway admission has not started provider work yet. If this owner swap
+    // is not durable, reject the dispatch instead of registering a sibling or
+    // leaving a live successor that restart recovery cannot identify.
+    persistenceFailure: "throw",
     // Persist the follow-up text so restart recovery cannot reissue the task that
     // the child already yielded on.
     task: params.task,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -27,6 +27,7 @@ import {
   subagentRuns,
 } from "./subagent-registry-memory.js";
 import { createSubagentRegistryPublicApi } from "./subagent-registry-public-api.js";
+import { getLatestLiveSubagentRunByChildSessionKey } from "./subagent-registry-read.js";
 import { createSubagentRegistryRestorer } from "./subagent-registry-restore.js";
 import {
   createSubagentRunManager,
@@ -474,6 +475,47 @@ export const registerSubagentRun: (params: RegisterSubagentRunParams) => void =
   subagentRunManager.registerSubagentRun;
 export const startQueuedSubagentRun = subagentRunManager.startQueuedSubagentRun;
 export const settleFailedQueuedSubagentLaunch = subagentRunManager.settleFailedQueuedSubagentLaunch;
+
+/**
+ * Continues a `sessions_yield`-paused run under a new gateway runId.
+ *
+ * A follow-up dispatched to a paused child session is the same unit of work as
+ * the run that yielded, so it must adopt that row instead of minting a sibling.
+ * Registering a new row would move the requester to the child's own main session
+ * and strand the original requester's paused row as merely superseded: its
+ * announce stays gated on `pauseReason`, and its settle batch keeps deferring
+ * because the row still counts as an unsettled descendant. Returns false when no
+ * paused row owns the session, leaving ordinary registration to the caller.
+ */
+export function adoptPausedSubagentRunForFollowUp(params: {
+  childSessionKey: string;
+  runId: string;
+  task: string;
+}): boolean {
+  const childSessionKey = params.childSessionKey.trim();
+  const runId = params.runId.trim();
+  if (!childSessionKey || !runId) {
+    return false;
+  }
+  const paused = getLatestLiveSubagentRunByChildSessionKey(childSessionKey);
+  if (!paused || paused.pauseReason !== "sessions_yield") {
+    return false;
+  }
+  return subagentRunManager.replaceSubagentRunAfterSteer({
+    previousRunId: paused.runId,
+    nextRunId: runId,
+    expected: paused,
+    // A paused row is terminal by construction; adoption is exactly the case the
+    // ended-source gate exists to keep out of unrelated replacement callers.
+    allowEndedSource: true,
+    // The original requester is idle behind its own yield, so its wake credential
+    // is the only path back to it once this follow-up settles.
+    preserveRequesterSettleWake: true,
+    // Persist the follow-up text so restart recovery cannot reissue the task that
+    // the child already yielded on.
+    task: params.task,
+  });
+}
 
 function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   clearScheduledResumeTimers();

--- a/src/gateway/server-methods/agent-task-tracking.ts
+++ b/src/gateway/server-methods/agent-task-tracking.ts
@@ -168,7 +168,24 @@ export async function registerPluginSubagentRunFromGateway(params: {
     agentId: resolveAgentIdFromSessionKey(childSessionKey),
   });
   const requesterSessionKey = params.requester?.sessionKey ?? ownerSessionKey;
-  const { registerSubagentRun } = await import("../../agents/subagent-registry.js");
+  const { adoptPausedSubagentRunForFollowUp, registerSubagentRun } =
+    await import("../../agents/subagent-registry.js");
+  // A follow-up aimed at a session paused by sessions_yield continues that run.
+  // Registering a sibling row here would reassign the requester to this agent's
+  // own main session and leave the original requester waiting behind a row that
+  // can no longer announce. A follow-up that names its own requester is opting
+  // into its own delivery, so it registers normally rather than silently
+  // inheriting the paused row's audience.
+  if (
+    !params.requester &&
+    adoptPausedSubagentRunForFollowUp({
+      childSessionKey,
+      runId: params.runId,
+      task: params.task,
+    })
+  ) {
+    return;
+  }
   registerSubagentRun({
     runId: params.runId,
     childSessionKey,

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -370,50 +370,6 @@ describe("gateway agent handler", () => {
     });
   });
 
-  it("adopts a sessions_yield-paused run when a plugin follow-up targets its session", async () => {
-    await withTempDir({ prefix: "openclaw-gateway-plugin-subagent-adopt-" }, async (root) => {
-      useTestStateDir(root);
-      resetSubagentRegistryForTests({ persist: false });
-      const childSessionKey = "agent:work:subagent:plugin-yield-followup";
-      const originalRequester = "agent:main:telegram:direct:777";
-      addSubagentRunForTests({
-        runId: "plugin-subagent-paused",
-        childSessionKey,
-        requesterSessionKey: originalRequester,
-        requesterDisplayKey: originalRequester,
-        task: "wait for the remote job",
-        endedAt: 2_000,
-        pauseReason: "sessions_yield",
-        expectsCompletionMessage: true,
-      });
-
-      await registerPluginSubagentRunFromGateway({
-        cfg: {
-          session: { mainKey: "main", scope: "per-sender" },
-          agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-        },
-        runId: "plugin-subagent-followup",
-        childSessionKey,
-        task: "the remote job finished",
-        pluginId: "memory-core",
-      });
-
-      const run = requireValue(
-        getSubagentRunByChildSessionKey(childSessionKey),
-        "expected adopted plugin subagent run",
-      );
-      // A follow-up without requester context would otherwise register a sibling
-      // row owned by the child's own agent session, stranding the requester that
-      // is still parked behind its yield.
-      expectRecordFields(run, {
-        runId: "plugin-subagent-followup",
-        requesterSessionKey: originalRequester,
-        task: "the remote job finished",
-        pauseReason: undefined,
-      });
-    });
-  });
-
   it("registers normally when a follow-up to a paused session names its own requester", async () => {
     await withTempDir(
       { prefix: "openclaw-gateway-plugin-subagent-own-requester-" },
@@ -525,7 +481,7 @@ describe("gateway agent handler", () => {
     );
   });
 
-  it("rejects plugin SDK subagent runs and releases admission when registry persistence fails", async () => {
+  it("rejects plugin SDK subagent registration and adoption when persistence fails", async () => {
     await withTempDir(
       { prefix: "openclaw-gateway-plugin-subagent-registry-fail-" },
       async (root) => {
@@ -602,6 +558,54 @@ describe("gateway agent handler", () => {
           expect.stringContaining("rejecting untracked dispatch"),
         );
 
+        resetSubagentRegistryForTests({ persist: false });
+        const pausedRunId = "plugin-subagent-paused-before-persistence-failure";
+        addSubagentRunForTests({
+          runId: pausedRunId,
+          childSessionKey,
+          requesterSessionKey: "agent:main:telegram:direct:777",
+          requesterDisplayKey: "agent:main:telegram:direct:777",
+          task: "wait for the remote job",
+          endedAt: 2_000,
+          pauseReason: "sessions_yield",
+          expectsCompletionMessage: true,
+        });
+        persistSubagentRunsToDiskOrThrow.mockImplementationOnce(() => {
+          throw new Error("disk full during paused-run adoption");
+        });
+        const adoptionRunId = "plugin-subagent-adoption-registry-fail";
+        const adoptionRespond = vi.fn();
+        await invokeAgent(
+          {
+            message: "the remote job finished",
+            sessionKey: childSessionKey,
+            idempotencyKey: adoptionRunId,
+          },
+          {
+            context,
+            reqId: adoptionRunId,
+            respond: adoptionRespond,
+            client: {
+              connect: baseClient.connect,
+              internal: {
+                ...baseClient.internal,
+                agentRunTracking: "plugin_subagent",
+                pluginRuntimeOwnerId: "memory-core",
+              },
+            },
+          },
+        );
+
+        expect(mocks.agentCommand).toHaveBeenCalledTimes(commandCallCount);
+        expect(getSubagentRunByChildSessionKey(childSessionKey)).toMatchObject({
+          runId: pausedRunId,
+          pauseReason: "sessions_yield",
+        });
+        expect(getSubagentRunByChildSessionKey(childSessionKey)?.runId).not.toBe(adoptionRunId);
+        const adoptionError = expectRespondError(adoptionRespond, { code: ErrorCodes.UNAVAILABLE });
+        expectStringFieldContains(adoptionError, "message", "run was not started");
+
+        resetSubagentRegistryForTests({ persist: false });
         const retryRunId = "plugin-subagent-registry-retry";
         await invokeAgent(
           {

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -7,6 +7,7 @@ import { createAgentRunRestartAbortError } from "../../agents/run-termination.js
 import {
   addSubagentRunForTests,
   getSubagentRunByChildSessionKey,
+  listSubagentRunsForRequester,
   resetSubagentRegistryForTests,
 } from "../../agents/subagent-registry.test-helpers.js";
 import { getDetachedTaskLifecycleRuntime } from "../../tasks/detached-task-runtime.js";
@@ -457,6 +458,68 @@ describe("gateway agent handler", () => {
         expectRecordFields(run, {
           runId: "plugin-subagent-own-requester",
           requesterSessionKey: followUpRequester.sessionKey,
+        });
+      },
+    );
+  });
+
+  it("still adopts the paused owner for a default follow-up after a requester-bound sibling", async () => {
+    await withTempDir(
+      { prefix: "openclaw-gateway-plugin-subagent-mixed-delivery-" },
+      async (root) => {
+        useTestStateDir(root);
+        resetSubagentRegistryForTests({ persist: false });
+        const childSessionKey = "agent:work:subagent:plugin-yield-mixed-delivery";
+        const originalRequester = "agent:main:telegram:direct:777";
+        const cfg = {
+          session: { mainKey: "main", scope: "per-sender" as const },
+          agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+        };
+        addSubagentRunForTests({
+          runId: "plugin-subagent-paused",
+          childSessionKey,
+          requesterSessionKey: originalRequester,
+          requesterDisplayKey: originalRequester,
+          task: "wait for the remote job",
+          endedAt: 2_000,
+          pauseReason: "sessions_yield",
+          expectsCompletionMessage: true,
+        });
+
+        // A requester-bound follow-up lands at a higher generation than the paused
+        // owner, so it becomes the newest row for this session.
+        await registerPluginSubagentRunFromGateway({
+          cfg,
+          runId: "plugin-subagent-sibling",
+          childSessionKey,
+          task: "deliver to me instead",
+          requester: {
+            sessionKey: "agent:main:telegram:direct:555",
+            origin: { channel: "telegram", to: "telegram:555", accountId: "work" },
+          },
+          pluginId: "memory-core",
+        });
+
+        await registerPluginSubagentRunFromGateway({
+          cfg,
+          runId: "plugin-subagent-default-followup",
+          childSessionKey,
+          task: "the remote job finished",
+          pluginId: "memory-core",
+        });
+
+        // Adoption selects the newest *paused* row, not the newest row overall.
+        // Matching on generation alone would pick the sibling, decline adoption,
+        // and leave the original requester parked behind a row that can never
+        // announce. The sibling's own liveness is irrelevant to that choice.
+        const requesterRuns = listSubagentRunsForRequester(originalRequester);
+        expect(requesterRuns.map((entry) => entry.runId)).toEqual([
+          "plugin-subagent-default-followup",
+        ]);
+        expectRecordFields(requireValue(requesterRuns[0], "expected adopted run"), {
+          childSessionKey,
+          task: "the remote job finished",
+          pauseReason: undefined,
         });
       },
     );

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -5,6 +5,7 @@ import type { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { registerExecApprovalFollowupRuntimeHandoff } from "../../agents/bash-tools.exec-approval-followup-state.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import {
+  addSubagentRunForTests,
   getSubagentRunByChildSessionKey,
   resetSubagentRegistryForTests,
 } from "../../agents/subagent-registry.test-helpers.js";
@@ -366,6 +367,99 @@ describe("gateway agent handler", () => {
       });
       expectRecordFields(run.completion, { required: true });
     });
+  });
+
+  it("adopts a sessions_yield-paused run when a plugin follow-up targets its session", async () => {
+    await withTempDir({ prefix: "openclaw-gateway-plugin-subagent-adopt-" }, async (root) => {
+      useTestStateDir(root);
+      resetSubagentRegistryForTests({ persist: false });
+      const childSessionKey = "agent:work:subagent:plugin-yield-followup";
+      const originalRequester = "agent:main:telegram:direct:777";
+      addSubagentRunForTests({
+        runId: "plugin-subagent-paused",
+        childSessionKey,
+        requesterSessionKey: originalRequester,
+        requesterDisplayKey: originalRequester,
+        task: "wait for the remote job",
+        endedAt: 2_000,
+        pauseReason: "sessions_yield",
+        expectsCompletionMessage: true,
+      });
+
+      await registerPluginSubagentRunFromGateway({
+        cfg: {
+          session: { mainKey: "main", scope: "per-sender" },
+          agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+        },
+        runId: "plugin-subagent-followup",
+        childSessionKey,
+        task: "the remote job finished",
+        pluginId: "memory-core",
+      });
+
+      const run = requireValue(
+        getSubagentRunByChildSessionKey(childSessionKey),
+        "expected adopted plugin subagent run",
+      );
+      // A follow-up without requester context would otherwise register a sibling
+      // row owned by the child's own agent session, stranding the requester that
+      // is still parked behind its yield.
+      expectRecordFields(run, {
+        runId: "plugin-subagent-followup",
+        requesterSessionKey: originalRequester,
+        task: "the remote job finished",
+        pauseReason: undefined,
+      });
+    });
+  });
+
+  it("registers normally when a follow-up to a paused session names its own requester", async () => {
+    await withTempDir(
+      { prefix: "openclaw-gateway-plugin-subagent-own-requester-" },
+      async (root) => {
+        useTestStateDir(root);
+        resetSubagentRegistryForTests({ persist: false });
+        const childSessionKey = "agent:work:subagent:plugin-yield-own-requester";
+        const followUpRequester = {
+          sessionKey: "agent:main:telegram:direct:555",
+          origin: { channel: "telegram", to: "telegram:555", accountId: "work" },
+        } as const;
+        addSubagentRunForTests({
+          runId: "plugin-subagent-paused",
+          childSessionKey,
+          requesterSessionKey: "agent:main:telegram:direct:777",
+          requesterDisplayKey: "agent:main:telegram:direct:777",
+          task: "wait for the remote job",
+          endedAt: 2_000,
+          pauseReason: "sessions_yield",
+          expectsCompletionMessage: true,
+        });
+
+        await registerPluginSubagentRunFromGateway({
+          cfg: {
+            session: { mainKey: "main", scope: "per-sender" },
+            agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+          },
+          runId: "plugin-subagent-own-requester",
+          childSessionKey,
+          task: "deliver to me instead",
+          requester: followUpRequester,
+          pluginId: "memory-core",
+        });
+
+        // An explicit requester is a delivery opt-in. Adopting the paused row here
+        // would drop that audience with nothing recording why, so the follow-up
+        // gets its own row and the paused run keeps its original requester.
+        const run = requireValue(
+          getSubagentRunByChildSessionKey(childSessionKey),
+          "expected separately registered plugin subagent run",
+        );
+        expectRecordFields(run, {
+          runId: "plugin-subagent-own-requester",
+          requesterSessionKey: followUpRequester.sessionKey,
+        });
+      },
+    );
   });
 
   it("rejects plugin SDK subagent runs and releases admission when registry persistence fails", async () => {

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -224,7 +224,11 @@ vi.mock("../../infra/agent-run-registry.js", () => ({
   registerAgentRunContext: mocks.registerAgentRunContext,
 }));
 
-vi.mock("../../agents/subagent-registry-read.js", () => ({
+// Only the lookup this harness asserts on is stubbed; the rest of the read
+// surface stays real so registry paths reached through the gateway (paused-run
+// adoption, descendant queries) observe the runs these tests seed.
+vi.mock("../../agents/subagent-registry-read.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/subagent-registry-read.js")>()),
   getLatestSubagentRunByChildSessionKey: mocks.getLatestSubagentRunByChildSessionKey,
 }));
 


### PR DESCRIPTION
Closes #120157

## What Problem This Solves

A parent can spawn a sub-agent and yield while it waits for completion. If the child also calls `sessions_yield`, a plugin may later continue the child by calling `api.runtime.subagent.run` with the same `sessionKey` and default delivery.

Before this change, gateway admission always registered that follow-up as a new row. Without an explicit requester, the new row belonged to the child agent's main session rather than the original parent. Execution-time reactivation then read the newer running row and returned without adopting the paused owner. The follow-up result was therefore lost or attributed to the wrong requester. The registry sweeper can later revisit the original settle-wake state, but it cannot reconstruct the follow-up result that was recorded on the sibling row, so it is not a prompt result-bearing wake.

## Why This Change Was Made

Default-delivery plugin follow-ups now adopt the newest `sessions_yield`-paused owner for the child session before provider execution begins. The transition:

- preserves the original requester and completion-delivery contract;
- carries `requesterSettleWake` forward and remaps its frozen `batchRunIds` from the retired run ID to the follow-up run ID;
- retains the follow-up task text for restart recovery;
- fails gateway admission closed if the owner swap cannot be persisted, restoring the paused source row instead of starting untracked work or registering a sibling; and
- leaves explicit-requester follow-ups as separate siblings, because those calls intentionally choose their own delivery audience.

The related frozen-result refill path now skips paused rows. A yield deliberately clears that row's result, so text produced by a later turn must not be refrozen as the paused run's completion.

No plugin SDK, gateway protocol, config, or schema surface changes.

## User Impact

Plugins can use a yielded sub-agent as a durable waiter for external work. A default-delivery `api.runtime.subagent.run` follow-up on the paused session continues the original unit of work and delivers its final result to the waiting requester. A follow-up that yields again remains paused. A follow-up with an explicit requester still runs independently and delivers to that requester.

## Evidence

### Exact-head mock-gateway behavior

Verified on `99496dd6826443d8076d71ba77e8f6e69441d6e2`, with local HEAD equal to the live PR head:

```text
OPENCLAW_E2E_VERBOSE=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.e2e.config.ts \
  extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts

Test Files  1 passed (1)
     Tests  1 passed (1)
  Duration  67.70s (tests 55.03s)
```

The test uses a mock channel API, mock OpenAI provider, and a real ephemeral gateway child. It observes no outbound message during the child's 15-second paused window, dispatches the default-delivery plugin follow-up through an authenticated gateway route, and observes exactly one result marker in the original requester conversation.

```json
{
  "schemaVersion": 1,
  "status": "passed",
  "head": "99496dd6826443d8076d71ba77e8f6e69441d6e2",
  "source": "local-exact-head-fallback",
  "harness": "qa-channel+mock-openai+ephemeral-child",
  "deliverySeamStubbed": false,
  "checks": {
    "spawnAcknowledged": true,
    "pausedQuietWindowMs": 15000,
    "pausedOutboundCount": 0,
    "followUpHttpStatus": 200,
    "followUpDelivery": "default",
    "distinctGatewayRunId": true,
    "originalRequesterMarkerDelivered": true,
    "markerDeliveryCount": 1
  },
  "counts": {
    "passed": 1,
    "failed": 0
  }
}
```

The local fallback was required because the Blacksmith Testbox launcher was not installed on this host and the configured managed Crabbox broker returned 401 before allocation. Neither attempt created a lease or ran repository code.

### Focused regression suites

```text
node scripts/run-vitest.mjs \
  src/agents/subagent-registry.test.ts \
  src/agents/subagent-registry-lifecycle.test.ts \
  src/agents/subagent-registry-restart-recovery.test.ts \
  src/agents/subagent-control.test.ts \
  src/gateway/server-methods/agent.test.ts

Gateway:                  272 passed
Agents core:              333 passed
Agents core isolated:      29 passed
Total:                    634 passed
```

Coverage retains the owner-boundary cases that pay rent: wake/batch remapping, a follow-up that yields again, explicit-requester separation, adoption past a newer requester-bound sibling, frozen-result refill exclusion, and persistence-failure rollback before provider start. Two duplicate/trivial cases were removed during maintainer review.

### Static and review evidence

- `git diff --check`: passed.
- Targeted changed gate: conflict markers, env-var and max-lines ratchets, formatting, dependency pins, Plugin SDK boundaries, package patches, and dead-export scans passed.
- Local fallback typecheck was not authoritative because the no-install review worktree resolved root `string-width@4.2.3` for untouched `packages/terminal-core`, while that workspace requires and the canonical checkout contains `string-width@8.2.2`. Exact-head CI remains the typecheck gate.
- Autoreview of the uncommitted maintainer delta: clean, no accepted/actionable findings.
- Autoreview of the full rebased branch against `origin/main`: clean, no accepted/actionable findings.

### LOC delta

- Production: `+135 / -8` (net `+127`)
- Tests and QA harness: `+582 / -5`
- Docs: `+21 / -0`
- Test config: `+5 / -4`
- Total: `+743 / -17`

The positive production delta establishes the missing registry ownership and durability boundary. It avoids reconstructing requester identity downstream after admission has already lost it.
