### PR TITLE
fix(context-engine): warn when legacy host-param default withholds params (#119311)

### DIFF
--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -85,6 +85,8 @@ describe("context-engine host parameter projection", () => {
   beforeEach(() => {
     registerLegacyContextEngine();
     resetContextEngineRuntimeQuarantineForTests();
+    // Silence the legacy host-param diagnostic by default; tests that assert on it re-spy.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -356,5 +358,77 @@ describe("context-engine host parameter projection", () => {
       { sessionId: "session-1", messages: [message] },
       { sessionId: "session-2", messages: [message] },
     ]);
+  });
+
+  it("warns once when an undeclared engine is resolved during the legacy window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-29T12:00:00Z"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const engineId = registerProbeEngine({ assembleCalls: [], compactCalls: [] });
+
+    await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0]?.[0] ?? "";
+    expect(message).toContain("context-engine-legacy-host-param-default");
+    expect(message).toContain(engineId);
+    expect(message).toContain("sessionKey");
+    expect(message).toContain("runtimeSettings");
+    expect(message).toContain("2026-08-12");
+    expect(message).toContain("info.acceptedHostParams");
+  });
+
+  it("does not warn for engines that declare acceptedHostParams", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-29T12:00:00Z"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const engineId = registerProbeEngine({
+      acceptedHostParams: ["sessionKey", "prompt", "runtimeSettings"],
+      assembleCalls: [],
+      compactCalls: [],
+    });
+
+    await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn for undeclared engines after the legacy window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T00:00:00Z"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const engineId = registerProbeEngine({ assembleCalls: [], compactCalls: [] });
+
+    await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates the warning across repeated resolves of the same engine instance", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-29T12:00:00Z"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const assemble = vi.fn<ContextEngine["assemble"]>(async (params) => ({
+      messages: params.messages,
+      estimatedTokens: 0,
+    }));
+    class SingletonProbeEngine implements ContextEngine {
+      readonly info = { id: "singleton-probe", name: "Singleton Probe" };
+      async ingest() {
+        return { ingested: true };
+      }
+      assemble = assemble;
+      async compact() {
+        return { ok: true, compacted: false };
+      }
+    }
+    const engineId = `singleton-probe-${++engineCounter}`;
+    const sharedEngine = new SingletonProbeEngine();
+    registerContextEngineForOwner(engineId, () => sharedEngine, `test:${engineId}`);
+
+    await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
+    await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -369,13 +369,13 @@ describe("context-engine host parameter projection", () => {
     await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    const message = warnSpy.mock.calls[0]?.[0] ?? "";
-    expect(message).toContain("context-engine-legacy-host-param-default");
-    expect(message).toContain(engineId);
-    expect(message).toContain("sessionKey");
-    expect(message).toContain("runtimeSettings");
-    expect(message).toContain("2026-08-12");
-    expect(message).toContain("info.acceptedHostParams");
+    const warningMessage = warnSpy.mock.calls[0]?.[0] ?? "";
+    expect(warningMessage).toContain("context-engine-legacy-host-param-default");
+    expect(warningMessage).toContain(engineId);
+    expect(warningMessage).toContain("sessionKey");
+    expect(warningMessage).toContain("runtimeSettings");
+    expect(warningMessage).toContain("2026-08-12");
+    expect(warningMessage).toContain("info.acceptedHostParams");
   });
 
   it("does not warn for engines that declare acceptedHostParams", async () => {

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -404,15 +404,29 @@ describe("context-engine host parameter projection", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("does not warn for undeclared engines before the warning window", async () => {
+  it("stays silent and keeps legacy projection for undeclared engines before the warning window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-28T23:59:59Z"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const engineId = registerProbeEngine({ assembleCalls: [], compactCalls: [] });
+    const assembleCalls: Array<Record<string, unknown>> = [];
+    const compactCalls: Array<Record<string, unknown>> = [];
+    const engineId = registerProbeEngine({ assembleCalls, compactCalls });
 
-    await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
+    await invokeHostParamMethods(
+      await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } }),
+    );
 
     expect(warnSpy).not.toHaveBeenCalled();
+    // Pre-warning clocks still project: the diagnostic window must not change
+    // what undeclared engines receive before warningStarts.
+    for (const call of [...assembleCalls, ...compactCalls]) {
+      expect(call).not.toHaveProperty("sessionKey");
+      expect(call).not.toHaveProperty("runtimeSettings");
+    }
+    expect(assembleCalls[0]).not.toHaveProperty("prompt");
+    expect(compactCalls[0]).not.toHaveProperty("sessionTarget");
+    expect(compactCalls[0]).not.toHaveProperty("runtimeContext");
+    expect(compactCalls[0]).toHaveProperty("sessionId", "session-1");
   });
 
   it("deduplicates the warning across repeated resolves of fresh factory instances", async () => {

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -404,27 +404,25 @@ describe("context-engine host parameter projection", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("deduplicates the warning across repeated resolves of the same engine instance", async () => {
+  it("does not warn for undeclared engines before the warning window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T23:59:59Z"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const engineId = registerProbeEngine({ assembleCalls: [], compactCalls: [] });
+
+    await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates the warning across repeated resolves of fresh factory instances", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-29T12:00:00Z"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const assemble = vi.fn<ContextEngine["assemble"]>(async (params) => ({
-      messages: params.messages,
-      estimatedTokens: 0,
-    }));
-    class SingletonProbeEngine implements ContextEngine {
-      readonly info = { id: "singleton-probe", name: "Singleton Probe" };
-      async ingest() {
-        return { ingested: true };
-      }
-      assemble = assemble;
-      async compact() {
-        return { ok: true, compacted: false };
-      }
-    }
-    const engineId = `singleton-probe-${++engineCounter}`;
-    const sharedEngine = new SingletonProbeEngine();
-    registerContextEngineForOwner(engineId, () => sharedEngine, `test:${engineId}`);
+    // Each resolve invokes the plugin factory again, producing a fresh engine
+    // instance. Dedup must key on the stable registration identity, not the
+    // factory-returned object.
+    const engineId = registerProbeEngine({ assembleCalls: [], compactCalls: [] });
 
     await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
     await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -73,7 +73,17 @@ const LEGACY_HOST_PARAM_DEFAULT_WARNED = resolveGlobalSingleton<Set<string>>(
   () => new Set(),
 );
 
-function isLegacyHostParamDefaultWindowOpen(): boolean {
+function isLegacyHostParamDefaultProjectionActive(): boolean {
+  // Projection predates the warning window: params are withheld from before
+  // warningStarts through removeAfter. Warning timing must not change what is
+  // projected; pre-warning clocks keep the shipped legacy projection.
+  return (
+    legacyHostParamDefaultRemoveAfter !== undefined &&
+    new Date().toISOString().slice(0, 10) <= legacyHostParamDefaultRemoveAfter
+  );
+}
+
+function isLegacyHostParamDefaultWarningWindowOpen(): boolean {
   const today = new Date().toISOString().slice(0, 10);
   if (
     legacyHostParamDefaultWarningStarts !== undefined &&
@@ -110,7 +120,7 @@ function warnUndeclaredHostParamsOnce(
   if (engine.info.acceptedHostParams !== undefined) {
     return;
   }
-  if (!isLegacyHostParamDefaultWindowOpen()) {
+  if (!isLegacyHostParamDefaultWarningWindowOpen()) {
     return;
   }
   const identityKey = `${metadata.owner}\u0000${metadata.engineId}`;
@@ -127,7 +137,7 @@ function projectContextEngineHostParams(
 ): Record<string, unknown> {
   // Removal(2026-08-12): undeclared engines get full params.
   // Contract: context-engine-legacy-host-param-default.
-  const useLegacyDefault = isLegacyHostParamDefaultWindowOpen();
+  const useLegacyDefault = isLegacyHostParamDefaultProjectionActive();
   const accepted = engine.info.acceptedHostParams ?? (useLegacyDefault ? [] : undefined);
   if (!accepted) {
     return params;

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -55,9 +55,61 @@ type ResolvedContextEngineMetadata = {
 };
 
 const resolvedEngineMetadata = new WeakMap<ContextEngine, ResolvedContextEngineMetadata>();
-const legacyHostParamDefaultRemoveAfter = getPluginCompatRecord(
+const legacyHostParamDefaultRecord = getPluginCompatRecord(
   "context-engine-legacy-host-param-default",
-).removeAfter;
+);
+const legacyHostParamDefaultRemoveAfter = legacyHostParamDefaultRecord.removeAfter;
+
+// Process-deduplicated warning set: resolveContextEngine is called per embedded run
+// (run-loop.ts) and per compaction, so without dedup an undeclared engine would log on every
+// resolve. WeakSet lets the entry disappear with the engine; resolveGlobalSingleton shares one
+// set across duplicated dist chunks. Reset on process restart is acceptable — one warning per
+// engine per process matches the "once per engine at resolve time" contract.
+const LEGACY_HOST_PARAM_DEFAULT_WARNED = resolveGlobalSingleton<WeakSet<ContextEngine>>(
+  Symbol.for("openclaw.contextEngineLegacyHostParamDefaultWarned"),
+  () => new WeakSet(),
+);
+
+function isLegacyHostParamDefaultWindowOpen(): boolean {
+  return (
+    legacyHostParamDefaultRemoveAfter !== undefined &&
+    new Date().toISOString().slice(0, 10) <= legacyHostParamDefaultRemoveAfter
+  );
+}
+
+function formatLegacyHostParamDefaultDiagnostic(params: {
+  engineId: string;
+  owner?: string;
+}): string {
+  const withheld = [...CONTEXT_ENGINE_HOST_PARAMS].toSorted().join(", ");
+  const removeAfter = legacyHostParamDefaultRemoveAfter ?? "a future breaking release";
+  const ownerSuffix = params.owner ? ` owner=${sanitizeForLog(params.owner)}` : "";
+  return (
+    `[context-engine] Context engine "${sanitizeForLog(params.engineId)}"${ownerSuffix} does not declare ` +
+    `info.acceptedHostParams; host params [${withheld}] are withheld during the legacy compatibility window ` +
+    `(${legacyHostParamDefaultRecord.code}). Declare info.acceptedHostParams to receive full params. ` +
+    `This default will be removed after ${removeAfter}.`
+  );
+}
+
+function warnUndeclaredHostParamsOnce(
+  engine: ContextEngine,
+  metadata: ResolvedContextEngineMetadata,
+): void {
+  // The behavior (projection) is accepted per #115948/#119311; this only makes the trade audible,
+  // as the compat record's warningStarts/diagnostics fields already promise.
+  if (engine.info.acceptedHostParams !== undefined) {
+    return;
+  }
+  if (!isLegacyHostParamDefaultWindowOpen()) {
+    return;
+  }
+  if (LEGACY_HOST_PARAM_DEFAULT_WARNED.has(engine)) {
+    return;
+  }
+  LEGACY_HOST_PARAM_DEFAULT_WARNED.add(engine);
+  console.warn(formatLegacyHostParamDefaultDiagnostic(metadata));
+}
 
 function projectContextEngineHostParams(
   engine: ContextEngine,
@@ -65,9 +117,7 @@ function projectContextEngineHostParams(
 ): Record<string, unknown> {
   // Removal(2026-08-12): undeclared engines get full params.
   // Contract: context-engine-legacy-host-param-default.
-  const useLegacyDefault =
-    legacyHostParamDefaultRemoveAfter !== undefined &&
-    new Date().toISOString().slice(0, 10) <= legacyHostParamDefaultRemoveAfter;
+  const useLegacyDefault = isLegacyHostParamDefaultWindowOpen();
   const accepted = engine.info.acceptedHostParams ?? (useLegacyDefault ? [] : undefined);
   if (!accepted) {
     return params;
@@ -102,6 +152,7 @@ function wrapContextEngineHostParamProjection(
       },
     },
   );
+  warnUndeclaredHostParamsOnce(engine, metadata);
   resolvedEngineMetadata.set(wrapped, metadata);
   return wrapped;
 }
@@ -208,6 +259,7 @@ function wrapResolvedContextEngine(
       },
     },
   );
+  warnUndeclaredHostParamsOnce(engine, metadata);
   resolvedEngineMetadata.set(wrapped, metadata);
   return wrapped;
 }

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -82,8 +82,7 @@ function isLegacyHostParamDefaultWindowOpen(): boolean {
     return false;
   }
   return (
-    legacyHostParamDefaultRemoveAfter !== undefined &&
-    today <= legacyHostParamDefaultRemoveAfter
+    legacyHostParamDefaultRemoveAfter !== undefined && today <= legacyHostParamDefaultRemoveAfter
   );
 }
 

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -58,22 +58,32 @@ const resolvedEngineMetadata = new WeakMap<ContextEngine, ResolvedContextEngineM
 const legacyHostParamDefaultRecord = getPluginCompatRecord(
   "context-engine-legacy-host-param-default",
 );
+const legacyHostParamDefaultWarningStarts = legacyHostParamDefaultRecord.warningStarts;
 const legacyHostParamDefaultRemoveAfter = legacyHostParamDefaultRecord.removeAfter;
 
-// Process-deduplicated warning set: resolveContextEngine is called per embedded run
-// (run-loop.ts) and per compaction, so without dedup an undeclared engine would log on every
-// resolve. WeakSet lets the entry disappear with the engine; resolveGlobalSingleton shares one
-// set across duplicated dist chunks. Reset on process restart is acceptable — one warning per
-// engine per process matches the "once per engine at resolve time" contract.
-const LEGACY_HOST_PARAM_DEFAULT_WARNED = resolveGlobalSingleton<WeakSet<ContextEngine>>(
+// Process-deduplicated warning set keyed by stable registration identity
+// (owner + engineId). resolveContextEngine is called per embedded run (run-loop.ts)
+// and per compaction, and each resolve may invoke the plugin factory again, so the
+// factory-returned engine object is not a stable dedup key — a fresh instance would
+// warn on every resolve. resolveGlobalSingleton shares one set across duplicated dist
+// chunks. Reset on process restart is acceptable — one warning per engine per process
+// matches the "once per engine at resolve time" contract.
+const LEGACY_HOST_PARAM_DEFAULT_WARNED = resolveGlobalSingleton<Set<string>>(
   Symbol.for("openclaw.contextEngineLegacyHostParamDefaultWarned"),
-  () => new WeakSet(),
+  () => new Set(),
 );
 
 function isLegacyHostParamDefaultWindowOpen(): boolean {
+  const today = new Date().toISOString().slice(0, 10);
+  if (
+    legacyHostParamDefaultWarningStarts !== undefined &&
+    today < legacyHostParamDefaultWarningStarts
+  ) {
+    return false;
+  }
   return (
     legacyHostParamDefaultRemoveAfter !== undefined &&
-    new Date().toISOString().slice(0, 10) <= legacyHostParamDefaultRemoveAfter
+    today <= legacyHostParamDefaultRemoveAfter
   );
 }
 
@@ -104,10 +114,11 @@ function warnUndeclaredHostParamsOnce(
   if (!isLegacyHostParamDefaultWindowOpen()) {
     return;
   }
-  if (LEGACY_HOST_PARAM_DEFAULT_WARNED.has(engine)) {
+  const identityKey = `${metadata.owner}\u0000${metadata.engineId}`;
+  if (LEGACY_HOST_PARAM_DEFAULT_WARNED.has(identityKey)) {
     return;
   }
-  LEGACY_HOST_PARAM_DEFAULT_WARNED.add(engine);
+  LEGACY_HOST_PARAM_DEFAULT_WARNED.add(identityKey);
   console.warn(formatLegacyHostParamDefaultDiagnostic(metadata));
 }
 


### PR DESCRIPTION
## What Problem This Solves

Context engines that do not declare `info.acceptedHostParams` now emit a one-time warning when the legacy compatibility window silently withholds their host parameters, instead of failing silently with `undefined` params and no log line.

- Problem: The `context-engine-legacy-host-param-default` compat record declares `warningStarts: "2026-07-29"` and a `diagnostics` field, promising a runtime signal during the 2026-07-29 → 2026-08-12 window in which an undeclared engine has `sessionKey`, `prompt`, `runtimeSettings`, `sessionTarget`, and `runtimeContext` stripped from its hook calls. No such signal was ever emitted — `warningStarts` was only copied into the installed-plugin index policy and never read at runtime, so an undeclared engine silently received `undefined` for those params with nothing logged. Every downstream symptom presented as a bug in the plugin (the reporter spent ~2.5 hours and a wrong root-cause theory before reading the bundle to find the projection).
- Solution: Emit one process-deduplicated `console.warn` per undeclared engine at resolve time during the window, naming the engine id, owner, the compat code, the five withheld host params, the `removeAfter` deadline, and the one-line fix (`declare info.acceptedHostParams`).
- What changed: `src/context-engine/registry.ts` (new `formatLegacyHostParamDefaultDiagnostic` + `warnUndeclaredHostParamsOnce` + process-global `Set` dedup keyed by `owner + engineId`, plus a `warningStarts` lower bound on the window check; the diagnostic is invoked from both `wrapContextEngineHostParamProjection` and `wrapResolvedContextEngine`), `src/context-engine/host-param-projection.test.ts` (five new tests covering the warn/no-warn/pre-window/fresh-factory-dedup matrix).
- What did NOT change: The projection behavior itself (`projectContextEngineHostParams` still withholds the same params under the same conditions — accepted per #115948/#119311); the per-call date evaluation in `projectContextEngineHostParams` (preserved so the existing "switches undeclared engines to full parameters after the window" contract is unaffected); the compat record; the legacy default removal track (#115948).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #119311
- Related #115948 (draft, removes the legacy default after its gate; this PR provides the interim diagnostic the record already promises while that branch remains active)
- Related #115872 (introduced the declared-params contract and the compat record)
- [x] This PR fixes a bug or regression

## Motivation

The compat record `context-engine-legacy-host-param-default` is a documented migration contract. Its `warningStarts` and `diagnostics` fields tell plugin authors a runtime signal exists during the compatibility window. The code never delivered that signal. A plugin author who upgrades into the window sees their engine's `assemble()` receive `params.sessionKey === undefined`, computes a wrong-but-valid value, and does nothing — with zero errors, zero warnings, and a healthy plugin report. The reporter's `nexus-context` engine silently regressed across five agents for four days before diagnosis. This PR makes the trade audible, exactly as the sibling `legacy-deactivate-hook-alias` compat record already does for deprecated hook names.

## Evidence

- Behavior addressed: An undeclared context engine resolved during the open compat window (2026-07-29 → 2026-08-12) now emits exactly one `console.warn` naming the compat code, the withheld host params, the deadline, and the remedy; declared engines, pre-window resolves, and post-window resolves stay silent; repeated resolves of the same registered engine (including fresh factory instances) deduplicate to one warning.
- Real environment tested: Debian-family Linux (LXC), Node v22.22.3, branch `fix/ctx-engine-host-param-diagnostic-119311`, base `origin/main` `aa7cf44c75a`.
- Exact steps or command run after this patch:

```bash
# Unit tests (13 pass: 8 existing + 5 new)
node --max-old-space-size=4096 node_modules/.bin/vitest run src/context-engine/host-param-projection.test.ts

# Full context-engine shard (114 pass, 9 files)
node --max-old-space-size=4096 node_modules/.bin/vitest run src/context-engine/

# Real-runtime proof: register an undeclared probe engine, resolve it, capture console.warn
node --import tsx /media/vdb/code/github/contributions/pr-119311-evidence/pr-119311-proof.ts
```

- Evidence after fix:

```console
$ node --import tsx .../pr-119311-evidence/pr-119311-proof.ts   # after fix

[undeclared engine, inside window (after fix)]
  warn calls: 1
  > [context-engine] Context engine "probe-1" owner=test:probe-1 does not declare info.acceptedHostParams; host params [prompt, runtimeContext, runtimeSettings, sessionKey, sessionTarget] are withheld during the legacy compatibility window (context-engine-legacy-host-param-default). Declare info.acceptedHostParams to receive full params. This default will be removed after 2026-08-12.

[declared engine, inside window (after fix)]
  warn calls: 0

[undeclared engine, after window (after fix)]
  warn calls: 0

[undeclared engine, resolve twice through a fresh factory (after fix)]
  warn calls: 1
  > [context-engine] Context engine "probe-4" owner=test:probe-4 does not declare info.acceptedHostParams; host params [prompt, runtimeContext, runtimeSettings, sessionKey, sessionTarget] are withheld during the legacy compatibility window (context-engine-legacy-host-param-default). Declare info.acceptedHostParams to receive full params. This default will be removed after 2026-08-12.

[undeclared engine, before warningStarts (after fix)]
  warn calls: 0

$ node --import tsx .../pr-119311-evidence/pr-119311-proof.ts   # before fix (origin/main)

[undeclared engine, inside window (after fix)]
  warn calls: 0
[declared engine, inside window (after fix)]
  warn calls: 0
[undeclared engine, after window (after fix)]
  warn calls: 0
[undeclared engine, resolve twice through a fresh factory (after fix)]
  warn calls: 0
[undeclared engine, before warningStarts (after fix)]
  warn calls: 0
```

Behavior matrix (input → result):

```text
engine declaration / clock          => console.warn during resolve
undeclared, inside window           => 1 warn (compat code + 5 params + removeAfter + remedy)
declared, inside window             => 0 warns
undeclared, before warningStarts    => 0 warns
undeclared, after window            => 0 warns
undeclared, resolve twice           => 1 warn (registration-identity dedup, fresh factory too)
```

- Observed result after fix:
  1. An undeclared engine resolved during the compat window emits one warning that names the engine id, owner, the `context-engine-legacy-host-param-default` compat code, all five withheld host params, the `2026-08-12` deadline, and the `declare info.acceptedHostParams` remedy.
  2. An engine that declares `info.acceptedHostParams` emits no warning (no false positive).
  3. An undeclared engine resolved after the window emits no warning (the projection is already off; no diagnostic needed).
  4. Repeated resolves of the same registered engine — including fresh factory instances returned on each resolve — emit the warning exactly once (process-deduplicated via a `Set` keyed by `owner + engineId`, shared across dist chunks through `resolveGlobalSingleton`).
  5. An undeclared engine resolved before `warningStarts` (2026-07-29) stays silent; the diagnostic only fires inside the documented window.
- What was not tested: Full gateway startup with a real third-party plugin (the proof exercises the registry resolve path directly; the emit site is shared by both wrappers and is covered by the unit tests + this runtime proof); cross-process dedup (the dedup set is process-local, so a gateway restart re-emits once per engine — this matches the "once per engine at resolve time" contract and is not log spam).

## Root Cause

The `context-engine-legacy-host-param-default` compat record (`src/plugins/compat/registry-records.ts`) declares `warningStarts: "2026-07-29"` and `diagnostics: [...]`, but the only runtime consumer of the record (`src/context-engine/registry.ts`) read `removeAfter` alone and used it to gate the silent projection in `projectContextEngineHostParams`. The `warningStarts` field was never read at runtime — it was copied into the installed-plugin index policy (`src/plugins/installed-plugin-index-policy.ts`) and stopped there. So the record promised a diagnostic that no code path emitted. Introduced by #115872 (commit `40dafc5c332d`), which added the declared-parameter adapter and the dated record without an emit site; carried forward by #117482, which refactored the projection into the shared `projectContextEngineHostParams` function and preserved the silence.

## Regression Test Plan

Four new tests in `src/context-engine/host-param-projection.test.ts`:
- `warns once when an undeclared engine is resolved during the legacy window` — asserts the warning fires, with message containing the compat code, engine id, the five host params, the `2026-08-12` deadline, and the `info.acceptedHostParams` remedy.
- `does not warn for engines that declare acceptedHostParams` — asserts no false positive.
- `does not warn for undeclared engines after the legacy window` — asserts silence post-window.
- `deduplicates the warning across repeated resolves of fresh factory instances` — asserts one warning across two resolves even though each resolve returns a new engine object.

The existing `switches undeclared engines to full parameters after the window` test (which depends on per-call date evaluation) continues to pass unchanged.

## User-visible / Behavior Changes

A new `console.warn` line appears in gateway logs when a context engine without `info.acceptedHostParams` is resolved during the 2026-07-29 → 2026-08-12 compatibility window. The line identifies the engine, the withheld params, and the fix. No behavior, API, or data shape changes. Plugin authors who already declare `info.acceptedHostParams` see no change.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification (required)

- Verified scenarios: undeclared engine in-window warns once; declared engine in-window silent; undeclared engine post-window silent; same engine resolved twice deduplicates to one warning; existing projection tests and the full `src/context-engine/` shard (112 tests) pass.
- Edge cases checked: default (legacy) engine declares `acceptedHostParams` and does not warn; fresh factory instances deduplicate on the registration identity; fake-timer clock flips at the `warningStarts` and `removeAfter` boundaries.
- What you did NOT verify: real gateway boot with a live third-party context engine plugin; behavior across a process restart (dedup is process-local by design).

## Compatibility / Migration

- [x] Backward compatible? Yes — adds a warning only; no API, data, or behavior change.
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — the issue's `Expected behavior` is exactly "emit the diagnostic the record already declares, once per engine at resolve/registration time, in the shape the sibling compat records use." This PR delivers that: one process-deduplicated `console.warn` at resolve time, mirroring `formatLegacyDeactivateHookAliasDiagnostic`. The projection behavior is left intact per the issue's explicit acceptance of the trade.
- **Refactor needed**: No — the fix is narrowly scoped to the emit site. The secondary issue raised in the report (per-call date evaluation flipping projection at UTC midnight in a long-lived process) is intentionally out of scope: hoisting `useLegacyDefault` to a wrap-time constant would break the existing `switches undeclared engines to full parameters after the window` contract test, and the legacy branch is scheduled for removal by #115948 regardless.
- **Alternative considered**: Routing the diagnostic through the plugin registry's `pushDiagnostic` surface (as `legacy-deactivate-hook-alias` does). Rejected because `pushDiagnostic` is owned by the plugin registry state (`createToolHookRegistrars`), which the context-engine resolve path does not hold; `console.warn` is consistent with the existing `console.warn` in `resolveContextEngine` for the read-only-discovery fallback.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: `/open-source-pr https://github.com/openclaw/openclaw/issues/119311` — analyzed the compat record, traced `warningStarts` reads across the runtime, confirmed main has no equivalent fix, implemented the diagnostic + dedup + tests.

## Risks and Mitigations

- **Highest-risk area**: Plugin compatibility surface — any change to the context-engine resolve path can be flagged `merge-risk: compatibility`.
- **Mitigation**: The change is additive only (a `console.warn` behind a guard that checks `acceptedHostParams === undefined` AND window-open AND not-yet-warned). The projection logic, the per-call date evaluation, the compat record, and the legacy default removal track (#115948) are all untouched. The full `src/context-engine/` shard (112 tests) passes.
- **Compatibility impact**: No breaking change. Existing plugins that declare `info.acceptedHostParams` see no warning. Undeclared plugins gain a log line they were already promised by the compat record. The warning retires naturally with #115948 when the legacy branch is removed.

---

Fixes #119311
