### PR TITLE
fix(plugins): reject malformed percent-encoding in local JSON Schema $ref anchors

### DIFF
--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -52,6 +52,13 @@ describe("normalizeJsonSchemaForTypeBox", () => {
     ).toBeUndefined();
   });
 
+  it.each(["#%", "#foo%zz", "#anchor%"])(
+    "reports malformed percent-encoding in local ref anchor %s as unresolved instead of throwing",
+    (ref) => {
+      expect(findJsonSchemaShapeError({ $ref: ref })).toBe("<schema>.$ref: unresolved ref");
+    },
+  );
+
   it("preserves Control UI nullable value semantics", () => {
     const schema = {
       type: "string",

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -254,7 +254,16 @@ function resolveLocalRef(
       : { found: false };
   }
   if (ref.startsWith("#")) {
-    const resolved = resolveLocalAnchor(resourceRoot, decodeURIComponent(ref.slice(1)));
+    // The pointer branch decodes through decodePointerSegment's try/catch;
+    // anchor fragments deserve the same tolerance so a malformed escape
+    // resolves to "not found" instead of throwing a raw URIError.
+    let anchor: string;
+    try {
+      anchor = decodeURIComponent(ref.slice(1));
+    } catch {
+      return { found: false };
+    }
+    const resolved = resolveLocalAnchor(resourceRoot, anchor);
     return resolved === undefined
       ? { found: false }
       : { found: true, schema: resolved, resourceRoot, resourceBaseId };


### PR DESCRIPTION
## Summary

`fix(plugins): reject malformed percent-encoding in local JSON Schema $ref anchors so a typo'd anchor surfaces as "unresolved ref" instead of crashing validation with a raw URIError`

## What Problem This Solves

`findJsonSchemaShapeError` is the preflight guard whose job is to turn structurally broken schemas into a clean `invalid schema: <path>.$ref: ...` diagnostic. A third-party plugin (or channel) config schema written by hand can contain a malformed percent escape in a local `$ref` anchor — one stray `%`, e.g. `{ "$ref": "#%" }` or `{ "$ref": "#foo%zz" }`.

When that happens today, the user does not get a schema diagnostic at all: validation crashes with a raw `URIError: URI malformed` that points nowhere near the offending schema. The error escapes `validateJsonSchemaValue` (`src/plugins/schema-validator.ts:340`), and none of its callers catch it — plugin config validation (`src/config/validation-plugin-config.ts`), channel config validation, gateway plugin-host hooks, and doctor all surface the opaque `URIError` (or die on it) instead of rejecting the schema cleanly.

**Code evidence**: in `src/shared/json-schema-defaults.ts` (main, before this fix):

- `src/shared/json-schema-defaults.ts:122-130` — the JSON-pointer branch (`#/...`) decodes segments through `decodePointerSegment`, which wraps `decodeURIComponent` in try/catch.
- `src/shared/json-schema-defaults.ts:257` — the plain-anchor branch (`#name`) called `decodeURIComponent(ref.slice(1))` bare. Any malformed escape throws `URIError` out of `resolveLocalRef`.

Minimal reproduction: `findJsonSchemaShapeError({ $ref: "#%" })` throws `URIError: URI malformed` — see Real Behavior Proof below.

## Root Cause

- Violated invariant: `resolveLocalRef` must never throw on malformed input — its contract is a `{ found: boolean }` result, and every other malformed-input path in it (bad pointer segments, missing anchors, unresolvable refs) already fails soft. The anchor branch bypassed the tolerance the pointer branch already had, so one decode path was throw-safe and the other was not.
- Trigger condition: any schema containing a local `$ref` whose anchor fragment is not valid percent-encoding (hand-written plugin schemas are the realistic source), reaching either `findJsonSchemaShapeError` (preflight) or `applySchemaDefaults → resolveSchemaRef` (defaults hydration).

## Why This Fix

- Option A: guard the decode in the anchor branch and return `{ found: false }` on failure (chosen) — mirrors the existing `decodePointerSegment` tolerance exactly where the invariant is violated; malformed anchors deterministically surface as `<path>.$ref: unresolved ref`, the same diagnostic an unknown anchor already produces.
- Option B: catch `URIError` in `validateJsonSchemaValue` and the other callers — rejected: fixes the symptom at N call sites, leaves the second reachable path (`applySchemaDefaults`) unprotected, and still treats a decode failure differently from an unknown anchor.
- Option C: pre-validate the whole `$ref` string with a regex before decoding — rejected: duplicates percent-encoding rules that `decodeURIComponent` already implements, and a try/catch is the smaller, exact change.

Option A is the minimal change that makes the two local-ref decode paths equally throw-safe; three regression tests pin the behavior.

## User Impact

- Affected scenario: loading/validating a plugin or channel whose config schema contains a malformed local `$ref` anchor (a single `%` typo).
- Before: config validation / doctor / gateway startup crashes with `URIError: URI malformed` and no indication of which schema or `$ref` caused it.
- After: the schema is rejected with the intended diagnostic, e.g. `invalid schema: <schema>.properties.a.$ref: unresolved ref`, pointing at the exact field.
- Behavior change: malformed anchors now behave identically to unknown anchors; valid schemas are unaffected.


## Evidence

### Before (on main)

```bash
$ node_modules/.bin/tsx proof.mjs   # main: decodeURIComponent(ref.slice(1)) bare
findJsonSchemaShapeError({ $ref: "#%" }) THREW: URIError URI malformed
findJsonSchemaShapeError({ $ref: "#foo%zz" }) THREW: URIError URI malformed
findJsonSchemaShapeError({ $ref: "#missing" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#/$defs/ok" }) -> undefined
validateJsonSchemaValue(properties.a.$ref = #%) THREW: URIError URI malformed
BEHAVIOR: FAIL - a malformed local $ref anchor escapes as a raw URIError instead of an "unresolved ref" schema diagnostic
exit=1
```

### After (with fix)

```bash
$ node_modules/.bin/tsx proof.mjs   # HEAD: guarded decode -> { found: false }
findJsonSchemaShapeError({ $ref: "#%" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#foo%zz" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#missing" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#/$defs/ok" }) -> undefined
validateJsonSchemaValue(properties.a.$ref = #%) THREW: Error invalid schema: <schema>.properties.a.$ref: unresolved ref
BEHAVIOR: PASS - malformed local $ref anchors resolve to { found: false } and surface as '.$ref: unresolved ref'
exit=0
```

Note the `validateJsonSchemaValue` line: it still throws, but now with the **intended** `invalid schema: ... unresolved ref` message that names the exact `$ref`, instead of an opaque `URIError`.

### Source, test, and history

- Source: the inspected PR base (`3bc188efe55eede47c13f97e9ab172754a0bed9e`) has the bare plain-anchor decode at `src/shared/json-schema-defaults.ts:256-260`; exact head `8d0e515c3ce9a18cf943bb723cb49f7c3320f02d` catches malformed decoding and returns `{ found: false }` at `src/shared/json-schema-defaults.ts:256-264`.
- Test: exact head adds the table-driven regression for `#%`, `#foo%zz`, and `#anchor%` at `src/shared/json-schema-defaults.test.ts:55-59`; the focused run recorded above passed 15/15 tests.
- History: `05a03c66fe7` is `fix: cap local tsgo CPU usage (#119517)` and only changes `scripts/lib/local-heavy-check-runtime.mjs` and `test/scripts/local-heavy-check-runtime.test.ts`; it is unrelated to this resolver. The inspected file history last shows `b3ce00b480d4` (`refactor(schema): share config validation runtime (#116622)`) before this PR, but the exact introduction point is not established, so no historical-origin claim is made.

## Real Behavior Proof

No mocks, no stubs: the proof drives the real exported `findJsonSchemaShapeError` (`src/shared/json-schema-defaults.ts`) and the real `validateJsonSchemaValue` (`src/plugins/schema-validator.ts`) with real malformed schemas (`#%`, `#foo%zz`), plus two control cases (unknown anchor `#missing`, valid pointer `#/$defs/ok`).

### Before (on main)

```bash
$ node_modules/.bin/tsx proof.mjs   # main: decodeURIComponent(ref.slice(1)) bare
findJsonSchemaShapeError({ $ref: "#%" }) THREW: URIError URI malformed
findJsonSchemaShapeError({ $ref: "#foo%zz" }) THREW: URIError URI malformed
findJsonSchemaShapeError({ $ref: "#missing" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#/$defs/ok" }) -> undefined
validateJsonSchemaValue(properties.a.$ref = #%) THREW: URIError URI malformed
BEHAVIOR: FAIL - a malformed local $ref anchor escapes as a raw URIError instead of an "unresolved ref" schema diagnostic
exit=1
```

### After (with fix)

```bash
$ node_modules/.bin/tsx proof.mjs   # HEAD: guarded decode -> { found: false }
findJsonSchemaShapeError({ $ref: "#%" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#foo%zz" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#missing" }) -> "<schema>.$ref: unresolved ref"
findJsonSchemaShapeError({ $ref: "#/$defs/ok" }) -> undefined
validateJsonSchemaValue(properties.a.$ref = #%) THREW: Error invalid schema: <schema>.properties.a.$ref: unresolved ref
BEHAVIOR: PASS - malformed local $ref anchors resolve to { found: false } and surface as '.$ref: unresolved ref'
exit=0
```

Note the `validateJsonSchemaValue` line: it still throws, but now with the **intended** `invalid schema: ... unresolved ref` message that names the exact `$ref`, instead of an opaque `URIError`.

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/shared/json-schema-defaults.test.ts` — 15/15 tests passed, including the new regression test `reports malformed percent-encoding in local ref anchor %s as unresolved instead of throwing` (`#%`, `#foo%zz`, `#anchor%`).
- Manual verification (the proof above):
  1. On main, both entry points throw `URIError` for `#%` / `#foo%zz` — FAIL.
  2. With the fix, the same inputs return `<schema>.$ref: unresolved ref`, valid refs still resolve, and `validateJsonSchemaValue` reports the field-accurate diagnostic — PASS.

