### PR TITLE
fix(imessage): stop dropping user text that collides with recent outbound sends

### DIFF
--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -1,9 +1,11 @@
 // Imessage tests cover monitor.watch subscribe retry plugin behavior.
+import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
 import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { createIMessageRpcClient, IMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import type { attachIMessageMonitorAbortHandler } from "./monitor/abort-handler.js";
+import { rememberPersistedIMessageEcho } from "./monitor/persisted-echo-cache.js";
 import {
   installIMessageFailingStateRuntimeForTest,
   installIMessageStateRuntimeForTest,
@@ -33,6 +35,7 @@ function createRuntime() {
   return {
     log: vi.fn(),
     error: vi.fn(),
+    exit: vi.fn(),
   };
 }
 
@@ -268,5 +271,61 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     expect(diagnostics[0]).not.toContain("outbound-guid");
     expect(diagnostics[0]).not.toContain("private message text");
     expect(diagnostics[0]).not.toContain("+15550001111");
+  });
+
+  it("redacts the conversation identifier in rate-limit suppression warnings", async () => {
+    vi.useRealTimers();
+    installIMessageStateRuntimeForTest();
+    const runtime = createRuntime();
+    const sender = "+15550002222";
+    const chatId = 456;
+    const scope = `default:chat_id:${chatId}`;
+    rememberPersistedIMessageEcho({ scope, text: "loop echo" });
+    let onNotification:
+      | ((message: { method: string; params: unknown }) => void | Promise<void>)
+      | undefined;
+    const notify = async (id: number, text: string) => {
+      await onNotification?.({
+        method: "message",
+        params: {
+          message: {
+            id,
+            guid: `p:0/message-${id}`,
+            chat_id: chatId,
+            sender,
+            is_from_me: false,
+            is_group: true,
+            text,
+            created_at: new Date().toISOString(),
+          },
+        },
+      });
+    };
+    const client = createRpcClient({
+      waitForClose: async () => {
+        for (let id = 1; id <= 5; id += 1) {
+          await notify(id, "loop echo");
+        }
+        await notify(6, "legitimate inbound");
+      },
+    });
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return client;
+    });
+
+    await monitorIMessageProvider({
+      config: { channels: { imessage: { groupPolicy: "open" } } },
+      runtime,
+    });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    const logs = runtime.log.mock.calls.map(([message]) => String(message));
+    const warning = logs.find((message) => message.includes("rate limiter tripped"));
+    expect(warning, `logs: ${JSON.stringify(logs)}`).toBeDefined();
+    expect(warning).toContain(`group:${redactIdentifier(`group:${chatId}`)}`);
+    expect(warning).not.toContain(sender);
   });
 });

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -102,6 +102,7 @@ class DefaultSentMessageCache implements SentMessageCache {
         text: lookup.text,
         media: lookup.media,
         messageId: lookup.messageId,
+        skipIdShortCircuit: resolvedOptions.skipIdShortCircuit,
         includePendingText: resolvedOptions.includePendingText,
       })
     ) {

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
@@ -167,6 +167,22 @@ describe("iMessage sent-message echo cache", () => {
     ).toBe(true);
   });
 
+  it("does not match persisted text when both message ids differ", () => {
+    // Outbound "ok" recorded with its GUID; a user later sends "ok" with a new
+    // GUID. Same text, conflicting ids — a NEW message, not a reconnect echo.
+    const scope = "acct:imessage:+1555";
+    rememberPersistedIMessageEcho({ scope, text: "ok", messageId: "guid-agent-text" });
+
+    expect(hasPersistedIMessageEcho({ scope, text: "ok", messageId: "guid-user-text" })).toBe(
+      false,
+    );
+    // Genuine echo still matches by id, and id-less probes still match by text.
+    expect(hasPersistedIMessageEcho({ scope, text: "ok", messageId: "guid-agent-text" })).toBe(
+      true,
+    );
+    expect(hasPersistedIMessageEcho({ scope, text: "ok" })).toBe(true);
+  });
+
   it("matches persisted media through the primary sent-message cache", () => {
     const scope = "acct:imessage:+1555";
     const media = { contentType: "image/png", kind: "image" as const };

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
@@ -183,6 +183,22 @@ describe("iMessage sent-message echo cache", () => {
     expect(hasPersistedIMessageEcho({ scope, text: "ok" })).toBe(true);
   });
 
+  it("matches persisted self-chat text after the in-memory cache expires", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const scope = "acct:imessage:+1555";
+    const cache = createSentMessageCache();
+    const text = "Delayed self-chat echo";
+    const outboundGuid = "p:0/guid-agent-text";
+
+    rememberPersistedIMessageEcho({ scope, text, messageId: outboundGuid });
+    cache.remember(scope, { text, messageId: outboundGuid });
+    vi.advanceTimersByTime(4_001);
+
+    expect(cache.has(scope, { text, messageId: "12345" }, { skipIdShortCircuit: true })).toBe(true);
+    expect(cache.has(scope, { text, messageId: "p:0/guid-user-text" })).toBe(false);
+  });
+
   it("matches persisted media through the primary sent-message cache", () => {
     const scope = "acct:imessage:+1555";
     const media = { contentType: "image/png", kind: "image" as const };

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -27,6 +27,7 @@ import {
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { normalizeScpRemoteHost } from "openclaw/plugin-sdk/host-runtime";
+import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
 import { isInboundPathAllowed, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveTextChunkLimit, type GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
@@ -873,9 +874,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       // A tripped limiter silently eats real user messages — surface it at
       // default log level (once per conversation) instead of verbose-only.
       if (!loggedThrottledDropDiagnostics.check(`${rateLimitKey}:rate-limited`)) {
+        const conversationKind = chatId != null ? "group" : "dm";
+        const diagnosticConversationKey = `${conversationKind}:${redactIdentifier(conversationKey)}`;
         runtime.log?.(
           warn(
-            `[imessage:${accountInfo.accountId}] Suppressing inbound from ${conversationKey}: echo loop detected (rate limiter tripped)`,
+            `[imessage:${accountInfo.accountId}] Suppressing inbound from ${diagnosticConversationKey}: echo loop detected (rate limiter tripped)`,
           ),
         );
       }

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -827,12 +827,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     if (decision.kind === "drop") {
       // Record echo/reflection drops so the rate limiter can detect sustained loops.
       // Only loop-related drop reasons feed the counter; policy/mention/empty drops
-      // are normal and should not escalate.
+      // are normal and should not escalate. "from me" is excluded: every own-send
+      // (agent replies, multi-chunk sends, operator phone traffic) produces a
+      // from-me row, so counting it lets a normal outbound burst trip the limiter
+      // and silently suppress the next legitimate inbound message.
       const isLoopDrop =
         decision.reason === "echo" ||
         decision.reason === "self-chat echo" ||
-        decision.reason === "reflected assistant content" ||
-        decision.reason === "from me";
+        decision.reason === "reflected assistant content";
       if (isLoopDrop) {
         loopRateLimiter.record(rateLimitKey);
       }
@@ -868,7 +870,15 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     // remaining messages as a safety net against amplification that slips
     // through the primary guards.
     if (decision.kind === "dispatch" && loopRateLimiter.isRateLimited(rateLimitKey)) {
-      logVerbose(`imessage: rate-limited conversation ${conversationKey} (echo loop detected)`);
+      // A tripped limiter silently eats real user messages — surface it at
+      // default log level (once per conversation) instead of verbose-only.
+      if (!loggedThrottledDropDiagnostics.check(`${rateLimitKey}:rate-limited`)) {
+        runtime.log?.(
+          warn(
+            `[imessage:${accountInfo.accountId}] Suppressing inbound from ${conversationKey}: echo loop detected (rate limiter tripped)`,
+          ),
+        );
+      }
       return;
     }
 

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -207,6 +207,7 @@ export function hasPersistedIMessageEcho(params: {
   text?: string;
   media?: MediaPlaceholderTextFact;
   messageId?: string;
+  skipIdShortCircuit?: boolean;
   includePendingText?: boolean;
 }): boolean {
   const text = normalizeText(params.text);
@@ -225,12 +226,12 @@ export function hasPersistedIMessageEcho(params: {
     const hasConflictingMessageIds = Boolean(
       messageId && entry.messageId && messageId !== entry.messageId,
     );
-    // Same-id echoes match on the messageId branch above; an inbound message
-    // whose GUID differs from the recorded outbound GUID is a NEW message even
-    // when the text collides ("ok", "done"), never a reconnect echo.
+    // Same-id echoes match on the messageId branch above. Known conflicting
+    // GUIDs identify new messages, while no-GUID self-chat rows opt into text
+    // fallback because their numeric SQLite IDs cannot equal outbound GUIDs.
     if (
       text &&
-      !hasConflictingMessageIds &&
+      (!hasConflictingMessageIds || params.skipIdShortCircuit) &&
       entry.text === text &&
       (!entry.pending || params.includePendingText)
     ) {

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -225,7 +225,15 @@ export function hasPersistedIMessageEcho(params: {
     const hasConflictingMessageIds = Boolean(
       messageId && entry.messageId && messageId !== entry.messageId,
     );
-    if (text && entry.text === text && (!entry.pending || params.includePendingText)) {
+    // Same-id echoes match on the messageId branch above; an inbound message
+    // whose GUID differs from the recorded outbound GUID is a NEW message even
+    // when the text collides ("ok", "done"), never a reconnect echo.
+    if (
+      text &&
+      !hasConflictingMessageIds &&
+      entry.text === text &&
+      (!entry.pending || params.includePendingText)
+    ) {
       return true;
     }
     if (


### PR DESCRIPTION
## What Problem This Solves

Fixes two message-loss paths in the iMessage monitor:

1. **Text echo false positives.** The persisted 12-hour echo cache matched inbound user text against previously sent outbound text even when the message GUIDs conflicted. A user replying "ok" or "done" within 12 hours of the agent sending the same short text in that conversation was silently classified as a reconnect echo and dropped — permanently. The media branch directly below already had the `hasConflictingMessageIds` guard (added in 0ac7b24d56ca7); the text branch was missing it.
2. **Loop limiter tripped by normal sends.** Every `is_from_me` row fed the echo-loop rate limiter, so an ordinary outbound burst — agent replies, multi-chunk sends, the operator texting from their own phone — could trip the limiter, which then silently suppressed the next legitimate inbound messages (verbose-only log).

## Why This Change Was Made

Genuine reconnect echoes match via the messageId branch (same GUID) or via id-less pending entries, so the id-conflict guard is a no-op for every legitimate echo — its absence protected nothing and violated the in-memory cache's documented "never message loss" contract. For the limiter, own-send rows are expected transport traffic, not amplification signal; only `echo`/`self-chat echo`/`reflected assistant content` remain loop signals. A tripped limiter now also logs a default-level warning once per conversation, so suppression is never invisible.

## User Impact

iMessage users can send short replies that collide with recent agent output without losing them, and busy conversations no longer silently mute after outbound bursts.

## Evidence

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/cache-lifecycle.test.ts extensions/imessage/src/monitor/inbound-processing.test.ts extensions/imessage/src/send.test.ts` — pass, with a new regression proving text+conflicting-id is not an echo while same-id and id-less matches still work.
- Both findings confirmed by adversarial verification against current main (round-2 stress audit findings #2, #3).
