### PR TITLE
fix: strip slack text emoji tool warnings

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -918,6 +918,7 @@ describe("sanitizeAssistantVisibleText", () => {
       "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open (agent) failed: command timed out",
       "⚠️ 🛠️ Exec failed: `python3 /path/to/daily-cost-audit.py` (exit 1)",
       "⚠️ 🛠️ Bash failed: `git status` (workspace) (exit 1)",
+      ':warning: :hammer_and_wrench: Bash failed: `search "1786020243|1786037375|1786090730" in !node_modules` (agent)',
       "⚠️ 🛠️ Exec failed (exit 1)",
       "⚠️ 🛠️ Bash failed",
       "🛠️ run git status",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -15,13 +15,13 @@ const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
 const LEGACY_BRACKET_TOOL_BLOCK_QUICK_RE = /\[\s*\/?\s*TOOL_(?:CALL|RESULT)\s*\]/i;
 const INTERNAL_TRACE_LINE_QUICK_RE =
-  /(?:📊|🛠️|📖|📝|🔍|🔎|⚙️|tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call)/i;
+  /(?:📊|🛠️|📖|📝|🔍|🔎|⚙️|:hammer_and_wrench:|tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call)/i;
 const INTERNAL_TRACE_LINE_RE =
   /^(?:>\s*)?(?:⚠️\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
 // The current producer reserves "⚠️ 🛠️ Exec|Bash failed[:...]" for exec warnings, so
 // echoed copies must be removed. The second branch preserves the historical "(agent) failed" shape.
 const INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE =
-  /^(?:>\s*)?⚠️\s*🛠️\s+(?:(?:Exec|Bash)\s+failed(?:(?:\s+\(exit\s+-?\d+\))|(?:\s*:[^\r\n]*))?|\S[^\r\n]*\s+\(agent\)`{0,2}\s+failed(?:\s*:[^\r\n]*)?)\s*$/i;
+  /^(?:>\s*)?(?:⚠️|:warning:)\s*(?:🛠️|:hammer_and_wrench:)\s+(?:(?:Exec|Bash)\s+failed(?:(?:\s+\(exit\s+-?\d+\))|(?:\s*:[^\r\n]*))?|\S[^\r\n]*\s+\(agent\)`{0,2}\s+failed(?:\s*:[^\r\n]*)?)\s*$/i;
 const INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
   /^(?:>\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
 const INTERNAL_CHANNEL_TRACE_LINE_RE =


### PR DESCRIPTION
## What Problem This Solves

Slack text-emoji formatted internal tool failure traces can leak into assistant-visible delivery text, as seen in Nora's leaked warning/tool trace line. This strips those internal traces before assistant-visible text is built.

## Summary

- Strip Slack text-emoji formatted internal tool failure traces from assistant-visible delivery text.
- Add Nora timestamp-search regression coverage for the leaked warning/tool trace line.

## Evidence

- Local focused test after rebasing onto current upstream: `pnpm exec vitest run src/shared/text/assistant-visible-text.test.ts`
- Result: 1 test file passed, 122 tests passed.
- PR head: `c86b909d8a0cea7b3a28be3c38d9af661780310d`