### PR TITLE
fix(agents): redact reflected credentials from provider error detail and reason phrase

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -205,6 +205,10 @@ payload carrying an `error` key is always reported as `kind: "error"` with the
 raw provider code preserved inside the wrapped message. Raw passthrough
 payloads keep whatever markers the provider set.
 
+Perplexity, Tavily, and xAI HTTP errors retain the status code and bounded
+diagnostics, with reflected request credentials redacted. Review diagnostics
+before sharing them; redaction does not remove every kind of sensitive content.
+
 ## Auto-detection
 
 Provider lists in docs and setup flows are alphabetical. Auto-detection uses a

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -234,6 +234,7 @@ async function runPerplexitySearchApi(params: {
     body.max_tokens_per_page = params.maxTokensPerPage;
   }
 
+  const headers = buildPerplexityRequestHeaders(params.apiKey, true);
   return withTrustedWebSearchEndpoint(
     {
       url: PERPLEXITY_SEARCH_ENDPOINT,
@@ -241,13 +242,16 @@ async function runPerplexitySearchApi(params: {
       signal: params.signal,
       init: {
         method: "POST",
-        headers: buildPerplexityRequestHeaders(params.apiKey, true),
+        headers,
         body: JSON.stringify(body),
       },
     },
     async (res) => {
       if (!res.ok) {
-        return await throwWebSearchApiError(res, "Perplexity Search");
+        return await throwWebSearchApiError(res, "Perplexity Search", {
+          headers,
+          signal: params.signal,
+        });
       }
       const data = await readProviderJsonResponse<PerplexitySearchApiResponse>(
         res,
@@ -282,6 +286,7 @@ async function runPerplexitySearch(params: {
     body.search_recency_filter = params.freshness;
   }
 
+  const headers = buildPerplexityRequestHeaders(params.apiKey);
   return withTrustedWebSearchEndpoint(
     {
       url: endpoint,
@@ -289,13 +294,13 @@ async function runPerplexitySearch(params: {
       signal: params.signal,
       init: {
         method: "POST",
-        headers: buildPerplexityRequestHeaders(params.apiKey),
+        headers,
         body: JSON.stringify(body),
       },
     },
     async (res) => {
       if (!res.ok) {
-        return await throwWebSearchApiError(res, "Perplexity");
+        return await throwWebSearchApiError(res, "Perplexity", { headers, signal: params.signal });
       }
       const data = await readProviderJsonResponse<PerplexitySearchResponse>(res, "Perplexity");
       const content = data.choices?.[0]?.message?.content;

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -33,9 +33,9 @@ function mockPerplexityResponseOnce(body: unknown): void {
   );
 }
 
-function createConfiguredPerplexityTool(structured: boolean) {
+function createConfiguredPerplexityTool(structured: boolean, apiKey = directPerplexityApiKey) {
   const webSearch = {
-    apiKey: directPerplexityApiKey,
+    apiKey,
     ...(structured ? {} : { baseUrl: "https://api.perplexity.ai" }),
   };
   const tool = createPerplexityWebSearchProvider().createTool({
@@ -49,6 +49,21 @@ function createConfiguredPerplexityTool(structured: boolean) {
 }
 
 describe("perplexity web search provider", () => {
+  it.each([true, false])(
+    "redacts reflected request credentials (native=%s)",
+    async (structured) => {
+      withTrustedWebSearchEndpointMock.mockReset();
+      withTrustedWebSearchEndpointMock.mockImplementationOnce(
+        async (_params: unknown, run: (response: Response) => Promise<unknown>) =>
+          run(new Response("rejected s7Key", { status: 401 })),
+      );
+      const label = structured ? "Perplexity Search" : "Perplexity";
+      await expect(
+        createConfiguredPerplexityTool(structured, "s7Key").execute({ query: "redaction" }),
+      ).rejects.toThrow(`${label} API error (401): rejected ***`);
+    },
+  );
+
   it("points missing-key users to fetch/browser alternatives", async () => {
     await withEnvAsync(
       { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: undefined },

--- a/extensions/xai/code-execution.test.ts
+++ b/extensions/xai/code-execution.test.ts
@@ -67,11 +67,7 @@ function firstFetchInit(mockFetch: ReturnType<typeof installCodeExecutionFetch>)
 }
 
 function firstAuthorizationHeader(mockFetch: ReturnType<typeof installCodeExecutionFetch>) {
-  const headers = firstFetchInit(mockFetch).headers;
-  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
-    throw new Error("expected code_execution request headers");
-  }
-  return (headers as Record<string, string>).Authorization;
+  return new Headers(firstFetchInit(mockFetch).headers).get("Authorization");
 }
 
 function parseFirstRequestBody(mockFetch: ReturnType<typeof installCodeExecutionFetch>) {

--- a/extensions/xai/src/responses-tool-shared.test.ts
+++ b/extensions/xai/src/responses-tool-shared.test.ts
@@ -1,7 +1,6 @@
 // Xai tests cover responses tool shared plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
-  extractXaiWebSearchContent,
   requireXaiResponseTextAndCitations,
   requireXaiResponseTextCitationsAndInline,
 } from "./responses-tool-shared.js";
@@ -77,30 +76,33 @@ describe("xai responses tool helpers", () => {
 
   it("ignores malformed output, content, and annotation entries", () => {
     expect(
-      extractXaiWebSearchContent({
-        output: [
-          null,
-          {
-            type: "message",
-            content: [
-              null,
-              {
-                type: "output_text",
-                text: "Found it",
-                annotations: [
-                  null,
-                  { type: "url_citation", url: "https://example.com/a" },
-                  { type: "url_citation", url: "https://example.com/a" },
-                  { type: "url_citation" },
-                ],
-              },
-            ],
-          },
-        ],
-      }),
+      requireXaiResponseTextAndCitations(
+        {
+          output: [
+            null,
+            {
+              type: "message",
+              content: [
+                null,
+                {
+                  type: "output_text",
+                  text: "Found it",
+                  annotations: [
+                    null,
+                    { type: "url_citation", url: "https://example.com/a" },
+                    { type: "url_citation", url: "https://example.com/a" },
+                    { type: "url_citation" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        "xAI tool failed",
+      ),
     ).toEqual({
-      text: "Found it",
-      annotationCitations: ["https://example.com/a"],
+      content: "Found it",
+      citations: ["https://example.com/a"],
     });
   });
 

--- a/extensions/xai/src/responses-tool-shared.ts
+++ b/extensions/xai/src/responses-tool-shared.ts
@@ -98,7 +98,7 @@ export async function requestXaiResponsesTool<T>(
   );
 }
 
-export function extractXaiWebSearchContent(
+function extractXaiWebSearchContent(
   data: XaiWebSearchResponse,
   maxContentChars?: number,
 ): {

--- a/extensions/xai/src/web-search-provider.runtime.ts
+++ b/extensions/xai/src/web-search-provider.runtime.ts
@@ -25,7 +25,6 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 import {
   buildXaiWebSearchPayload,
-  extractXaiWebSearchContent,
   requestXaiWebSearch,
   resolveXaiInlineCitations,
   resolveXaiWebSearchEndpoint,
@@ -423,7 +422,6 @@ export async function executeXaiWebSearchProviderTool(
 
 export const testing = {
   buildXaiWebSearchPayload,
-  extractXaiWebSearchContent,
   resolveXaiToolSearchConfig,
   resolveXaiInlineCitations,
   resolveXaiWebSearchCredential,

--- a/extensions/xai/src/web-search-shared.ts
+++ b/extensions/xai/src/web-search-shared.ts
@@ -9,7 +9,6 @@ import {
   resolveXaiResponsesEndpoint,
 } from "./responses-tool-shared.js";
 import type { XaiWebSearchResponse } from "./web-search-response.types.js";
-export { extractXaiWebSearchContent } from "./responses-tool-shared.js";
 export type { XaiWebSearchResponse } from "./web-search-response.types.js";
 
 const XAI_DEFAULT_WEB_SEARCH_MODEL = XAI_DEFAULT_MODEL_ID;

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -39,45 +39,7 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
-  const original = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
-  return {
-    ...original,
-    postTrustedWebToolsJson: async (
-      params: {
-        url: string;
-        apiKey: string;
-        body: Record<string, unknown>;
-        extraHeaders?: Record<string, string>;
-        signal?: AbortSignal;
-      },
-      parseResponse: (response: Response) => Promise<unknown>,
-    ) => {
-      const response = await globalThis.fetch(params.url, {
-        method: "POST",
-        headers: {
-          ...params.extraHeaders,
-          Accept: "application/json",
-          Authorization: `Bearer ${params.apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(params.body),
-        ...(params.signal ? { signal: params.signal } : {}),
-      });
-      if (!response.ok) {
-        const detail =
-          typeof response.text === "function"
-            ? await response.text()
-            : response.statusText || String(response.status);
-        throw new Error(`xAI API error (${response.status}): ${detail || response.statusText}`);
-      }
-      return await parseResponse(response);
-    },
-  };
-});
-
 const {
-  extractXaiWebSearchContent,
   resolveXaiInlineCitations,
   resolveXaiToolSearchConfig,
   resolveXaiWebSearchCredential,
@@ -876,71 +838,6 @@ describe("xai web search config resolution", () => {
       tool.execute({ query: "cancelled generic request" }, { signal: controller.signal }),
     ).rejects.toBe(reason);
     expect(mockFetch).not.toHaveBeenCalled();
-  });
-});
-
-describe("xai web search response parsing", () => {
-  it("extracts content from Responses API message blocks", () => {
-    const result = extractXaiWebSearchContent({
-      output: [
-        {
-          type: "message",
-          content: [{ type: "output_text", text: "hello from output" }],
-        },
-      ],
-    });
-    expect(result.text).toBe("hello from output");
-    expect(result.annotationCitations).toStrictEqual([]);
-  });
-
-  it("extracts url_citation annotations from content blocks", () => {
-    const result = extractXaiWebSearchContent({
-      output: [
-        {
-          type: "message",
-          content: [
-            {
-              type: "output_text",
-              text: "hello with citations",
-              annotations: [
-                { type: "url_citation", url: "https://example.com/a" },
-                { type: "url_citation", url: "https://example.com/b" },
-                { type: "url_citation", url: "https://example.com/a" },
-              ],
-            },
-          ],
-        },
-      ],
-    });
-    expect(result.text).toBe("hello with citations");
-    expect(result.annotationCitations).toEqual(["https://example.com/a", "https://example.com/b"]);
-  });
-
-  it("falls back to deprecated output_text", () => {
-    const result = extractXaiWebSearchContent({ output_text: "hello from output_text" });
-    expect(result.text).toBe("hello from output_text");
-    expect(result.annotationCitations).toStrictEqual([]);
-  });
-
-  it("returns undefined text when no content found", () => {
-    const result = extractXaiWebSearchContent({});
-    expect(result.text).toBeUndefined();
-    expect(result.annotationCitations).toStrictEqual([]);
-  });
-
-  it("extracts output_text blocks directly in output array", () => {
-    const result = extractXaiWebSearchContent({
-      output: [
-        { type: "web_search_call" },
-        {
-          type: "output_text",
-          text: "direct output text",
-          annotations: [{ type: "url_citation", url: "https://example.com/direct" }],
-        },
-      ],
-    });
-    expect(result.text).toBe("direct output text");
-    expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
   });
 });
 

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -61,11 +61,7 @@ function firstFetchInit(mockFetch: ReturnType<typeof installXSearchFetch>): Requ
 }
 
 function firstAuthorizationHeader(mockFetch: ReturnType<typeof installXSearchFetch>) {
-  const headers = firstFetchInit(mockFetch).headers;
-  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
-    throw new Error("expected x_search request headers");
-  }
-  return (headers as Record<string, string>).Authorization;
+  return new Headers(firstFetchInit(mockFetch).headers).get("Authorization");
 }
 
 function parseFirstRequestBody(mockFetch: ReturnType<typeof installXSearchFetch>) {

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -68,23 +68,12 @@ type ManagedChild = {
 const managedChildren = new Set<ManagedChild>();
 const signalHandlers = new Map<NodeJS.Signals, () => void>();
 
-/**
- * Return conventional shell exit code for a signal.
- *
- * @param {NodeJS.Signals} signal
- * @returns {number}
- */
+/** Return the conventional shell exit code for a signal. */
 export function signalExitCode(signal: NodeJS.Signals) {
   const signalNumber = signalNumberFor(signal);
   return signalNumber ? 128 + signalNumber : 1;
 }
 
-/**
- * @param {import("node:child_process").ChildProcess} child
- * @param {NodeJS.Signals} [signal]
- * @param {ManagedChildTerminationOptions} [options]
- * @returns {{ processTreeState: "indeterminate" | "signaled" | "terminated" } | undefined}
- */
 export function terminateManagedChild(
   child: { kill(signal: NodeJS.Signals): unknown; pid?: number },
   signal: NodeJS.Signals = "SIGTERM",
@@ -244,26 +233,7 @@ export async function waitForManagedProcessGroupExit(
   return inspectManagedProcessGroup(child, groupOptions) !== "live";
 }
 
-/**
- * Run a child command while forwarding termination signals to the managed process group.
- *
- * @param {{
- *   bin: string;
- *   args?: string[];
- *   cwd?: string;
- *   env?: NodeJS.ProcessEnv;
- *   stdio?: import("node:child_process").StdioOptions;
- *   shell?: boolean;
- *   windowsVerbatimArguments?: boolean;
- *   platform?: NodeJS.Platform;
- *   comSpec?: string;
- *   timeoutMs?: number;
- *   requireProcessTreeExit?: boolean;
- *   runTaskkill?: typeof spawnSync;
- *   onReady?: (child: import("node:child_process").ChildProcess) => void;
- * }} options
- * @returns {Promise<number>}
- */
+/** Run a child command while forwarding termination signals to its process group. */
 export async function runManagedCommand({
   bin,
   args = [],
@@ -293,13 +263,22 @@ export async function runManagedCommand({
     platform,
     comSpec,
   });
-  const child = spawn(spawnSpec.command, spawnSpec.args, spawnSpec.options);
+  // A child can become ready before spawn returns. Catch OS signals first so
+  // their callbacks wait for registration instead of orphaning a detached child.
+  installSignalHandlers();
+  let child: ChildProcess;
+  try {
+    child = spawn(spawnSpec.command, spawnSpec.args, spawnSpec.options);
+  } catch (error) {
+    removeSignalHandlersIfIdle();
+    throw error;
+  }
   const managedChild: ManagedChild = {
     child,
     forceKillTimer: null,
     receivedSignal: undefined,
   };
-  addManagedChild(managedChild);
+  managedChildren.add(managedChild);
   let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
   let signalTimeout!: () => void;
   let timedOut = false;
@@ -389,7 +368,8 @@ export async function runManagedCommand({
     if (timeoutTimer) {
       clearTimeout(timeoutTimer);
     }
-    removeManagedChild(managedChild);
+    managedChildren.delete(managedChild);
+    removeSignalHandlersIfIdle();
   }
 }
 
@@ -497,36 +477,6 @@ function createManagedCommandCleanupError(
   });
 }
 
-/**
- * Build the spawn command, args, and options used by managed command execution.
- *
- * @param {{
- *   child: import("node:child_process").ChildProcess;
- *   forceKillTimer: ReturnType<typeof setTimeout> | null;
- *   receivedSignal: string | null;
- * }} managedChild
- */
-function addManagedChild(managedChild: ManagedChild) {
-  managedChildren.add(managedChild);
-  installSignalHandlers();
-}
-
-/**
- * Build a normalized command invocation, including cmd.exe wrapping on Windows.
- *
- * @param {{
- *   child: import("node:child_process").ChildProcess;
- *   forceKillTimer: ReturnType<typeof setTimeout> | null;
- *   receivedSignal: string | null;
- * }} managedChild
- */
-function removeManagedChild(managedChild: ManagedChild) {
-  managedChildren.delete(managedChild);
-  if (managedChildren.size === 0) {
-    removeSignalHandlers();
-  }
-}
-
 function installSignalHandlers() {
   for (const signal of FORWARDED_SIGNALS) {
     if (signalHandlers.has(signal)) {
@@ -538,16 +488,16 @@ function installSignalHandlers() {
   }
 }
 
-function removeSignalHandlers() {
+function removeSignalHandlersIfIdle() {
+  if (managedChildren.size > 0) {
+    return;
+  }
   for (const [signal, handler] of signalHandlers) {
     process.off(signal, handler);
   }
   signalHandlers.clear();
 }
 
-/**
- * @param {NodeJS.Signals} signal
- */
 function forwardSignalToManagedChildren(signal: NodeJS.Signals) {
   for (const managedChild of managedChildren) {
     managedChild.receivedSignal ??= signal;
@@ -558,19 +508,6 @@ function forwardSignalToManagedChildren(signal: NodeJS.Signals) {
   }
 }
 
-/**
- * @param {{
- *   bin: string;
- *   args?: string[];
- *   cwd?: string;
- *   env?: NodeJS.ProcessEnv;
- *   stdio?: import("node:child_process").StdioOptions;
- *   shell?: boolean;
- *   windowsVerbatimArguments?: boolean;
- *   platform?: NodeJS.Platform;
- *   comSpec?: string;
- * }} options
- */
 export function createManagedCommandSpawnSpec({
   bin,
   args = [],
@@ -606,17 +543,6 @@ export function createManagedCommandSpawnSpec({
   };
 }
 
-/**
- * @param {{
- *   bin: string;
- *   args?: string[];
- *   env?: NodeJS.ProcessEnv;
- *   shell?: boolean;
- *   windowsVerbatimArguments?: boolean;
- *   platform?: NodeJS.Platform;
- *   comSpec?: string;
- * }} options
- */
 export function createManagedCommandInvocation({
   bin,
   args = [],

--- a/src/agents/tools/web-search-provider-common.test.ts
+++ b/src/agents/tools/web-search-provider-common.test.ts
@@ -1,5 +1,99 @@
-// Shared web_search provider tests cover module-local cache isolation.
-import { describe, expect, it, vi } from "vitest";
+// Shared web-search tests cover HTTP error ownership and module-local cache isolation.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { redactToolPayloadText } from "../../logging/redact.js";
+import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
+import { postTrustedWebToolsJson, throwWebSearchApiError } from "./web-search-provider-common.js";
+
+const realFetch = globalThis.fetch;
+afterEach(() => vi.unstubAllGlobals());
+
+function postSearch(overrides: Partial<Parameters<typeof postTrustedWebToolsJson>[0]> = {}) {
+  return postTrustedWebToolsJson(
+    {
+      url: "https://search.example.com/search",
+      timeoutSeconds: 5,
+      apiKey: "s7Key",
+      body: { query: "test" },
+      errorLabel: "Search",
+      extraHeaders: { authorization: "Bearer synthetic-stale-key" },
+      ...overrides,
+    },
+    (response) => response.json(),
+  );
+}
+
+describe("web provider HTTP errors", () => {
+  it.each([
+    ["short body credential", "s7Key", "rejected $key", "", undefined, "rejected ***"],
+    ["short reason credential", "s7Key", "", "rejected $key", undefined, "rejected ***"],
+    ["bearer reflection", "synthetic-web-key-long", "Bearer $key", "", undefined, "Bearer ***"],
+    ["truncated credential", "synthetic-web-key-long", "rejected $key", "", 15, "rejected ***"],
+    ["ordinary detail", "s7Key", "quota exceeded", "", undefined, "quota exceeded"],
+  ] as const)(
+    "redacts %s without discarding diagnostics",
+    async (_, apiKey, body, phrase, maxErrorBytes, expected) => {
+      let authorization: string | undefined;
+      await withServer(
+        (request, response) => {
+          authorization = request.headers.authorization;
+          response.writeHead(401, phrase.replace("$key", apiKey));
+          response.end(body.replace("$key", apiKey));
+        },
+        async (baseUrl) => {
+          // Only routing is injected: the guarded owner consumes a real HTTP response body.
+          vi.stubGlobal(
+            "fetch",
+            vi.fn((_input, init) => realFetch(baseUrl, init)),
+          );
+          const error = await postSearch({ apiKey, maxErrorBytes }).catch(
+            (cause: unknown) => cause,
+          );
+          expect(authorization).toBe(`Bearer ${apiKey}`);
+          expect(error).toEqual(new Error(`Search API error (401): ${expected}`));
+        },
+      );
+    },
+  );
+
+  it("preserves caller cancellation after error headers arrive", async () => {
+    const controller = new AbortController();
+    const reason = new Error("synthetic caller cancellation");
+    await withServer(
+      (_request, response) => {
+        response.writeHead(401);
+        response.write("partial diagnostic");
+      },
+      async (baseUrl) => {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (_input, init) => {
+            const response = await realFetch(baseUrl, init);
+            controller.abort(reason);
+            return response;
+          }),
+        );
+        await expect(postSearch({ signal: controller.signal })).rejects.toBe(reason);
+      },
+    );
+  });
+
+  it("keeps successful responses and existing two-argument SDK calls usable", async () => {
+    expect(redactToolPayloadText("Bearer tokens")).toBe("Bearer tokens");
+    await withServer(
+      (_request, response) => response.end('{"answer":"Bearer tokens"}'),
+      async (baseUrl) => {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn((_input, init) => realFetch(baseUrl, init)),
+        );
+        await expect(postSearch()).resolves.toEqual({ answer: "Bearer tokens" });
+      },
+    );
+    await expect(
+      throwWebSearchApiError(new Response("quota exceeded", { status: 429 }), "Search"),
+    ).rejects.toThrow("Search API error (429): quota exceeded");
+  });
+});
 
 describe("web_search shared cache", () => {
   it("keeps cache entries module-local instead of exposing them on a global symbol", async () => {

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
+import { createProviderErrorTextRedactor } from "../provider-http-errors.js";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
   DEFAULT_TIMEOUT_SECONDS,
@@ -29,17 +30,12 @@ const webGuardedFetchLoader = createLazyImportLoader<WebGuardedFetchModule>(
   () => import("./web-guarded-fetch.js"),
 );
 
-async function loadTrustedWebToolsEndpoint(): Promise<
-  WebGuardedFetchModule["withTrustedWebToolsEndpoint"]
-> {
-  return (await webGuardedFetchLoader.load()).withTrustedWebToolsEndpoint;
-}
-
-async function loadSelfHostedWebToolsEndpoint(): Promise<
-  WebGuardedFetchModule["withSelfHostedWebToolsEndpoint"]
-> {
-  return (await webGuardedFetchLoader.load()).withSelfHostedWebToolsEndpoint;
-}
+type WebSearchEndpointOptions = {
+  url: string;
+  timeoutSeconds: number;
+  init: RequestInit;
+  signal?: AbortSignal;
+};
 
 export type SearchConfigRecord = (NonNullable<OpenClawConfig["tools"]>["web"] extends infer Web
   ? Web extends { search?: infer Search }
@@ -88,45 +84,19 @@ export function readProviderEnvValue(envVars: string[]): string | undefined {
 }
 
 export async function withTrustedWebSearchEndpoint<T>(
-  params: {
-    url: string;
-    timeoutSeconds: number;
-    init: RequestInit;
-    signal?: AbortSignal;
-  },
+  params: WebSearchEndpointOptions,
   run: (response: Response) => Promise<T>,
 ): Promise<T> {
-  const withTrustedWebToolsEndpoint = await loadTrustedWebToolsEndpoint();
-  return withTrustedWebToolsEndpoint(
-    {
-      url: params.url,
-      init: params.init,
-      timeoutSeconds: params.timeoutSeconds,
-      signal: params.signal,
-    },
-    async ({ response }) => run(response),
-  );
+  const { withTrustedWebToolsEndpoint } = await webGuardedFetchLoader.load();
+  return withTrustedWebToolsEndpoint(params, async ({ response }) => run(response));
 }
 
 export async function withSelfHostedWebSearchEndpoint<T>(
-  params: {
-    url: string;
-    timeoutSeconds: number;
-    init: RequestInit;
-    signal?: AbortSignal;
-  },
+  params: WebSearchEndpointOptions,
   run: (response: Response) => Promise<T>,
 ): Promise<T> {
-  const withSelfHostedWebToolsEndpoint = await loadSelfHostedWebToolsEndpoint();
-  return withSelfHostedWebToolsEndpoint(
-    {
-      url: params.url,
-      init: params.init,
-      timeoutSeconds: params.timeoutSeconds,
-      signal: params.signal,
-    },
-    async ({ response }) => run(response),
-  );
+  const { withSelfHostedWebToolsEndpoint } = await webGuardedFetchLoader.load();
+  return withSelfHostedWebToolsEndpoint(params, async ({ response }) => run(response));
 }
 
 export async function postTrustedWebToolsJson<T>(
@@ -142,41 +112,51 @@ export async function postTrustedWebToolsJson<T>(
   },
   parseResponse: (response: Response) => Promise<T>,
 ): Promise<T> {
-  const withTrustedWebToolsEndpoint = await loadTrustedWebToolsEndpoint();
-  return withTrustedWebToolsEndpoint(
+  const headers = new Headers(params.extraHeaders);
+  headers.set("Accept", "application/json");
+  headers.set("Authorization", `Bearer ${params.apiKey}`);
+  headers.set("Content-Type", "application/json");
+  return withTrustedWebSearchEndpoint(
     {
       url: params.url,
       timeoutSeconds: params.timeoutSeconds,
       signal: params.signal,
       init: {
         method: "POST",
-        headers: {
-          ...params.extraHeaders,
-          Accept: "application/json",
-          Authorization: `Bearer ${params.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify(params.body),
       },
     },
-    async ({ response }) => {
+    async (response) => {
       if (!response.ok) {
-        const detail = await readResponseText(response, {
-          maxBytes: params.maxErrorBytes ?? 64_000,
+        return await throwWebSearchApiError(response, params.errorLabel, {
+          headers,
+          maxBytes: params.maxErrorBytes,
+          signal: params.signal,
         });
-        throw new Error(
-          `${params.errorLabel} API error (${response.status}): ${detail.text || response.statusText}`,
-        );
       }
       return await parseResponse(response);
     },
   );
 }
 
-export async function throwWebSearchApiError(res: Response, providerLabel: string): Promise<never> {
-  const detailResult = await readResponseText(res, { maxBytes: 64_000 });
-  const detail = detailResult.text;
-  throw new Error(`${providerLabel} API error (${res.status}): ${detail || res.statusText}`);
+export async function throwWebSearchApiError(
+  res: Response,
+  providerLabel: string,
+  request?: { headers: HeadersInit; maxBytes?: number; signal?: AbortSignal },
+): Promise<never> {
+  const detail = await readResponseText(res, { maxBytes: request?.maxBytes ?? 64_000 });
+  // Best-effort error-body reads must not turn caller cancellation into a provider failure.
+  request?.signal?.throwIfAborted();
+  const redact = createProviderErrorTextRedactor({
+    headers: new Headers(request?.headers),
+    defaultAuthHeader: "Authorization",
+    defaultAuthPrefix: "Bearer ",
+  });
+  const message = redact(detail.text || res.statusText, {
+    truncated: Boolean(detail.text) && detail.truncated,
+  });
+  throw new Error(`${providerLabel} API error (${res.status}): ${message}`);
 }
 
 export function resolveSiteName(url: string | undefined): string | undefined {

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -388,7 +388,7 @@ describe("managed-child-process", () => {
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("shares process signal listeners across parallel managed commands", async () => {
+  it("shares signal listeners across parallel commands even when another spawn throws", async () => {
     const signals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
     const baseline = new Map(signals.map((signal) => [signal, process.listenerCount(signal)]));
     const children: Array<Parameters<typeof terminateManagedChild>[0]> = [];
@@ -408,6 +408,9 @@ describe("managed-child-process", () => {
 
     try {
       await waitFor(() => readyCount === commands.length);
+      await expect(runManagedCommand({ bin: "invalid\0command" })).rejects.toMatchObject({
+        code: "ERR_INVALID_ARG_VALUE",
+      });
       for (const signal of signals) {
         expect(process.listenerCount(signal)).toBe((baseline.get(signal) ?? 0) + 1);
       }
@@ -421,6 +424,16 @@ describe("managed-child-process", () => {
     for (const signal of signals) {
       expect(process.listenerCount(signal)).toBe(baseline.get(signal) ?? 0);
     }
+  });
+
+  it.each([
+    { bin: "invalid\0command", code: "ERR_INVALID_ARG_VALUE" },
+    { bin: "/missing/openclaw-test-command", code: "ENOENT" },
+  ])("restores signal listeners after a $code spawn failure", async ({ bin, code }) => {
+    const signals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+    const baseline = signals.map((signal) => process.listenerCount(signal));
+    await expect(runManagedCommand({ bin, shell: false })).rejects.toMatchObject({ code });
+    expect(signals.map((signal) => process.listenerCount(signal))).toEqual(baseline);
   });
 
   it("times out and kills managed command descendants", async () => {

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -2,6 +2,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   createSparseTsgoSkipEnv,
@@ -354,37 +355,78 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
     expect(result.stderr.trim().split("\n").at(-1)).toBe("[tsgo] FAILED (exit 1)");
   }, 30_000);
 
-  it("lets the inner supervisor reap a wedged compiler before the wrapper exits on SIGTERM", async () => {
-    const cwd = createTempDir("openclaw-run-tsgo-signal-");
-    const pidFile = path.join(cwd, "fake-tsgo.pid");
-    fs.writeFileSync(path.join(cwd, "tsconfig.extensions.json"), "{}\n");
-    writeFakeTsgo(
-      cwd,
-      '#!/bin/sh\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\ntrap \'\' TERM HUP INT\nwhile true; do sleep 1; done\n',
-    );
-    const wrapper = spawn(
-      process.execPath,
-      [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
-      { cwd, stdio: "ignore" },
-    );
-
-    try {
-      const compilerPid = await waitForPidFile(pidFile, 10_000);
-      wrapper.kill("SIGTERM");
-
-      const wrapperResult = await waitForChildClose(wrapper, 15_000);
-      expect([
-        { code: 143, signal: null },
-        { code: null, signal: "SIGTERM" },
-      ]).toContainEqual(wrapperResult);
-      await expect(waitForDead(compilerPid, 2_000)).resolves.toBeUndefined();
-    } finally {
-      if (wrapper.exitCode === null && wrapper.signalCode === null) {
-        wrapper.kill("SIGKILL");
-      }
-      reapFakeTsgo(cwd);
+  it.each(["wrapper", "spawn"])(
+    "reaps a wedged compiler on SIGTERM during %s",
+    async (phase) => {
+      const cwd = fs.realpathSync(createTempDir("openclaw-run-tsgo-signal-"));
+      const pidFile = path.join(cwd, "fake-tsgo.pid");
+      fs.writeFileSync(path.join(cwd, "tsconfig.extensions.json"), "{}\n");
+      writeFakeTsgo(
+        cwd,
+        '#!/bin/sh\ntrap \'\' TERM HUP INT\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\nwhile true; do sleep 1; done\n',
+      );
+      const preloadPath = path.join(cwd, "signal-during-spawn.mjs");
+      // Hold the real spawn boundary until the compiler is ready, then deliver an
+      // OS signal before the supervisor can register the returned child.
+      fs.writeFileSync(
+        preloadPath,
+        `
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+const spawn = childProcess.spawn;
+childProcess.spawn = (...args) => {
+  const child = spawn(...args);
+  if (args[0] === ${JSON.stringify(path.join(cwd, "node_modules/.bin/tsgo"))}) {
+    const pidFile = ${JSON.stringify(pidFile)};
+    const deadline = Date.now() + 10_000;
+    while (!fs.existsSync(pidFile) || Number(fs.readFileSync(pidFile, "utf8")) !== child.pid) {
+      if (Date.now() >= deadline) throw new Error("compiler readiness timed out");
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
     }
-  }, 20_000);
+    process.kill(process.pid, "SIGTERM");
+  }
+  return child;
+};
+syncBuiltinESMExports();
+`,
+      );
+      const wrapper = spawn(
+        process.execPath,
+        [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
+        {
+          cwd,
+          stdio: "ignore",
+          env: {
+            ...process.env,
+            NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""}${phase === "spawn" ? ` --import=${pathToFileURL(preloadPath).href}` : ""}`,
+          },
+        },
+      );
+      const wrapperClose = waitForChildClose(wrapper, 15_000);
+
+      try {
+        const compilerPid = await waitForPidFile(pidFile, 10_000);
+        if (phase === "wrapper") {
+          wrapper.kill("SIGTERM");
+        }
+
+        const wrapperResult = await wrapperClose;
+        expect([
+          { code: 143, signal: null },
+          { code: null, signal: "SIGTERM" },
+        ]).toContainEqual(wrapperResult);
+        await expect(waitForDead(compilerPid, 2_000)).resolves.toBeUndefined();
+      } finally {
+        if (wrapper.exitCode === null && wrapper.signalCode === null) {
+          wrapper.kill("SIGKILL");
+        }
+        reapFakeTsgo(cwd);
+        await wrapperClose;
+      }
+    },
+    20_000,
+  );
 
   // Every bound that must leave a completing compiler alone. The ceiling case is the
   // regression that matters: without saturation Node collapses the delay to 1ms and


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where web-search users could expose their request credential in an error when a provider or proxy reflected it in the response body or HTTP reason phrase. Short keys and credentials cut by the diagnostic byte limit also need protection.

Related: #117304, #119536.

## Why This Change Was Made

The maintainer rewrite keeps this policy at the authenticated request owner. The shared web helper now passes the actual outgoing headers to the existing request-aware provider-error redactor. Perplexity's native Search and Sonar/OpenRouter paths carry the same context. General tool-payload redaction is unchanged, so ordinary text such as `Bearer tokens` remains intact.

Request construction now uses `Headers.set` for owned fields: differently cased caller headers cannot combine two Authorization values. Error-body cancellation retains the caller's original reason. The existing two-argument SDK error helper remains usable; request context is an optional third argument.

Removed copied xAI HTTP mocks, duplicate parser-only checks, and test-only parser exports. Retained tests now exercise the shared HTTP owner and the production citation parser caller.

The first hosted CI run exposed an existing process-supervisor race: a detached compiler could become ready before its supervisor installed signal handlers. An early SIGTERM could then orphan the compiler. The shared managed-process owner now installs handlers before spawning, retains them for concurrent commands, and removes idle handlers after either synchronous or asynchronous spawn failure. The regression exercises the real process boundary; no timeout was increased.

## User Impact

Perplexity, Tavily, and the xAI web/X-search/code-execution family retain provider labels, HTTP status, and bounded diagnostics while removing recognized reflected credentials. Successful responses and ordinary chat/tool prose are unchanged. No new configuration, dependencies, schema, or persistent-state design.

Thanks @zenglingbiao for the report, initial fix, and reflection reproductions; contributor co-authorship is preserved.

## Evidence

Rewritten head: `b66c19aee848087f612d6745f3ec8b2dea015217`. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33121764838) **passed** at 22:29:17 UTC on August 27, 2026. Native validation, prepare and merge completed successfully; merged as [213804d77046ce5d0e3cae84fa0fc4742625f064](https://github.com/openclaw/openclaw/commit/213804d77046ce5d0e3cae84fa0fc4742625f064) at 23:17:31 UTC. All 15 landed file blobs independently match the reviewed head, and the merge is an ancestor of freshly fetched main. The [previous run](https://github.com/openclaw/openclaw/actions/runs/33118473402) failed the compiler-reaping regression described below, not the web-provider tests.

- On the unchanged main baseline, real loopback HTTP responses reproduced four credential leaks and the post-header cancellation bug: **5 failed / 3 passed**. These tests inject routing only; they consume actual HTTP response bodies and are not authenticated provider proof.
- Both Perplexity transport regressions failed before passing request context: **2 failed**.
- A second HTTP regression reproduced combined mixed-case Authorization headers: **5 failed**, then passed after canonical request construction.
- Final focused and sibling suites: **230 passed** across the shared HTTP/error/guard helpers, Perplexity, Tavily, xAI web search, X search, code execution, and citation parsing.
- Final isolated Codex autoreview of the assembled **15-file** patch: **no actionable P0 findings**. A separate whole-owner review identified the mixed-case header defect above; it is fixed and regression-tested.
- Full local build passed, including public SDK export/declaration checks and Control UI build checks; no ineffective dynamic-import warning.
- Final authenticated live provider calls succeeded for Perplexity native Search and Sonar. Real invalid-key requests to both Perplexity transports and Tavily safely reported 401. Tavily authenticated success is not claimed.
- Built-Gateway `/tools/invoke` proof passed with real Perplexity: valid auth returned HTTP 200 with a normalized search result; invalid auth returned the documented sanitized HTTP 500 while recording the provider's 401 diagnostic without the synthetic credential. Both isolated instances and their temporary state were removed.
- The full changed-file gate passed, including all production/test typechecks, typed lint, dead-export checks, SDK boundaries, and runtime import-cycle checks. One earlier attempt caught a missing `unknown` annotation in a test catch callback; it is fixed and all eight shared-owner tests passed again. Application production bytes are unchanged from the successful build/live proof. Exact-head hosted CI remains required before landing.
- CI repair: a deterministic real-process probe observed the pre-fix wrapper exit on SIGTERM with zero registered listeners and a live compiler. The repaired supervisor registered its listener before spawn and exited 143 after reaping the compiler. The tracked regression also failed with the old ordering restored. All **91 tests across four tooling/helper files**, the additional local changed-file gate, and a fresh isolated P0 review passed. All twelve web-fix file blobs are unchanged from the preceding verified head; the added tooling repair is separately covered.
- The final-head `pnpm openclaw --help` invocation completed successfully after the normal git-head-triggered rebuild. ClawSweeper's separate build-plus-help probe timed out before its build completed; that timeout is not reported as a successful probe. The completed local build, help invocation, and authenticated provider/Gateway flows above provide the actual evidence.

Commands run:

```sh
node scripts/run-vitest.mjs src/agents/tools/web-search-provider-common.test.ts src/agents/tools/web-shared.test.ts src/agents/tools/web-guarded-fetch.test.ts src/agents/provider-http-errors.test.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts extensions/tavily/src/tavily-client.test.ts extensions/tavily/src/tavily-tools.test.ts extensions/xai/web-search.test.ts extensions/xai/src/responses-tool-shared.test.ts extensions/xai/x-search.test.ts extensions/xai/code-execution.test.ts
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/run-tsgo.test.ts test/scripts/direct-run-entrypoints.test.ts test/helpers/process-wait.test.ts
git diff --name-only -z | xargs -0 env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs --
env -u OPENCLAW_TESTBOX pnpm build
env -u OPENCLAW_TESTBOX pnpm docs:list
env -u OPENCLAW_TESTBOX pnpm openclaw --help
```

Judged LOC: application production **−18**, tooling production **−74** (combined **−92**), tests **+55**, docs **+4**; **total −33**. No generated, lockfile, or snapshot churn.

Latest ClawSweeper review at 21:40 UTC reports no blocking correctness findings and retains exact-head hosted checks as the remaining gate. Those checks are now green. Earlier rank-up moves are addressed: request-local short-credential redaction, preserved global ordinary-prose behavior, current-main owner comparison, and real HTTP proof. A fresh review was requested after the additional CI process-owner repair.

Provenance: the raw-error helper was already present in [3de973ffff2e6803b85906ba94ed8ace77f3618d](https://github.com/openclaw/openclaw/commit/3de973ffff2e6803b85906ba94ed8ace77f3618d), authored and committed by @Takhoffman on March 18, 2026. This establishes an earlier occurrence, not the first introduction; no associated PR was returned. The local shallow boundary cannot establish the header-construction defect's original author.

Named follow-up: Exa and Parallel have separately owned `x-api-key` error paths that do not carry request-aware redaction context. This PR does not claim to cover those paths or every possible encoding of sensitive response data.

Separate process-owner follow-up: `scripts/run-with-env.mts` also installs handlers after spawning. That distinct path has not been reproduced here and is not claimed fixed by this PR.
