### PR TITLE
fix(ai): treat OpenAI Responses thinking signatures as untrusted JSON during replay

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -613,6 +613,76 @@ describe("convertResponsesMessages", () => {
     expect(functionCall).not.toHaveProperty("id");
   });
 
+  it("skips malformed thinking signatures as untrusted JSON during replay", () => {
+    const assistantWithSignature = (thinkingSignature: string, text: string): AssistantMessage => ({
+      role: "assistant",
+      api: nativeOpenAIModel.api,
+      provider: nativeOpenAIModel.provider,
+      model: nativeOpenAIModel.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 1,
+      content: [
+        { type: "thinking", thinking: "hidden chain of thought", thinkingSignature },
+        {
+          type: "text",
+          text,
+          textSignature: JSON.stringify({ v: 1, id: `msg_${text}` }),
+        },
+      ],
+    });
+
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          // Plain provenance tag written by openai-completions reasoning paths.
+          assistantWithSignature("reasoning", "first"),
+          { role: "user", content: "next", timestamp: 2 },
+          // Truncated JSON from a corrupted session-history entry.
+          assistantWithSignature('{"type":"reasoning","summary":[', "second"),
+          { role: "user", content: "again", timestamp: 3 },
+          assistantWithSignature(
+            JSON.stringify({
+              type: "reasoning",
+              id: "rs_valid",
+              summary: [],
+              encrypted_content: "ciphertext",
+            }),
+            "third",
+          ),
+        ],
+      } satisfies Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false },
+    ) as unknown as Array<Record<string, unknown>>;
+
+    const reasoningItems = input.filter((item) => item.type === "reasoning");
+    expect(reasoningItems).toHaveLength(1);
+    expect(reasoningItems[0]).toMatchObject({
+      type: "reasoning",
+      id: "rs_valid",
+      encrypted_content: "ciphertext",
+    });
+
+    const assistantTexts = input.filter(
+      (item) => item.type === "message" && item.role === "assistant",
+    );
+    expect(assistantTexts).toHaveLength(3);
+    // A dropped reasoning item breaks the pairing for signed text ids.
+    expect(assistantTexts[0]).not.toHaveProperty("id");
+    expect(assistantTexts[1]).not.toHaveProperty("id");
+    expect(assistantTexts[2]).toHaveProperty("id", "msg_third");
+  });
+
   it("replays update_plan-style empty non-image tool results as no output", () => {
     const input = convertResponsesMessages(
       nativeOpenAIModel,

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -12,6 +12,7 @@ import type {
   ResponseStreamEvent,
 } from "openai/resources/responses/responses.js";
 import { clampThinkingLevel } from "../model-utils.js";
+import { parseResponsesReasoningSignature } from "../transports/openai-responses-replay.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import { transportAbortError } from "../transports/transport-stream-shared.js";
 import type {
@@ -309,9 +310,13 @@ export function convertResponsesMessages<TApi extends Api>(
 
       for (const block of msg.content) {
         if (block.type === "thinking") {
-          if (block.thinkingSignature) {
+          const reasoningSignature = parseResponsesReasoningSignature(block.thinkingSignature);
+          if (!reasoningSignature) {
+            // A dropped reasoning item breaks the pairing for signed text ids.
+            previousReplayItemWasReasoning = false;
+          } else {
             const reasoningItem = normalizeResponsesReasoningReplayItem({
-              item: JSON.parse(block.thinkingSignature) as ReplayableResponseReasoningItem,
+              item: reasoningSignature,
               replayResponsesItemIds: shouldReplayResponsesItemIds,
             });
             output.push(reasoningItem as ResponseInputItem);

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -27,7 +27,10 @@ import {
   type ReplayableResponseReasoningItem,
 } from "./openai-responses-contracts.js";
 import type { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
-import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
+import {
+  parseResponsesReasoningSignature,
+  resolveReplayableResponsesMessageId,
+} from "./openai-responses-replay.js";
 import { log } from "./openai-transport-shared.js";
 import {
   sanitizeNonEmptyTransportPayloadText,
@@ -434,19 +437,13 @@ export function convertResponsesMessages(
         msg.model !== model.id && msg.provider === model.provider && msg.api === model.api;
       for (const block of msg.content) {
         if (block.type === "thinking") {
-          if (
-            shouldReplayReasoningItems &&
-            block.thinkingSignature &&
-            block.thinkingSignature.startsWith("{")
-          ) {
-            // openai-completions plain-text reasoning paths persist a
-            // provenance tag (e.g. "reasoning", "reasoning_details", "content")
-            // as thinkingSignature rather than a JSON-encoded reasoning item.
-            // Replaying those values would corrupt the next request payload
-            // (OpenRouter returns HTTP 500), so skip non-JSON signatures.
-            const reasoningItem = JSON.parse(
-              block.thinkingSignature,
-            ) as ReplayableResponseReasoningItem;
+          const reasoningItem = shouldReplayReasoningItems
+            ? parseResponsesReasoningSignature(block.thinkingSignature)
+            : undefined;
+          if (!reasoningItem) {
+            // A dropped reasoning item breaks the pairing for signed text ids.
+            previousReplayItemWasReasoning = false;
+          } else {
             const replayableReasoningItem = prepareOpenAIResponsesReasoningItemForReplay(
               reasoningItem,
               replayContext,

--- a/packages/ai/src/transports/openai-responses-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-replay.test.ts
@@ -1,0 +1,114 @@
+import type { Context, Model } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import {
+  convertResponsesMessages,
+  encodeTextSignatureV1,
+} from "./openai-responses-replay-internal.js";
+import { parseResponsesReasoningSignature } from "./openai-responses-replay.js";
+
+const nativeOpenAIModel = {
+  id: "gpt-5.5",
+  name: "GPT-5.5",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 8192,
+} satisfies Model;
+
+const allowedToolCallProviders = new Set(["openai"]);
+
+describe("parseResponsesReasoningSignature", () => {
+  it("returns undefined for missing, non-JSON, and malformed signatures", () => {
+    expect(parseResponsesReasoningSignature(undefined)).toBeUndefined();
+    // Plain provenance tags written by openai-completions reasoning paths.
+    expect(parseResponsesReasoningSignature("reasoning")).toBeUndefined();
+    expect(parseResponsesReasoningSignature("reasoning_content")).toBeUndefined();
+    // Truncated JSON from a corrupted session-history entry.
+    expect(parseResponsesReasoningSignature('{"type":"reasoning","summary":[')).toBeUndefined();
+    // Valid JSON that is not an object cannot be a reasoning item.
+    expect(parseResponsesReasoningSignature('"{}"')).toBeUndefined();
+  });
+
+  it("parses a JSON-encoded reasoning item", () => {
+    expect(
+      parseResponsesReasoningSignature(
+        JSON.stringify({ type: "reasoning", id: "rs_1", summary: [] }),
+      ),
+    ).toMatchObject({ type: "reasoning", id: "rs_1", summary: [] });
+  });
+});
+
+describe("convertResponsesMessages reasoning replay", () => {
+  const assistantWithSignature = (
+    thinkingSignature: string,
+    text: string,
+  ): Context["messages"][number] => ({
+    role: "assistant",
+    api: nativeOpenAIModel.api,
+    provider: nativeOpenAIModel.provider,
+    model: nativeOpenAIModel.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 1,
+    content: [
+      { type: "thinking", thinking: "hidden chain of thought", thinkingSignature },
+      { type: "text", text, textSignature: encodeTextSignatureV1(`msg_${text}`) },
+    ],
+  });
+
+  it("skips malformed thinking signatures as untrusted JSON during replay", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          assistantWithSignature("reasoning", "first"),
+          { role: "user", content: "next", timestamp: 2 },
+          assistantWithSignature('{"type":"reasoning","summary":[', "second"),
+          { role: "user", content: "again", timestamp: 3 },
+          assistantWithSignature(
+            JSON.stringify({
+              type: "reasoning",
+              id: "rs_valid",
+              summary: [],
+              encrypted_content: "ciphertext",
+            }),
+            "third",
+          ),
+        ],
+      } satisfies Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false },
+    ) as unknown as Array<Record<string, unknown>>;
+
+    const reasoningItems = input.filter((item) => item.type === "reasoning");
+    expect(reasoningItems).toHaveLength(1);
+    expect(reasoningItems[0]).toMatchObject({
+      type: "reasoning",
+      id: "rs_valid",
+    });
+    // prepareOpenAIResponsesReasoningItemForReplay intentionally strips
+    // encrypted_content when no matching replay metadata is present.
+    expect(reasoningItems[0]).not.toHaveProperty("encrypted_content");
+
+    const assistantTexts = input.filter(
+      (item) => item.type === "message" && item.role === "assistant",
+    );
+    expect(assistantTexts).toHaveLength(3);
+    // A dropped reasoning item breaks the pairing for signed text ids.
+    expect(assistantTexts[0]).not.toHaveProperty("id");
+    expect(assistantTexts[1]).not.toHaveProperty("id");
+    expect(assistantTexts[2]).toHaveProperty("id", "msg_third");
+  });
+});

--- a/packages/ai/src/transports/openai-responses-replay.ts
+++ b/packages/ai/src/transports/openai-responses-replay.ts
@@ -1,3 +1,31 @@
+import type { ReplayableResponseReasoningItem } from "./openai-responses-contracts.js";
+
+/**
+ * Parses a persisted thinkingSignature into a replayable Responses reasoning
+ * item. Signatures are untrusted input: openai-completions plain-text
+ * reasoning paths persist a provenance tag (e.g. "reasoning",
+ * "reasoning_content") instead of a JSON-encoded reasoning item, and session
+ * history or plugin providers can carry truncated or foreign JSON. Anything
+ * that is not a JSON object is skipped (returns undefined) instead of
+ * throwing, so one malformed history block cannot fail every later turn.
+ */
+export function parseResponsesReasoningSignature(
+  signature: string | undefined,
+): ReplayableResponseReasoningItem | undefined {
+  if (!signature || !signature.startsWith("{")) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(signature);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as ReplayableResponseReasoningItem;
+    }
+  } catch {
+    // Fall through: malformed signatures skip the reasoning item.
+  }
+  return undefined;
+}
+
 /** Resolves the assistant message id that can be replayed to OpenAI Responses. */
 export function resolveReplayableResponsesMessageId(params: {
   replayResponsesItemIds: boolean;


### PR DESCRIPTION
## Summary

`fix(ai): treat OpenAI Responses thinking signatures as untrusted JSON during replay so one malformed history block cannot brick every later turn of a session`

## What Problem This Solves

When an assistant message with a `thinking` block is replayed to the OpenAI Responses API, both conversion lanes parse the persisted `thinkingSignature` with a bare `JSON.parse`. But `thinkingSignature` is not always JSON:

- openclaw's own openai-completions lane writes plain provenance tags (`"reasoning"`, `"reasoning_content"`, `"reasoning_text"`) into this field (`packages/ai/src/providers/openai-completions.ts:476-480`).
- Session-history JSONL can carry truncated or foreign signatures (hand-edited, migrated, or written by another tool), and plugin providers can put arbitrary provenance strings in the signature slot.

A non-JSON signature, or a JSON-looking signature truncated at a crash boundary, makes `JSON.parse` throw a raw `SyntaxError` during request construction. Because the offending block persists in the session history, **every later turn on that session fails identically** — the session is bricked, and the surfaced error (`Unexpected token 'r', "reasoning" is not valid JSON`) points at JSON parsing rather than the actual cause (pattern: error message misreports real behavior).

**Code evidence** (main, before this fix):

- `packages/ai/src/providers/openai-responses-shared.ts:313-318` — `JSON.parse(block.thinkingSignature)` with no guard at all; any non-JSON signature throws.
- `packages/ai/src/transports/openai-responses-replay-internal.ts:437-449` — guarded only by `startsWith("{")` with no try/catch (the comment even acknowledges non-JSON signatures exist); a *truncated* JSON signature still throws.

Minimal reproduction: convert a context containing an assistant message `{ provider: "openai", api: "openai-responses" }` with a thinking block `thinkingSignature: "reasoning"` — see the Evidence section below.

## Root Cause

- The bare parse in the shared lane and the startsWith-only guard in the transport lane both predate the current history root (`05a03c66fe7`).
- Violated invariant: data read back from session history is untrusted input and must never throw during request construction. The same files already honor this for text signatures (`parseTextSignature` wraps its parse in try/catch and falls back); the reasoning-signature path did not.
- Trigger condition: a persisted thinking block whose signature is a plain provenance tag (cross-API session continued on an openai-responses model) or malformed/truncated JSON, replayed by `convertResponsesMessages`.

## Why This Fix

- Option A: one shared helper `parseResponsesReasoningSignature` used by both lanes (chosen) — try/catch around `JSON.parse`, plus an object-shape check; on failure the reasoning item is skipped (`previousReplayItemWasReasoning = false`, so signed text ids fall back correctly), mirroring the existing `parseTextSignature` tolerance. One helper removes the divergence between the two lanes instead of patching each differently.
- Option B: wrap each call site in its own try/catch — rejected: two copies of the same guard, and the startsWith("{") heuristic would remain inconsistently applied (shared lane had none).
- Option C: validate signatures at session-write time — rejected: history written by older versions, other tools, or plugins still exists; read-side tolerance is required regardless.

## User Impact

- Affected scenario: continuing a session on an OpenAI Responses model when the history contains a thinking block with a non-JSON or malformed signature (cross-API migrations, hand-edited or corrupted JSONL, plugin providers using the signature slot as a tag).
- Before: every turn fails with a raw `SyntaxError` ("... is not valid JSON" / "Unexpected end of JSON input"); the session is unusable with that model.
- After: the malformed reasoning item is skipped, the request is built without it, and the turn proceeds; valid JSON signatures still replay exactly as before.
- Behavior change: malformed signatures degrade to "no reasoning replay" instead of a hard error; valid sessions are unaffected.

## Evidence

No mocks: the proof drives the real exported `convertResponsesMessages` from both lanes (`packages/ai/src/providers/openai-responses-shared.ts` and `packages/ai/src/transports/openai-responses-replay-internal.ts`) with a real context: three signatures -- a plain provenance tag (`"reasoning"`), truncated JSON (`{"type":"reasoning","summary":[`), and a valid JSON reasoning item.

### Before (on main)

```bash
$ node_modules/.bin/tsx proof.mjs   # main: bare JSON.parse / startsWith("{")-only guard
shared    signature="reasoning" THREW: SyntaxError Unexpected token 'r', "reasoning" is not valid JSON
shared    signature="{\"type\":\"reasoning\",\"summary\":[" THREW: SyntaxError Unexpected end of JSON input
shared    signature="{\"type\":\"reasoning\",\"id\":\"rs_valid\",...}" -> built request: reasoningItems=1 assistantTextItems=1 (ok)
transport signature="reasoning" -> built request: reasoningItems=0 assistantTextItems=1 (ok)
transport signature="{\"type\":\"reasoning\",\"summary\":[" THREW: SyntaxError Unexpected end of JSON input
transport signature="{\"type\":\"reasoning\",\"id\":\"rs_valid\",...}" -> built request: reasoningItems=1 assistantTextItems=1 (ok)
BEHAVIOR: FAIL - 3 case(s) threw or mis-replayed; a non-JSON thinkingSignature bricks request construction for the whole session
exit=1
```

### After (with fix)

```bash
$ node_modules/.bin/tsx proof.mjs   # HEAD: parseResponsesReasoningSignature at both lanes
shared    signature="reasoning" -> built request: reasoningItems=0 assistantTextItems=1 (ok)
shared    signature="{\"type\":\"reasoning\",\"summary\":[" -> built request: reasoningItems=0 assistantTextItems=1 (ok)
shared    signature="{\"type\":\"reasoning\",\"id\":\"rs_valid\",...}" -> built request: reasoningItems=1 assistantTextItems=1 (ok)
transport signature="reasoning" -> built request: reasoningItems=0 assistantTextItems=1 (ok)
transport signature="{\"type\":\"reasoning\",\"summary\":[" -> built request: reasoningItems=0 assistantTextItems=1 (ok)
transport signature="{\"type\":\"reasoning\",\"id\":\"rs_valid\",...}" -> built request: reasoningItems=1 assistantTextItems=1 (ok)
BEHAVIOR: PASS - malformed thinking signatures are skipped as untrusted JSON, valid signatures still replay
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run packages/ai/src/providers/openai-responses-shared.test.ts packages/ai/src/transports/openai-responses-replay.test.ts` -- 75/75 tests passed, including the new regression tests: malformed signatures are skipped in both lanes, valid signatures still replay, and dropped reasoning items correctly reset signed-text-id pairing. (The transport-lane test asserts `encrypted_content` is stripped for a signature without matching replay metadata -- the pre-existing designed behavior of `prepareOpenAIResponsesReasoningItemForReplay`.)
- Manual verification (the proof above):
  1. On main, both lanes throw `SyntaxError` for the provenance tag and/or truncated JSON -- FAIL.
  2. With the fix, malformed signatures are skipped, valid signatures replay, and no throw occurs -- PASS.

Note: proof and tests were run with Node 22 (repo-bundled); the module graph requires `Set.prototype.union`, unavailable on Node 20.
