### PR TITLE
fix(googlechat): reject invalid UTF-8 in API JSON responses

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -40,7 +40,7 @@ async function readGoogleChatJsonResponse<T>(response: Response, label: string):
     onOverflow: ({ maxBytes }) => new Error(`${label}: JSON response exceeds ${maxBytes} bytes`),
   });
   try {
-    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as T;
   } catch (cause) {
     throw new Error(`${label}: malformed JSON response`, { cause });
   }

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -287,6 +287,43 @@ describe("googlechat group policy", () => {
   });
 });
 
+describe("googlechat API JSON response decoding", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects invalid UTF-8 in API JSON responses instead of corrupting identifiers", async () => {
+    const raw = Buffer.concat([
+      Buffer.from('{"name":"spaces/'),
+      Buffer.from([0xff]),
+      Buffer.from('AAA"}'),
+    ]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(new Uint8Array(raw), { status: 200 })),
+    );
+
+    await expect(
+      sendGoogleChatMessage({ account, space: "spaces/AAA", text: "hello" }),
+    ).rejects.toThrow(/malformed JSON response/);
+  });
+
+  it("keeps valid UTF-8 API JSON responses unchanged (negative control)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(new Uint8Array(Buffer.from('{"name":"spaces/AAA"}')), { status: 200 }),
+        ),
+    );
+
+    await expect(
+      sendGoogleChatMessage({ account, space: "spaces/AAA", text: "hello" }),
+    ).resolves.toEqual({ messageName: "spaces/AAA", threadName: undefined });
+  });
+});
+
 describe("downloadGoogleChatMedia", () => {
   afterEach(() => {
     unregisterGoogleChatManualApprovalFollowupSuppression("12345678-1234-1234-1234-123456789012");


### PR DESCRIPTION
## What Problem This Solves

Google Chat API JSON responses containing invalid UTF-8 bytes were decoded
with replacement characters, so a corrupted `name` identifier silently became
`spaces/\uFFFDAAA` and could be used by later API calls.

## Why This Change Was Made

`readGoogleChatJsonResponse` now uses a fatal UTF-8 decoder, so malformed
response bytes fail fast as a malformed-JSON error instead of silently
corrupting identifiers. This follows the strict-decode contract already used
by provider JSON readers (PR #108849).

## User Impact

Malformed Google Chat API responses surface as clear errors instead of
corrupted message or space identifiers.

## Evidence

- Base `f4387b7a5ef`: same byte-level response through the production
  `sendGoogleChatMessage` -> `readGoogleChatJsonResponse` path resolved
  `messageName: "spaces/\uFFFDAAA"` — the corrupted identifier was accepted.
- Head `607a006803f`: the same input rejects with
  `Google Chat API: malformed JSON response`.
- Negative control: a valid UTF-8 response still returns
  `messageName: "spaces/AAA"` unchanged.

```text
$ node_modules/.bin/vitest run extensions/googlechat/src/targets.test.ts -- googlechat API JSON response decoding
base (f4387b7a5ef):  promise resolved { messageName: 'spaces/\uFFFDAAA', threadName: undefined }
head (607a006803f):  rejected Google Chat API: malformed JSON response
negative control:    resolved { messageName: 'spaces/AAA', threadName: undefined }
```

<details>
<summary>repro source</summary>

```ts
const raw = Buffer.concat([
  Buffer.from('{"name":"spaces/'),
  Buffer.from([0xff]),
  Buffer.from('AAA"}'),
]);
vi.stubGlobal(
  "fetch",
  vi.fn().mockResolvedValue(new Response(new Uint8Array(raw), { status: 200 })),
);
await expect(
  sendGoogleChatMessage({ account, space: "spaces/AAA", text: "hello" }),
).rejects.toThrow(/malformed JSON response/);
```

</details>

AI-assisted: built with Codex
