### PR TITLE
feat(plugins): read the ai.openclaw Agent Plugins extension namespace

### DIFF
--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -239,8 +239,11 @@ These are recognized and shown in diagnostics, but OpenClaw does not run them:
       skills keep loading; invalid individual server entries are skipped
     - `.mcp.json` (dot-prefixed) and inline manifest `mcpServers` are **not**
       read for this format; the standard's closed schema wins
-    - Reverse-domain client directories and manifest `extensions` namespaces
-      are ignored, as the standard allows for incremental adoption
+    - OpenClaw reads `extensions["ai.openclaw"]`; it currently supports
+      `activation` with the same semantics as other bundle manifests
+    - Other manifest extension namespaces are ignored and reserved for their
+      clients
+    - Reverse-domain client directories are ignored and reserved
 
   </Accordion>
 

--- a/src/plugins/bundle-manifest.test.ts
+++ b/src/plugins/bundle-manifest.test.ts
@@ -183,7 +183,6 @@ describe("bundle manifest parsing", () => {
             name: "Portable.Bundle",
             description: "Agent Plugins fixture",
             version: "1.2.3",
-            extensions: "ignored",
             unknown: true,
           },
         });
@@ -532,6 +531,72 @@ describe("bundle manifest parsing", () => {
     });
 
     expect(expectLoadedManifest(rootDir, "agent").skills).toStrictEqual([]);
+  });
+
+  it("loads ai.openclaw activation like an equivalent Claude bundle", () => {
+    const activation = {
+      onStartup: true,
+      onCommands: [" summarize ", ""],
+      onCapabilities: ["tool", "unknown"],
+    };
+    const agentRoot = makeTempDir();
+    writeBundleManifest(agentRoot, AGENT_BUNDLE_MANIFEST_RELATIVE_PATH, {
+      $schema: AGENT_BUNDLE_MANIFEST_SCHEMA,
+      name: "portable",
+      extensions: {
+        "ai.openclaw": { activation },
+      },
+    });
+    const claudeRoot = makeTempDir();
+    writeBundleManifest(claudeRoot, CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH, {
+      name: "claude",
+      activation,
+    });
+
+    const agentActivation = expectLoadedManifest(agentRoot, "agent").activation;
+    expect(agentActivation).toEqual({
+      onStartup: true,
+      onCommands: ["summarize"],
+      onCapabilities: ["tool"],
+    });
+    expect(agentActivation).toEqual(expectLoadedManifest(claudeRoot, "claude").activation);
+  });
+
+  it.each([
+    { name: "non-object extensions", extensions: "invalid" },
+    {
+      name: "non-object ai.openclaw extension",
+      extensions: { "ai.openclaw": "invalid" },
+    },
+    {
+      name: "unknown extension namespace",
+      extensions: { "com.example": { activation: { onStartup: true } } },
+    },
+  ])("ignores $name", ({ extensions }) => {
+    const rootDir = makeTempDir();
+    writeBundleManifest(rootDir, AGENT_BUNDLE_MANIFEST_RELATIVE_PATH, {
+      $schema: AGENT_BUNDLE_MANIFEST_SCHEMA,
+      name: "portable",
+      extensions,
+    });
+
+    expect(expectLoadedManifest(rootDir, "agent").activation).toBeUndefined();
+  });
+
+  it("ignores unknown fields inside the ai.openclaw extension", () => {
+    const rootDir = makeTempDir();
+    writeBundleManifest(rootDir, AGENT_BUNDLE_MANIFEST_RELATIVE_PATH, {
+      $schema: AGENT_BUNDLE_MANIFEST_SCHEMA,
+      name: "portable",
+      extensions: {
+        "ai.openclaw": {
+          activation: { onStartup: true },
+          futureField: { enabled: true },
+        },
+      },
+    });
+
+    expect(expectLoadedManifest(rootDir, "agent").activation).toEqual({ onStartup: true });
   });
 
   it.each([

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -9,6 +9,7 @@ import { normalizeUniqueSingleOrTrimmedStringList } from "@openclaw/normalizatio
 import JSON5 from "json5";
 import { matchRootFileOpenFailure } from "../infra/boundary-file-read.js";
 import { readRootStructuredFileSync } from "../infra/json-files.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isRecord } from "../utils.js";
 import type { PluginBundleFormat } from "./manifest-types.js";
 import type { PluginManifestActivation } from "./manifest.js";
@@ -24,8 +25,10 @@ export const CODEX_BUNDLE_MANIFEST_RELATIVE_PATH = ".codex-plugin/plugin.json";
 export const CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH = ".claude-plugin/plugin.json";
 export const CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH = ".cursor-plugin/plugin.json";
 export const AGENT_BUNDLE_MANIFEST_RELATIVE_PATH = "plugin.json";
+const AGENT_BUNDLE_EXTENSION_NAMESPACE = "ai.openclaw";
 const AGENT_BUNDLE_MANIFEST_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
 const MAX_AGENT_BUNDLE_MANIFEST_BYTES = 256 * 1024;
+const log = createSubsystemLogger("plugins/bundle-manifest");
 
 /** Normalized bundle manifest shape consumed by plugin discovery. */
 type BundlePluginManifest = {
@@ -359,6 +362,30 @@ function buildAgentCapabilities(rootDir: string): string[] {
   return capabilities;
 }
 
+function resolveAgentActivation(
+  raw: Record<string, unknown>,
+  manifestPath: string,
+): PluginManifestActivation | undefined {
+  if (raw.extensions === undefined) {
+    return undefined;
+  }
+  if (!isRecord(raw.extensions)) {
+    log.warn(`ignoring Agent Plugins extensions in ${manifestPath}: expected an object`);
+    return undefined;
+  }
+  const openclawExtension = raw.extensions[AGENT_BUNDLE_EXTENSION_NAMESPACE];
+  if (openclawExtension === undefined) {
+    return undefined;
+  }
+  if (!isRecord(openclawExtension)) {
+    log.warn(
+      `ignoring Agent Plugins ${AGENT_BUNDLE_EXTENSION_NAMESPACE} extension in ${manifestPath}: expected an object`,
+    );
+    return undefined;
+  }
+  return normalizeManifestActivation(openclawExtension.activation);
+}
+
 export function loadBundleManifest(params: {
   rootDir: string;
   rootRealPath?: string;
@@ -422,6 +449,7 @@ export function loadBundleManifest(params: {
         settingsFiles: [],
         hooks: [],
         bundleFormat: "agent",
+        activation: resolveAgentActivation(raw, loaded.manifestPath),
         capabilities: buildAgentCapabilities(params.rootDir),
       },
       manifestPath: loaded.manifestPath,


### PR DESCRIPTION
## What Problem This Solves

Closes #120151. PR #120115 added the Agent Plugins 1.0.0 bundle format but ignored the spec's client-extension surfaces, so a portable package could not carry any OpenClaw-specific metadata: the `agent` format always loaded with `activation: undefined`, while every other bundle format can declare activation hints — a portable package was strictly poorer on OpenClaw than the same content shipped as a client-specific bundle.

## Why This Change Was Made

Implements the v1 design frozen in #120151: OpenClaw's namespace is `ai.openclaw` (product domain reversed, mirroring Codex's bare-vendor `com.openai` precedent in `codex-rs/core-plugins/src/agent_plugin_manifest.rs`). The agent-format loader reads `extensions["ai.openclaw"].activation` through the existing `normalizeManifestActivation` — the same semantics as the other three bundle formats. Spec-conformant ignore rules: non-object `extensions`, non-object namespace values, unknown namespaces, and unknown fields inside `ai.openclaw` are ignored (with a warning for the malformed shapes), never fatal. Reverse-domain client directories stay reserved/ignored; provider/channel/config-schema declarations are explicitly rejected for bundles in the issue (trust boundary — bundles have no in-process runtime).

## User Impact

A portable Agent Plugins package can now declare OpenClaw activation hints without shipping a client-specific manifest. Docs: the Agent Plugins accordion in the bundles guide documents the namespace and the reserved surfaces.

## Evidence

- Behavioral equivalence test: an agent bundle declaring activation via `extensions["ai.openclaw"]` loads with the same activation as the equivalent Claude bundle manifest; ignore-path coverage for non-object `extensions`, non-object namespace value, unknown namespace, and unknown in-namespace fields (`node scripts/run-vitest.mjs src/plugins/bundle-manifest.test.ts`, 32 tests green).
- `check:changed` green via the sanctioned local fallback (Crabbox unavailable on this host).
- Live check against an isolated `OPENCLAW_STATE_DIR`: fixture package with `extensions` (including a foreign `com.example.other` namespace) installs and loads cleanly as `agent (Agent Plugins)`.
- Codex autoreview clean (0.99), no accepted findings.
- Production delta +28 LOC (new capability from #120151); tests +67, docs +5/-2.
