### PR TITLE
fix(qqbot): validate gateway heartbeat_interval before scheduling

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -399,6 +399,9 @@ const config = {
     // Mirror config parsing, redaction mapping, cap fitting, and the runner are
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
+    // Heartbeat interval clamping is asserted by the focused gateway connection
+    // tests; production resolves the HELLO interval in-module.
+    "extensions/qqbot/src/engine/gateway/gateway-connection.ts": ["exports"],
     "src/infra/heartbeat-wake.ts": ["exports"],
   },
   workspaces: {

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -7,7 +7,7 @@ import { stopBackgroundTokenRefresh } from "../messaging/sender.js";
 import { flushRefIndex } from "../ref/store.js";
 import { flushKnownUsers } from "../session/known-users.js";
 import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
-import { GatewayConnection } from "./gateway-connection.js";
+import { GatewayConnection, resolveHeartbeatIntervalMs } from "./gateway-connection.js";
 import { QQBotIngressAdmissionError, type QQBotIngressMonitor } from "./ingress.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
@@ -527,5 +527,59 @@ describe("GatewayConnection heartbeat liveness", () => {
     expect(ws.terminate).not.toHaveBeenCalled();
     controller.abort();
     await started;
+  });
+
+  it("falls back to the default interval when HELLO carries a malformed heartbeat_interval", async () => {
+    // heartbeat_interval: 0 would schedule a ~1ms heartbeat that trips the
+    // missed-ACK terminate almost immediately; the handler must substitute the
+    // 45s default instead of scheduling the raw value.
+    const { ws, controller, started } = await startConnection({});
+    ws.readyState = 1; // OPEN
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HELLO, d: { heartbeat_interval: 0 } }));
+
+    // Under the raw value this window would span thousands of ~1ms ticks and
+    // terminate on the third; with the fallback not even one tick has fired.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+    expect(ws.terminate).not.toHaveBeenCalled();
+
+    // The missed-ACK liveness rule still applies at the default cadence.
+    await vi.advanceTimersByTimeAsync(45_000); // tick 1: send (outstanding=1)
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+    await vi.advanceTimersByTimeAsync(45_000); // tick 2: send (outstanding=2)
+    await vi.advanceTimersByTimeAsync(45_000); // tick 3: two unanswered → terminate
+    expect(ws.terminate).toHaveBeenCalledTimes(1);
+    controller.abort();
+    await started;
+  });
+
+  it("falls back to the default interval when HELLO omits heartbeat_interval", async () => {
+    const { ws, controller, started } = await startConnection({});
+    ws.readyState = 1; // OPEN
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HELLO, d: {} }));
+
+    await vi.advanceTimersByTimeAsync(44_999);
+    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"op":1'));
+    expect(ws.terminate).not.toHaveBeenCalled();
+    controller.abort();
+    await started;
+  });
+});
+
+describe("resolveHeartbeatIntervalMs", () => {
+  it("falls back to the default for missing, non-finite, or out-of-range intervals", () => {
+    for (const raw of [undefined, null, 0, -5, Number.NaN, 500, 3e9]) {
+      expect(resolveHeartbeatIntervalMs(raw)).toBe(45_000);
+    }
+  });
+
+  it("passes a valid interval through unchanged", () => {
+    expect(resolveHeartbeatIntervalMs(41_250)).toBe(41_250);
+    expect(resolveHeartbeatIntervalMs(1_000)).toBe(1_000);
+    expect(resolveHeartbeatIntervalMs(2_147_483_647)).toBe(2_147_483_647);
   });
 });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -39,6 +39,32 @@ import type {
 } from "./types.js";
 import { createQQWSClient } from "./ws-client.js";
 
+// Node clamps setInterval delays into a signed 32-bit range: 0/negative/NaN
+// fire ~every 1ms and anything above 2^31-1 warns (TimeoutOverflowWarning) and
+// also fires ~every 1ms. A malformed HELLO heartbeat_interval would therefore
+// spin the heartbeat until the missed-ACK threshold terminates the socket, so
+// fall back to the QQ default instead of scheduling it.
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 45_000;
+const MIN_HEARTBEAT_INTERVAL_MS = 1_000;
+const MAX_HEARTBEAT_INTERVAL_MS = 2_147_483_647; // setInterval signed 32-bit max
+
+/**
+ * Resolve the HELLO `heartbeat_interval` into a delay that is safe to schedule.
+ * Anything non-finite or outside [MIN, MAX] falls back to the default so a
+ * malformed gateway frame cannot busy-loop or overflow the heartbeat timer.
+ */
+export function resolveHeartbeatIntervalMs(raw: unknown): number {
+  if (
+    typeof raw !== "number" ||
+    !Number.isFinite(raw) ||
+    raw < MIN_HEARTBEAT_INTERVAL_MS ||
+    raw > MAX_HEARTBEAT_INTERVAL_MS
+  ) {
+    return DEFAULT_HEARTBEAT_INTERVAL_MS;
+  }
+  return raw;
+}
+
 interface GatewayConnectionContext {
   account: GatewayAccount;
   abortSignal: AbortSignal;
@@ -494,7 +520,15 @@ export class GatewayConnection {
       );
     }
 
-    const interval = (d as { heartbeat_interval: number }).heartbeat_interval;
+    const rawInterval = (d as { heartbeat_interval?: unknown }).heartbeat_interval;
+    const interval = resolveHeartbeatIntervalMs(rawInterval);
+    if (interval !== rawInterval) {
+      // Log the raw value so a misbehaving gateway stays diagnosable; the
+      // socket keeps heartbeating on the default instead of churning.
+      this.ctx.log?.error(
+        `Invalid heartbeat_interval ${String(rawInterval)} in HELLO; using default ${interval}ms`,
+      );
+    }
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);
     }


### PR DESCRIPTION
## Summary

`fix(qqbot): validate gateway heartbeat_interval before scheduling`

## What Problem This Solves

The QQ gateway HELLO frame carries `heartbeat_interval`, the cadence the client must heartbeat at. `GatewayConnection.handleHello` took that value and passed it straight to `setInterval` with no validation. If a misbehaving gateway (or a middlebox rewriting frames) sends a HELLO with a missing, zero, negative, or non-finite `heartbeat_interval` -- or one above Node's signed 32-bit timer max -- the connection enters hot connect/terminate churn:

- Missing/0/negative/NaN delays are clamped by Node to ~1ms, so the heartbeat fires every ~1ms.
- The heartbeat callback allows only 2 unanswered sends before terminating the socket, so within ~3 ticks (~3-15ms) it calls `ws.terminate()` and logs `Heartbeat ACK overdue (2 unanswered); terminating gateway socket` -- blaming the peer for missing ACKs when the real cause is a nonsensical interval.
- The close handler reconnects, the next HELLO carries the same malformed value, and the loop repeats: a CPU- and log-burning connect/heartbeat/terminate churn against the live gateway.

**Code evidence**: in `extensions/qqbot/src/engine/gateway/gateway-connection.ts` (main, before this fix):

- `extensions/qqbot/src/engine/gateway/gateway-connection.ts:497` -- `const interval = (d as { heartbeat_interval: number }).heartbeat_interval;` takes the raw HELLO value with no validation.
- `extensions/qqbot/src/engine/gateway/gateway-connection.ts:505-518` -- that raw value is the `setInterval` delay; the callback terminates the socket after 2 unanswered heartbeats, so a ~1ms interval self-destructs the connection almost immediately.

Minimal reproduction: spin a real `ws` server, connect the real `GatewayConnection`, send a real HELLO frame with `heartbeat_interval: 0` -- the socket is terminated ~14ms later with the misleading `Heartbeat ACK overdue` log. See the Evidence section below.

## Root Cause

- Bug present since the qqbot engine gateway entered the tree in `05a03c66fe7` (2026-08-05, current history).
- Violated invariant: any delay handed to `setInterval` must be a finite number inside Node's schedulable range. Node clamps out-of-range delays instead of rejecting them (0/negative/NaN become ~1ms; >2^31-1 emits a `TimeoutOverflowWarning` and also becomes ~1ms), so an unvalidated network-supplied interval silently degrades into a busy loop. Every other timer in this module uses a local constant; the heartbeat delay was the only one sourced from the wire without a sanity check.
- Trigger condition: any HELLO frame whose `d.heartbeat_interval` is missing, not a finite number, below ~1s, or above 2147483647. The missed-ACK threshold (2 unanswered sends) then converts the ~1ms heartbeat into an immediate terminate, and the reconnect path re-connects into the same malformed HELLO.

## Why This Fix

- Option A: validate at the scheduling site via a small exported helper `resolveHeartbeatIntervalMs(raw)` -- non-finite or out-of-range values log the raw value and fall back to a 45s default (chosen). The invariant is enforced exactly where it is violated, the helper is directly unit-testable, and the raw value is still logged so a misbehaving gateway stays diagnosable.
- Option B: clamp out-of-range values into range (e.g. 0 -> 1000ms floor) instead of defaulting -- rejected: it keeps a heartbeat cadence the server never actually asked for (a floor of 1s is still 45x faster than QQ's documented ~40s+ intervals and risks gateway-side rate limiting), and it makes the fallback value depend on the bad input.
- Option C: reject the HELLO entirely (terminate and reconnect) on an invalid interval -- rejected: that is the churn the bug already causes; a single malformed frame would permanently block an otherwise usable gateway. Falling back to the documented-ish default keeps the session alive and the missed-ACK liveness rule still applies at the default cadence.

Option A is the minimal change: one pure helper plus a guarded call site; four regression tests pin the behavior.

## User Impact

- Affected scenario: a QQ gateway endpoint (or proxy) that delivers a HELLO frame with a missing/invalid/extreme `heartbeat_interval`.
- Before: the client schedules a ~1ms heartbeat, terminates the socket within milliseconds (`Heartbeat ACK overdue`, misattributing the cause), reconnects into the same HELLO, and churns hot until stopped.
- After: the client logs `Invalid heartbeat_interval <raw> in HELLO; using default 45000ms` and heartbeats at the default cadence; the connection stays up and the missed-ACK liveness rule keeps working.
- Behavior change: valid intervals (including 41250) are passed through unchanged; only malformed/out-of-range values take the fallback.

## Evidence

No mocks, no stubbed network: the proof spins a real `ws` WebSocketServer on 127.0.0.1, connects a real client socket via the repo's own `createQQWSClient`, constructs the real `GatewayConnection`, and has the server send a real HELLO frame with `heartbeat_interval: 0` over the wire, dispatched through the real `handleSocketMessage -> handleHello` path. The server counts heartbeat frames and records client terminates. A valid-interval control (1200ms) confirms scheduling still works, and `resolveHeartbeatIntervalMs` is unit-driven with 0/undefined/-5/3e9/41250.

### Before (on main)

```bash
$ node_modules/.bin/tsx proof.mjs   # main: raw d.heartbeat_interval passed straight to setInterval
resolveHeartbeatIntervalMs table (unit-driven):
  (not exported - the raw HELLO value is passed straight to setInterval)

scenario: HELLO with heartbeat_interval: 0 (malformed)
  heartbeats received server-side in 500ms: 2 (at ~9ms, ~10ms)
  server saw client close/terminate: yes, ~14ms after HELLO
  client socket OPEN at end of window: no
  [log:error] Heartbeat ACK overdue (2 unanswered); terminating gateway socket

scenario: HELLO with heartbeat_interval: 1200 (valid control)
  heartbeats received server-side in 1400ms: 1 (at ~1228ms)
  server saw client close/terminate: no
  client socket OPEN at end of window: yes

BEHAVIOR: FAIL - malformed heartbeat_interval=0 scheduled a ~1ms heartbeat loop (heartbeats=2, socket terminated ~14ms after HELLO) instead of falling back to a sane default
exit=1
```

### After (with fix)

```bash
$ node_modules/.bin/tsx proof.mjs   # HEAD: resolveHeartbeatIntervalMs guards the setInterval delay
resolveHeartbeatIntervalMs table (unit-driven):
  resolveHeartbeatIntervalMs(0) -> 45000
  resolveHeartbeatIntervalMs(undefined) -> 45000
  resolveHeartbeatIntervalMs(-5) -> 45000
  resolveHeartbeatIntervalMs(3000000000) -> 45000
  resolveHeartbeatIntervalMs(41250) -> 41250

scenario: HELLO with heartbeat_interval: 0 (malformed)
  heartbeats received server-side in 500ms: 0
  server saw client close/terminate: no
  client socket OPEN at end of window: yes
  [log:error] Invalid heartbeat_interval 0 in HELLO; using default 45000ms

scenario: HELLO with heartbeat_interval: 1200 (valid control)
  heartbeats received server-side in 1400ms: 1 (at ~1207ms)
  server saw client close/terminate: no
  client socket OPEN at end of window: yes

BEHAVIOR: PASS - malformed heartbeat_interval falls back to the default (connection stays up) and valid intervals still schedule
exit=0
```

Note the log line change: instead of the misleading `Heartbeat ACK overdue` terminate, the client now names the actual cause (`Invalid heartbeat_interval 0 in HELLO`) and keeps the connection up.

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run extensions/qqbot/src/engine/gateway/gateway-connection.test.ts` -- 18/18 tests passed, including the new regression tests `falls back to the default interval when HELLO carries a malformed heartbeat_interval`, `falls back to the default interval when HELLO omits heartbeat_interval`, and the `resolveHeartbeatIntervalMs` describe (invalid/missing/huge values fall back to 45000; a valid 41250 passes through unchanged).
- `pnpm deadcode:full` (knip production scan) flagged `resolveHeartbeatIntervalMs` as an unused export because only the focused tests import it cross-module, so `config/knip.config.ts` now marks the file as a test seam via `ignoreIssues` -- the same pattern as the existing `extensions/signal` and `extensions/beam` test-seam entries; the full-tree companion scan still audits the export against its test consumers.
- Manual verification (the proof above):
  1. On main, a real HELLO with `heartbeat_interval: 0` terminated the real socket ~14ms after HELLO with the misattributed `Heartbeat ACK overdue` log -- FAIL.
  2. With the fix, the same frame falls back to the 45s default (0 heartbeats in a 500ms window, connection still open, cause logged), and a valid 1200ms interval still schedules exactly one heartbeat in its window -- PASS.
