### PR TITLE
fix(cron): isolate post-persist notification failures from the store write

### DIFF
--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -43,6 +43,7 @@ import {
   ensureLoaded,
   persist,
   persistOrRestore,
+  runPostPersistCronNotifications,
   snapshotStoreForRollback,
   type CronRollbackSnapshot,
   warnIfDisabled,
@@ -514,9 +515,7 @@ export async function removeAgentJobsTransactional<T>(
     } catch (error) {
       if (error instanceof AgentDeletionCommitUncertainError) {
         // Uncertain roster writes intentionally keep the cron deletion durable.
-        for (const notify of postPersistNotifications) {
-          notify();
-        }
+        runPostPersistCronNotifications(state, postPersistNotifications);
         armTimer(state);
         for (const job of removedJobs) {
           noteActiveCronJobRemoval(job.id);
@@ -540,9 +539,7 @@ export async function removeAgentJobsTransactional<T>(
       }
       throw error;
     }
-    for (const notify of postPersistNotifications) {
-      notify();
-    }
+    runPostPersistCronNotifications(state, postPersistNotifications);
     for (const job of removedJobs) {
       noteActiveCronJobRemoval(job.id);
       try {

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -233,7 +233,9 @@ describe("cron service store seam coverage", () => {
     expect(notify).toHaveBeenCalledOnce();
   });
 
-  it("does not restore speculative state after a post-persist notification throws", async () => {
+  it("contains a throwing post-persist notification without dropping siblings or the write", async () => {
+    // A notification failure happens after the durable commit: it must not
+    // reject the persist, skip sibling notifications, or roll back the store.
     const { storePath } = await makeStorePath();
     const nextRunAtMs = STORE_TEST_NOW + 120_000;
     await writeSingleJobStore(storePath, createReloadCronJob());
@@ -242,17 +244,18 @@ describe("cron service store seam coverage", () => {
     const snapshot = snapshotStoreForRollback(state);
     const job = findJobOrThrow(state, "reload-cron-expr-job");
     job.state.nextRunAtMs = nextRunAtMs;
+    const siblingNotify = vi.fn();
 
-    await expect(
-      persistOrRestore(state, snapshot, {
-        postPersistNotifications: [
-          () => {
-            throw new Error("notification failed");
-          },
-        ],
-      }),
-    ).rejects.toThrow("notification failed");
+    await persistOrRestore(state, snapshot, {
+      postPersistNotifications: [
+        () => {
+          throw new Error("notification failed");
+        },
+        siblingNotify,
+      ],
+    });
 
+    expect(siblingNotify).toHaveBeenCalledOnce();
     expect(job.state.nextRunAtMs).toBe(nextRunAtMs);
     expect((await loadCronStore(storePath)).jobs[0]?.state.nextRunAtMs).toBe(nextRunAtMs);
   });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -294,10 +294,30 @@ export async function persist(state: CronServiceState, opts?: PersistOptions) {
     stateOnly,
     suppressScheduledJobId: opts?.suppressScheduledJobId,
   });
-  for (const notify of opts?.postPersistNotifications ?? []) {
-    notify();
-  }
+  runPostPersistCronNotifications(state, opts?.postPersistNotifications);
   return true;
+}
+
+/**
+ * Notifications run after the durable commit; one throwing notify (e.g. an
+ * auto-disable notice for a removed agent) must not drop its siblings or
+ * masquerade as a store-write failure — at startup that keeps the whole
+ * scheduler down.
+ */
+export function runPostPersistCronNotifications(
+  state: CronServiceState,
+  notifications: DeferredCronNotifications | undefined,
+) {
+  for (const notify of notifications ?? []) {
+    try {
+      notify();
+    } catch (err) {
+      state.deps.log.warn(
+        { error: err instanceof Error ? err.message : String(err) },
+        "cron: post-persist notification failed",
+      );
+    }
+  }
 }
 
 /** Captures the live cron state that must stay aligned with the durable store. */
@@ -315,23 +335,14 @@ export async function persistOrRestore(
   snapshot: CronRollbackSnapshot,
   opts: Omit<PersistOptions, "stateOnly"> = {},
 ) {
-  let writeCompleted = false;
-  const postPersistNotifications = opts.postPersistNotifications?.map((notify) => () => {
-    // Notification failures happen after commit and must not restore the
-    // speculative snapshot over rows that are already durable.
-    writeCompleted = true;
-    notify();
-  });
   try {
-    const persisted = await persist(state, { ...opts, postPersistNotifications });
+    // Notification failures are contained inside persist(), so a throw here
+    // always means the durable write itself failed and the snapshot must win.
+    const persisted = await persist(state, opts);
     if (!persisted) {
       throw new Error("cron: durable store write did not complete");
     }
-    writeCompleted = true;
   } catch (err) {
-    if (writeCompleted) {
-      throw err;
-    }
     state.store = snapshot.store;
     state.durableNextRunAtMsByJobId = snapshot.durableNextRunAtMsByJobId;
     throw err;


### PR DESCRIPTION
## What Problem This Solves

`persist()` ran deferred post-persist notifications bare (`for (...) { notify(); }`). Notifications can throw — the gateway `enqueueSystemEvent`/`requestHeartbeat` deps route through `resolveCronTarget → resolveCronAgent`, which throws `cron job agent is unavailable: <id>` for any job whose agent left config, and the auto-disable notice calls exactly those deps. One throwing notify therefore:

- dropped every remaining sibling notification in the batch,
- converted an already-committed durable write into a thrown error (spurious `cron: timer tick failed`), and never retried the notice (auto-disabled state suppresses re-notification, the alert cooldown is consumed),
- worst case at startup: `ops-lifecycle start()` persists repaired interrupted runs with deferred notifications; a throwing notify made `start()` reject and the whole cron scheduler stayed down for the gateway's lifetime while every job silently never ran.

(Confirmed P1 from the round-2 stress audit, finding #8 — silent-failure class.)

## Why This Change Was Made

A post-commit notification failure is not a store-write failure. `persist()` now drains notifications through `runPostPersistCronNotifications`, which try/catches each notify and logs a warning, so siblings still run and the committed write reports success. The `persistOrRestore` wrapper's per-notify `writeCompleted` shim is deleted — with failures contained inside `persist()`, a throw there always means the durable write itself failed and the rollback snapshot must win. The two bare drain loops in `ops-mutations.ts` (agent-deletion paths that intentionally fire notifications outside `persist`) reuse the same helper.

## User Impact

Cron auto-disable notices and sibling notifications are delivered (or logged) even when one target agent no longer resolves; a stale job can no longer keep the entire cron scheduler from starting at gateway boot.

## Evidence

- `node scripts/run-vitest.mjs src/cron/service/store.test.ts src/cron/service/startup-run-repair.auto-disable.test.ts src/cron/service/timer.batch-finalization.test.ts` — 45 passed.
- Rewrote the old "does not restore speculative state after a post-persist notification throws" test into "contains a throwing post-persist notification without dropping siblings or the write": persistOrRestore now resolves, the sibling notify runs, and the durable row keeps the committed nextRunAtMs.

Production LOC ~net-neutral (+29/-21 across store.ts/ops-mutations.ts, mostly the doc comment; deleted the writeCompleted wrapper path).
