### PR TITLE
fix(cron): treat zero sessionRetention as disabled instead of pruning all run sessions

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -799,7 +799,7 @@ Disable automations: `cron.enabled: false` or `OPENCLAW_SKIP_CRON=1`.
 
   </Accordion>
   <Accordion title="Maintenance">
-    `cron.sessionRetention` (default `24h`, `false` disables) prunes isolated run-session entries. Run history keeps the newest 2000 terminal rows per job; lost rows retain their 24-hour cleanup window.
+    `cron.sessionRetention` (default `24h`, `false` or `"0h"` disables) prunes isolated run-session entries. Run history keeps the newest 2000 terminal rows per job; lost rows retain their 24-hour cleanup window.
   </Accordion>
   <Accordion title="Legacy store migration">
     On upgrade, run `openclaw doctor --fix` to import historical `~/.openclaw/cron/jobs.json`, `jobs-state.json`, `jobs-quarantine.json`, and `runs/*.jsonl` files into SQLite and archive the originals with a `.migrated` suffix. Malformed job rows remain recoverable in SQLite while valid jobs keep running.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -216,7 +216,7 @@ The scheduler does not classify final-output prose or approval-looking refusal p
 
 Retention behavior:
 
-- `cron.sessionRetention` (default `24h`, or `false` to disable) prunes completed isolated run sessions.
+- `cron.sessionRetention` (default `24h`, or `false` to disable; a zero duration such as `"0h"` also disables) prunes completed isolated run sessions.
 - Run history keeps the newest 2000 terminal rows per job. Lost rows retain the standard 24-hour lost-task cleanup window.
 
 ## Migrating older jobs

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1470,14 +1470,14 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
     webhookSsrfPolicy: {
       allowedHostnames: ["127.0.0.1"], // optional exact exception for a trusted receiver
     },
-    sessionRetention: "24h", // duration string or false
+    sessionRetention: "24h", // duration string ("0h" disables) or false
   },
 }
 ```
 
 - `enabled`: execute stored automation jobs (default: `true`). Set `false` to pause all automation execution without deleting jobs.
 - `triggers.enabled`: also run event-driven automation triggers (default: `false`).
-- `sessionRetention`: how long to keep completed isolated automation run sessions before pruning SQLite session rows. Also controls cleanup of archived deleted automation transcripts. Default: `24h`; set `false` to disable.
+- `sessionRetention`: how long to keep completed isolated automation run sessions before pruning SQLite session rows. Also controls cleanup of archived deleted automation transcripts. Default: `24h`; set `false` or a zero duration such as `"0h"` to disable (negative durations are invalid).
 - Run history automatically keeps the newest 2000 terminal rows per job. Lost rows retain their 24-hour cleanup window.
 - `webhookToken`: bearer token used for automation webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 - `webhookSsrfPolicy`: shared outbound SSRF policy for primary, completion, failure-destination, and failure-alert webhooks. Private/internal targets are blocked when omitted. Prefer exact `allowedHostnames`; use `dangerouslyAllowPrivateNetwork: true` only for trusted private-network receivers. The narrow fake-IP proxy flags are `allowRfc2544BenchmarkRange` and `allowIpv6UniqueLocalRange`.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -414,7 +414,7 @@ candidate contains a redacted secret placeholder such as `***` or `[redacted]`.
     }
     ```
 
-    - `sessionRetention`: prune completed isolated run sessions from SQLite session rows (default `24h`; set `false` to disable).
+    - `sessionRetention`: prune completed isolated run sessions from SQLite session rows (default `24h`; set `false` or a zero duration such as `"0h"` to disable).
     - Run history automatically keeps the newest 2000 terminal rows per job; lost rows retain their 24-hour cleanup window.
     - See [Cron jobs](/automation/cron-jobs) for feature overview and CLI examples.
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -108,7 +108,7 @@ artifacts before importing.
 
 Isolated cron runs create their own session entries/transcripts with dedicated retention:
 
-- `cron.sessionRetention` (default `"24h"`) prunes old isolated cron run sessions from the store; `false` disables.
+- `cron.sessionRetention` (default `"24h"`) prunes old isolated cron run sessions from the store; `false` or a zero duration such as `"0h"` disables.
 - Run history keeps the newest 2000 terminal rows per cron job. Lost rows retain their 24-hour cleanup window.
 
 When cron force-creates a new isolated run session, it sanitizes the previous `cron:<jobId>` session entry before writing the new row: it carries safe preferences (thinking/fast/verbose/reasoning settings, labels, display name) and explicit user-selected model/auth overrides, but drops ambient conversation context (channel/group routing, send/queue policy, elevation, origin, ACP runtime binding) so a fresh isolated run cannot inherit stale delivery or runtime authority from an older run.

--- a/src/config/schema.help.automation.ts
+++ b/src/config/schema.help.automation.ts
@@ -100,7 +100,7 @@ export const AUTOMATION_FIELD_HELP: Record<string, string> = {
   "cron.webhookSsrfPolicy.allowIpv6UniqueLocalRange":
     "Allows automation webhooks to IPv6 Unique Local Addresses (fc00::/7). Use only with trusted fake-IP proxy environments.",
   "cron.sessionRetention":
-    "Controls how long completed automation run sessions are kept before pruning (`24h`, `7d`, `1h30m`, or `false` to disable pruning; default: `24h`). Use shorter retention to reduce storage growth on high-frequency schedules.",
+    "Controls how long completed automation run sessions are kept before pruning (`24h`, `7d`, `1h30m`, or `false` to disable pruning; a zero duration such as `0h` also disables; default: `24h`). Use shorter retention to reduce storage growth on high-frequency schedules.",
   transcripts:
     "Core transcript capture settings for meeting notes, recording-capable agent tools, and configured live meeting auto-start sources. Meeting plugins capture durable notes by default; set enabled to false to opt out globally.",
   "transcripts.enabled":

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -32,6 +32,7 @@ export type CronConfig = {
   /**
    * How long to retain completed cron run sessions before automatic pruning.
    * Accepts a duration string (e.g. "24h", "7d", "1h30m") or `false` to disable pruning.
+   * A zero duration (e.g. "0h") also disables pruning; negative durations are invalid.
    * Default: "24h".
    */
   sessionRetention?: string | false;

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -527,6 +527,32 @@ describe("sweepCronRunSessions", () => {
     expect(result.pruned).toBe(0);
   });
 
+  it.each([["0h"], ["0s"], ["0"]])(
+    "treats a zero retention (%s) as disabled instead of pruning everything",
+    async (sessionRetention) => {
+      const now = Date.now();
+      const store: Record<string, SessionEntry> = {
+        "agent:main:cron:job1:run:run1": {
+          sessionId: "run1",
+          updatedAt: now - 100 * 3_600_000,
+        },
+      };
+      await seedSessionEntries(storePath, store);
+
+      const result = await sweepCronRunSessions({
+        cronConfig: { sessionRetention },
+        sessionStorePath: storePath,
+        nowMs: now,
+        log,
+        force: true,
+      });
+
+      expect(result.swept).toBe(false);
+      expect(result.pruned).toBe(0);
+      expect(readSessionEntries(storePath)).toHaveProperty("agent:main:cron:job1:run:run1");
+    },
+  );
+
   it("sweeps immediately when disabled retention is enabled again", async () => {
     const now = Date.now();
     const sessionKey = "agent:main:cron:job1:run:expired-run";

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -33,7 +33,15 @@ function resolveRetentionMs(cronConfig?: CronConfig): number | null {
   const raw = cronConfig?.sessionRetention;
   if (typeof raw === "string" && raw.trim()) {
     try {
-      return parseDurationMs(raw.trim(), { defaultUnit: "h" });
+      const ms = parseDurationMs(raw.trim(), { defaultUnit: "h" });
+      // A zero retention ("0h") is a disable signal, not "prune everything":
+      // cutoff would equal now and the next sweep would delete every cron run
+      // session. Negative durations never get here (the parser rejects them);
+      // the <= 0 check stays defensive.
+      if (ms <= 0) {
+        return null;
+      }
+      return ms;
     } catch {
       return DEFAULT_RETENTION_MS;
     }


### PR DESCRIPTION
## Summary

`cron.sessionRetention: "0h"` parsed successfully but made the cron session reaper compute `cutoff = now`, so the next sweep deleted **every** cron run session — the entire run history. A zero retention is now treated as a disable signal, matching what a user means when they write `"0h"` (negative durations remain invalid: the duration parser rejects them).

## What Problem This Solves

- The config schema validates only that `cron.sessionRetention` is parseable (`src/config/zod-schema.root-shape.ts:333-345`), and `"0h"` parses fine to `0`.
- `resolveRetentionMs` (`src/cron/session-reaper.ts:29`) returned that `0` verbatim; the sweep then computed `cutoff = now - 0 = now`, and every cron run session — all of them have `updatedAt < now` — was pruned on the next tick (`:91-93`).
- Users writing `"0h"` reasonably mean "never prune" (the same mental model as `false`, which the field already accepts), not "delete all history immediately". The result is silent, unrecoverable loss of all cron run session history on the very next sweep.

**代码证据**: on `main`, seeding one 1-hour-old cron run session and sweeping with `sessionRetention: "0h"` returns `swept=true pruned=1` and leaves the store empty.

Same defect class as the merged #119422 (`session.maintenance.maxDiskBytes: 0`), which established the "non-positive means disabled, not destroy-everything" contract for the sibling maintenance settings.

## Root Cause

`resolveRetentionMs` validated parseability but never range-checked the parsed value. The violated invariant: retention must be a positive duration or an explicit disable; a zero/negative duration has no meaningful sweep semantics and must never reach the cutoff arithmetic. The schema's job is syntax (parseable duration); the resolver owns the value's semantics — and it had a hole.

## Why This Fix

- `if (ms <= 0) return null` inside the existing parse branch — `null` is already the "pruning disabled" signal (`sessionRetention: false` maps to it), and the sweep short-circuits before touching the store. One check reuses the established disabled path instead of inventing a new one. The check is `<= 0` defensively, but only zero can reach it: the duration parser rejects negative input, and config validation flags negative durations at load.
- Kept the `"0h"`-means-disable interpretation (rather than rejecting at schema load) for consistency with `false` and with #119422's resolution for `maxDiskBytes`.
- Documented the zero-only contract on every surface that names the disable path: the field JSDoc in `types.cron.ts` ("A zero duration (e.g. "0h") also disables pruning; negative durations are invalid."), the canonical schema help (`schema.help.automation.ts`), and the cron/session docs (`configuration-reference.md`, `cron-jobs.md`, `session-management-compaction.md`).
- Alternative considered: rejecting `"0h"` in the zod schema — rejected; it would break configs that currently load fine, while the user's intent ("disable") is unambiguous and cheap to honor.

## User Impact

- Users with `cron.sessionRetention: "0h"` keep their cron run session history; pruning is simply off, exactly as if they had written `false`.
- Positive durations and the default path are unchanged.

## Evidence

- **Before**: real `sweepCronRunSessions` against a real session store holding one recent cron run session; `sessionRetention: "0h"` → `swept=true pruned=1`, store empty → FAIL (history deleted).
- **After**: same store and sweep on this branch → `swept=false pruned=0`, session entry preserved → PASS.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
config: cron.sessionRetention = "0h"
sweep result: swept=true pruned=1
remaining sessions: []
FAIL: sessionRetention "0h" deleted cron run session history (cutoff == now)
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
config: cron.sessionRetention = "0h"
sweep result: swept=false pruned=0
remaining sessions: ["agent:main:cron:job1:run:run1"]
PASS: sessionRetention "0h" treated as disabled; run session history preserved
```

(Real session store seeded through the real `replaceSessionEntry` mutation API in a temp state dir; the sweep invoked is the exact `sweepCronRunSessions()` the gateway cron tick calls.)

## Tests and Validation

- `node scripts/check.mjs` passed
- `npx vitest run src/cron/session-reaper.test.ts` passed (26 tests, incl. new regression cases: `"0h"`, `"0s"`, and bare `"0"` all leave a stale cron run session untouched — `swept=false, pruned=0`)
