### PR TITLE
fix: prevent re-entrant session reset stack overflow at shared lifecycle

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -493,28 +493,6 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    // Reject reset of the default agent's main session key (e.g. agent:main:main
-    // when "main" is the default agent). The gateway's own runtime session must
-    // not be rotated while it is in use; doing so can trigger unbounded recursion
-    // through session lifecycle hooks. This mirrors the protected-session guard
-    // that sessions.delete applies to the resolved main-session canonical key.
-    // Non-default agent main sessions (e.g. agent:work:main) are safe to reset.
-    const cfg = context.getRuntimeConfig();
-    if (isAgentMainSessionKey(cfg, key)) {
-      const parsed = parseAgentSessionKey(key);
-      if (parsed && normalizeAgentId(parsed.agentId) === resolveDefaultAgentId(cfg)) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            `Cannot reset the main session (${key}). Use sessions.delete to remove it.`,
-          ),
-        );
-        return;
-      }
-    }
-
     const reason = p.reason === "new" ? "new" : "reset";
     const { performGatewaySessionReset } = await loadSessionsRuntimeModule();
     const result = await performGatewaySessionReset({

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -493,6 +493,28 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       return;
     }
 
+    // Reject reset of the default agent's main session key (e.g. agent:main:main
+    // when "main" is the default agent). The gateway's own runtime session must
+    // not be rotated while it is in use; doing so can trigger unbounded recursion
+    // through session lifecycle hooks. This mirrors the protected-session guard
+    // that sessions.delete applies to the resolved main-session canonical key.
+    // Non-default agent main sessions (e.g. agent:work:main) are safe to reset.
+    const cfg = context.getRuntimeConfig();
+    if (isAgentMainSessionKey(cfg, key)) {
+      const parsed = parseAgentSessionKey(key);
+      if (parsed && normalizeAgentId(parsed.agentId) === resolveDefaultAgentId(cfg)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `Cannot reset the main session (${key}). Use sessions.delete to remove it.`,
+          ),
+        );
+        return;
+      }
+    }
+
     const reason = p.reason === "new" ? "new" : "reset";
     const { performGatewaySessionReset } = await loadSessionsRuntimeModule();
     const result = await performGatewaySessionReset({

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -127,6 +127,13 @@ const mcpRunEndWatchers = mcpRunEndWatcherState.watchers;
 
 const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
 
+// Prevent synchronous re-entrancy at the shared reset lifecycle boundary.
+// Resetting a session that is already mid-reset (e.g. via hooks or callbacks
+// on the default agent's own session) causes "Maximum call stack size exceeded".
+// Tracking by canonical key blocks re-entrant calls while preserving first-time
+// reset behavior for every supported entry path (RPC, chat commands, aliases).
+const activeResets = new Set<string>();
+
 export function archiveSessionTranscriptsForSessionDetailed(params: {
   sessionId: string | undefined;
   storePath: string;
@@ -1069,6 +1076,16 @@ export async function performGatewaySessionReset(params: {
   if (!resetTarget.ok) {
     return resetTarget;
   }
+  const resetCanonicalKey = resetTarget.target.canonicalKey;
+  if (activeResets.has(resetCanonicalKey)) {
+    return {
+      ok: false,
+      error: errorShape(
+        ErrorCodes.UNAVAILABLE,
+        `Session ${resetCanonicalKey} is already being reset; try again in a moment.`,
+      ),
+    };
+  }
   const initialResetEntry = loadSessionEntry(
     params.key,
     resetTarget.requestedAgentId ? { agentId: resetTarget.requestedAgentId } : undefined,
@@ -1135,6 +1152,7 @@ export async function performGatewaySessionReset(params: {
       ),
     };
   }
+  activeResets.add(resetCanonicalKey);
   let admittedWorkReleased = true;
   let resetOwnershipError: ReturnType<typeof errorShape> | undefined;
   return await runExclusiveSessionLifecycleMutation({
@@ -1670,6 +1688,8 @@ export async function performGatewaySessionReset(params: {
         storePath,
       };
     },
+  }).finally(() => {
+    activeResets.delete(resetCanonicalKey);
   });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Closes #118627

## What Problem This Solves

Fixes an issue where `sessions.reset` (or `/new`) on a session whose lifecycle hooks synchronously re-enter the reset path causes `RangeError: Maximum call stack size exceeded` (UNAVAILABLE). Reported on the default agent's main session (`agent:main:main`) in 2026.7.2-beta.7, but the re-entrancy risk exists whenever internal handlers or hooks re-enter `performGatewaySessionReset` for the same canonical key.

## Why This Change Was Made

The fix lives in `performGatewaySessionReset` — the shared reset lifecycle owner — so every entry path (RPC `sessions.reset`, `/new` chat commands, embedded clients, and aliases like `"main"`) is protected:

1. A module-level `Set<string>` tracks in-progress resets by canonical key.
2. After target resolution, a re-entrant call returns `UNAVAILABLE` cleanly.
3. After pre-flight validation, the key is added to the set before the lifecycle mutation.
4. A `.finally()` callback removes the key when the reset settles.

This preserves normal first-time reset behavior for ALL entry paths — reset still succeeds for `agent:main:main`, `"main"` alias, and global scope sessions.

The earlier RPC-handler-only guard has been removed (net -2 production LOC).

## User Impact

- Re-entrant resets now receive a clean `UNAVAILABLE` error with a message suggesting retry.
- Normal (non-re-entrant) reset behavior is unchanged for all entry paths.
- No behavior regression: existing tests for `agent:main:main`, `"main"` alias, and global scope resets all pass.

## Evidence

- **Tests**: 22/22 reset-hooks tests pass; all existing reset paths preserved
- **Scope**: +20 lines in `session-reset-service.ts`, -22 lines in `sessions-mutations.ts` (net -2)
- **Owner boundary**: `performGatewaySessionReset` is the single shared entry point for all session reset paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)