### PR TITLE
fix(diffs): restore GET/HEAD Content-Length parity on viewer routes

### DIFF
--- a/extensions/diffs/src/http.test.ts
+++ b/extensions/diffs/src/http.test.ts
@@ -1,0 +1,88 @@
+// Diffs plugin module implements http tests.
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { describe, expect, it } from "vitest";
+import { createDiffsHttpHandler } from "./http.js";
+import type { DiffArtifactStore } from "./store.js";
+
+const VIEWER_RUNTIME_PATH = "/plugins/diffs/assets/viewer-runtime.js";
+const UNKNOWN_ASSET_PATH = "/plugins/diffs/assets/does-not-exist.js";
+const UNKNOWN_VIEW_PATH = "/plugins/diffs/view/not-an-artifact/not-a-token";
+
+type ServedResponse = {
+  status: number;
+  contentLength: string | null;
+  bodyBytes: number;
+};
+
+async function withDiffsServer(run: (base: string) => Promise<void>): Promise<void> {
+  const handler = createDiffsHttpHandler({ store: {} as DiffArtifactStore });
+  const server: Server = createServer((req, res) => {
+    void handler(req, res).then((handled) => {
+      if (!handled) {
+        res.statusCode = 404;
+        res.end();
+      }
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function fetchServed(base: string, path: string, method = "GET"): Promise<ServedResponse> {
+  const response = await fetch(`${base}${path}`, { method });
+  const body = await response.arrayBuffer();
+  return {
+    status: response.status,
+    contentLength: response.headers.get("content-length"),
+    bodyBytes: body.byteLength,
+  };
+}
+
+describe("diffs viewer http handler", () => {
+  it("sends byte-accurate Content-Length on HEAD asset responses", async () => {
+    await withDiffsServer(async (base) => {
+      const get = await fetchServed(base, VIEWER_RUNTIME_PATH);
+      const head = await fetchServed(base, VIEWER_RUNTIME_PATH, "HEAD");
+
+      expect(get.status).toBe(200);
+      expect(get.bodyBytes).toBeGreaterThan(0);
+      expect(get.contentLength).toBe(String(get.bodyBytes));
+      expect(head.status).toBe(200);
+      expect(head.bodyBytes).toBe(0);
+      expect(head.contentLength).toBe(String(get.bodyBytes));
+    });
+  });
+
+  it("sends Content-Length on HEAD 404 responses for missing assets", async () => {
+    await withDiffsServer(async (base) => {
+      const head = await fetchServed(base, UNKNOWN_ASSET_PATH, "HEAD");
+
+      expect(head.status).toBe(404);
+      expect(head.bodyBytes).toBe(0);
+      expect(head.contentLength).toBe(String(Buffer.byteLength("Asset not found")));
+    });
+  });
+
+  it("sends Content-Length on HEAD 404 responses for unknown diff views", async () => {
+    await withDiffsServer(async (base) => {
+      const head = await fetchServed(base, UNKNOWN_VIEW_PATH, "HEAD");
+
+      expect(head.status).toBe(404);
+      expect(head.bodyBytes).toBe(0);
+      expect(head.contentLength).toBe(String(Buffer.byteLength("Diff not found")));
+    });
+  });
+});

--- a/extensions/diffs/src/http.test.ts
+++ b/extensions/diffs/src/http.test.ts
@@ -1,13 +1,20 @@
 // Diffs plugin module implements http tests.
 import { createServer } from "node:http";
 import type { Server } from "node:http";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { createDiffsHttpHandler } from "./http.js";
 import type { DiffArtifactStore } from "./store.js";
+import { ensureCuratedViewerRuntimeForTests } from "./test-helpers.js";
 
 const VIEWER_RUNTIME_PATH = "/plugins/diffs/assets/viewer-runtime.js";
 const UNKNOWN_ASSET_PATH = "/plugins/diffs/assets/does-not-exist.js";
 const UNKNOWN_VIEW_PATH = "/plugins/diffs/view/not-an-artifact/not-a-token";
+
+beforeAll(async () => {
+  // viewer-runtime.js is ignored generated output; build the fixture before
+  // serving assets in a clean checkout.
+  await ensureCuratedViewerRuntimeForTests();
+});
 
 type ServedResponse = {
   status: number;

--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -76,10 +76,8 @@ export function createDiffsHttpHandler(params: {
     if (!access.localRequest) {
       const throttled = viewerFailureLimiter.check(access.remoteKey);
       if (!throttled.allowed) {
-        res.statusCode = 429;
-        setSharedHeaders(res, "text/plain; charset=utf-8");
         res.setHeader("Retry-After", String(Math.max(1, Math.ceil(throttled.retryAfterMs / 1000))));
-        res.end("Too Many Requests");
+        respondText(res, 429, "Too Many Requests");
         return true;
       }
     }
@@ -162,6 +160,7 @@ async function serveAsset(
       asset.contentType,
       pathname === VIEWER_RUNTIME_PATH ? IMMUTABLE_ASSET_CACHE_CONTROL : undefined,
     );
+    res.setHeader("content-length", String(Buffer.byteLength(asset.body)));
     if (req.method === "HEAD") {
       res.end();
     } else {
@@ -178,6 +177,9 @@ async function serveAsset(
 function respondText(res: ServerResponse, statusCode: number, body: string): void {
   res.statusCode = statusCode;
   setSharedHeaders(res, "text/plain; charset=utf-8");
+  // Node suppresses the HEAD body but never synthesizes Content-Length; set it
+  // explicitly so error responses keep GET/HEAD header parity (RFC 9110 §8.6).
+  res.setHeader("content-length", String(Buffer.byteLength(body)));
   res.end(body);
 }
 


### PR DESCRIPTION
## Summary

The `/plugins/diffs` viewer HTTP handler now sends an explicit `Content-Length` on HEAD responses — for viewer assets (200), for error responses from `respondText` (404/405/500), and for the rate-limited 429 — matching the byte length of the corresponding GET response.

## What Problem This Solves

The diffs viewer serves its static assets and viewer documents over loopback/plugin HTTP routes and explicitly allows `HEAD` (non-GET/HEAD methods get a 405 with the asset routes accepting HEAD by design). But HEAD responses were missing `Content-Length`:

- `serveAsset` (`extensions/diffs/src/http.ts`) ended HEAD responses with a bare `res.end()` and never set `Content-Length`, while the GET path got the header for free from Node's single-chunk `res.end(body)` fast path.
- `respondText` (404/405/500) and the 429 lockout response had the same asymmetry: GET carried `Content-Length`, HEAD did not.
- The sibling viewer-document route in the same file already sets `content-length` explicitly for both methods (`http.ts` viewer html branch) — the asset and error paths were simply missed.

Per RFC 9110 §8.6, a HEAD response SHOULD carry the same `Content-Length` the GET would have produced. Clients that preflight with HEAD (cache validators, download managers, uptime/probe tooling) rely on that header to learn the representation size; its absence forces them to fall back to a full GET.

**Code evidence**: in `extensions/diffs/src/http.ts`, `serveAsset` set status and shared headers but no `content-length` before `res.end()` on HEAD, and `respondText` ended the response without ever setting the header.

## Root Cause

- Introduced by commit `612ed5b3e1e` ("diffs plugin", 2026-02-28): the HEAD branches were added without an explicit length header.
- Violated invariant: the handler assumes "Node will take care of framing headers". Node's HTTP server only synthesizes `Content-Length` when the whole body is passed to a single `res.end(body)` call; for HEAD it suppresses the body and synthesizes nothing, so the header simply never appears.
- Trigger condition: any `HEAD` request to `/plugins/diffs/assets/*` (200 or 404) or to `/plugins/diffs/view/...` error paths (404/429/500).

## Why This Fix

- Set `content-length` explicitly at each of the three sites, computed with `Buffer.byteLength(...)` from the exact body the GET would send (`asset.body` is `string | Buffer`; `Buffer.byteLength` handles both).
- The 429 branch now routes through `respondText` (setting `Retry-After` first), so all text error responses share one code path that cannot drift out of parity again.
- Alternative considered: only patch the HEAD branch of `serveAsset` and leave `respondText` alone — rejected, because 404/405/500/429 HEAD responses would keep dropping the header, and a single canonical responder is what the merged sibling fixes (#120210, #120212) converged on.

## User Impact

- Affected operations: `HEAD /plugins/diffs/assets/viewer-runtime.js` (and any sibling asset), plus HEAD on viewer error paths.
- After the fix, HEAD responses carry the byte-accurate `Content-Length` of the GET representation (verified below: 4,939,663 bytes for the runtime bundle), so HEAD-based preflight tooling sees correct sizes with an empty body.

## Evidence

- **Before**: on `main`, the proof script reports `FAIL` for all three probes — `HEAD asset content-length=null want 4939663`, `HEAD 404 content-length=null`, `HEAD view 404 content-length=null`.
- **After**: on this branch, the same script reports `ALL CHECKS PASSED` — HEAD asset `content-length=4939663` (identical to the GET body), HEAD 404 `content-length=15`, HEAD view 404 `content-length=14`.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
GET  asset -> 200, content-length=4939663, body=4939663 bytes
HEAD asset -> 200, content-length=null, body=0 bytes
FAIL: HEAD asset Content-Length matches GET body bytes (head content-length=null want 4939663)
HEAD missing asset -> 404, content-length=null
FAIL: HEAD 404 carries Content-Length (head content-length=null)
HEAD unknown view -> 404, content-length=null
FAIL: HEAD view 404 carries Content-Length (head content-length=null)
3 CHECK(S) FAILED
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
GET  asset -> 200, content-length=4939663, body=4939663 bytes
HEAD asset -> 200, content-length=4939663, body=0 bytes
PASS: HEAD asset Content-Length matches GET body bytes (head content-length=4939663 want 4939663)
HEAD missing asset -> 404, content-length=15
PASS: HEAD 404 carries Content-Length (head content-length=15)
HEAD unknown view -> 404, content-length=14
PASS: HEAD view 404 carries Content-Length (head content-length=14)
ALL CHECKS PASSED
```

## Tests and Validation

- New regression tests in `extensions/diffs/src/http.test.ts` spin up a real `node:http` server around `createDiffsHttpHandler` and assert GET/HEAD `Content-Length` parity for the 200 asset route and the 404 asset/view routes.
- `pnpm vitest run extensions/diffs` — 14 files, 156 tests passed.
- `pnpm check` — all guards pass except the local `npm package-lock guard`, which fails on a registry integrity mismatch for the transitive `set-blocking` package (npm returns sha1, `pnpm-lock.yaml` pins sha512). That failure is pre-existing and unrelated: this PR changes no dependency or lockfile.
- Same fix family as the merged #117961 (canvas A2UI HEAD `Content-Length`); sibling plugin `diffs-language-pack` has the identical pattern and is fixed in a separate PR.
