### PR TITLE
fix(qa): preserve script evidence coverage

### DIFF
--- a/test/e2e/qa-lab/media/hosted-media-provider-live.test.ts
+++ b/test/e2e/qa-lab/media/hosted-media-provider-live.test.ts
@@ -80,7 +80,7 @@ describe("hosted media provider live QA producer", () => {
     expect(classifyHostedMediaFailureStatus("provider response was malformed")).toBe("fail");
   });
 
-  it("leaves video provider coverage mapping to the scenario catalog", () => {
+  it("binds video provider coverage from the scenario catalog", () => {
     const artifactBase = path.join(os.tmpdir(), "openclaw-hosted-media-live-test");
     const options = parseHostedMediaOptions(["--suite", "video", "--artifact-base", artifactBase]);
     const evidence = buildHostedMediaEvidence({
@@ -91,7 +91,11 @@ describe("hosted media provider live QA producer", () => {
       },
     });
 
-    expect(evidence.entries[0]?.coverage).toEqual([]);
+    expect(evidence.entries[0]?.coverage).toEqual([
+      { id: "hosted-providers.video-generation-providers", role: "primary" },
+      { id: "media.reference-image-video-and-audio-inputs", role: "primary" },
+      { id: "media.video-generation-tool-invocation", role: "secondary" },
+    ]);
   });
 });
 

--- a/test/e2e/qa-lab/runtime/browser-plugin-profiles-packaged.ts
+++ b/test/e2e/qa-lab/runtime/browser-plugin-profiles-packaged.ts
@@ -11,7 +11,6 @@ const SCENARIO_ID = "browser-plugin-profiles-packaged";
 const SOURCE_PATH = "test/e2e/qa-lab/runtime/browser-plugin-profiles-packaged.ts";
 const SCRIPT_PATH = "scripts/e2e/browser-plugin-profiles-docker.sh";
 const SUCCESS_MARKER = "BROWSER_PLUGIN_PROFILES_PACKAGED_OK";
-const PRIMARY_COVERAGE_IDS = ["tools.browser-plugin-service", "tools.profiles"] as const;
 
 type ProducerOptions = { artifactBase: string; repoRoot: string };
 type DockerOutcome = {
@@ -89,7 +88,6 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
     codeRefs: [SOURCE_PATH, SCRIPT_PATH, "extensions/browser/src/gateway/browser-request.ts"],
     docsRefs: ["docs/tools/browser.md", "docs/help/testing.md"],
     id: SCENARIO_ID,
-    primaryCoverageIds: PRIMARY_COVERAGE_IDS,
     sourcePath: SOURCE_PATH,
     title: "Packaged browser plugin profiles",
   };

--- a/test/e2e/qa-lab/runtime/diagnostic-events-boundary-runtime.test.ts
+++ b/test/e2e/qa-lab/runtime/diagnostic-events-boundary-runtime.test.ts
@@ -1,7 +1,9 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateQaEvidenceSummaryJson } from "../../../../extensions/qa-lab/api.js";
 import {
   runDiagnosticEventsBoundaryRuntime,
   testing,
@@ -10,6 +12,7 @@ import {
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
 
@@ -17,13 +20,54 @@ describe("diagnostic events boundary runtime", () => {
   it("composes async dispatch, trusted subscriptions, and model-call trace propagation", async () => {
     const artifactBase = await fs.mkdtemp(path.join(os.tmpdir(), "diagnostic-events-boundary-"));
     tempDirs.push(artifactBase);
+    const repoRoot = process.cwd();
+    const checkoutSha = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim();
+    vi.stubEnv("OPENCLAW_QA_REF", checkoutSha);
+    vi.stubEnv("OPENCLAW_QA_PACKAGE_SOURCE_KIND", "source-checkout");
+    vi.stubEnv("OPENCLAW_QA_PACKAGE_SOURCE_SHA", checkoutSha);
 
     const { evidence, summary } = await runDiagnosticEventsBoundaryRuntime({
       artifactBase,
-      repoRoot: process.cwd(),
+      repoRoot,
     });
 
-    expect(evidence.entries[0]?.result.status).toBe("pass");
+    const diskEvidence = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(path.join(artifactBase, "qa-evidence.json"), "utf8")),
+    );
+    expect(diskEvidence).toEqual(evidence);
+    expect(evidence.schemaVersion).toBe(2);
+    expect(evidence.entries).toHaveLength(1);
+    expect(evidence.entries[0]).toMatchObject({
+      coverage: [
+        { id: "observability.async-dispatch", role: "primary" },
+        { id: "observability.diagnostic-event-types", role: "primary" },
+        { id: "observability.model-call-diagnostic-events", role: "primary" },
+        { id: "observability.plugin-sdk-diagnostic-runtime-exports", role: "primary" },
+        { id: "observability.trusted-diagnostic-event-subscription", role: "primary" },
+        { id: "observability.trusted-trace-context", role: "primary" },
+        { id: "observability.w3c-trace-context-creation", role: "primary" },
+      ],
+      execution: {
+        artifacts: [
+          { kind: "log", path: "diagnostic-events-boundary.log", source: "script" },
+          {
+            kind: "summary",
+            path: "diagnostic-events-boundary-summary.json",
+            source: "script",
+          },
+        ],
+        environment: { ref: checkoutSha },
+        packageSource: { kind: "source-checkout", sha: checkoutSha },
+      },
+      result: { status: "pass" },
+      test: {
+        id: "diagnostic-events-boundary",
+        source: { path: "test/e2e/qa-lab/runtime/diagnostic-events-boundary-runtime.ts" },
+      },
+    });
     expect(summary).toMatchObject({
       deliveredBeforeDrain: 0,
       eventTypes: ["model.call.started", "model.call.completed"],
@@ -43,7 +87,6 @@ describe("diagnostic events boundary runtime", () => {
       "utf8",
     );
     expect(summaryText).not.toContain("diagnostic-boundary-private-input");
-    await expect(fs.stat(path.join(artifactBase, "qa-evidence.json"))).resolves.toBeDefined();
   });
 
   it("rejects missing output-dir values", () => {

--- a/test/e2e/qa-lab/runtime/script-evidence.test.ts
+++ b/test/e2e/qa-lab/runtime/script-evidence.test.ts
@@ -19,6 +19,7 @@ async function makeWriter(params: { maxDetailsBytes?: number; maxLogBytes?: numb
     repoRoot,
     writer: createQaScriptEvidenceWriter({
       artifactBase: path.join(repoRoot, ".artifacts", "qa-e2e", "script"),
+      coverageBinding: "none",
       logFileName: "producer.log",
       maxDetailsBytes: params.maxDetailsBytes,
       maxLogBytes: params.maxLogBytes ?? 64,
@@ -58,6 +59,7 @@ describe("QA script evidence writer", () => {
       });
 
       expect(evidence.entries[0]).toMatchObject({
+        coverage: [],
         execution: {
           artifacts: [
             { kind: "log", path: "producer.log", source: "script" },
@@ -78,6 +80,23 @@ describe("QA script evidence writer", () => {
       ).toEqual({ qaEvidence: "qa-evidence.json" });
     });
   }
+
+  it("rejects uncataloged targets unless coverage binding is disabled", () => {
+    expect(() =>
+      createQaScriptEvidenceWriter({
+        artifactBase: path.join(os.tmpdir(), "openclaw-script-evidence-unknown"),
+        logFileName: "producer.log",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        providerMode: "mock-openai",
+        repoRoot: process.cwd(),
+        target: {
+          id: "script-evidence-test",
+          sourcePath: "test/e2e/qa-lab/runtime/script-evidence.test.ts",
+          title: "Script evidence test",
+        },
+      }),
+    ).toThrow("unknown qa scenario: script-evidence-test");
+  });
 
   it("keeps only the bounded log tail", async () => {
     const { artifactBase, writer } = await makeWriter({ maxLogBytes: 24 });

--- a/test/e2e/qa-lab/runtime/script-evidence.ts
+++ b/test/e2e/qa-lab/runtime/script-evidence.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   buildScriptEvidenceSummary,
   QA_EVIDENCE_FILENAME,
+  readQaScenarioById,
   type QaEvidencePackageSource,
   type QaEvidenceStatus,
   type QaEvidenceSummaryJson,
@@ -44,6 +45,7 @@ type QaScriptEvidenceResult = {
 
 type QaScriptEvidenceWriterOptions = {
   artifactBase: string;
+  coverageBinding?: "catalog" | "none";
   env?: NodeJS.ProcessEnv;
   evidenceMode?: "full" | "slim";
   logFileName: string;
@@ -146,6 +148,18 @@ export function createQaScriptBlockedStatusTracker(blockedPatterns: readonly Reg
 }
 
 export function createQaScriptEvidenceWriter(options: QaScriptEvidenceWriterOptions) {
+  const coverage =
+    options.coverageBinding === "none" ? undefined : readQaScenarioById(options.target.id).coverage;
+  // The catalog owns semantic coverage; producers own execution facts only.
+  const evidenceTarget = {
+    codeRefs: options.target.codeRefs,
+    docsRefs: options.target.docsRefs,
+    id: options.target.id,
+    primaryCoverageIds: coverage?.primary ?? [],
+    secondaryCoverageIds: coverage?.secondary ?? [],
+    sourcePath: options.target.sourcePath,
+    title: options.target.title,
+  };
   const maxLogBytes = resolveByteLimit(options.maxLogBytes, DEFAULT_CHILD_OUTPUT_TAIL_BYTES);
   const logFile = resolveArtifactPath(options.artifactBase, options.logFileName);
   const maxDetailsBytes = resolveByteLimit(
@@ -201,7 +215,7 @@ export function createQaScriptEvidenceWriter(options: QaScriptEvidenceWriterOpti
       providerMode: options.providerMode,
       repoRoot: options.repoRoot,
       runner: "script",
-      targets: [options.target],
+      targets: [evidenceTarget],
       results: [
         {
           id: options.target.id,

--- a/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
+++ b/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
@@ -54,7 +54,7 @@ function makeScenario(
           config,
         };
   return {
-    id: "tui-pty-producer-test",
+    id: "tui-pty-evidence-producer-contract",
     title: "TUI PTY producer test",
     surface: "tui",
     objective: "Prove the TUI PTY evidence producer contract.",

--- a/test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+++ b/test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
@@ -446,8 +446,6 @@ export async function runTuiPtyEvidenceProducer(
     codeRefs: scenario.codeRefs,
     docsRefs: scenario.docsRefs,
     id: scenario.id,
-    primaryCoverageIds: scenario.coverage?.primary ?? [],
-    secondaryCoverageIds: scenario.coverage?.secondary ?? [],
     sourcePath: SOURCE_PATH,
     title: scenario.title,
   };


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/99374
Related: https://github.com/openclaw/openclaw/pull/110280

## What Problem This Solves

Fixes an operational issue where standalone script-produced schema-v2 `qa-evidence.json` could report `status: pass` with `coverage: []`, even though the scenario catalog already defined the canonical coverage. That left otherwise valid QA evidence semantically incomplete for direct artifact consumers.

## Why This Change Was Made

#99374 introduced the shared script evidence writer with caller-owned coverage metadata. #110280 then made the scenario catalog the semantic coverage owner and replaced producer coverage during aggregate ingestion, but standalone writer output bypassed that aggregate overwrite and could remain empty.

The canonical fix is at `createQaScriptEvidenceWriter`, the earliest shared catalog-aware boundary for standalone script producers:

- resolve canonical coverage once by exact scenario ID when the writer is created;
- construct a fresh evidence target so hidden caller-supplied coverage fields cannot leak through;
- fail closed for unknown catalog IDs;
- allow coverage-free output only through an explicit `coverageBinding: "none"` opt-out used by the synthetic writer unit fixture;
- remove duplicate browser and TUI coverage metadata now owned by the catalog.

This is the best fix because it repairs direct artifacts at their producer while preserving aggregate overwrite as defense in depth. Rejected alternatives were restoring per-producer coverage fields, which would recreate drift and reverse #110280; relying only on aggregate overwrite, which leaves standalone artifacts broken; and moving catalog lookup into the generic summary builder, which would couple a generic formatter to catalog-only semantics and break intentional uncataloged fixtures.

Scope is deliberately limited to QA producer/tooling and tests. There are no product runtime behavior, config, dependency, workflow, protocol, release, or OTEL changes.

## User Impact

QA and release operators can trust standalone script evidence to carry the same canonical coverage semantics as aggregate evidence. There is no shipped product runtime behavior change.

## Evidence

- Exact signed head: `7205d8616ea98bd74f8f0673cdd1d6c62628e053`.
- Single synchronization rebase base: `8c68f74ef914763e846f4b3c2fef8b80ace56f5e` (#120313); that infrastructure fix is an ancestor of the fetched `origin/main`.
- Patch preservation across the rebase:
  - `git range-diff`: `9213088b4e4 = 7205d8616ea`;
  - stable patch ID: `88cbe84fa1bf0ee65339f708b8f43540a030799e` before and after;
  - binary diff SHA-256: `b4a83018f8d644d1915d913b27f732cc13b221f81fa928fa4154d217bc1c96da` before and after;
  - unchanged scope: seven QA files, +88/-12.
- Exact-head hosted-gate classifier:
  - [CI run 31215248362](https://github.com/openclaw/openclaw/actions/runs/31215248362): success;
  - [Workflow Sanity run 31215248247](https://github.com/openclaw/openclaw/actions/runs/31215248247): success;
  - Blacksmith Testbox: **not applicable**;
  - Blacksmith ARM Testbox: **not applicable**;
  - Blacksmith Build Artifacts Testbox: **not applicable**;
  - selection mode: `exact-head`; no fallback, bypass, or manual hosted dispatch.
- Supported-Node focused proof:
  - command: `fnm exec --using v24.15.0 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/script-evidence.test.ts test/e2e/qa-lab/runtime/diagnostic-events-boundary-runtime.test.ts`;
  - result: 2 files, 15 tests passed.
- Representative actual producer artifact:
  - command: `OPENCLAW_QA_REF=7205d8616ea98bd74f8f0673cdd1d6c62628e053 OPENCLAW_QA_PACKAGE_SOURCE_KIND=source-checkout OPENCLAW_QA_PACKAGE_SOURCE_SHA=7205d8616ea98bd74f8f0673cdd1d6c62628e053 fnm exec --using v24.15.0 node --import tsx test/e2e/qa-lab/runtime/diagnostic-events-boundary-runtime.ts --output-dir .artifacts/qa-e2e/pr120286-diagnostic-events-boundary`;
  - schema v2, `result.status = pass`;
  - seven ordered primary coverage IDs: `observability.async-dispatch`, `observability.diagnostic-event-types`, `observability.model-call-diagnostic-events`, `observability.plugin-sdk-diagnostic-runtime-exports`, `observability.trusted-diagnostic-event-subscription`, `observability.trusted-trace-context`, `observability.w3c-trace-context-creation`;
  - exact head SHA in both execution environment and source-checkout package metadata;
  - log and summary artifacts present;
  - `qa-evidence.json` SHA-256: `73f735b1ca66109cd8bdcffe3cc372dd548116d7be3b3840bc1a0271817ef12a`.
- Patch-identical prior broad focused proof: 8 files, 172 tests passed.
- Targeted `oxfmt --check`, `git diff --check`, and the changed-gate dry-run passed without changing the patch.
- Fresh exact-head autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; clean, no accepted/actionable findings (overall 0.98).

### Change Size

- Total: +88/-12.
- QA producer/tooling: +15/-5.
- Tests: +73/-7.
- Product runtime: +0/-0.

### Changelog

No `CHANGELOG.md` entry. The changelog is release-only, and this changes QA tooling/test evidence behavior rather than shipped product behavior.

### AI Assistance

AI-assisted: yes. Codex assisted implementation, review, and proof. A sanitized local agent transcript is included below.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":3,"user":1,"assistant":1,"toolCalls":123,"toolOutputsDropped":123,"web":0,"redactions":0,"omittedUnsafe":0,"rawEntries":19}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

[assistant]
hi, i’m grounding the exact branch, prior QA-evidence context, repo policy, and available agent lanes first. then i’ll hand the audited scope to an executor, verify the result independently, and amend the existing commit only.

the branch is exactly at the draft SHA, one commit ahead and one behind `origin/main`; the worktree is clean, dependencies are correctly symlinked, and disk is fine. i’m now mapping the writer, catalog owner, all callers, and #110280 history before anyone edits.

the historical intent is confirmed at `132d91e4275` (#110280): catalog YAML became the sole semantic coverage owner. the current draft only changes a type and a synthetic test, so it cannot fix the writer’s runtime artifact. next i’m freezing the precise writer/caller map and fallback contract for the review agents.

the likely contract is now sharp: catalog lookup should be the writer’s default and unknown IDs should throw; noncatalog tests must explicitly opt out. i’m checking all 66 script scenarios and the two legacy callers that currently shuttle coverage themselves so the executor can remove duplication instead of adding another path.

the owner boundary is clear now: the shared script writer must resolve catalog coverage, while synthetic targets need an explicit opt-out. i’m capturing a real pre-fix artifact next, then i’ll have the independent audit lanes challenge the exact patch scope before the executor edits.

the representative producer is a good one: `diagnostic-events-boundary` already writes both a summary artifact and schema-v2 evidence, and its catalog owns seven primary coverage IDs. i’m running that unchanged path now so the before/after proof is from real bytes, not a mocked writer assertion.

the baseline is confirmed on disk: schema v2, passing result, exact ref `a6f6721…`, source-checkout package binding, both script artifacts present, and `coverage: []`. i’m now checking every writer caller for whether its target ID is catalog-backed or intentionally synthetic; that decides whether the default should fail closed.

one audit lane confirmed the important edge case: bind by target ID, not script path, because `heartbeat-active-hours` has a valid catalog ID but a Vitest catalog execution. unknown IDs should fail by default; only the writer’s synthetic unit target needs an explicit no-catalog escape hatch.

the audits converge. proposed patch is six tight surfaces: writer binding, two duplicate-metadata removals, an explicit synthetic opt-out, one actual producer regression, and updates to the two existing tests whose assumptions change. i’m sending that exact scope through an independent plan review before any file edit.

the scope is holding: no core QA-lab change, no scenario edits, no path matching, no fallback. the likely tooling delta is a single catalog snapshot plus deletion of the two existing metadata duplicates; the rest is proof that the real artifact contract changed.

the reviewed edit is now locked to seven files. the writer will eagerly snapshot catalog coverage by ID, explicit `none` will forcibly clear coverage, hidden caller fields cannot leak, and the two old duplicate metadata shuttles are being deleted. no OTEL or workflow surface is in scope.

the executor is applying the reviewed patch now. once it lands, i’ll review the combined diff first, then run only the affected writer/producer tests under Node 24.15 before touching commit history.

focused verification is clean: 5 files, 51 tests, with the writer split across the repo’s fast and tooling Vitest shards. i’m doing the required ownership audit now; only the seven reviewed paths will be staged into the amended commit.

[tool summary]
51 read, 5 write, 49 execute, 18 other; raw tool outputs dropped: 123
````

</details>
<!-- agent-transcript:end -->

