### PR TITLE
fix(daemon): protect Windows restart CLI from its own taskkill /T (#120134)

### DIFF
--- a/src/daemon/schtasks-process.tree-guard.test.ts
+++ b/src/daemon/schtasks-process.tree-guard.test.ts
@@ -1,0 +1,70 @@
+// Tree-guard tests for the Windows scheduled-task restart path (#120134).
+// Agent exec commands are direct children of the gateway; `taskkill /T` must
+// not terminate a tree that contains the calling process, or an exec-driven
+// `openclaw gateway restart` would kill itself before `schtasks /Run` runs.
+import { describe, expect, it } from "vitest";
+import { isProcessDescendantOf } from "./schtasks-process.js";
+
+type Entry = { ProcessId?: number; ParentProcessId?: number; CommandLine?: string | null };
+
+describe("isProcessDescendantOf", () => {
+  it("returns true for a direct child of the target", () => {
+    const snapshot: Entry[] = [
+      { ProcessId: 100, ParentProcessId: 1, CommandLine: "gateway" },
+      { ProcessId: 200, ParentProcessId: 100, CommandLine: "openclaw gateway restart" },
+    ];
+    expect(isProcessDescendantOf(100, 200, snapshot)).toBe(true);
+  });
+
+  it("returns true for a grandchild of the target", () => {
+    const snapshot: Entry[] = [
+      { ProcessId: 100, ParentProcessId: 1, CommandLine: "gateway" },
+      { ProcessId: 150, ParentProcessId: 100, CommandLine: "node wrapper" },
+      { ProcessId: 200, ParentProcessId: 150, CommandLine: "openclaw gateway restart" },
+    ];
+    expect(isProcessDescendantOf(100, 200, snapshot)).toBe(true);
+  });
+
+  it("returns true when the current process is the target itself", () => {
+    const snapshot: Entry[] = [{ ProcessId: 100, ParentProcessId: 1, CommandLine: "gateway" }];
+    expect(isProcessDescendantOf(100, 100, snapshot)).toBe(true);
+  });
+
+  it("returns false for a process outside the target tree", () => {
+    const snapshot: Entry[] = [
+      { ProcessId: 100, ParentProcessId: 1, CommandLine: "gateway" },
+      { ProcessId: 200, ParentProcessId: 1, CommandLine: "unrelated cli" },
+    ];
+    expect(isProcessDescendantOf(100, 200, snapshot)).toBe(false);
+  });
+
+  it("returns false for an empty snapshot", () => {
+    expect(isProcessDescendantOf(100, 200, [])).toBe(false);
+  });
+
+  it("returns false when the parent chain is not in the snapshot", () => {
+    const snapshot: Entry[] = [
+      { ProcessId: 100, ParentProcessId: 1, CommandLine: "gateway" },
+      // 200's parent (150) is missing, so ancestry cannot be proven.
+      { ProcessId: 200, ParentProcessId: 150, CommandLine: "restart cli" },
+    ];
+    expect(isProcessDescendantOf(100, 200, snapshot)).toBe(false);
+  });
+
+  it("terminates on a parent-cycle and returns false", () => {
+    const snapshot: Entry[] = [
+      { ProcessId: 100, ParentProcessId: 200, CommandLine: "gateway" },
+      { ProcessId: 200, ParentProcessId: 100, CommandLine: "restart cli" },
+    ];
+    expect(isProcessDescendantOf(100, 200, snapshot)).toBe(true);
+    expect(isProcessDescendantOf(300, 200, snapshot)).toBe(false);
+  });
+
+  it("treats missing or non-positive ParentProcessId as a root", () => {
+    const snapshot: Entry[] = [
+      { ProcessId: 100, CommandLine: "gateway" },
+      { ProcessId: 200, ParentProcessId: 0, CommandLine: "restart cli" },
+    ];
+    expect(isProcessDescendantOf(100, 200, snapshot)).toBe(false);
+  });
+});

--- a/src/daemon/schtasks-process.ts
+++ b/src/daemon/schtasks-process.ts
@@ -18,6 +18,7 @@ import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-t
 
 type WindowsProcessSnapshotEntry = {
   ProcessId?: number;
+  ParentProcessId?: number;
   CommandLine?: string | null;
 };
 
@@ -299,6 +300,38 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boole
   return probeProcessState(pid) === "missing";
 }
 
+/**
+ * True when `currentPid` is `targetPid` itself or a descendant of it.
+ * Mirrors the POSIX "leader verification avoids signaling our group" guard:
+ * the Windows restart path must not `taskkill /T` a tree that contains the
+ * calling process (agent exec commands are direct children of the gateway),
+ * or the restart CLI would terminate itself before `schtasks /Run` executes.
+ */
+export function isProcessDescendantOf(
+  targetPid: number,
+  currentPid: number,
+  snapshot: WindowsProcessSnapshotEntry[],
+): boolean {
+  const parentByPid = new Map<number, number>();
+  for (const entry of snapshot) {
+    const pid = getSnapshotProcessId(entry);
+    const parentPid = entry.ParentProcessId;
+    if (pid && typeof parentPid === "number" && Number.isFinite(parentPid) && parentPid > 0) {
+      parentByPid.set(pid, parentPid);
+    }
+  }
+  let cursor = currentPid;
+  const visited = new Set<number>();
+  while (cursor > 0 && !visited.has(cursor)) {
+    if (cursor === targetPid) {
+      return true;
+    }
+    visited.add(cursor);
+    cursor = parentByPid.get(cursor) ?? 0;
+  }
+  return false;
+}
+
 export async function terminateGatewayProcessTree(pid: number, graceMs: number): Promise<void> {
   if (process.platform !== "win32") {
     // These PIDs come from argv/port ownership; leader verification avoids signaling our group.
@@ -306,20 +339,37 @@ export async function terminateGatewayProcessTree(pid: number, graceMs: number):
     return;
   }
   const taskkillPath = getWindowsSystem32ExePath("taskkill.exe");
-  const graceful = spawnSync(taskkillPath, ["/T", "/PID", String(pid)], {
-    stdio: "ignore",
-    timeout: 5_000,
-    windowsHide: true,
-  });
+  // When this process is inside the target's tree (agent exec commands are
+  // direct children of the gateway), taskkill /T terminates the caller too:
+  // `openclaw gateway restart` via exec would kill itself before the restart
+  // completes, leaving the gateway stopped with no auto-recovery. Drop the
+  // tree flag in that case so only the gateway is terminated; the caller is
+  // orphaned and survives to finish the restart. Without a readable process
+  // snapshot the tree kill is kept as the previous behavior.
+  const snapshot = readWindowsProcessSnapshot();
+  const treeKill = !(snapshot && isProcessDescendantOf(pid, process.pid, snapshot));
+  const graceful = spawnSync(
+    taskkillPath,
+    treeKill ? ["/T", "/PID", String(pid)] : ["/PID", String(pid)],
+    {
+      stdio: "ignore",
+      timeout: 5_000,
+      windowsHide: true,
+    },
+  );
   // taskkill can race with exit; only a missing PID avoids forcing the verified owner.
   if (await waitForProcessExit(pid, graceful.status === 0 && !graceful.error ? graceMs : 0)) {
     return;
   }
-  const forced = spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
-    stdio: "ignore",
-    timeout: 5_000,
-    windowsHide: true,
-  });
+  const forced = spawnSync(
+    taskkillPath,
+    treeKill ? ["/F", "/T", "/PID", String(pid)] : ["/F", "/PID", String(pid)],
+    {
+      stdio: "ignore",
+      timeout: 5_000,
+      windowsHide: true,
+    },
+  );
   if (forced.error || forced.status !== 0) {
     if (probeProcessState(pid) === "missing") {
       return;
@@ -359,7 +409,7 @@ export function readWindowsProcessSnapshot(): WindowsProcessSnapshotEntry[] | nu
     [
       "-NoProfile",
       "-Command",
-      "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
     ],
     { encoding: "utf8", timeout: 5_000, windowsHide: true },
   );

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -132,7 +132,7 @@ async function writeNodeScript(env: Record<string, string>, port = "18789") {
 }
 
 const NODE_PROCESS_QUERY =
-  "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress";
+  "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress";
 
 function makeNodeServiceEnv(env: Record<string, string>): Record<string, string> {
   return {
@@ -912,7 +912,12 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env, new PassThrough(), "19433");
 
-      expect(processQueries).toBe(5);
+      // One extra snapshot query vs. the pre-#120134 flow: the Windows
+      // termination guard reads the process tree once to avoid `taskkill /T`
+      // killing a caller inside the gateway's tree. The mock answers that
+      // query with a failure (status 1), which also proves the guard keeps the
+      // previous tree-kill behavior when the snapshot is unavailable.
+      expect(processQueries).toBe(6);
       await expect(fs.access(startupEntryPath)).rejects.toThrow();
     });
   });
@@ -1518,7 +1523,7 @@ describe("Windows startup fallback", () => {
           command === getWindowsPowerShellExePath() &&
           Array.isArray(args) &&
           args.includes(
-            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
           )
         ) {
           return {
@@ -1588,7 +1593,7 @@ describe("Windows startup fallback", () => {
           command === getWindowsPowerShellExePath() &&
           Array.isArray(args) &&
           args.includes(
-            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
           )
         ) {
           return {
@@ -1741,7 +1746,7 @@ describe("Windows startup fallback", () => {
           command === getWindowsPowerShellExePath() &&
           Array.isArray(args) &&
           args.includes(
-            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress",
           )
         ) {
           return {


### PR DESCRIPTION
## What Problem This Solves

Fixes https://github.com/openclaw/openclaw/issues/120134. When an agent runs `openclaw gateway restart` through the exec tool on Windows (gateway installed as a Scheduled Task), the restart **kills the CLI process itself** and the gateway is left completely stopped with no auto-recovery. Root cause: the exec command process is a direct child of the gateway, and the Windows restart flow uses `taskkill /T` (kill process tree) to terminate the gateway — which also terminates the restart CLI because it sits inside the gateway's process tree. The subsequent `schtasks /Run` step never executes, so the gateway never comes back.

## Why This Change Was Made

`terminateGatewayProcessTree()` in `src/daemon/schtasks-process.ts` has an explicit guard on the non-Windows branch ("leader verification avoids signaling our group") but the Windows branch had **no equivalent protection** — both the graceful (`/T /PID`) and forced (`/F /T /PID`) `taskkill` invocations unconditionally killed the whole tree. The restart sequence (`restartRegisteredScheduledTask`) is `schtasks /End` → `taskkill /T` ← kills the restart CLI too → wait for port release → `schtasks /Run` ← never reached.

This change mirrors the POSIX guard on Windows: the process snapshot now includes `ParentProcessId`, and before terminating, the code walks the parent chain to check whether the calling process is inside the target's tree. When it is, the `/T` tree flag is dropped from both the graceful and forced `taskkill` calls so only the gateway process is terminated — the restart CLI is orphaned, survives, and completes the restart. When the snapshot is unavailable, the previous tree-kill behavior is preserved (fail-open), so existing flows are unchanged.

## User Impact

Windows users who ask the agent (via Control UI / TUI exec) to run `openclaw gateway restart` no longer lose the gateway entirely: the CLI survives to execute `schtasks /Run`, the gateway restarts, and Web Control UI / TUI reconnect automatically. This removes the crash-loop class where the gateway stays down until someone manually restarts from an interactive terminal. Processes outside the gateway tree keep the exact previous behavior.

## Evidence

- **Code change** (`src/daemon/schtasks-process.ts`): `readWindowsProcessSnapshot()` now selects `ParentProcessId` from `Win32_Process`; new exported helper `isProcessDescendantOf(targetPid, currentPid, snapshot)` walks the parent chain (cycle-safe, missing-parent-safe); `terminateGatewayProcessTree()` drops `/T` for graceful and forced `taskkill` when the caller is inside the target's tree.
- **Unit tests** (`src/daemon/schtasks-process.tree-guard.test.ts`, 8 cases): direct child → protected; grandchild → protected; self → protected; unrelated process → tree-kill kept; empty snapshot → tree-kill kept; broken parent chain → tree-kill kept; parent cycle → terminates; missing/non-positive `ParentProcessId` → treated as root.
- **Updated existing tests**: `schtasks.startup-fallback.test.ts` CIM-query mocks updated to the new `ParentProcessId` selection; the migration test's snapshot-query count now 6 (the extra query is the tree-guard read, and its mocked failure also proves the fail-open path keeps the previous tree-kill behavior).
- **Verification**: `pnpm vitest run src/daemon/schtasks.test.ts src/daemon/schtasks.exec.test.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks-process.tree-guard.test.ts` → 149/149 passed. `pnpm tsgo:core` typecheck clean; oxlint on changed files: 0 warnings, 0 errors.
- Note: the Windows-only behavior change is covered by the pure helper tests (ancestry logic) plus the existing Windows-mocked startup-fallback suite; the live `taskkill` path itself requires a Windows host (e2e suite) and is not runnable on this Linux CI host.

[AI-assisted]
