### PR TITLE
fix(ui): bound usage-mosaic hour iteration across extreme activity spans

### DIFF
--- a/ui/src/pages/usage/metrics.test.ts
+++ b/ui/src/pages/usage/metrics.test.ts
@@ -521,6 +521,101 @@ describe("usage mosaic token buckets", () => {
   });
 });
 
+describe("extreme session activity spans", () => {
+  // Corrupt/clock-skewed timestamps: a ~506-year span. Boundaries fall in
+  // UTC hours 0 and 12; hour 6 is inside the span but not a boundary.
+  const SPAN_START = Date.parse("2020-01-01T00:00:00.000Z");
+  const SPAN_END = Date.parse("2026-08-01T12:00:00.000Z") + 500 * 365 * 86_400_000;
+
+  const makeExtremeSpanSession = (usage: Partial<UsageSessionEntry["usage"]>): UsageSessionEntry =>
+    ({
+      key: "extreme-span-session",
+      updatedAt: SPAN_END,
+      usage: {
+        totalTokens: 24_000,
+        totalCost: 0,
+        input: 0,
+        output: 24_000,
+        cacheRead: 0,
+        cacheWrite: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+        firstActivity: SPAN_START,
+        lastActivity: SPAN_END,
+        ...usage,
+      },
+    }) as unknown as UsageSessionEntry;
+
+  const nonEmptyMosaicHours = (container: HTMLElement): number[] => {
+    const cells = [...container.querySelectorAll<HTMLElement>(".usage-hour-cell")];
+    return cells
+      .map((cell, hour) => ({ cell, hour }))
+      .filter(({ cell }) => !cell.title.includes("0 tokens"))
+      .map(({ hour }) => hour);
+  };
+
+  it("attributes extreme spans to their boundary hours only in the mosaic", () => {
+    const session = makeExtremeSpanSession({});
+    const container = document.createElement("div");
+    render(renderUsageMosaic([session], "utc", [], vi.fn()), container);
+
+    expect(nonEmptyMosaicHours(container)).toStrictEqual([0, 12]);
+    const cells = container.querySelectorAll<HTMLElement>(".usage-hour-cell");
+    expect(cells[0]?.title).toContain("12.0K");
+    expect(cells[12]?.title).toContain("12.0K");
+    expect(container.querySelector(".usage-mosaic-total")?.textContent).toContain("24.0K");
+  });
+
+  it("bounds peak-error fallback allocation for extreme spans", () => {
+    const session = makeExtremeSpanSession({
+      messageCounts: { total: 10, user: 5, assistant: 5, toolCalls: 0, toolResults: 0, errors: 5 },
+    });
+
+    const result = buildPeakErrorHours([session], "utc");
+    expect(result.map(({ value }) => value)).toStrictEqual(["50.00%", "50.00%"]);
+  });
+
+  it("bounds hour-filter matching for extreme spans to boundary hours", () => {
+    const session = makeExtremeSpanSession({});
+
+    expect(sessionTouchesSelectedHours(session, [0], "utc")).toBe(true);
+    expect(sessionTouchesSelectedHours(session, [12], "utc")).toBe(true);
+    expect(sessionTouchesSelectedHours(session, [6], "utc")).toBe(false);
+  });
+
+  it("still walks normal spans hour by hour", () => {
+    const start = Date.parse("2026-03-15T10:00:00.000Z");
+    const session = {
+      key: "normal-span-session",
+      updatedAt: start + 2 * 3_600_000,
+      usage: {
+        totalTokens: 4_000,
+        totalCost: 0,
+        input: 0,
+        output: 4_000,
+        cacheRead: 0,
+        cacheWrite: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+        firstActivity: start,
+        lastActivity: start + 2 * 3_600_000,
+      },
+    } as unknown as UsageSessionEntry;
+    const container = document.createElement("div");
+    render(renderUsageMosaic([session], "utc", [], vi.fn()), container);
+
+    expect(nonEmptyMosaicHours(container)).toStrictEqual([10, 11]);
+    expect(sessionTouchesSelectedHours(session, [11], "utc")).toBe(true);
+    expect(sessionTouchesSelectedHours(session, [13], "utc")).toBe(false);
+  });
+});
+
 describe("formatUsageTokens", () => {
   it("formats values below 1,000 verbatim", () => {
     expect(formatUsageTokens(0)).toBe("0");

--- a/ui/src/pages/usage/metrics.ts
+++ b/ui/src/pages/usage/metrics.ts
@@ -13,6 +13,12 @@ import type { UsageSessionEntry, UsageTotals, UsageAggregates } from "./types.ts
 
 const CHARS_PER_TOKEN = 4;
 const DAY_MS = 86_400_000;
+// Activity timestamps arrive verbatim from the gateway; a corrupt or
+// clock-skewed entry can claim a span of centuries. The mosaic and the hour
+// filter only bucket by hour-of-day, so cap the per-hour span walk at the
+// longest span worth slicing and attribute longer sessions to their boundary
+// hours only.
+const MAX_SESSION_SPAN_MS = 366 * DAY_MS;
 
 type UsageCostWindowSummary = {
   days: number;
@@ -77,6 +83,21 @@ function forEachSessionHourSlice(
   }
 
   const totalMinutes = (endMs - startMs) / 60000;
+  if (endMs - startMs > MAX_SESSION_SPAN_MS) {
+    // Extreme spans would iterate once per hour for centuries; attribute the
+    // session to its start and end hours only (split evenly, approximate).
+    for (const boundaryMs of [startMs, endMs]) {
+      const date = new Date(boundaryMs);
+      visitor({
+        usage,
+        hour: getZonedHour(date, timeZone),
+        weekday: getZonedWeekday(date, timeZone),
+        share: 0.5,
+      });
+    }
+    return true;
+  }
+
   let cursor = startMs;
   while (cursor < endMs) {
     const date = new Date(cursor);
@@ -252,6 +273,14 @@ function sessionSpanTouchesSelectedHours(
   }
   const startMs = Math.min(start, end);
   const endMs = Math.max(start, end);
+  if (endMs - startMs > MAX_SESSION_SPAN_MS) {
+    // Same bound as forEachSessionHourSlice: extreme spans are attributed to
+    // their boundary hours only, so only those can match the selection.
+    return (
+      hours.includes(getZonedHour(new Date(startMs), timeZone)) ||
+      hours.includes(getZonedHour(new Date(endMs), timeZone))
+    );
+  }
   let cursor = startMs;
   while (cursor <= endMs) {
     const date = new Date(cursor);


### PR DESCRIPTION
## Summary

`fix(ui): bound usage-mosaic hour iteration across extreme activity spans`

## What Problem This Solves

The Usage tab's mosaic and hour filter fall back to a time-based proportional walk for sessions that have no quarter-hour buckets: they iterate once per hour between `usage.firstActivity` and `usage.lastActivity`. Those timestamps arrive verbatim from the gateway response (`UsageSessionEntry` = `SessionsUsageEntry`) with no span clamp anywhere in the UI.

A single corrupt or clock-skewed session entry -- e.g. a far-future `lastActivity` of `8.64e15` -- turns that walk into ~2.4e9 iterations with two `Date` allocations each, per session. The Usage tab freezes permanently; every render re-walks the span. Same symptom class as the merged "workboard card lists stall with large boards" fix: unbounded linear work driven by unvalidated input size.

**Code evidence**: in `ui/src/pages/usage/metrics.ts` (main, before this fix):

- `ui/src/pages/usage/metrics.ts:79-93` -- `forEachSessionHourSlice` runs `while (cursor < endMs)`, stepping one hour per iteration over the raw `firstActivity`/`lastActivity` span. Used by the mosaic fallback (`buildUsageMosaicStats`) and the peak-error fallback (`buildPeakErrorHours`).
- `ui/src/pages/usage/metrics.ts:255-265` -- the twin loop in `sessionSpanTouchesSelectedHours` (hour filter) walks the same unbounded span.

(Note: a `firstActivity` of exactly `0` is caught by the existing `!start || !end` falsy guard; any nonzero-but-ancient or far-future timestamp slips past it.)

Minimal reproduction: one legacy session (no `utcQuarterHour*` buckets) with `firstActivity` = 2020-01-01 and `lastActivity` = now + 500 years makes the real `buildPeakErrorHours` burn ~4.4M hour slices and ~4.8s per call -- see the Evidence section below.

## Root Cause

- Bug present since the file entered the tree in `05a03c66fe7` (current history).
- Violated invariant: UI rendering must never do work proportional to unvalidated server-supplied magnitudes. The per-hour walk is O(span in hours) with no ceiling, and the span comes from the gateway verbatim.
- Trigger condition: any session entry whose `firstActivity`/`lastActivity` span is enormous (corrupt state, clock skew, or a malicious/buggy gateway peer) and that lacks precise quarter-hour buckets, so the legacy span walk runs.

## Why This Fix

- Option A: clamp at the two walk sites -- spans beyond `MAX_SESSION_SPAN_MS` (366 days, the longest period the hour-of-day mosaic/filter can meaningfully display) skip the per-hour walk and attribute the session to its start/end hours only (chosen) -- the ceiling lives exactly where the unbounded iteration happens, both loops are covered, and normal spans are bit-for-bit unaffected.
- Option B: clamp `firstActivity`/`lastActivity` at the gateway-response parsing layer -- rejected: the UI renders `SessionsUsageEntry` objects that also come from caches and test fixtures; clamping at ingestion would not protect every path that reaches the walk, and it would silently rewrite data other consumers may want to see raw.
- Option C: cap iterations with a counter inside the loop and bail out mid-span -- rejected: produces a partial, misleading attribution (all tokens in the first N hours); boundary-hour attribution is deterministic and honest about the approximation.

Option A is the minimal change that makes both walks O(1) for extreme spans while preserving exact per-hour behavior for every realistic span.

## User Impact

- Affected scenario: opening the Usage tab (or using its hour filter) with a session whose recorded activity span is corrupt/clock-skewed into the centuries range.
- Before: the tab freezes -- each render iterates once per hour across the span (measured: ~4.8s for a 500-year span; ~2.4e9 iterations, i.e. effectively forever, at the max-Date span).
- After: the tab renders promptly; the offending session is attributed to its start and end hours only (even 50/50 share in the mosaic), and the hour filter matches only those boundary hours.
- Behavior change: only sessions with spans over 366 days change attribution; every normal span keeps the exact per-hour walk.

## Evidence

No mocks, no stubs: the proof drives the real exported `buildPeakErrorHours` and `sessionTouchesSelectedHours` from `ui/src/pages/usage/metrics.ts` with a real legacy session entry (`firstActivity` = 2020-01-01, `lastActivity` = now + 500 years, no quarter-hour buckets), plus a normal 2-hour control span.

### Before (on main)

```bash
$ node_modules/.bin/tsx proof.mjs   # main: while (cursor < endMs) with no span ceiling
ok control 2h span: buildPeakErrorHours prompt (59.6ms, 2 entries)
ok control 2h span: hour filter touches middle hour 11
extreme 500y span: ~4,437,708 hour slices between firstActivity/lastActivity; buildPeakErrorHours took 4834.7ms -> 5 entries
extrapolated max-Date span (firstActivity 1, lastActivity 8.64e15): ~2.4e9 slices, est 0.7h at measured rate
NOT-OK extreme 500y span: buildPeakErrorHours bounded (prompt) (4834.7ms >= 250ms means unbounded per-hour walk)
NOT-OK extreme 500y span: attributed to boundary hours only (5 entries)
NOT-OK extreme span: hour filter only matches boundary hours (sessionTouchesSelectedHours([6]) = true)
ok extreme span: hour filter still matches boundary hour 0
BEHAVIOR: FAIL - extreme session activity spans drive an unbounded per-hour walk (3 check(s) failed)
exit=1
```

### After (with fix)

```bash
$ node_modules/.bin/tsx proof.mjs   # HEAD: spans > 366 days clamp to boundary hours
ok control 2h span: buildPeakErrorHours prompt (61.7ms, 2 entries)
ok control 2h span: hour filter touches middle hour 11
extreme 500y span: ~4,437,708 hour slices between firstActivity/lastActivity; buildPeakErrorHours took 3.1ms -> 2 entries
extrapolated max-Date span (firstActivity 1, lastActivity 8.64e15): ~2.4e9 slices, est 0.0h at measured rate
ok extreme 500y span: buildPeakErrorHours bounded (prompt) (3.1ms >= 250ms means unbounded per-hour walk)
ok extreme 500y span: attributed to boundary hours only (2 entries)
ok extreme span: hour filter only matches boundary hours (sessionTouchesSelectedHours([6]) = false)
ok extreme span: hour filter still matches boundary hour 0
BEHAVIOR: PASS - extreme session activity spans are clamped to boundary hours and return promptly
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run ui/src/pages/usage/metrics.test.ts` -- 28/28 tests passed, including the new `extreme session activity spans` regression suite: boundary-only mosaic attribution, bounded peak-error fallback, boundary-only hour-filter matching, and a normal-span control proving the per-hour walk is unchanged.
- Manual verification (the proof above):
  1. On main, the extreme-span session makes `buildPeakErrorHours` walk all ~4.4M hour slices in ~4.8s and the hour filter matches a mid-span hour -- FAIL.
  2. With the fix, the same call returns in ~3ms with boundary-hour attribution, and the normal 2-hour control span behaves exactly as before -- PASS.
