### PR TITLE
fix(gateway): send Content-Length on probe and fallthrough HEAD responses

### DIFF
--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -836,4 +836,67 @@ describe("gateway probe endpoints", () => {
       },
     });
   });
+
+  it("sends Content-Length on HEAD probe responses matching the GET body", async () => {
+    await withGatewayServer({
+      prefix: "probe-head-content-length",
+      resolvedAuth: AUTH_NONE,
+      run: async (server) => {
+        const get = createResponse();
+        await dispatchRequest(server, createRequest({ path: "/healthz" }), get.res);
+        const head = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/healthz", method: "HEAD" }),
+          head.res,
+        );
+
+        const expectedLength = String(Buffer.byteLength(get.getBody()));
+        expect(get.res.statusCode).toBe(200);
+        expect(head.res.statusCode).toBe(200);
+        expect(head.getBody()).toBe("");
+        expect(head.setHeader).toHaveBeenCalledWith("Content-Length", expectedLength);
+      },
+    });
+  });
+
+  it("sends Content-Length on HEAD responses for unclaimed paths", async () => {
+    await withGatewayServer({
+      prefix: "catch-all-head-content-length",
+      resolvedAuth: AUTH_NONE,
+      run: async (server) => {
+        const head = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/no-such-route", method: "HEAD" }),
+          head.res,
+        );
+
+        expect(head.res.statusCode).toBe(404);
+        expect(head.setHeader).toHaveBeenCalledWith("Content-Length", "9");
+      },
+    });
+  });
+
+  it("sends Content-Length on HEAD responses while the plugin runtime starts", async () => {
+    await withGatewayServer({
+      prefix: "plugin-starting-head-content-length",
+      resolvedAuth: AUTH_NONE,
+      overrides: { isStartupPluginRuntimeReady: () => false },
+      run: async (server) => {
+        const head = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/no-such-route", method: "HEAD" }),
+          head.res,
+        );
+
+        expect(head.res.statusCode).toBe(503);
+        expect(head.setHeader).toHaveBeenCalledWith(
+          "Content-Length",
+          String(Buffer.byteLength("Plugin runtime is starting")),
+        );
+      },
+    });
+  });
 });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -32,6 +32,7 @@ import {
   CONTROL_UI_CATALOG_ICON_PATH_PREFIX,
   CONTROL_UI_PLUGIN_ICON_PATH_PREFIX,
 } from "./control-ui-contract.js";
+import { respondNotFound, respondPlainText } from "./control-ui-http-utils.js";
 import {
   isControlUiApprovalDocumentPath,
   isControlUiPluginManagerRequest,
@@ -236,6 +237,9 @@ async function handleGatewayProbeRequest(
     body = JSON.stringify({ ok: true, status });
   }
   res.statusCode = statusCode;
+  // Node suppresses the HEAD body but never synthesizes Content-Length; set it
+  // explicitly so probes keep GET/HEAD header parity (RFC 9110 §8.6).
+  res.setHeader("Content-Length", String(Buffer.byteLength(body)));
   res.end(method === "HEAD" ? undefined : body);
   return true;
 }
@@ -561,18 +565,14 @@ export function createGatewayHttpServer(opts: {
         }),
         async () => {
           if (!controlUiEnabled) {
-            res.statusCode = 404;
-            res.setHeader("Content-Type", "text/plain; charset=utf-8");
-            res.end("Not Found");
+            respondNotFound(res);
             return true;
           }
           const handled = await handleControlUiRequest();
           if (handled) {
             return true;
           }
-          res.statusCode = 404;
-          res.setHeader("Content-Type", "text/plain; charset=utf-8");
-          res.end("Not Found");
+          respondNotFound(res);
           return true;
         },
       );
@@ -728,17 +728,13 @@ export function createGatewayHttpServer(opts: {
       // Startup owns sidecar readiness. The plugin registry is still empty here, so an
       // unclaimed path may be a plugin route that would otherwise dead-end as a transient 404.
       if (opts.isStartupPluginRuntimeReady?.() === false) {
-        res.statusCode = 503;
         res.setHeader("Cache-Control", "no-store");
         res.setHeader("Retry-After", "1");
-        res.setHeader("Content-Type", "text/plain; charset=utf-8");
-        res.end("Plugin runtime is starting");
+        respondPlainText(res, 503, "Plugin runtime is starting");
         return;
       }
 
-      res.statusCode = 404;
-      res.setHeader("Content-Type", "text/plain; charset=utf-8");
-      res.end("Not Found");
+      respondNotFound(res);
     } catch (err) {
       console.error("[gateway-http] unhandled error in request handler:", err);
       finishFailedGatewayHttpResponse(res);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators probing Gateway health, readiness, startup, and fallback routes with `HEAD` would receive no `Content-Length`, even though the equivalent `GET` response had a known representation length.

The affected paths are:

- `/health`, `/healthz`, `/ready`, and `/readyz`
- the unclaimed-route 404 response
- the plugin-runtime-starting 503 response
- reserved approval-document 404 responses

## Why This Change Was Made

The probe handler now records the byte length of its already-materialized JSON representation. Static plain-text fallbacks reuse the existing `respondPlainText` and `respondNotFound` helpers, which own UTF-8 `Content-Type` and byte-accurate `Content-Length`.

This is recommended and permitted HTTP behavior, not a claim that every HEAD response must include `Content-Length`. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2) says a server SHOULD send the same header fields for HEAD as for GET, permits omission of fields determined only while generating content, and allows `Content-Length` on HEAD only when it equals the octet count the corresponding GET would send.

Alternative rejected: a HEAD-only special case. Setting representation metadata on the shared response path keeps GET and HEAD aligned and avoids duplicate policy.

Original fix and regression tests by @zenglingbiao. Maintainer validation preserved the contributor's exact head and authorship.

## User Impact

Health checkers, uptime monitors, caches, and other clients using HEAD can now observe the same known representation length as GET on these Gateway routes. GET status, headers, and body content remain unchanged; HEAD still sends zero body bytes.

## Evidence

- Exact reviewed head: `e4dfd64d8e8b84cdb192d45f434c108d06bb1a5e`
- Secretless AWS Crabbox proof: [run `run_2a0eceaf9bca`](https://crabbox.openclaw.ai/portal/runs/run_2a0eceaf9bca), lease `cbx_aa32c3843c41`
- Focused Gateway suite: 28/28 twice, then 20 bounded repetitions; 616/616 total test cases passed
- Real raw-TCP matrix on Node 22.22.3, 24.15.0, and 26:
  - GET/HEAD parity for `/health`, `/healthz`, `/ready`, and `/readyz`
  - terminal 404, startup 503, and reserved approval-document 404
  - matching status, `Content-Type`, and byte-accurate `Content-Length`
  - Unicode readiness detail measured as 57 UTF-8 bytes
  - zero HEAD response body bytes in every case
- `git diff --check`: passed
- Path-scoped `check:changed`: passed, including formatting, core/test type checks, lint, boundary guards, dependency guards, dead-export scans, schema guards, and import-cycle checks
- Exact-head CI: [green CI run](https://github.com/openclaw/openclaw/actions/runs/31169679075)
- Max-P1 autoreview: no actionable findings, correctness confidence 0.95
- Exact-head ClawSweeper review: [no findings; proof sufficient](https://github.com/openclaw/openclaw/pull/120210#issuecomment-5216071622)

## Release Note

Gateway HEAD responses for probes and static fallback routes now include byte-accurate `Content-Length` metadata matching GET.

No changelog edit is included; contributor PRs record release-note context here for maintainer release tooling.

Punchcard-Session: calm-willow-river-a7
