### PR TITLE
fix(plugins): bound session-catalog history import pagination

### DIFF
--- a/src/plugins/session-catalog-history-import.ts
+++ b/src/plugins/session-catalog-history-import.ts
@@ -9,6 +9,12 @@ import { withSessionTranscriptWriteLock } from "../plugin-sdk/session-transcript
 const SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS = 200;
 const SESSION_CATALOG_HISTORY_IMPORT_MAX_BYTES = 512 * 1024;
 const SESSION_CATALOG_HISTORY_IMPORT_PAGE_LIMIT = 100;
+// Liveness bound for pathological providers: the item and byte caps only
+// advance on retained items, so a provider that keeps answering with empty
+// (or non-importable) pages and a fresh cursor would paginate forever. Count
+// only consecutive empty pages so honest short-page providers (e.g. one item
+// per page) still import their full history.
+const SESSION_CATALOG_HISTORY_IMPORT_MAX_EMPTY_PAGES = 50;
 
 function importedSessionCatalogMessage(params: {
   catalogId: string;
@@ -105,6 +111,7 @@ async function readBoundedSessionCatalogHistory(params: {
   let cursor: string | undefined;
   let itemCount = 0;
   let bytes = 0;
+  let emptyPageCount = 0;
   while (itemCount < SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS) {
     const page = await params.read({
       limit: Math.min(
@@ -148,6 +155,14 @@ async function readBoundedSessionCatalogHistory(params: {
     pages.push(retained);
     if (!page.nextCursor || page.nextCursor === cursor) {
       break;
+    }
+    if (retained.length === 0) {
+      emptyPageCount += 1;
+      if (emptyPageCount >= SESSION_CATALOG_HISTORY_IMPORT_MAX_EMPTY_PAGES) {
+        break;
+      }
+    } else {
+      emptyPageCount = 0;
     }
     cursor = page.nextCursor;
   }

--- a/src/plugins/session-catalog.test.ts
+++ b/src/plugins/session-catalog.test.ts
@@ -203,6 +203,41 @@ describe("importSessionCatalogHistory", () => {
     expect(transcript.messages.map(messageText)).toEqual(["visible answer"]);
   });
 
+  it("stops paginating when every page is empty but the cursor keeps advancing", async () => {
+    let cursor = 0;
+    const read = vi.fn<Parameters<typeof importSessionCatalogHistory>[0]["read"]>(async () => {
+      cursor += 1;
+      return {
+        hostId: "gateway",
+        threadId: "thread-1",
+        items: [],
+        nextCursor: `page-${String(cursor)}`,
+      };
+    });
+
+    await importHistory([], { read }).result;
+
+    expect(read).toHaveBeenCalledTimes(50);
+    expect(transcript.messages).toEqual([]);
+  });
+
+  it("imports a full 200-item history served one item per page", async () => {
+    // Short pages are valid in the catalog contract: the liveness bound must
+    // count consecutive empty pages, never total pages.
+    const items = Array.from({ length: 200 }, (_, index) => ({
+      id: `m-${String(index)}`,
+      type: "userMessage" as const,
+      text: `message ${String(index)}`,
+    }));
+
+    const { read, result } = importHistory(items, { maxPageSize: 1 });
+    await result;
+
+    expect(read).toHaveBeenCalledTimes(200);
+    expect(transcript.messages).toHaveLength(200);
+    expect(transcript.messages.map(messageText)).toEqual(items.map((item) => item.text));
+  });
+
   it("does not open the transcript write lock when a paged read fails", async () => {
     const read = vi
       .fn<Parameters<typeof importSessionCatalogHistory>[0]["read"]>()


### PR DESCRIPTION
## Summary

`fix(plugins): bound session-catalog history import pagination so a provider that keeps emitting empty pages with fresh cursors cannot hang Control-UI session adoption indefinitely`

## What Problem This Solves

`readBoundedSessionCatalogHistory` paginates an external session catalog's transcript store when the Control UI "continue session" flow adopts an external pi/opencode session (`createSessionEntry({ afterCreate })`). The loop is meant to be bounded, but its three exit conditions all fail for one realistic provider behavior:

- the item cap (`MAX_ITEMS = 200`) only counts **retained** items,
- the byte cap (512 KB) likewise only accrues on retained items,
- the cursor check only stops on a missing or repeated `nextCursor`.

A provider that returns pages of zero importable items (e.g. advancing its cursor over raw events that are not importable) with a **fresh, distinct** `nextCursor` each call therefore paginates forever: each iteration awaits another provider read inside one `afterCreate`, hanging the adoption request indefinitely (and even for honest providers, reading a huge upstream history page-by-page at 100 items/page means thousands of sequential reads before the first byte is retained). The upstream transcript store is data outside openclaw's control, so this is not hypothetical hardening -- it only takes one odd upstream session.

**Code evidence**: `src/plugins/session-catalog-history-import.ts:105-155` (main, before this fix) -- `while (itemCount < SESSION_CATALOG_HISTORY_IMPORT_MAX_ITEMS)` with no page counter; `itemCount` increments only inside the retain branch (`:139`), and the only loop exits are the byte/item caps and `!page.nextCursor || page.nextCursor === cursor` (`:149`).

Minimal reproduction: a `read` closure returning `{ items: [], nextCursor: String(++n) }` forever -- see the Evidence section below.

## Root Cause

- The unbounded loop predates the current history root (`05a03c66fe7`).
- Violated invariant: every pagination loop over untrusted external data needs a termination guarantee independent of the payload's contents. Here both quantitative caps are functions of *retained* data, so a stream of pages that yields nothing bypasses them while still costing a full read per page.
- Trigger condition: adopting an external session whose transcript paginates into many consecutive empty/non-importable pages with advancing cursors (or a provider that emits distinct cursors past end-of-history).

## Why This Fix

- Option A: absolute page bound (`MAX_PAGES = 50`) inside the loop -- rejected: a page is only wasteful when it retains nothing. An honest provider serving a full 200-item history one item per page legitimately needs 200 pages (short pages are valid in the catalog contract), so any absolute cap small enough to stop a spinner quickly also truncates real imports (scenario C in the Evidence section demonstrates exactly this import).
- Option B: bound *consecutive empty* pages (`MAX_EMPTY_PAGES = 50`, chosen) -- a page that retains at least one item advances the 200-item cap, so at most 200 non-empty pages can ever occur; pages that retain nothing are the only unbounded case. Bounding their longest streak terminates every cursor-spinning pattern (an interleaved junk item still counts toward the item cap) while never truncating honest short-page providers.
- Option C: time-based deadline -- rejected: wall-clock budgets make imports flaky on slow machines and still waste the full budget per adoption; an empty-page streak bound is deterministic and testable.

## User Impact

- Affected scenario: Control-UI "continue session" adoption of an external pi/opencode session whose transcript provider returns empty pages with advancing cursors (buggy or pathological upstream session).
- Before: the adoption request hangs indefinitely (sequential provider reads with no termination; in the proof, 1.32M reads in 5 seconds and still going when the watchdog fired).
- After: the import stops after 50 consecutive empty pages (a spinner resolves with whatever was retained and the session opens); a full 200-item history still imports in full because retained items terminate the loop via the item cap first.
- Behavior change: imports that would previously spin forever now complete; honest providers -- including short-page providers serving one item per page -- are unaffected (200 retained items or end-of-history always arrive before the empty-page streak bound).

## Evidence

No mocks, no stubbed module graph: the proof runs the real adoption path end to end -- `createSessionEntryWithTranscript` (real sqlite session entry under a real `OPENCLAW_STATE_DIR`) -> `importSessionCatalogHistory` (the exact entry the acpx/opencode `afterCreate` adoption hook calls) with the real importable filter, real byte/item accounting, real `withSessionTranscriptWriteLock`, and real sqlite transcript persistence. Scenario A additionally uses the real local pi provider read chain (a real pi session JSONL on disk parsed by the real `readLocalPiTranscriptPage`). Scenarios B/C drive the provider boundary itself, the exact interface where external pi/opencode data enters: B is the pathological empty-pages spinner wrapped in a 5-second watchdog, C is an honest short-page provider (1 item per page).

### Before (on main)

```bash
$ node node_modules/tsx/dist/cli.mjs proof.mjs   # main: no pagination liveness bound
A real pi provider (on-disk session.jsonl via real readLocalPiTranscriptPage): imported 3 transcript messages
B empty pages + fresh cursors: STILL PAGINATING after 1324472 reads when the 5s watchdog fired
C 200 one-item pages: imported 200/200 items in 200 reads
BEHAVIOR: FAIL - empty-page spinner hangs adoption
exit=1
```

### After (with fix)

```bash
$ node node_modules/tsx/dist/cli.mjs proof.mjs   # HEAD: SESSION_CATALOG_HISTORY_IMPORT_MAX_EMPTY_PAGES = 50
A real pi provider (on-disk session.jsonl via real readLocalPiTranscriptPage): imported 3 transcript messages
B empty pages + fresh cursors: adoption RESOLVED after 50 reads
C 200 one-item pages: imported 200/200 items in 200 reads
BEHAVIOR: PASS - spinner stops at the empty-page bound, valid short-page history imports fully, real pi provider path works
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/plugins/session-catalog.test.ts` -- 9/9 tests passed, including the new regression tests `stops paginating when every page is empty but the cursor keeps advancing` (asserts the read stops at exactly 50 calls) and `imports a full 200-item history served one item per page` (asserts the liveness bound never truncates honest short-page providers: 200 reads, 200 messages) alongside the existing paged-import suites.
- Manual verification (the proof above):
  1. On main, the empty-pages provider is still paginating after 1.32M reads when the 5s watchdog fires -- FAIL.
  2. With the fix, the same provider resolves after exactly 50 empty pages, the full 200-item one-item-per-page history imports completely, and the real pi provider path is unchanged -- PASS.

Note: the proof was run with Node 24.19.0 (the SQLite WAL-safety gate in `src/infra/node-sqlite.ts` blocks the repo-bundled Node 22.20.0); the vitest suite runs under the repo toolchain.
