### PR TITLE
fix: TUI source smoke no longer fails without a build

### DIFF
--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -63,6 +63,9 @@ type GatewayScenario = MockModelBehavior & {
 };
 
 const SHARED_GATEWAY_AGENT_ID = "tui-pty-gateway";
+// These cases spawn openclaw.mjs outside the source TUI runner. CI opts in only
+// after the exact head has a complete build, so source-mode PTY smoke must skip them.
+const itWithBuiltCli = process.env.OPENCLAW_TUI_PTY_USE_BUILT_CLI === "1" ? it : it.skip;
 
 const GATEWAY_SCENARIOS = {
   validation: {
@@ -1344,7 +1347,7 @@ describe("TUI PTY real backends", () => {
     LOCAL_TEST_TIMEOUT_MS,
   );
 
-  it(
+  itWithBuiltCli(
     "repairs isolated config through the approved built CLI and resumes local chat",
     async ({ onTestFinished }) => {
       const fixture = await startLocalModeTui(onTestFinished, {
@@ -1398,7 +1401,7 @@ describe("TUI PTY real backends", () => {
     LOCAL_TEST_TIMEOUT_MS,
   );
 
-  it(
+  itWithBuiltCli(
     "authenticates a manifest-discovered provider and resumes the unchanged local model",
     async ({ onTestFinished }) => {
       const pluginId = "t05-local-auth-fixture";


### PR DESCRIPTION
Closes #120220

## What Problem This Solves

Fixes an issue where developers running the documented source-mode TUI PTY smoke command would wait roughly sixteen minutes and receive two false failures when the checkout had not already produced `dist/entry.js` or `dist/entry.mjs`.

## Why This Change Was Made

Two cases invoke the repository launcher outside the source-backed TUI runner: one explicitly verifies config repair through the built CLI, and the manifest-provider auth flow resumes through the same launcher boundary. They now share the existing `OPENCLAW_TUI_PTY_USE_BUILT_CLI=1` opt-in that CI sets only after building the exact head. Source-mode smoke keeps all source-backed coverage and skips only these packaged-launcher cases.

Production LOC: +0/-0. Test code: +5/-2. No config, protocol, storage, or runtime behavior changes.

## User Impact

There is no product runtime change. Developers get a trustworthy source-mode TUI smoke result instead of deterministic missing-build noise, while built CI continues to exercise both launcher-dependent flows.

## Evidence

- Current-main repro on `f4387b7a5effd63fe2c0f05495175b9eacd12cec`: 84/86 TUI PTY cases passed; the two launcher-dependent cases failed after 975 seconds because `openclaw.mjs` had no build output. Cross-surface run: https://github.com/openclaw/openclaw/actions/runs/31168697912
- Exact built control before the patch: both cases passed in 35.9 seconds. https://github.com/openclaw/openclaw/actions/runs/31170850345
- Patched exact-head proof: source mode skipped the two cases in 6 seconds, then a production build ran both successfully in 35.9 seconds. https://github.com/openclaw/openclaw/actions/runs/31171350803
- Node 24 changed gate: formatting, core-test typecheck/lint, dependency and boundary guards all passed. https://github.com/openclaw/openclaw/actions/runs/31171850533
- P2 AutoReview: clean, no accepted/actionable findings, confidence 0.94.
- Gateway/node product E2Es and the complete Control UI Chromium suite also passed in the discovery run above.

Strict source-blind validation was not claimed because this one-thread campaign had already inspected the implementation before runtime validation.
