### PR TITLE
fix(e2e): expose prerelease registry dist-tags

### DIFF
--- a/scripts/e2e/lib/plugins/npm-registry-server.mjs
+++ b/scripts/e2e/lib/plugins/npm-registry-server.mjs
@@ -60,6 +60,11 @@ if (!portFile || packageArgs.length === 0 || packageArgs.length % 3 !== 0) {
 
 const packages = new Map();
 
+function inferPrereleaseDistTags(version) {
+  const match = /^\d+\.\d+\.\d+-(alpha|beta)(?:\.|$)/u.exec(version);
+  return match ? { [match[1]]: version } : {};
+}
+
 function readPackageManifest(tarballPath, packageName) {
   try {
     const packageJson = JSON.parse(
@@ -105,6 +110,7 @@ const metadataFor = (entry, baseUrl) => ({
   name: entry.packageName,
   "dist-tags": {
     latest: entry.latestVersion,
+    ...inferPrereleaseDistTags(entry.latestVersion),
     ...Object.fromEntries(distTagOverrides),
   },
   versions: Object.fromEntries(

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -742,6 +742,58 @@ ${command}
     }
   });
 
+  it("infers prerelease dist-tags per fixture package", async () => {
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-dist-tags-");
+    const portFile = path.join(root, "port");
+    const tarballPath = path.join(root, "plugin.tgz");
+    writeFileSync(tarballPath, "fixture package archive", "utf8");
+
+    const child = spawn(
+      process.execPath,
+      [
+        "scripts/e2e/lib/plugins/npm-registry-server.mjs",
+        portFile,
+        "@openclaw/codex",
+        "2026.8.1-beta.1",
+        tarballPath,
+        "@openclaw/discord",
+        "2026.8.1-beta.1",
+        tarballPath,
+        "@openclaw/brave",
+        "2026.8.1",
+        tarballPath,
+      ],
+      { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    try {
+      const port = await waitForPortFile(portFile);
+      const [codex, discord, brave] = await Promise.all(
+        ["codex", "discord", "brave"].map(async (name) =>
+          JSON.parse((await requestFixtureRegistry(port, `/@openclaw%2F${name}`)).body),
+        ),
+      );
+
+      expect(codex["dist-tags"]).toEqual({
+        latest: "2026.8.1-beta.1",
+        beta: "2026.8.1-beta.1",
+      });
+      expect(discord["dist-tags"]).toEqual({
+        latest: "2026.8.1-beta.1",
+        beta: "2026.8.1-beta.1",
+      });
+      expect(brave["dist-tags"]).toEqual({ latest: "2026.8.1" });
+      expect(brave["dist-tags"]).not.toHaveProperty("beta");
+    } finally {
+      if (child.exitCode === null) {
+        child.kill();
+        await new Promise((resolve) => {
+          child.once("close", resolve);
+        });
+      }
+    }
+  });
+
   it("serves tarball dependencies using the request-visible registry origin", async () => {
     const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-package-");
     const packageDir = path.join(root, "package");
@@ -777,7 +829,7 @@ ${command}
         cwd: process.cwd(),
         env: {
           ...process.env,
-          OPENCLAW_NPM_REGISTRY_DIST_TAGS: "latest=0.0.0,beta=2026.7.1-beta.3",
+          OPENCLAW_NPM_REGISTRY_DIST_TAGS: "latest=0.0.0,beta=2026.7.1-beta.2",
         },
         stdio: ["ignore", "pipe", "pipe"],
       },
@@ -793,7 +845,7 @@ ${command}
       expect(response.statusCode).toBe(200);
       expect(metadata["dist-tags"]).toEqual({
         latest: "0.0.0",
-        beta: "2026.7.1-beta.3",
+        beta: "2026.7.1-beta.2",
       });
       expect(metadata.versions["2026.7.1-beta.3"].dependencies).toEqual({
         "@openclaw/ai": "2026.7.1-beta.3",


### PR DESCRIPTION
Related: #120175

## What Problem This Solves

Fixes an issue where artifact-only prerelease upgrade validation could serve candidate plugin packages without matching prerelease npm dist-tags, causing installs such as `@openclaw/codex@beta` to miss the packaged candidate.

## Why This Change Was Made

The fixture registry now infers `alpha` or `beta` per package from a strict prerelease version prefix while preserving `latest`. Explicit `OPENCLAW_NPM_REGISTRY_DIST_TAGS` entries remain the final override, and stable packages do not inherit synthetic prerelease tags from sibling packages.

## User Impact

Release maintainers can validate mixed stable and prerelease plugin registries while npm tag resolution selects the exact packaged prerelease.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugins-assertions.test.ts`: 43/43 passed
- `git diff --check`: passed
- Production LOC: +6/-0; tests: +54/-2
- Trusted changed gate: https://github.com/openclaw/openclaw/actions/runs/31161831188
- Combined artifact-only proof: https://github.com/openclaw/openclaw/actions/runs/31165503304
  - `upgrade-survivor` passed: https://github.com/openclaw/openclaw/actions/runs/31165503304/job/92828805443
  - The published-baseline lane resolved both `@openclaw/codex@beta` and `@openclaw/discord@beta` to `2026.8.1-beta.1` before the unrelated gateway restart-health failure tracked in #120095: https://github.com/openclaw/openclaw/actions/runs/31165503304/job/92828805427
  - The combined harness head was `8b2962d45e4adab9932e5bad465993ac1253c4c6`; the selected frozen release candidate was `272b3098c71af4143882e68e13193437ef605dd9`.

AI-assisted: yes. No agent transcript is included.
