### PR TITLE
fix: scope embedded-run session ownership by derived agent

### DIFF
--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -283,16 +283,6 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
           sessionKeys.add(sessionKey);
         }
       }
-      // The session ownership checks below list persisted entries to locate the
-      // claimed session ids/files. Those listings need a concrete agent scope;
-      // when the caller did not pass one (embedded runs are key-driven), derive
-      // it from the session key so the ownership check stays scoped to the agent
-      // that actually owns the target session instead of failing to resolve.
-      const scopedAgentId =
-        agentId ??
-        [...sessionKeys]
-          .map((key) => parseAgentSessionKey(key)?.agentId)
-          .find((value): value is string => Boolean(value));
       for (const sessionKey of sessionKeys) {
         assertStoredSessionEntryOwned({
           action: params.action,
@@ -320,7 +310,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         return;
       }
       const entries = registryParams.runtime.agent.session.listSessionEntries({
-        ...(scopedAgentId ? { agentId: scopedAgentId } : {}),
+        ...(agentId ? { agentId } : {}),
         ...(storePath ? { storePath } : {}),
         readOnly: true,
       });
@@ -464,7 +454,11 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
       }
       assertSessionIdentitiesOwned({
         action: "run",
-        agentId: target?.agentId ?? params.agentId,
+        // Embedded runs are key-driven and reach here with an exact one session
+        // key; scope the ownership listing to that key's agent so the persisted
+        // id/file check stays pinned to the agent that owns the target session
+        // instead of relying on the caller to name it.
+        agentId: agentId ?? (sessionKey ? parseAgentSessionKey(sessionKey)?.agentId : undefined),
         sessionFiles: [params.sessionFile],
         sessionIds: [target?.sessionId ?? params.sessionId],
         sessionKeys: [target?.sessionKey ?? params.sessionKey],

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -24,6 +24,7 @@ import {
   type PluginStateKeyedStore,
   type PluginStateSyncKeyedStore,
 } from "../plugin-state/plugin-state-store.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import {
   isAgentHarnessSessionKey,
   isAgentHarnessSessionKeyOwnedBy,
@@ -282,6 +283,16 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
           sessionKeys.add(sessionKey);
         }
       }
+      // The session ownership checks below list persisted entries to locate the
+      // claimed session ids/files. Those listings need a concrete agent scope;
+      // when the caller did not pass one (embedded runs are key-driven), derive
+      // it from the session key so the ownership check stays scoped to the agent
+      // that actually owns the target session instead of failing to resolve.
+      const scopedAgentId =
+        agentId ??
+        [...sessionKeys]
+          .map((key) => parseAgentSessionKey(key)?.agentId)
+          .find((value): value is string => Boolean(value));
       for (const sessionKey of sessionKeys) {
         assertStoredSessionEntryOwned({
           action: params.action,
@@ -309,7 +320,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         return;
       }
       const entries = registryParams.runtime.agent.session.listSessionEntries({
-        ...(agentId ? { agentId } : {}),
+        ...(scopedAgentId ? { agentId: scopedAgentId } : {}),
         ...(storePath ? { storePath } : {}),
         readOnly: true,
       });

--- a/src/plugins/registry.runtime-config.sqlite.test.ts
+++ b/src/plugins/registry.runtime-config.sqlite.test.ts
@@ -1,0 +1,87 @@
+// Real SQLite-backed proof for embedded-run session ownership (#120178): the
+// ownership listing must resolve against the real per-agent SQLite session
+// store when the embedded run carries only a session key (no agentId). The fix
+// derives the agent scope from the key so the real accessor can open the store
+// instead of throwing "Cannot resolve SQLite session scope without an agent id".
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { replaceSqliteSessionEntry } from "../config/sessions/session-accessor.sqlite-entry.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withTempHome } from "../plugin-sdk/test-env.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { createPluginRecord } from "./loader-records.js";
+import { createPluginRegistry } from "./registry.js";
+import { createPluginRuntime } from "./runtime/index.js";
+
+function createTestRegistry(runtime: ReturnType<typeof createPluginRuntime>) {
+  return createPluginRegistry({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    runtime,
+    activateGlobalSideEffects: false,
+  });
+}
+
+describe("embedded-run session ownership resolves through the real SQLite session store", () => {
+  it("scopes the key-only ownership listing to the derived agent (#120178)", async () => {
+    await withTempHome(async (home) => {
+      const env = { OPENCLAW_STATE_DIR: path.join(home, ".openclaw") };
+      const { storeEnv, storePath } = {
+        storeEnv: { ...process.env, ...env },
+        storePath: path.join(home, "shared.sqlite"),
+      };
+      try {
+        // Seed a real shared SQLite session store with one entry for agent main.
+        const sessionId = "main-real-session";
+        await replaceSqliteSessionEntry(
+          {
+            agentId: "main",
+            defaultAgentId: "main",
+            env: storeEnv,
+            sessionKey: "agent:main:skill-workshop-review:incognito-1",
+            storePath,
+          },
+          { sessionId, updatedAt: Date.now() },
+        );
+
+        // The registry runtime is created with the real session facade. Only the
+        // terminal embedded-run kernel is mocked; ownership resolution keeps the
+        // real `session.listSessionEntries` -> SQLite accessor path untouched.
+        const runtime = createPluginRuntime();
+        const runEmbeddedAgent = vi.fn(async () => ({ ok: true })) as unknown as ReturnType<
+          typeof createPluginRuntime
+        >["agent"]["runEmbeddedAgent"];
+        Object.defineProperties(runtime.agent, {
+          runEmbeddedAgent: { configurable: true, value: runEmbeddedAgent },
+          runEmbeddedPiAgent: { configurable: true, value: runEmbeddedAgent },
+        });
+
+        const pluginRegistry = createTestRegistry(runtime);
+        const record = createPluginRecord({
+          id: "extractor-plugin",
+          source: "/plugins/extractor-plugin/index.js",
+          origin: "bundled",
+          enabled: true,
+          configSchema: false,
+        });
+        const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
+
+        // Key-only embedded run: no agentId. Ownership must derive agent "main"
+        // from the key and resolve the real store, not throw.
+        await expect(
+          api.runtime.agent.runEmbeddedAgent({
+            sessionId,
+            sessionKey: "agent:main:skill-workshop-review:incognito-1",
+            storePath,
+            workspaceDir: path.join(home, "ws"),
+            prompt: "continue",
+            timeoutMs: 1,
+            runId: "run-1",
+          } as never),
+        ).resolves.toEqual({ ok: true });
+        expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+      }
+    });
+  });
+});

--- a/src/plugins/registry.runtime-config.sqlite.test.ts
+++ b/src/plugins/registry.runtime-config.sqlite.test.ts
@@ -25,12 +25,14 @@ describe("embedded-run session ownership resolves through the real SQLite sessio
   it("scopes the key-only ownership listing to the derived agent (#120178)", async () => {
     await withTempHome(async (home) => {
       const env = { OPENCLAW_STATE_DIR: path.join(home, ".openclaw") };
-      const { storeEnv, storePath } = {
-        storeEnv: { ...process.env, ...env },
-        storePath: path.join(home, "shared.sqlite"),
-      };
+      const storeEnv = { ...process.env, ...env };
+      const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = env.OPENCLAW_STATE_DIR;
       try {
-        // Seed a real shared SQLite session store with one entry for agent main.
+        // Seed agent main's default SQLite session store (resolved from
+        // OPENCLAW_STATE_DIR) with one entry. No custom storePath on either the
+        // seed or the run: the ownership listing must resolve the same default
+        // store purely from the session key's derived agent + env.
         const sessionId = "main-real-session";
         await replaceSqliteSessionEntry(
           {
@@ -38,7 +40,6 @@ describe("embedded-run session ownership resolves through the real SQLite sessio
             defaultAgentId: "main",
             env: storeEnv,
             sessionKey: "agent:main:skill-workshop-review:incognito-1",
-            storePath,
           },
           { sessionId, updatedAt: Date.now() },
         );
@@ -65,13 +66,13 @@ describe("embedded-run session ownership resolves through the real SQLite sessio
         });
         const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
 
-        // Key-only embedded run: no agentId. Ownership must derive agent "main"
-        // from the key and resolve the real store, not throw.
+        // Key-only embedded run: no agentId, no storePath. The ownership
+        // listing must derive agent "main" from the key and resolve the same
+        // default store the seed wrote (env-based), not throw.
         await expect(
           api.runtime.agent.runEmbeddedAgent({
             sessionId,
             sessionKey: "agent:main:skill-workshop-review:incognito-1",
-            storePath,
             workspaceDir: path.join(home, "ws"),
             prompt: "continue",
             timeoutMs: 1,
@@ -80,6 +81,11 @@ describe("embedded-run session ownership resolves through the real SQLite sessio
         ).resolves.toEqual({ ok: true });
         expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
       } finally {
+        if (originalStateDir === undefined) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = originalStateDir;
+        }
         closeOpenClawAgentDatabasesForTest();
       }
     });

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -875,4 +875,73 @@ describe("plugin registry runtime config scope", () => {
     ).resolves.toEqual({ ok: true });
     expect(listedAgentIds).toContain("main");
   });
+
+  it("rejects a locked session identity in another agent via the shared session path (#120227)", async () => {
+    const runtime = createPluginRuntime();
+    const session = runtime.agent.session;
+    const otherAgentReservedKey = `agent:assistant:harness:codex:thread-1`;
+    const otherAgentReservedEntry = {
+      sessionId: "assistant-reserved-session",
+      updatedAt: 1,
+      agentHarnessId: "codex",
+      modelSelectionLocked: true as const,
+    };
+    const mainOrdinaryKey = "agent:main:ordinary";
+    const mainOrdinaryEntry = { sessionId: "main-ordinary-session", updatedAt: 1 };
+    const entries = {
+      [otherAgentReservedKey]: otherAgentReservedEntry,
+      [mainOrdinaryKey]: mainOrdinaryEntry,
+    } as unknown as Record<string, SessionEntry>;
+    session.getSessionEntry = vi.fn(
+      (params) => entries[params.sessionKey],
+    ) as typeof session.getSessionEntry;
+    // The shared ownership check lists persisted entries to locate claimed ids.
+    // It must not narrow that listing to the first parseable key's agent; that
+    // would drop the locked foreign-agent identity below and skip its rejection.
+    session.listSessionEntries = vi.fn(() =>
+      Object.entries(entries).map(([sessionKey, entry]) => ({ sessionKey, entry })),
+    ) as typeof session.listSessionEntries;
+    const gatewayRequest = vi.fn(async () => ({ ok: true }));
+    runtime.gateway = {
+      isAvailable: vi.fn(async () => true),
+      request: gatewayRequest as unknown as PluginRuntime["gateway"]["request"],
+    };
+
+    const pluginRegistry = createTestRegistry(runtime);
+    const ownerRecord = createPluginRecord({
+      id: "codex-owner",
+      source: "/plugins/codex-owner/index.js",
+      origin: "bundled",
+      enabled: true,
+      configSchema: false,
+    });
+    const otherRecord = createPluginRecord({
+      id: "other-plugin",
+      source: "/plugins/other-plugin/index.js",
+      origin: "bundled",
+      enabled: true,
+      configSchema: false,
+    });
+    const ownerApi = pluginRegistry.createApi(ownerRecord, { config: {} as OpenClawConfig });
+    const otherApi = pluginRegistry.createApi(otherRecord, { config: {} as OpenClawConfig });
+    ownerApi.registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => {
+        throw new Error("unused");
+      },
+    } as never);
+
+    // A gateway request names the locked identity by session id while also
+    // carrying the plugin's own main-agent session key. The ownership check must
+    // still reject the foreign locked identity instead of scoping the listing to
+    // the main-agent key and silently skipping it.
+    await expect(
+      otherApi.runtime.gateway.request("sessions.abort", {
+        sessionId: otherAgentReservedEntry.sessionId,
+        sessionKey: mainOrdinaryKey,
+      }),
+    ).rejects.toThrow('owned by plugin "codex-owner"');
+  });
 });

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -824,4 +824,55 @@ describe("plugin registry runtime config scope", () => {
       otherApi.runtime.gateway.request("voicecall.start", { to: "+15550001234" }),
     ).resolves.toEqual({ ok: true });
   });
+
+  it("derives the session ownership listing agent from the embedded run session key (#120178)", async () => {
+    const runtime = createPluginRuntime();
+    const session = runtime.agent.session;
+    Object.defineProperties(runtime.agent, {
+      runEmbeddedAgent: {
+        configurable: true,
+        value: (async () => ({
+          ok: true,
+        })) as unknown as PluginRuntime["agent"]["runEmbeddedAgent"],
+      },
+    });
+    const listedAgentIds: Array<string | undefined> = [];
+    // The real SQLite accessor throws when it cannot resolve an agent scope.
+    // Emulate that so the test proves the ownership listing is scoped to the
+    // agent derived from the session key when the caller omits agentId.
+    session.listSessionEntries = vi.fn((params) => {
+      listedAgentIds.push(params.agentId);
+      if (!params.agentId) {
+        throw new Error("Cannot resolve SQLite session scope without an agent id");
+      }
+      return [];
+    }) as typeof session.listSessionEntries;
+    session.getSessionEntry = vi.fn(() => ({
+      sessionId: "incognito-session",
+      updatedAt: 1,
+    })) as typeof session.getSessionEntry;
+
+    const pluginRegistry = createTestRegistry(runtime);
+    const record = createPluginRecord({
+      id: "memory-plugin",
+      source: "/plugins/memory-plugin/index.js",
+      origin: "bundled",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
+
+    await expect(
+      api.runtime.agent.runEmbeddedAgent({
+        sessionId: "incognito-session",
+        sessionKey:
+          "agent:main:skill-workshop-review:incognito-00000000-0000-4000-8000-000000000001",
+        workspaceDir: "/tmp",
+        prompt: "extract",
+        timeoutMs: 1,
+        runId: "run-incognito",
+      } as Parameters<PluginRuntime["agent"]["runEmbeddedAgent"]>[0]),
+    ).resolves.toEqual({ ok: true });
+    expect(listedAgentIds).toContain("main");
+  });
 });


### PR DESCRIPTION
{"body": "Closes #120178\n\n## What Problem This Solves\n\nFixes an issue where plugins calling `runEmbeddedAgent()` (e.g. the memory-tencentdb plugin's L1 extraction) would fail with `Cannot resolve SQLite session scope without an agent id` whenever the run identified its session only by a session key (as embedded runs do), because the session-ownership check tried to enumerate the agent's sessions with no agent scope. L1/L2/L3 memory extraction never ran, and 0 memories were produced.\n\n## Why This Change Was Made\n\n`resolveRunSessionExecutionOwner()` asserts that the run's session targets belong to the calling plugin. For session ids/files it lists the agent's persisted session entries, and that listing needs a concrete agent scope. When the caller did not pass `agentId` (the `runEmbeddedAgent()` contract is key-driven), the listing fell through to the SQLite accessor with an empty scope and threw. Since the run always carries a session key, the fix derives the agent from that key and scopes the ownership listing to it \u2014 the agent that actually owns the target session. Sessions without a resolvable key still fail closed exactly as before.\n\n## User Impact\n\nPlugins that trigger embedded runs against incognito/dashboard/cron session keys (memory extraction, sub-agent hooks, etc.) no longer crash on session ownership checks, so L1/L2/L3 memory pipelines and similar plugin flows run again.\n\n## Evidence\n\n- P1 review item (agent-scope derivation placed in the shared ownership helper could narrow a gateway request's id/file listing to the first parseable key's agent and skip an identity in another agent). Resolved: derivation moved into the exact-one-key embedded-run path only. New regression `registry.runtime-config.test.ts` (\"rejects a locked session identity in another agent via the shared session path (#120227)\") proves a gateway `sessions.abort` carrying a foreign locked session id plus the plugin's own main-agent key still rejects `owned by plugin \"codex-owner\"` instead of scoping the listing away from it.\n- Real SQLite behavior proof `src/plugins/registry.runtime-config.sqlite.test.ts`: seeds agent main's **default** store (resolved from `OPENCLAW_STATE_DIR`, no custom storePath) and drives a key-only `runEmbeddedAgent()` (no agentId, no storePath) with the **real** session accessor (only the terminal run kernel is mocked). The ownership listing resolves the same env-based default store purely from the key's derived agent, so the seeded row is on the resolved path. Reverting the derivation reproduces the exact issue:\n\n\n  ```\n  AssertionError: promise rejected \"Error: Cannot resolve SQLite session scop\u2026\" instead of resolving\n  Caused by: Error: Cannot resolve SQLite session scope without an agent id\n  ```\n\n  After the fix, the same key-only embedded run resolves `{ ok: true }`.\n\n- Commands (repo test lane):\n  ```\n  node scripts/run-vitest.mjs src/plugins/registry.runtime-config.test.ts src/plugins/registry.runtime-config.sqlite.test.ts src/plugins/runtime/index.test.ts\n  ```\n  13/13 (runtime-config + sqlite) and 27/27 (runtime) tests pass. (Note: a seed-observation flaw in the first proof draft \u2014 the listed store was a shared store the ownership check never reads \u2014 is fixed in `ef285385`, which now routes through the env-based default store so the seed is genuinely observed.) `oxfmt --check` clean on all changed files.\n\nAI-assisted: yes."}