### PR TITLE
test(diagnostics): cover OTEL exporter contracts

### DIFF
--- a/extensions/diagnostics-otel/src/service-disabled.integration.test.ts
+++ b/extensions/diagnostics-otel/src/service-disabled.integration.test.ts
@@ -19,6 +19,48 @@ const OTEL_GLOBAL_API_KEY = Symbol.for("opentelemetry.js.api.1");
 const OTEL_GLOBAL_LOGS_KEY = Symbol.for("io.opentelemetry.js.api.logs");
 const JAEGER_DEPRECATION_WARNING =
   'The Jaeger propagator is deprecated and will be removed in a future release. Use the W3C TraceContext propagator ("tracecontext") instead.';
+const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const SPAN_ID = "00f067aa0ba902b7";
+const PROPAGATED_SPAN_CONTEXT = {
+  traceId: TRACE_ID,
+  spanId: SPAN_ID,
+  traceFlags: 1,
+  isRemote: true,
+} as const;
+const PROPAGATION_ROUNDTRIP_CASES = [
+  {
+    label: "W3C",
+    value: "tracecontext",
+    incoming: { traceparent: `00-${TRACE_ID}-${SPAN_ID}-01` },
+    outgoing: { traceparent: `00-${TRACE_ID}-${SPAN_ID}-01` },
+  },
+  {
+    label: "B3",
+    value: "b3",
+    incoming: { b3: `${TRACE_ID}-${SPAN_ID}-1` },
+    outgoing: { b3: `${TRACE_ID}-${SPAN_ID}-1` },
+  },
+  {
+    label: "B3MULTI",
+    value: "b3multi",
+    incoming: {
+      "x-b3-traceid": TRACE_ID,
+      "x-b3-spanid": SPAN_ID,
+      "x-b3-sampled": "1",
+    },
+    outgoing: {
+      "x-b3-traceid": TRACE_ID,
+      "x-b3-spanid": SPAN_ID,
+      "x-b3-sampled": "1",
+    },
+  },
+  {
+    label: "Jaeger",
+    value: "jaeger",
+    incoming: { "uber-trace-id": `${TRACE_ID}:${SPAN_ID}:0:1` },
+    outgoing: { "uber-trace-id": `${TRACE_ID}:${SPAN_ID}:0:01` },
+  },
+] as const;
 
 type OtelGlobalRegistrations = {
   context?: Parameters<typeof context.setGlobalContextManager>[0];
@@ -267,6 +309,36 @@ test.each([
       await service.stop?.(ctx);
     }
     expect(propagation.fields()).toEqual([]);
+  },
+);
+
+test.each(PROPAGATION_ROUNDTRIP_CASES)(
+  "retains and roundtrips $label propagation across async context",
+  async ({ value, incoming, outgoing: expectedOutgoing }) => {
+    process.env.OTEL_SDK_DISABLED = "true";
+    process.env.OTEL_PROPAGATORS = value;
+    const { service, ctx } = await startOtelService();
+
+    try {
+      const extracted = propagation.extract(ROOT_CONTEXT, incoming);
+      expect(trace.getSpanContext(extracted)).toEqual(PROPAGATED_SPAN_CONTEXT);
+
+      const outgoing: Record<string, string> = {};
+      await context.with(extracted, async () => {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(trace.getSpanContext(context.active())).toEqual(PROPAGATED_SPAN_CONTEXT);
+        propagation.inject(context.active(), outgoing);
+      });
+
+      expect(outgoing).toEqual(expectedOutgoing);
+      expect(trace.getSpanContext(propagation.extract(ROOT_CONTEXT, outgoing))).toEqual(
+        PROPAGATED_SPAN_CONTEXT,
+      );
+    } finally {
+      await service.stop?.(ctx);
+    }
   },
 );
 

--- a/extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts
+++ b/extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts
@@ -300,6 +300,41 @@ test("records a final failure after persistent real OTLP 503 responses", async (
   }
 }, 15_000);
 
+test.each([400, 408, 500] as const)(
+  "records one final failure for a non-retryable real OTLP HTTP $statusCode response",
+  async (statusCode) => {
+    const receiver = await startExporterHealthReceiver((_request, response) => {
+      response.writeHead(statusCode);
+      response.end();
+    });
+    const capture = captureExporterEvents();
+    const { service, ctx } = await startTraceExporterHealthService(receiver.endpoint, "1000");
+
+    try {
+      emitExporterHealthSpan(`http-${statusCode}`);
+      await waitForDiagnosticEventsDrained();
+      await Promise.resolve(service.stop?.(ctx)).catch(() => {});
+      await waitForDiagnosticEventsDrained();
+      expect(receiver.requestCount).toBe(1);
+      expect(
+        capture.events.filter(
+          (event) => event.status === "failure" && event.reason === "emit_failed",
+        ),
+      ).toHaveLength(1);
+      expect(
+        getReportedExporterHealth(ctx).filter(
+          (event) => event.status === "failure" && event.reason === "export_failed",
+        ),
+      ).toHaveLength(1);
+    } finally {
+      capture.unsubscribe();
+      await service.stop?.(ctx);
+      await receiver.close();
+    }
+  },
+  15_000,
+);
+
 test("records a final failure for a real OTLP connection reset", async () => {
   const receiver = await startExporterHealthReceiver((request) => {
     request.socket.destroy();

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -9,7 +9,7 @@
 // Collector-boundary cases run owned mode, which now composes private providers and never
 // registers global SDK state; teardown still restores the preloaded globals for trace cases.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { createServer } from "node:http";
+import { createServer, type IncomingHttpHeaders } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -59,6 +59,7 @@ const ENDPOINT_ENV_KEYS = [
   "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
   "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
   "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+  "OTEL_EXPORTER_OTLP_HEADERS",
   "OTEL_EXPORTER_OTLP_TIMEOUT",
   "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
   "OTEL_EXPORTER_OTLP_CERTIFICATE",
@@ -203,6 +204,7 @@ function captureOtelDiagnostics(): string[] {
 async function startOtlpReceiver() {
   const requests: Array<{
     contentType: string | undefined;
+    headers: IncomingHttpHeaders;
     method: string | undefined;
     url: string;
   }> = [];
@@ -211,6 +213,7 @@ async function startOtlpReceiver() {
     request.on("end", () => {
       requests.push({
         contentType: request.headers["content-type"],
+        headers: request.headers,
         method: request.method,
         url: request.url ?? "",
       });
@@ -306,9 +309,11 @@ test.each(SHARED_ENDPOINT_ROUTING_CASES)(
   30_000,
 );
 
-test("keeps the required protobuf content type over a colliding custom header", async () => {
+test("merges exporter headers with config and required protobuf precedence", async () => {
   const receiver = await startOtlpReceiver();
   releasePreloadedOtelGlobals();
+  process.env.OTEL_EXPORTER_OTLP_HEADERS =
+    "x-env-only=env-value,x-precedence=env-value,content-type=text/plain";
   const { service, ctx } = await startOtelService({
     endpoint: receiver.endpoint,
     traces: true,
@@ -316,7 +321,9 @@ test("keeps the required protobuf content type over a colliding custom header", 
     logs: true,
     configure: (serviceContext) => {
       serviceContext.config.diagnostics!.otel!.headers = {
-        "content-type": "text/plain",
+        "content-type": "application/json",
+        "x-config-only": "config-value",
+        "x-precedence": "config-value",
       };
     },
   });
@@ -329,9 +336,15 @@ test("keeps the required protobuf content type over a colliding custom header", 
       new Set(["/v1/traces", "/v1/metrics", "/v1/logs"]),
     );
     expect(
-      receiver.requests.every(
-        (request) => request.method === "POST" && request.contentType === "application/x-protobuf",
-      ),
+      receiver.requests.every((request) => {
+        return (
+          request.method === "POST" &&
+          request.headers["content-type"] === "application/x-protobuf" &&
+          request.headers["x-config-only"] === "config-value" &&
+          request.headers["x-env-only"] === "env-value" &&
+          request.headers["x-precedence"] === "config-value"
+        );
+      }),
     ).toBe(true);
   } finally {
     await service.stop?.(ctx);


### PR DESCRIPTION
## What Problem This Solves

The healthy diagnostics OTEL runtime lacked committed integration coverage for three dependency-backed contracts: non-retryable OTLP HTTP failures, exporter header precedence, and propagation roundtrips across asynchronous context.

## Why This Change Was Made

Adds seven table-driven regressions to the existing canonical integration suites. The tests use real local OTLP receivers and public OpenTelemetry APIs; no production code, test-only production seams, QA evidence, or workflow logic changed.

Canonical placement:

- `extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts`: 400/408/500 each make one request and record one final `export_failed` fact.
- `extensions/diagnostics-otel/src/service.otlp-export.test.ts`: env-only headers survive, explicit config wins collisions, and required protobuf `content-type` wins last for traces, metrics, and logs.
- `extensions/diagnostics-otel/src/service-disabled.integration.test.ts`: W3C, B3, B3MULTI, and Jaeger extract -> async retention -> inject -> re-extract roundtrips.

Alternatives considered:

- A standalone post-merge probe was rejected because it would duplicate canonical harnesses and drift from owned-mode exporter behavior.
- New production exports or test seams were rejected because the current runtime already satisfies the contracts.

## User Impact

No runtime behavior changes. Maintainers now get deterministic regression coverage for exporter failure cardinality, header construction, and supported propagation formats.

## Evidence

OpenTelemetry JS was inspected at exact release commit `76fa6b509e2b48d9cbee31cb37a2efc61dc4d384` (`experimental/v0.221.0`, with stable packages at `v2.10.0`):

- Non-retryable HTTP behavior: `experimental/packages/otlp-exporter-base/src/is-export-retryable.ts:6-12`, `transport/http-transport-utils.ts:84-107`, `retrying-transport.ts:42-87`, `otlp-export-delegate.ts:88-132`.
- Header precedence: `experimental/packages/otlp-exporter-base/src/configuration/otlp-node-http-env-configuration.ts:14-44` and `otlp-http-configuration.ts:20-46`.
- Required protobuf header: `experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts:22-36`, `opentelemetry-exporter-metrics-otlp-proto/src/platform/node/OTLPMetricExporter.ts:22-35`, and `exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts:23-41`.
- Propagation/context: `packages/opentelemetry-core/src/trace/W3CTraceContextPropagator.ts:61-113`, `packages/opentelemetry-propagator-b3/src/B3Propagator.ts:26-68`, `B3SinglePropagator.ts:44-89`, `B3MultiPropagator.ts:86-146`, `packages/opentelemetry-propagator-jaeger/src/JaegerPropagator.ts:38-157`, and `packages/opentelemetry-context-async-hooks/src/AsyncLocalStorageContextManager.ts:11-40`.
- Public installed types: `@opentelemetry/otlp-exporter-base/build/src/configuration/legacy-base-configuration.d.ts:3-38`, `export-response.d.ts:1-14`, `@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.d.ts:3-9`, and the W3C/B3/Jaeger propagator declarations.
- Protocol/spec: OTLP HTTP only retries 429/502/503/504 and forbids retries for other 4xx/5xx responses (`opentelemetry-proto/docs/specification.md:634-660`); propagation inject/extract and W3C/B3 requirements are in `opentelemetry-specification/specification/context/api-propagators.md:81-112,382-433`; configured propagator names are in `specification/configuration/sdk-environment-variables.md:113-131`.

Focused proof:

- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts` -> 9 passed.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.otlp-export.test.ts` -> 84 passed.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service-disabled.integration.test.ts` -> 16 passed.
- Combined focused run -> 3 files, 109 tests passed.
- `pnpm format:check <three touched paths>` and `git diff --check` passed.
- `node scripts/check-changed.mjs -- <three touched paths>` classified `extensionTests`; delegated `ci-fast` had no ready provider. The documented local fallback passed every guard before extension-test typecheck, which is locally blocked by the shared install resolving `string-width@4.2.3` while `packages/terminal-core/package.json` pins `8.2.2`. Hosted CI uses a fresh dependency graph.
- Project autoreview: clean, no accepted/actionable findings.

Diff accounting:

- Production: `+0/-0`.
- Tests: `+126/-6` across three existing test files.
- Net new test cases: 7.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":125,"toolOutputsDropped":124,"web":0,"redactions":2,"omittedUnsafe":0,"rawEntries":18}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
hi. i’m grounding current main, prior OTEL context, and the required repo workflows first; then i’ll create the isolated GWT and keep all edits there.

current `origin/main` is `a23444fc74b0ddfea5e4b2aad6ae2f81fdc6cf8b`; the planning checkout is intentionally stale and untouched. i found prior OTEL landing context in memory, but i’m treating it as orientation only and will verify every contract against the fresh tree and pinned upstream source.

`gwt` routed the first attempt into `[HOME_PATH]`, which violates the requested shared-worktree shape. that worktree is task-owned and still clean; i’m removing only that new worktree and recreating the same branch under the explicit shared root.

the shared GWT is clean at the exact base SHA, has 972 GiB free, and `node_modules` is the required symlink. the graph project is available; i’m using it only to locate ownership and canonical tests, then checking every result against `a23444f` in this worktree.

policy is loaded. one useful constraint from current repo docs: this is an explicitly authorized contract-coverage PR, not a test tweak for an already-red `main` failure, so it fits the narrow maintainer exception. next i’m mapping the exact canonical files and live OTEL merge history before deciding the smallest test placement.

the prototype’s overall shape is right, but one detail is stale after #120131: it creates a span through the global tracer, while owned mode now uses private providers. i’m adapting the canonical test to emit through the real diagnostics recorder path; that avoids a false zero-request result and still exercises the actual exporter boundary.

the fresh shared worktree is clean at `a23444fc74b0ddfea5e4b2aad6ae2f81fdc6cf8b`. i’ve mapped the canonical owners; next i’m pinning exact upstream line evidence, then i’ll add and run each contract independently so any real runtime defect stops the branch immediately.

the pinned implementation and protocol agree on the important edge: only 429/502/503/504 are retryable, so 400/408/500 must be single-shot failures. the installed 0.221.0 merge path also confirms env fallback, explicit config override, then mandatory protobuf headers last.

i’m editing three canonical test owners only: `service-exporter-health.integration.test.ts` gets a 400/408/500 real-receiver table, `service.otlp-export.test.ts` strengthens the existing header test to cover env/config/required precedence, and `service-disabled.integration.test.ts` gets four propagation roundtrips across an async boundary. no probe file, helper export, or production seam.

the non-retryable receiver contract is green: all three rows passed, with one request and one final health fact each. i’m moving to header precedence now; this strengthens the existing three-signal real-exporter test instead of adding a parallel harness.

all three contracts pass against current main; no runtime defect surfaced. i’m formatting only the three test files, then i’ll run the combined focused suite, changed classifier, diff checks, and local autoreview against the actual branch delta.

the focused suite is 109/109 and formatting is clean. `check-changed` classified the scope but its delegated `ci-fast` proof hit a concrete infrastructure blocker: no Crabbox provider was ready; i’m inspecting the wrapper’s documented local fallback instead of repeating the same failed dispatch.

the local fallback is now running the real changed lane, not just the three tests. classification is `extensionTests`; guards, plugin boundaries, dependency pins, dead-code scans, and formatting are already clean, with extension test typecheck still in flight.

the changed lane caught three real type errors in my receiver capture; i’m fixing those now. it also exposed an unrelated current-main error in `packages/terminal-core/src/ansi.ts:194`, so after the task-owned fix i’ll rerun the failed typecheck surface and separate branch proof from that base failure explicitly.

the task-owned type errors are gone; the rerun now reports only the untouched `origin/main` `stringWidth` signature error at `packages/terminal-core/src/ansi.ts:194`. focused behavior remains 109/109, so i’m starting the mandatory uncommitted-diff autoreview now.

autoreview is clean and the test-only commit is `c8721bfcdb1`. i’m preparing the draft PR with exact contract citations and proof; before publishing i’m reading the transcript helper and native PR commands verbatim so the body and later landing flow match repo policy.

[tool summary]
49 read, 6 write, 70 execute; raw tool outputs dropped: 124
````

</details>
<!-- agent-transcript:end -->
