### PR TITLE
fix(agents): failed compaction no longer zeroes live assistant usage

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
@@ -397,6 +397,44 @@ describe("handleCompactionEnd", () => {
     expect(freshAssistant.usage).toEqual(freshUsage);
   });
 
+  it("preserves live assistant usage when compaction fails or is aborted", async () => {
+    // A failed/aborted end never rewrote history; zeroing usage here would
+    // disable the persistent-error compaction trigger for degraded sessions.
+    const failureEnds = [
+      { name: "failed", result: undefined, aborted: false },
+      { name: "aborted", result: { kept: 12 }, aborted: true },
+    ] as const;
+    for (const failure of failureEnds) {
+      const liveUsage = makeUsageSnapshot(123_000);
+      const messages = [
+        makeAssistantUsageMessage({
+          text: `live answer (${failure.name})`,
+          timestamp: 1_000,
+          usage: liveUsage,
+        }),
+      ] as AgentMessage[];
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-usage-keep-"));
+      const storePath = path.join(tmp, "sessions.json");
+      const ctx = createCompactionContext({
+        storePath,
+        sessionKey: "main",
+        initialCount: 0,
+        messages,
+      });
+
+      handleCompactionEnd(ctx, {
+        type: "compaction_end",
+        reason: "threshold",
+        result: failure.result,
+        willRetry: false,
+        aborted: failure.aborted,
+      });
+
+      const liveAssistant = messages[0] as Extract<AgentMessage, { role: "assistant" }>;
+      expect(liveAssistant.usage, failure.name).toEqual(liveUsage);
+    }
+  });
+
   it("uses the compaction timestamp for summary-first transcripts", async () => {
     const staleUsage = makeUsageSnapshot(120_000);
     const freshUsage = makeUsageSnapshot(1_250);

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -167,7 +167,11 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
     }
     ctx.maybeResolveCompactionWait();
     const messages = ctx.params.session.messages;
-    if (Array.isArray(messages)) {
+    // Only a compaction that actually rewrote history invalidates prior usage.
+    // A failed/aborted/skipped end must keep live assistant usage intact —
+    // zeroing it disables the persistent-error compaction trigger exactly in
+    // the degraded sessions that need it.
+    if (completed && Array.isArray(messages)) {
       // Marker-free final compaction has no fresh boundary, so stale totals
       // must be cleared before later context counters inspect assistant usage.
       stripStaleAssistantUsageBeforeLatestCompaction(messages, {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.compaction-and-tool-summaries.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.compaction-and-tool-summaries.test.ts
@@ -141,9 +141,10 @@ describe("fenced output and compaction retries", () => {
     expect(subscription.isCompacting()).toBe(false);
   });
 
-  it("resets assistant usage to a zero snapshot after compaction without retry", () => {
-    // When compaction ends the active assistant message is synthetic, so usage
-    // should reset to a zero snapshot instead of carrying stale token totals.
+  it("resets assistant usage to a zero snapshot after a completed compaction without retry", () => {
+    // A completed compaction rewrites history, so the surviving assistant usage
+    // refers to the old context and must reset to a zero snapshot. Only a
+    // completed end does this; a failed/aborted end keeps live usage intact.
     const listeners: SessionEventHandler[] = [];
     const session = {
       messages: [
@@ -172,7 +173,7 @@ describe("fenced output and compaction retries", () => {
     });
 
     for (const listener of listeners) {
-      listener({ type: "compaction_end", willRetry: false });
+      listener({ type: "compaction_end", result: { kept: 1 }, aborted: false, willRetry: false });
     }
 
     const usage = (session.messages?.[0] as { usage?: unknown } | undefined)?.usage;


### PR DESCRIPTION
## What Problem This Solves

`handleCompactionEnd` unconditionally called `stripStaleAssistantUsageBeforeLatestCompaction(..., { whenMissingCompactionSummary: "zeroAssistantUsage" })` on every non-retry compaction end — including failed and aborted ones. On a marker-free transcript (no compaction summary yet), a failed compaction therefore zeroed the *live* assistant usage snapshots. That disables the token-threshold/persistent-error compaction trigger exactly in the degraded sessions that need compaction most: the session's usage reads as ~0 tokens, so compaction never re-fires, and the session eventually dies on context overflow instead. (Confirmed P1 from the round-2 stress audit, findings #19/#21.)

## Why This Change Was Made

Only a compaction that actually rewrote history invalidates prior usage. The handler already computes `completed = hasResult && !wasAborted` for counter/reconcile purposes; the strip call now gates on the same fact.

## User Impact

Sessions where a compaction attempt fails or is aborted keep accurate assistant usage, so the automatic compaction trigger keeps working and the session recovers on the next attempt instead of silently losing its overflow protection.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.compaction.test.ts` — 12 passed, including new regression "preserves live assistant usage when compaction fails or is aborted" (failed-result and aborted variants) plus the existing completed-path strip test still passing.
