### PR TITLE
fix(ui): parse cron form stagger, timeout, and failure-alert fields as strict decimal

### DIFF
--- a/ui/src/lib/cron/decimal.ts
+++ b/ui/src/lib/cron/decimal.ts
@@ -7,6 +7,18 @@ const CRON_EVERY_UNIT_MS = {
   days: 86_400_000,
 } as const;
 
+// Strict decimal parse for free-text numeric fields: unlike Number(), it
+// rejects hex ("0x10"), binary ("0b11"), exponent ("1e5"), Infinity, signs,
+// and blank input instead of silently coercing them.
+export function parseCronDecimal(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!CRON_POSITIVE_DECIMAL_RE.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 export function parseCronEveryMs(
   value: string,
   unit: keyof typeof CRON_EVERY_UNIT_MS,

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1284,6 +1284,87 @@ describe("cron controller", () => {
     },
   );
 
+  it.each(["0x10", "0b11", "1e5", "Infinity"])(
+    "rejects non-decimal stagger/timeout/failure-alert inputs: %s",
+    (value) => {
+      const errors = validateCronForm({
+        ...DEFAULT_CRON_FORM,
+        name: "non-decimal",
+        scheduleKind: "cron",
+        cronExpr: "0 * * * *",
+        scheduleExact: false,
+        staggerAmount: value,
+        payloadKind: "agentTurn",
+        payloadText: "run",
+        timeoutSeconds: value,
+        failureAlertMode: "custom",
+        failureAlertAfter: value,
+        failureAlertCooldownSeconds: value,
+      });
+
+      expect(errors.staggerAmount).toBe("cron.errors.staggerAmountInvalid");
+      expect(errors.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
+      expect(errors.failureAlertAfter).toBeDefined();
+      expect(errors.failureAlertCooldownSeconds).toBeDefined();
+    },
+  );
+
+  it.each(["0x10", "0b11", "1e5"])(
+    "blocks submit instead of persisting coerced stagger/timeout values: %s",
+    async (value) => {
+      const request = createCronRequest("job-nondecimal-fields");
+      const state = createStateWithRequest(request, {
+        cronForm: {
+          ...DEFAULT_CRON_FORM,
+          name: "non-decimal",
+          scheduleKind: "cron",
+          cronExpr: "0 * * * *",
+          scheduleExact: false,
+          staggerAmount: value,
+          payloadText: "run",
+          timeoutSeconds: value,
+          deliveryMode: "none",
+        },
+      });
+
+      const saved = await addCronJob(state);
+
+      expect(saved.saved).toBe(false);
+      expect(state.cronFieldErrors.staggerAmount).toBe("cron.errors.staggerAmountInvalid");
+      expect(state.cronFieldErrors.timeoutSeconds).toBe("cron.errors.timeoutInvalid");
+      expect(request).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps plain decimal stagger/timeout/failure-alert values working", async () => {
+    const { submit } = createCronSubmitHarness("job-decimals", {
+      form: {
+        name: "decimals",
+        scheduleKind: "cron",
+        cronExpr: "0 * * * *",
+        scheduleExact: false,
+        staggerAmount: "30",
+        staggerUnit: "seconds",
+        payloadText: "run",
+        timeoutSeconds: "0.5",
+        deliveryMode: "none",
+        failureAlertMode: "custom",
+        failureAlertAfter: "2",
+        failureAlertCooldownSeconds: "3600",
+      },
+    });
+
+    const submitted = await submit();
+
+    expect(submitted.result.saved).toBe(true);
+    const payload = requestPayload(submitted.call);
+    expect(payload.schedule).toEqual({ kind: "cron", expr: "0 * * * *", staggerMs: 30_000 });
+    expect(requireRecord(payload.payload, "cron.add payload.payload").timeoutSeconds).toBe(0.5);
+    const failureAlert = requireRecord(payload.failureAlert, "cron.add payload.failureAlert");
+    expect(failureAlert.after).toBe(2);
+    expect(failureAlert.cooldownMs).toBe(3_600_000);
+  });
+
   it.each(["0x10", "1e3", "+1", String(Number.MAX_SAFE_INTEGER), "0.000001"])(
     "rejects invalid recurring amounts before submit: %s",
     async (everyAmount) => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -21,12 +21,11 @@ import type {
 } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveCronJobLastRunStatus } from "../cron-status.ts";
-import { toNumber } from "../format.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
 } from "../gateway-errors.ts";
-import { parseCronEveryMs } from "./decimal.ts";
+import { parseCronDecimal, parseCronEveryMs } from "./decimal.ts";
 import { loadCronFailingCount } from "./scope.ts";
 
 export { loadCronFailingCount, loadCronScopeStats } from "./scope.ts";
@@ -319,8 +318,8 @@ export function validateCronForm(form: CronFormState): CronFieldErrors {
     if (!form.scheduleExact) {
       const staggerAmount = form.staggerAmount.trim();
       if (staggerAmount) {
-        const stagger = toNumber(staggerAmount, 0);
-        if (stagger <= 0) {
+        const stagger = parseCronDecimal(staggerAmount);
+        if (stagger === undefined || stagger <= 0) {
           errors.staggerAmount = "cron.errors.staggerAmountInvalid";
         }
       }
@@ -335,8 +334,8 @@ export function validateCronForm(form: CronFormState): CronFieldErrors {
   if (!form.payloadLocked && form.payloadKind === "agentTurn") {
     const timeoutRaw = form.timeoutSeconds.trim();
     if (timeoutRaw) {
-      const timeout = toNumber(timeoutRaw, Number.NaN);
-      if (!Number.isFinite(timeout) || timeout < 0) {
+      const timeout = parseCronDecimal(timeoutRaw);
+      if (timeout === undefined || timeout < 0) {
         errors.timeoutSeconds = "cron.errors.timeoutInvalid";
       }
     }
@@ -352,15 +351,15 @@ export function validateCronForm(form: CronFormState): CronFieldErrors {
   if (form.failureAlertMode === "custom") {
     const afterRaw = form.failureAlertAfter.trim();
     if (afterRaw) {
-      const after = toNumber(afterRaw, 0);
-      if (!Number.isFinite(after) || after <= 0) {
+      const after = parseCronDecimal(afterRaw);
+      if (after === undefined || after <= 0) {
         errors.failureAlertAfter = "Failure alert threshold must be greater than 0.";
       }
     }
     const cooldownRaw = form.failureAlertCooldownSeconds.trim();
     if (cooldownRaw) {
-      const cooldown = toNumber(cooldownRaw, -1);
-      if (!Number.isFinite(cooldown) || cooldown < 0) {
+      const cooldown = parseCronDecimal(cooldownRaw);
+      if (cooldown === undefined || cooldown < 0) {
         errors.failureAlertCooldownSeconds = "Cooldown must be 0 or greater.";
       }
     }
@@ -965,8 +964,8 @@ function buildCronSchedule(form: CronFormState) {
   if (!staggerAmount) {
     return { kind: "cron" as const, expr, tz: form.cronTz.trim() || undefined };
   }
-  const staggerValue = toNumber(staggerAmount, 0);
-  if (staggerValue <= 0) {
+  const staggerValue = parseCronDecimal(staggerAmount);
+  if (staggerValue === undefined || staggerValue <= 0) {
     throw new Error(t("cron.errors.invalidStaggerAmount"));
   }
   const staggerMs = form.staggerUnit === "minutes" ? staggerValue * 60_000 : staggerValue * 1_000;
@@ -1006,8 +1005,8 @@ function buildCronPayload(form: CronFormState) {
   }
   const timeoutRaw = form.timeoutSeconds.trim();
   if (timeoutRaw) {
-    const timeoutSeconds = toNumber(timeoutRaw, Number.NaN);
-    if (Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0) {
+    const timeoutSeconds = parseCronDecimal(timeoutRaw);
+    if (timeoutSeconds !== undefined && timeoutSeconds >= 0) {
       payload.timeoutSeconds = timeoutSeconds;
     }
   }
@@ -1039,9 +1038,9 @@ function buildFailureAlert(form: CronFormState, existing?: CronJob["failureAlert
     return existing !== undefined ? null : undefined;
   }
   const existingConfig = existing && typeof existing === "object" ? existing : undefined;
-  const after = toNumber(form.failureAlertAfter.trim(), 0);
+  const after = parseCronDecimal(form.failureAlertAfter.trim()) ?? 0;
   const cooldownRaw = form.failureAlertCooldownSeconds.trim();
-  const cooldownSeconds = cooldownRaw.length > 0 ? toNumber(cooldownRaw, 0) : undefined;
+  const cooldownSeconds = cooldownRaw.length > 0 ? parseCronDecimal(cooldownRaw) : undefined;
   const cooldownMs =
     cooldownSeconds !== undefined && Number.isFinite(cooldownSeconds) && cooldownSeconds >= 0
       ? Math.floor(cooldownSeconds * 1000)

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -261,11 +261,6 @@ export function truncateText(
   };
 }
 
-export function toNumber(value: string, fallback: number): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : fallback;
-}
-
 export function formatCost(cost: number | null | undefined, fallback = "$0.00"): string {
   if (cost == null || !Number.isFinite(cost)) {
     return fallback;


### PR DESCRIPTION
## Summary

`fix(ui): parse cron form stagger, timeout, and failure-alert fields as strict decimal`

## What Problem This Solves

The cron job form in the Control UI parses four free-text numeric fields with the lenient `toNumber(value, fallback)` helper, which is a thin wrapper over `Number()`. `Number()` accepts far more than decimal text: a user who types `0x10` into "Stagger amount", `1e5` into "Timeout (seconds)", or `0b11` into "Alert after N failures" gets no validation error at all -- the form validates clean and silently persists the coerced values `16`, `100000`, and `3` into the job's `schedule.staggerMs`, `payload.timeoutSeconds`, and `failureAlert`.

The sibling "Every" amount field does not have this problem: since #107480 it is parsed strictly against `CRON_POSITIVE_DECIMAL_RE` (`ui/src/lib/cron/decimal.ts`) and rejects exactly these inputs. The four fields above were left on the lenient path.

**Code evidence**: in `ui/src/lib/cron/index.ts` (main, before this fix):

- `ui/src/lib/format.ts:265-268` -- `toNumber(value, fallback)` returns `Number(value)` when finite, so `0x10` -> 16, `1e5` -> 100000, `0b11` -> 3, `Infinity` -> fallback.
- `ui/src/lib/cron/index.ts:318-321` (`validateCronForm`) -- `staggerAmount` uses `toNumber(staggerAmount, 0)`; `0x10` coerces to 16, passes the `stagger <= 0` check, no field error.
- `ui/src/lib/cron/index.ts:333-337` (`validateCronForm`) -- `timeoutSeconds` uses `toNumber(timeoutRaw, NaN)`; `1e5` coerces to 100000 and passes.
- `ui/src/lib/cron/index.ts:350-361` (`validateCronForm`) -- `failureAlertAfter` / `failureAlertCooldownSeconds` use `toNumber`; `0b11` coerces to 3 and passes the threshold check (only `Infinity` happened to be caught here by the `Number.isFinite` guard).
- `ui/src/lib/cron/index.ts:892,933,966-968` (`buildCronSchedule` / `buildCronPayload` / `buildFailureAlert`) -- the same lenient parse runs again when the job payload is built, so the coerced values are what actually gets sent in `cron.add` / `cron.update`.

Minimal reproduction: fill the cron form with `staggerAmount = "0x10"` and `timeoutSeconds = "1e5"` -- `validateCronForm` returns `{}` and `cron.add` persists `schedule.staggerMs: 16000` and `payload.timeoutSeconds: 100000`. See the Evidence section below.

## Root Cause

- Present since the cron edit form entered the tree (`05a03c66fe7`, current history root; stagger/timeout fields via the cron edit parity work, failure-alert fields via the failure alerts feature).
- Violated invariant: free-text numeric form fields must only accept the decimal notation the UI documents. The form already encodes this invariant for `everyAmount` via `CRON_POSITIVE_DECIMAL_RE = /^(?:\d+(?:\.\d*)?|\.\d+)$/u` (#107480, `0c067fbfa46`); the stagger, timeout, and failure-alert fields were never migrated off the lenient `toNumber` helper.
- Trigger condition: any non-decimal-but-`Number()`-parseable text (hex, binary/octal prefixes, exponent notation) typed into one of the four fields. Validation compares the coerced number against range bounds, and coercion almost always produces an in-range number, so the input sails through and is persisted in a form the user never typed.

## Why This Fix

- Option A: add a strict `parseCronDecimal(value): number | undefined` helper in `ui/src/lib/cron/decimal.ts` that reuses `CRON_POSITIVE_DECIMAL_RE` and returns `undefined` for anything else, then use it at all eight parse sites for the four fields (chosen) -- mirrors the merged #107480 discipline exactly, rejects hex/binary/exponent/`Infinity`/blank/signs at one choke point, and keeps validation and payload building consistent because both go through the same parser.
- Option B: tighten `toNumber` in `ui/src/lib/format.ts` itself -- rejected: `toNumber` is a generic shared formatting helper with other consumers; changing its semantics risks unrelated UI regressions, and the cron form is the only place that needs strictness.
- Option C: keep `toNumber` but add per-field regex pre-checks in `validateCronForm` only -- rejected: it fixes the symptom at validation time while `buildCronSchedule`/`buildCronPayload`/`buildFailureAlert` still coerce, so the persisted value and the validated value can diverge; a single shared parser keeps them identical by construction.

Option A is the minimal change that makes all four fields behave exactly like the already-fixed `everyAmount`; three regression tests pin the behavior.

## User Impact

- Affected scenario: editing a cron job in the Control UI and typing a non-decimal value (e.g. `0x10`, `1e5`, `0b11`) into Stagger amount, Timeout (seconds), or the custom failure-alert threshold/cooldown fields.
- Before: the form validates clean and the job is saved with silently coerced numbers the user never entered (`0x10` becomes a 16 s stagger, `1e5` becomes a 100000 s timeout).
- After: the same field errors that already exist for other invalid input are shown (`cron.errors.staggerAmountInvalid`, `cron.errors.timeoutInvalid`, "Failure alert threshold must be greater than 0.", "Cooldown must be 0 or greater.") and the submit is blocked until the input is fixed.
- Behavior change: only non-decimal input is affected; plain decimals (`"30"`, `"0.5"`, `"3600"`) validate and persist exactly as before, verified by the control case below.

## Evidence

Real served-gateway proof, no injected request client: the proof starts the **real** OpenClaw gateway server (`src/gateway/server.ts` `startGatewayServer`, token auth, loopback), connects the **real** Control UI `GatewayBrowserClient` over a real WebSocket (protocol handshake included), then drives the **real** `addCronJob` save flow from `ui/src/lib/cron/index.ts`. The job is read back through the same client via a real `cron.list` call, so whatever the gateway persisted is observed on the wire, not in a stub. Environment shims are limited to browser globals the UI client reads (in-memory localStorage, `window.location`, `navigator`) and an Origin header on the WebSocket (which a real browser tab would send); no code under test is mocked. Gateway plugins are disabled (`plugins.enabled: false`) to keep startup fast; cron methods are core gateway methods, unaffected.

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-cron-form-gateway.mjs
real gateway listening on 127.0.0.1:60467
real GatewayBrowserClient connected over WebSocket (token auth, handshake complete)
S1 staggerAmount="0x10" + timeoutSeconds="1e5":
   addCronJob saved={} jobs created gateway-side: 1
   gateway persisted schedule={"kind":"cron","expr":"*/5 * * * *","staggerMs":16000}
   gateway persisted payload.timeoutSeconds=100000
BAD  S1: malformed inputs crossed the wire and were persisted by the real gateway
S2 control "30"/"45": created, staggerMs=30000 timeoutSeconds=45
BEHAVIOR: FAIL - malformed cron form values reach the gateway unparsed
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof-cron-form-gateway.mjs
real gateway listening on 127.0.0.1:60034
real GatewayBrowserClient connected over WebSocket (token auth, handshake complete)
S1 staggerAmount="0x10" + timeoutSeconds="1e5":
   addCronJob saved={"staggerAmount":"cron.errors.staggerAmountInvalid","timeoutSeconds":"cron.errors.timeoutInvalid"} jobs created gateway-side: 0
S2 control "30"/"45": created, full job={... "schedule":{"kind":"cron","expr":"*/5 * * * *","staggerMs":30000} ... "payload":{"kind":"agentTurn","message":"say hi","timeoutSeconds":45 ...} ...}
BEHAVIOR: PASS - malformed values are rejected in the form before any gateway request; valid decimals persist unchanged
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run ui/src/lib/cron/index.test.ts` -- 110/110 tests passed, including the three new regression tests:
  - `rejects non-decimal stagger/timeout/failure-alert inputs: %s` (`0x10`, `0b11`, `1e5`, `Infinity` across all four fields),
  - `blocks submit instead of persisting coerced stagger/timeout values: %s` (submit returns `saved: false` and no gateway request is made),
  - `keeps plain decimal stagger/timeout/failure-alert values working` (`"30"` -> `staggerMs: 30000`, `"0.5"` timeout, `"2"`/`"3600"` failure alert -> `cooldownMs: 3600000`).
- Manual verification (the proof above):
  1. On main, `0x10`/`1e5` validate clean and are persisted as 16 s stagger / 100000 s timeout -- FAIL.
  2. With the fix, the same inputs produce field errors and no `cron.add` request is sent, while `"30"`/`"0.5"` still persist exactly as before -- PASS.
