### PR TITLE
fix(cli-runner): preserve streamed assistant text when a claude live turn is aborted

### DIFF
--- a/src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts
+++ b/src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts
@@ -1,0 +1,133 @@
+/** Claude live session: aborted turns must surface already-streamed assistant text. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import { buildClaudeLiveRunContext, mockClaudeLiveRun } from "../cli-runner.test-helpers.js";
+import { supervisorSpawnMock } from "../cli-runner.test-support.js";
+import { runClaudeLiveSessionTurn } from "./claude-live-session.js";
+import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+beforeEach(() => {
+  resetClaudeLiveSessionsForTest();
+  supervisorSpawnMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetClaudeLiveSessionsForTest();
+});
+
+function getProcessSupervisorForTest() {
+  return {
+    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    getRecord: vi.fn(),
+  };
+}
+
+function startLiveTurnWithAbortSignal(runId: string, signal: AbortSignal) {
+  const context = buildClaudeLiveRunContext({ runId, timeoutMs: 60_000 });
+  context.params = { ...context.params, abortSignal: signal };
+  return runClaudeLiveSessionTurn({
+    context,
+    args: context.preparedBackend.backend.args ?? [],
+    env: {},
+    prompt: "hi",
+    useResume: false,
+    noOutputTimeoutMs: 5_000,
+    getProcessSupervisor: getProcessSupervisorForTest,
+    onAssistantDelta: () => {},
+    cleanup: async () => {},
+  });
+}
+
+describe("claude live session aborted-turn partial output", () => {
+  it("resolves an aborted turn with the assistant text streamed before the abort", async () => {
+    const controller = new AbortController();
+    let textEmitted = false;
+    const fixture = mockClaudeLiveRun(supervisorSpawnMock, {
+      onWrite: ({ emit }) => {
+        emit([
+          { type: "system", subtype: "init", session_id: "live-abort-partial" },
+          {
+            type: "stream_event",
+            session_id: "live-abort-partial",
+            event: {
+              type: "content_block_delta",
+              delta: { type: "text_delta", text: "Here is the answer so far" },
+            },
+          },
+        ]);
+        textEmitted = true;
+      },
+    });
+
+    const turnPromise = startLiveTurnWithAbortSignal("run-abort-partial", controller.signal);
+    // Wait until the stdin write drove the streaming events above; aborting
+    // before any text streams must keep the existing reject behavior.
+    await vi.waitFor(() => {
+      expect(textEmitted).toBe(true);
+    });
+    controller.abort();
+
+    await expect(turnPromise).resolves.toMatchObject({
+      output: { text: expect.stringContaining("Here is the answer so far") },
+    });
+    expect(fixture.lifecycle.cancel).toHaveBeenCalledWith("manual-cancel");
+  });
+
+  it("still rejects genuine CLI failures after streamed text instead of masking them", async () => {
+    const controller = new AbortController();
+    mockClaudeLiveRun(supervisorSpawnMock, {
+      onWrite: ({ emit }) => {
+        emit([
+          { type: "system", subtype: "init", session_id: "live-abort-failover" },
+          {
+            type: "assistant",
+            session_id: "live-abort-failover",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Partial answer before failure" }],
+            },
+          },
+          {
+            type: "result",
+            subtype: "error_during_execution",
+            is_error: true,
+            session_id: "live-abort-failover",
+            result: "tool failed",
+          },
+        ]);
+      },
+    });
+
+    const turnPromise = startLiveTurnWithAbortSignal("run-abort-failover", controller.signal);
+    await expect(turnPromise).rejects.toMatchObject({
+      name: "FailoverError",
+    });
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it("still rejects an abort when no assistant text was streamed yet", async () => {
+    const controller = new AbortController();
+    mockClaudeLiveRun(supervisorSpawnMock, {
+      onWrite: ({ emit }) => {
+        emit([{ type: "system", subtype: "init", session_id: "live-abort-empty" }]);
+      },
+    });
+
+    const turnPromise = startLiveTurnWithAbortSignal("run-abort-empty", controller.signal);
+    await vi.waitFor(() => {
+      expect(supervisorSpawnMock).toHaveBeenCalledOnce();
+    });
+    controller.abort();
+
+    await expect(turnPromise).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -4,7 +4,10 @@
 import crypto from "node:crypto";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
-import { createAbortError as createNamedAbortError } from "../../infra/abort-signal.js";
+import {
+  createAbortError as createNamedAbortError,
+  isAbortError,
+} from "../../infra/abort-signal.js";
 import {
   emitTrustedDiagnosticEvent,
   type DiagnosticToolParamsSummary,
@@ -516,6 +519,23 @@ function failTurn(session: ClaudeLiveSession, error: unknown): void {
   clearTurnTimers(turn);
   clearOutstandingBackgroundTasks(session);
   session.currentTurn = null;
+  // An aborted turn may already have streamed a complete or near-complete
+  // answer. Settle it with the parsed partial output instead of rejecting so
+  // the transcript flush and agent_end hooks still run — mirroring the
+  // embedded runner, which settles aborted attempts rather than rethrowing and
+  // silently starving every agent_end consumer (attempt-stream-finalize.ts).
+  // Genuine failures (FailoverError paths) keep rejecting so fallback works.
+  if (isAbortError(error)) {
+    const partialOutput = turn.streamingParser.getOutput();
+    if (partialOutput?.text?.trim()) {
+      cliBackendLog.info(
+        `claude live session aborted turn preserved partial output: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} ${formatCliBackendOutputDigest(partialOutput.text)}`,
+      );
+      turn.resolve(partialOutput);
+      scheduleIdleClose(session);
+      return;
+    }
+  }
   turn.reject(error);
 }
 


### PR DESCRIPTION
Fixes #120207

## What Problem This Solves

In the claude-cli live-session backend, `failTurn()` discards the turn's accumulated streamed output. It calls `turn.streamingParser.finish()` — the exact same call `finishTurn()` makes — and then rejects the turn promise without ever reading `turn.streamingParser.getOutput()` (`src/agents/cli-runner/claude-live-session.ts:538`). Every abort path funnels through `failTurn` (`abortTurn` → `closeLiveSession(session, "abort", error)`), so an aborted turn yields **zero** assistant text to the caller, even when the model had already streamed a complete or near-complete answer.

The embedded (non-CLI) runner explicitly does *not* behave this way: it settles aborted attempts so transcript flush and `agent_end` still run, with a comment stating that rethrowing "silently starves every agent_end consumer for aborted runs" (`src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts:79`). The CLI runner was the outlier — an asymmetry between two runners, not a missing seam.

## Why

User-visible effect of the bug: an aborted turn shows as a message that was never answered — no assistant text and no error entry in the transcript, even though the JSONL raw lines were parsed and streamed. `failTurn` already reports partial state for tool calls (`failActiveClaudeLiveTools` emits `tool.execution.error` with `errorCategory="aborted"` at `src/agents/cli-runner/claude-live-session.ts:776`); assistant text was the one thing it dropped. Aborted results already do not trigger model fallback (`src/agents/embedded-agent-runner/result-fallback-classifier.ts:187` checks `result.meta.aborted`), so settling the turn with partial output cannot start a fallback chain.

## User Impact

Users running agents on a `claude-cli` provider who abort an in-flight turn (via `abortChatRunById` with a timeout stop reason, the gateway's stuck-session recovery `abort_embedded_run` path, or any abortSignal trip) now keep whatever assistant text was already produced: the partial answer is persisted to the transcript and `agent_end`/`llm_output` hook consumers run, matching the embedded runner. Aborts with no streamed text, and genuine failures (CLI errors, timeouts, output-limit aborts — all `FailoverError` paths), behave exactly as before: they reject and fall back as usual.

## Evidence

**Change** — `src/agents/cli-runner/claude-live-session.ts`, `failTurn()`: after `streamingParser.finish()`, when the error is an abort (`isAbortError`) and the parser has substantive text, resolve the turn with the partial output (plus the same `scheduleIdleClose` tail `finishTurn` uses) instead of rejecting. `FailoverError` paths are untouched.

**Inline verification** — new focused suite `src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts` (3 tests, runs in both `agents-core` and `agents-support` projects):

1. `resolves an aborted turn with the assistant text streamed before the abort` — streams `stream_event`/`content_block_delta` text, then aborts mid-turn; asserts the turn **resolves** with `output.text` containing the streamed text (previously it rejected with `AbortError` and dropped the text).
2. `still rejects genuine CLI failures after streamed text instead of masking them` — streams text then a `result` with `error_during_execution`; asserts it still **rejects with `FailoverError`** so fallback is preserved.
3. `still rejects an abort when no assistant text was streamed yet` — aborts after `init` only; asserts it still **rejects with `AbortError`** (no empty-output resolution).

**Before/after** (test 1, captured during development): before the fix `failTurn` logged `{ errorKind: 'AbortError', isAbort: true, output: null }` and the turn rejected; after the fix the same abort resolves with `output: { text: 'Here is the answer so far', ... }` and the run settles so transcript flush and `agent_end` run.

**Regression run** — `claude-live-session.background-tasks.test.ts` (20), `claude-live-session.capability.test.ts` (4), `claude-live-session.abort-partial-output.test.ts` (3): **54/54 pass** across both workspace projects. `pnpm tsgo:core` and `pnpm tsgo:core:test` both exit 0; `oxlint` clean on both changed files.

[AI-assisted]
