### PR TITLE
fix(daemon): avoid taskkill /T killing the restart CLI on Windows

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -376,6 +376,9 @@ const config = {
     "src/gateway/board-view-ticket.ts": ["exports"],
     // Focused startup tests consume this explicit seam; production imports only the bootstrap.
     "src/gateway/server-startup-bootstrap.ts": ["exports"],
+    // Focused process-tree tests exercise the parent-pid helpers directly;
+    // production uses them in-module via isCurrentProcessInsideGatewayTree.
+    "src/daemon/schtasks-process.ts": ["exports", "types"],
     // Registry facades retain direct registration/reset compatibility seams used by focused
     // tests; the full-tree scan still audits every named export against those consumers.
     "src/agents/harness/registry.ts": ["exports"],

--- a/src/daemon/schtasks-process.test.ts
+++ b/src/daemon/schtasks-process.test.ts
@@ -1,0 +1,47 @@
+// Process-tree ancestry helpers for Windows scheduled-task gateway termination.
+import { describe, expect, it } from "vitest";
+import {
+  buildWindowsParentPidIndex,
+  isWindowsProcessDescendant,
+  type WindowsProcessSnapshotEntry,
+} from "./schtasks-process.js";
+
+const SNAPSHOT: WindowsProcessSnapshotEntry[] = [
+  { ProcessId: 4, ParentProcessId: 0, CommandLine: "System" },
+  { ProcessId: 100, ParentProcessId: 4, CommandLine: "services.exe" },
+  { ProcessId: 200, ParentProcessId: 100, CommandLine: "openclaw gateway --port 18789" },
+  { ProcessId: 300, ParentProcessId: 200, CommandLine: "node exec child" },
+  { ProcessId: 400, ParentProcessId: 300, CommandLine: "openclaw gateway restart" },
+  { ProcessId: 500, ParentProcessId: 100, CommandLine: "unrelated.exe" },
+];
+
+describe("buildWindowsParentPidIndex", () => {
+  it("maps each process to its parent and skips roots and self-parents", () => {
+    const index = buildWindowsParentPidIndex(SNAPSHOT);
+    expect(index.get(200)).toBe(100);
+    expect(index.get(400)).toBe(300);
+    expect(index.has(4)).toBe(false);
+  });
+});
+
+describe("isWindowsProcessDescendant", () => {
+  const index = buildWindowsParentPidIndex(SNAPSHOT);
+
+  it("detects a deep descendant of the gateway", () => {
+    expect(isWindowsProcessDescendant(400, 200, index)).toBe(true);
+  });
+
+  it("treats the ancestor itself as inside the tree", () => {
+    expect(isWindowsProcessDescendant(200, 200, index)).toBe(true);
+  });
+
+  it("rejects unrelated processes", () => {
+    expect(isWindowsProcessDescendant(500, 200, index)).toBe(false);
+    expect(isWindowsProcessDescendant(100, 200, index)).toBe(false);
+  });
+
+  it("returns false for unknown pids and empty indexes", () => {
+    expect(isWindowsProcessDescendant(9999, 200, index)).toBe(false);
+    expect(isWindowsProcessDescendant(300, 200, new Map())).toBe(false);
+  });
+});

--- a/src/daemon/schtasks-process.ts
+++ b/src/daemon/schtasks-process.ts
@@ -106,7 +106,7 @@ export function isWindowsProcessDescendant(
  * process tree (e.g. `openclaw gateway restart` spawned by the gateway's own
  * agent exec tool). Requires a Windows process snapshot; false when unknown.
  */
-export async function isCurrentProcessInsideGatewayTree(pid: number): Promise<boolean> {
+async function isCurrentProcessInsideGatewayTree(pid: number): Promise<boolean> {
   if (process.platform !== "win32" || pid === process.pid) {
     return false;
   }

--- a/src/daemon/schtasks-process.ts
+++ b/src/daemon/schtasks-process.ts
@@ -16,8 +16,9 @@ import { readScheduledTaskCommand } from "./schtasks-layout.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-types.js";
 
-type WindowsProcessSnapshotEntry = {
+export type WindowsProcessSnapshotEntry = {
   ProcessId?: number;
+  ParentProcessId?: number | null;
   CommandLine?: string | null;
 };
 
@@ -60,6 +61,60 @@ function matchesInstalledProgramArguments(
 function getSnapshotProcessId(entry: WindowsProcessSnapshotEntry): number | null {
   const pid = entry.ProcessId;
   return typeof pid === "number" && Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+function getSnapshotParentProcessId(entry: WindowsProcessSnapshotEntry): number | null {
+  const parentPid = entry.ParentProcessId;
+  return typeof parentPid === "number" && Number.isFinite(parentPid) && parentPid > 0
+    ? parentPid
+    : null;
+}
+
+/** Builds a pid -> parent-pid index from a Windows process snapshot. */
+export function buildWindowsParentPidIndex(
+  entries: readonly WindowsProcessSnapshotEntry[],
+): Map<number, number> {
+  const parentById = new Map<number, number>();
+  for (const entry of entries) {
+    const pid = getSnapshotProcessId(entry);
+    const parentPid = getSnapshotParentProcessId(entry);
+    if (pid !== null && parentPid !== null && parentPid !== pid) {
+      parentById.set(pid, parentPid);
+    }
+  }
+  return parentById;
+}
+
+/** True when `descendantPid` is `ancestorPid` or sits inside its process tree. */
+export function isWindowsProcessDescendant(
+  descendantPid: number,
+  ancestorPid: number,
+  parentById: ReadonlyMap<number, number>,
+): boolean {
+  let cursor = descendantPid;
+  for (let hops = 0; cursor > 0 && hops < 64; hops += 1) {
+    if (cursor === ancestorPid) {
+      return true;
+    }
+    cursor = parentById.get(cursor) ?? 0;
+  }
+  return false;
+}
+
+/**
+ * True when the current process is the gateway process itself or inside its
+ * process tree (e.g. `openclaw gateway restart` spawned by the gateway's own
+ * agent exec tool). Requires a Windows process snapshot; false when unknown.
+ */
+export async function isCurrentProcessInsideGatewayTree(pid: number): Promise<boolean> {
+  if (process.platform !== "win32" || pid === process.pid) {
+    return false;
+  }
+  const snapshot = readWindowsProcessSnapshot();
+  if (!snapshot) {
+    return false;
+  }
+  return isWindowsProcessDescendant(process.pid, pid, buildWindowsParentPidIndex(snapshot));
 }
 
 export function findInstalledProcessPid(
@@ -305,21 +360,35 @@ export async function terminateGatewayProcessTree(pid: number, graceMs: number):
     killProcessTree(pid, { graceMs });
     return;
   }
+  // When the current process lives inside the target tree (e.g. `openclaw gateway
+  // restart` run through the gateway's own agent exec tool), `taskkill /T` would
+  // terminate us before the restart can relaunch the gateway, leaving it stopped.
+  // Kill only the gateway process itself in that case: its children survive as
+  // orphans, the port is released, and the caller's `schtasks /Run` step restarts.
+  const treeKill = !(await isCurrentProcessInsideGatewayTree(pid));
   const taskkillPath = getWindowsSystem32ExePath("taskkill.exe");
-  const graceful = spawnSync(taskkillPath, ["/T", "/PID", String(pid)], {
-    stdio: "ignore",
-    timeout: 5_000,
-    windowsHide: true,
-  });
+  const graceful = spawnSync(
+    taskkillPath,
+    treeKill ? ["/T", "/PID", String(pid)] : ["/PID", String(pid)],
+    {
+      stdio: "ignore",
+      timeout: 5_000,
+      windowsHide: true,
+    },
+  );
   // taskkill can race with exit; only a missing PID avoids forcing the verified owner.
   if (await waitForProcessExit(pid, graceful.status === 0 && !graceful.error ? graceMs : 0)) {
     return;
   }
-  const forced = spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
-    stdio: "ignore",
-    timeout: 5_000,
-    windowsHide: true,
-  });
+  const forced = spawnSync(
+    taskkillPath,
+    treeKill ? ["/F", "/T", "/PID", String(pid)] : ["/F", "/PID", String(pid)],
+    {
+      stdio: "ignore",
+      timeout: 5_000,
+      windowsHide: true,
+    },
+  );
   if (forced.error || forced.status !== 0) {
     if (probeProcessState(pid) === "missing") {
       return;
@@ -359,7 +428,7 @@ export function readWindowsProcessSnapshot(): WindowsProcessSnapshotEntry[] | nu
     [
       "-NoProfile",
       "-Command",
-      "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
     ],
     { encoding: "utf8", timeout: 5_000, windowsHide: true },
   );

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -132,7 +132,7 @@ async function writeNodeScript(env: Record<string, string>, port = "18789") {
 }
 
 const NODE_PROCESS_QUERY =
-  "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress";
+  "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress";
 
 function makeNodeServiceEnv(env: Record<string, string>): Record<string, string> {
   return {
@@ -912,7 +912,7 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env, new PassThrough(), "19433");
 
-      expect(processQueries).toBe(5);
+      expect(processQueries).toBe(6);
       await expect(fs.access(startupEntryPath)).rejects.toThrow();
     });
   });
@@ -1518,7 +1518,7 @@ describe("Windows startup fallback", () => {
           command === getWindowsPowerShellExePath() &&
           Array.isArray(args) &&
           args.includes(
-            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
           )
         ) {
           return {
@@ -1588,7 +1588,7 @@ describe("Windows startup fallback", () => {
           command === getWindowsPowerShellExePath() &&
           Array.isArray(args) &&
           args.includes(
-            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
           )
         ) {
           return {
@@ -1741,7 +1741,7 @@ describe("Windows startup fallback", () => {
           command === getWindowsPowerShellExePath() &&
           Array.isArray(args) &&
           args.includes(
-            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
           )
         ) {
           return {


### PR DESCRIPTION
## What Problem This Solves

On Windows, when an agent runs `openclaw gateway restart` through the exec tool (gateway installed as a Scheduled Task), the restart **kills the CLI process itself** and leaves the gateway completely stopped. The exec command is a direct child of the gateway process; `terminateGatewayProcessTree()` in `src/daemon/schtasks-process.ts` uses `taskkill /T /PID <gateway>` (kill process tree), which terminates the restart CLI mid-flight — the subsequent `schtasks /Run` step never executes and the gateway never comes back until someone manually restarts it from an interactive terminal.

## Why

The non-Windows branch of `terminateGatewayProcessTree` has an explicit guard comment ("leader verification avoids signaling our group") before signaling the tree, but the Windows branch has no equivalent protection. `schtasks /End` alone already terminates the scheduled task; the tree-kill is only a fallback, yet it currently nukes the very process that is trying to perform the restart. Any process spawned by the gateway (agent exec commands, sub-agents running CLI commands) that calls `openclaw gateway restart` hits this.

## User Impact

`openclaw gateway restart` now completes regardless of whether the invoking CLI is inside the gateway process tree: the gateway is terminated, the port is released, and `schtasks /Run` relaunches it. Agents using the exec tool to manage the gateway no longer strand it in a stopped state requiring manual intervention. When the invoking process is *outside* the tree, behavior is unchanged (full tree kill, as before).

## Evidence

- **Implementation** (`src/daemon/schtasks-process.ts`): added `buildWindowsParentPidIndex()` / `isWindowsProcessDescendant()` (pure helpers walking the ParentProcessId chain, with a 64-hop guard), plus `isCurrentProcessInsideGatewayTree()` which reads the existing Windows process snapshot (query extended to select `ParentProcessId`). `terminateGatewayProcessTree()` now drops the `/T` flag (graceful and forced variants) when the current process is a descendant of the target PID, so only the gateway itself is killed and the CLI survives to run `schtasks /Run`. Non-Windows path untouched.
- **Inline verification** — new `src/daemon/schtasks-process.test.ts` (5 tests, all passing): parent index maps children to parents and skips roots/self-parents; a deep descendant of the gateway is detected; the ancestor itself counts as inside the tree; unrelated and unknown PIDs are rejected; empty indexes return false.
  - `pnpm vitest run src/daemon/schtasks-process.test.ts` → 5/5 passed.
- **Typecheck**: `pnpm tsgo:core` and `pnpm tsgo:test:src` both pass (RC 0).
- **Repro mechanism** matches the issue's control experiment: interactive PowerShell (CLI outside gateway tree) → tree-kill path, works; agent exec (CLI inside gateway tree) → now takes the non-tree path and completes the restart instead of dying.

[AI-assisted]
