### PR TITLE
fix(parallel): redact x-api-key reflected in web search error bodies

### DIFF
--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -18,6 +18,7 @@ import {
   withTrustedWebSearchEndpoint,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildParallelCacheKey,
@@ -160,7 +161,15 @@ async function runParallelSearch(params: {
         const detail = await readResponseTextLimited(res, PARALLEL_ERROR_BODY_LIMIT_BYTES).catch(
           () => "",
         );
-        throw new Error(`Parallel API error (${res.status}): ${detail || res.statusText}`);
+        // Provider/proxy error pages can reflect request headers (including the
+        // x-api-key), and the empty-body statusText fallback is server-controlled
+        // too. Strip credential material from the composed detail before it lands
+        // in user-facing error text; tools mode keeps redaction on regardless of
+        // log config, and covers header-shaped reflections (x-api-key: <value>)
+        // that the payload redactor alone leaves readable.
+        throw new Error(
+          `Parallel API error (${res.status}): ${redactSensitiveText(detail || res.statusText, { mode: "tools" })}`,
+        );
       }
       return await readProviderJsonResponse<ParallelSearchResponse>(res, "Parallel API", {
         maxBytes: PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES,

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { readPluginPackageVersion } from "openclaw/plugin-sdk/extension-shared";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderJsonResponse,
   readResponseTextLimited,
@@ -18,7 +19,6 @@ import {
   withTrustedWebSearchEndpoint,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
-import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildParallelCacheKey,
@@ -163,12 +163,13 @@ async function runParallelSearch(params: {
         );
         // Provider/proxy error pages can reflect request headers (including the
         // x-api-key), and the empty-body statusText fallback is server-controlled
-        // too. Strip credential material from the composed detail before it lands
-        // in user-facing error text; tools mode keeps redaction on regardless of
-        // log config, and covers header-shaped reflections (x-api-key: <value>)
-        // that the payload redactor alone leaves readable.
+        // too. Run the composed detail through the canonical tool-payload
+        // redactor before it lands in user-facing error text: tools mode keeps
+        // redaction on regardless of log config, and configured
+        // logging.redactPatterns are merged with the built-in credential
+        // patterns so organization-specific secrets are stripped as well.
         throw new Error(
-          `Parallel API error (${res.status}): ${redactSensitiveText(detail || res.statusText, { mode: "tools" })}`,
+          `Parallel API error (${res.status}): ${redactToolPayloadText(detail || res.statusText)}`,
         );
       }
       return await readProviderJsonResponse<ParallelSearchResponse>(res, "Parallel API", {

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -19,6 +19,7 @@ import {
   withTrustedWebSearchEndpoint,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildParallelCacheKey,
@@ -163,13 +164,14 @@ async function runParallelSearch(params: {
         );
         // Provider/proxy error pages can reflect request headers (including the
         // x-api-key), and the empty-body statusText fallback is server-controlled
-        // too. Run the composed detail through the canonical tool-payload
-        // redactor before it lands in user-facing error text: tools mode keeps
-        // redaction on regardless of log config, and configured
-        // logging.redactPatterns are merged with the built-in credential
-        // patterns so organization-specific secrets are stripped as well.
+        // too. Redact in two passes before the detail lands in user-facing error
+        // text: the tools-mode pass masks header-shaped reflections while the
+        // header name is intact (a configured pattern like api[_-]?key would
+        // otherwise rewrite the name first and hide the shape from the
+        // structured matcher), then the canonical tool-payload redactor applies
+        // the operator's logging.redactPatterns on top of the built-in defaults.
         throw new Error(
-          `Parallel API error (${res.status}): ${redactToolPayloadText(detail || res.statusText)}`,
+          `Parallel API error (${res.status}): ${redactToolPayloadText(redactSensitiveText(detail || res.statusText, { mode: "tools" }))}`,
         );
       }
       return await readProviderJsonResponse<ParallelSearchResponse>(res, "Parallel API", {

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -460,6 +460,45 @@ describe("parallel web search provider", () => {
     expect(tracked.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
   });
+  it("redacts reflected credentials from Parallel API error bodies", async () => {
+    // No dictionary words: the value must be masked even when only the
+    // header-shaped (x-api-key: <value>) redaction can catch it.
+    const apiKey = "par-live-4c9d2e7ab1f0c9d2e7ab1f0c9d2e7";
+    endpointMockState.responses.push(
+      new Response(`<html><body>edge failure for request with x-api-key: ${apiKey}</body></html>`, {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+    const error = await paidTool({ parallel: { apiKey } })
+      .execute({
+        objective: `parallel-error-redact-${Date.now()}`,
+        search_queries: ["openclaw"],
+      })
+      .catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("Parallel API error (502)");
+    expect((error as Error).message).not.toContain(apiKey);
+  });
+  it("redacts credentials reflected in the statusText fallback when the body is empty", async () => {
+    const apiKey = "par-live-4c9d2e7ab1f0c9d2e7ab1f0c9d2e7";
+    endpointMockState.responses.push(
+      new Response("", {
+        status: 502,
+        statusText: `Bad Gateway reflected x-api-key: ${apiKey}`,
+      }),
+    );
+    const error = await paidTool({ parallel: { apiKey } })
+      .execute({
+        objective: `parallel-error-redact-reason-${Date.now()}`,
+        search_queries: ["openclaw"],
+      })
+      .catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("Parallel API error (502)");
+    expect((error as Error).message).not.toContain(apiKey);
+  });
   it("bounds successful Parallel JSON bodies instead of buffering the whole response", async () => {
     const streamed = createStreamingResponse({
       chunkCount: 200,

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -503,24 +503,32 @@ describe("parallel web search provider", () => {
     expect((error as Error).message).not.toContain(apiKey);
   });
   it("applies configured logging.redactPatterns to reflected Parallel error bodies", async () => {
-    // Organization-specific secret shape that no built-in pattern covers.
+    // Organization-specific secret shape that no built-in pattern covers, plus a
+    // configured field-name pattern that would rewrite the x-api-key header name
+    // before the structured matcher can see it — the key value must stay masked.
     const orgSecret = "acme-internal-bluefin-042";
+    const apiKey = "par-live-4c9d2e7ab1f0c9d2e7ab1f0c9d2e7";
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "parallel-redact-config-"));
     const configPath = path.join(configDir, "openclaw.json");
     fs.writeFileSync(
       configPath,
-      JSON.stringify({ logging: { redactPatterns: ["acme-internal-[a-z0-9-]+"] } }),
+      JSON.stringify({
+        logging: { redactPatterns: ["acme-internal-[a-z0-9-]+", "api[_-]?key"] },
+      }),
     );
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
     try {
       endpointMockState.responses.push(
-        new Response(`<html><body>edge failure for ${orgSecret}</body></html>`, {
-          status: 502,
-          statusText: "Bad Gateway",
-          headers: { "Content-Type": "text/html" },
-        }),
+        new Response(
+          `<html><body>edge failure for ${orgSecret} on request with x-api-key: ${apiKey}</body></html>`,
+          {
+            status: 502,
+            statusText: "Bad Gateway",
+            headers: { "Content-Type": "text/html" },
+          },
+        ),
       );
-      const error = await paidTool()
+      const error = await paidTool({ parallel: { apiKey } })
         .execute({
           objective: `parallel-error-redact-config-${Date.now()}`,
           search_queries: ["openclaw"],
@@ -529,6 +537,7 @@ describe("parallel web search provider", () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toContain("Parallel API error (502)");
       expect((error as Error).message).not.toContain(orgSecret);
+      expect((error as Error).message).not.toContain(apiKey);
     } finally {
       vi.unstubAllEnvs();
       fs.rmSync(configDir, { force: true, recursive: true });

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
@@ -498,6 +501,38 @@ describe("parallel web search provider", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("Parallel API error (502)");
     expect((error as Error).message).not.toContain(apiKey);
+  });
+  it("applies configured logging.redactPatterns to reflected Parallel error bodies", async () => {
+    // Organization-specific secret shape that no built-in pattern covers.
+    const orgSecret = "acme-internal-bluefin-042";
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "parallel-redact-config-"));
+    const configPath = path.join(configDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ logging: { redactPatterns: ["acme-internal-[a-z0-9-]+"] } }),
+    );
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+    try {
+      endpointMockState.responses.push(
+        new Response(`<html><body>edge failure for ${orgSecret}</body></html>`, {
+          status: 502,
+          statusText: "Bad Gateway",
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
+      const error = await paidTool()
+        .execute({
+          objective: `parallel-error-redact-config-${Date.now()}`,
+          search_queries: ["openclaw"],
+        })
+        .catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("Parallel API error (502)");
+      expect((error as Error).message).not.toContain(orgSecret);
+    } finally {
+      vi.unstubAllEnvs();
+      fs.rmSync(configDir, { force: true, recursive: true });
+    }
   });
   it("bounds successful Parallel JSON bodies instead of buffering the whole response", async () => {
     const streamed = createStreamingResponse({


### PR DESCRIPTION
## Summary

The Parallel web_search provider (`extensions/parallel/src/parallel-web-search-provider.runtime.ts`) posts with an `x-api-key` header and, on a non-2xx response, splices server-controlled error text — the bounded body, or the `statusText` reason phrase when the body is empty — into the thrown error message. Any proxy/edge error page that reflects request material then leaks the API key into user-facing error text. The composed detail is now redacted in two layers: a tools-mode pass that masks header-shaped reflections, then the canonical `redactToolPayloadText` so configured `logging.redactPatterns` apply on top of the built-in credential patterns.

## What Problem This Solves

- `runParallelSearch()` sends `x-api-key: params.apiKey` and, on `!res.ok`, throws `` `Parallel API error (${res.status}): ${detail || res.statusText}` `` with the raw text (`extensions/parallel/src/parallel-web-search-provider.runtime.ts:163`).
- The Parallel endpoint is operator-configurable (`plugins.entries.parallel.config.webSearch.baseUrl`), so deployments routinely front it with corporate proxies or gateways — exactly the class of intermediary whose error responses echo request material, including `x-api-key`.
- The leak has two channels: the HTML error body, and the HTTP reason phrase. Undici surfaces the upstream reason phrase as response data, so an empty-body 502 with a reason phrase like `Bad Gateway reflected x-api-key: <key>` exposes the key through the `statusText` fallback even when there is no body.
- The reflected key lands verbatim in the thrown `Error` message, and from there into tool results, transcripts, and logs.

**代码证据**: on `main`, pointing `baseUrl` at a local server that answers 502 with the request's `x-api-key` reflected in the page produces `Error: Parallel API error (502): …x-api-key: par-live-4c9d2e7ab1f0c9d2e7ab1f0c9d2e7…`; an empty-body 502 with the key in the reason phrase leaks it through the fallback the same way.

Same defect class as the merged #117304 (voice-call) and #119536 (discord) fixes, and the sibling web-search-provider-common fix in #120200.

## Root Cause

The error path was written for diagnostics (`status + bounded body snippet`) before credential redaction became the house standard for tool-facing text. The violated invariant: text derived from the response to an authenticated request — body and reason phrase alike — must be treated as potentially containing the request's credentials and may only reach user-facing surfaces after redaction. The body read is already bounded (`PARALLEL_ERROR_BODY_LIMIT_BYTES` = 8 KiB, with a `.catch(() => "")`), so only the redaction pass was missing.

## Why This Fix

- Redact the **composed** detail (body with `statusText` fallback) so neither server-controlled channel can carry credential material into the message: `redactToolPayloadText(redactSensitiveText(detail || res.statusText, { mode: "tools" }))`.
- Why two layers: `redactSensitiveText(…, { mode: "tools" })` masks header-shaped reflections (`x-api-key: <key>` → `x-api-key: par-li…d2e7`) via the structured auth-header matcher, and keeps redaction on regardless of the operator's log-redaction config. `redactToolPayloadText` (the canonical `openclaw/plugin-sdk/logging-core` surface) then applies configured `logging.redactPatterns` merged with the built-in defaults, so organization-specific secrets are stripped too.
- The layering order matters: a configured field-name pattern such as `api[_-]?key` rewrites the header name to `x-***` before the structured matcher can recognize the shape, so running the canonical redactor alone (or first) leaves `x-***: <value still visible>`; running the tools-mode pass first preserves the shape for the structured matcher, and the canonical pass then handles configured patterns. Verified with both pattern classes configured at once.
- Both redactors return `""` for empty input, so the `||` fallback semantics are preserved exactly: non-empty body → redacted body; empty/unreadable body → redacted reason phrase.
- The body is still bounded to 8 KiB exactly as before; only credential material is masked.
- Alternative considered: masking only the configured API key — rejected, because error pages can also reflect other credential material (proxy auth, cookies), which the central patterns already cover.

## User Impact

- Users of the Parallel web_search provider no longer expose their `PARALLEL_API_KEY` in error text when a proxy or the provider edge reflects request material — in the error page or in the reason phrase.
- Error messages keep the provider label, HTTP status, and the non-secret portion of the detail; diagnostics are unaffected.

## Evidence

- **Before**: real local HTTP server reflecting the request's `x-api-key` (1) into a 502 HTML page and (2) into the reason phrase of an empty-body 502; the real `executeParallelWebSearchProviderTool()` entry point ran end to end through the SSRF-guarded fetch → both messages contain the full key → FAIL ×2.
- **After**: same setup on this branch → the key is masked on both paths (`x-api-key: par-li…d2e7`), status and label intact → PASS ×2.
- **After (configured patterns)**: with `logging.redactPatterns: ["acme-internal-[a-z0-9-]+", "api[_-]?key"]`, a 502 page reflecting both an org-specific secret and the key masks both (`edge failure for acme-i…-042 on request with x-***: par-li…d2e7`) → PASS. (The `api[_-]?key` case proves the layering: the header name gets rewritten by the configured pattern, and the value stays masked because the tools-mode pass ran first.)

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
case 1 (body reflection):   Error: Parallel API error (502): <html><head><title>502 Bad Gateway</title></head><body>edge failure for request with x-api-key: par-live-4c9d2e7ab1f0c9d2e7ab1f0c9d2e7</body></html>
case 2 (reason reflection): Error: Parallel API error (502): Bad Gateway reflected x-api-key: par-live-4c9d2e7ab1f0c9d2e7ab1f0c9d2e7
FAIL: API key reflected via the body path leaks into the error message
FAIL: API key reflected via the reason path leaks into the error message
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
case 1 (body reflection):   Error: Parallel API error (502): <html><head><title>502 Bad Gateway</title></head><body>edge failure for request with x-api-key: par-li…tml>
case 2 (reason reflection): Error: Parallel API error (502): Bad Gateway reflected x-api-key: par-li…d2e7
PASS: credential material redacted from the body path
PASS: credential material redacted from the reason path
```

(Real `node:http` server bound to 198.18.0.1 — the RFC 2544 benchmark range the trusted-endpoint SSRF policy explicitly allows, since loopback is blocked — with `baseUrl` pointed at it; the full guarded fetch, header injection, and error path execute for real. The proof key contains no dictionary words, so only credential-aware redaction can mask it.)

## Tests and Validation

- `node scripts/check.mjs` passed
- `npx vitest run extensions/parallel/src/parallel-web-search-provider.test.ts` passed (54 tests, incl. regression tests: a 502 page echoing the configured key surfaces with the key masked — using a dictionary-word-free key so only credential-aware redaction catches it — an empty-body 502 with the key in the reason phrase is masked through the `statusText` fallback, and a 502 page reflecting an organization-specific secret plus the key under configured `logging.redactPatterns` (including a header-name-mangling pattern) masks both, while the label and status stay intact)

