### PR TITLE
chore(cua-computer): pin CUA Driver 0.19.0

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -16,7 +16,7 @@ The agent emits one uniform command, `computer.act`; it cannot tell how a node f
 - A paired, connected node advertising both `computer.act` and `screen.snapshot`, with `screen.snapshot` returning `displayFrameId`.
 - **macOS fulfiller:** app setting **Allow Computer Control** enabled. It defaults on; an explicit off choice stays off.
 - **macOS fulfiller:** **Accessibility** and Event Posting access granted to OpenClaw (for pointer/keyboard injection), plus **Screen Recording** permission (for `screen.snapshot`).
-- **Windows/Linux fulfiller:** bundled `cua-computer` plugin enabled. Its package includes the pinned CUA Driver SDK 0.14.1 runtime; no `cua-driver` executable, daemon, or MCP server is configured.
+- **Windows/Linux fulfiller:** bundled `cua-computer` plugin enabled. Its package includes the pinned CUA Driver SDK 0.19.0 runtime; no `cua-driver` executable, daemon, or MCP server is configured.
 - The pairing update that includes `computer.act` approved on the gateway.
 - A vision-capable agent model.
 - Tool policy that exposes `computer`. The default `coding` profile does not. Add `computer` to `tools.alsoAllow`; sandboxed agents also need it in `tools.sandbox.tools.alsoAllow`.
@@ -37,7 +37,7 @@ Screenshots are kept **model-only**: they are never auto-delivered to the chat c
 
 ## Windows and Linux (experimental, via CUA Driver SDK)
 
-The bundled `cua-computer` plugin provides an experimental fulfiller for Windows and Linux node hosts. It is disabled by default and uses the pinned CUA Driver SDK 0.14.1 contract directly:
+The bundled `cua-computer` plugin provides an experimental fulfiller for Windows and Linux node hosts. It is disabled by default and uses the pinned CUA Driver SDK 0.19.0 contract directly:
 
 1. Enable the plugin:
 

--- a/docs/plugins/reference/cua-computer.md
+++ b/docs/plugins/reference/cua-computer.md
@@ -9,7 +9,7 @@ title: "Cua Computer plugin"
 
 Experimental CUA Driver SDK computer control for Windows and Linux node hosts. It preserves
 the node `screen.snapshot` and `computer.act` contract while using a configured, trusted
-CUA Driver 0.14.1 SDK session directly; it does not run a CUA daemon or MCP proxy.
+CUA Driver 0.19.0 SDK session directly; it does not run a CUA daemon or MCP proxy.
 
 ## Distribution
 

--- a/docs/plugins/reference/cua-computer.md
+++ b/docs/plugins/reference/cua-computer.md
@@ -7,9 +7,7 @@ title: "Cua Computer plugin"
 
 # Cua Computer plugin
 
-Experimental CUA Driver SDK computer control for Windows and Linux node hosts. It preserves
-the node `screen.snapshot` and `computer.act` contract while using a configured, trusted
-CUA Driver 0.19.0 SDK session directly; it does not run a CUA daemon or MCP proxy.
+Experimental CUA Driver SDK computer control for Windows and Linux node hosts.
 
 ## Distribution
 

--- a/extensions/cua-computer/package.json
+++ b/extensions/cua-computer/package.json
@@ -4,7 +4,7 @@
   "description": "Experimental CUA Driver SDK computer control for Windows and Linux node hosts",
   "type": "module",
   "dependencies": {
-    "@trycua/cua-driver": "0.14.1",
+    "@trycua/cua-driver": "0.19.0",
     "rastermill": "0.3.1",
     "zod": "4.4.3"
   },

--- a/extensions/cua-computer/src/driver-client.ts
+++ b/extensions/cua-computer/src/driver-client.ts
@@ -16,7 +16,7 @@ type CuaDriverSdk = Pick<
 
 export type CuaToolResult = import("@trycua/cua-driver").ToolResult;
 
-// These numeric values are part of the pinned 0.14.1 SDK contract and are also
+// These numeric values are part of the pinned 0.19.0 SDK contract and are also
 // frozen in driver-contract-fixtures. Keeping them local avoids loading the
 // native library while OpenClaw is only registering the bundled plugin.
 export const ClickButton = {

--- a/extensions/cua-computer/src/driver-contract-fixtures.test-fixtures.ts
+++ b/extensions/cua-computer/src/driver-contract-fixtures.test-fixtures.ts
@@ -1,32 +1,32 @@
 /**
- * Frozen CUA Driver 0.14.1 desktop contract fixtures used by the CUA fulfiller tests.
+ * Frozen CUA Driver 0.19.0 desktop contract fixtures used by the CUA fulfiller tests.
  *
- * Evidence: cua-driver-rs-v0.14.1 (41ae29b44b49b68c6e01c934fffbbe74d22e26fb)
- * and @trycua/cua-driver@0.14.1. The SDK declarations name these methods with
+ * Evidence: cua-driver-rs-v0.19.0 (bb8efbfe6caadbccba54221096d959607ed9f574)
+ * and @trycua/cua-driver@0.19.0. The SDK declarations name these methods with
  * camelCase and encode DesktopScope.Desktop as 0; MCP uses the snake_case tool
  * names and the "desktop" scope string below.
  */
-export const CUA_DRIVER_0141_CONTRACT = {
-  version: "0.14.1",
-  releaseTag: "cua-driver-rs-v0.14.1",
-  releaseCommit: "41ae29b44b49b68c6e01c934fffbbe74d22e26fb",
+export const CUA_DRIVER_0190_CONTRACT = {
+  version: "0.19.0",
+  releaseTag: "cua-driver-rs-v0.19.0",
+  releaseCommit: "bb8efbfe6caadbccba54221096d959607ed9f574",
   npmIntegrity:
-    "sha512-/o16k+vcTbdqwmvQqgFCKzrYksSQHz282qO8RkpD67GQoY4Vp3pyDndQexRJ8AbzNQpUt1bIXSAAaFBaMad6rg==",
+    "sha512-IyQ+yWQdgumtxWSSO1ueQQQGi7lqhecawwo2JrXhV88I2y62LhGaAzUDcdyg3TNTSCw3hsovMQrkj+sYhEy9jw==",
   serverName: "cua-driver",
   capabilityVersion: "1",
   schemaVersion: "1",
 } as const;
 
-export const CUA_DRIVER_0141_SDK_DESKTOP_SCOPE = 0 as const;
+export const CUA_DRIVER_0190_SDK_DESKTOP_SCOPE = 0 as const;
 
-export const CUA_DRIVER_0141_SDK_FIXTURES = {
+export const CUA_DRIVER_0190_SDK_FIXTURES = {
   getDesktopState: {},
   getScreenSize: {},
   getCursorPosition: {},
   click: {
     x: 960,
     y: 540,
-    scope: CUA_DRIVER_0141_SDK_DESKTOP_SCOPE,
+    scope: CUA_DRIVER_0190_SDK_DESKTOP_SCOPE,
     button: 0,
     count: 1,
   },
@@ -35,35 +35,35 @@ export const CUA_DRIVER_0141_SDK_FIXTURES = {
     fromY: 200,
     toX: 960,
     toY: 540,
-    scope: CUA_DRIVER_0141_SDK_DESKTOP_SCOPE,
+    scope: CUA_DRIVER_0190_SDK_DESKTOP_SCOPE,
     durationMs: 500n,
   },
-  moveCursor: { x: 960, y: 540, scope: CUA_DRIVER_0141_SDK_DESKTOP_SCOPE },
+  moveCursor: { x: 960, y: 540, scope: CUA_DRIVER_0190_SDK_DESKTOP_SCOPE },
   scroll: {
     x: 960,
     y: 540,
     direction: 1,
-    scope: CUA_DRIVER_0141_SDK_DESKTOP_SCOPE,
+    scope: CUA_DRIVER_0190_SDK_DESKTOP_SCOPE,
     by: 0,
     amount: 3n,
   },
-  typeText: { text: "hello", scope: CUA_DRIVER_0141_SDK_DESKTOP_SCOPE },
+  typeText: { text: "hello", scope: CUA_DRIVER_0190_SDK_DESKTOP_SCOPE },
   pressKey: {
     key: "enter",
-    scope: CUA_DRIVER_0141_SDK_DESKTOP_SCOPE,
+    scope: CUA_DRIVER_0190_SDK_DESKTOP_SCOPE,
     modifiers: ["shift"],
   },
-  hotkey: { keys: ["ctrl", "c"], scope: CUA_DRIVER_0141_SDK_DESKTOP_SCOPE },
+  hotkey: { keys: ["ctrl", "c"], scope: CUA_DRIVER_0190_SDK_DESKTOP_SCOPE },
 } as const;
 
-export const CUA_DRIVER_0141_MCP_FIXTURES = {
+export const CUA_DRIVER_0190_MCP_FIXTURES = {
   serverInfo: {
-    name: CUA_DRIVER_0141_CONTRACT.serverName,
-    version: CUA_DRIVER_0141_CONTRACT.version,
+    name: CUA_DRIVER_0190_CONTRACT.serverName,
+    version: CUA_DRIVER_0190_CONTRACT.version,
   },
   toolsList: {
-    capability_version: CUA_DRIVER_0141_CONTRACT.capabilityVersion,
-    schema_version: CUA_DRIVER_0141_CONTRACT.schemaVersion,
+    capability_version: CUA_DRIVER_0190_CONTRACT.capabilityVersion,
+    schema_version: CUA_DRIVER_0190_CONTRACT.schemaVersion,
   },
   desktopState: {
     platform: "linux",
@@ -78,7 +78,7 @@ export const CUA_DRIVER_0141_MCP_FIXTURES = {
   screenSize: { width: 3840, height: 2160, scale_factor: 1 },
 } as const;
 
-export const CUA_DRIVER_0141_FAILURE_FIXTURES = {
+export const CUA_DRIVER_0190_FAILURE_FIXTURES = {
   invalidArguments: {
     isError: true,
     content: [{ type: "text", text: "click: invalid arguments: missing field `x`" }],
@@ -91,12 +91,12 @@ export const CUA_DRIVER_0141_FAILURE_FIXTURES = {
   },
 } as const;
 
-export const CUA_DRIVER_0141_GENERATION_FIXTURE = {
+export const CUA_DRIVER_0190_GENERATION_FIXTURE = {
   initial: "connection-e8dcf30c",
   reconnected: "connection-7857c486",
 } as const;
 
-export const CUA_DRIVER_0141_DESKTOP_OPERATIONS = [
+export const CUA_DRIVER_0190_DESKTOP_OPERATIONS = [
   "get_desktop_state",
   "get_screen_size",
   "get_cursor_position",
@@ -109,10 +109,10 @@ export const CUA_DRIVER_0141_DESKTOP_OPERATIONS = [
   "hotkey",
 ] as const;
 
-type CuaDriver0141DesktopOperation = (typeof CUA_DRIVER_0141_DESKTOP_OPERATIONS)[number];
-type CuaDriver0141SdkMethod = keyof typeof CUA_DRIVER_0141_SDK_FIXTURES;
+type CuaDriver0190DesktopOperation = (typeof CUA_DRIVER_0190_DESKTOP_OPERATIONS)[number];
+type CuaDriver0190SdkMethod = keyof typeof CUA_DRIVER_0190_SDK_FIXTURES;
 
-export const CUA_DRIVER_0141_COMPUTER_ACT_PARITY = [
+export const CUA_DRIVER_0190_COMPUTER_ACT_PARITY = [
   {
     operation: "get_desktop_state",
     sdkMethod: "getDesktopState",
@@ -174,8 +174,8 @@ export const CUA_DRIVER_0141_COMPUTER_ACT_PARITY = [
     computerActions: [],
   },
 ] as const satisfies readonly {
-  operation: CuaDriver0141DesktopOperation;
-  sdkMethod: CuaDriver0141SdkMethod;
+  operation: CuaDriver0190DesktopOperation;
+  sdkMethod: CuaDriver0190SdkMethod;
   disposition: "screen.snapshot" | "frame verification" | "computer.act" | "not projected";
   computerActions: readonly string[];
 }[];
@@ -198,10 +198,10 @@ export const COMPUTER_ACT_ACTION_FIXTURES = [
   "wait",
 ] as const;
 
-export const CUA_DRIVER_0141_UNSUPPORTED_COMPUTER_ACT_ACTIONS = [
+export const CUA_DRIVER_0190_UNSUPPORTED_COMPUTER_ACT_ACTIONS = [
   "hold_key",
   "left_mouse_down",
   "left_mouse_up",
 ] as const;
 
-export const CUA_DRIVER_0141_CORE_LOCAL_COMPUTER_ACT_ACTIONS = ["wait"] as const;
+export const CUA_DRIVER_0190_CORE_LOCAL_COMPUTER_ACT_ACTIONS = ["wait"] as const;

--- a/extensions/cua-computer/src/driver-contract-fixtures.test.ts
+++ b/extensions/cua-computer/src/driver-contract-fixtures.test.ts
@@ -1,60 +1,60 @@
 import { describe, expect, it } from "vitest";
 import {
   COMPUTER_ACT_ACTION_FIXTURES,
-  CUA_DRIVER_0141_COMPUTER_ACT_PARITY,
-  CUA_DRIVER_0141_CONTRACT,
-  CUA_DRIVER_0141_CORE_LOCAL_COMPUTER_ACT_ACTIONS,
-  CUA_DRIVER_0141_DESKTOP_OPERATIONS,
-  CUA_DRIVER_0141_FAILURE_FIXTURES,
-  CUA_DRIVER_0141_GENERATION_FIXTURE,
-  CUA_DRIVER_0141_MCP_FIXTURES,
-  CUA_DRIVER_0141_SDK_DESKTOP_SCOPE,
-  CUA_DRIVER_0141_SDK_FIXTURES,
-  CUA_DRIVER_0141_UNSUPPORTED_COMPUTER_ACT_ACTIONS,
+  CUA_DRIVER_0190_COMPUTER_ACT_PARITY,
+  CUA_DRIVER_0190_CONTRACT,
+  CUA_DRIVER_0190_CORE_LOCAL_COMPUTER_ACT_ACTIONS,
+  CUA_DRIVER_0190_DESKTOP_OPERATIONS,
+  CUA_DRIVER_0190_FAILURE_FIXTURES,
+  CUA_DRIVER_0190_GENERATION_FIXTURE,
+  CUA_DRIVER_0190_MCP_FIXTURES,
+  CUA_DRIVER_0190_SDK_DESKTOP_SCOPE,
+  CUA_DRIVER_0190_SDK_FIXTURES,
+  CUA_DRIVER_0190_UNSUPPORTED_COMPUTER_ACT_ACTIONS,
 } from "./driver-contract-fixtures.test-fixtures.js";
 
-describe("cua-driver 0.14.1 computer.act parity fixtures", () => {
+describe("cua-driver 0.19.0 computer.act parity fixtures", () => {
   it("pins the released CUA driver identity and SDK desktop-scope representation", () => {
-    expect(CUA_DRIVER_0141_CONTRACT).toMatchObject({
-      version: "0.14.1",
-      releaseTag: "cua-driver-rs-v0.14.1",
-      releaseCommit: "41ae29b44b49b68c6e01c934fffbbe74d22e26fb",
+    expect(CUA_DRIVER_0190_CONTRACT).toMatchObject({
+      version: "0.19.0",
+      releaseTag: "cua-driver-rs-v0.19.0",
+      releaseCommit: "bb8efbfe6caadbccba54221096d959607ed9f574",
       serverName: "cua-driver",
       capabilityVersion: "1",
       schemaVersion: "1",
     });
-    expect(CUA_DRIVER_0141_SDK_FIXTURES.click.scope).toBe(CUA_DRIVER_0141_SDK_DESKTOP_SCOPE);
-    expect(CUA_DRIVER_0141_SDK_FIXTURES.drag.durationMs).toBe(500n);
-    expect(Object.keys(CUA_DRIVER_0141_SDK_FIXTURES)).toEqual(
-      CUA_DRIVER_0141_COMPUTER_ACT_PARITY.map(({ sdkMethod }) => sdkMethod),
+    expect(CUA_DRIVER_0190_SDK_FIXTURES.click.scope).toBe(CUA_DRIVER_0190_SDK_DESKTOP_SCOPE);
+    expect(CUA_DRIVER_0190_SDK_FIXTURES.drag.durationMs).toBe(500n);
+    expect(Object.keys(CUA_DRIVER_0190_SDK_FIXTURES)).toEqual(
+      CUA_DRIVER_0190_COMPUTER_ACT_PARITY.map(({ sdkMethod }) => sdkMethod),
     );
-    expect(CUA_DRIVER_0141_MCP_FIXTURES.desktopState.screenshot_mime_type).toBe("image/png");
+    expect(CUA_DRIVER_0190_MCP_FIXTURES.desktopState.screenshot_mime_type).toBe("image/png");
   });
 
   it("freezes driver failures and reconnect generations for later runtime migration", () => {
-    expect(CUA_DRIVER_0141_FAILURE_FIXTURES.invalidArguments).toMatchObject({
+    expect(CUA_DRIVER_0190_FAILURE_FIXTURES.invalidArguments).toMatchObject({
       isError: true,
       structuredContent: { code: "invalid_arguments", tool: "click" },
     });
-    expect(CUA_DRIVER_0141_FAILURE_FIXTURES.refusal).toMatchObject({
+    expect(CUA_DRIVER_0190_FAILURE_FIXTURES.refusal).toMatchObject({
       isError: true,
       structuredContent: { code: "desktop_unavailable" },
     });
-    expect(typeof CUA_DRIVER_0141_GENERATION_FIXTURE.initial).toBe("string");
-    expect(CUA_DRIVER_0141_GENERATION_FIXTURE.reconnected).not.toBe(
-      CUA_DRIVER_0141_GENERATION_FIXTURE.initial,
+    expect(typeof CUA_DRIVER_0190_GENERATION_FIXTURE.initial).toBe("string");
+    expect(CUA_DRIVER_0190_GENERATION_FIXTURE.reconnected).not.toBe(
+      CUA_DRIVER_0190_GENERATION_FIXTURE.initial,
     );
   });
 
   it("classifies every frozen desktop operation and computer action exactly once", () => {
-    const operations = CUA_DRIVER_0141_COMPUTER_ACT_PARITY.map(({ operation }) => operation);
+    const operations = CUA_DRIVER_0190_COMPUTER_ACT_PARITY.map(({ operation }) => operation);
     expect(new Set(operations).size).toBe(operations.length);
-    expect(new Set(operations)).toEqual(new Set(CUA_DRIVER_0141_DESKTOP_OPERATIONS));
+    expect(new Set(operations)).toEqual(new Set(CUA_DRIVER_0190_DESKTOP_OPERATIONS));
 
     const classifiedActions = [
-      ...CUA_DRIVER_0141_COMPUTER_ACT_PARITY.flatMap(({ computerActions }) => computerActions),
-      ...CUA_DRIVER_0141_UNSUPPORTED_COMPUTER_ACT_ACTIONS,
-      ...CUA_DRIVER_0141_CORE_LOCAL_COMPUTER_ACT_ACTIONS,
+      ...CUA_DRIVER_0190_COMPUTER_ACT_PARITY.flatMap(({ computerActions }) => computerActions),
+      ...CUA_DRIVER_0190_UNSUPPORTED_COMPUTER_ACT_ACTIONS,
+      ...CUA_DRIVER_0190_CORE_LOCAL_COMPUTER_ACT_ACTIONS,
     ];
     expect(classifiedActions).toHaveLength(COMPUTER_ACT_ACTION_FIXTURES.length);
     expect(new Set(classifiedActions).size).toBe(COMPUTER_ACT_ACTION_FIXTURES.length);
@@ -63,12 +63,12 @@ describe("cua-driver 0.14.1 computer.act parity fixtures", () => {
 
   it("keeps the existing model-facing projection narrow", () => {
     expect(
-      CUA_DRIVER_0141_COMPUTER_ACT_PARITY.filter(
+      CUA_DRIVER_0190_COMPUTER_ACT_PARITY.filter(
         ({ disposition }) => disposition === "computer.act",
       ).map(({ operation }) => operation),
     ).toEqual(["click", "drag", "move_cursor", "scroll", "type_text", "press_key"]);
     expect(
-      CUA_DRIVER_0141_COMPUTER_ACT_PARITY.filter(
+      CUA_DRIVER_0190_COMPUTER_ACT_PARITY.filter(
         ({ disposition }) => disposition === "not projected",
       ).map(({ operation }) => operation),
     ).toEqual(["get_cursor_position", "hotkey"]);

--- a/package.json
+++ b/package.json
@@ -1968,7 +1968,7 @@
     "@openclaw/fs-safe": "0.5.2",
     "@openclaw/proxyline": "0.3.4",
     "@silvia-odwyer/photon-node": "0.3.4",
-    "@trycua/cua-driver": "0.14.1",
+    "@trycua/cua-driver": "0.19.0",
     "acorn": "8.17.0",
     "chalk": "6.0.0",
     "chokidar": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ importers:
         specifier: 0.3.4
         version: 0.3.4
       '@trycua/cua-driver':
-        specifier: 0.14.1
-        version: 0.14.1
+        specifier: 0.19.0
+        version: 0.19.0
       acorn:
         specifier: 8.17.0
         version: 8.17.0
@@ -696,8 +696,8 @@ importers:
   extensions/cua-computer:
     dependencies:
       '@trycua/cua-driver':
-        specifier: 0.14.1
-        version: 0.14.1
+        specifier: 0.19.0
+        version: 0.19.0
       rastermill:
         specifier: 0.3.1
         version: 0.3.1
@@ -5271,40 +5271,40 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@trycua/cua-driver-darwin-arm64@0.14.1':
-    resolution: {integrity: sha512-Ijt252VfIbebSbNsoSLw66UAQKe/OV9wGVf80Qyt6F8DSrVSRQQOb4c+vWUYVF2349SQvKA0kJuY2i3Lj23zXw==}
+  '@trycua/cua-driver-darwin-arm64@0.19.0':
+    resolution: {integrity: sha512-waYnMDajUM8pd2rsMr+14SlD/nqsTn30+rfBQJUglcFy9CAVZEpTjw1WSk+n4nQR8gXUZsDWfyaTSwdNux4DlA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@trycua/cua-driver-darwin-x64@0.14.1':
-    resolution: {integrity: sha512-3kfPWxemK/zg/kSMIwk3EWF83OpZq6p19sB3BJzbk0zZqlCSKmZVPNIyFGOG7Bq1AxSdvEgHb4djrsFOEo9adA==}
+  '@trycua/cua-driver-darwin-x64@0.19.0':
+    resolution: {integrity: sha512-DrKkx/kn4v+FbFpt/RkX0jkXK4NWNrnsec8CxrVYS3GJC6Cz6Q3TlXVNmSI7sN7O7SuMQ6e3ohUNruiWOWymGg==}
     cpu: [x64]
     os: [darwin]
 
-  '@trycua/cua-driver-linux-arm64-gnu@0.14.1':
-    resolution: {integrity: sha512-MGbJDlmGWm/yp8mojTfBDMI09TzlC/UlIuFmW2UsapqyBAeBp01x5nRVs5c6xFXO5XIHasrYCwU93gzIvtjO4Q==}
+  '@trycua/cua-driver-linux-arm64-gnu@0.19.0':
+    resolution: {integrity: sha512-UXm02Wt1AbBVDyBTfZ3cITnL9dM9xrIWYo0fgctdzTK6gXF7f1lNCY20R7rFOSzIapleJIEgqEaXEXF8Sv81dQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@trycua/cua-driver-linux-x64-gnu@0.14.1':
-    resolution: {integrity: sha512-uzhoOKRiTdzSVXP8MlO73JnuLXkpwvEGmyEVjNhiK1MKy9aIZfteRpBATZHUM/E+PG/IgvIqxuM+JWgB5QagEg==}
+  '@trycua/cua-driver-linux-x64-gnu@0.19.0':
+    resolution: {integrity: sha512-ub2z4yKXNXLcZsK18hMSgu/SMfbIwnc1yDKTiEl218R8hY8OiyZYDCgpT14N1qknjN5LTfmyRTHyTN+pNb+30Q==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@trycua/cua-driver-win32-arm64-msvc@0.14.1':
-    resolution: {integrity: sha512-n3/hDOz2H2JQhH0slANAl9C0rUqPadBNy7t0HdsvHPyDM9vV9WtbvptI6pW4ZQH+3fPqy7gV41/V33/8f3mHnQ==}
+  '@trycua/cua-driver-win32-arm64-msvc@0.19.0':
+    resolution: {integrity: sha512-WrYoviN98P2k5+cV2kkgP39XsFSts99MyAXslzj1dieIQyx60NRxUPf9UmwQRBA6+A5snLf29sJfbCwWXMX8rg==}
     cpu: [arm64]
     os: [win32]
 
-  '@trycua/cua-driver-win32-x64-msvc@0.14.1':
-    resolution: {integrity: sha512-7ALlbufJBfSCR64kO8fwatzp2+aWohNc+A63JHthwS+9c28bWOSzVzOBe+QUrxUVwx7j4SP2wWJIQewP6v5yPQ==}
+  '@trycua/cua-driver-win32-x64-msvc@0.19.0':
+    resolution: {integrity: sha512-QsdDfAZrjz98Nxe6Fme4DaiEtlGfU5Z5pqMQdumzq5GqNVXY6OUT+3qApARMPmiCIh/zIdBK0HZgzTy8+HB1kQ==}
     cpu: [x64]
     os: [win32]
 
-  '@trycua/cua-driver@0.14.1':
-    resolution: {integrity: sha512-/o16k+vcTbdqwmvQqgFCKzrYksSQHz282qO8RkpD67GQoY4Vp3pyDndQexRJ8AbzNQpUt1bIXSAAaFBaMad6rg==}
+  '@trycua/cua-driver@0.19.0':
+    resolution: {integrity: sha512-IyQ+yWQdgumtxWSSO1ueQQQGi7lqhecawwo2JrXhV88I2y62LhGaAzUDcdyg3TNTSCw3hsovMQrkj+sYhEy9jw==}
 
   '@tufjs/canonical-json@2.0.0':
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
@@ -12418,35 +12418,35 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@trycua/cua-driver-darwin-arm64@0.14.1':
+  '@trycua/cua-driver-darwin-arm64@0.19.0':
     optional: true
 
-  '@trycua/cua-driver-darwin-x64@0.14.1':
+  '@trycua/cua-driver-darwin-x64@0.19.0':
     optional: true
 
-  '@trycua/cua-driver-linux-arm64-gnu@0.14.1':
+  '@trycua/cua-driver-linux-arm64-gnu@0.19.0':
     optional: true
 
-  '@trycua/cua-driver-linux-x64-gnu@0.14.1':
+  '@trycua/cua-driver-linux-x64-gnu@0.19.0':
     optional: true
 
-  '@trycua/cua-driver-win32-arm64-msvc@0.14.1':
+  '@trycua/cua-driver-win32-arm64-msvc@0.19.0':
     optional: true
 
-  '@trycua/cua-driver-win32-x64-msvc@0.14.1':
+  '@trycua/cua-driver-win32-x64-msvc@0.19.0':
     optional: true
 
-  '@trycua/cua-driver@0.14.1':
+  '@trycua/cua-driver@0.19.0':
     dependencies:
       '@ubjs/core': 0.31.0-3
       '@ubjs/node': 0.31.0-3
     optionalDependencies:
-      '@trycua/cua-driver-darwin-arm64': 0.14.1
-      '@trycua/cua-driver-darwin-x64': 0.14.1
-      '@trycua/cua-driver-linux-arm64-gnu': 0.14.1
-      '@trycua/cua-driver-linux-x64-gnu': 0.14.1
-      '@trycua/cua-driver-win32-arm64-msvc': 0.14.1
-      '@trycua/cua-driver-win32-x64-msvc': 0.14.1
+      '@trycua/cua-driver-darwin-arm64': 0.19.0
+      '@trycua/cua-driver-darwin-x64': 0.19.0
+      '@trycua/cua-driver-linux-arm64-gnu': 0.19.0
+      '@trycua/cua-driver-linux-x64-gnu': 0.19.0
+      '@trycua/cua-driver-win32-arm64-msvc': 0.19.0
+      '@trycua/cua-driver-win32-x64-msvc': 0.19.0
 
   '@tufjs/canonical-json@2.0.0': {}
 


### PR DESCRIPTION
Related: #120169

## What Problem This Solves

The bundled `cua-computer` plugin still pins `@trycua/cua-driver@0.14.1`, so the merged ESM loader and Gateway-policy work cannot be exercised against CUA Driver 0.19.0 on Windows and Linux node hosts.

## Why This Change Was Made

Pin the plugin-owned and bundled-runtime dependency to `0.19.0`, refresh the lockfile's six platform packages, advance the frozen contract identity to the matching release tag, commit, and npm integrity, and align the operator docs. The model-facing projection and Gateway configuration are unchanged.

## User Impact

Operators testing the experimental `cua-computer` plugin receive CUA Driver `0.19.0` on supported Windows, Linux, and macOS architectures. No OpenClaw config migration or new permission is introduced.

## Evidence

- Runtime candidate `bbc10b7363b5ce558b9a02876cd16e4261f69237`, based on `openclaw/openclaw@dcb125d202ed4fbf0cef1f9009aa250895f12b3f`.
- Current PR head `a9ef53fe80dd5eab9c6a717bddff094da4b1f552` adds only a generated-reference repair after runtime certification; it does not change executable code or dependency resolution.
- `pnpm test:extension cua-computer` — 6 files and 51 tests passed.
- `pnpm build` — passed, including CLI import guards, plugin SDK export checks, Control UI build, and 704 generated sidecar checks.
- Live Node import of `@trycua/cua-driver@0.19.0` exposed 108 exports, including `CuaDriver`.
- `pnpm --config.minimum-release-age=0 install --frozen-lockfile` verified lockfile consistency.
- `pnpm plugins:inventory:gen` reproduced the CUA plugin reference from source metadata; the committed generated diff is scoped to that reference.
- `git diff --check` passed.

### Pre-maturity native integration

- Linux XFCE VM: built the runtime candidate from source, installed it as a persistent user node service, paired it to the host Gateway, and verified `screen.snapshot` plus `computer.act`. A 1200x750 JPEG snapshot succeeded; `Ctrl+Alt+T` visibly opened a new terminal in a fresh snapshot; `Alt+F4` closed only that test terminal; a final snapshot confirmed cleanup.
- Windows VM: built the runtime candidate from source, installed it as a persistent Scheduled Task node, paired it through an authenticated SSH reverse tunnel, and verified a 1024x768 JPEG snapshot. A frame-authorized Start click visibly opened the menu, text entry and Enter launched Calculator, and cleanup preserved the pre-existing user windows.
- Windows caveats observed with CUA Driver 0.19.0: `Win+R` returned success but did not open Run, and foreground-changing desktop clicks visibly took effect while returning `foreground_unavailable`. These findings make the current result a partial Windows behavior pass, not a clean certification.
- Screenshots were inspected locally but are intentionally not attached because the test desktops contain private user content.

The package and its six native optional dependencies were published on 2026-08-06 around 15:25 UTC. This PR must remain draft until the repository's normal 48-hour maturity policy accepts them after 2026-08-08 15:25:48 UTC. At that point, rebase onto current `main`, rerun the frozen install without the maturity override, run standard CI, and repeat the affected Windows evidence on the resulting executable SHA before making the PR ready.

Normal CI lanes are skipped while the PR remains a draft.

AI-assisted: yes. The dependency contract, generated lockfile diff, resulting source changes, and native integration behavior were reviewed directly.
