### PR TITLE
refactor(test): replace logic-bearing vi.mock factories with boundary fakes, batch 3

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -19,8 +19,6 @@ import { setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 
 const saveRemoteMedia = vi.fn();
-const saveMediaBuffer = vi.fn();
-const readRemoteMediaBuffer = vi.fn();
 const rootRead = vi.fn();
 const { triggerInternalHookMock } = vi.hoisted(() => ({
   triggerInternalHookMock: vi.fn<(event: unknown) => Promise<void>>(async () => undefined),
@@ -43,35 +41,11 @@ vi.mock("openclaw/plugin-sdk/file-access-runtime", () => ({
   }),
 }));
 
-vi.mock("./bot/delivery.resolve-media.runtime.js", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
-    "openclaw/plugin-sdk/media-runtime",
-  );
+vi.mock("./telegram-media.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./telegram-media.runtime.js")>();
   return {
-    readRemoteMediaBuffer: (...args: unknown[]) => readRemoteMediaBuffer(...args),
-    formatErrorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
-    logVerbose: () => {},
-    MediaFetchError: actual.MediaFetchError,
-    resolveTelegramApiBase: (apiRoot?: string) =>
-      apiRoot?.trim() ? apiRoot.replace(/\/+$/u, "") : "https://api.telegram.org",
-    retryAsync: async (fn: () => unknown) => await fn(),
-    saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
-    saveRemoteMedia: async (...args: unknown[]) => {
-      try {
-        return await saveRemoteMedia(...args);
-      } catch (err) {
-        if (err instanceof actual.MediaFetchError) {
-          throw err;
-        }
-        throw new actual.MediaFetchError(
-          "fetch_failed",
-          err instanceof Error ? err.message : String(err),
-          { cause: err },
-        );
-      }
-    },
-    shouldRetryTelegramTransportFallback: vi.fn(() => false),
-    warn: (s: string) => s,
+    ...actual,
+    saveRemoteMedia: (...args: unknown[]) => saveRemoteMedia(...args),
   };
 });
 
@@ -391,7 +365,9 @@ function expectTelegramDownloadWarning(messageId: number, warning?: string) {
 
 function rejectFirstTelegramAlbumDownloadWhen(partial: boolean) {
   if (partial) {
-    saveRemoteMedia.mockRejectedValueOnce(new Error("MediaFetchError: Failed to fetch media"));
+    saveRemoteMedia.mockRejectedValueOnce(
+      new MediaFetchError("fetch_failed", "Failed to fetch media"),
+    );
   }
 }
 
@@ -399,9 +375,10 @@ async function rejectTelegramAlbumDownload(shutdown: AbortController, abort: boo
   if (abort) {
     shutdown.abort();
   }
-  throw abort
+  const cause = abort
     ? Object.assign(new Error("aborted"), { name: "AbortError" })
-    : new Error("MediaFetchError: Failed to fetch media");
+    : new Error("Failed to fetch media");
+  throw new MediaFetchError("fetch_failed", cause.message, { cause });
 }
 
 describe("createTelegramBot channel_post media", () => {
@@ -443,7 +420,7 @@ describe("createTelegramBot channel_post media", () => {
         const response = await params.fetchImpl(params.url);
         const buffer = new Uint8Array(await response.arrayBuffer());
         if (buffer.length > params.maxBytes) {
-          throw new Error(`media exceeds ${params.maxBytes} MB limit`);
+          throw new MediaFetchError("max_bytes", `media exceeds ${params.maxBytes} MB limit`);
         }
         return {
           path: "/tmp/telegram-media.bin",
@@ -451,8 +428,6 @@ describe("createTelegramBot channel_post media", () => {
         };
       },
     );
-    saveMediaBuffer.mockReset();
-    readRemoteMediaBuffer.mockReset();
     rootRead.mockReset();
   });
 
@@ -556,7 +531,9 @@ describe("createTelegramBot channel_post media", () => {
 
   it("notifies users when media download fails for direct messages", async () => {
     setOpenTelegramDirectConfig();
-    saveRemoteMedia.mockRejectedValueOnce(new Error("MediaFetchError: Failed to fetch media"));
+    saveRemoteMedia.mockRejectedValueOnce(
+      new MediaFetchError("fetch_failed", "Failed to fetch media"),
+    );
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch failed"));
     try {
       createTelegramBot({ token: "tok" });
@@ -627,7 +604,9 @@ describe("createTelegramBot channel_post media", () => {
     {
       name: "retryable shutdown abort",
       messageId: 98076,
-      error: Object.assign(new Error("aborted"), { name: "AbortError" }),
+      error: new MediaFetchError("fetch_failed", "aborted", {
+        cause: Object.assign(new Error("aborted"), { name: "AbortError" }),
+      }),
       result: { kind: "failed-retryable", error: expect.any(MediaFetchError) },
       warnings: 0,
     },
@@ -641,7 +620,7 @@ describe("createTelegramBot channel_post media", () => {
     {
       name: "permanent SSRF rejection",
       messageId: 98078,
-      error: new Error("blocked by SSRF guard: private address"),
+      error: new MediaFetchError("fetch_failed", "blocked by SSRF guard: private address"),
       result: { kind: "completed" },
       warnings: 1,
     },
@@ -901,7 +880,7 @@ describe("createTelegramBot channel_post media", () => {
       groups: { "*": { requireMention: true, ...(testCase.ingest ? { ingest: true } : {}) } },
       ...("denyPatterns" in testCase ? { providerPolicy: { mode: "deny" } } : {}),
     });
-    saveRemoteMedia.mockRejectedValueOnce(new Error("MediaFetchError: ECONNRESET"));
+    saveRemoteMedia.mockRejectedValueOnce(new MediaFetchError("fetch_failed", "ECONNRESET"));
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNRESET"));
     try {
       createTelegramBot({ token: "tok" });
@@ -937,7 +916,8 @@ describe("createTelegramBot channel_post media", () => {
     saveRemoteMedia.mockImplementationOnce(async () => {
       if (shutdownAbort) {
         shutdown.abort();
-        throw Object.assign(new Error("aborted"), { name: "AbortError" });
+        const cause = Object.assign(new Error("aborted"), { name: "AbortError" });
+        throw new MediaFetchError("fetch_failed", "aborted", { cause });
       }
       throw new MediaFetchError("http_error", "rate limited", { status: 429 });
     });

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -2,6 +2,20 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveEmbeddedSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
+import {
+  clearSessionQueues,
+  enqueueFollowupRun,
+  getFollowupQueueDepth,
+  type FollowupRun,
+} from "../../auto-reply/reply/queue.js";
+import { createQueueTestRun } from "../../auto-reply/reply/queue.test-helpers.js";
+import {
+  CommandLaneClearedError,
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  setCommandLaneConcurrency,
+} from "../../process/command-queue.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
@@ -32,9 +46,12 @@ import type { GatewayClient } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const sessionKey = "agent:main:rewind-handler";
+const sourceSessionId = "rewind-handler-source";
+const sessionLane = resolveEmbeddedSessionLane(sessionKey);
 const storedImageId = "stored-image.png";
 const storedImagePath = `/state/media/inbound/${storedImageId}`;
 const storedImageData = Buffer.from("stored-image");
+const queuedCommandSettlements = new Set<Promise<void>>();
 
 beforeEach(async () => {
   mocks.upstreamFork.mockReset();
@@ -54,12 +71,12 @@ beforeEach(async () => {
   await upsertSessionEntry(
     { agentId: "main", sessionKey },
     {
-      sessionId: "rewind-handler-source",
+      sessionId: sourceSessionId,
       updatedAt: Date.now(),
     },
   );
   for (const event of [
-    { type: "session", id: "rewind-handler-source", version: 3 },
+    { type: "session", id: sourceSessionId, version: 3 },
     {
       type: "message",
       id: "user-entry",
@@ -99,7 +116,7 @@ beforeEach(async () => {
       targetId: "assistant-entry",
     },
   ]) {
-    const scope = { agentId: "main", sessionId: "rewind-handler-source", sessionKey };
+    const scope = { agentId: "main", sessionId: sourceSessionId, sessionKey };
     if (event.type === "message") {
       await appendTranscriptMessage(scope, {
         eventId: event.id,
@@ -112,7 +129,11 @@ beforeEach(async () => {
   }
 });
 
-afterEach(() => {
+afterEach(async () => {
+  clearSessionQueues([sessionKey, sourceSessionId]);
+  setCommandLaneConcurrency(sessionLane, 1);
+  await Promise.all(queuedCommandSettlements);
+  queuedCommandSettlements.clear();
   resetPluginRuntimeStateForTest();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
@@ -123,7 +144,7 @@ function context(active = false): GatewayRequestContext {
   return {
     broadcastToConnIds: vi.fn(),
     chatAbortControllers: new Map(
-      active ? [["active-run", { sessionId: "rewind-handler-source", sessionKey }]] : undefined,
+      active ? [["active-run", { sessionId: sourceSessionId, sessionKey }]] : undefined,
     ),
     getRuntimeConfig: () => ({ agents: { list: [{ id: "main", default: true }] } }),
     getSessionEventSubscriberConnIds: () => new Set(),
@@ -162,6 +183,63 @@ async function invoke(
     isWebchatConnect: () => false,
   });
   return respond;
+}
+
+type QueuedSessionWork = {
+  command: Promise<string>;
+  followup: FollowupRun;
+  hasCommandRun: () => boolean;
+};
+
+function enqueueSessionWork(label: string): QueuedSessionWork {
+  const followupFixture = createQueueTestRun({ prompt: `${label} follow-up` });
+  const followup: FollowupRun = {
+    ...followupFixture,
+    run: {
+      ...followupFixture.run,
+      agentId: "main",
+      sessionId: sourceSessionId,
+      sessionKey,
+    },
+  };
+  expect(
+    enqueueFollowupRun(sessionKey, followup, { mode: "followup" }, "none", undefined, false),
+  ).toBe(true);
+
+  setCommandLaneConcurrency(sessionLane, 0);
+  let commandRan = false;
+  const command = enqueueCommandInLane(sessionLane, async () => {
+    commandRan = true;
+    return `${label} command`;
+  });
+  const settlement = command.then(
+    () => undefined,
+    () => undefined,
+  );
+  queuedCommandSettlements.add(settlement);
+
+  return { command, followup, hasCommandRun: () => commandRan };
+}
+
+function expectSessionWorkQueued(work: QueuedSessionWork): void {
+  expect(getFollowupQueueDepth(sessionKey)).toBe(1);
+  expect(work.followup.queueAbortSignal?.aborted).toBe(false);
+  expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+    activeCount: 0,
+    queuedCount: 1,
+  });
+  expect(work.hasCommandRun()).toBe(false);
+}
+
+async function expectSessionWorkCleared(work: QueuedSessionWork): Promise<void> {
+  expect(getFollowupQueueDepth(sessionKey)).toBe(0);
+  expect(work.followup.queueAbortSignal?.aborted).toBe(true);
+  expect(getCommandLaneSnapshot(sessionLane)).toMatchObject({
+    activeCount: 0,
+    queuedCount: 0,
+  });
+  await expect(work.command).rejects.toBeInstanceOf(CommandLaneClearedError);
+  expect(work.hasCommandRun()).toBe(false);
 }
 
 function linkToUpstreamConversation(): void {
@@ -242,6 +320,51 @@ describe("session message-cut methods", () => {
 
     const switched = await invoke("sessions.branches.switch", "off-path-entry");
     expect(switched).toHaveBeenCalledWith(true, {}, undefined);
+  });
+
+  it("clears queued session work after a successful branch switch", async () => {
+    const work = enqueueSessionWork("branch switch");
+    expectSessionWorkQueued(work);
+
+    const respond = await invoke("sessions.branches.switch", "off-path-entry");
+
+    expect(respond).toHaveBeenCalledWith(true, {}, undefined);
+    await expectSessionWorkCleared(work);
+  });
+
+  it("clears queued session work after a successful rewind", async () => {
+    const work = enqueueSessionWork("rewind");
+    expectSessionWorkQueued(work);
+
+    const respond = await invoke("sessions.rewind", "user-entry");
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ editorText: "edit me" }),
+      undefined,
+    );
+    await expectSessionWorkCleared(work);
+  });
+
+  it("preserves queued session work after a rejected branch switch", async () => {
+    const work = enqueueSessionWork("rejected branch switch");
+    expectSessionWorkQueued(work);
+
+    const respond = await invoke("sessions.branches.switch", "missing");
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message: expect.stringContaining("branch entry not found"),
+      }),
+    );
+    expectSessionWorkQueued(work);
+
+    setCommandLaneConcurrency(sessionLane, 1);
+    await expect(work.command).resolves.toBe("rejected branch switch command");
+    expect(work.hasCommandRun()).toBe(true);
   });
 
   it.each([

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -7,57 +7,13 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
-  active: false,
-  capability: false,
-  external: false,
   upstreamFork: vi.fn(),
-  queueClear: vi.fn(),
   readMediaBuffer: vi.fn(),
 }));
 
 vi.mock("../../media/store.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../media/store.js")>();
   return { ...actual, readMediaBuffer: mocks.readMediaBuffer };
-});
-
-vi.mock("../../agents/harness/registry.js", () => ({
-  listRegisteredAgentHarnesses: () =>
-    mocks.capability
-      ? [
-          {
-            harness: {
-              sessionFork: {
-                upstreamKinds: ["codex-app-server"],
-                fork: mocks.upstreamFork,
-              },
-            },
-          },
-        ]
-      : [],
-}));
-
-vi.mock("../../auto-reply/reply/queue/cleanup.js", () => ({
-  clearSessionQueues: mocks.queueClear,
-}));
-
-vi.mock("../../sessions/session-upstream-links.js", () => ({
-  readSessionUpstreamLink: () =>
-    mocks.external
-      ? {
-          agentId: "main",
-          catalogId: "codex",
-          hostId: "gateway:local",
-          marker: { turnId: "turn-2", userMessageCount: 1 },
-          sessionKey,
-          threadId: "thread-source",
-          upstreamKind: "codex-app-server",
-          upstreamRef: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
-        }
-      : undefined,
-}));
-
-vi.mock("./session-active-runs.js", () => {
-  return { hasVisibleActiveSessionRun: () => mocks.active };
 });
 
 import {
@@ -67,7 +23,10 @@ import {
   loadSessionEntry,
   upsertSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { listSessionStateEventsSince } from "../../sessions/session-state-events.js";
+import { upsertSessionUpstreamLink } from "../../sessions/session-upstream-links.js";
 import { sessionRewindHandlers } from "./sessions-rewind.js";
 import type { GatewayClient } from "./types.js";
 
@@ -78,11 +37,7 @@ const storedImagePath = `/state/media/inbound/${storedImageId}`;
 const storedImageData = Buffer.from("stored-image");
 
 beforeEach(async () => {
-  mocks.active = false;
-  mocks.capability = false;
-  mocks.external = false;
   mocks.upstreamFork.mockReset();
-  mocks.queueClear.mockReset();
   mocks.readMediaBuffer.mockReset().mockImplementation(async (id: string) => {
     if (id !== storedImageId) {
       throw new Error(`missing media: ${id}`);
@@ -94,6 +49,7 @@ beforeEach(async () => {
       size: storedImageData.byteLength,
     };
   });
+  setActivePluginRegistry(createEmptyPluginRegistry());
   vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-rewind-handler-"));
   await upsertSessionEntry(
     { agentId: "main", sessionKey },
@@ -157,15 +113,18 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  resetPluginRuntimeStateForTest();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
   vi.unstubAllEnvs();
 });
 
-function context(): GatewayRequestContext {
+function context(active = false): GatewayRequestContext {
   return {
     broadcastToConnIds: vi.fn(),
-    chatAbortControllers: new Map(),
+    chatAbortControllers: new Map(
+      active ? [["active-run", { sessionId: "rewind-handler-source", sessionKey }]] : undefined,
+    ),
     getRuntimeConfig: () => ({ agents: { list: [{ id: "main", default: true }] } }),
     getSessionEventSubscriberConnIds: () => new Set(),
   } as unknown as GatewayRequestContext;
@@ -181,6 +140,7 @@ async function invoke(
   method: MessageCutMethod,
   entryId?: string,
   client: GatewayClient | null = null,
+  active = false,
 ) {
   const respond = vi.fn();
   await expectDefined(
@@ -197,11 +157,47 @@ async function invoke(
           : { entryId }),
     },
     respond: respond as unknown as RespondFn,
-    context: context(),
+    context: context(active),
     client,
     isWebchatConnect: () => false,
   });
   return respond;
+}
+
+function linkToUpstreamConversation(): void {
+  expect(
+    upsertSessionUpstreamLink({
+      agentId: "main",
+      catalogId: "codex",
+      hostId: "gateway:local",
+      marker: { turnId: "turn-2", userMessageCount: 1 },
+      sessionKey,
+      threadId: "thread-source",
+      upstreamKind: "codex-app-server",
+      upstreamRef: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
+    }),
+  ).toBe(true);
+}
+
+function installUpstreamForkHarness(): void {
+  const registry = createEmptyPluginRegistry();
+  registry.agentHarnesses.push({
+    pluginId: "test-harness",
+    source: "runtime",
+    harness: {
+      id: "test-harness",
+      label: "Test harness",
+      runAttempt: async () => {
+        throw new Error("not used");
+      },
+      sessionFork: {
+        upstreamKinds: ["codex-app-server"],
+        fork: mocks.upstreamFork,
+      },
+      supports: () => ({ supported: false }),
+    },
+  });
+  setActivePluginRegistry(registry);
 }
 
 describe("session message-cut methods", () => {
@@ -246,7 +242,6 @@ describe("session message-cut methods", () => {
 
     const switched = await invoke("sessions.branches.switch", "off-path-entry");
     expect(switched).toHaveBeenCalledWith(true, {}, undefined);
-    expect(mocks.queueClear).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -318,7 +313,6 @@ describe("session message-cut methods", () => {
       undefined,
     );
     expect(mocks.readMediaBuffer).toHaveBeenCalledTimes(4);
-    expect(mocks.queueClear).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -335,11 +329,10 @@ describe("session message-cut methods", () => {
         message: expect.stringContaining(message),
       }),
     );
-    expect(mocks.queueClear).not.toHaveBeenCalled();
   });
 
   it("rejects externally owned conversations", async () => {
-    mocks.external = true;
+    linkToUpstreamConversation();
     const respond = await invoke("sessions.branches.switch", "off-path-entry");
     const listed = await invoke("sessions.branches.list");
 
@@ -358,8 +351,8 @@ describe("session message-cut methods", () => {
   it.each(["sessions.rewind", "sessions.branches.switch"] as const)(
     "rejects %s for upstream-linked sessions even with a fork-capable harness",
     async (method) => {
-      mocks.external = true;
-      mocks.capability = true;
+      linkToUpstreamConversation();
+      installUpstreamForkHarness();
       const respond = await invoke(method, "user-entry");
 
       expect(respond).toHaveBeenCalledWith(
@@ -375,8 +368,8 @@ describe("session message-cut methods", () => {
   );
 
   it("delegates complete upstream fork materialization to the harness", async () => {
-    mocks.external = true;
-    mocks.capability = true;
+    linkToUpstreamConversation();
+    installUpstreamForkHarness();
     mocks.upstreamFork.mockResolvedValue({
       status: "created",
       key: "agent:main:dashboard:forked",
@@ -404,8 +397,8 @@ describe("session message-cut methods", () => {
   });
 
   it("does not mutate the local session when the upstream fork fails", async () => {
-    mocks.external = true;
-    mocks.capability = true;
+    linkToUpstreamConversation();
+    installUpstreamForkHarness();
     mocks.upstreamFork.mockResolvedValue({
       status: "failed",
       code: "upstream-unavailable",
@@ -429,8 +422,8 @@ describe("session message-cut methods", () => {
   it.each(["steer-message", "in-progress-turn", "drift-mismatch"] as const)(
     "passes through the %s boundary failure",
     async (reason) => {
-      mocks.external = true;
-      mocks.capability = true;
+      linkToUpstreamConversation();
+      installUpstreamForkHarness();
       mocks.upstreamFork.mockResolvedValue({
         status: "failed",
         code: reason,
@@ -456,10 +449,11 @@ describe("session message-cut methods", () => {
     ["sessions.rewind", "Rewind"],
     ["sessions.branches.switch", "Branch switch"],
   ] as const)("rejects %s while the source run is active", async (method, label) => {
-    mocks.active = true;
     const respond = await invoke(
       method,
       method === "sessions.branches.switch" ? "off-path-entry" : "user-entry",
+      null,
+      true,
     );
 
     expect(respond).toHaveBeenCalledWith(
@@ -470,6 +464,5 @@ describe("session message-cut methods", () => {
         message: `${label} is unavailable while the agent is working.`,
       }),
     );
-    expect(mocks.queueClear).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/tools-invoke-http.abort.test.ts
+++ b/src/gateway/tools-invoke-http.abort.test.ts
@@ -16,47 +16,15 @@ const lifecycle = vi.hoisted(() => ({
     blocked: false as const,
     params: args.params,
   })),
-  cleanup: vi.fn(),
   handled: vi.fn(),
-  sendJson: vi.fn(),
-  watch: vi.fn(),
   execute: vi.fn(async (_toolCallId: string, _args: unknown, _signal?: AbortSignal) => ({
     ok: true,
   })),
 }));
 
-vi.mock("./http-common.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./http-common.js")>();
-  return {
-    ...actual,
-    sendJson: (...args: Parameters<typeof actual.sendJson>) => {
-      lifecycle.sendJson();
-      return actual.sendJson(...args);
-    },
-    watchClientDisconnect: (
-      req: IncomingMessage,
-      res: ServerResponse,
-      controller: AbortController,
-      onDisconnect?: () => void,
-    ) => {
-      lifecycle.watch();
-      const stopWatching = actual.watchClientDisconnect(req, res, controller, onDisconnect);
-      return () => {
-        lifecycle.cleanup();
-        stopWatching();
-      };
-    },
-  };
-});
-
-vi.mock("./http-utils.js", () => ({
+vi.mock("./http-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./http-utils.js")>()),
   authorizeScopedGatewayHttpRequestOrReply: lifecycle.authorize,
-  getHeader: (req: IncomingMessage, name: string) => {
-    const header = req.headers[name];
-    return typeof header === "string" ? header : undefined;
-  },
-  resolveOpenAiCompatibleHttpOperatorScopes: () => ["operator.write"],
-  resolveOpenAiCompatibleHttpSenderIsOwner: () => true,
 }));
 
 vi.mock("./tool-resolution.js", () => ({
@@ -74,26 +42,6 @@ vi.mock("./tool-resolution.js", () => ({
 
 vi.mock("../agents/agent-tools.before-tool-call.js", () => ({
   runBeforeToolCallHook: lifecycle.beforeHook,
-}));
-
-vi.mock("../agents/agent-tools.js", () => ({
-  resolveToolLoopDetectionConfig: () => undefined,
-}));
-
-vi.mock("../config/sessions.js", () => ({
-  resolveMainSessionKey: () => "agent:main:main",
-}));
-
-vi.mock("../agents/channel-tools.js", () => ({
-  getChannelAgentToolMeta: () => undefined,
-}));
-
-vi.mock("../plugins/tools.js", () => ({
-  getPluginToolMeta: () => undefined,
-}));
-
-vi.mock("../logger.js", () => ({
-  logWarn: vi.fn(),
 }));
 
 const { handleToolsInvokeHttpRequest } = await import("./tools-invoke-http.js");
@@ -143,10 +91,7 @@ beforeEach(() => {
   lifecycle.authorize.mockReset();
   lifecycle.authorize.mockResolvedValue({ cfg: {}, requestAuth: { ok: true } });
   lifecycle.beforeHook.mockClear();
-  lifecycle.cleanup.mockReset();
   lifecycle.handled.mockReset();
-  lifecycle.sendJson.mockReset();
-  lifecycle.watch.mockReset();
   lifecycle.execute.mockReset();
   lifecycle.execute.mockResolvedValue({ ok: true });
 });
@@ -171,9 +116,7 @@ describe("POST /tools/invoke request cancellation", () => {
     const response = await invokeAbortProbe();
 
     expect(response.status).toBe(401);
-    expect(lifecycle.watch).not.toHaveBeenCalled();
     expect(lifecycle.execute).not.toHaveBeenCalled();
-    expect(lifecycle.cleanup).not.toHaveBeenCalled();
   });
 
   it("does not start a tool after the client disconnects during authorization", async () => {
@@ -203,9 +146,7 @@ describe("POST /tools/invoke request cancellation", () => {
 
       releaseAuthorization?.();
       await expect.poll(() => lifecycle.handled.mock.calls.length).toBe(1);
-      expect(lifecycle.watch).not.toHaveBeenCalled();
       expect(lifecycle.execute).not.toHaveBeenCalled();
-      expect(lifecycle.sendJson).not.toHaveBeenCalled();
     } finally {
       releaseAuthorization?.();
       requestController.abort();
@@ -226,7 +167,6 @@ describe("POST /tools/invoke request cancellation", () => {
     expect(lifecycle.beforeHook).toHaveBeenCalledWith(
       expect.objectContaining({ signal: toolSignal }),
     );
-    expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("aborts the running tool when its HTTP client disconnects", async () => {
@@ -255,8 +195,6 @@ describe("POST /tools/invoke request cancellation", () => {
       requestController.abort();
       await expect(response).rejects.toThrow();
       await expect.poll(() => toolSignal?.aborted).toBe(true);
-      await expect.poll(() => lifecycle.cleanup.mock.calls.length).toBe(1);
-      expect(lifecycle.sendJson).not.toHaveBeenCalled();
     } finally {
       requestController.abort();
       releaseExecution?.();
@@ -294,8 +232,6 @@ describe("POST /tools/invoke request cancellation", () => {
       releaseHook?.();
       await expect.poll(() => lifecycle.handled.mock.calls.length).toBe(1);
       expect(lifecycle.execute).not.toHaveBeenCalled();
-      expect(lifecycle.sendJson).not.toHaveBeenCalled();
-      expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
     } finally {
       releaseHook?.();
       requestController.abort();
@@ -313,6 +249,5 @@ describe("POST /tools/invoke request cancellation", () => {
       ok: false,
       error: { type: "tool_error", message: "tool execution failed" },
     });
-    expect(lifecycle.cleanup).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Continues the test de-stubbing pattern from #120117. Three high-density suites were proving behavior through logic-bearing `vi.mock` factories and wrapper-spy call counts, which let duplicated test policy drift away from the real modules.

The converted suites are:

- `src/gateway/server-methods/sessions-rewind.test.ts`
- `extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts`
- `src/gateway/tools-invoke-http.abort.test.ts`

## Why This Change Was Made

The rewrites execute the real session rewind, Telegram media-policy, and HTTP cancellation collaborators while retaining fakes only at true media, transport, authorization, policy-hook, and tool-execution boundaries. Assertions now cover persisted session behavior, policy-visible Telegram outcomes, HTTP status/body, handler completion, whether execution starts, and the actual request-owned `AbortSignal` lifecycle.

Two ranked candidates were intentionally skipped because an honest test-only conversion needs a production injection seam, and this batch forbids production edits:

- `src/gateway/server-runtime-subscriptions.test.ts`: lazy dynamic `server-chat`/`server-session-events` handler failure and recovery tests require loader/factory injection. A test-only rewrite would either retain logic-bearing factories or delete resilience coverage.
- `src/plugins/management-service.test.ts`: 14 imported collaborators span config persistence, discovery, slot/preflight, registry refresh, catalogs, install records, and install/uninstall atomicity. Without injectable dependencies, a test-only rewrite would retain policy factories or delete failure/atomicity coverage.

Deleted stub-proving assertions (no tests were deleted):

- `lists branches and switches to an inactive tip`: removed `queueClear` called-once assertion because the successful response and real branch mutation are observable; cleanup-owner tests cover its mechanics.
- `returns editor text for rewind and a new key for fork`: removed `queueClear` times-one assertion because the fork/rewind response, session entry, and state event are stronger evidence.
- `returns a typed validation error for %s`: removed `queueClear` not-called assertion because the typed error and unchanged session behavior cover the contract.
- `rejects %s while the source run is active`: removed `queueClear` not-called assertion because real active-run state and the unavailable result prove admission behavior.
- `never attaches a disconnect watcher to an unauthorized request`: removed watcher and cleanup not-called assertions because the 401 response and execution not starting are the observable contract.
- `does not start a tool after the client disconnects during authorization`: removed watcher and `sendJson` not-called assertions because handler completion, rejected client response, and execution not starting cover behavior without wrapper internals.
- `passes a request-owned abort signal to the tool and releases its disconnect watcher`: removed cleanup-called assertion because the successful HTTP response and live, request-owned signal prove behavior.
- `aborts the running tool when its HTTP client disconnects`: removed cleanup-called and `sendJson` not-called assertions because the rejected client response and actual tool signal becoming aborted prove cancellation.
- `does not start a tool after the client disconnects during its policy hook`: removed `sendJson` not-called and cleanup-called assertions because hook-signal abortion, handler completion, and execution not starting are observable.
- `releases its disconnect watcher when tool execution fails`: removed cleanup-called assertion because the 500 response body proves the failure contract; watcher cleanup mechanics belong to `http-common` tests.

The requested estimate was −300 to −1,500 lines. The actual test delta is −92 lines because three of five candidates converted cleanly while the two remaining candidates require production seams and were skipped rather than weakening coverage or changing production code.

## User Impact

No production behavior changes. Maintainers get smaller, more trustworthy tests that exercise the same real policy and lifecycle code users run, with less duplicated mock logic and fewer assertions coupled to implementation mechanics.

## Evidence

Focused and shadowed-module proof:

- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-rewind.test.ts src/agents/harness/registry.test.ts src/gateway/server-methods/session-active-runs.test.ts src/sessions/session-upstream-monitor.test.ts src/auto-reply/reply/queue/cleanup.test.ts` — 4 shards, 64/64 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts` — 42/42 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot/delivery.resolve-media-local.test.ts extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts` — 54/54 passed.
- `node scripts/run-vitest.mjs src/gateway/tools-invoke-http.abort.test.ts` — 6/6 passed.
- `node scripts/run-vitest.mjs src/gateway/http-common.test.ts src/gateway/http-utils.authorize-request.test.ts src/agents/agent-tools.deferred-followup-guidance.test.ts src/agents/channel-tools.test.ts src/config/sessions.test.ts src/plugins/tools.optional.test.ts src/logger.test.ts src/gateway/tools-invoke-http.test.ts` — 6 shards, 212/212 passed.
- Independent combined run: `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-rewind.test.ts src/agents/harness/registry.test.ts src/gateway/server-methods/session-active-runs.test.ts src/sessions/session-upstream-monitor.test.ts src/auto-reply/reply/queue/cleanup.test.ts extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts extensions/telegram/src/bot/delivery.resolve-media-local.test.ts extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts src/gateway/tools-invoke-http.abort.test.ts src/gateway/http-common.test.ts src/gateway/http-utils.authorize-request.test.ts src/agents/agent-tools.deferred-followup-guidance.test.ts src/agents/channel-tools.test.ts src/config/sessions.test.ts src/plugins/tools.optional.test.ts src/logger.test.ts src/gateway/tools-invoke-http.test.ts` — 10 shards, 378/378 passed.
- `node scripts/run-oxlint.mjs extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts src/gateway/server-methods/sessions-rewind.test.ts src/gateway/tools-invoke-http.abort.test.ts` — clean.
- `git diff --check origin/main...HEAD` — clean.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — `autoreview clean: no accepted/actionable findings reported` (`patch is correct`, 0.99).

Pre-push gate:

- `node scripts/check-changed.mjs` delegated through the repository router to owned AWS lease `cbx_fa249db83727` after Blacksmith health checks were unavailable. Conflict markers, environment-variable and max-lines ratchets, changelog attribution, wildcard export guards, duplicate target coverage, dependency pins, changed-file formatting, deprecated API use, plugin boundaries, and package patch checks all passed. The subsequent production dead-export scan failed on a large pre-existing `src/config/**` export set. This branch changes only tests and has no production delta, so the unrelated production failure was reported without modifying production code.

Production vs. test numstat against `5e477aff2adc0`:

- Production: +0/−0 (net 0)
- Tests: +81/−173 (net −92)
- `extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts`: +21/−41
- `src/gateway/server-methods/sessions-rewind.test.ts`: +58/−65
- `src/gateway/tools-invoke-http.abort.test.ts`: +2/−67

No `CHANGELOG.md` or `CLAUDE.md` changes.
