### PR TITLE
fix(discord): surface inbound attachment download failures

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.test.ts
+++ b/extensions/discord/src/monitor/message-handler.context.test.ts
@@ -174,6 +174,48 @@ describe("discord buildDiscordMessageProcessContext sender bot status", () => {
     expect(result.ctxPayload.InboundHistory).toHaveLength(2);
   });
 
+  it("records an unavailable-attachment notice for path-less media facts", async () => {
+    // Failed downloads produce path-less facts that core drops from the media
+    // projection; the body notice is the model's only record of the attachment.
+    const ctx = await createBaseDiscordMessageContext();
+
+    const result = await buildDiscordMessageProcessContext({
+      ctx,
+      text: "look at this",
+      mediaList: [
+        { contentType: "image/png", kind: "image" },
+        { path: "/tmp/ok.png", contentType: "image/png", kind: "image" },
+      ],
+    });
+    if (!result) {
+      throw new Error("expected a built Discord message context");
+    }
+
+    expect(result.ctxPayload.Body).toContain("look at this");
+    expect(result.ctxPayload.Body).toContain("[discord attachment unavailable]");
+  });
+
+  it("pluralizes the unavailable notice and skips it when all media resolved", async () => {
+    const ctx = await createBaseDiscordMessageContext();
+
+    const failedTwice = await buildDiscordMessageProcessContext({
+      ctx,
+      text: "two broken",
+      mediaList: [
+        { contentType: "image/png", kind: "image" },
+        { contentType: "video/mp4", kind: "video" },
+      ],
+    });
+    expect(failedTwice?.ctxPayload.Body).toContain("[discord 2 attachments unavailable]");
+
+    const allResolved = await buildDiscordMessageProcessContext({
+      ctx: await createBaseDiscordMessageContext(),
+      text: "fine",
+      mediaList: [{ path: "/tmp/ok.png", contentType: "image/png", kind: "image" }],
+    });
+    expect(allResolved?.ctxPayload.Body).not.toContain("unavailable");
+  });
+
   it("does not inject stale pending history when history is disabled", async () => {
     const guildHistories = new Map<string, DiscordHistoryEntry[]>([
       ["c1", [historyEntry({ id: "stale", senderId: "111", sender: "Alice", body: "stale body" })]],

--- a/extensions/discord/src/monitor/message-handler.context.test.ts
+++ b/extensions/discord/src/monitor/message-handler.context.test.ts
@@ -193,6 +193,28 @@ describe("discord buildDiscordMessageProcessContext sender bot status", () => {
 
     expect(result.ctxPayload.Body).toContain("look at this");
     expect(result.ctxPayload.Body).toContain("[discord attachment unavailable]");
+    // BodyForAgent is what the model reads; Body alone would leave it silent.
+    // It derives from the raw message text (harness baseText), not the envelope.
+    expect(result.ctxPayload.BodyForAgent).toContain("hi");
+    expect(result.ctxPayload.BodyForAgent).toContain("[discord attachment unavailable]");
+  });
+
+  it("keeps audio-transcript precedence in the agent text when media fails", async () => {
+    const ctx = await createBaseDiscordMessageContext({
+      preflightAudioTranscript: "spoken words",
+    });
+
+    const result = await buildDiscordMessageProcessContext({
+      ctx,
+      text: "look at this",
+      mediaList: [{ contentType: "image/png", kind: "image" }],
+    });
+    if (!result) {
+      throw new Error("expected a built Discord message context");
+    }
+
+    expect(result.ctxPayload.BodyForAgent).toContain("spoken words");
+    expect(result.ctxPayload.BodyForAgent).toContain("[discord attachment unavailable]");
   });
 
   it("pluralizes the unavailable notice and skips it when all media resolved", async () => {

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -2,6 +2,7 @@
 import {
   buildChannelInboundEventContext,
   formatInboundEnvelope,
+  formatInboundMediaUnavailableText,
   resolveEnvelopeFormatOptions,
   toHistoryMediaEntries,
   toInboundMediaFactsWithMetadata,
@@ -167,11 +168,23 @@ export async function buildDiscordMessageProcessContext(params: {
   });
   const channelHistory = createChannelHistoryWindow({ historyMap: guildHistories });
   let visibleChannelHistory: DiscordHistoryEntry[] | undefined;
+  // Failed downloads (CDN error, SSRF block, size cap, timeout) produce
+  // path-less facts that core drops from the media projection. Record the
+  // outcome in the body like sibling channels so the turn never silently
+  // ignores an attachment the user sent.
+  const unavailableMediaCount = mediaList.filter((media) => !media.path).length;
+  const bodyWithMediaNotice =
+    unavailableMediaCount > 0
+      ? formatInboundMediaUnavailableText({
+          body: text,
+          notice: `[discord ${unavailableMediaCount > 1 ? `${unavailableMediaCount} attachments` : "attachment"} unavailable]`,
+        })
+      : text;
   let combinedBody = formatInboundEnvelope({
     channel: "Discord",
     from: fromLabel,
     timestamp: resolveTimestampMs(message.timestamp),
-    body: text,
+    body: bodyWithMediaNotice,
     chatType: isDirectMessage ? "direct" : "channel",
     senderLabel,
     previousTimestamp,

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -173,13 +173,14 @@ export async function buildDiscordMessageProcessContext(params: {
   // outcome in the body like sibling channels so the turn never silently
   // ignores an attachment the user sent.
   const unavailableMediaCount = mediaList.filter((media) => !media.path).length;
-  const bodyWithMediaNotice =
+  const appendMediaUnavailableNotice = (body: string | undefined) =>
     unavailableMediaCount > 0
       ? formatInboundMediaUnavailableText({
-          body: text,
+          body,
           notice: `[discord ${unavailableMediaCount > 1 ? `${unavailableMediaCount} attachments` : "attachment"} unavailable]`,
         })
-      : text;
+      : body;
+  const bodyWithMediaNotice = appendMediaUnavailableNotice(text) ?? text;
   let combinedBody = formatInboundEnvelope({
     channel: "Discord",
     from: fromLabel,
@@ -405,7 +406,9 @@ export async function buildDiscordMessageProcessContext(params: {
       inboundEventKind: ctx.inboundEventKind,
       body: combinedBody,
       rawBody: preflightAudioTranscript ?? baseText,
-      bodyForAgent: preflightAudioTranscript ?? baseText ?? text,
+      // BodyForAgent wins over Body for the model's text, so the notice has to
+      // ride the agent-facing source too — keeping transcript precedence.
+      bodyForAgent: appendMediaUnavailableNotice(preflightAudioTranscript ?? baseText ?? text),
       commandBody: preflightAudioTranscript ?? baseText,
       inboundHistory,
     },

--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -6,7 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { getFileExtension, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
 import { saveRemoteMedia, type FetchLike } from "openclaw/plugin-sdk/media-runtime";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { getChildLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -401,7 +401,12 @@ async function appendResolvedMediaFromAttachments(params: {
       });
     } catch (err) {
       const id = attachment.id ?? attachmentUrl;
-      logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
+      // Warn on the default path: the failed download becomes a path-less fact
+      // that core drops from the media projection, so this log plus the body
+      // notice are the only records of the missing attachment.
+      getChildLogger({ module: "discord-media" }).warn(
+        `${params.errorPrefix} ${id}: ${String(err)}`,
+      );
       const classification = resolveDiscordMediaClassification({ attachment });
       params.out.push({
         ...classification,
@@ -506,7 +511,10 @@ async function appendResolvedMediaFromStickers(params: {
       }
     }
     if (lastError) {
-      logVerbose(`${params.errorPrefix} ${sticker.id}: ${formatStickerError(lastError)}`);
+      // Same visibility contract as failed attachments: path-less fact + warn.
+      getChildLogger({ module: "discord-media" }).warn(
+        `${params.errorPrefix} ${sticker.id}: ${formatStickerError(lastError)}`,
+      );
       const fallback = candidates[0];
       if (fallback) {
         params.out.push({


### PR DESCRIPTION
## What Problem This Solves

Discord was the only channel where a failed inbound attachment download (CDN error, SSRF block, size cap, timeout) was completely silent. The catch paths in `appendResolvedMediaFromAttachments`/`appendResolvedMediaFromStickers` logged only via `logVerbose` (off by default) and pushed a path-less classification that core's `buildInboundMediaNoteProjection` drops (it keeps only facts with `path`/`url`). A user who sent only an image got a reply that ignored it, with no recorded reason anywhere — the worst bug class per repo doctrine. (Confirmed P1 from the round-2 stress audit, finding #18.)

Every sibling channel already records this outcome: WhatsApp appends `[whatsapp attachment unavailable]`, iMessage counts unavailable attachments, MSTeams/Feishu/SMS/Signal/Zalo use `formatInboundMediaUnavailableText`, Telegram sends a user-visible warning. This was a missing consumer of the type-only failure-fact contract introduced in #111665, not intent.

## Why This Change Was Made

- `buildDiscordMessageProcessContext` now counts path-less media facts and appends `[discord attachment unavailable]` (pluralized) to the message body via the shared `formatInboundMediaUnavailableText` helper, matching the MSTeams/WhatsApp pattern.
- The download-failure catch paths (attachments and stickers) now log a real `warn` through `getChildLogger({ module: "discord-media" })` instead of debug-gated `logVerbose`, so operators see the failure on the default path.

## User Impact

When a Discord attachment can't be downloaded, the model is told an attachment was unavailable (so it can respond honestly instead of ignoring the image), and the gateway log records why.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.context.test.ts extensions/discord/src/monitor/message-media.test.ts` — 43 passed, including two new regressions: notice present + original text preserved for a mixed resolved/failed list, pluralized notice for multiple failures, and no notice when all media resolved.
