### PR TITLE
fix(agents): quota suspension resolves the real owning agent instead of no-opping

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -56,6 +56,7 @@ import {
   createEmbeddedRunStageTracker,
 } from "./run/attempt-stage-timing.js";
 import { withExecutionPhaseDiagnostics } from "./run/execution-phase-diagnostics.js";
+import { buildEmbeddedFailureSuspension } from "./run/failure-suspension.js";
 import { hasEmbeddedRunConfiguredModelFallbacks } from "./run/fallbacks.js";
 import type {
   RunEmbeddedAgentInternalParams,
@@ -149,7 +150,11 @@ async function runEmbeddedAgentOrchestrated(
   // candidate remains. Direct and final-candidate runs suspend normally.
   const failureSuspension = resolveSessionSuspensionTarget();
   const suspendForFailure = (suspensionParams: Omit<SessionSuspensionParams, "laneId">) => {
-    const suspension = { ...suspensionParams, laneId: globalLane };
+    const suspension = buildEmbeddedFailureSuspension({
+      suspension: suspensionParams,
+      runAgentId: params.agentId,
+      laneId: globalLane,
+    });
     if (failureSuspension.mode === "defer") {
       failureSuspension.defer(suspension);
       return;

--- a/src/agents/embedded-agent-runner/run/failure-suspension.test.ts
+++ b/src/agents/embedded-agent-runner/run/failure-suspension.test.ts
@@ -1,0 +1,45 @@
+// Embedded failure suspensions must reach the owning agent's session store.
+import { describe, expect, it } from "vitest";
+import { buildEmbeddedFailureSuspension } from "./failure-suspension.js";
+
+const baseSuspension = {
+  cfg: undefined,
+  sessionId: "session-1",
+  reason: "quota_exhausted",
+  failedProvider: "anthropic",
+  failedModel: "claude-opus-4-6",
+} as const;
+
+describe("buildEmbeddedFailureSuspension", () => {
+  it("fills the run's agent id when the failure caller only knows agentDir", () => {
+    // Assistant/prompt failures pass agentDir only; an unregistered or shared
+    // directory resolves no owner and would suspend the default agent instead.
+    const suspension = buildEmbeddedFailureSuspension({
+      suspension: { ...baseSuspension, agentDir: "/state/agents/work/agent" },
+      runAgentId: "work",
+      laneId: "main",
+    });
+
+    expect(suspension.agentId).toBe("work");
+    expect(suspension.agentDir).toBe("/state/agents/work/agent");
+    expect(suspension.laneId).toBe("main");
+  });
+
+  it("keeps an explicit caller agent id and tolerates a run without one", () => {
+    expect(
+      buildEmbeddedFailureSuspension({
+        suspension: { ...baseSuspension, agentId: "explicit" },
+        runAgentId: "run-owner",
+        laneId: "main",
+      }).agentId,
+    ).toBe("explicit");
+
+    expect(
+      buildEmbeddedFailureSuspension({
+        suspension: baseSuspension,
+        runAgentId: undefined,
+        laneId: "main",
+      }).agentId,
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/failure-suspension.ts
+++ b/src/agents/embedded-agent-runner/run/failure-suspension.ts
@@ -1,0 +1,21 @@
+/**
+ * Builds the suspension request for an embedded run failure.
+ *
+ * The run owns the canonical agent id; failure callers only carry agentDir,
+ * which cannot identify the owner of an unregistered or shared directory.
+ */
+import type { SessionSuspensionParams } from "../../session-suspension.js";
+
+export function buildEmbeddedFailureSuspension(params: {
+  suspension: Omit<SessionSuspensionParams, "laneId">;
+  runAgentId?: string;
+  laneId: string;
+}): SessionSuspensionParams {
+  return {
+    ...params.suspension,
+    // A caller-supplied id wins; the run id only fills the gap so an
+    // unregistered agentDir cannot fall back to the default agent's store.
+    agentId: params.suspension.agentId ?? params.runAgentId,
+    laneId: params.laneId,
+  };
+}

--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -604,6 +604,7 @@ export function throwFallbackFailureSummary(params: {
   soonestCooldownExpiry?: number | null;
   attribution?: FailoverAttribution;
   cfg?: OpenClawConfig;
+  agentId?: string;
   agentDir?: string;
 }): never {
   if (params.attempts.length <= 1 && params.lastError) {
@@ -612,6 +613,7 @@ export function throwFallbackFailureSummary(params: {
   if (params.attribution?.sessionId) {
     void suspendSession({
       cfg: params.cfg,
+      agentId: params.agentId,
       agentDir: params.agentDir,
       sessionId: params.attribution.sessionId,
       laneId: params.attribution.lane,

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -430,6 +430,7 @@ async function runWithModelFallbackInternal<T>(
               deferredSuspension.pending = undefined;
               void suspendSession({
                 cfg: params.cfg,
+                agentId: params.agentId,
                 agentDir: params.agentDir,
                 sessionId: params.sessionId,
                 laneId,
@@ -768,6 +769,7 @@ async function runWithModelFallbackInternal<T>(
     }),
     attribution: { sessionId: params.sessionId, lane: resolveTerminalSuspensionLane() },
     cfg: params.cfg,
+    agentId: params.agentId,
     agentDir: params.agentDir,
   });
 }

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -17,12 +17,14 @@ vi.mock("../config/sessions/session-accessor.js", () => sessionAccessorMocks);
 
 vi.mock("../process/command-queue.js", () => commandQueueMocks);
 
-vi.mock("./command/session.js", () => ({
-  resolveStoredSessionKeyForSessionId: () => ({
+const sessionKeyResolverMocks = vi.hoisted(() => ({
+  resolveStoredSessionKeyForSessionId: vi.fn(() => ({
     sessionKey: "session-key",
     storePath: "/tmp/openclaw-session-suspension-test/sessions.json",
-  }),
+  })),
 }));
+
+vi.mock("./command/session.js", () => sessionKeyResolverMocks);
 
 async function suspendLane(ttlMs: number, cfg: OpenClawConfig, laneId: CommandLane) {
   // All cases exercise the public suspendSession path with fixed failure metadata.
@@ -50,6 +52,58 @@ describe("session suspension", () => {
     resetSessionSuspensionStateForTest();
     sessionAccessorMocks.patchSessionEntry.mockClear();
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
+  });
+
+  it("resolves the session store with the explicit agent id, never the agentDir basename", async () => {
+    const { suspendSession } = await import("./session-suspension.js");
+    sessionKeyResolverMocks.resolveStoredSessionKeyForSessionId.mockClear();
+
+    await suspendSession({
+      cfg: {} as OpenClawConfig,
+      agentId: "work",
+      // Default layout: <state>/agents/<id>/agent — basename is always "agent".
+      agentDir: "/state/agents/work/agent",
+      sessionId: "session-1",
+      laneId: CommandLane.Main,
+      reason: "quota_exhausted",
+      failedProvider: "anthropic",
+      failedModel: "claude-opus-4-6",
+      ttlMs: 1,
+    });
+
+    expect(sessionKeyResolverMocks.resolveStoredSessionKeyForSessionId).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "work" }),
+    );
+  });
+
+  it("falls back to the registered agent-dir owner when no explicit agent id is given", async () => {
+    const { suspendSession } = await import("./session-suspension.js");
+    const { registerResolvedAgentDir, unregisterResolvedAgentDir } =
+      await import("./agent-dir-registry.js");
+    sessionKeyResolverMocks.resolveStoredSessionKeyForSessionId.mockClear();
+
+    registerResolvedAgentDir({ agentId: "research", agentDir: "/state/agents/research/agent" });
+    try {
+      await suspendSession({
+        cfg: {} as OpenClawConfig,
+        agentDir: "/state/agents/research/agent",
+        sessionId: "session-2",
+        laneId: CommandLane.Main,
+        reason: "quota_exhausted",
+        failedProvider: "anthropic",
+        failedModel: "claude-opus-4-6",
+        ttlMs: 1,
+      });
+    } finally {
+      unregisterResolvedAgentDir({
+        agentId: "research",
+        agentDir: "/state/agents/research/agent",
+      });
+    }
+
+    expect(sessionKeyResolverMocks.resolveStoredSessionKeyForSessionId).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "research" }),
+    );
   });
 
   it("auto-resumes main lane to configured agent concurrency", async () => {

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -4,7 +4,6 @@
  * Records quota/manual/circuit suspensions and temporarily lowers command-lane concurrency.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
-import path from "node:path";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { resolveCronMaxConcurrentRuns } from "../config/cron-limits.js";
 import { patchSessionEntry } from "../config/sessions/session-accessor.js";
@@ -18,6 +17,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
   resolveTimerTimeoutMs,
 } from "../shared/number-coercion.js";
+import { resolveRegisteredAgentIdForDir } from "./agent-dir-registry.js";
 import { resolveStoredSessionKeyForSessionId } from "./command/session.js";
 import type { FailoverReason } from "./embedded-agent-helpers/types.js";
 
@@ -116,6 +116,7 @@ type SessionSuspensionTarget =
   | { mode: "suspend" };
 export type SessionSuspensionParams = {
   cfg: OpenClawConfig | undefined;
+  agentId?: string;
   agentDir?: string;
   sessionId: string;
   laneId?: string;
@@ -312,10 +313,15 @@ async function suspendSessionQueued(params: SessionSuspensionParams, queuedGener
     return;
   }
 
+  // agentDir is <state>/agents/<id>/agent, so basename(agentDir) is always the
+  // literal "agent" — only the registry lookup recovers the real owner id.
+  const agentIdFromDir = params.agentDir
+    ? resolveRegisteredAgentIdForDir(params.agentDir)
+    : undefined;
   const { sessionKey, storePath } = resolveStoredSessionKeyForSessionId({
     cfg: params.cfg,
     sessionId: params.sessionId,
-    agentId: params.agentDir ? path.basename(params.agentDir) : undefined,
+    agentId: params.agentId ?? agentIdFromDir,
   });
 
   if (!sessionKey) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where session quota suspension silently no-opped. `suspendSession` derived the owning agent id via `path.basename(params.agentDir)` — but `resolveAgentDir` returns `<state>/agents/<id>/agent`, so the basename is always the literal `"agent"` on the default layout. `normalizeAgentId("agent")` passes validation, the quota-suspension marker was written to a nonexistent agent's store, and the actual session never got suspended: a provider exhausting quota kept the session hammering the provider instead of backing off, with nothing recorded on the real session.

## Why This Change Was Made

The callers already know the real agent id — `runWithModelFallback` carries `params.agentId` (cron executor, embedded run-entry, compact path all pass it). The fix adds `agentId` to `SessionSuspensionParams` and threads it through both suspension call sites (`model-fallback-runner` skip-candidate path and `throwFallbackFailureSummary`); for any dir-only caller, `resolveRegisteredAgentIdForDir` from the agent-dir registry recovers the owner instead of the meaningless basename. The `path.basename` derivation is deleted.

## User Impact

Quota/circuit suspensions now land on the real session: suspended sessions stop retrying exhausted providers and resume on schedule.

## Evidence

- `node scripts/run-vitest.mjs src/agents/session-suspension.test.ts` — passes, with two new regressions: explicit agentId wins over the basename, and the registry fallback resolves dir-only callers.
- `node scripts/run-vitest.mjs src/agents/model-fallback` — both suites pass with the threaded param.
- Finding confirmed by adversarial verification against current main (round-2 stress audit finding #14).
