### PR TITLE
fix(voice-call): prevent stale runtimes after gateway restart

### DIFF
--- a/extensions/voice-call/index.lifecycle.test.ts
+++ b/extensions/voice-call/index.lifecycle.test.ts
@@ -1,0 +1,282 @@
+import os from "node:os";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "./api.js";
+import type { VoiceCallRuntime } from "./runtime-entry.js";
+
+vi.mock("./runtime-entry.js", () => ({
+  createVoiceCallRuntime: vi.fn(),
+}));
+
+import plugin from "./index.js";
+import { createVoiceCallRuntime } from "./runtime-entry.js";
+
+type VoiceCallService = Parameters<OpenClawPluginApi["registerService"]>[0];
+type VoiceCallTool = {
+  execute: (toolCallId: string, params: unknown) => Promise<VoiceCallToolResult>;
+};
+type VoiceCallToolFactory = (context: Record<string, unknown>) => VoiceCallTool;
+type VoiceCallToolResult = {
+  content?: Array<{ text?: string }>;
+  details?: { error?: unknown };
+};
+
+type RuntimeFixture = {
+  initiateCall: ReturnType<typeof vi.fn>;
+  runtime: VoiceCallRuntime;
+  stop: ReturnType<typeof vi.fn>;
+};
+
+const serviceContext = {
+  config: {},
+  stateDir: os.tmpdir(),
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+} as Parameters<VoiceCallService["start"]>[0];
+
+function createLogger(onError?: (message: string) => void) {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn((message: string) => onError?.(message)),
+    debug: vi.fn(),
+  };
+}
+
+function createRuntime(callId: string, toNumber: string, stopImpl?: () => Promise<void>) {
+  const initiateCall = vi.fn(async () => ({ callId, success: true }));
+  const stop = vi.fn(stopImpl ?? (async () => {}));
+  const runtime = {
+    config: { toNumber, realtime: { enabled: false } },
+    manager: { initiateCall },
+    stop,
+  } as unknown as VoiceCallRuntime;
+  return { initiateCall, runtime, stop } satisfies RuntimeFixture;
+}
+
+function registerVoiceCall(params: {
+  config?: Record<string, unknown>;
+  logger?: ReturnType<typeof createLogger>;
+  registrationMode?: OpenClawPluginApi["registrationMode"];
+}) {
+  let service: VoiceCallService | undefined;
+  let toolFactory: VoiceCallToolFactory | undefined;
+  const api = createTestPluginApi({
+    id: "voice-call",
+    name: "Voice Call",
+    description: "test",
+    version: "0",
+    source: "test",
+    registrationMode: params.registrationMode ?? "full",
+    config: {},
+    pluginConfig: { provider: "mock", ...params.config },
+    runtime: { tts: { textToSpeechTelephony: vi.fn() } } as unknown as OpenClawPluginApi["runtime"],
+    logger: params.logger ?? createLogger(),
+    registerGatewayMethod: () => {},
+    registerTool: (registration) => {
+      toolFactory =
+        typeof registration === "function"
+          ? (registration as unknown as VoiceCallToolFactory)
+          : () => registration as unknown as VoiceCallTool;
+    },
+    registerCli: () => {},
+    registerService: (registeredService) => {
+      service = registeredService;
+    },
+    resolvePath: (value) => value,
+  });
+  plugin.register(api);
+  if (!service || !toolFactory) {
+    throw new Error("expected voice-call service and tool registrations");
+  }
+  const registeredToolFactory = toolFactory;
+  return { service, toolFactory: registeredToolFactory, tool: () => registeredToolFactory({}) };
+}
+
+function executeCall(tool: VoiceCallTool): Promise<VoiceCallToolResult> {
+  return tool.execute("call", { action: "initiate_call", message: "hello" });
+}
+
+function expectLifecycleError(result: VoiceCallToolResult, text: string): void {
+  const detail = result.details?.error;
+  const error = typeof detail === "string" ? detail : JSON.stringify(detail ?? "");
+  expect(error).toContain(text);
+  expect(result.content?.some((entry) => entry.text?.includes(error))).toBe(true);
+}
+
+describe("voice-call runtime lifecycle", () => {
+  beforeEach(() => {
+    vi.mocked(createVoiceCallRuntime).mockReset();
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<PropertyKey, unknown>)[
+      Symbol.for("openclaw.voice-call.runtimeCoordinator")
+    ];
+    vi.restoreAllMocks();
+  });
+
+  it("shares one pending runtime between full and tool-discovery registrations", async () => {
+    const runtimeReady = createDeferred<VoiceCallRuntime>();
+    const fixture = createRuntime("call-a", "+15550000001");
+    vi.mocked(createVoiceCallRuntime).mockReturnValue(runtimeReady.promise);
+    const full = registerVoiceCall({ registrationMode: "full" });
+
+    expect(full.service.start(serviceContext)).toBeUndefined();
+    const discovery = registerVoiceCall({ registrationMode: "tool-discovery" });
+    const fullCall = executeCall(full.tool());
+    const discoveryCall = executeCall(discovery.tool());
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+
+    runtimeReady.resolve(fixture.runtime);
+    await Promise.all([fullCall, discoveryCall]);
+
+    expect(fixture.initiateCall).toHaveBeenCalledTimes(2);
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("retires a pending generation and stops its late runtime once", async () => {
+    const runtimeReady = createDeferred<VoiceCallRuntime>();
+    const fixture = createRuntime("call-a", "+15550000001");
+    const logger = createLogger();
+    vi.mocked(createVoiceCallRuntime).mockReturnValue(runtimeReady.promise);
+    const generationA = registerVoiceCall({ logger });
+
+    expect(generationA.service.start(serviceContext)).toBeUndefined();
+    const firstStop = generationA.service.stop?.(serviceContext);
+    const secondStop = generationA.service.stop?.(serviceContext);
+    runtimeReady.resolve(fixture.runtime);
+    await Promise.all([firstStop, secondStop]);
+
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+    expect(fixture.stop).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+    expectLifecycleError(await executeCall(generationA.tool()), "retired");
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for A stopping before creating B with B config", async () => {
+    const aStopEntered = createDeferred<void>();
+    const releaseAStop = createDeferred<void>();
+    const runtimeA = createRuntime("call-a", "+15550000001", () => {
+      aStopEntered.resolve();
+      return releaseAStop.promise;
+    });
+    const runtimeB = createRuntime("call-b", "+15550000002");
+    vi.mocked(createVoiceCallRuntime)
+      .mockResolvedValueOnce(runtimeA.runtime)
+      .mockResolvedValueOnce(runtimeB.runtime);
+    const generationA = registerVoiceCall({ config: { toNumber: "+15550000001" } });
+    await executeCall(generationA.tool());
+    const generationB = registerVoiceCall({ config: { toNumber: "+15550000002" } });
+
+    const stoppingA = generationA.service.stop?.(serviceContext);
+    const callB = executeCall(generationB.tool());
+    await aStopEntered.promise;
+    expect(runtimeA.stop).toHaveBeenCalledTimes(1);
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+
+    releaseAStop.resolve();
+    await Promise.all([stoppingA, callB]);
+
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(createVoiceCallRuntime).mock.calls[1]?.[0].config.toNumber).toBe(
+      "+15550000002",
+    );
+    expect(runtimeB.initiateCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a stale A stop clear or stop running B", async () => {
+    const runtimeB = createRuntime("call-b", "+15550000002");
+    vi.mocked(createVoiceCallRuntime).mockResolvedValue(runtimeB.runtime);
+    const generationA = registerVoiceCall({ config: { toNumber: "+15550000001" } });
+    const generationB = registerVoiceCall({ config: { toNumber: "+15550000002" } });
+
+    await executeCall(generationB.tool());
+    await generationA.service.stop?.(serviceContext);
+    await executeCall(generationB.tool());
+
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+    expect(runtimeB.initiateCall).toHaveBeenCalledTimes(2);
+    expect(runtimeB.stop).not.toHaveBeenCalled();
+  });
+
+  it("rejects retained concrete and cold-registry A tools once B activates", async () => {
+    const runtimeA = createRuntime("call-a", "+15550000001");
+    const runtimeB = createRuntime("call-b", "+15550000002");
+    vi.mocked(createVoiceCallRuntime)
+      .mockResolvedValueOnce(runtimeA.runtime)
+      .mockResolvedValueOnce(runtimeB.runtime);
+    const generationA = registerVoiceCall({ registrationMode: "full" });
+    const concreteToolA = generationA.tool();
+    await executeCall(concreteToolA);
+    const coldRegistryA = registerVoiceCall({ registrationMode: "tool-discovery" });
+    const coldToolA = coldRegistryA.toolFactory({});
+    const generationB = registerVoiceCall({ registrationMode: "full" });
+
+    await executeCall(concreteToolA);
+    await executeCall(coldToolA);
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+    expect(runtimeA.initiateCall).toHaveBeenCalledTimes(3);
+
+    expect(generationB.service.start(serviceContext)).toBeUndefined();
+    expectLifecycleError(await executeCall(concreteToolA), "superseded");
+    expectLifecycleError(await executeCall(coldToolA), "superseded");
+    await generationA.service.stop?.(serviceContext);
+    await executeCall(generationB.tool());
+    await generationB.service.stop?.(serviceContext);
+    expectLifecycleError(await executeCall(concreteToolA), "superseded");
+    expectLifecycleError(await executeCall(coldToolA), "superseded");
+
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(2);
+    expect(runtimeA.stop).toHaveBeenCalledTimes(1);
+    expect(runtimeB.initiateCall).toHaveBeenCalledTimes(1);
+    expect(runtimeB.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not revive an older staged A after activated B stops", async () => {
+    const runtimeB = createRuntime("call-b", "+15550000002");
+    vi.mocked(createVoiceCallRuntime).mockResolvedValue(runtimeB.runtime);
+    const stagedA = registerVoiceCall({ registrationMode: "full" });
+    const retainedToolA = stagedA.tool();
+    const generationB = registerVoiceCall({ registrationMode: "full" });
+
+    await executeCall(generationB.tool());
+    await generationB.service.stop?.(serviceContext);
+    expectLifecycleError(await executeCall(retainedToolA), "superseded");
+
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+    expect(runtimeB.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs when successor startup is blocked by an active predecessor", async () => {
+    const logged = createDeferred<string>();
+    const runtimeA = createRuntime("call-a", "+15550000001");
+    vi.mocked(createVoiceCallRuntime).mockResolvedValue(runtimeA.runtime);
+    const generationA = registerVoiceCall({});
+    await executeCall(generationA.tool());
+    const generationB = registerVoiceCall({ logger: createLogger(logged.resolve) });
+
+    expect(generationB.service.start(serviceContext)).toBeUndefined();
+    await expect(logged.promise).resolves.toContain("previous voice call runtime generation");
+
+    await generationA.service.stop?.(serviceContext);
+    await generationB.service.stop?.(serviceContext);
+  });
+
+  it("logs a genuine startup failure and retries the same generation", async () => {
+    const logged = createDeferred<string>();
+    const runtimeA = createRuntime("call-a", "+15550000001");
+    vi.mocked(createVoiceCallRuntime)
+      .mockRejectedValueOnce(new Error("provider boom"))
+      .mockResolvedValueOnce(runtimeA.runtime);
+    const generationA = registerVoiceCall({ logger: createLogger(logged.resolve) });
+
+    expect(generationA.service.start(serviceContext)).toBeUndefined();
+    await expect(logged.promise).resolves.toContain("Failed to start runtime: provider boom");
+
+    await executeCall(generationA.tool());
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(2);
+    expect(runtimeA.initiateCall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -139,6 +139,7 @@ function setup(
     description: "test",
     version: "0",
     source: "test",
+    registrationMode: "full",
     config: {},
     pluginConfig: config,
     runtime: { tts: { textToSpeechTelephony: vi.fn() } } as unknown as OpenClawPluginApi["runtime"],
@@ -219,6 +220,7 @@ async function registerVoiceCallCli(
     description: "test",
     version: "0",
     source: "test",
+    registrationMode: "full",
     config: {},
     pluginConfig,
     runtime: { tts: { textToSpeechTelephony: vi.fn() } },
@@ -253,12 +255,8 @@ describe("voice-call plugin", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
-    delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.voice-call.runtime")];
     delete (globalThis as Record<PropertyKey, unknown>)[
-      Symbol.for("openclaw.voice-call.runtimePromise")
-    ];
-    delete (globalThis as Record<PropertyKey, unknown>)[
-      Symbol.for("openclaw.voice-call.runtimeStopPromise")
+      Symbol.for("openclaw.voice-call.runtimeCoordinator")
     ];
   });
 
@@ -289,53 +287,6 @@ describe("voice-call plugin", () => {
     expect(createVoiceCallRuntime).not.toHaveBeenCalled();
   });
 
-  it("reuses a started runtime across plugin registration contexts", async () => {
-    const first = setup({ provider: "mock" });
-    const second = setup({ provider: "mock" });
-
-    await first.service?.start(createServiceContext());
-    const handler = second.methods.get("voicecall.initiate") as
-      | ((ctx: {
-          params: Record<string, unknown>;
-          respond: ReturnType<typeof vi.fn>;
-        }) => Promise<void>)
-      | undefined;
-    const respond = vi.fn();
-    await handler?.({ params: { message: "Hi" }, respond });
-
-    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
-    expect(runtimeStub.manager["initiateCall"]).toHaveBeenCalledTimes(1);
-    expect(respond).toHaveBeenCalledWith(true, { callId: "call-1", initiated: true });
-  });
-
-  it("does not block service startup while runtime exposure initializes", async () => {
-    let resolveRuntime: ((runtime: VoiceCallRuntime) => void) | undefined;
-    vi.mocked(createVoiceCallRuntime).mockReturnValueOnce(
-      new Promise<VoiceCallRuntime>((resolve) => {
-        resolveRuntime = resolve;
-      }),
-    );
-    const { service, methods } = setup({ provider: "mock" });
-
-    if (!service) {
-      throw new Error("expected voice-call service");
-    }
-    expect(service.start(createServiceContext())).toBeUndefined();
-    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
-
-    resolveRuntime?.(runtimeStub);
-    const handler = methods.get("voicecall.initiate") as
-      | ((ctx: {
-          params: Record<string, unknown>;
-          respond: ReturnType<typeof vi.fn>;
-        }) => Promise<void>)
-      | undefined;
-    const respond = vi.fn();
-    await handler?.({ params: { message: "Hi" }, respond });
-
-    expect(respond).toHaveBeenCalledWith(true, { callId: "call-1", initiated: true });
-  });
-
   it("does not start the webhook runtime for CLI-only plugin loading", async () => {
     vi.stubEnv("OPENCLAW_CLI", "1");
     const { service } = setup({ provider: "mock" });
@@ -357,26 +308,6 @@ describe("voice-call plugin", () => {
     } finally {
       process.argv = previousArgv;
     }
-  });
-
-  it("creates a fresh shared runtime after service stop", async () => {
-    const first = setup({ provider: "mock" });
-    await first.service?.start(createServiceContext());
-    await first.service?.stop?.(createServiceContext());
-
-    runtimeStub = createRuntimeStub("call-2");
-    const second = setup({ provider: "mock" });
-    const handler = second.methods.get("voicecall.initiate") as
-      | ((ctx: {
-          params: Record<string, unknown>;
-          respond: ReturnType<typeof vi.fn>;
-        }) => Promise<void>)
-      | undefined;
-    const respond = vi.fn();
-    await handler?.({ params: { message: "Hi" }, respond });
-
-    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(2);
-    expect(respond).toHaveBeenCalledWith(true, { callId: "call-2", initiated: true });
   });
 
   it("does not log a startup error when provider setup is incomplete", async () => {

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -1,6 +1,7 @@
 // Voice Call plugin entrypoint registers its OpenClaw integration.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { ErrorCodes, errorShape } from "openclaw/plugin-sdk/gateway-runtime";
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import { normalizeAgentId, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import {
   asOptionalRecord,
@@ -236,22 +237,69 @@ function isCliOnlyProcess(): boolean {
   return process.env.OPENCLAW_CLI === "1" && !process.argv.slice(2).includes("gateway");
 }
 
-const VOICE_CALL_RUNTIME_KEY = Symbol.for("openclaw.voice-call.runtime");
-const VOICE_CALL_RUNTIME_PROMISE_KEY = Symbol.for("openclaw.voice-call.runtimePromise");
-const VOICE_CALL_RUNTIME_STOP_PROMISE_KEY = Symbol.for("openclaw.voice-call.runtimeStopPromise");
+const VOICE_CALL_RUNTIME_COORDINATOR_KEY = Symbol.for("openclaw.voice-call.runtimeCoordinator");
 
-type VoiceCallRuntimeGlobalState = typeof globalThis & {
-  [VOICE_CALL_RUNTIME_KEY]?: VoiceCallRuntime | null;
-  [VOICE_CALL_RUNTIME_PROMISE_KEY]?: Promise<VoiceCallRuntime> | null;
-  [VOICE_CALL_RUNTIME_STOP_PROMISE_KEY]?: Promise<void> | null;
+type VoiceCallRuntimeGeneration = {
+  epoch: number;
+  retired: boolean;
+  stopPromise?: Promise<void>;
 };
 
-function getVoiceCallRuntimeGlobalState(): VoiceCallRuntimeGlobalState {
-  const state = globalThis as VoiceCallRuntimeGlobalState;
-  state[VOICE_CALL_RUNTIME_KEY] ??= null;
-  state[VOICE_CALL_RUNTIME_PROMISE_KEY] ??= null;
-  state[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY] ??= null;
-  return state;
+type VoiceCallRuntimeSlot =
+  | {
+      state: "starting";
+      owner: VoiceCallRuntimeGeneration;
+      promise: Promise<VoiceCallRuntime>;
+    }
+  | {
+      state: "running";
+      owner: VoiceCallRuntimeGeneration;
+      runtime: VoiceCallRuntime;
+    }
+  | {
+      state: "stopping";
+      owner: VoiceCallRuntimeGeneration;
+      promise: Promise<void>;
+    };
+
+type VoiceCallRuntimeCoordinator = {
+  current?: VoiceCallRuntimeGeneration;
+  // Activation advances this fence; construction alone stays rollback-safe.
+  epochCounter: number;
+  registeredEpoch: number;
+  slot?: VoiceCallRuntimeSlot;
+};
+
+class VoiceCallRuntimeLifecycleError extends Error {}
+
+function getVoiceCallRuntimeCoordinator(): VoiceCallRuntimeCoordinator {
+  return resolveGlobalSingleton(VOICE_CALL_RUNTIME_COORDINATOR_KEY, () => ({
+    epochCounter: 0,
+    registeredEpoch: 0,
+  }));
+}
+
+function activateVoiceCallRuntimeGeneration(
+  coordinator: VoiceCallRuntimeCoordinator,
+  generation: VoiceCallRuntimeGeneration,
+): void {
+  if (generation.epoch < coordinator.registeredEpoch) {
+    throw new VoiceCallRuntimeLifecycleError(
+      "Voice call runtime generation was superseded; use the current plugin registration",
+    );
+  }
+  if (generation.retired) {
+    throw new VoiceCallRuntimeLifecycleError(
+      "Voice call runtime generation is retired; use the current plugin registration",
+    );
+  }
+  if (coordinator.current !== generation) {
+    if (coordinator.current) {
+      coordinator.current.retired = true;
+    }
+    coordinator.current = generation;
+    coordinator.registeredEpoch = generation.epoch;
+  }
 }
 
 export default definePluginEntry({
@@ -263,13 +311,21 @@ export default definePluginEntry({
     const config = resolveVoiceCallConfig(voiceCallConfigSchema.parse(api.pluginConfig));
     const validation = validateProviderConfig(config);
 
-    const runtimeState = getVoiceCallRuntimeGlobalState();
+    const runtimeCoordinator = getVoiceCallRuntimeCoordinator();
+    const runtimeGeneration: VoiceCallRuntimeGeneration =
+      api.registrationMode !== "full" && runtimeCoordinator.current
+        ? runtimeCoordinator.current
+        : {
+            epoch: ++runtimeCoordinator.epochCounter,
+            retired: false,
+          };
     const continueOperationStore = createVoiceCallContinueOperationStore({
       config,
       coreConfig: api.config as CoreConfig,
     });
 
     const ensureRuntime = async (): Promise<VoiceCallRuntime> => {
+      activateVoiceCallRuntimeGeneration(runtimeCoordinator, runtimeGeneration);
       if (!config.enabled) {
         throw new Error("Voice call disabled in plugin config");
       }
@@ -278,49 +334,63 @@ export default definePluginEntry({
       }
 
       while (true) {
-        if (runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY]) {
-          await runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY];
-          continue;
-        }
+        activateVoiceCallRuntimeGeneration(runtimeCoordinator, runtimeGeneration);
+        const slot = runtimeCoordinator.slot;
+        if (slot) {
+          if (slot.owner !== runtimeGeneration) {
+            if (slot.state === "stopping") {
+              await slot.promise;
+              continue;
+            }
+            throw new VoiceCallRuntimeLifecycleError(
+              "A previous voice call runtime generation is still active; retry after it stops",
+            );
+          }
 
-        const runtime = runtimeState[VOICE_CALL_RUNTIME_KEY];
-        if (runtime) {
-          return runtime;
-        }
-
-        let runtimePromise = runtimeState[VOICE_CALL_RUNTIME_PROMISE_KEY];
-        if (!runtimePromise) {
-          runtimePromise = createVoiceCallRuntime({
-            config,
-            coreConfig: api.config as CoreConfig,
-            fullConfig: api.config,
-            agentRuntime: api.runtime.agent,
-            stateRuntime: api.runtime.state,
-            ttsRuntime: api.runtime.tts,
-            logger: api.logger,
-          });
-          runtimeState[VOICE_CALL_RUNTIME_PROMISE_KEY] = runtimePromise;
-        }
-
-        try {
-          const createdRuntime = await runtimePromise;
-          if (runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY]) {
+          if (slot.state === "running") {
+            return slot.runtime;
+          }
+          if (slot.state === "stopping") {
+            await slot.promise;
             continue;
           }
-          if (runtimeState[VOICE_CALL_RUNTIME_PROMISE_KEY] !== runtimePromise) {
+
+          let createdRuntime: VoiceCallRuntime;
+          try {
+            createdRuntime = await slot.promise;
+          } catch (err) {
+            if (runtimeCoordinator.slot === slot) {
+              runtimeCoordinator.slot = undefined;
+            }
+            throw err;
+          }
+          activateVoiceCallRuntimeGeneration(runtimeCoordinator, runtimeGeneration);
+          if (runtimeCoordinator.slot !== slot) {
             continue;
           }
-          runtimeState[VOICE_CALL_RUNTIME_KEY] = createdRuntime;
+          runtimeCoordinator.slot = {
+            state: "running",
+            owner: runtimeGeneration,
+            runtime: createdRuntime,
+          };
           return createdRuntime;
-        } catch (err) {
-          if (runtimeState[VOICE_CALL_RUNTIME_PROMISE_KEY] === runtimePromise) {
-            // Reset shared state so the next call can retry instead of caching
-            // a rejected promise across plugin contexts. See: #32387, #58115.
-            runtimeState[VOICE_CALL_RUNTIME_PROMISE_KEY] = null;
-            runtimeState[VOICE_CALL_RUNTIME_KEY] = null;
-          }
-          throw err;
         }
+
+        const runtimePromise = createVoiceCallRuntime({
+          config,
+          coreConfig: api.config as CoreConfig,
+          fullConfig: api.config,
+          agentRuntime: api.runtime.agent,
+          stateRuntime: api.runtime.state,
+          ttsRuntime: api.runtime.tts,
+          logger: api.logger,
+        });
+        const startingSlot: VoiceCallRuntimeSlot = {
+          state: "starting",
+          owner: runtimeGeneration,
+          promise: runtimePromise,
+        };
+        runtimeCoordinator.slot = startingSlot;
       }
     };
 
@@ -592,6 +662,14 @@ export default definePluginEntry({
         if (isCliOnlyProcess()) {
           return;
         }
+        try {
+          activateVoiceCallRuntimeGeneration(runtimeCoordinator, runtimeGeneration);
+        } catch (err) {
+          if (err instanceof VoiceCallRuntimeLifecycleError) {
+            return;
+          }
+          throw err;
+        }
         if (!config.enabled) {
           return;
         }
@@ -602,31 +680,57 @@ export default definePluginEntry({
           return;
         }
         void ensureRuntime().catch((err: unknown) => {
+          const staleGeneration =
+            runtimeGeneration.retired ||
+            runtimeGeneration.epoch < runtimeCoordinator.registeredEpoch;
+          if (err instanceof VoiceCallRuntimeLifecycleError && staleGeneration) {
+            return;
+          }
           api.logger.error(`[voice-call] Failed to start runtime: ${formatErrorMessage(err)}`);
         });
       },
       stop: async () => {
-        if (runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY]) {
-          await runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY];
-          return;
+        if (runtimeGeneration.stopPromise) {
+          return await runtimeGeneration.stopPromise;
         }
-        const runtime = runtimeState[VOICE_CALL_RUNTIME_KEY];
-        const runtimePromise = runtimeState[VOICE_CALL_RUNTIME_PROMISE_KEY];
-        if (!runtime && !runtimePromise) {
-          return;
+        runtimeGeneration.retired = true;
+        const ownedSlot =
+          runtimeCoordinator.slot?.owner === runtimeGeneration
+            ? runtimeCoordinator.slot
+            : undefined;
+        let stoppingSlot: VoiceCallRuntimeSlot | undefined;
+        const stopPromise =
+          ownedSlot?.state === "stopping"
+            ? ownedSlot.promise
+            : Promise.resolve().then(async () => {
+                if (!ownedSlot) {
+                  return;
+                }
+                const runtime =
+                  ownedSlot.state === "running" ? ownedSlot.runtime : await ownedSlot.promise;
+                await runtime.stop();
+              });
+        runtimeGeneration.stopPromise = stopPromise;
+        if (ownedSlot && ownedSlot.state !== "stopping") {
+          stoppingSlot = {
+            state: "stopping",
+            owner: runtimeGeneration,
+            promise: stopPromise,
+          };
+          if (runtimeCoordinator.slot === ownedSlot) {
+            runtimeCoordinator.slot = stoppingSlot;
+          }
+        } else if (ownedSlot) {
+          stoppingSlot = ownedSlot;
         }
-        runtimeState[VOICE_CALL_RUNTIME_KEY] = null;
-        runtimeState[VOICE_CALL_RUNTIME_PROMISE_KEY] = null;
-        const stopPromise = (async () => {
-          const rt = runtime ?? (await runtimePromise!);
-          await rt.stop();
-        })();
-        runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY] = stopPromise;
         try {
           await stopPromise;
         } finally {
-          if (runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY] === stopPromise) {
-            runtimeState[VOICE_CALL_RUNTIME_STOP_PROMISE_KEY] = null;
+          if (stoppingSlot && runtimeCoordinator.slot === stoppingSlot) {
+            runtimeCoordinator.slot = undefined;
+          }
+          if (runtimeCoordinator.current === runtimeGeneration) {
+            runtimeCoordinator.current = undefined;
           }
         }
       },


### PR DESCRIPTION
Closes #120288

## What Problem This Solves

Fixes an issue where operators restarting or reloading a gateway with the Voice Call plugin could end up with stale runtime state when an older plugin generation finished startup or cleanup after its successor was already attached. That timing could recreate a runtime from old configuration, let old cleanup disrupt the new runtime, or leave Voice Call unavailable after restart.

## Why This Change Was Made

Voice Call now owns its process-global runtime through an explicit plugin-generation coordinator. Startup, running, and stopping slots carry an exact owner; activation advances a monotonic epoch only when a staged generation actually starts or is used, so failed/staged registrations do not disturb the active generation and retired closures cannot revive later.

The fix stays inside the plugin boundary. Gateway shutdown grace and registry-bound tool retention remain unchanged; retained tools now receive a visible lifecycle error instead of adopting or mutating successor state. A focused lifecycle suite uses controlled promises to prove the original execution order and exact-owner cleanup.

AI-assisted: implementation and review used Claude Code and Codex. The final diff was manually inspected and passed the repository autoreview gate.

## User Impact

Voice Call restarts and plugin configuration reloads now keep runtime ownership deterministic. A successor generation waits for the predecessor's actual stop barrier where appropriate, while delayed startup, stale service cleanup, and retained tool closures cannot recreate or interfere with another generation's runtime.

## Evidence

- `node scripts/run-vitest.mjs extensions/voice-call/index.test.ts extensions/voice-call/index.lifecycle.test.ts` — 55 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` — passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` — passed.
- `node scripts/run-oxlint.mjs extensions/voice-call/index.ts extensions/voice-call/index.test.ts extensions/voice-call/index.lifecycle.test.ts` — passed.
- `node_modules/.bin/oxfmt --check extensions/voice-call/index.ts extensions/voice-call/index.test.ts extensions/voice-call/index.lifecycle.test.ts` — passed.
- `git diff --check` — passed.
- Codex autoreview, `--mode uncommitted` — clean; no accepted/actionable findings.
- `node scripts/check-changed.mjs -- ...` classified the extension production/test lanes but remote Crabbox/Testbox providers were unavailable; the exact extension typecheck, lint, format, focused test, and diff checks above were run locally as the documented trusted-source fallback.

The production delta is the new runtime ownership boundary (`+170/-66`); tests are separate (`+285/-72`) and move the prior lifecycle cases into a dedicated deterministic suite.
