### PR TITLE
fix(cli): validate webhooks gmail --tailscale mode at parse time

### DIFF
--- a/src/cli/webhooks-cli.test.ts
+++ b/src/cli/webhooks-cli.test.ts
@@ -61,4 +61,40 @@ describe("webhooks cli", () => {
     expect(mocks.runGmailSetup).not.toHaveBeenCalled();
     expect(mocks.runGmailService).not.toHaveBeenCalled();
   });
+
+  it.each([["setup"], ["run"]])("rejects invalid gmail %s --tailscale mode", async (command) => {
+    const program = createProgram();
+    const args =
+      command === "setup"
+        ? ["webhooks", "gmail", command, "--account", "default", "--tailscale", "offf"]
+        : ["webhooks", "gmail", command, "--tailscale", "offf"];
+
+    await expect(program.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors().join("\n")).toContain(
+      "Invalid --tailscale (must be funnel, serve, or off).",
+    );
+    expect(mocks.runGmailSetup).not.toHaveBeenCalled();
+    expect(mocks.runGmailService).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["setup", "funnel"],
+    ["setup", "serve"],
+    ["setup", "off"],
+    ["run", "funnel"],
+    ["run", "serve"],
+    ["run", "off"],
+  ])("accepts valid gmail %s --tailscale %s", async (command, mode) => {
+    const program = createProgram();
+    const args =
+      command === "setup"
+        ? ["webhooks", "gmail", command, "--account", "default", "--tailscale", mode]
+        : ["webhooks", "gmail", command, "--tailscale", mode];
+
+    await program.parseAsync(args, { from: "user" });
+
+    const runner = command === "setup" ? mocks.runGmailSetup : mocks.runGmailService;
+    expect(runner).toHaveBeenCalledWith(expect.objectContaining({ tailscale: mode }));
+  });
 });

--- a/src/cli/webhooks-cli.test.ts
+++ b/src/cli/webhooks-cli.test.ts
@@ -62,12 +62,19 @@ describe("webhooks cli", () => {
     expect(mocks.runGmailService).not.toHaveBeenCalled();
   });
 
-  it.each([["setup"], ["run"]])("rejects invalid gmail %s --tailscale mode", async (command) => {
+  it.each([
+    ["setup", "offf"],
+    ["setup", ""],
+    ["setup", " "],
+    ["run", "offf"],
+    ["run", ""],
+    ["run", " "],
+  ])("rejects invalid gmail %s --tailscale mode %j", async (command, mode) => {
     const program = createProgram();
     const args =
       command === "setup"
-        ? ["webhooks", "gmail", command, "--account", "default", "--tailscale", "offf"]
-        : ["webhooks", "gmail", command, "--tailscale", "offf"];
+        ? ["webhooks", "gmail", command, "--account", "default", "--tailscale", mode]
+        : ["webhooks", "gmail", command, "--tailscale", mode];
 
     await expect(program.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
 
@@ -96,5 +103,15 @@ describe("webhooks cli", () => {
 
     const runner = command === "setup" ? mocks.runGmailSetup : mocks.runGmailService;
     expect(runner).toHaveBeenCalledWith(expect.objectContaining({ tailscale: mode }));
+  });
+
+  it("preserves an omitted gmail run --tailscale mode", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["webhooks", "gmail", "run"], { from: "user" });
+
+    expect(mocks.runGmailService).toHaveBeenCalledWith(
+      expect.objectContaining({ tailscale: undefined }),
+    );
   });
 });

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -109,7 +109,7 @@ export function registerWebhooksCli(program: Command) {
     });
 }
 
-function parseGmailSetupOptions(raw: Record<string, unknown>): GmailSetupOptions {
+export function parseGmailSetupOptions(raw: Record<string, unknown>): GmailSetupOptions {
   const accountRaw = raw.account;
   const account = normalizeOptionalString(accountRaw) ?? "";
   if (!account) {
@@ -127,7 +127,7 @@ function parseGmailSetupOptions(raw: Record<string, unknown>): GmailSetupOptions
   };
 }
 
-function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOptions {
+export function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOptions {
   const common = parseGmailCommonOptions(raw);
   return {
     account: normalizeOptionalString(raw.account),
@@ -136,6 +136,15 @@ function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOptions {
 }
 
 function parseGmailCommonOptions(raw: Record<string, unknown>) {
+  const tailscaleRaw = normalizeOptionalString(raw.tailscale);
+  if (
+    tailscaleRaw !== undefined &&
+    tailscaleRaw !== "funnel" &&
+    tailscaleRaw !== "serve" &&
+    tailscaleRaw !== "off"
+  ) {
+    throw new Error("Invalid --tailscale (must be funnel, serve, or off).");
+  }
   return {
     topic: normalizeOptionalString(raw.topic),
     subscription: normalizeOptionalString(raw.subscription),
@@ -149,7 +158,7 @@ function parseGmailCommonOptions(raw: Record<string, unknown>) {
     includeBody: booleanOption(raw.includeBody),
     maxBytes: numberOption(raw.maxBytes, "--max-bytes"),
     renewEveryMinutes: numberOption(raw.renewMinutes, "--renew-minutes"),
-    tailscaleRaw: normalizeOptionalString(raw.tailscale),
+    tailscaleRaw,
     tailscalePath: normalizeOptionalString(raw.tailscalePath),
     tailscaleTarget: normalizeOptionalString(raw.tailscaleTarget),
   };

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -177,7 +177,7 @@ function gmailOptionsFromCommon(
   };
 }
 
-function tailscaleModeOption(value: unknown) {
+function tailscaleModeOption(value: unknown): GmailRunOptions["tailscale"] {
   if (value === undefined || value === null) {
     return undefined;
   }

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -109,7 +109,7 @@ export function registerWebhooksCli(program: Command) {
     });
 }
 
-export function parseGmailSetupOptions(raw: Record<string, unknown>): GmailSetupOptions {
+function parseGmailSetupOptions(raw: Record<string, unknown>): GmailSetupOptions {
   const accountRaw = raw.account;
   const account = normalizeOptionalString(accountRaw) ?? "";
   if (!account) {
@@ -127,7 +127,7 @@ export function parseGmailSetupOptions(raw: Record<string, unknown>): GmailSetup
   };
 }
 
-export function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOptions {
+function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOptions {
   const common = parseGmailCommonOptions(raw);
   return {
     account: normalizeOptionalString(raw.account),
@@ -136,15 +136,6 @@ export function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOpti
 }
 
 function parseGmailCommonOptions(raw: Record<string, unknown>) {
-  const tailscaleRaw = normalizeOptionalString(raw.tailscale);
-  if (
-    tailscaleRaw !== undefined &&
-    tailscaleRaw !== "funnel" &&
-    tailscaleRaw !== "serve" &&
-    tailscaleRaw !== "off"
-  ) {
-    throw new Error("Invalid --tailscale (must be funnel, serve, or off).");
-  }
   return {
     topic: normalizeOptionalString(raw.topic),
     subscription: normalizeOptionalString(raw.subscription),
@@ -158,7 +149,7 @@ function parseGmailCommonOptions(raw: Record<string, unknown>) {
     includeBody: booleanOption(raw.includeBody),
     maxBytes: numberOption(raw.maxBytes, "--max-bytes"),
     renewEveryMinutes: numberOption(raw.renewMinutes, "--renew-minutes"),
-    tailscaleRaw,
+    tailscale: tailscaleModeOption(raw.tailscale),
     tailscalePath: normalizeOptionalString(raw.tailscalePath),
     tailscaleTarget: normalizeOptionalString(raw.tailscaleTarget),
   };
@@ -180,10 +171,21 @@ function gmailOptionsFromCommon(
     includeBody: common.includeBody,
     maxBytes: common.maxBytes,
     renewEveryMinutes: common.renewEveryMinutes,
-    tailscale: common.tailscaleRaw as GmailRunOptions["tailscale"],
+    tailscale: common.tailscale,
     tailscalePath: common.tailscalePath,
     tailscaleTarget: common.tailscaleTarget,
   };
+}
+
+function tailscaleModeOption(value: unknown) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const mode = normalizeOptionalString(value);
+  if (mode === "funnel" || mode === "serve" || mode === "off") {
+    return mode;
+  }
+  throw new Error("Invalid --tailscale (must be funnel, serve, or off).");
 }
 
 function numberOption(value: unknown, label: string): number | undefined {


### PR DESCRIPTION
## Summary

Validate `openclaw webhooks gmail setup|run --tailscale <mode>` at the shared CLI parse boundary. Only the documented `funnel`, `serve`, and `off` values are accepted; omission is preserved.

## What Problem This Solves

The Gmail webhook CLI normalized `--tailscale` as an arbitrary string and then cast it to the closed Gmail mode union. A typo such as `--tailscale offf` therefore passed parsing. The setup path treats every value other than `off` as enabled, so an invalid mode could reach Gmail/Tailscale setup and fail late after unrelated work.

The bug is visible on the pre-fix base in `src/cli/webhooks-cli.ts`: `raw.tailscale` was normalized without checking the value, then asserted as `GmailRunOptions["tailscale"]`. Downstream, `src/hooks/gmail-ops.ts` uses `opts.tailscale !== "off"` as the enablement gate.

## Fix

- Parse the mode once in the shared Gmail option parser used by setup and run.
- Reject invalid, empty, whitespace-only, and non-string supplied values before dispatch.
- Preserve an actually omitted option as `undefined`.
- Return the declared `GmailRunOptions["tailscale"]` type, removing the unchecked cast.

This is intentionally at the parser owner boundary. Commander `.choices()` would duplicate the contract on two option declarations, while validation in Gmail operations would happen after dispatch.

## Compatibility

This constrains one existing CLI option. The documented values and omission are unchanged. Previously accepted but undocumented invalid values now fail immediately with:

```text
Invalid --tailscale (must be funnel, serve, or off).
```

## Evidence

`src/cli/webhooks-cli.test.ts` drives the registered Commander commands through `parseAsync` and proves, for both setup and run:

- `offf`, an empty value, and whitespace are rejected;
- downstream Gmail setup/service functions are not called on rejection;
- `funnel`, `serve`, and `off` are accepted and dispatched with the selected mode;
- an omitted run mode remains `undefined`.

Exact-head real CLI proof for `585d736976a66734b27cf90df8a87ded6881b8da` ran on a secretless GitHub-hosted Ubuntu runner after a clean install and full build: [run](https://github.com/RomneyDa/openclaw/actions/runs/31377260506), [proof job](https://github.com/RomneyDa/openclaw/actions/runs/31377260506/job/93419230466). The job asserts `git rev-parse HEAD` equals the reviewed SHA. Relevant redacted terminal output:

```text
$ node openclaw.mjs webhooks gmail run --tailscale offf
Error: Invalid --tailscale (must be funnel, serve, or off).
exit=1

$ node openclaw.mjs webhooks gmail run --tailscale off
Error: gog not installed; install it and retry
exit=1
```

The proof runner intentionally removes `gog` from `PATH`. The invalid mode fails with the parser error and never reaches the Gmail service dependency check; the documented `off` mode passes parsing and reaches that safe dependency boundary. No Gmail or Tailscale service call is made, and the job contains no credentials.

Exact-head CI:

- [production types: passed](https://github.com/openclaw/openclaw/actions/runs/31376892103/job/93418279677)
- [test types: passed](https://github.com/openclaw/openclaw/actions/runs/31376892103/job/93418279708)
- [full CI: passed](https://github.com/openclaw/openclaw/actions/runs/31376892103)

The earlier PR body described a direct-import parser proof that did not match the final private API surface. That claim has been removed and replaced by the exact-head real CLI run above. No external-fork code was executed locally.
