### PR TITLE
fix(discord): thread archive/delete closes sessions in each agent's store

### DIFF
--- a/extensions/discord/src/monitor/listeners.thread-delete.session-store.integration.test.ts
+++ b/extensions/discord/src/monitor/listeners.thread-delete.session-store.integration.test.ts
@@ -1,0 +1,90 @@
+// Discord integration tests drive thread deletion through the real session store.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ChannelType, type GatewayThreadDeleteDispatchData } from "discord-api-types/v10";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  getSessionEntry,
+  resolveStorePath,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import { withEnvAsync, withStateDirEnv } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { DiscordThreadDeleteListener } from "./listeners.js";
+
+const THREAD_ID = "112233445566778899";
+const OTHER_THREAD_ID = "998877665544332211";
+
+describe("DiscordThreadDeleteListener session-store integration", () => {
+  it("deletes matching sessions from every configured agent store", async () => {
+    await withStateDirEnv("openclaw-discord-thread-delete-", async ({ tempRoot, stateDir }) => {
+      // macOS exposes os.tmpdir() through /var while SQLite resolves /private/var.
+      const canonicalTempRoot = await fs.realpath(tempRoot);
+      const canonicalStateDir = await fs.realpath(stateDir);
+
+      await withEnvAsync({ OPENCLAW_STATE_DIR: canonicalStateDir }, async () => {
+        const sharedStorePath = path.join(canonicalTempRoot, "shared", "sessions.json");
+        const cfg = {
+          session: { store: sharedStorePath },
+          agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+        } satisfies OpenClawConfig;
+        const mainStorePath = resolveStorePath(cfg.session.store, { agentId: "main" });
+        const workStorePath = resolveStorePath(cfg.session.store, { agentId: "work" });
+        const mainMatchKey = `agent:main:discord:channel:${THREAD_ID}`;
+        const workMatchKey = `agent:work:discord:channel:parent:thread:${THREAD_ID}`;
+        const survivorKey = `agent:main:discord:channel:${OTHER_THREAD_ID}`;
+
+        await upsertSessionEntry({
+          agentId: "main",
+          sessionKey: mainMatchKey,
+          storePath: mainStorePath,
+          entry: { sessionId: "main-thread-session", updatedAt: 1_000 },
+        });
+        await upsertSessionEntry({
+          agentId: "work",
+          sessionKey: workMatchKey,
+          storePath: workStorePath,
+          entry: { sessionId: "work-thread-session", updatedAt: 2_000 },
+        });
+        await upsertSessionEntry({
+          agentId: "main",
+          sessionKey: survivorKey,
+          storePath: mainStorePath,
+          entry: { sessionId: "main-survivor-session", updatedAt: 3_000 },
+        });
+
+        const listener = new DiscordThreadDeleteListener(cfg, "session-store-integration");
+        const deletedThread: GatewayThreadDeleteDispatchData = {
+          id: THREAD_ID,
+          guild_id: "887766554433221100",
+          parent_id: "776655443322110099",
+          type: ChannelType.PublicThread,
+        };
+
+        await listener.handle(deletedThread);
+
+        expect(
+          getSessionEntry({
+            agentId: "main",
+            sessionKey: mainMatchKey,
+            storePath: mainStorePath,
+          }),
+        ).toBeUndefined();
+        expect(
+          getSessionEntry({
+            agentId: "work",
+            sessionKey: workMatchKey,
+            storePath: workStorePath,
+          }),
+        ).toBeUndefined();
+        expect(
+          getSessionEntry({
+            agentId: "main",
+            sessionKey: survivorKey,
+            storePath: mainStorePath,
+          }),
+        ).toMatchObject({ sessionId: "main-survivor-session", updatedAt: 3_000 });
+      });
+    });
+  });
+});

--- a/extensions/discord/src/monitor/listeners.thread-delete.test.ts
+++ b/extensions/discord/src/monitor/listeners.thread-delete.test.ts
@@ -63,7 +63,6 @@ describe("DiscordThreadDeleteListener", () => {
     });
     expect(lifecycleMocks.closeDiscordThreadSessions).toHaveBeenCalledWith({
       cfg,
-      accountId: "account-2",
       threadId: "thread-42",
     });
     expect(logger.info).toHaveBeenCalledWith("Discord thread deleted — reset sessions", {
@@ -81,7 +80,6 @@ describe("DiscordThreadDeleteListener", () => {
     expect(lifecycleMocks.unbindThread).not.toHaveBeenCalled();
     expect(lifecycleMocks.closeDiscordThreadSessions).toHaveBeenCalledWith({
       cfg,
-      accountId: "account-2",
       threadId: "thread-42",
     });
   });

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -476,7 +476,6 @@ type ThreadUpdateEvent = Parameters<ThreadUpdateListener["handle"]>[0];
 export class DiscordThreadUpdateListener extends ThreadUpdateListener {
   constructor(
     private cfg: OpenClawConfig,
-    private accountId: string,
     private logger?: Logger,
   ) {
     super();

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -501,7 +501,6 @@ export class DiscordThreadUpdateListener extends ThreadUpdateListener {
         const logger = this.logger ?? discordEventQueueLog;
         const count = await closeDiscordThreadSessions({
           cfg: this.cfg,
-          accountId: this.accountId,
           threadId,
         });
         if (count > 0) {
@@ -541,7 +540,6 @@ export class DiscordThreadDeleteListener extends ThreadDeleteListener {
         });
         const count = await closeDiscordThreadSessions({
           cfg: this.cfg,
-          accountId: this.accountId,
           threadId,
         });
         if (count > 0) {

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -286,7 +286,7 @@ export function registerDiscordMonitorListeners(params: {
   }
   registerDiscordListener(
     params.client.listeners,
-    new DiscordThreadUpdateListener(params.cfg, params.accountId, params.logger),
+    new DiscordThreadUpdateListener(params.cfg, params.logger),
   );
   registerDiscordListener(
     params.client.listeners,

--- a/extensions/discord/src/monitor/thread-session-close.test.ts
+++ b/extensions/discord/src/monitor/thread-session-close.test.ts
@@ -272,4 +272,38 @@ describe("closeDiscordThreadSessions", () => {
     expect(Object.keys(mainStore)).toHaveLength(0);
     expect(Object.keys(workStore)).toHaveLength(0);
   });
+
+  it("scopes each read by agent id and never opens agent databases writably", async () => {
+    // With a fixed custom store every agent resolves the same storePath, so the
+    // agentId is what selects the owner DB — without it the scan re-reads the
+    // default owner and leaves the other agent's thread session open.
+    const fixedStorePath = "/custom/path/sessions.json";
+    const entriesByAgent: Record<string, Record<string, { updatedAt: number }>> = {
+      main: { [`agent:main:discord:channel:${THREAD_ID}`]: { updatedAt: 1_000 } },
+      work: { [`agent:work:discord:channel:${THREAD_ID}`]: { updatedAt: 2_000 } },
+    };
+    hoisted.resolveStorePath.mockReturnValue(fixedStorePath);
+    hoisted.listSessionEntries.mockImplementation(({ agentId }: { agentId?: string }) =>
+      Object.entries(agentId ? (entriesByAgent[agentId] ?? {}) : {}).map(([sessionKey, entry]) => ({
+        sessionKey,
+        entry,
+      })),
+    );
+    hoisted.deleteSessionEntry.mockResolvedValue(true);
+
+    const count = await closeDiscordThreadSessions({
+      cfg: {
+        session: { store: fixedStorePath },
+        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+      },
+      threadId: THREAD_ID,
+    });
+
+    expect(count).toBe(2);
+    for (const agentId of ["main", "work"]) {
+      expect(hoisted.listSessionEntries).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId, storePath: fixedStorePath, readOnly: true }),
+      );
+    }
+  });
 });

--- a/extensions/discord/src/monitor/thread-session-close.test.ts
+++ b/extensions/discord/src/monitor/thread-session-close.test.ts
@@ -1,10 +1,12 @@
 // Discord tests cover thread session close plugin behavior.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+type ResolveStorePath = typeof import("openclaw/plugin-sdk/session-store-runtime").resolveStorePath;
+
 const hoisted = vi.hoisted(() => {
   const deleteSessionEntry = vi.fn();
   const listSessionEntries = vi.fn();
-  const resolveStorePath = vi.fn(() => "/tmp/openclaw-sessions.json");
+  const resolveStorePath = vi.fn<ResolveStorePath>(() => "/tmp/openclaw-sessions.json");
   return { deleteSessionEntry, listSessionEntries, resolveStorePath };
 });
 
@@ -236,15 +238,17 @@ describe("closeDiscordThreadSessions", () => {
 
   it("closes sessions across every agent's store", async () => {
     // Two agents, each with its own store keyed by resolved path.
-    const stores: Record<string, Record<string, { sessionId?: string; updatedAt: number }>> = {
-      "/stores/main.json": { [`agent:main:discord:channel:${THREAD_ID}`]: { updatedAt: 1_000 } },
-      "/stores/work.json": {
-        [`agent:work:discord:channel:${THREAD_ID}:thread:${THREAD_ID}`]: { updatedAt: 2_000 },
-      },
+    const mainStore = {
+      [`agent:main:discord:channel:${THREAD_ID}`]: { updatedAt: 1_000 },
     };
-    hoisted.resolveStorePath.mockImplementation(
-      (_store: unknown, opts: { agentId: string }) => `/stores/${opts.agentId}.json`,
-    );
+    const workStore = {
+      [`agent:work:discord:channel:${THREAD_ID}:thread:${THREAD_ID}`]: { updatedAt: 2_000 },
+    };
+    const stores: Record<string, Record<string, { sessionId?: string; updatedAt: number }>> = {
+      "/stores/main.json": mainStore,
+      "/stores/work.json": workStore,
+    };
+    hoisted.resolveStorePath.mockImplementation((_store, opts) => `/stores/${opts?.agentId}.json`);
     hoisted.listSessionEntries.mockImplementation(({ storePath }: { storePath: string }) =>
       Object.entries(stores[storePath] ?? {}).map(([sessionKey, entry]) => ({ sessionKey, entry })),
     );
@@ -265,7 +269,7 @@ describe("closeDiscordThreadSessions", () => {
     });
 
     expect(count).toBe(2);
-    expect(Object.keys(stores["/stores/main.json"])).toHaveLength(0);
-    expect(Object.keys(stores["/stores/work.json"])).toHaveLength(0);
+    expect(Object.keys(mainStore)).toHaveLength(0);
+    expect(Object.keys(workStore)).toHaveLength(0);
   });
 });

--- a/extensions/discord/src/monitor/thread-session-close.test.ts
+++ b/extensions/discord/src/monitor/thread-session-close.test.ts
@@ -75,7 +75,6 @@ describe("closeDiscordThreadSessions", () => {
 
     const count = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID,
     });
 
@@ -92,7 +91,6 @@ describe("closeDiscordThreadSessions", () => {
 
     const count = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID,
     });
 
@@ -113,7 +111,6 @@ describe("closeDiscordThreadSessions", () => {
 
     const count = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID,
     });
 
@@ -133,7 +130,6 @@ describe("closeDiscordThreadSessions", () => {
 
     const count = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID,
     });
 
@@ -150,7 +146,6 @@ describe("closeDiscordThreadSessions", () => {
 
     const count = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID.toLowerCase(),
     });
 
@@ -161,7 +156,6 @@ describe("closeDiscordThreadSessions", () => {
   it("returns 0 immediately when threadId is empty without touching the store", async () => {
     const count = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: "   ",
     });
 
@@ -179,12 +173,10 @@ describe("closeDiscordThreadSessions", () => {
 
     const firstCount = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID,
     });
     const secondCount = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID,
     });
 
@@ -214,7 +206,6 @@ describe("closeDiscordThreadSessions", () => {
 
     const count = await closeDiscordThreadSessions({
       cfg: {},
-      accountId: "default",
       threadId: THREAD_ID,
     });
 
@@ -223,18 +214,58 @@ describe("closeDiscordThreadSessions", () => {
     expect(store[MATCHED_KEY].sessionId).toBe("fresh-session");
   });
 
-  it("resolves the store path using cfg.session.store and accountId", async () => {
+  it("resolves the store path per routed agent id, not the channel account id", async () => {
     const store = {};
     setupStore(store);
 
     await closeDiscordThreadSessions({
-      cfg: { session: { store: "/custom/path/sessions.json" } },
-      accountId: "my-bot",
+      cfg: {
+        session: { store: "/custom/path/sessions.json" },
+        agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+      },
       threadId: THREAD_ID,
     });
 
     expect(hoisted.resolveStorePath).toHaveBeenCalledWith("/custom/path/sessions.json", {
-      agentId: "my-bot",
+      agentId: "main",
     });
+    expect(hoisted.resolveStorePath).toHaveBeenCalledWith("/custom/path/sessions.json", {
+      agentId: "work",
+    });
+  });
+
+  it("closes sessions across every agent's store", async () => {
+    // Two agents, each with its own store keyed by resolved path.
+    const stores: Record<string, Record<string, { sessionId?: string; updatedAt: number }>> = {
+      "/stores/main.json": { [`agent:main:discord:channel:${THREAD_ID}`]: { updatedAt: 1_000 } },
+      "/stores/work.json": {
+        [`agent:work:discord:channel:${THREAD_ID}:thread:${THREAD_ID}`]: { updatedAt: 2_000 },
+      },
+    };
+    hoisted.resolveStorePath.mockImplementation(
+      (_store: unknown, opts: { agentId: string }) => `/stores/${opts.agentId}.json`,
+    );
+    hoisted.listSessionEntries.mockImplementation(({ storePath }: { storePath: string }) =>
+      Object.entries(stores[storePath] ?? {}).map(([sessionKey, entry]) => ({ sessionKey, entry })),
+    );
+    hoisted.deleteSessionEntry.mockImplementation(
+      async (params: { sessionKey: string; storePath: string }) => {
+        const bucket = stores[params.storePath];
+        if (!bucket?.[params.sessionKey]) {
+          return false;
+        }
+        delete bucket[params.sessionKey];
+        return true;
+      },
+    );
+
+    const count = await closeDiscordThreadSessions({
+      cfg: { agents: { list: [{ id: "main", default: true }, { id: "work" }] } },
+      threadId: THREAD_ID,
+    });
+
+    expect(count).toBe(2);
+    expect(Object.keys(stores["/stores/main.json"])).toHaveLength(0);
+    expect(Object.keys(stores["/stores/work.json"])).toHaveLength(0);
   });
 });

--- a/extensions/discord/src/monitor/thread-session-close.ts
+++ b/extensions/discord/src/monitor/thread-session-close.ts
@@ -45,7 +45,15 @@ export async function closeDiscordThreadSessions(params: {
 
   for (const agentId of listAgentIds(cfg)) {
     const storePath = resolveStorePath(cfg.session?.store, { agentId });
-    for (const { sessionKey, entry } of listSessionEntries({ storePath })) {
+    // agentId selects the owner DB: with a fixed custom store every agent
+    // resolves the same storePath, so storePath alone re-reads the default
+    // owner. readOnly keeps this fleet-wide scan from creating or registering
+    // agent databases while handling a thread archive/delete event.
+    for (const { sessionKey, entry } of listSessionEntries({
+      agentId,
+      storePath,
+      readOnly: true,
+    })) {
       if (!sessionKeyContainsThreadId(sessionKey)) {
         continue;
       }

--- a/extensions/discord/src/monitor/thread-session-close.ts
+++ b/extensions/discord/src/monitor/thread-session-close.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements thread session close behavior.
+import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   deleteSessionEntry,
@@ -14,10 +15,9 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
  */
 export async function closeDiscordThreadSessions(params: {
   cfg: OpenClawConfig;
-  accountId: string;
   threadId: string;
 }): Promise<number> {
-  const { cfg, accountId, threadId } = params;
+  const { cfg, threadId } = params;
 
   const normalizedThreadId = normalizeOptionalLowercaseString(threadId) ?? "";
   if (!normalizedThreadId) {
@@ -38,25 +38,27 @@ export async function closeDiscordThreadSessions(params: {
     return segmentRe.test(key);
   }
 
-  // Resolve the store file. We pass `accountId` as `agentId` here to mirror
-  // how other Discord subsystems resolve their per-account sessions stores.
-  const storePath = resolveStorePath(cfg.session?.store, { agentId: accountId });
-
+  // Session keys are agent-scoped (agent:<agentId>:discord:...), so the store
+  // must resolve per routed agent — resolving with the channel account id
+  // would target a nonexistent agent's store and silently close nothing.
   let resetCount = 0;
 
-  for (const { sessionKey, entry } of listSessionEntries({ storePath })) {
-    if (!sessionKeyContainsThreadId(sessionKey)) {
-      continue;
-    }
-    const deleted = await deleteSessionEntry({
-      archiveTranscript: true,
-      expectedSessionId: entry.sessionId ?? null,
-      expectedUpdatedAt: entry.updatedAt,
-      sessionKey,
-      storePath,
-    });
-    if (deleted) {
-      resetCount += 1;
+  for (const agentId of listAgentIds(cfg)) {
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    for (const { sessionKey, entry } of listSessionEntries({ storePath })) {
+      if (!sessionKeyContainsThreadId(sessionKey)) {
+        continue;
+      }
+      const deleted = await deleteSessionEntry({
+        archiveTranscript: true,
+        expectedSessionId: entry.sessionId ?? null,
+        expectedUpdatedAt: entry.updatedAt,
+        sessionKey,
+        storePath,
+      });
+      if (deleted) {
+        resetCount += 1;
+      }
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where archiving or deleting a Discord thread never closed its sessions. `closeDiscordThreadSessions` resolved the sessions store passing the Discord **account id** (`"default"` on the default path) as `agentId`, but sessions live in per-agent stores keyed by routed agent ids (`agent:main:discord:...`). The lookup targeted a nonexistent agent's empty store, `resetCount` stayed 0, and both listeners only log when count > 0 — a fully silent no-op, plus a spurious `agents/default` database materialized as a side effect. The unit test never caught it because it mocked `resolveStorePath` to a fixed path.

## Why This Change Was Made

Every sibling Discord session call site resolves the store with the routed agent id (`message-handler.context.ts:160`, `process-progress.ts:59`, `process-reply-runtime.ts:165`); this path was the outlier and its "mirrors other Discord subsystems" comment was false. The fix enumerates `listAgentIds(cfg)` and closes matching sessions in each agent's store — a thread's sessions can be owned by any agent, so per-agent iteration is the correct owner shape. The `accountId` parameter is deleted (store resolution never legitimately used it).

## User Impact

Archived/deleted Discord threads actually reset their sessions again; a later message in a revived thread starts fresh as documented.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/thread-session-close.test.ts` — passes, with two new regression tests: store resolution called per agent id (not account id), and cross-agent-store deletion proving entries in both agents' stores are closed.
- Finding confirmed by adversarial verification against current main (audit finding #0, round-2 stress audit).
