### PR TITLE
fix(cron): cap command payload outputMaxBytes to prevent unbounded output buffering

### DIFF
--- a/src/cron/command-runner.ts
+++ b/src/cron/command-runner.ts
@@ -4,6 +4,7 @@ import {
   buildCronCommandSummary,
   isCronCommandActionCriticalLine,
 } from "./command-output-summary.js";
+import { MAX_CRON_COMMAND_OUTPUT_MAX_BYTES } from "./normalize-payload.js";
 import type { CronRunDiagnostics, CronRunOutcome, CronRunStatus, CronJob } from "./types.js";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 10 * 60_000;
@@ -104,7 +105,10 @@ export async function runCronCommandJob(params: {
       ...(payload.input !== undefined ? { input: payload.input } : {}),
       ...(payload.env ? { env: payload.env } : {}),
       ...(noOutputTimeoutMs !== undefined ? { noOutputTimeoutMs } : {}),
-      ...(payload.outputMaxBytes !== undefined ? { maxOutputBytes: payload.outputMaxBytes } : {}),
+      // Clamp here too so rows persisted before the cap cannot disable output limits.
+      ...(payload.outputMaxBytes !== undefined
+        ? { maxOutputBytes: Math.min(MAX_CRON_COMMAND_OUTPUT_MAX_BYTES, payload.outputMaxBytes) }
+        : {}),
       preserveOutputLine: isCronCommandActionCriticalLine,
       ...(params.abortSignal ? { signal: params.abortSignal } : {}),
       killProcessTree: true,

--- a/src/cron/normalize-payload.ts
+++ b/src/cron/normalize-payload.ts
@@ -12,6 +12,9 @@ import {
 
 type UnknownRecord = Record<string, unknown>;
 
+/** Hard cap for cron command payload output buffering, matching the sibling script/stream caps. */
+export const MAX_CRON_COMMAND_OUTPUT_MAX_BYTES = 64 * 1024 * 1024;
+
 function normalizeTrimmedStringArray(
   value: unknown,
   options?: { allowNull?: boolean },
@@ -184,7 +187,7 @@ export function normalizeCronPayload(payload: UnknownRecord): UnknownRecord {
   if ("outputMaxBytes" in next) {
     const outputMaxBytes = parseOptionalField(TimeoutSecondsFieldSchema, next.outputMaxBytes);
     if (outputMaxBytes !== undefined && outputMaxBytes > 0) {
-      next.outputMaxBytes = Math.floor(outputMaxBytes);
+      next.outputMaxBytes = Math.min(MAX_CRON_COMMAND_OUTPUT_MAX_BYTES, Math.floor(outputMaxBytes));
     } else {
       delete next.outputMaxBytes;
     }

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -4,6 +4,7 @@ import {
   validateCronAddParams,
   validateCronUpdateParams,
 } from "../../packages/gateway-protocol/src/index.js";
+import { MAX_CRON_COMMAND_OUTPUT_MAX_BYTES } from "./normalize-payload.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "./normalize.js";
 
 type UnknownRecord = Record<string, unknown>;
@@ -286,6 +287,31 @@ describe("normalizeCronJobCreate", () => {
       outputMaxBytes: 4096,
     });
     expect(validateCronAddParams(normalized)).toBe(true);
+  });
+  it("clamps command outputMaxBytes above the hard cap instead of disabling output limits", () => {
+    const normalized = createDefaulted({
+      kind: "command",
+      argv: ["sh", "-lc", "echo ok"],
+      outputMaxBytes: 1_000_000_000_000,
+    });
+    expect(child(normalized, "payload").outputMaxBytes).toBe(MAX_CRON_COMMAND_OUTPUT_MAX_BYTES);
+    expect(validateCronAddParams(normalized)).toBe(true);
+  });
+  it("passes through reasonable command outputMaxBytes values", () => {
+    const normalized = createDefaulted({
+      kind: "command",
+      argv: ["sh", "-lc", "echo ok"],
+      outputMaxBytes: 4096,
+    });
+    expect(child(normalized, "payload").outputMaxBytes).toBe(4096);
+  });
+  it.each([0, -5, Number.NaN])("drops invalid command outputMaxBytes value %s", (value) => {
+    const normalized = createDefaulted({
+      kind: "command",
+      argv: ["sh", "-lc", "echo ok"],
+      outputMaxBytes: value,
+    });
+    expect(normalized.payload).not.toHaveProperty("outputMaxBytes");
   });
   it("preserves command argv argument bytes", () => {
     const normalized = createDefaulted({


### PR DESCRIPTION
## Summary

`fix(cron): cap command payload outputMaxBytes to prevent unbounded output buffering`

## What Problem This Solves

Cron `command` payloads accept an optional `outputMaxBytes` knob that controls how much stdout/stderr the gateway buffers when running the command. `runCommandWithTimeout` applies a 16 MB default cap (`DEFAULT_COMMAND_OUTPUT_MAX_BYTES`) whenever the caller does not supply its own limit -- but any positive finite number supplied by the payload overrides it, and normalization imposes no upper bound.

So a job created with `payload.outputMaxBytes: 1e12` silently disables the 16 MB safety cap. A chatty or compromised scheduled command then buffers unbounded stdout/stderr in the gateway process, growing memory without limit until OOM. Every sibling knob is already hard-capped: script `timeoutSeconds <= 900` and `toolBudget <= 200` (`src/cron/script-payload.ts:4-6`), stream `maxBatchBytes <= 65536` (`src/cron/stream-schedule.ts:10`). `outputMaxBytes` is the lone outlier.

**Code evidence** (main, before this fix):

- `src/cron/normalize-payload.ts:184-191` -- `outputMaxBytes` is parsed through `TimeoutSecondsFieldSchema` and only floored; any finite positive value is kept verbatim.
- `src/cron/delivery-field-schemas.ts:34` -- `TimeoutSecondsFieldSchema = z.number().finite().nonnegative()`, no upper bound.
- `src/cron/command-runner.ts:107` -- the payload value is passed straight through as `maxOutputBytes` to `runCommandWithTimeout`.
- `src/process/exec-output.ts:25,39-44` -- the 16 MB default only applies when the supplied value is missing/invalid; `1e12` is accepted as-is.

Minimal reproduction: `normalizeCronPayload({ kind: "command", argv: ["echo", "hi"], outputMaxBytes: 1e12 }).outputMaxBytes` returns `1000000000000`, and a real child process writing 20 MB under that limit is buffered untruncated -- see the Evidence section below.

## Root Cause

- Bug present since the field entered the tree in `05a03c66fe7` (2026-08-05, current history).
- Violated invariant: every cron payload knob that controls gateway-side resource consumption must have a hard cap, so no persisted or user-supplied job config can disable a safety limit. `outputMaxBytes` reused `TimeoutSecondsFieldSchema` (designed for durations, where "unbounded" values are still clamped downstream by timer-safe ms conversion) and inherited no maximum, while byte limits directly size in-memory buffers.
- Trigger condition: any cron command job whose payload carries a very large `outputMaxBytes` (hand-written config, imported job, or a row persisted by other tooling), running a command that emits more than 16 MB of output.

## Why This Fix

- Option A: clamp to a 64 MB hard cap in `normalizeCronPayload`, and clamp again at the `command-runner.ts` hand-off (chosen) -- normalization is where every other payload field is sanitized, and the runner-side `Math.min` is defense-in-depth for job rows persisted before the cap existed (they never re-pass through normalization before execution). Clamp-to-cap matches the sibling clamp style in `script-payload.ts` / `stream-schedule.ts`, so an over-large value still runs with a generous limit instead of being dropped to the 16 MB default.
- Option B: add `.max(...)` to the zod schema in `delivery-field-schemas.ts` -- rejected: that schema is shared by genuine duration fields (`timeoutSeconds`, `noOutputTimeoutSeconds`, `toolBudget`) where a byte cap makes no sense, and dropping the field on parse failure (rather than clamping) would silently downgrade huge values to the 16 MB default. It also would not protect pre-cap persisted rows at the runner layer.
- Option C: clamp only inside `runCommandWithTimeout` / `exec-output.ts` -- rejected: that path is shared by non-cron callers (plugin tools, node runners) that legitimately negotiate their own limits; the missing invariant is specific to cron payload input, so the cap belongs at the cron boundary.

Option A is the minimal change that restores the "all resource knobs are capped" invariant at both the write path and the execution path; four regression tests pin the behavior.

## User Impact

- Affected scenario: cron command jobs carrying an `outputMaxBytes` larger than 64 MB (new, imported, or previously persisted).
- Before: the value was kept verbatim, disabling the 16 MB default output cap; a verbose command could buffer unbounded output and OOM the gateway.
- After: values above 64 MB are clamped to 64 MB at job creation/patch time, and the runner re-clamps any older persisted row before spawning the command; oversized output is truncated and flagged via the existing `truncated` diagnostics.
- Behavior change: only payloads above the new 64 MB cap change (clamped, not dropped); reasonable values pass through untouched, and `0` / negative / NaN are still dropped as before.

## Evidence

No mocks, no stubs: the proof drives the real `normalizeCronPayload` (`src/cron/normalize-payload.ts`), the real `runCommandWithTimeout` (`src/process/exec.js` -> `src/process/exec-output.ts`), and the real `runCronCommandJob` (`src/cron/command-runner.ts`) with real child processes (`node -e` writing 20 MB / 70 MB to stdout), plus a control case with a reasonable 4096 value.

### Before (on main)

```bash
$ node_modules/.bin/tsx proof.mjs   # main: no upper bound on outputMaxBytes
normalizeCronPayload(outputMaxBytes: 1e12) -> outputMaxBytes = 1000000000000
normalizeCronPayload(outputMaxBytes: 4096) -> outputMaxBytes = 4096
runCommandWithTimeout(20MB child, maxOutputBytes: <default>) -> stdout 16777216 bytes, truncated 4194304 bytes
runCommandWithTimeout(20MB child, maxOutputBytes: 1e12) -> stdout 20971520 bytes, truncated undefined bytes
CONFIRMED: maxOutputBytes=1e12 silently disables the 16 MB default cap (20 MB buffered untruncated)
runCronCommandJob(persisted row outputMaxBytes: 1e12, 70MB child) -> status ok, output truncated: false
BEHAVIOR: FAIL - outputMaxBytes 1e12 survives normalization (=1000000000000) and/or the runner hand-off (truncated=false), disabling the output cap
exit=1
```

### After (with fix)

```bash
$ node_modules/.bin/tsx proof.mjs   # HEAD: clamp to 64 MB at both layers
normalizeCronPayload(outputMaxBytes: 1e12) -> outputMaxBytes = 67108864
normalizeCronPayload(outputMaxBytes: 4096) -> outputMaxBytes = 4096
runCommandWithTimeout(20MB child, maxOutputBytes: <default>) -> stdout 16777216 bytes, truncated 4194304 bytes
runCommandWithTimeout(20MB child, maxOutputBytes: 1e12) -> stdout 20971520 bytes, truncated undefined bytes
CONFIRMED: maxOutputBytes=1e12 silently disables the 16 MB default cap (20 MB buffered untruncated)
runCronCommandJob(persisted row outputMaxBytes: 1e12, 70MB child) -> status ok, output truncated: true
BEHAVIOR: PASS - outputMaxBytes is clamped to 64 MB at normalization and at the command-runner hand-off
exit=0
```

Note the two layers proven independently: normalization clamps `1e12` to `67108864` (64 MB), and a simulated pre-cap persisted row passed directly to `runCronCommandJob` now truncates a 70 MB child (`truncated: true`) instead of buffering it whole (`truncated: false` on main).

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/cron/normalize.test.ts src/cron/command-runner.test.ts` -- 72 passed, 1 skipped (pre-existing skip), including the new regression tests: `clamps command outputMaxBytes above the hard cap instead of disabling output limits`, `passes through reasonable command outputMaxBytes values`, and `drops invalid command outputMaxBytes value %s` (`0`, `-5`, `NaN`).
- Manual verification (the proof above):
  1. On main, `normalizeCronPayload` retains `outputMaxBytes: 1e12`, a real 20 MB child buffers untruncated under that limit while the default path truncates at 16 MB, and a persisted `1e12` row buffers 70 MB whole -- FAIL (exit 1).
  2. With the fix, the same payload normalizes to 64 MB, reasonable values pass through, and the pre-cap persisted row is clamped at the runner hand-off (70 MB child truncated) -- PASS (exit 0).
