### PR TITLE
fix(gateway): prevent approval E2E startup timeout

### DIFF
--- a/src/gateway/operator-approvals-client.e2e.test.ts
+++ b/src/gateway/operator-approvals-client.e2e.test.ts
@@ -34,6 +34,14 @@ const TEST_ENV_KEYS = [
   "OPENCLAW_GATEWAY_URL",
   "OPENCLAW_GATEWAY_TOKEN",
   "OPENCLAW_GATEWAY_PASSWORD",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
 ];
 
 type Cleanup = () => Promise<void> | void;
@@ -59,6 +67,17 @@ async function requestExecApproval(params: {
     status: "accepted",
     id: params.id,
   });
+}
+
+function configureApprovalGatewayTestEnv(tempHome: string): void {
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(tempHome, "no-plugins"));
 }
 
 describe("operator approval gateway client e2e", () => {
@@ -88,6 +107,7 @@ describe("operator approval gateway client e2e", () => {
     await fs.mkdir(stateDir, { recursive: true });
     setTestEnvValue("HOME", tempHome);
     setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    configureApprovalGatewayTestEnv(tempHome);
 
     const port = await getFreeGatewayPort();
     const token = "approval-client-e2e-token";
@@ -192,6 +212,7 @@ describe("operator approval gateway client e2e", () => {
     await fs.mkdir(stateDir, { recursive: true });
     setTestEnvValue("HOME", tempHome);
     setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    configureApprovalGatewayTestEnv(tempHome);
 
     const requesterIdentity = loadOrCreateDeviceIdentity({
       path: path.join(stateDir, "test-device-identities", "approval-requester.sqlite"),

--- a/src/gateway/operator-approvals-client.e2e.test.ts
+++ b/src/gateway/operator-approvals-client.e2e.test.ts
@@ -24,24 +24,19 @@ import {
   disconnectGatewayClient,
   getFreeGatewayPort,
 } from "./test-helpers.e2e.js";
-import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "./test-helpers.env.js";
+import {
+  configureManualGatewayBackgroundEnv,
+  MANUAL_GATEWAY_ENV_KEYS,
+} from "./test-helpers.manual-gateway-env.js";
 
 const TEST_ENV_KEYS = [
   "HOME",
-  ...GATEWAY_STARTUP_MUTATED_ENV_KEYS,
+  ...MANUAL_GATEWAY_ENV_KEYS,
   "OPENCLAW_STATE_DIR",
   "OPENCLAW_CONFIG_PATH",
   "OPENCLAW_GATEWAY_URL",
   "OPENCLAW_GATEWAY_TOKEN",
   "OPENCLAW_GATEWAY_PASSWORD",
-  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
-  "OPENCLAW_SKIP_GMAIL_WATCHER",
-  "OPENCLAW_SKIP_CANVAS_HOST",
-  "OPENCLAW_SKIP_CHANNELS",
-  "OPENCLAW_SKIP_PROVIDERS",
-  "OPENCLAW_SKIP_CRON",
-  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
-  "OPENCLAW_BUNDLED_PLUGINS_DIR",
 ];
 
 type Cleanup = () => Promise<void> | void;
@@ -67,17 +62,6 @@ async function requestExecApproval(params: {
     status: "accepted",
     id: params.id,
   });
-}
-
-function configureApprovalGatewayTestEnv(tempHome: string): void {
-  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
-  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
-  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
-  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
-  setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
-  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
-  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
-  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(tempHome, "no-plugins"));
 }
 
 describe("operator approval gateway client e2e", () => {
@@ -107,7 +91,7 @@ describe("operator approval gateway client e2e", () => {
     await fs.mkdir(stateDir, { recursive: true });
     setTestEnvValue("HOME", tempHome);
     setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-    configureApprovalGatewayTestEnv(tempHome);
+    configureManualGatewayBackgroundEnv(tempHome);
 
     const port = await getFreeGatewayPort();
     const token = "approval-client-e2e-token";
@@ -212,7 +196,7 @@ describe("operator approval gateway client e2e", () => {
     await fs.mkdir(stateDir, { recursive: true });
     setTestEnvValue("HOME", tempHome);
     setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-    configureApprovalGatewayTestEnv(tempHome);
+    configureManualGatewayBackgroundEnv(tempHome);
 
     const requesterIdentity = loadOrCreateDeviceIdentity({
       path: path.join(stateDir, "test-device-identities", "approval-requester.sqlite"),

--- a/src/gateway/server-methods/plugin-approval-turn-source-routing.e2e.test.ts
+++ b/src/gateway/server-methods/plugin-approval-turn-source-routing.e2e.test.ts
@@ -22,11 +22,14 @@ import {
   disconnectGatewayClient,
   getFreeGatewayPort,
 } from "../test-helpers.e2e.js";
-import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../test-helpers.env.js";
+import {
+  configureManualGatewayBackgroundEnv,
+  MANUAL_GATEWAY_ENV_KEYS,
+} from "../test-helpers.manual-gateway-env.js";
 
 const TEST_ENV_KEYS = [
   "HOME",
-  ...GATEWAY_STARTUP_MUTATED_ENV_KEYS,
+  ...MANUAL_GATEWAY_ENV_KEYS,
   "OPENCLAW_STATE_DIR",
   "OPENCLAW_CONFIG_PATH",
   "OPENCLAW_GATEWAY_URL",
@@ -56,6 +59,7 @@ describe("plugin.approval.request delivery routing (real gateway)", () => {
     await fs.mkdir(stateDir, { recursive: true });
     setTestEnvValue("HOME", tempHome);
     setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    configureManualGatewayBackgroundEnv(tempHome);
 
     const port = await getFreeGatewayPort();
     const token = "plugin-approval-turn-source-e2e-token";

--- a/src/gateway/test-helpers.manual-gateway-env.ts
+++ b/src/gateway/test-helpers.manual-gateway-env.ts
@@ -1,0 +1,31 @@
+import path from "node:path";
+import { setTestEnvValue } from "../test-utils/env.js";
+import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "./test-helpers.env.js";
+
+const MANUAL_GATEWAY_BACKGROUND_ENV_KEYS = [
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+] as const;
+
+export const MANUAL_GATEWAY_ENV_KEYS = [
+  ...GATEWAY_STARTUP_MUTATED_ENV_KEYS,
+  ...MANUAL_GATEWAY_BACKGROUND_ENV_KEYS,
+] as const;
+
+/** Keeps manual RPC suites on the real core Gateway without unrelated startup work. */
+export function configureManualGatewayBackgroundEnv(tempHome: string): void {
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(tempHome, "no-plugins"));
+}


### PR DESCRIPTION
Closes #120194

AI-assisted: yes

## What Problem This Solves

Fixes an issue where maintainers running the isolated operator-approval Gateway E2E would wait several minutes for a deterministic 120-second startup timeout. The current-main file completes only 1/2 tests and exits red after about 244 seconds.

## Why This Change Was Made

Manual real-Gateway approval suites now share one test-owned startup scope that keeps unrelated browser, provider, channel, cron, Gmail, Canvas, and bundled-plugin background work disabled. The same helper owns the complete environment snapshot key list, so both the operator-approval and plugin-approval sibling suites restore exactly what they configure.

The real core Gateway and approval RPC paths remain active. No timeout, assertion, production runtime, protocol, auth, config, dependency, migration, or persistent-state behavior changes.

## User Impact

There is no end-user behavior change. Maintainers and CI get fast, deterministic approval RPC coverage instead of a multi-minute timeout.

## Evidence

Before on current `main` `5a913fa453c2078a586b23f7d3fa6577f9d8a741`:

- `node scripts/run-vitest.mjs src/gateway/operator-approvals-client.e2e.test.ts`
- 1/2 tests; `uses runtime authority only for generated local gateway URLs` timed out at 120 seconds.
- File duration: 243.93 seconds; nonzero exit.

After on exact head `98dab4b4c982ab`:

- Operator plus plugin approval suites: 4/4 in 13.71 seconds.
- Fresh-process stress: 10/10 runs, 40/40 tests, roughly 5.5–5.9 seconds per run after warm transform caches.
- Whole-branch AutoReview at P2 depth: clean at 0.93; TruffleHog clean.
- Node 24 `check:changed`: green on Blacksmith Testbox `tbx_01kzdnfknxf07d9pqfnzmgfs0n`, run https://github.com/openclaw/openclaw/actions/runs/31161936140. The preceding attempt never reached the command because Testbox sync timed out; the wrapper stopped that lease and the supported retry synchronized successfully.
- Exact-head hosted CI: green, https://github.com/openclaw/openclaw/actions/runs/31162974019.
- Exact-head ClawSweeper: patch correct at 0.90, patch tier A, no findings, security cleared; its wait-for-CI rank-up move is satisfied, https://github.com/openclaw/clawsweeper/actions/runs/31163082502.

## Test Plan

- [x] exact-current-main timeout reproduction
- [x] paired operator/plugin approval suites
- [x] 10 fresh-process stress runs
- [x] whole-branch AutoReview
- [x] exact Node 24 changed gate on Blacksmith Testbox
- [x] exact-head hosted PR CI
- [x] exact-head ClawSweeper review
