### PR TITLE
fix(gateway): refresh session lists after external identity writes

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -1,6 +1,7 @@
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
+import { readSessionIdentityMutationVersion } from "../../sessions/session-lifecycle-events.js";
 import { isGatewayAdmin } from "../session-sharing.js";
 import { readSessionTitleProjectionUnavailableVersion } from "../session-transcript-title-reader.js";
 import type { SessionsListResult } from "../session-utils.types.js";
@@ -10,6 +11,7 @@ import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js
 
 type SessionListFence = {
   agentRunIndexVersion: number;
+  sessionIdentityMutationVersion: number;
   sessionsMutationVersion: number;
   titleProjectionUnavailableVersion: number;
 };
@@ -27,6 +29,7 @@ const sessionListsByContext = new WeakMap<GatewayRequestContext, SessionListStat
 function readSessionListFence(context: GatewayRequestContext): SessionListFence {
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
+    sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
     sessionsMutationVersion: readSessionsMutationVersion(context),
     titleProjectionUnavailableVersion: readSessionTitleProjectionUnavailableVersion(),
   };
@@ -35,6 +38,7 @@ function readSessionListFence(context: GatewayRequestContext): SessionListFence 
 function matchesSessionListFence(value: SessionListFence, fence: SessionListFence): boolean {
   return (
     value.agentRunIndexVersion === fence.agentRunIndexVersion &&
+    value.sessionIdentityMutationVersion === fence.sessionIdentityMutationVersion &&
     value.sessionsMutationVersion === fence.sessionsMutationVersion &&
     value.titleProjectionUnavailableVersion === fence.titleProjectionUnavailableVersion
   );
@@ -112,8 +116,8 @@ export async function respondWithCachedSessionList(params: {
 }): Promise<void> {
   const workKey = sessionListWorkKey(params.request, params.client);
   const state = sessionListState(params.context, params.config);
-  // Every input that can change a projected row must fence reuse. Store mutations and
-  // live-run transitions have separate owners, so their monotonic counters stay separate.
+  // Every input that can change a projected row must fence reuse. Session identity,
+  // Gateway projection, and live-run mutations have separate monotonic owners.
   const fence = readSessionListFence(params.context);
   // Activity windows and child retention expire without mutations; hidden paginated rows
   // prevent deriving a safe deadline, so only concurrent temporal requests share work.

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -290,6 +290,31 @@ describe("sessions.list single-flight", () => {
     });
   });
 
+  it("invalidates a completed result after an external session identity mutation", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+
+      const first = await listSessions({ client, context, request });
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey: "agent:main:external" },
+        {
+          sessionId: "main-external",
+          updatedAt: 500,
+          createdActor: { type: "human", id: "owner@example.com" },
+          visibility: "shared",
+        },
+      );
+      const refreshed = await listSessions({ client, context, request });
+
+      expect(refreshed).not.toBe(first);
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+      expect(refreshed.sessions.map((session) => session.key)).toContain("agent:main:external");
+    });
+  });
+
   it("expires completed rows at the earliest projected agent-status deadline", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);

--- a/src/sessions/session-lifecycle-events.test.ts
+++ b/src/sessions/session-lifecycle-events.test.ts
@@ -1,6 +1,12 @@
 // Session lifecycle event tests cover lifecycle event ordering and serialization.
 import { describe, expect, it } from "vitest";
-import { emitSessionLifecycleEvent, onSessionLifecycleEvent } from "./session-lifecycle-events.js";
+import {
+  emitSessionIdentityMutation,
+  emitSessionLifecycleEvent,
+  onSessionIdentityMutation,
+  onSessionLifecycleEvent,
+  readSessionIdentityMutationVersion,
+} from "./session-lifecycle-events.js";
 
 function createListenerSpy(options: { throws?: boolean } = {}) {
   const calls: unknown[][] = [];
@@ -16,6 +22,27 @@ function createListenerSpy(options: { throws?: boolean } = {}) {
 }
 
 describe("session lifecycle events", () => {
+  it("advances the identity mutation version before notifying listeners", () => {
+    const previousVersion = readSessionIdentityMutationVersion();
+    const observedVersions: number[] = [];
+    const unsubscribe = onSessionIdentityMutation(() => {
+      observedVersions.push(readSessionIdentityMutationVersion());
+    });
+
+    try {
+      emitSessionIdentityMutation({
+        kind: "create",
+        previous: { sessionKeys: [] },
+        current: { sessionId: "session-1", sessionKeys: ["agent:main:external"] },
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(readSessionIdentityMutationVersion()).toBe(previousVersion + 1);
+    expect(observedVersions).toEqual([previousVersion + 1]);
+  });
+
   it("delivers events to active listeners and stops after unsubscribe", () => {
     const { calls, listener } = createListenerSpy();
     const unsubscribe = onSessionLifecycleEvent(listener);

--- a/src/sessions/session-lifecycle-events.ts
+++ b/src/sessions/session-lifecycle-events.ts
@@ -1,5 +1,5 @@
 /** Session lifecycle event broadcast to observers when a session is created or linked. */
-import { resolveGlobalSet } from "../shared/global-singleton.js";
+import { resolveGlobalSet, resolveGlobalSingleton } from "../shared/global-singleton.js";
 export type SessionLifecycleEvent = {
   sessionKey: string;
   reason: string;
@@ -36,6 +36,10 @@ const SESSION_IDENTITY_MUTATION_LISTENERS = resolveGlobalSet<SessionIdentityMuta
   Symbol.for("openclaw.sessionIdentityMutationListeners"),
   "close-and-restart",
 );
+const SESSION_IDENTITY_MUTATION_STATE = resolveGlobalSingleton(
+  Symbol.for("openclaw.sessionIdentityMutationState"),
+  () => ({ version: 0 }),
+);
 
 /** Registers a session lifecycle listener. */
 export function onSessionLifecycleEvent(listener: SessionLifecycleListener): () => void {
@@ -63,7 +67,13 @@ export function onSessionIdentityMutation(listener: SessionIdentityMutationListe
   };
 }
 
+/** Monotonic fence for projections that consume session identities across owner boundaries. */
+export function readSessionIdentityMutationVersion(): number {
+  return SESSION_IDENTITY_MUTATION_STATE.version;
+}
+
 export function emitSessionIdentityMutation(mutation: SessionIdentityMutation): void {
+  SESSION_IDENTITY_MUTATION_STATE.version += 1;
   for (const listener of SESSION_IDENTITY_MUTATION_LISTENERS) {
     try {
       listener(mutation);


### PR DESCRIPTION
Closes #120202

AI-assisted: yes

## What Problem This Solves

Fixes an issue where Gateway clients calling `sessions.list` could keep receiving a completed cached result after a plugin, cron job, or other external owner created, moved, replaced, reset, or deleted session identity. The stale projection could silently omit a valid session.

## Why This Change Was Made

The authoritative session-identity event owner now advances a process-wide monotonic version before notifying listeners. The session-list cache includes that version alongside its existing Gateway-context, agent-run, and title-projection fences, so external identity writes invalidate completed and in-flight reuse without coupling every writer to one Gateway request context.

Production delta is +17/-3; tests are +53/-1. No protocol, config, dependency, migration, or persistent-state schema changes.

## User Impact

Session lists refresh after committed identity changes regardless of which in-process owner made the write. Session pickers, automation, and operators no longer remain on a stale cached inventory until an unrelated Gateway-context mutation occurs.

## Evidence

Before on current `main` `2dd0e9b950462acc1f24fa9b207e9b7b0b4bd36b`:

- The focused external-upsert regression failed in 558 ms.
- The second `sessions.list` returned the same object as the first (`Object.is` equality) and omitted `agent:main:external`.

After on exact head `0ad5346395fbb932242d9348881b82fa02274253`:

- Focused external mutation regression: pass in 551 ms.
- Full session-list cache, lifecycle-event, and session-accessor suites: 117/117.
- Fresh-process stress: 20/20 runs, 20/20 regressions, about 392–469 ms test time per run.
- Whole-branch AutoReview at P2 depth: clean at 0.95; TruffleHog clean.
- Node 24 `check:changed`: green on Blacksmith Testbox `tbx_01kzdr6g1mqj1tdg19jef5nahg`, https://github.com/openclaw/openclaw/actions/runs/31165254766.
- Exact-head hosted CI: green, https://github.com/openclaw/openclaw/actions/runs/31166165371.
- Exact-head ClawSweeper: no findings, best-fix verdict yes, patch quality B/4, security cleared; its wait-for-CI gate is satisfied, https://github.com/openclaw/openclaw/pull/120203#issuecomment-5215399272.

## Test Plan

- [x] exact-current-main stale-cache reproduction
- [x] focused repaired regression
- [x] full session-list/lifecycle/accessor suites
- [x] 20 fresh-process stress runs
- [x] whole-branch AutoReview
- [x] exact Node 24 changed gate on Blacksmith Testbox
- [x] exact-head hosted PR CI
- [x] exact-head ClawSweeper review
