### PR TITLE
fix(browser): bound batch action nesting depth in act request normalization

### DIFF
--- a/extensions/browser/src/browser/routes/agent.act.normalize.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.test.ts
@@ -1,5 +1,6 @@
 // Browser tests cover agent.act.normalize plugin behavior.
 import { describe, expect, it } from "vitest";
+import { ACT_MAX_BATCH_DEPTH } from "../act-policy.js";
 import { canonicalizeActTargetIds, normalizeActRequest } from "./agent.act.normalize.js";
 
 const MAX_SAFE_TIMEOUT_DELAY_MS = 2_147_483_647;
@@ -142,5 +143,30 @@ describe("normalizeActRequest numeric fields", () => {
         height: 600,
       }),
     ).toThrow("resize requires positive width and height");
+  });
+});
+
+describe("normalizeActRequest batch nesting depth", () => {
+  const buildNestedBatch = (depth: number): Record<string, unknown> => {
+    let action: Record<string, unknown> = { kind: "click", ref: "1" };
+    for (let i = 0; i < depth; i += 1) {
+      action = { kind: "batch", actions: [action] };
+    }
+    return action;
+  };
+
+  it("normalizes batches nested up to the executor depth limit", () => {
+    const normalized = normalizeActRequest(buildNestedBatch(ACT_MAX_BATCH_DEPTH));
+    expect(normalized).toMatchObject({ kind: "batch" });
+  });
+
+  it("rejects nesting past the depth limit with a clear error instead of overflowing the stack", () => {
+    // A ~1MB JSON body fits tens of thousands of levels; without a depth bound the
+    // recursive normalization throws RangeError before the action-count check runs.
+    for (const depth of [ACT_MAX_BATCH_DEPTH + 1, 30_000]) {
+      expect(() => normalizeActRequest(buildNestedBatch(depth))).toThrow(
+        `batch nesting exceeds maximum depth of ${ACT_MAX_BATCH_DEPTH}`,
+      );
+    }
   });
 });

--- a/extensions/browser/src/browser/routes/agent.act.normalize.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.test.ts
@@ -156,14 +156,14 @@ describe("normalizeActRequest batch nesting depth", () => {
   };
 
   it("normalizes batches nested up to the executor depth limit", () => {
-    const normalized = normalizeActRequest(buildNestedBatch(ACT_MAX_BATCH_DEPTH));
+    const normalized = normalizeActRequest(buildNestedBatch(ACT_MAX_BATCH_DEPTH + 1));
     expect(normalized).toMatchObject({ kind: "batch" });
   });
 
   it("rejects nesting past the depth limit with a clear error instead of overflowing the stack", () => {
     // A ~1MB JSON body fits tens of thousands of levels; without a depth bound the
     // recursive normalization throws RangeError before the action-count check runs.
-    for (const depth of [ACT_MAX_BATCH_DEPTH + 1, 30_000]) {
+    for (const depth of [ACT_MAX_BATCH_DEPTH + 2, 30_000]) {
       expect(() => normalizeActRequest(buildNestedBatch(depth))).toThrow(
         `batch nesting exceeds maximum depth of ${ACT_MAX_BATCH_DEPTH}`,
       );

--- a/extensions/browser/src/browser/routes/agent.act.normalize.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.ts
@@ -6,6 +6,7 @@
  */
 import {
   ACT_MAX_BATCH_ACTIONS,
+  ACT_MAX_BATCH_DEPTH,
   ACT_MAX_CLICK_DELAY_MS,
   ACT_MAX_VIEWPORT_DIMENSION,
   ACT_MAX_WAIT_TIME_MS,
@@ -87,11 +88,11 @@ function normalizeFields(rawFields: unknown): BrowserFormField[] {
     .filter((field): field is BrowserFormField => field !== null);
 }
 
-function normalizeBatchAction(value: unknown): BrowserActRequest {
+function normalizeBatchAction(value: unknown, depth: number): BrowserActRequest {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("batch actions must be objects");
   }
-  return normalizeActRequest(value as Record<string, unknown>, { source: "batch" });
+  return normalizeActRequest(value as Record<string, unknown>, { source: "batch", depth });
 }
 
 function readActionNonNegativeInteger(
@@ -131,9 +132,10 @@ function readResizeDimension(body: Record<string, unknown>, key: "width" | "heig
 /** Normalize one model/client action payload into a BrowserActRequest. */
 export function normalizeActRequest(
   body: Record<string, unknown>,
-  options?: { source?: "request" | "batch" },
+  options?: { source?: "request" | "batch"; depth?: number },
 ): BrowserActRequest {
   const source = options?.source ?? "request";
+  const depth = options?.depth ?? 0;
   const kind = normalizeActKind(body.kind);
 
   switch (kind) {
@@ -396,7 +398,15 @@ export function normalizeActRequest(
       };
     }
     case "batch": {
-      const actions = Array.isArray(body.actions) ? body.actions.map(normalizeBatchAction) : [];
+      // Bound nesting before recursing: oversized bodies parse fine, but
+      // unbounded recursion overflows the stack before the count check runs.
+      // Matches the executor's ACT_MAX_BATCH_DEPTH enforcement.
+      if (depth >= ACT_MAX_BATCH_DEPTH) {
+        throw new Error(`batch nesting exceeds maximum depth of ${ACT_MAX_BATCH_DEPTH}`);
+      }
+      const actions = Array.isArray(body.actions)
+        ? body.actions.map((action) => normalizeBatchAction(action, depth + 1))
+        : [];
       if (!actions.length) {
         throw new Error(source === "batch" ? "batch requires actions" : "actions are required");
       }

--- a/extensions/browser/src/browser/routes/agent.act.normalize.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.ts
@@ -401,7 +401,7 @@ export function normalizeActRequest(
       // Bound nesting before recursing: oversized bodies parse fine, but
       // unbounded recursion overflows the stack before the count check runs.
       // Matches the executor's ACT_MAX_BATCH_DEPTH enforcement.
-      if (depth >= ACT_MAX_BATCH_DEPTH) {
+      if (depth > ACT_MAX_BATCH_DEPTH) {
         throw new Error(`batch nesting exceeds maximum depth of ${ACT_MAX_BATCH_DEPTH}`);
       }
       const actions = Array.isArray(body.actions)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deeply nested Browser `/act` batch payloads could overflow the JavaScript stack during request normalization, before the existing action-count and executor depth checks produced a useful validation result.

The route accepts bodies up to 1 MB, so hostile inputs can contain tens of thousands of one-child batch wrappers. Before this change, `normalizeActRequest` recursively walked that tree without a depth bound and surfaced `RangeError: Maximum call stack size exceeded` as the HTTP 400 message.

## Why This Change Was Made

The request normalizer now carries the existing `ACT_MAX_BATCH_DEPTH` policy through nested batch parsing and rejects the seventh batch wrapper before recursing into it. The boundary matches the Playwright executor's depth convention: the outer batch starts at depth 0, so six wrappers are valid at depths 0 through 5 and the seventh would enter depth 6.

This keeps one shared depth policy and bounds the later recursive action-count and target-ID walks without adding another traversal or compatibility path.

## User Impact

Valid batches with up to six wrappers continue to normalize and execute. Deeper payloads now receive the deterministic validation error `batch nesting exceeds maximum depth of 5` instead of an internal stack-overflow message.

## Evidence

- Before the threshold correction, the updated six-wrapper boundary test failed because the normalizer rejected it at depth 5.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/browser/src/browser/routes/agent.act.normalize.test.ts extensions/browser/src/browser/routes/agent.act.normalize.batch-contract.test.ts` — 2 files, 15 tests passed.
- The regression tests accept six wrappers, reject seven wrappers, and reject a 30,000-wrapper payload with the clear depth error.
- `git diff --check` — passed.
- Codex autoreview of the complete branch diff — clean, no accepted/actionable findings.
