### PR TITLE
fix(mcp): listen on the loopback OAuth redirect during mcp login

### DIFF
--- a/src/agents/mcp-oauth-provider.ts
+++ b/src/agents/mcp-oauth-provider.ts
@@ -21,19 +21,20 @@ export type McpOAuthConfig = {
 
 const LEGACY_DEFAULT_REDIRECT_URL = "http://127.0.0.1:8989/oauth/callback";
 
-function resolveTokenExpiresAt(tokens: OAuthTokens): number | undefined {
-  const expiresIn = tokens.expires_in;
-  return typeof expiresIn === "number" && Number.isFinite(expiresIn)
-    ? Date.now() + expiresIn * 1000
-    : undefined;
-}
-
-function resolveOAuthRedirectUrl(config: McpOAuthConfig, store: McpOAuthStore = {}): string {
+/** Resolves the redirect URI a login flow would register for the given config/store state. */
+export function resolveOAuthRedirectUrl(config: McpOAuthConfig, store: McpOAuthStore = {}): string {
   return (
     normalizeOptionalString(config.redirectUrl) ??
     normalizeOptionalString(store.redirectUrl) ??
     LEGACY_DEFAULT_REDIRECT_URL
   );
+}
+
+function resolveTokenExpiresAt(tokens: OAuthTokens): number | undefined {
+  const expiresIn = tokens.expires_in;
+  return typeof expiresIn === "number" && Number.isFinite(expiresIn)
+    ? Date.now() + expiresIn * 1000
+    : undefined;
 }
 
 function buildOAuthClientMetadata(

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -9,6 +9,7 @@ import {
 import {
   bindMcpOAuthLeaseAssertion,
   createMcpOAuthClientProvider,
+  resolveOAuthRedirectUrl,
   type McpOAuthConfig,
   withMcpOAuthLeaseSignal,
 } from "./mcp-oauth-provider.js";
@@ -37,6 +38,16 @@ const LOCALHOST_REDIRECT_URL = "http://localhost:8989/oauth/callback";
 const TOKEN_EXPIRY_SKEW_MS = 30_000;
 const MCP_OAUTH_LEASE_MS = 60_000;
 const MCP_OAUTH_LEASE_WAIT_MS = 30_000;
+
+/** Resolves the redirect URI the next login flow would register, before any flow runs. */
+export function resolveMcpOAuthEffectiveRedirectUrl(params: {
+  serverName: string;
+  serverUrl: string;
+  config?: McpOAuthConfig;
+}): string {
+  const storeKey = resolveMcpOAuthStoreKey(params.serverName, params.serverUrl);
+  return resolveOAuthRedirectUrl(params.config ?? {}, readMcpOAuthStoreReadOnly(storeKey));
+}
 
 function isMcpOAuthRedirectRegistrationError(error: unknown): boolean {
   return /invalid_client_metadata|redirect_uri/i.test(String(error));

--- a/src/cli/mcp-cli.login-loopback.test.ts
+++ b/src/cli/mcp-cli.login-loopback.test.ts
@@ -1,0 +1,259 @@
+// MCP CLI login loopback tests cover the OAuth loopback callback flow.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome } from "../config/home-env.test-harness.js";
+import { registerMcpCli } from "./mcp-cli.js";
+
+type CreateSessionMcpRuntime =
+  typeof import("../agents/agent-bundle-mcp-runtime.js").createSessionMcpRuntime;
+
+const mocks = vi.hoisted(() => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }),
+    writeJson: vi.fn((value: unknown, space = 2) => {
+      runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+    }),
+  };
+  return {
+    runtime,
+    serveOpenClawChannelMcp: vi.fn(),
+    clearMcpOAuthCredentials: vi.fn(),
+    readMcpOAuthCredentialsStatus: vi.fn(),
+    resolveMcpOAuthEffectiveRedirectUrl: vi.fn(),
+    runMcpOAuthLogin: vi.fn(),
+    createSessionMcpRuntimeOverride: undefined as CreateSessionMcpRuntime | undefined,
+  };
+});
+
+const mockLog = mocks.runtime.log;
+const mockError = mocks.runtime.error;
+const readMcpOAuthCredentialsStatus = mocks.readMcpOAuthCredentialsStatus;
+const resolveMcpOAuthEffectiveRedirectUrl = mocks.resolveMcpOAuthEffectiveRedirectUrl;
+const runMcpOAuthLogin = mocks.runMcpOAuthLogin;
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+vi.mock("../mcp/channel-server.js", () => ({
+  serveOpenClawChannelMcp: mocks.serveOpenClawChannelMcp,
+}));
+
+vi.mock("../agents/mcp-oauth.js", () => ({
+  clearMcpOAuthCredentials: mocks.clearMcpOAuthCredentials,
+  readMcpOAuthCredentialsStatus: mocks.readMcpOAuthCredentialsStatus,
+  resolveMcpOAuthEffectiveRedirectUrl: mocks.resolveMcpOAuthEffectiveRedirectUrl,
+  runMcpOAuthLogin: mocks.runMcpOAuthLogin,
+}));
+
+vi.mock("../agents/agent-bundle-mcp-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/agent-bundle-mcp-runtime.js")>();
+  return {
+    ...actual,
+    createSessionMcpRuntime: (params: Parameters<CreateSessionMcpRuntime>[0]) =>
+      mocks.createSessionMcpRuntimeOverride?.(params) ?? actual.createSessionMcpRuntime(params),
+  };
+});
+
+const tempDirs: string[] = [];
+
+async function createWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-mcp-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitForLogContaining(text: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (mockLog.mock.calls.some((call) => String(call[0]).includes(text))) {
+      return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 25);
+    });
+  }
+  throw new Error(`Timed out waiting for log containing: ${text}`);
+}
+
+async function findFreePort(): Promise<number> {
+  const net = await import("node:net");
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => (port > 0 ? resolve(port) : reject(new Error("No free port"))));
+    });
+  });
+}
+
+let sharedProgram: Command;
+
+async function runMcpCommand(args: string[]) {
+  await sharedProgram.parseAsync(args, { from: "user" });
+}
+
+describe("mcp cli login loopback", () => {
+  if (!sharedProgram) {
+    sharedProgram = new Command();
+    sharedProgram.exitOverride();
+    registerMcpCli(sharedProgram);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createSessionMcpRuntimeOverride = undefined;
+    readMcpOAuthCredentialsStatus.mockResolvedValue({
+      hasTokens: false,
+      requiresAuthorization: false,
+      hasClientInformation: false,
+      hasCodeVerifier: false,
+      hasDiscoveryState: false,
+      hasLastAuthorizationUrl: false,
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("completes login through the loopback callback server", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const port = await findFreePort();
+      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
+      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
+      runMcpOAuthLogin.mockImplementation(
+        async (params: {
+          authorizationCode?: string;
+          onAuthorizationUrl?: (url: URL) => void | Promise<void>;
+        }) => {
+          if (params.authorizationCode) {
+            return "authorized";
+          }
+          await params.onAuthorizationUrl?.(
+            new URL("https://auth.example.com/authorize?state=state-123"),
+          );
+          return "redirect";
+        },
+      );
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      const commandPromise = runMcpCommand(["mcp", "login", "docs"]);
+      await waitForLogContaining("Waiting for the browser");
+      const response = await fetch(`${redirectUrl}?code=code-456&state=state-123`);
+      expect(response.ok).toBe(true);
+      await commandPromise;
+
+      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(2);
+      expect(runMcpOAuthLogin).toHaveBeenLastCalledWith(
+        expect.objectContaining({ authorizationCode: "code-456" }),
+      );
+      expect(mockLog).toHaveBeenCalledWith('MCP OAuth credentials saved for "docs".');
+    });
+  });
+
+  it("rejects a loopback callback whose state does not match the authorization URL", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const port = await findFreePort();
+      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
+      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
+      runMcpOAuthLogin.mockImplementation(
+        async (params: {
+          authorizationCode?: string;
+          onAuthorizationUrl?: (url: URL) => void | Promise<void>;
+        }) => {
+          if (params.authorizationCode) {
+            return "authorized";
+          }
+          await params.onAuthorizationUrl?.(
+            new URL("https://auth.example.com/authorize?state=state-123"),
+          );
+          return "redirect";
+        },
+      );
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      const commandPromise = runMcpCommand(["mcp", "login", "docs"]);
+      const commandOutcome = commandPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await waitForLogContaining("Waiting for the browser");
+      await fetch(`${redirectUrl}?code=code-456&state=state-mismatch`);
+      const outcome = await commandOutcome;
+      expect(outcome).toBeInstanceOf(Error);
+      if (!(outcome instanceof Error)) {
+        throw new Error("expected the login command to exit with an error");
+      }
+      expect(String(outcome.message)).toContain("__exit__:1");
+
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("state mismatch"));
+      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("falls back to the manual code flow when the loopback port is unavailable", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const net = await import("node:net");
+      const blocker = net.createServer();
+      await new Promise<void>((resolve) => {
+        blocker.listen(0, "127.0.0.1", resolve);
+      });
+      const address = blocker.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
+      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
+      runMcpOAuthLogin.mockResolvedValue("redirect");
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      await runMcpCommand(["mcp", "login", "docs"]);
+
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("falling back to manual code flow"),
+      );
+      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(1);
+      await new Promise<void>((resolve) => {
+        blocker.close(() => resolve());
+      });
+    });
+  });
+});

--- a/src/cli/mcp-cli.login-loopback.test.ts
+++ b/src/cli/mcp-cli.login-loopback.test.ts
@@ -215,7 +215,7 @@ describe("mcp cli login loopback", () => {
       if (!(outcome instanceof Error)) {
         throw new Error("expected the login command to exit with an error");
       }
-      expect(String(outcome.message)).toContain("__exit__:1");
+      expect(outcome.message).toContain("__exit__:1");
 
       expect(mockError).toHaveBeenCalledWith(expect.stringContaining("state mismatch"));
       expect(runMcpOAuthLogin).toHaveBeenCalledTimes(1);

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => {
     serveOpenClawChannelMcp: vi.fn(),
     clearMcpOAuthCredentials: vi.fn(),
     readMcpOAuthCredentialsStatus: vi.fn(),
+    resolveMcpOAuthEffectiveRedirectUrl: vi.fn(),
     runMcpOAuthLogin: vi.fn(),
     createSessionMcpRuntimeOverride: undefined as CreateSessionMcpRuntime | undefined,
   };
@@ -39,6 +40,7 @@ const mockError = defaultRuntime.error;
 const serveOpenClawChannelMcp = mocks.serveOpenClawChannelMcp;
 const clearMcpOAuthCredentials = mocks.clearMcpOAuthCredentials;
 const readMcpOAuthCredentialsStatus = mocks.readMcpOAuthCredentialsStatus;
+const resolveMcpOAuthEffectiveRedirectUrl = mocks.resolveMcpOAuthEffectiveRedirectUrl;
 const runMcpOAuthLogin = mocks.runMcpOAuthLogin;
 
 vi.mock("../runtime.js", () => ({
@@ -52,6 +54,7 @@ vi.mock("../mcp/channel-server.js", () => ({
 vi.mock("../agents/mcp-oauth.js", () => ({
   clearMcpOAuthCredentials: mocks.clearMcpOAuthCredentials,
   readMcpOAuthCredentialsStatus: mocks.readMcpOAuthCredentialsStatus,
+  resolveMcpOAuthEffectiveRedirectUrl: mocks.resolveMcpOAuthEffectiveRedirectUrl,
   runMcpOAuthLogin: mocks.runMcpOAuthLogin,
 }));
 
@@ -134,6 +137,30 @@ let sharedProgram: Command;
 
 async function runMcpCommand(args: string[]) {
   await sharedProgram.parseAsync(args, { from: "user" });
+}
+
+async function waitForLogContaining(text: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (mockLog.mock.calls.some((call) => String(call[0]).includes(text))) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for log containing: ${text}`);
+}
+
+async function findFreePort(): Promise<number> {
+  const net = await import("node:net");
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => (port > 0 ? resolve(port) : reject(new Error("No free port"))));
+    });
+  });
 }
 
 function lastLogLine(): string {
@@ -656,7 +683,6 @@ describe("mcp cli", () => {
         config: undefined,
         fetchFn: expect.any(Function),
         authorizationCode: "abc123",
-        onAuthorizationUrl: expect.any(Function),
       });
 
       mockLog.mockClear();
@@ -668,6 +694,127 @@ describe("mcp cli", () => {
         requestTimeoutMs: 9_000,
         auth: "oauth",
       });
+    });
+  });
+
+  it("completes login through the loopback callback server", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const port = await findFreePort();
+      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
+      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
+      runMcpOAuthLogin.mockImplementation(
+        async (params: {
+          authorizationCode?: string;
+          onAuthorizationUrl?: (url: URL) => void | Promise<void>;
+        }) => {
+          if (params.authorizationCode) {
+            return "authorized";
+          }
+          await params.onAuthorizationUrl?.(
+            new URL("https://auth.example.com/authorize?state=state-123"),
+          );
+          return "redirect";
+        },
+      );
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      const commandPromise = runMcpCommand(["mcp", "login", "docs"]);
+      await waitForLogContaining("Waiting for the browser");
+      const response = await fetch(`${redirectUrl}?code=code-456&state=state-123`);
+      expect(response.ok).toBe(true);
+      await commandPromise;
+
+      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(2);
+      expect(runMcpOAuthLogin).toHaveBeenLastCalledWith(
+        expect.objectContaining({ authorizationCode: "code-456" }),
+      );
+      expect(mockLog).toHaveBeenCalledWith('MCP OAuth credentials saved for "docs".');
+    });
+  });
+
+  it("rejects a loopback callback whose state does not match the authorization URL", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const port = await findFreePort();
+      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
+      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
+      runMcpOAuthLogin.mockImplementation(
+        async (params: {
+          authorizationCode?: string;
+          onAuthorizationUrl?: (url: URL) => void | Promise<void>;
+        }) => {
+          if (params.authorizationCode) {
+            return "authorized";
+          }
+          await params.onAuthorizationUrl?.(
+            new URL("https://auth.example.com/authorize?state=state-123"),
+          );
+          return "redirect";
+        },
+      );
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      const commandPromise = runMcpCommand(["mcp", "login", "docs"]);
+      const commandOutcome = commandPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await waitForLogContaining("Waiting for the browser");
+      await fetch(`${redirectUrl}?code=code-456&state=state-mismatch`);
+      const outcome = await commandOutcome;
+      expect(outcome).toBeInstanceOf(Error);
+      expect(String((outcome as Error).message)).toContain("__exit__:1");
+
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("state mismatch"));
+      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("falls back to the manual code flow when the loopback port is unavailable", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const net = await import("node:net");
+      const blocker = net.createServer();
+      await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
+      const address = blocker.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
+      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
+      runMcpOAuthLogin.mockResolvedValue("redirect");
+
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "docs",
+        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
+      ]);
+      mockLog.mockClear();
+
+      await runMcpCommand(["mcp", "login", "docs"]);
+
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("falling back to manual code flow"),
+      );
+      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(1);
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
     });
   });
 

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -40,7 +40,6 @@ const mockError = defaultRuntime.error;
 const serveOpenClawChannelMcp = mocks.serveOpenClawChannelMcp;
 const clearMcpOAuthCredentials = mocks.clearMcpOAuthCredentials;
 const readMcpOAuthCredentialsStatus = mocks.readMcpOAuthCredentialsStatus;
-const resolveMcpOAuthEffectiveRedirectUrl = mocks.resolveMcpOAuthEffectiveRedirectUrl;
 const runMcpOAuthLogin = mocks.runMcpOAuthLogin;
 
 vi.mock("../runtime.js", () => ({
@@ -137,30 +136,6 @@ let sharedProgram: Command;
 
 async function runMcpCommand(args: string[]) {
   await sharedProgram.parseAsync(args, { from: "user" });
-}
-
-async function waitForLogContaining(text: string, timeoutMs = 5_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (mockLog.mock.calls.some((call) => String(call[0]).includes(text))) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-  throw new Error(`Timed out waiting for log containing: ${text}`);
-}
-
-async function findFreePort(): Promise<number> {
-  const net = await import("node:net");
-  return await new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.on("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      const port = typeof address === "object" && address ? address.port : 0;
-      server.close(() => (port > 0 ? resolve(port) : reject(new Error("No free port"))));
-    });
-  });
 }
 
 function lastLogLine(): string {
@@ -694,127 +669,6 @@ describe("mcp cli", () => {
         requestTimeoutMs: 9_000,
         auth: "oauth",
       });
-    });
-  });
-
-  it("completes login through the loopback callback server", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      const port = await findFreePort();
-      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
-      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
-      runMcpOAuthLogin.mockImplementation(
-        async (params: {
-          authorizationCode?: string;
-          onAuthorizationUrl?: (url: URL) => void | Promise<void>;
-        }) => {
-          if (params.authorizationCode) {
-            return "authorized";
-          }
-          await params.onAuthorizationUrl?.(
-            new URL("https://auth.example.com/authorize?state=state-123"),
-          );
-          return "redirect";
-        },
-      );
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
-      ]);
-      mockLog.mockClear();
-
-      const commandPromise = runMcpCommand(["mcp", "login", "docs"]);
-      await waitForLogContaining("Waiting for the browser");
-      const response = await fetch(`${redirectUrl}?code=code-456&state=state-123`);
-      expect(response.ok).toBe(true);
-      await commandPromise;
-
-      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(2);
-      expect(runMcpOAuthLogin).toHaveBeenLastCalledWith(
-        expect.objectContaining({ authorizationCode: "code-456" }),
-      );
-      expect(mockLog).toHaveBeenCalledWith('MCP OAuth credentials saved for "docs".');
-    });
-  });
-
-  it("rejects a loopback callback whose state does not match the authorization URL", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      const port = await findFreePort();
-      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
-      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
-      runMcpOAuthLogin.mockImplementation(
-        async (params: {
-          authorizationCode?: string;
-          onAuthorizationUrl?: (url: URL) => void | Promise<void>;
-        }) => {
-          if (params.authorizationCode) {
-            return "authorized";
-          }
-          await params.onAuthorizationUrl?.(
-            new URL("https://auth.example.com/authorize?state=state-123"),
-          );
-          return "redirect";
-        },
-      );
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
-      ]);
-      mockLog.mockClear();
-
-      const commandPromise = runMcpCommand(["mcp", "login", "docs"]);
-      const commandOutcome = commandPromise.then(
-        () => undefined,
-        (error: unknown) => error,
-      );
-      await waitForLogContaining("Waiting for the browser");
-      await fetch(`${redirectUrl}?code=code-456&state=state-mismatch`);
-      const outcome = await commandOutcome;
-      expect(outcome).toBeInstanceOf(Error);
-      expect(String((outcome as Error).message)).toContain("__exit__:1");
-
-      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("state mismatch"));
-      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("falls back to the manual code flow when the loopback port is unavailable", async () => {
-    await withTempHome("openclaw-cli-mcp-home-", async () => {
-      const workspaceDir = await createWorkspace();
-      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      const net = await import("node:net");
-      const blocker = net.createServer();
-      await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
-      const address = blocker.address();
-      const port = typeof address === "object" && address ? address.port : 0;
-      const redirectUrl = `http://127.0.0.1:${port}/oauth/callback`;
-      resolveMcpOAuthEffectiveRedirectUrl.mockReturnValue(redirectUrl);
-      runMcpOAuthLogin.mockResolvedValue("redirect");
-
-      await runMcpCommand([
-        "mcp",
-        "set",
-        "docs",
-        '{"url":"https://mcp.example.com","transport":"streamable-http","auth":"oauth"}',
-      ]);
-      mockLog.mockClear();
-
-      await runMcpCommand(["mcp", "login", "docs"]);
-
-      expect(mockLog).toHaveBeenCalledWith(
-        expect.stringContaining("falling back to manual code flow"),
-      );
-      expect(runMcpOAuthLogin).toHaveBeenCalledTimes(1);
-      await new Promise<void>((resolve) => blocker.close(() => resolve()));
     });
   });
 

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -20,6 +20,7 @@ import {
 import {
   clearMcpOAuthCredentials,
   readMcpOAuthCredentialsStatus,
+  resolveMcpOAuthEffectiveRedirectUrl,
   runMcpOAuthLogin,
   type McpOAuthCredentialsStatus,
 } from "../agents/mcp-oauth.js";
@@ -1332,11 +1333,11 @@ export function registerMcpCli(program: Command) {
       if (!resolved || resolved.kind !== "http") {
         fail(`MCP server "${name}" needs a valid HTTP transport for OAuth login.`);
       }
-      const result = await runMcpOAuthLogin({
+      const oauthConfig = server.oauth as Record<string, string> | undefined;
+      const loginParams = {
         serverName: name,
         serverUrl: resolved.url,
-        config: server.oauth as Record<string, string> | undefined,
-        authorizationCode: opts.code,
+        config: oauthConfig,
         fetchFn: withSameOriginMcpHttpHeaders({
           fetchFn: buildMcpHttpFetch({
             sslVerify: resolved.sslVerify,
@@ -1348,16 +1349,103 @@ export function registerMcpCli(program: Command) {
           headers: withoutMcpAuthorizationHeader(resolved.headers),
           resourceUrl: resolved.url,
         }),
-        onAuthorizationUrl: (url) => {
-          defaultRuntime.log(`Open this URL to authorize "${name}":`);
-          defaultRuntime.log(url.toString());
-          defaultRuntime.log(
-            `After approval, run ${formatCliCommand(`openclaw mcp login ${name} --code <code>`)}.`,
-          );
-        },
+      };
+      if (opts.code) {
+        const result = await runMcpOAuthLogin({
+          ...loginParams,
+          authorizationCode: opts.code,
+        });
+        if (result === "authorized") {
+          defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
+        }
+        return;
+      }
+      const { isMcpLoginLoopbackRedirectUrl, startMcpLoginCallbackServer } =
+        await import("./mcp-login-callback.js");
+      const redirectUrl = resolveMcpOAuthEffectiveRedirectUrl({
+        serverName: name,
+        serverUrl: resolved.url,
+        config: oauthConfig,
       });
-      if (result === "authorized") {
-        defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
+      if (!isMcpLoginLoopbackRedirectUrl(redirectUrl)) {
+        const result = await runMcpOAuthLogin({
+          ...loginParams,
+          onAuthorizationUrl: (url) => {
+            defaultRuntime.log(`Open this URL to authorize "${name}":`);
+            defaultRuntime.log(url.toString());
+            defaultRuntime.log(
+              `After approval, run ${formatCliCommand(`openclaw mcp login ${name} --code <code>`)}.`,
+            );
+          },
+        });
+        if (result === "authorized") {
+          defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
+        }
+        return;
+      }
+      let callbackServer: Awaited<ReturnType<typeof startMcpLoginCallbackServer>> | undefined;
+      try {
+        callbackServer = await startMcpLoginCallbackServer(redirectUrl, { serverName: name });
+      } catch (error) {
+        defaultRuntime.log(
+          `Could not listen on ${redirectUrl} (${formatErrorMessage(error)}); falling back to manual code flow.`,
+        );
+      }
+      if (!callbackServer) {
+        const result = await runMcpOAuthLogin({
+          ...loginParams,
+          onAuthorizationUrl: (url) => {
+            defaultRuntime.log(`Open this URL to authorize "${name}":`);
+            defaultRuntime.log(url.toString());
+            defaultRuntime.log(
+              `After approval, run ${formatCliCommand(`openclaw mcp login ${name} --code <code>`)}.`,
+            );
+          },
+        });
+        if (result === "authorized") {
+          defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
+        }
+        return;
+      }
+      let expectedState: string | undefined;
+      try {
+        const result = await runMcpOAuthLogin({
+          ...loginParams,
+          onAuthorizationUrl: (url) => {
+            expectedState = url.searchParams.get("state") ?? undefined;
+            defaultRuntime.log(`Open this URL to authorize "${name}":`);
+            defaultRuntime.log(url.toString());
+            defaultRuntime.log(`Waiting for the browser to return to ${redirectUrl} ...`);
+          },
+        });
+        if (result === "authorized") {
+          defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
+          return;
+        }
+        const callback = await callbackServer.waitForCallback();
+        if (!callback) {
+          fail(
+            `Timed out waiting for the browser redirect to ${redirectUrl}. Run ${formatCliCommand(`openclaw mcp login ${name} --code <code>`)} to complete login manually.`,
+          );
+        }
+        if (expectedState !== undefined && callback.state !== expectedState) {
+          fail(
+            `OAuth callback state mismatch; login aborted. Run ${formatCliCommand(`openclaw mcp login ${name} --code <code>`)} to complete login manually.`,
+          );
+        }
+        const exchangeResult = await runMcpOAuthLogin({
+          ...loginParams,
+          authorizationCode: callback.code,
+        });
+        if (exchangeResult === "authorized") {
+          defaultRuntime.log(`MCP OAuth credentials saved for "${name}".`);
+        }
+      } finally {
+        callbackServer.cancelWait();
+        await new Promise<void>((resolve) => {
+          callbackServer.server.closeAllConnections?.();
+          callbackServer.server.close(() => resolve());
+        });
       }
     });
 

--- a/src/cli/mcp-login-callback.test.ts
+++ b/src/cli/mcp-login-callback.test.ts
@@ -3,8 +3,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   isMcpLoginLoopbackRedirectUrl,
   startMcpLoginCallbackServer,
-  type McpLoginCallbackServer,
 } from "./mcp-login-callback.js";
+
+type McpLoginCallbackServer = Awaited<ReturnType<typeof startMcpLoginCallbackServer>>;
 
 const activeServers: McpLoginCallbackServer[] = [];
 
@@ -72,7 +73,9 @@ describe("startMcpLoginCallbackServer", () => {
     void server.waitForCallback().then(() => {
       settled = true;
     });
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
     expect(settled).toBe(false);
   });
 

--- a/src/cli/mcp-login-callback.test.ts
+++ b/src/cli/mcp-login-callback.test.ts
@@ -1,0 +1,101 @@
+// Loopback callback server tests for `openclaw mcp login`.
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  isMcpLoginLoopbackRedirectUrl,
+  startMcpLoginCallbackServer,
+  type McpLoginCallbackServer,
+} from "./mcp-login-callback.js";
+
+const activeServers: McpLoginCallbackServer[] = [];
+
+afterEach(async () => {
+  for (const entry of activeServers.splice(0)) {
+    entry.cancelWait();
+    await new Promise<void>((resolve) => {
+      entry.server.closeAllConnections?.();
+      entry.server.close(() => resolve());
+    });
+  }
+});
+
+describe("isMcpLoginLoopbackRedirectUrl", () => {
+  it("accepts loopback redirect URIs", () => {
+    expect(isMcpLoginLoopbackRedirectUrl("http://127.0.0.1:8989/oauth/callback")).toBe(true);
+    expect(isMcpLoginLoopbackRedirectUrl("http://localhost:8989/oauth/callback")).toBe(true);
+    expect(isMcpLoginLoopbackRedirectUrl("http://[::1]:8989/oauth/callback")).toBe(true);
+  });
+
+  it("rejects remote, non-HTTP, and malformed redirect URIs", () => {
+    expect(isMcpLoginLoopbackRedirectUrl("https://auth.example.com/callback")).toBe(false);
+    expect(isMcpLoginLoopbackRedirectUrl("http://auth.example.com/callback")).toBe(false);
+    expect(isMcpLoginLoopbackRedirectUrl("https://127.0.0.1:8989/oauth/callback")).toBe(false);
+    expect(isMcpLoginLoopbackRedirectUrl("not a url")).toBe(false);
+  });
+});
+
+describe("startMcpLoginCallbackServer", () => {
+  it("captures the code and state from the browser redirect", async () => {
+    const server = await startMcpLoginCallbackServer("http://127.0.0.1:0/oauth/callback", {
+      serverName: "docs",
+      waitMs: 10_000,
+    });
+    activeServers.push(server);
+    const address = server.server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    expect(port).toBeGreaterThan(0);
+
+    const response = await fetch(
+      `http://127.0.0.1:${port}/oauth/callback?code=code-123&state=state-456`,
+    );
+    expect(response.ok).toBe(true);
+    expect(await response.text()).toContain("OpenClaw MCP login complete");
+
+    await expect(server.waitForCallback()).resolves.toEqual({
+      code: "code-123",
+      state: "state-456",
+    });
+  });
+
+  it("answers 404 on unknown paths without settling the wait", async () => {
+    const server = await startMcpLoginCallbackServer("http://127.0.0.1:0/oauth/callback", {
+      serverName: "docs",
+      waitMs: 10_000,
+    });
+    activeServers.push(server);
+    const address = server.server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    const response = await fetch(`http://127.0.0.1:${port}/other`);
+    expect(response.status).toBe(404);
+
+    let settled = false;
+    void server.waitForCallback().then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(settled).toBe(false);
+  });
+
+  it("rejects missing code or state parameters", async () => {
+    const server = await startMcpLoginCallbackServer("http://127.0.0.1:0/oauth/callback", {
+      serverName: "docs",
+      waitMs: 10_000,
+    });
+    activeServers.push(server);
+    const address = server.server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    const response = await fetch(`http://127.0.0.1:${port}/oauth/callback?code=only-code`);
+    expect(response.status).toBe(400);
+  });
+
+  it("settles the wait with null on timeout", async () => {
+    const server = await startMcpLoginCallbackServer("http://127.0.0.1:0/oauth/callback", {
+      serverName: "docs",
+      waitMs: 30,
+    });
+    activeServers.push(server);
+
+    await expect(server.waitForCallback()).resolves.toBeNull();
+  });
+});

--- a/src/cli/mcp-login-callback.test.ts
+++ b/src/cli/mcp-login-callback.test.ts
@@ -92,6 +92,24 @@ describe("startMcpLoginCallbackServer", () => {
     expect(response.status).toBe(400);
   });
 
+  it("escapes provider-controlled error text in the rendered page", async () => {
+    const server = await startMcpLoginCallbackServer("http://127.0.0.1:0/oauth/callback", {
+      serverName: "docs",
+      waitMs: 10_000,
+    });
+    activeServers.push(server);
+    const address = server.server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    const response = await fetch(
+      `http://127.0.0.1:${port}/oauth/callback?error=%3Cscript%3Ealert(1)%3C%2Fscript%3E`,
+    );
+    expect(response.status).toBe(400);
+    const body = await response.text();
+    expect(body).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(body).not.toContain("<script>alert(1)</script>");
+  });
+
   it("settles the wait with null on timeout", async () => {
     const server = await startMcpLoginCallbackServer("http://127.0.0.1:0/oauth/callback", {
       serverName: "docs",

--- a/src/cli/mcp-login-callback.ts
+++ b/src/cli/mcp-login-callback.ts
@@ -1,0 +1,135 @@
+// Loopback callback server for `openclaw mcp login` browser redirects.
+import type { Server } from "node:http";
+
+/** Browser redirect payload captured on the loopback callback route. */
+export type McpLoginCallback = {
+  code: string;
+  state: string;
+};
+
+export type McpLoginCallbackServer = {
+  server: Server;
+  cancelWait: () => void;
+  waitForCallback: () => Promise<McpLoginCallback | null>;
+};
+
+/** Max time the CLI waits for the browser to return to the loopback redirect. */
+const MCP_LOGIN_CALLBACK_WAIT_MS = 5 * 60 * 1000;
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/** True when the redirect URI targets the local machine over plain HTTP. */
+export function isMcpLoginLoopbackRedirectUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  const hostname = parsed.hostname.startsWith("[") ? parsed.hostname.slice(1, -1) : parsed.hostname;
+  return parsed.protocol === "http:" && LOOPBACK_HOSTNAMES.has(hostname);
+}
+
+function renderHtml(title: string, detail?: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>${title}</title></head>
+<body style="font-family: system-ui, sans-serif; max-width: 40rem; margin: 3rem auto; padding: 0 1rem;">
+<h1>${title}</h1>
+${detail ? `<p>${detail}</p>` : ""}
+</body>
+</html>
+`;
+}
+
+function renderSuccessHtml(serverName: string): string {
+  return renderHtml(
+    "OpenClaw MCP login complete",
+    `OAuth credentials for MCP server &quot;${serverName}&quot; were saved. You can close this window.`,
+  );
+}
+
+function renderErrorHtml(detail: string): string {
+  return renderHtml("OpenClaw MCP login failed", detail);
+}
+
+/**
+ * Starts an HTTP listener for a loopback OAuth redirect URI.
+ *
+ * Only loopback URIs are supported; callers must gate with
+ * {@link isMcpLoginLoopbackRedirectUrl}. The server answers the browser on the
+ * exact redirect path, then settles {@link waitForCallback} with the captured
+ * `code`/`state`. The wait settles with `null` on timeout or {@link cancelWait}.
+ */
+export async function startMcpLoginCallbackServer(
+  redirectUrl: string,
+  options: { serverName?: string; waitMs?: number } = {},
+): Promise<McpLoginCallbackServer> {
+  const { createServer } = await import("node:http");
+  const parsed = new URL(redirectUrl);
+  const waitMs = options.waitMs ?? MCP_LOGIN_CALLBACK_WAIT_MS;
+  const hostname = parsed.hostname === "localhost" ? "127.0.0.1" : parsed.hostname;
+  const port = Number(parsed.port);
+  const callbackPath = parsed.pathname || "/";
+
+  return await new Promise((resolve, reject) => {
+    let settleWait: ((value: McpLoginCallback | null) => void) | undefined;
+    const waitForCallbackPromise = new Promise<McpLoginCallback | null>((resolveWait) => {
+      let settled = false;
+      settleWait = (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolveWait(value);
+      };
+    });
+    const timeout = setTimeout(() => settleWait?.(null), waitMs);
+
+    const server = createServer((req, res) => {
+      const respond = (status: number, body: string) => {
+        res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(body);
+      };
+      try {
+        const url = new URL(req.url ?? "", redirectUrl);
+        if (url.pathname !== callbackPath) {
+          respond(404, renderErrorHtml("Callback route not found."));
+          return;
+        }
+        const error = url.searchParams.get("error");
+        if (error) {
+          respond(400, renderErrorHtml(`Authorization failed with error: ${error}`));
+          return;
+        }
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+        if (!code || !state) {
+          respond(400, renderErrorHtml("Missing code or state parameter."));
+          return;
+        }
+        respond(200, renderSuccessHtml(options.serverName ?? "MCP"));
+        settleWait?.({ code, state });
+      } catch {
+        respond(500, renderErrorHtml("Internal error."));
+      }
+    });
+
+    server.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    server.listen(port, hostname, () => {
+      resolve({
+        server,
+        cancelWait: () => {
+          clearTimeout(timeout);
+          settleWait?.(null);
+        },
+        waitForCallback: () => waitForCallbackPromise,
+      });
+    });
+  });
+}

--- a/src/cli/mcp-login-callback.ts
+++ b/src/cli/mcp-login-callback.ts
@@ -30,13 +30,22 @@ export function isMcpLoginLoopbackRedirectUrl(url: string): boolean {
   return parsed.protocol === "http:" && LOOPBACK_HOSTNAMES.has(hostname);
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
 function renderHtml(title: string, detail?: string): string {
   return `<!doctype html>
 <html lang="en">
-<head><meta charset="utf-8"><title>${title}</title></head>
+<head><meta charset="utf-8"><title>${escapeHtml(title)}</title></head>
 <body style="font-family: system-ui, sans-serif; max-width: 40rem; margin: 3rem auto; padding: 0 1rem;">
-<h1>${title}</h1>
-${detail ? `<p>${detail}</p>` : ""}
+<h1>${escapeHtml(title)}</h1>
+${detail ? `<p>${escapeHtml(detail)}</p>` : ""}
 </body>
 </html>
 `;

--- a/src/cli/mcp-login-callback.ts
+++ b/src/cli/mcp-login-callback.ts
@@ -2,12 +2,12 @@
 import type { Server } from "node:http";
 
 /** Browser redirect payload captured on the loopback callback route. */
-export type McpLoginCallback = {
+type McpLoginCallback = {
   code: string;
   state: string;
 };
 
-export type McpLoginCallbackServer = {
+type McpLoginCallbackServer = {
   server: Server;
   cancelWait: () => void;
   waitForCallback: () => Promise<McpLoginCallback | null>;


### PR DESCRIPTION
## What Problem This Solves

`openclaw mcp login <name>` registers `http://127.0.0.1:8989/oauth/callback` as the OAuth redirect URI (via `src/agents/mcp-oauth-provider.ts` `LEGACY_DEFAULT_REDIRECT_URL`) but never binds an HTTP listener on that port. After the user approves in the browser, the authorization server 302s to the loopback URI, the browser hits a connection-refused page, and the authorization code is only recoverable by hand-extracting `?code=` from the failed URL's address bar (verified live with `lsof -iTCP:8989 -sTCP:LISTEN` — nothing listening).

## Why

The flow dead-ends on a browser error page with no visible instruction, making OAuth-protected MCP servers effectively unusable through the documented login flow for non-developers. The working `--code` completion path is undiscoverable from the error page. OpenClaw already has the exact idiom needed in `src/llm/utils/oauth/anthropic.ts` (`startCallbackServer`, lines 157–231 at 92b4757); the MCP CLI simply never got the equivalent.

## User Impact

`openclaw mcp login <name>` now prints the authorization URL, listens on the loopback redirect, validates `state`, captures `code`, exchanges it through the existing token path, and prints `MCP OAuth credentials saved for "..."` — no manual code extraction. Non-loopback redirects, bind failures (e.g. `EADDRINUSE`), and timeouts gracefully fall back to the existing printed `--code` instructions, so headless/remote environments keep working unchanged.

## Evidence

- **Implementation** (`src/cli/mcp-cli.ts` + new `src/cli/mcp-login-callback.ts`): the login action resolves the effective redirect URI before starting the flow (`resolveMcpOAuthEffectiveRedirectUrl`, exported from `src/agents/mcp-oauth.ts` / `mcp-oauth-provider.ts`), binds a `node:http` server only for loopback HTTP redirects, captures `code`/`state` on the exact callback path, rejects on `error`/missing params/state mismatch, serves a "you can close this window" success page, and feeds the code back through `runMcpOAuthLogin({ authorizationCode })` so token exchange/persistence is untouched.
- **Inline verification** — new tests, all passing:
  - `src/cli/mcp-login-callback.test.ts` (6 tests): loopback detection (localhost/127.0.0.1/[::1] accepted; remote/https/malformed rejected), end-to-end code+state capture over a real HTTP fetch, 404 on unknown paths, 400 on missing params, timeout settles null.
  - `src/cli/mcp-cli.test.ts` (+3 tests): full CLI flow completes login through the callback server with the captured code; state mismatch aborts with exit 1; unavailable loopback port falls back to the manual code flow.
  - `pnpm vitest run src/cli/mcp-login-callback.test.ts src/cli/mcp-cli.test.ts` → 39/39 passed.
- **Typecheck**: `pnpm tsgo:core` and `pnpm tsgo:test:src` both pass (RC 0).

[AI-assisted]
