### PR TITLE
fix(diagnostics-prometheus): send Content-Length on metrics HEAD responses

### DIFF
--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -56,10 +56,12 @@ function createMetricsHarness() {
     } as TrustedExporterInternalDiagnostics,
   });
   return {
+    handler: exporter.handler,
     record(event: DiagnosticEventPayload, metadata: DiagnosticEventMetadata) {
       expectDefined(listener, "Prometheus diagnostics listener")(event, metadata, {});
     },
     render: exporter.render,
+    stop: () => exporter.service.stop?.(),
   };
 }
 
@@ -899,10 +901,25 @@ describe("diagnostics-prometheus service", () => {
 });
 
 describe("metrics HTTP handler", () => {
-  it("sends Content-Length on HEAD responses matching the GET body", async () => {
-    const exporter = createDiagnosticsPrometheusExporter();
+  it("sends byte-accurate representation metadata on HEAD", async () => {
+    const metrics = createMetricsHarness();
+    metrics.record(
+      {
+        ...baseEvent(),
+        type: "run.completed",
+        runId: "run-1",
+        sessionKey: "session-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        channel: "discord",
+        trigger: "message",
+        durationMs: 1500,
+        outcome: "completed",
+      },
+      trusted,
+    );
     const server = createServer((req, res) => {
-      void exporter.handler(req, res);
+      void metrics.handler(req, res);
     });
     await new Promise<void>((resolve) => {
       server.listen(0, "127.0.0.1", resolve);
@@ -916,12 +933,19 @@ describe("metrics HTTP handler", () => {
       const get = await fetch(base);
       const getBody = await get.text();
       const head = await fetch(base, { method: "HEAD" });
-      await head.arrayBuffer();
+      const headBody = await head.arrayBuffer();
+      const getBodyBytes = Buffer.byteLength(getBody);
       expect(get.status).toBe(200);
+      expect(getBodyBytes).toBeGreaterThan(0);
+      expect(get.headers.get("content-length")).toBe(String(getBodyBytes));
       expect(head.status).toBe(200);
-      expect(head.headers.get("content-length")).toBe(String(Buffer.byteLength(getBody)));
+      expect(head.headers.get("content-length")).toBe(String(getBodyBytes));
+      expect(headBody.byteLength).toBe(0);
     } finally {
-      server.close();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      metrics.stop();
     }
   });
 });

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -1,3 +1,4 @@
+import { createServer } from "node:http";
 import { expectDefined } from "@openclaw/normalization-core";
 // Diagnostics Prometheus tests cover service plugin behavior.
 import type { DiagnosticEventPrivateData } from "openclaw/plugin-sdk/diagnostic-runtime";
@@ -894,5 +895,33 @@ describe("diagnostics-prometheus service", () => {
       status: "dropped",
     });
     expect(exporter.render()).toBe("");
+  });
+});
+
+describe("metrics HTTP handler", () => {
+  it("sends Content-Length on HEAD responses matching the GET body", async () => {
+    const exporter = createDiagnosticsPrometheusExporter();
+    const server = createServer((req, res) => {
+      void exporter.handler(req, res);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected TCP server address");
+    }
+    try {
+      const base = `http://127.0.0.1:${address.port}/api/diagnostics/prometheus`;
+      const get = await fetch(base);
+      const getBody = await get.text();
+      const head = await fetch(base, { method: "HEAD" });
+      await head.arrayBuffer();
+      expect(get.status).toBe(200);
+      expect(head.status).toBe(200);
+      expect(head.headers.get("content-length")).toBe(String(Buffer.byteLength(getBody)));
+    } finally {
+      server.close();
+    }
   });
 });

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -992,8 +992,6 @@ function createMetricsHandler(store: PrometheusMetricStore): OpenClawPluginHttpR
     res.statusCode = 200;
     res.setHeader("Cache-Control", "no-store");
     res.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
-    // Node suppresses the HEAD body but never synthesizes Content-Length; set
-    // it explicitly so scrapers probing with HEAD see the same metadata as GET.
     res.setHeader("Content-Length", String(Buffer.byteLength(body)));
     if (req.method === "HEAD") {
       res.end();

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -992,6 +992,9 @@ function createMetricsHandler(store: PrometheusMetricStore): OpenClawPluginHttpR
     res.statusCode = 200;
     res.setHeader("Cache-Control", "no-store");
     res.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+    // Node suppresses the HEAD body but never synthesizes Content-Length; set
+    // it explicitly so scrapers probing with HEAD see the same metadata as GET.
+    res.setHeader("Content-Length", String(Buffer.byteLength(body)));
     if (req.method === "HEAD") {
       res.end();
       return true;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `HEAD /api/diagnostics/prometheus` omitted the representation length even though the equivalent `GET` returned a fully rendered metrics body.

HTTP permits `Content-Length` on a HEAD response. When present, its value must match the octet count that the corresponding GET response would send.

## Why This Change Was Made

The metrics handler already materializes the canonical Prometheus text before it branches on the request method. It now records `Buffer.byteLength(body)` once for both GET and HEAD, while preserving the existing empty HEAD body.

The regression uses the existing diagnostics listener to record a real non-empty metric, then serves the real handler over a loopback HTTP server. It verifies:

- GET returns a non-empty body and a byte-accurate `Content-Length`.
- HEAD returns the same `Content-Length`.
- HEAD returns no body bytes.
- Server shutdown is awaited so the test cannot leak a listener.

No auth, routing, cache, content type, config, SDK, or plugin contract changes.

## User Impact

Monitoring clients that probe the Prometheus endpoint with HEAD now receive accurate representation metadata without downloading the metrics body. GET behavior and body bytes are unchanged.

## Evidence

- Current-main loopback reproduction: GET returned `2972` bytes with `Content-Length: 2972`; HEAD returned no `Content-Length` and zero body bytes.
- Rewritten-head loopback proof: GET and HEAD both returned `Content-Length: 2972`; HEAD returned zero body bytes.
- Focused owner suite: 21/21 passed.
- Focused regression: 20/20 repeated runs passed.
- Targeted formatting and `git diff --check`: passed.
- Local ClawSweeper on patch-identical tree `ddb4fcc2877d57503214f57c71423a951bef4419`: complete, high confidence, no actionable P0/P1 findings, no rank-up moves.
- Max-P1 autoreview: clean, patch correct with 0.99 confidence.

Production delta: +1 line. Test delta: +53 lines.

Punchcard-Session: ember-willow-timber-gk
