### PR TITLE
fix(ui): keep screen awake during voice activity

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -58,6 +58,19 @@ suite.define(() => {
       await page.setViewportSize({ width: 320, height: 720 });
       await page.getByRole("button", { name: "Start voice input" }).click();
 
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  openclawTalkE2eState?: { wakeLocksRequested: number };
+                }
+              ).openclawTalkE2eState?.wakeLocksRequested,
+          ),
+        )
+        .toBe(1);
+
       const createRequest = await gateway.waitForRequest("talk.client.create");
       expect(createRequest.params).toMatchObject({ sessionKey: "main" });
       await expect
@@ -176,18 +189,23 @@ suite.define(() => {
           page.evaluate(() => {
             const state = (
               window as Window & {
-                openclawTalkE2eState?: { audioContextsClosed: number; tracksStopped: number };
+                openclawTalkE2eState?: {
+                  audioContextsClosed: number;
+                  tracksStopped: number;
+                  wakeLocksReleased: number;
+                };
               }
             ).openclawTalkE2eState;
             return state
               ? {
                   audioContextsClosed: state.audioContextsClosed,
                   tracksStopped: state.tracksStopped,
+                  wakeLocksReleased: state.wakeLocksReleased,
                 }
               : null;
           }),
         )
-        .toEqual({ audioContextsClosed: 2, tracksStopped: 1 });
+        .toEqual({ audioContextsClosed: 2, tracksStopped: 1, wakeLocksReleased: 1 });
 
       await gateway.deliverLatest({ setupComplete: {} });
       await expect

--- a/ui/src/e2e/browser-talk-start-stop.fixtures.ts
+++ b/ui/src/e2e/browser-talk-start-stop.fixtures.ts
@@ -21,6 +21,8 @@ export async function installTalkBrowserFixtures(page: Page) {
     const state = {
       audioContextsClosed: 0,
       tracksStopped: 0,
+      wakeLocksReleased: 0,
+      wakeLocksRequested: 0,
       constraints: [] as unknown[],
       inputProcessor: null as InputProcessor | null,
       meterLevel: 0,
@@ -37,6 +39,26 @@ export async function installTalkBrowserFixtures(page: Page) {
         getUserMedia: async (constraints: unknown) => {
           state.constraints.push(constraints);
           return { getTracks: () => [track] };
+        },
+      },
+    });
+    Object.defineProperty(navigator, "wakeLock", {
+      configurable: true,
+      value: {
+        request: async () => {
+          state.wakeLocksRequested += 1;
+          const lock = new EventTarget();
+          Object.defineProperties(lock, {
+            release: {
+              value: async () => {
+                state.wakeLocksReleased += 1;
+                lock.dispatchEvent(new Event("release"));
+              },
+            },
+            released: { value: false },
+            type: { value: "screen" },
+          });
+          return lock;
         },
       },
     });

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -15,6 +15,8 @@ const listeners = new Set<GatewayListener>();
 const processors: MockProcessor[] = [];
 let request: ReturnType<typeof vi.fn>;
 let getUserMedia: ReturnType<typeof vi.fn>;
+let requestWakeLock: ReturnType<typeof vi.fn>;
+let releaseWakeLock: ReturnType<typeof vi.fn>;
 
 class MockAudioContext {
   readonly destination = {};
@@ -145,6 +147,14 @@ beforeEach(() => {
     configurable: true,
     value: { getUserMedia },
   });
+  releaseWakeLock = vi.fn(async () => undefined);
+  const wakeLock = new EventTarget() as WakeLockSentinel;
+  Object.defineProperty(wakeLock, "release", { value: releaseWakeLock });
+  requestWakeLock = vi.fn(async () => wakeLock);
+  Object.defineProperty(globalThis.navigator, "wakeLock", {
+    configurable: true,
+    value: { request: requestWakeLock },
+  });
   vi.stubGlobal("AudioContext", MockAudioContext);
 });
 
@@ -152,12 +162,24 @@ afterEach(() => {
   document.body.replaceChildren();
   listeners.clear();
   processors.length = 0;
+  Reflect.deleteProperty(globalThis.navigator, "wakeLock");
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
 describe("ComposerDictationController", () => {
+  it("keeps the screen awake while dictation records", async () => {
+    const { controller, target } = createHarness();
+
+    await startHold(target);
+
+    expect(requestWakeLock).toHaveBeenCalledWith("screen");
+    document.dispatchEvent(pointer("pointercancel"));
+    await waitForFast(() => expect(releaseWakeLock).toHaveBeenCalledOnce());
+    controller.dispose();
+  });
+
   it("keeps a quick pointer gesture as the existing tap action", async () => {
     const { controller, onTap, target } = createHarness();
 

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -10,6 +10,7 @@ import {
 } from "./realtime-talk-audio.ts";
 import { describeRealtimeTalkInputError, openRealtimeTalkInput } from "./realtime-talk-input.ts";
 import { RealtimeTalkLevelSignal } from "./realtime-talk-level.ts";
+import { ScreenWakeLock } from "./screen-wake-lock.ts";
 
 const HOLD_THRESHOLD_MS = 250;
 const FINAL_TRANSCRIPT_QUIET_MS = 1500;
@@ -402,6 +403,7 @@ class ComposerDictationSession {
 
 export class ComposerDictationController {
   readonly inputLevel = new RealtimeTalkLevelSignal();
+  private readonly screenWakeLock = new ScreenWakeLock();
   private options: ComposerDictationControllerOptions;
   private phase: DictationPhase = "idle";
   private partialTranscript = "";
@@ -601,6 +603,7 @@ export class ComposerDictationController {
       return;
     }
     this.setPhase("connecting");
+    this.screenWakeLock.start();
     this.startElapsedTimer();
     const session = new ComposerDictationSession(client, {
       onError: (message) => {
@@ -638,6 +641,7 @@ export class ComposerDictationController {
       return;
     }
     const wasActive = this.active;
+    this.screenWakeLock.stop();
     this.clearGesture();
     this.stopElapsedTimer();
     const session = this.session;

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -28,6 +28,7 @@ import {
   waitForTranscriptRetry,
 } from "./realtime-talk-transcript-owner.ts";
 import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
+import { ScreenWakeLock } from "./screen-wake-lock.ts";
 
 export type { RealtimeTalkStatus };
 
@@ -141,6 +142,7 @@ function compactLaunchParams(
 }
 
 export class RealtimeTalkSession {
+  private readonly screenWakeLock = new ScreenWakeLock();
   private transport: RealtimeTalkTransport | null = null;
   private pendingTransport: RealtimeTalkTransport | null = null;
   private closed = false;
@@ -170,6 +172,7 @@ export class RealtimeTalkSession {
       const lifecycleGeneration = ++this.lifecycleGeneration;
       this.stopPendingTransport();
       this.closed = false;
+      this.screenWakeLock.start();
       this.callbacks.onStatus?.("connecting");
       const existingTransport = this.transport;
       const existingVoiceSessionId = this.voiceSessionId;
@@ -436,6 +439,7 @@ export class RealtimeTalkSession {
   stop(): void {
     this.lifecycleGeneration += 1;
     this.closed = true;
+    this.screenWakeLock.stop();
     this.videoOperation += 1;
     this.videoEnabled = false;
     activeRealtimeTalkSessions.delete(this);
@@ -559,6 +563,7 @@ export class RealtimeTalkSession {
     }
     this.lifecycleGeneration += 1;
     this.closed = true;
+    this.screenWakeLock.stop();
     this.videoOperation += 1;
     this.videoEnabled = false;
     activeRealtimeTalkSessions.delete(this);

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -83,10 +83,7 @@ type RealtimeTalkConfigResult = {
 };
 
 function normalizeLaunchTransport(value: unknown): RealtimeTalkLaunchTransport | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const transport = normalizeTalkTransport(value);
+  const transport = typeof value === "string" ? normalizeTalkTransport(value) : undefined;
   if (
     transport === "webrtc" ||
     transport === "provider-websocket" ||

--- a/ui/src/pages/chat/screen-wake-lock.test.ts
+++ b/ui/src/pages/chat/screen-wake-lock.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ScreenWakeLock } from "./screen-wake-lock.ts";
+
+beforeEach(() => {
+  const documentTarget = new EventTarget();
+  Object.defineProperty(documentTarget, "visibilityState", { value: "visible" });
+  vi.stubGlobal("document", documentTarget as Document);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ScreenWakeLock", () => {
+  it("holds a screen wake lock until the microphone activity stops", async () => {
+    const { release, request } = installWakeLock();
+    const screenWakeLock = new ScreenWakeLock();
+
+    screenWakeLock.start();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("screen"));
+    screenWakeLock.stop();
+
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("reacquires a released lock when the page becomes visible again", async () => {
+    const first = createWakeLock();
+    const second = createWakeLock();
+    const request = vi.fn().mockResolvedValueOnce(first.lock).mockResolvedValueOnce(second.lock);
+    const addEventListener = vi.spyOn(first.lock, "addEventListener");
+    stubWakeLock(request);
+    const screenWakeLock = new ScreenWakeLock();
+
+    screenWakeLock.start();
+    await vi.waitFor(() =>
+      expect(addEventListener).toHaveBeenCalledWith("release", expect.anything(), {
+        once: true,
+      }),
+    );
+    await Promise.resolve();
+    first.lock.dispatchEvent(new Event("release"));
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    screenWakeLock.stop();
+  });
+
+  it("does not fail when wake locks are unavailable", () => {
+    const screenWakeLock = new ScreenWakeLock();
+
+    expect(() => {
+      screenWakeLock.start();
+      screenWakeLock.stop();
+    }).not.toThrow();
+  });
+});
+
+function installWakeLock() {
+  const wakeLock = createWakeLock();
+  const request = vi.fn(async () => wakeLock.lock);
+  stubWakeLock(request);
+  return { ...wakeLock, request };
+}
+
+function createWakeLock() {
+  const lock = new EventTarget() as WakeLockSentinel;
+  const release = vi.fn(async () => undefined);
+  Object.defineProperties(lock, {
+    release: { value: release },
+    released: { value: false },
+    type: { value: "screen" },
+  });
+  return { lock, release };
+}
+
+function stubWakeLock(request: ReturnType<typeof vi.fn>): void {
+  vi.stubGlobal("navigator", { wakeLock: { request } });
+}

--- a/ui/src/pages/chat/screen-wake-lock.ts
+++ b/ui/src/pages/chat/screen-wake-lock.ts
@@ -1,0 +1,72 @@
+export class ScreenWakeLock {
+  private active = false;
+  private lock: WakeLockSentinel | null = null;
+  private request: Promise<void> | null = null;
+
+  start(): void {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
+    if (typeof document === "undefined" || typeof navigator === "undefined") {
+      return;
+    }
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    this.acquire();
+  }
+
+  stop(): void {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    }
+    const lock = this.lock;
+    this.lock = null;
+    void lock?.release();
+  }
+
+  private readonly handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      this.acquire();
+    }
+  };
+
+  private acquire(): void {
+    if (
+      !this.active ||
+      this.lock ||
+      this.request ||
+      document.visibilityState !== "visible" ||
+      !("wakeLock" in navigator)
+    ) {
+      return;
+    }
+    this.request = navigator.wakeLock
+      .request("screen")
+      .then(async (lock) => {
+        if (!this.active) {
+          await lock.release();
+          return;
+        }
+        this.lock = lock;
+        lock.addEventListener(
+          "release",
+          () => {
+            if (this.lock === lock) {
+              this.lock = null;
+            }
+          },
+          { once: true },
+        );
+      })
+      .catch(() => {
+        // Microphone features remain available when the browser or OS declines this optional aid.
+      })
+      .finally(() => {
+        this.request = null;
+      });
+  }
+}


### PR DESCRIPTION
Closes #120245

## What Problem This Solves

Fixes an issue where users running Browser Talk or holding the composer voice-dictation control on a mobile browser can have the interaction interrupted when the device's normal screen timeout expires.

This was reproduced on a Huawei P30 Pro using Brave Browser on Android.

## Why This Change Was Made

Use the browser Screen Wake Lock API while microphone-driven Talk or dictation is active, release the lock when the activity stops, and reacquire it when the page becomes visible again. The feature is progressive: unsupported browsers and rejected wake-lock requests continue with the existing microphone behavior, with no new configuration, dependency, or backend protocol.

## User Impact

Mobile users can continue a Browser Talk session or voice dictation without periodically touching the screen solely to prevent display timeout. The screen is allowed to sleep normally again as soon as the microphone activity ends.

## Evidence

- Reproduced before the change on a Huawei P30 Pro in Brave Browser on Android: allowing the normal display timeout to expire disrupted the active Browser Talk interaction.
- Verified the reversible Control UI backport on the same device: the display remained awake while Browser Talk was active and returned to normal timeout behavior after the session ended.
- `node scripts/run-vitest.mjs ui/src/pages/chat/screen-wake-lock.test.ts` — 3 tests passed.
- `node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk-lifecycle.test.ts` — 21 tests passed.
- Focused wake-lock, Talk, and dictation test suite during initial implementation — 43 tests passed.
- Formatting across all seven changed files — passed.
- Production Control UI build, precompressed-asset verification, and performance checks — passed.
- `git diff --check` — passed.
- The Browser Talk Playwright fixture and assertions cover wake-lock acquisition and release. Local Chromium execution is unavailable on this host, so that E2E scenario was not run locally.
- The standalone composer-dictation test invocation is blocked before test collection by the repository browser-test harness resolving `node:` imports (`ERR_UNKNOWN_BUILTIN_MODULE`); no dictation assertion failed.

No visual layout changes are introduced, so before/after screenshots would be identical. The relevant before/after evidence is the device screen-timeout behavior described above.

## AI Assistance

AI assistance was used to inspect the codebase, implement the change, add tests, run validation, and draft this PR. Matt  reproduced the original issue and manually verified the live behaviour on the stated Android device and browser. The submitted diff and evidence were reviewed before publication.
