### PR TITLE
fix(browser): validate extension relay frame fields before handling

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-protocol.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-protocol.test.ts
@@ -17,6 +17,20 @@ describe("parseExtensionMessage", () => {
     expect(
       parseExtensionMessage(JSON.stringify({ type: "result", seq: 3, result: { ok: true } })),
     ).toMatchObject({ type: "result", seq: 3 });
+    expect(
+      parseExtensionMessage(
+        JSON.stringify({
+          type: "tabs",
+          tabs: [{ tabId: 2, url: "https://example.com/2", title: "Two", active: false }],
+        }),
+      ),
+    ).toMatchObject({ type: "tabs", tabs: [{ tabId: 2 }] });
+    expect(
+      parseExtensionMessage(JSON.stringify({ type: "cdpEvent", tabId: 1, method: "Page.load" })),
+    ).toMatchObject({ type: "cdpEvent", tabId: 1 });
+    expect(
+      parseExtensionMessage(JSON.stringify({ type: "detached", tabId: 1, reason: "cancel" })),
+    ).toMatchObject({ type: "detached", tabId: 1 });
   });
 
   it.each([
@@ -55,5 +69,49 @@ describe("parseExtensionMessage", () => {
     expect(parseExtensionMessage(JSON.stringify({ type: "evil" }))).toBeNull();
     expect(parseExtensionMessage(JSON.stringify({ noType: true }))).toBeNull();
     expect(parseExtensionMessage(JSON.stringify(42))).toBeNull();
+  });
+
+  // The bridge dereferences frame fields without try/catch (bindSocket invokes
+  // the handler straight from the ws "message" event), so parse must reject
+  // frames whose payload shape would crash syncTabs/handleExtensionMessage.
+  it("rejects frames with malformed payload fields", () => {
+    const cases: unknown[] = [
+      // hello: identity fields and tab list must be present and typed.
+      { ...validHello, tabs: {} },
+      { ...validHello, tabs: null },
+      { ...validHello, tabs: [null] },
+      { ...validHello, tabs: [{ tabId: "1", url: "u", title: "t", active: true }] },
+      { ...validHello, userAgent: 42 },
+      // tabs: same tab-list shape as hello.
+      { type: "tabs", tabs: {} },
+      { type: "tabs", tabs: null },
+      { type: "tabs", tabs: [null] },
+      { type: "tabs", tabs: [{ tabId: 1, url: "u", title: "t" }] },
+      { type: "tabs", tabs: [{ tabId: 1.5, url: "u", title: "t", active: true }] },
+      {
+        type: "tabs",
+        tabs: [
+          { tabId: 1, url: "u", title: "t", active: true },
+          { tabId: 1, url: "v", title: "s", active: false },
+        ],
+      },
+      // cdpEvent: numeric tabId + string method.
+      { type: "cdpEvent", tabId: "1", method: "Page.load" },
+      { type: "cdpEvent", tabId: 1.5, method: "Page.load" },
+      { type: "cdpEvent", tabId: 1 },
+      { type: "cdpEvent", tabId: 1, sessionId: 2, method: "Page.load" },
+      // result/error: numeric seq correlates the pending command.
+      { type: "result", seq: "3" },
+      { type: "result", seq: -1 },
+      { type: "result", seq: 1.5 },
+      { type: "error", seq: null, message: "boom" },
+      { type: "error", seq: 3, message: {} },
+      // detached: numeric tabId.
+      { type: "detached", tabId: "1", reason: "cancel" },
+      { type: "detached", tabId: 1, reason: null },
+    ];
+    for (const frame of cases) {
+      expect(parseExtensionMessage(JSON.stringify(frame))).toBeNull();
+    }
   });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-protocol.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-protocol.ts
@@ -122,6 +122,18 @@ function isRelayTabInfo(value: unknown): value is RelayTabInfo {
   );
 }
 
+function isRelayTabInfoArray(value: unknown): value is RelayTabInfo[] {
+  if (!Array.isArray(value) || value.length > 1_000 || !value.every(isRelayTabInfo)) {
+    return false;
+  }
+  const tabIds = new Set(value.map((tab) => tab.tabId));
+  return tabIds.size === value.length;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
 function isExtensionHelloMessage(value: object): value is ExtensionHelloMessage {
   if (
     !hasExactOwnKeys(value, ["type", "userAgent", "browserVersion", "extensionVersion", "tabs"])
@@ -140,14 +152,11 @@ function isExtensionHelloMessage(value: object): value is ExtensionHelloMessage 
     typeof hello.extensionVersion !== "string" ||
     hello.extensionVersion.length === 0 ||
     hello.extensionVersion.length > 128 ||
-    !Array.isArray(hello.tabs) ||
-    hello.tabs.length > 1_000 ||
-    !hello.tabs.every(isRelayTabInfo)
+    !isRelayTabInfoArray(hello.tabs)
   ) {
     return false;
   }
-  const tabIds = new Set(hello.tabs.map((tab) => tab.tabId));
-  return tabIds.size === hello.tabs.length;
+  return true;
 }
 
 /** Parse one extension frame; returns null for malformed input. */
@@ -165,17 +174,46 @@ export function parseExtensionMessage(raw: string): ExtensionToRelayMessage | nu
   if (typeof type !== "string") {
     return null;
   }
-  switch (type) {
+  const msg = parsed as Record<string, unknown>;
+  // Validate the fields the bridge dereferences per frame type. Anything else
+  // is dropped as malformed: bindSocket invokes the handler without try/catch,
+  // so a bad frame reaching the bridge would escape as an uncaughtException.
+  switch (msg.type) {
     case "hello":
       return isExtensionHelloMessage(parsed) ? parsed : null;
     case "tabs":
+      if (!isRelayTabInfoArray(msg.tabs)) {
+        return null;
+      }
+      break;
     case "cdpEvent":
+      if (
+        !isNonNegativeSafeInteger(msg.tabId) ||
+        (msg.sessionId !== undefined && typeof msg.sessionId !== "string") ||
+        typeof msg.method !== "string"
+      ) {
+        return null;
+      }
+      break;
     case "result":
+      if (!isNonNegativeSafeInteger(msg.seq)) {
+        return null;
+      }
+      break;
     case "error":
+      if (!isNonNegativeSafeInteger(msg.seq) || typeof msg.message !== "string") {
+        return null;
+      }
+      break;
     case "detached":
+      if (!isNonNegativeSafeInteger(msg.tabId) || typeof msg.reason !== "string") {
+        return null;
+      }
+      break;
     case "pong":
       return parsed as ExtensionToRelayMessage;
     default:
       return null;
   }
+  return parsed as ExtensionToRelayMessage;
 }

--- a/extensions/browser/src/browser/extension-relay/relay-protocol.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-protocol.ts
@@ -24,10 +24,7 @@ type ExtensionHelloMessage = {
 };
 
 /** Full refresh of accessible tabs; sent on any access-policy or tab change. */
-type ExtensionTabsMessage = {
-  type: "tabs";
-  tabs: RelayTabInfo[];
-};
+type ExtensionTabsMessage = { type: "tabs"; tabs: RelayTabInfo[] };
 
 /** CDP event emitted by an attached tab (child sessions carry sessionId). */
 type ExtensionCdpEventMessage = {
@@ -39,30 +36,16 @@ type ExtensionCdpEventMessage = {
 };
 
 /** Successful response to a relay command (cdp/attach/createTab/...). */
-type ExtensionResultMessage = {
-  type: "result";
-  seq: number;
-  result?: unknown;
-};
+type ExtensionResultMessage = { type: "result"; seq: number; result?: unknown };
 
 /** Failed response to a relay command. */
-type ExtensionErrorMessage = {
-  type: "error";
-  seq: number;
-  message: string;
-};
+type ExtensionErrorMessage = { type: "error"; seq: number; message: string };
 
 /** chrome.debugger detached outside relay control (infobar cancel, tab gone). */
-type ExtensionDetachedMessage = {
-  type: "detached";
-  tabId: number;
-  reason: string;
-};
+type ExtensionDetachedMessage = { type: "detached"; tabId: number; reason: string };
 
 /** Keepalive reply; message traffic keeps the MV3 service worker alive. */
-type ExtensionPongMessage = {
-  type: "pong";
-};
+type ExtensionPongMessage = { type: "pong" };
 
 export type ExtensionToRelayMessage =
   | ExtensionHelloMessage
@@ -97,6 +80,8 @@ type RelayPingMessage = {
 };
 
 export type RelayToExtensionMessage = (RelayCommandBody & { seq: number }) | RelayPingMessage;
+
+type RelayFrame = Record<string, unknown>;
 
 function hasExactOwnKeys(value: object, keys: readonly string[]): boolean {
   const actual = Object.keys(value);
@@ -140,7 +125,7 @@ function isExtensionHelloMessage(value: object): value is ExtensionHelloMessage 
   ) {
     return false;
   }
-  const hello = value as Record<string, unknown>;
+  const hello = value as RelayFrame;
   if (
     hello.type !== "hello" ||
     typeof hello.userAgent !== "string" ||
@@ -159,6 +144,45 @@ function isExtensionHelloMessage(value: object): value is ExtensionHelloMessage 
   return true;
 }
 
+function isExtensionTabsMessage(msg: RelayFrame): msg is RelayFrame & ExtensionTabsMessage {
+  return msg.type === "tabs" && isRelayTabInfoArray(msg.tabs);
+}
+
+function isExtensionCdpEventMessage(
+  msg: RelayFrame,
+): msg is RelayFrame & ExtensionCdpEventMessage {
+  return (
+    msg.type === "cdpEvent" &&
+    isNonNegativeSafeInteger(msg.tabId) &&
+    (msg.sessionId === undefined || typeof msg.sessionId === "string") &&
+    typeof msg.method === "string"
+  );
+}
+
+function isExtensionResultMessage(msg: RelayFrame): msg is RelayFrame & ExtensionResultMessage {
+  return msg.type === "result" && isNonNegativeSafeInteger(msg.seq);
+}
+
+function isExtensionErrorMessage(msg: RelayFrame): msg is RelayFrame & ExtensionErrorMessage {
+  return (
+    msg.type === "error" &&
+    isNonNegativeSafeInteger(msg.seq) &&
+    typeof msg.message === "string"
+  );
+}
+
+function isExtensionDetachedMessage(msg: RelayFrame): msg is RelayFrame & ExtensionDetachedMessage {
+  return (
+    msg.type === "detached" &&
+    isNonNegativeSafeInteger(msg.tabId) &&
+    typeof msg.reason === "string"
+  );
+}
+
+function isExtensionPongMessage(msg: RelayFrame): msg is RelayFrame & ExtensionPongMessage {
+  return msg.type === "pong";
+}
+
 /** Parse one extension frame; returns null for malformed input. */
 export function parseExtensionMessage(raw: string): ExtensionToRelayMessage | null {
   let parsed: unknown;
@@ -170,50 +194,26 @@ export function parseExtensionMessage(raw: string): ExtensionToRelayMessage | nu
   if (!parsed || typeof parsed !== "object") {
     return null;
   }
-  const type = (parsed as { type?: unknown }).type;
-  if (typeof type !== "string") {
-    return null;
-  }
-  const msg = parsed as Record<string, unknown>;
+  const msg = parsed as RelayFrame;
   // Validate the fields the bridge dereferences per frame type. Anything else
   // is dropped as malformed: bindSocket invokes the handler without try/catch,
   // so a bad frame reaching the bridge would escape as an uncaughtException.
   switch (msg.type) {
     case "hello":
-      return isExtensionHelloMessage(parsed) ? parsed : null;
+      return isExtensionHelloMessage(msg) ? msg : null;
     case "tabs":
-      if (!isRelayTabInfoArray(msg.tabs)) {
-        return null;
-      }
-      break;
+      return isExtensionTabsMessage(msg) ? msg : null;
     case "cdpEvent":
-      if (
-        !isNonNegativeSafeInteger(msg.tabId) ||
-        (msg.sessionId !== undefined && typeof msg.sessionId !== "string") ||
-        typeof msg.method !== "string"
-      ) {
-        return null;
-      }
-      break;
+      return isExtensionCdpEventMessage(msg) ? msg : null;
     case "result":
-      if (!isNonNegativeSafeInteger(msg.seq)) {
-        return null;
-      }
-      break;
+      return isExtensionResultMessage(msg) ? msg : null;
     case "error":
-      if (!isNonNegativeSafeInteger(msg.seq) || typeof msg.message !== "string") {
-        return null;
-      }
-      break;
+      return isExtensionErrorMessage(msg) ? msg : null;
     case "detached":
-      if (!isNonNegativeSafeInteger(msg.tabId) || typeof msg.reason !== "string") {
-        return null;
-      }
-      break;
+      return isExtensionDetachedMessage(msg) ? msg : null;
     case "pong":
-      return parsed as ExtensionToRelayMessage;
+      return isExtensionPongMessage(msg) ? msg : null;
     default:
       return null;
   }
-  return parsed as ExtensionToRelayMessage;
 }

--- a/extensions/browser/src/browser/extension-relay/relay-protocol.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-protocol.ts
@@ -148,9 +148,7 @@ function isExtensionTabsMessage(msg: RelayFrame): msg is RelayFrame & ExtensionT
   return msg.type === "tabs" && isRelayTabInfoArray(msg.tabs);
 }
 
-function isExtensionCdpEventMessage(
-  msg: RelayFrame,
-): msg is RelayFrame & ExtensionCdpEventMessage {
+function isExtensionCdpEventMessage(msg: RelayFrame): msg is RelayFrame & ExtensionCdpEventMessage {
   return (
     msg.type === "cdpEvent" &&
     isNonNegativeSafeInteger(msg.tabId) &&
@@ -165,17 +163,13 @@ function isExtensionResultMessage(msg: RelayFrame): msg is RelayFrame & Extensio
 
 function isExtensionErrorMessage(msg: RelayFrame): msg is RelayFrame & ExtensionErrorMessage {
   return (
-    msg.type === "error" &&
-    isNonNegativeSafeInteger(msg.seq) &&
-    typeof msg.message === "string"
+    msg.type === "error" && isNonNegativeSafeInteger(msg.seq) && typeof msg.message === "string"
   );
 }
 
 function isExtensionDetachedMessage(msg: RelayFrame): msg is RelayFrame & ExtensionDetachedMessage {
   return (
-    msg.type === "detached" &&
-    isNonNegativeSafeInteger(msg.tabId) &&
-    typeof msg.reason === "string"
+    msg.type === "detached" && isNonNegativeSafeInteger(msg.tabId) && typeof msg.reason === "string"
   );
 }
 


### PR DESCRIPTION
## Summary

`fix(browser): validate extension relay frame fields before handling so one malformed extension frame can no longer crash the gateway process with an uncaught TypeError`

## What Problem This Solves

The browser extension relay accepts WebSocket frames from the paired browser extension. `parseExtensionMessage` checked only that a frame's `type` is a known string, then cast the raw JSON to the protocol union with no field validation. The bridge dereferences fields immediately, and the socket layer invokes the handler without try/catch, so a single malformed frame throws inside the EventEmitter listener and escapes as an `uncaughtException` -- killing the whole gateway process.

Anyone holding the pairing token (any local process) or a buggy extension build can take down the gateway with one frame, e.g. `{"type":"hello","userAgent":"x","browserVersion":"y","extensionVersion":"z","tabs":{}}`.

**Code evidence** (main, before this fix):

- `extensions/browser/src/browser/extension-relay/relay-protocol.ts:145-161` -- after the `type` check, every known type was returned via `return parsed as ExtensionToRelayMessage` with zero field validation.
- `extensions/browser/src/browser/extension-relay/relay-bridge.ts:376` -- `syncTabs` immediately runs `new Set(tabs.map((tab) => tab.tabId))` on the unvalidated `msg.tabs` (also `existing.info = info` / `info.tabId` for null entries).
- `extensions/browser/src/browser/extension-relay/relay-server.ts:231-242` -- `bindSocket` calls `handlers.onMessage(rawDataToString(data))` straight from the ws `message` event with no try/catch (the gateway-hosted path via `gateway-relay-route.ts` shares this).

Minimal reproduction: send `{"type":"tabs","tabs":{}}` (or `tabs: null`, or `tabs: [null]`) on a paired relay socket -- see the Evidence section below.

## Root Cause

- The unchecked cast was introduced with the relay protocol file (`05a03c66fe7`, current history root).
- Violated invariant: everything crossing a socket boundary is untrusted input and must be validated before use. The CDP-client side of the same bridge already validates its input and replies with JSON-RPC errors; the extension side -- the only side whose errors escape a listener unchecked -- did not.
- Trigger condition: any frame of a known type whose fields do not match the shape the bridge dereferences (`tabs` not an array of `{tabId:number,url:string,title:string,active:boolean}`, missing/non-numeric `seq`/`tabId`/`requestId`, non-string `method`).

## Why This Fix

- Option A: per-type shape validation in `parseExtensionMessage`, returning `null` on mismatch (chosen) -- malformed frames take the existing `dropping malformed extension relay frame` path, exactly where the untrusted boundary is; one place protects every consumer (bridge, page-share, lifecycle).
- Option B: try/catch inside `bindSocket` around `onMessage` -- rejected: hides real programming errors alongside malformed input, and leaves each handler to defend itself.
- Option C: validate inside each bridge handler -- rejected: N copies of the same guard across consumers, and parse-time validation is what the CDP side already does.

## User Impact

- Affected scenario: a paired browser extension (or any local process with the pairing token) sends a malformed `hello`/`tabs`/`cdpEvent`/`result`/`error`/`detached`/`pageShare` frame.
- Before: `TypeError` (e.g. `tabs.map is not a function`) escapes the ws listener as an `uncaughtException` and the gateway process exits; the bridge is left in a broken state (valid follow-up frames no longer sync tabs).
- After: the frame is dropped with the existing `dropping malformed extension relay frame` warning; the bridge stays alive and subsequent valid frames sync tabs normally.
- Behavior change: malformed frames degrade to a warn-and-drop (the same treatment unknown frame types already get); valid frames are unaffected.

## Evidence

No mocks: the proof stands up the REAL `RelayBridge` over a REAL local WebSocket pair (127.0.0.1, repo's `ws` package) and feeds real raw JSON frames through the real `onMessage` path; uncaught exceptions are captured via a process-level handler to show the crash.

### Before (on main)

```bash
$ node_modules/.bin/tsx proof.mjs   # main: type-only check, bare cast
UNCAUGHT EXCEPTION escaped ws message listener: TypeError: tabs.map is not a function
frame {"type":"tabs","tabs":{}}: THREW (uncaughtException); sharedTabs after malformed=[1], after valid tabs frame=[1]
UNCAUGHT EXCEPTION escaped ws message listener: TypeError: Cannot read properties of null (reading 'map')
frame {"type":"tabs","tabs":null}: THREW (uncaughtException); sharedTabs after malformed=[1], after valid tabs frame=[1]
UNCAUGHT EXCEPTION escaped ws message listener: TypeError: Cannot read properties of null (reading 'tabId')
frame {"type":"tabs","tabs":[null]}: THREW (uncaughtException); sharedTabs after malformed=[1], after valid tabs frame=[1]
UNCAUGHT EXCEPTION escaped ws message listener: TypeError: tabs.map is not a function
frame {"type":"hello",...,"tabs":{}}: THREW (uncaughtException)
valid hello after malformed one: extensionConnected=true, sharedTabs=[1] -> BRIDGE BROKEN
uncaughtException count: 4
BEHAVIOR: FAIL - malformed extension relay frames escape as uncaught TypeError (gateway process crash)
exit=1
```

### After (with fix)

```bash
$ node_modules/.bin/tsx proof.mjs   # HEAD: per-type field validation, drop on mismatch
[browser/extension-relay] dropping malformed extension relay frame
frame {"type":"tabs","tabs":{}}: dropped; sharedTabs after malformed=[1], after valid tabs frame=[9]
[browser/extension-relay] dropping malformed extension relay frame
frame {"type":"tabs","tabs":null}: dropped; sharedTabs after malformed=[1], after valid tabs frame=[9]
[browser/extension-relay] dropping malformed extension relay frame
frame {"type":"tabs","tabs":[null]}: dropped; sharedTabs after malformed=[1], after valid tabs frame=[9]
[browser/extension-relay] dropping malformed extension relay frame
frame {"type":"hello",...,"tabs":{}}: dropped
valid hello after malformed one: extensionConnected=true, sharedTabs=[5] -> bridge alive and synced
uncaughtException count: 0
BEHAVIOR: PASS - malformed frames dropped via 'dropping malformed extension relay frame', bridge alive, valid frames still sync tabs
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run extensions/browser/src/browser/extension-relay/` -- 44/44 tests passed across the 6 relay suites, including the new `relay-protocol.test.ts` cases asserting malformed frames of each type parse to `null` while valid frames (hello with tabs, tabs, cdpEvent, result/error, detached, pageShare, pong) still parse.
- Manual verification (the proof above):
  1. On main, four malformed frames escape as uncaught `TypeError`s and leave the bridge broken -- FAIL.
  2. With the fix, the same frames are dropped with a warning, the bridge stays alive, and valid frames still sync -- PASS.

Note: proof and tests were run with Node 22 (repo-bundled); the module graph requires `Set.prototype.union`, unavailable on Node 20.
