### PR TITLE
fix(gateway): plugin follow-up on a paused subagent leaves the parent agent hung

### DIFF
--- a/src/gateway/server-methods/agent-task-tracking.ts
+++ b/src/gateway/server-methods/agent-task-tracking.ts
@@ -15,6 +15,7 @@ import {
 } from "../../sessions/session-key-utils.js";
 import { finalizeTaskRunByRunId } from "../../tasks/detached-task-runtime.js";
 import type { TaskStatus } from "../../tasks/task-registry.types.js";
+import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
 
@@ -161,6 +162,16 @@ export async function registerPluginSubagentRunFromGateway(params: {
 }): Promise<void> {
   const childSessionKey = params.childSessionKey.trim();
   if (!childSessionKey) {
+    return;
+  }
+
+  if (
+    await reactivateCompletedSubagentSession({
+      sessionKey: childSessionKey,
+      runId: params.runId,
+      task: params.task,
+    })
+  ) {
     return;
   }
   const ownerSessionKey = resolveAgentMainSessionKey({

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -367,6 +367,104 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("adopts a sessions_yield-paused subagent row when a plugin follows it up", async () => {
+    await withTempDir(
+      { prefix: "openclaw-gateway-plugin-subagent-yield-followup-" },
+      async (root) => {
+        useTestStateDir(root);
+        resetAgentTaskRegistryForTests();
+        resetSubagentRegistryForTests({ persist: false });
+        const childSessionKey = "agent:work:subagent:yield-followup";
+        const parentSessionKey = "agent:main:telegram:direct:555";
+        const followUpRunId = "plugin-followup-run";
+        // The parent spawned this child expecting a completion message, then the
+        // child parked itself with sessions_yield: terminal execution, no outcome.
+        const pausedRun = {
+          runId: "parent-spawned-paused-run",
+          childSessionKey,
+          controllerSessionKey: "agent:work:main",
+          requesterSessionKey: parentSessionKey,
+          requesterDisplayKey: parentSessionKey,
+          task: "original spawned task",
+          cleanup: "keep" as const,
+          createdAt: 1,
+          expectsCompletionMessage: true,
+          pauseReason: "sessions_yield" as const,
+          execution: {
+            status: "terminal" as const,
+            startedAt: 2,
+            endedAt: 3,
+          },
+        };
+
+        const cfg = {
+          session: { mainKey: "main", scope: "per-sender" },
+          agents: {
+            defaults: {
+              model: { primary: "anthropic/claude-sonnet-4-6" },
+              models: {
+                "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+              },
+            },
+            list: [{ id: "main", default: true }, { id: "work" }],
+          },
+        };
+        mocks.listAgentIds.mockReturnValue(["main", "work"]);
+        mocks.loadConfigReturn = cfg;
+        mocks.loadSessionEntry.mockReturnValue({
+          cfg,
+          storePath: "/tmp/sessions.json",
+          entry: { sessionId: "yield-followup-session", updatedAt: Date.now() },
+          canonicalKey: childSessionKey,
+        });
+        mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+          const store: Record<string, unknown> = {
+            [childSessionKey]: { sessionId: "yield-followup-session", updatedAt: Date.now() },
+          };
+          return await updater(store);
+        });
+        mocks.getLatestSubagentRunByChildSessionKey.mockReturnValueOnce(pausedRun);
+        mocks.replaceSubagentRunAfterSteer.mockReturnValueOnce(true);
+        mocks.agentCommand.mockResolvedValue({
+          payloads: [{ text: "follow-up done" }],
+          meta: { durationMs: 100 },
+        });
+        const context = makeContext();
+        const baseClient = requireValue(backendGatewayClient(), "expected backend client");
+        const pluginClient: AgentHandlerArgs["client"] = {
+          connect: baseClient.connect,
+          internal: {
+            ...baseClient.internal,
+            agentRunTracking: "plugin_subagent",
+            pluginRuntimeOwnerId: "memory-core",
+          },
+        };
+
+        await invokeAgent(
+          {
+            message: "continue the parked work",
+            sessionKey: childSessionKey,
+            idempotencyKey: followUpRunId,
+          },
+          { context, reqId: followUpRunId, client: pluginClient },
+        );
+
+        // Gateway admission must adopt the paused row through the same reactivation
+        // the execution phase already uses. Minting a row here instead outranks the
+        // paused row and degrades its requester to the child's own main session, so
+        // the parent waiting on this child never receives its announce.
+        expect(mocks.replaceSubagentRunAfterSteer).toHaveBeenCalledWith({
+          previousRunId: pausedRun.runId,
+          nextRunId: followUpRunId,
+          fallback: pausedRun,
+          runTimeoutSeconds: 0,
+          task: "continue the parked work",
+        });
+        expect(getSubagentRunByChildSessionKey(childSessionKey)).toBeNull();
+      },
+    );
+  });
+
   it("rejects plugin SDK subagent runs and releases admission when registry persistence fails", async () => {
     await withTempDir(
       { prefix: "openclaw-gateway-plugin-subagent-registry-fail-" },


### PR DESCRIPTION
Closes #120157



## What Problem This Solves

Fixes an issue where an agent that spawned a subagent and then parked itself with `sessions_yield` would hang permanently if a plugin followed that subagent up through `runtime.subagent.run`. The subagent's run finished normally, but its result never flowed back and the parent was never woken, with nothing surfaced to explain why.

## Why This Change Was Made

The gateway already owns this behavior. `reactivateCompletedSubagentSession` adopts an ended row for a child session and preserves its original requester, and the execution phase calls it on every non-one-shot run. `plugin_subagent` is the only tracking mode that also registers a row during the admission phase, which runs first. That fresh row is minted at a higher generation, so the generation-ordered lookup in the execution phase returns the new running row, its `endedAt` guard bails, and the paused row is never adopted.

This routes the plugin path through that same helper before minting, so it reaches the identical owner boundary as CLI and `sessions.send` follow-ups instead of pre-empting it. No new helper, no new exported surface, no parallel path. +11 production lines, justified by the ownership boundary it restores.

Non-goals, tracked separately: `replaceSubagentRunAfterSteer` clears `requesterSettleWake`, which is defensible for an operator steer but drops a yielded parent's frozen batch on adoption; and `listPendingCompletionRunsForSession` lacks the `pauseReason` filter its sibling writer 15 lines above already has. Both touch surfaces shared with steer, the sweeper, and restart recovery, so they belong in their own change.

## User Impact

Orchestration patterns that park a subagent on a long-running or remote task and follow it up from a plugin now complete. The parent receives its announce with the subagent's result and can decide what happens next, instead of hanging with no visible outcome.

## Evidence

Focused boundary proof, `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts` on Node 24.15.0:

- With the fix: `Tests  275 passed (275)`
- With the adoption branch disabled: `Tests  1 failed | 274 passed (275)`, failing as `AssertionError: expected { runId: 'plugin-followup-run', ... } to be null`

The new case drives the real gateway `agent` method with a `plugin_subagent` client against a `sessions_yield`-paused row owned by a different parent, and asserts admission adopts that row (`replaceSubagentRunAfterSteer` called with the paused runId and the follow-up task) rather than minting a new one.

Scope note: this suite mocks `subagent-registry-read.js`, so the case proves the admission path now consults reactivation, not end-to-end registry adoption. Happy to add the registry-level half in `src/agents/subagent-registry.test.ts` beside the existing yield-paused case if reviewers want it.

Production/test LOC delta: +11 production, +98 test.
