### PR TITLE
fix(gateway): complete bounded file prefix reads

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -47,6 +47,12 @@ type PlaybackModeForSourceResolver = (
     (typeof import("../media/playback-transcode.js"))["resolvePlaybackModeForSource"]
   >
 ) => ReturnType<(typeof import("../media/playback-transcode.js"))["resolvePlaybackModeForSource"]>;
+type FileHandleRead = (
+  target: Uint8Array,
+  offset: number,
+  length: number,
+  position: number | null,
+) => Promise<{ bytesRead: number; buffer: Uint8Array }>;
 
 // Keeps bootstrap payload tests deterministic: the real resolver reports the
 // git branch of this checkout, which varies across CI and dev machines.
@@ -87,6 +93,7 @@ const REAL_PNG = Buffer.from(
 const REAL_PNG_DATA_URL = `data:image/png;base64,${REAL_PNG.toString("base64")}`;
 const testTempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => {
+  vi.restoreAllMocks();
   resetPluginRuntimeStateForTest();
   probeMediaFileDescriptorMock.mockReset();
   probeMediaFileDescriptorMock.mockResolvedValue({});
@@ -379,6 +386,23 @@ describe("handleControlUiHttpRequest", () => {
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }
+  }
+
+  async function forceFirstFileHandleShortRead(filePath: string, maxBytes: number) {
+    const probe = await fs.open(filePath, "r");
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as { read: FileHandleRead };
+    const originalRead = fileHandlePrototype.read;
+    await probe.close();
+    let constrained = false;
+    return vi
+      .spyOn(fileHandlePrototype, "read")
+      .mockImplementation(async function (this: unknown, target, offset, length, position) {
+        if (!constrained && position === 0 && length > maxBytes) {
+          constrained = true;
+          return await originalRead.call(this, target, offset, maxBytes, position);
+        }
+        return await originalRead.call(this, target, offset, length, position);
+      });
   }
 
   async function withBasePathRootFixture<T>(params: {
@@ -1038,6 +1062,50 @@ describe("handleControlUiHttpRequest", () => {
         expect(payload.available).toBe(true);
         expect(payload.mediaTicket).toMatch(/^v1\./);
         expect(Date.parse(payload.mediaTicketExpiresAt ?? "")).not.toBeNaN();
+      },
+    });
+  });
+
+  it("fully reads the assistant media metadata MIME prefix after a short read", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-meta-short-read-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "photo.bin");
+        await fs.writeFile(filePath, REAL_PNG);
+        const readSpy = await forceFirstFileHandleShortRead(filePath, 1);
+
+        const { res, handled, end } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(responseJson(end)).toMatchObject({ available: true, mimeType: "image/png" });
+        expect(readSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+      },
+    });
+  });
+
+  it("fully reads the served assistant media MIME prefix after a short read", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-serve-short-read-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "photo.bin");
+        await fs.writeFile(filePath, REAL_PNG);
+        const readSpy = await forceFirstFileHandleShortRead(filePath, 1);
+
+        const { res, handled, setHeader } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(setHeader).toHaveBeenCalledWith("Content-Type", "image/png");
+        expect(readSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -16,6 +16,7 @@ import { matchRootFileOpenFailure, openRootFileSync } from "../infra/boundary-fi
 import { readFileDescriptorBounded } from "../infra/boundary-file-read.js";
 import { resolveDevInstallGitBranch } from "../infra/dev-install-branch.js";
 import { listDevicePairing, verifyDeviceToken } from "../infra/device-pairing.js";
+import { readFileWindowFully } from "../infra/file-read.js";
 import { openLocalFileSafely, FsSafeError } from "../infra/fs-safe.js";
 import { safeFileURLToPath } from "../infra/local-file-access.js";
 import { verifyPairingToken } from "../infra/pairing-token.js";
@@ -570,7 +571,7 @@ async function resolveAssistantMediaAvailability(
         const sniffLength = Math.min(sizeBytes, 8192);
         const sniffBuffer = sniffLength > 0 ? Buffer.allocUnsafe(sniffLength) : undefined;
         const bytesRead = sniffBuffer
-          ? (await opened.handle.read(sniffBuffer, 0, sniffLength, 0)).bytesRead
+          ? await readFileWindowFully(opened.handle, sniffBuffer, 0)
           : 0;
         mimeType =
           (await detectMime({
@@ -687,9 +688,7 @@ export async function handleControlUiAssistantMediaRequest(
     const sniffLength = Math.min(opened.stat.size, 8192);
     const sniffBuffer = sniffLength > 0 ? Buffer.allocUnsafe(sniffLength) : undefined;
     const bytesRead =
-      sniffBuffer && sniffLength > 0
-        ? (await opened.handle.read(sniffBuffer, 0, sniffLength, 0)).bytesRead
-        : 0;
+      sniffBuffer && sniffLength > 0 ? await readFileWindowFully(opened.handle, sniffBuffer, 0) : 0;
     const mime = await detectMime({
       buffer: sniffBuffer?.subarray(0, bytesRead),
       filePath: localPath,

--- a/src/gateway/server-methods/workspace-fs.test.ts
+++ b/src/gateway/server-methods/workspace-fs.test.ts
@@ -1,0 +1,80 @@
+import { open, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { readWorkspaceFilePrefix } from "./workspace-fs.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type FileHandleRead = (
+  target: Uint8Array,
+  offset: number,
+  length: number,
+  position: number | null,
+) => Promise<{ bytesRead: number; buffer: Uint8Array }>;
+
+async function getFileHandleRead(filePath: string) {
+  const probe = await open(filePath, "r");
+  const fileHandlePrototype = Object.getPrototypeOf(probe) as { read: FileHandleRead };
+  await probe.close();
+  return fileHandlePrototype;
+}
+
+describe("readWorkspaceFilePrefix", () => {
+  it("fills the bounded prefix when the handle serves short reads", async () => {
+    const tempDir = tempDirs.make("openclaw-workspace-fs-prefix-");
+    const filePath = path.join(tempDir, "notes.txt");
+    const content = Buffer.from("prefix-bytes-that-must-not-be-truncated");
+    await writeFile(filePath, content);
+
+    const fileHandlePrototype = await getFileHandleRead(filePath);
+    const originalRead = fileHandlePrototype.read;
+    vi.spyOn(fileHandlePrototype, "read").mockImplementation(
+      async function (this: unknown, target, offset, length, position) {
+        return await originalRead.call(this, target, offset, Math.min(length, 1), position);
+      },
+    );
+
+    const result = await readWorkspaceFilePrefix(tempDir, "notes.txt", 100);
+
+    expect(result?.buffer).toEqual(content);
+    expect(result?.canonicalPath).toBe("notes.txt");
+    expect(result?.stat.size).toBe(content.length);
+  });
+
+  it("returns bytes read before an explicit EOF", async () => {
+    const tempDir = tempDirs.make("openclaw-workspace-fs-prefix-eof-");
+    const filePath = path.join(tempDir, "notes.txt");
+    await writeFile(filePath, "prefix");
+
+    const fileHandlePrototype = await getFileHandleRead(filePath);
+    const originalRead = fileHandlePrototype.read;
+    let readCount = 0;
+    vi.spyOn(fileHandlePrototype, "read").mockImplementation(
+      async function (this: unknown, target, offset, length, position) {
+        readCount += 1;
+        if (readCount === 2) {
+          return { bytesRead: 0, buffer: target };
+        }
+        return await originalRead.call(this, target, offset, Math.min(length, 3), position);
+      },
+    );
+
+    const result = await readWorkspaceFilePrefix(tempDir, "notes.txt", 100);
+
+    expect(result?.buffer.toString()).toBe("pre");
+    expect(readCount).toBe(2);
+  });
+
+  it("still bounds the returned prefix to maxBytes", async () => {
+    const tempDir = tempDirs.make("openclaw-workspace-fs-prefix-bound-");
+    await writeFile(path.join(tempDir, "notes.txt"), "bounded-prefix");
+
+    const result = await readWorkspaceFilePrefix(tempDir, "notes.txt", 7);
+
+    expect(result?.buffer.toString()).toBe("bounded");
+  });
+});

--- a/src/gateway/server-methods/workspace-fs.ts
+++ b/src/gateway/server-methods/workspace-fs.ts
@@ -3,6 +3,7 @@
 // hardlink rejection) so no caller can access files outside a workspace root.
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { readFileWindowFully } from "../../infra/file-read.js";
 import { root as fsSafeRoot, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
 
 type WorkspaceRoot = Awaited<ReturnType<typeof fsSafeRoot>>;
@@ -108,7 +109,7 @@ export async function readWorkspaceFilePrefix(
     });
     try {
       const buffer = Buffer.allocUnsafe(Math.min(maxBytes, opened.stat.size));
-      const { bytesRead } = await opened.handle.read(buffer, 0, buffer.byteLength, 0);
+      const bytesRead = await readFileWindowFully(opened.handle, buffer, 0);
       return {
         buffer: buffer.subarray(0, bytesRead),
         canonicalPath: path


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where workspace previews and assistant-media MIME detection could silently use a truncated file prefix when a valid positional file read returned fewer bytes than requested.

## Why This Change Was Made

All three pinned-handle prefix reads now use the existing `readFileWindowFully` owner helper. The rewrite covers the workspace prefix reader plus both Control UI MIME probes, removes the standalone proof script, and keeps path authorization, safe-open behavior, byte caps, and HTTP behavior unchanged.

## User Impact

Workspace file previews and assistant-media responses now classify files from the complete bounded prefix even when the filesystem serves a short read.

## Evidence

- Current-main source with the new regressions:
  - `src/gateway/server-methods/workspace-fs.test.ts`: 2 failures proving prefix truncation and missing EOF continuation.
  - `src/gateway/control-ui.http.test.ts --testNamePattern="short read"`: 2 failures proving both assistant-media MIME paths lose `image/png`.
- Exact head `d0daca30920d2170357cdcd4ee8c609918cec0d6`:
  - workspace filesystem suite: 3/3 passed.
  - Control UI HTTP suite: 136/136 passed.
  - bounded short-read stress loop: 20/20 iterations passed for the workspace suite and both Control UI MIME regressions.
- Blacksmith Testbox `tbx_01kzdxbzeg7s29x3rbz4xds42d` passed `pnpm check:changed && pnpm deadcode:knip`, including dependency pins, dead exports, production dependency analysis, core/test typechecks, lint, import cycles, and database/storage guards:
  https://github.com/openclaw/openclaw/actions/runs/31171500652
- Max-P1 autoreview: clean, no accepted/actionable findings, patch correctness 0.96.
- Local ClawSweeper review on the committed range: complete on the exact head, no correctness or security findings, best-fix verdict confirmed the canonical helper across all Gateway siblings.
- Production LOC: +5/-5 (net 0). Tests: +148/-0.

AI-assisted investigation, implementation, testing, and review were performed with Codex. The maintainer directed scope and publication.

<!-- punchcard-receipt: pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRFkwWlZOUUo2NEU1VFBSWjlRVzNSUwB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl8zODZGRjVCMzQxQTI2NzQzQjJDREEzMEY0RAB3cmtfMDFLWkRXOEMwS1BaU1M4UjVWTlJKU01OR0MAc2VzXzAxS1pEVzhEWkU2RFhRMkJFMlBTN0pWVDA2AGNvcmFsLXRpbWJlci1tZWFkb3ctbXMAb3BlbmNsYXcvb3BlbmNsYXcAADEyMDIwOAAzYTA2NGUzNmY4ZjQ4YjBiMzA4ZTIzOGQyOWNhZWU4Yzc0ZmNlYTY2OGE2ODhmMzc2ZjFjMmZiMzhkM2Y1ZDk5AHNpZ25pbmctdjEAUndFU0JfTDVvaFVXeHBzWXNoanlkLTVCcW1KNTZKcm1Sclp3YW96T2U0UG95RE1uTVdBVGxwOU5EOE1KSW9VNk8wWkVENHZUYVB1LXA2bE1TX0NBQ0EAMjAyNi0wOC0wN1QxMDo1OToxMC44MzdaAA.c8IqOXwr53BYAQuNvuv3iZ25XLl_G5QMr1zNBkLK0dYmTNHJN3hfZ3vVofe2yl5jZlCgep7zdduiICUYVGRBCg -->
