### PR TITLE
fix(diffs-language-pack): serve byte-accurate Content-Length on asset HEAD requests

### DIFF
--- a/extensions/diffs-language-pack/src/plugin.test.ts
+++ b/extensions/diffs-language-pack/src/plugin.test.ts
@@ -1,22 +1,19 @@
 // Diffs Language Pack plugin module implements plugin tests.
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
-import { createServer } from "node:http";
-import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, describe, expect, it } from "vitest";
-import type { OpenClawPluginApi } from "../api.js";
+import type { OpenClawPluginApi, OpenClawPluginHttpRouteHandler } from "../api.js";
 import { registerDiffsLanguagePackPlugin } from "./plugin.js";
 
 const execFileAsync = promisify(execFile);
 
 const VIEWER_RUNTIME_PATH = "/plugins/diffs-language-pack/assets/viewer-runtime.js";
 const UNKNOWN_ASSET_PATH = "/plugins/diffs-language-pack/assets/does-not-exist.js";
-
-type HttpRouteHandler = (req: IncomingMessage, res: ServerResponse) => boolean | Promise<boolean>;
 
 type ServedResponse = {
   status: number;
@@ -43,17 +40,19 @@ async function ensureViewerRuntimeForTests(): Promise<void> {
   }
   // viewer-runtime.js is ignored generated output; build the fixture before
   // serving assets in a clean checkout.
-  await execFileAsync(process.execPath, ["scripts/build-diffs-viewer-runtime.mjs", "full"], {
-    cwd: repoRoot,
-  });
+  await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", "scripts/build-diffs-viewer-runtime.mts", "full"],
+    { cwd: repoRoot },
+  );
 }
 
 beforeAll(async () => {
   await ensureViewerRuntimeForTests();
 }, 120_000);
 
-function captureHandler(): HttpRouteHandler {
-  let registeredHttpRouteHandler: HttpRouteHandler | undefined;
+function captureHandler(): OpenClawPluginHttpRouteHandler {
+  let registeredHttpRouteHandler: OpenClawPluginHttpRouteHandler | undefined;
   const api = createTestPluginApi({
     id: "diffs-language-pack",
     name: "Diffs Language Pack",
@@ -61,7 +60,7 @@ function captureHandler(): HttpRouteHandler {
     source: "test",
     config: {},
     registerHttpRoute(params: Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]) {
-      registeredHttpRouteHandler = params.handler as HttpRouteHandler;
+      registeredHttpRouteHandler = params.handler;
     },
   });
   registerDiffsLanguagePackPlugin(api as unknown as OpenClawPluginApi);
@@ -73,33 +72,22 @@ function captureHandler(): HttpRouteHandler {
 
 async function withLanguagePackServer(run: (base: string) => Promise<void>): Promise<void> {
   const handler = captureHandler();
-  const server: Server = createServer((req, res) => {
-    void (async () => {
-      const handled = await handler(req, res);
+  await withServer((req, res) => {
+    void Promise.resolve(handler(req, res)).then((handled) => {
       if (!handled) {
         res.statusCode = 404;
         res.end();
       }
-    })();
-  });
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("expected TCP server address");
-  }
-  try {
-    await run(`http://127.0.0.1:${address.port}`);
-  } finally {
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
     });
-  }
+  }, run);
 }
 
-async function fetchServed(base: string, path: string, method = "GET"): Promise<ServedResponse> {
-  const response = await fetch(`${base}${path}`, { method });
+async function fetchServed(
+  base: string,
+  requestPath: string,
+  method = "GET",
+): Promise<ServedResponse> {
+  const response = await fetch(`${base}${requestPath}`, { method });
   const body = await response.arrayBuffer();
   return {
     status: response.status,

--- a/extensions/diffs-language-pack/src/plugin.test.ts
+++ b/extensions/diffs-language-pack/src/plugin.test.ts
@@ -1,0 +1,99 @@
+// Diffs Language Pack plugin module implements plugin tests.
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it } from "vitest";
+import type { OpenClawPluginApi } from "../api.js";
+import { registerDiffsLanguagePackPlugin } from "./plugin.js";
+
+const VIEWER_RUNTIME_PATH = "/plugins/diffs-language-pack/assets/viewer-runtime.js";
+const UNKNOWN_ASSET_PATH = "/plugins/diffs-language-pack/assets/does-not-exist.js";
+
+type HttpRouteHandler = (req: IncomingMessage, res: ServerResponse) => boolean | Promise<boolean>;
+
+type ServedResponse = {
+  status: number;
+  contentLength: string | null;
+  bodyBytes: number;
+};
+
+function captureHandler(): HttpRouteHandler {
+  let registeredHttpRouteHandler: HttpRouteHandler | undefined;
+  const api = createTestPluginApi({
+    id: "diffs-language-pack",
+    name: "Diffs Language Pack",
+    description: "Diffs Language Pack",
+    source: "test",
+    config: {},
+    registerHttpRoute(params: Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]) {
+      registeredHttpRouteHandler = params.handler as HttpRouteHandler;
+    },
+  });
+  registerDiffsLanguagePackPlugin(api as unknown as OpenClawPluginApi);
+  if (!registeredHttpRouteHandler) {
+    throw new Error("expected the plugin to register an HTTP route");
+  }
+  return registeredHttpRouteHandler;
+}
+
+async function withLanguagePackServer(run: (base: string) => Promise<void>): Promise<void> {
+  const handler = captureHandler();
+  const server: Server = createServer((req, res) => {
+    void handler(req, res).then((handled) => {
+      if (!handled) {
+        res.statusCode = 404;
+        res.end();
+      }
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function fetchServed(base: string, path: string, method = "GET"): Promise<ServedResponse> {
+  const response = await fetch(`${base}${path}`, { method });
+  const body = await response.arrayBuffer();
+  return {
+    status: response.status,
+    contentLength: response.headers.get("content-length"),
+    bodyBytes: body.byteLength,
+  };
+}
+
+describe("diffs-language-pack viewer http handler", () => {
+  it("sends byte-accurate Content-Length on HEAD asset responses", async () => {
+    await withLanguagePackServer(async (base) => {
+      const get = await fetchServed(base, VIEWER_RUNTIME_PATH);
+      const head = await fetchServed(base, VIEWER_RUNTIME_PATH, "HEAD");
+
+      expect(get.status).toBe(200);
+      expect(get.bodyBytes).toBeGreaterThan(0);
+      expect(get.contentLength).toBe(String(get.bodyBytes));
+      expect(head.status).toBe(200);
+      expect(head.bodyBytes).toBe(0);
+      expect(head.contentLength).toBe(String(get.bodyBytes));
+    });
+  });
+
+  it("sends Content-Length on HEAD 404 responses for missing assets", async () => {
+    await withLanguagePackServer(async (base) => {
+      const head = await fetchServed(base, UNKNOWN_ASSET_PATH, "HEAD");
+
+      expect(head.status).toBe(404);
+      expect(head.bodyBytes).toBe(0);
+      expect(head.contentLength).toBe(String(Buffer.byteLength("Asset not found")));
+    });
+  });
+});

--- a/extensions/diffs-language-pack/src/plugin.test.ts
+++ b/extensions/diffs-language-pack/src/plugin.test.ts
@@ -1,10 +1,17 @@
 // Diffs Language Pack plugin module implements plugin tests.
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
 import { createServer } from "node:http";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
 import { registerDiffsLanguagePackPlugin } from "./plugin.js";
+
+const execFileAsync = promisify(execFile);
 
 const VIEWER_RUNTIME_PATH = "/plugins/diffs-language-pack/assets/viewer-runtime.js";
 const UNKNOWN_ASSET_PATH = "/plugins/diffs-language-pack/assets/does-not-exist.js";
@@ -16,6 +23,34 @@ type ServedResponse = {
   contentLength: string | null;
   bodyBytes: number;
 };
+
+async function ensureViewerRuntimeForTests(): Promise<void> {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+  const runtimePath = path.join(
+    repoRoot,
+    "extensions",
+    "diffs-language-pack",
+    "assets",
+    "viewer-runtime.js",
+  );
+  try {
+    await fs.stat(runtimePath);
+    return;
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+  // viewer-runtime.js is ignored generated output; build the fixture before
+  // serving assets in a clean checkout.
+  await execFileAsync(process.execPath, ["scripts/build-diffs-viewer-runtime.mjs", "full"], {
+    cwd: repoRoot,
+  });
+}
+
+beforeAll(async () => {
+  await ensureViewerRuntimeForTests();
+}, 120_000);
 
 function captureHandler(): HttpRouteHandler {
   let registeredHttpRouteHandler: HttpRouteHandler | undefined;
@@ -39,12 +74,13 @@ function captureHandler(): HttpRouteHandler {
 async function withLanguagePackServer(run: (base: string) => Promise<void>): Promise<void> {
   const handler = captureHandler();
   const server: Server = createServer((req, res) => {
-    void handler(req, res).then((handled) => {
+    void (async () => {
+      const handled = await handler(req, res);
       if (!handled) {
         res.statusCode = 404;
         res.end();
       }
-    });
+    })();
   });
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);

--- a/extensions/diffs-language-pack/src/plugin.ts
+++ b/extensions/diffs-language-pack/src/plugin.ts
@@ -37,6 +37,7 @@ function createDiffsLanguagePackHttpHandler() {
       asset.contentType,
       parsed.pathname === VIEWER_RUNTIME_PATH ? IMMUTABLE_ASSET_CACHE_CONTROL : undefined,
     );
+    res.setHeader("content-length", String(Buffer.byteLength(asset.body)));
     if (req.method === "HEAD") {
       res.end();
     } else {
@@ -60,6 +61,9 @@ function parseRequestUrl(rawUrl?: string): URL | null {
 function respondText(res: ServerResponse, statusCode: number, body: string): void {
   res.statusCode = statusCode;
   setSharedHeaders(res, "text/plain; charset=utf-8");
+  // Node suppresses the HEAD body but never synthesizes Content-Length; set it
+  // explicitly so error responses keep GET/HEAD header parity (RFC 9110 §8.6).
+  res.setHeader("content-length", String(Buffer.byteLength(body)));
   res.end(body);
 }
 


### PR DESCRIPTION
## Summary

The `/plugins/diffs-language-pack` viewer asset route now sends a byte-accurate `Content-Length` on `HEAD` asset 200 responses and missing-asset 404 responses. The shared error responder also sets the correct header on ordinary 405 responses; `HEAD` itself is an accepted method and therefore cannot return 405 through this route.

## What Problem This Solves

The language-pack viewer route accepts `HEAD` by design, but Node suppresses the `HEAD` response body without synthesizing the `Content-Length` that the corresponding single-chunk `GET` receives. This affected successful assets and missing assets. Clients that preflight with `HEAD` could not discover the representation size without downloading the body.

## Root Cause

- Introduced when the language pack was split from the diffs plugin in commit `d638611684a` (`feat: split diffs language pack`, 2026-05-27).
- The successful asset branch ended `HEAD` responses with `res.end()` before setting their length.
- The shared `respondText` owner also omitted the explicit length for its missing-asset response.

## Why This Change Was Made

- Set `content-length` at each existing response owner with `Buffer.byteLength(...)` of the exact representation.
- Keep `GET`, `HEAD`, missing-asset 404, and normal unsupported-method 405 response ownership unchanged.
- Match the canonical sibling diffs viewer fix in #120280 and the canvas precedent in #117961.
- Production change: four lines in the owning language-pack plugin; no new SDK, config, route, auth, or production test seam.

## User Impact

`HEAD /plugins/diffs-language-pack/assets/viewer-runtime.js` now returns the same byte-accurate `Content-Length` as `GET` with an empty body. A missing asset also returns a byte-accurate `HEAD` 404.

## Evidence

The original contributor exercised the actual registered plugin route through a real loopback HTTP server and a built viewer asset:

### Before

```text
GET  asset -> 200, content-length=10214533, body=10214533 bytes
HEAD asset -> 200, content-length=null, body=0 bytes
FAIL: HEAD asset Content-Length matches GET body bytes
HEAD missing asset -> 404, content-length=null
FAIL: HEAD 404 carries Content-Length
2 CHECK(S) FAILED
```

### After

```text
GET  asset -> 200, content-length=10214533, body=10214533 bytes
HEAD asset -> 200, content-length=10214533, body=0 bytes
PASS: HEAD asset Content-Length matches GET body bytes
HEAD missing asset -> 404, content-length=15
PASS: HEAD 404 carries Content-Length
ALL CHECKS PASSED
```

The production implementation under that real before/after proof is unchanged on the current head. The existing real-loopback owner regression now uses the public Plugin SDK `withServer` helper and the actual package-declared `node --import tsx scripts/build-diffs-viewer-runtime.mts full` build path; an obsolete builder path, duplicated server lifecycle, narrowed route-handler type, and lint-shadowing parameter were removed. Current exact-head hosted CI is the authoritative execution proof for the corrected regression; untrusted contributor code is not run on a credentialed maintainer host.

## Tests and Validation

- Existing owner regression registers the real plugin, captures its HTTP route, builds the actual viewer asset when absent, and compares real `GET`/`HEAD` 200 responses plus missing-asset `HEAD` 404 over loopback.
- `HEAD` 405 is intentionally not asserted: the handler accepts `HEAD`; 405 remains the ordinary unsupported-method branch.
- The canonical SDK server helper owns loopback listener and connection cleanup.
- Automatic exact-current-head hosted CI validates the rewritten regression and existing package build without running untrusted source locally.
