### PR TITLE
fix(ci): retire dead ClawSweeper commit dispatch

### DIFF
--- a/.agents/skills/clawsweeper/SKILL.md
+++ b/.agents/skills/clawsweeper/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: clawsweeper
-description: "Use for all ClawSweeper work: OpenClaw issue/PR sweep reports, commit-review reports, repair jobs, cloud fix PRs, @clawsweeper maintainer mention commands, trusted ClawSweeper-reviewed autofix/automerge, GitHub Actions monitoring, permissions, gates, and manual backfills."
+description: "Use for all ClawSweeper work: OpenClaw issue/PR sweep reports, repair jobs, cloud fix PRs, @clawsweeper maintainer mention commands, trusted ClawSweeper-reviewed autofix/automerge, GitHub Actions monitoring, permissions, gates, and manual backfills."
 ---
 
 # ClawSweeper
 
 ClawSweeper lives at `~/Projects/clawsweeper`. It is the one OpenClaw
-maintenance bot for sweeping, commit review, repair jobs, and guarded fix PRs.
+maintenance bot for sweeping, repair jobs, and guarded fix PRs.
 Use this skill whenever asked about reports, findings, dispatch health,
 repair/cloud PR creation, comment commands, automerge, permissions, or gates.
 
@@ -36,8 +36,7 @@ Required app setup:
 - Target app permissions: read target scan context; write issues and pull
   requests; contents write for report commits, repair branches, and workflow
   inputs; Actions write on `openclaw/clawsweeper` for comment-router
-  re-review dispatch, workflow dispatch, run cancellation, and self-heal;
-  optional Checks write for commit Check Runs.
+  re-review dispatch, workflow dispatch, run cancellation, and self-heal.
 
 Token boundary:
 
@@ -47,40 +46,10 @@ Token boundary:
   closes, and merges through short-lived GitHub App tokens.
 - Merge and write gates default closed.
 
-## Commit Reports
+## Hosted Commit Reviews
 
-Canonical commit reports:
-
-```text
-records/<repo-slug>/commits/<40-char-sha>.md
-```
-
-Use the lister:
-
-```bash
-pnpm commit-reports -- --since 6h
-pnpm commit-reports -- --since "24 hours ago" --findings
-pnpm commit-reports -- --since 7d --non-clean
-pnpm commit-reports -- --repo openclaw/openclaw --author steipete --since 7d
-pnpm commit-reports -- --since 24h --json
-```
-
-Results: `nothing_found`, `findings`, `inconclusive`, `failed`,
-`skipped_non_code`. One report per SHA; reruns overwrite the SHA-named report.
-
-Manual rerun/backfill:
-
-```bash
-gh workflow run commit-review.yml --repo openclaw/clawsweeper \
-  -f target_repo=openclaw/openclaw \
-  -f commit_sha=<end-sha> \
-  -f before_sha=<start-or-parent-sha> \
-  -f create_checks=false \
-  -f enabled=true
-```
-
-Use `create_checks=true` only when the requester explicitly wants target commit Check
-Runs. Add `-f additional_prompt="..."` for focused one-off review instructions.
+Hosted per-commit reports and commit Check Runs are retired. For local review of
+an already-committed change, use `$autoreview --mode commit --commit <sha>`.
 
 ## Sweep Reports
 
@@ -303,11 +272,13 @@ prose.
 Receiver workflows:
 
 ```bash
-gh run list --repo openclaw/clawsweeper --workflow "ClawSweeper Commit Review" \
+gh run list --repo openclaw/clawsweeper --workflow sweep.yml \
   --limit 12 --json databaseId,displayTitle,event,status,conclusion,createdAt,updatedAt,url
-gh run list --repo openclaw/clawsweeper --workflow "repair cluster worker" \
+gh run list --repo openclaw/clawsweeper --workflow repair-cluster-worker.yml \
   --limit 12 --json databaseId,displayTitle,event,status,conclusion,createdAt,updatedAt,url
-gh run list --repo openclaw/clawsweeper --workflow "repair comment router" \
+gh run list --repo openclaw/clawsweeper --workflow repair-comment-router.yml \
+  --limit 12 --json databaseId,displayTitle,event,status,conclusion,createdAt,updatedAt,url
+gh run list --repo openclaw/clawsweeper --workflow github-activity.yml \
   --limit 12 --json databaseId,displayTitle,event,status,conclusion,createdAt,updatedAt,url
 ```
 
@@ -315,21 +286,14 @@ Target dispatcher:
 
 ```bash
 gh run list --repo openclaw/openclaw --workflow "ClawSweeper Dispatch" \
-  --event push --limit 8 --json databaseId,displayTitle,event,status,conclusion,headSha,url
-```
-
-Target commit check:
-
-```bash
-gh api "repos/openclaw/openclaw/commits/<sha>/check-runs?per_page=100" \
-  --jq '.check_runs[] | select(.name=="ClawSweeper Commit Review") | [.status,.conclusion,.details_url] | @tsv'
+  --limit 8 --json databaseId,displayTitle,event,status,conclusion,headSha,url
 ```
 
 ## Reading Output
 
 For findings or failures, summarize:
 
-- target repo, item/PR/commit, run, report path
+- target repo, item/PR, run, report path
 - result, confidence, severity, and exact blocker
 - affected files or cluster refs
 - validation commands and whether they passed

--- a/.agents/skills/clawsweeper/SKILL.md
+++ b/.agents/skills/clawsweeper/SKILL.md
@@ -48,8 +48,10 @@ Token boundary:
 
 ## Hosted Commit Reviews
 
-Hosted per-commit reports and commit Check Runs are retired. For local review of
-an already-committed change, use `$autoreview --mode commit --commit <sha>`.
+Hosted per-commit reports and commit Check Runs are retired. For the retained
+offline review of a committed branch, use `pnpm local-review -- --base main`.
+`$autoreview --mode commit --commit <sha>` remains a separate general-purpose
+review path.
 
 ## Sweep Reports
 

--- a/.agents/skills/clawsweeper/agents/openai.yaml
+++ b/.agents/skills/clawsweeper/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ClawSweeper"
-  short_description: "Inspect ClawSweeper commit review reports and Actions runs."
-  default_prompt: "Review recent ClawSweeper commit reports and summarize findings."
+  short_description: "Inspect ClawSweeper issue/PR reports, queue health, and Actions runs."
+  default_prompt: "Review recent ClawSweeper issue/PR reports, queue health, and Actions runs."

--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -318,37 +318,3 @@ jobs:
           else
             echo "::warning::Skipping ClawSweeper comment dispatch because the configured credential could not dispatch to openclaw/clawsweeper."
           fi
-
-      - name: Dispatch ClawSweeper commit review
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.deleted != true }}
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          TARGET_REPO: ${{ github.repository }}
-          BEFORE_SHA: ${{ github.event.before }}
-          AFTER_SHA: ${{ github.sha }}
-          SOURCE_REF: ${{ github.ref }}
-          CREATE_CHECKS: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_CREATE_CHECKS || 'false' }}
-        run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::notice::Skipping ClawSweeper commit dispatch because no ClawSweeper app token is configured. Not falling back to a maintainer token."
-            exit 0
-          fi
-          . "$RUNNER_TEMP/github-api-backoff.sh"
-          case "$CREATE_CHECKS" in
-            true|TRUE|1|yes|YES|on|ON) create_checks=true ;;
-            *) create_checks=false ;;
-          esac
-          payload="$(jq -nc \
-            --arg target_repo "$TARGET_REPO" \
-            --arg before_sha "$BEFORE_SHA" \
-            --arg after_sha "$AFTER_SHA" \
-            --arg ref "$SOURCE_REF" \
-            --argjson create_checks "$create_checks" \
-            '{event_type:"clawsweeper_commit_review",client_payload:{target_repo:$target_repo,before_sha:$before_sha,after_sha:$after_sha,ref:$ref,enabled:true,create_checks:$create_checks}}')"
-          if gh_api_with_retry repos/openclaw/clawsweeper/dispatches \
-            --method POST \
-            --input - <<< "$payload"; then
-            echo "Dispatched ClawSweeper commit review."
-          else
-            echo "::warning::Skipping ClawSweeper commit dispatch because the configured credential could not dispatch to openclaw/clawsweeper."
-          fi

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -139,14 +139,15 @@ The `check-dependencies` shard runs production Knip dependency, unused-file, and
 
 `.github/workflows/clawsweeper-dispatch.yml` is the target-side bridge from OpenClaw repository activity into ClawSweeper. It does not check out or execute untrusted pull request code. The workflow creates a GitHub App token from `CLAWSWEEPER_APP_PRIVATE_KEY`, then dispatches compact `repository_dispatch` payloads to `openclaw/clawsweeper`.
 
-The workflow has four lanes:
+The workflow has three lanes:
 
 - `clawsweeper_item` for exact issue and pull request review requests;
 - `clawsweeper_comment` for explicit ClawSweeper commands in issue comments;
-- `clawsweeper_commit_review` for commit-level review requests on `main` pushes;
 - `github_activity` for general GitHub activity that the ClawSweeper agent may inspect.
 
 The `github_activity` lane forwards normalized metadata only: event type, action, actor, repository, item number, URL, title, state, and short excerpts for comments or reviews when present. It intentionally avoids forwarding the full webhook body. The receiving workflow in `openclaw/clawsweeper` is `.github/workflows/github-activity.yml`, which posts the normalized event to the OpenClaw Gateway hook for the ClawSweeper agent.
+
+Main pushes remain `github_activity` observations. They do not produce hosted per-commit reports or commit Check Runs.
 
 General activity is observation, not delivery-by-default. The ClawSweeper agent receives the Discord target in its prompt and should post to `#clawsweeper` only when the event is surprising, actionable, risky, or operationally useful. Routine opens, edits, bot churn, duplicate webhook noise, and normal review traffic should result in `NO_REPLY`.
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1062,6 +1062,39 @@ NODE
     });
   });
 
+  it("keeps ClawSweeper dispatch events aligned with receiver workflows", () => {
+    const workflowPath = ".github/workflows/clawsweeper-dispatch.yml";
+    const source = readFileSync(workflowPath, "utf8");
+    const workflow = readWorkflow(workflowPath);
+    const steps = workflow.jobs.dispatch.steps as WorkflowStep[];
+    const receiverDispatchSteps = steps.filter((step) =>
+      step.run?.includes("repos/openclaw/clawsweeper/dispatches"),
+    );
+    const eventTypes = receiverDispatchSteps.map((step) => {
+      const matches = [...(step.run ?? "").matchAll(/\bevent_type\s*:\s*"([^"]+)"/gu)];
+      expect(matches, step.name).toHaveLength(1);
+      return expectDefined(matches[0]?.[1], step.name ?? "ClawSweeper dispatch event");
+    });
+
+    // This allowlist mirrors the target repository receiver contract; changes require coordinated receiver updates.
+    expect(eventTypes.toSorted()).toEqual([
+      "clawsweeper_comment",
+      "clawsweeper_item",
+      "github_activity",
+    ]);
+    expect(source).not.toContain("clawsweeper_commit_review");
+    expect(source).not.toContain("CLAWSWEEPER_COMMIT_REVIEW_CREATE_CHECKS");
+    expect(workflow.on.push.branches).toEqual(["main"]);
+
+    const activityRun = expectDefined(
+      steps.find((step) => step.name === "Dispatch GitHub activity to ClawSweeper")?.run,
+      "ClawSweeper GitHub activity dispatch",
+    );
+    expect(activityRun).toMatch(
+      /push: \(if \$event_name == "push" then \{\s+before: \.before,\s+after: \.after,\s+ref: \.ref,\s+compare: \.compare,\s+head_commit: \.head_commit\.id\s+\} else null end\)/u,
+    );
+  });
+
   it("runs the PR context and evidence gate only for relevant PR changes", () => {
     const workflow = readRealBehaviorProofWorkflow();
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `main` pushes could complete the OpenClaw sender workflow successfully while dispatching the retired `clawsweeper_commit_review` event. GitHub accepted the unmatched repository dispatch, but current ClawSweeper created no receiver run, commit Check Run, or canonical commit report.

## Why This Change Was Made

ClawSweeper intentionally retired the hosted commit-review pipeline in [openclaw/clawsweeper#964](https://github.com/openclaw/clawsweeper/pull/964). This change removes the stale OpenClaw sender and operator instructions instead of restoring deleted ClawSweeper compatibility.

The workflow guard now declares the three receiver event types OpenClaw owns (`clawsweeper_item`, `clawsweeper_comment`, and `github_activity`) and fails if a target dispatch step uses any other or dynamic event type. Main-push activity observation, issue/PR review, sweep, repair, and comment-router paths remain supported.

## User Impact

Operators will no longer see a green sender run that falsely implies a hosted per-commit review was queued. Main pushes continue through `github_activity`; hosted commit reports and commit Check Runs remain retired, so no canonical commit report is expected.

## Evidence

- Exact review-fixed head: [`feb52d0aa5cb68d6efa43469055d3ff08cf120ca`](https://github.com/openclaw/openclaw/commit/feb52d0aa5cb68d6efa43469055d3ff08cf120ca), based on hosted-gate contract merge [`8c68f74ef914763e846f4b3c2fef8b80ace56f5e`](https://github.com/openclaw/openclaw/commit/8c68f74ef914763e846f4b3c2fef8b80ace56f5e).
- Feature preservation: `git range-diff` reports the original and rebased feature commits exact-equal, and both stable patch IDs are `b16decae34943e502359c28c45eb3c80f1f17fde`. The only follow-on commit applies the exact ClawSweeper rank-up move to preserve the retained offline review command.
- Historical failing contract: [OpenClaw sender run 31187412882](https://github.com/openclaw/openclaw/actions/runs/31187412882) completed sender-side without a matching commit-review receiver.
- Retirement source: [ClawSweeper deletion commit](https://github.com/openclaw/clawsweeper/commit/a1c13922af990ce0065a85420359b36f06dc96e3).
- Current supported activity proof: [ClawSweeper activity receiver run 31187490625](https://github.com/openclaw/clawsweeper/actions/runs/31187490625).
- Owner-contract disposition: current ClawSweeper main [`f6f6bfca7d65aa54eec9daa82ab84cda9ad6e0e8`](https://github.com/openclaw/clawsweeper/commit/f6f6bfca7d65aa54eec9daa82ab84cda9ad6e0e8) retains `pnpm local-review -- --base main` as the credential-scrubbed, web-disabled, clean committed-range path. Current Codex main [`8e4b10446eed7bafb39d8a469f9be25a41f4864f`](https://github.com/openai/codex/commit/8e4b10446eed7bafb39d8a469f9be25a41f4864f) confirms `--search` enables live web search, so autoreview remains documented only as a separate general-purpose path.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/check-workflows.test.ts`: 110 passed, 2 skipped.
- `node scripts/check-workflows.mjs`: passed (`zizmor` plus composite-run interpolation guard).
- `actionlint .github/workflows/clawsweeper-dispatch.yml`: passed.
- `node_modules/.bin/oxfmt --check ...`: passed for all five changed files.
- `node scripts/docs-list.js` and `git diff --check`: passed.
- Exact-head autoreview at `feb52d0aa5cb68d6efa43469055d3ff08cf120ca`: clean, no accepted/actionable findings; patch correctness 0.99.
- Exact-head hosted runs (terminal success required before merge): [CI 31217504526](https://github.com/openclaw/openclaw/actions/runs/31217504526), [ARM 31217504837](https://github.com/openclaw/openclaw/actions/runs/31217504837), [Testbox 31217507480](https://github.com/openclaw/openclaw/actions/runs/31217507480), [build artifacts 31217504618](https://github.com/openclaw/openclaw/actions/runs/31217504618), [workflow sanity 31217503362](https://github.com/openclaw/openclaw/actions/runs/31217503362), and [ClawSweeper dispatch 31217503381](https://github.com/openclaw/openclaw/actions/runs/31217503381).
- Production/tooling/docs: +20/-87 lines. Tests: +33/-0 lines. Runtime product code: 0 lines.

Terminal hosted conclusions and the durable exact-head ClawSweeper review will be recorded before merge.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":5,"user":2,"assistant":2,"toolCalls":272,"toolOutputsDropped":271,"web":0,"redactions":4,"omittedUnsafe":0,"rawEntries":33}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
hi — i’m taking the dispatch contract from live evidence through squash landing and post-merge receiver proof. first i’m grounding GitHub history, repo state, and the required workflow skills; i’ll keep all edits in a fresh `gwt` worktree.

the local checkout is 170 commits behind, so i’m not using it for conclusions. i’m checking the archived GitHub corpus now, then i’ll create the isolated worktree from the fetched remote tip and hand bounded investigation lanes to workers.

gitcrawl’s cloud archive is configured but unusable because `CRAWL_REMOTE_TOKEN` is absent; the three targeted searches all failed at that gate. i’ll use live GitHub for the consequential state, while codebase-memory-mcp maps the workflow/test ownership before anyone edits.

the graph service is healthy and has indexed both OpenClaw and ClawSweeper, but the OpenClaw graph reflects the stale checkout. i’m creating the mandated fresh `origin/main` worktree now; discovery workers will operate against that exact SHA and the current ClawSweeper checkout.

the skill’s documented `[HOME_PATH]` path is stale on this machine; the live checkout is `GIT/_Perso/clawsweeper`. i’m treating that as a path drift, not inventing a new repo copy, and will keep the dependency lane read-only unless its contract proves the receiver is actually broken.

the sender run is now nailed down: it posted a valid `204`-style dispatch success using the retired event, so GitHub accepted the request while the receiver ignored it. the fresh worktree is created at current `origin/main`; i’m finishing its integrity check, then the implementation lane will compare exact sender/receiver contracts and add the smallest enforceable test.

evidence now points to a clean owner boundary: ClawSweeper removed the old commit-review workflow/event, while OpenClaw kept emitting it. i’m holding the edit until the dependency and history workers return exact replacement fields, then one worker will patch the sender and contract test in the fresh GWT.

execution route:
1. freeze sender/receiver contract and provenance
2. patch only OpenClaw workflow + static contract coverage
3. run workflow syntax, focused tests, diff checks, and autoreview
4. open draft PR, assign `vincentkoc`, attach the approved redacted transcript, and wait for exact-head CI/ClawSweeper
5. complete repo-native review/prepare/squash merge
6. trigger the merged SHA through the repaired sender and prove receiver run + canonical report; remove any task-owned probe artifact if one is needed

the live dependency evidence is converging on an intentional retirement, not an event rename. i’m finishing the three independent checks now; if there is truly no supported receiver contract, your stop condition applies because producing the requested receiver run/report would require a ClawSweeper repo change.

the decisive fact is now hard proof: ClawSweeper PR #964 deliberately deleted the hosted commit-review workflow on July 30 after zero successful runs in its final 20 attempts. GitHub returns `204` for unmatched repository dispatches, which explains the green OpenClaw sender without any receiver run.

there is no replacement event to wire. the supported push path is `github_activity`; the commit reviewer, classifier/check publisher, finding intake, workflow, and report publication lane were deleted together. i’m checking the OpenClaw stale-reference/test surface once more, then i’ll apply your explicit cross-repo stop rule.

the worker evidence is consistent. i’m now doing the required primary-agent contract check directly against the fresh OpenClaw GWT and current local ClawSweeper main; i won’t base the stop decision only on delegated summaries.

primary verification matches the workers: live ClawSweeper `main` has no commit-review workflow or event listener, and the canonical report path is absent. restoring a receiver/report would require reintroducing deleted ClawSweeper code, so i’m stopping before edits or GitHub mutations exactly as requested.

hi. i stopped at the explicit cross-repo boundary.

This is not an OpenClaw event rename. ClawSweeper removed the receiver on May 29, 2026, then deleted the entire 648-line hosted commit-review/report pipeline on July 30 in https://github.com/openclaw/clawsweeper/pull/964. Current ClawSweeper main `f6f6bfca7d65aa54eec9daa82ab84cda9ad6e0e8` has no `clawsweeper_commit_review` receiver or canonical report publisher.

Evidence:
- Dead sender: `.github/workflows/clawsweeper-dispatch.yml:322`
- Successful sender-only run: https://github.com/openclaw/openclaw/actions/runs/[REDACTED_PHONE]
- Canonical deletion: https://github.com/openclaw/clawsweeper/commit/a1c13922af990ce0065a85420359b36f06dc96e3
- Supported activity receiver: https://github.com/openclaw/clawsweeper/actions/runs/[REDACTED_PHONE]
- Expected commit report for `3bc188e...`: absent

Fresh GWT is clean at `a23444fc74b0ddfea5e4b2aad6ae2f81fdc6cf8b`. No edits, PR, merge, dispatch mutation, or placeholder were created. Final diff is empty; therefore there are no PR, merge, or report URLs.

My recommendation: intentionally retire the stale OpenClaw dispatch step, docs, and skill instructions with a static event-contract guard. Restoring canonical commit reports requires a separately authorized ClawSweeper repair first.

[user]
Proceed with the evidence-backed OpenClaw owner fix: intentionally retire the dead hosted commit-review dispatch path. In your existing clean GWT, inspect every OpenClaw reference to `clawsweeper_commit_review`, canonical commit reports, and the removed workflow contract, including docs/skills/tests/history. Remove only stale sender/docs/instructions that claim this retired capability; preserve supported activity/sweep/review paths. Add a static regression/contract guard so OpenClaw cannot dispatch an event absent from the declared supported ClawSweeper contract (choose the leanest maintainable shape; do not couple runtime to a live repo). No ClawSweeper code restoration. Then focused workflow/static tests, actionlint if available, autoreview, draft PR/assignment/transcript, hosted CI, exact-head ClawSweeper, rank-up dispositions, native prepare/merge, squash. After merge, verify the dead event is absent on current main and supported ClawSweeper activity receiver still works; no canonical commit report is expected. Report exact PR/merge/proof URLs and production/tooling LOC.

[assistant]
hi. resuming in the existing repair worktree. i’m re-anchoring branch/state first, then i’ll audit every stale contract reference before editing.

the prior evidence still points to deletion, not replacement. i’m now checking the exact worktree against today’s `origin/main` and mapping the owning guides for `.github`, docs, skills, and workflow guards.

scope is narrow: one dead sender plus stale docs/skill claims. i’m splitting the audit into independent read-only lanes now: history/contracts, documentation/skill surface, and the leanest enforceable workflow guard.

the independent audits agree on the owner boundary: three supported target events remain, and the hosted commit lane has no receiver. the cleanup also needs to remove stale skill monitoring/check commands, not just the YAML block, or we’d leave operators chasing a workflow that no longer exists.

i’m making a deletion-first fix: remove the dead dispatch step, replace stale commit-report instructions with an explicit retirement/local-review note, retarget monitoring to live workflows, and add one structural allowlist test. supported push activity and issue/PR/comment paths stay untouched.

the implementation lane has finished its reference/history pass and is at the edit point. one local docs inventory command failed because pnpm’s registry-signature check could not reach/verify the pinned release; that is tooling infrastructure, not a repository failure, and the focused Node-based guards remain available.

continuing from the live implementation lane. i’m re-anchoring the worktree and worker state, then i’ll finish the static proof and landing sequence.

the code/docs/guard edit is in place. the only blocked surface is the protected ClawSweeper skill metadata; i’m letting that worker close cleanly, then i’ll apply those two evidence-backed removals through an allowed lane.

i’ve got the exact protected-file patch. i’m applying only the retired hosted-review instructions and metadata; supported sweep, repair, comment, and activity guidance stays intact.

the repository is now clean of live hosted commit-review claims; only the regression assertions and explicit retirement wording remain. next i’m validating the workflow parser, exact allowlist, formatting, and action syntax before review.

the exact contract test, formatting, and direct `actionlint` all pass. i’m widening only to the full workflow-guard file and the repo’s workflow checker now; no broad suite.

focused validation is green: 104 workflow guards, repo workflow checker, `actionlint`, and formatting. `origin/main` advanced by one commit while we worked, so i’m checking that delta before freezing the review head.

the branch delta is unrelated diagnostics tests, so the patch remains isolated. i’m freezing this dirty bundle for autoreview now; any accepted finding will be verified against the workflow and receiver contract before a change.

autoreview is clean with no actionable findings. i’m staging exactly the five owned files, then i’ll rebase the resulting commit onto current `origin/main` before pushing.

the commit is rebased onto current main; no overlap with the diagnostics change. i’m refreshing the exact-head static proof now, then i’ll push and open the draft PR.

exact-head local proof is green at `a6cf99e38958`. the user already authorized the redacted transcript, so i’m resolving the current local session and building the draft body before the GitHub mutation.

the remote branch matches the reviewed SHA exactly. i’m creating the draft with the repo template, dependency-retirement evidence, focused proof, LOC accounting, and the sanitized transcript, then i’ll read the live body back before proceeding.

[tool summary]
62 read, 8 write, 202 execute; raw tool outputs dropped: 271
````

</details>
<!-- agent-transcript:end -->
