### PR TITLE
refactor(test): compress repetitive fixtures in mega-tests, batch 3

### DIFF
--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -98,6 +98,22 @@ async function consumeMatrixSecretStorageKey(keyId = "SSSSKEY"): Promise<boolean
   return Boolean(result);
 }
 
+type FakeMatrixEventParams = {
+  roomId: string;
+  eventId: string;
+  sender: string;
+  type: string;
+  ts: number;
+  content: Record<string, unknown>;
+  stateKey?: string;
+  unsigned?: {
+    age?: number;
+    redacted_because?: unknown;
+  };
+  decryptionFailure?: boolean;
+  decryptionFailureReason?: DecryptionFailureCodeValue;
+};
+
 class FakeMatrixEvent extends EventEmitter {
   private readonly roomId: string;
   private readonly eventId: string;
@@ -122,21 +138,7 @@ class FakeMatrixEvent extends EventEmitter {
     },
   );
 
-  constructor(params: {
-    roomId: string;
-    eventId: string;
-    sender: string;
-    type: string;
-    ts: number;
-    content: Record<string, unknown>;
-    stateKey?: string;
-    unsigned?: {
-      age?: number;
-      redacted_because?: unknown;
-    };
-    decryptionFailure?: boolean;
-    decryptionFailureReason?: DecryptionFailureCodeValue;
-  }) {
+  constructor(params: FakeMatrixEventParams) {
     super();
     this.roomId = params.roomId;
     this.eventId = params.eventId;
@@ -241,6 +243,28 @@ class FakeMatrixEvent extends EventEmitter {
     this.decryptionFailure = false;
     this.decryptionFailureReasonValue = null;
   }
+}
+
+function makeMatrixEvent(overrides: Partial<FakeMatrixEventParams> = {}): FakeMatrixEvent {
+  return new FakeMatrixEvent({
+    roomId: "!room:example.org",
+    eventId: "$event",
+    sender: "@alice:example.org",
+    type: "m.room.encrypted",
+    ts: Date.now(),
+    content: {},
+    ...overrides,
+  });
+}
+
+function makeDecryptedMessageEvent(
+  overrides: Partial<FakeMatrixEventParams> = {},
+): FakeMatrixEvent {
+  return makeMatrixEvent({
+    type: "m.room.message",
+    content: { msgtype: "m.text", body: "hello" },
+    ...overrides,
+  });
 }
 
 type MatrixJsClientStub = {
@@ -394,6 +418,42 @@ vi.mock("matrix-js-sdk/lib/matrix.js", async () => {
 const { encodeRecoveryKey } = await import("matrix-js-sdk/lib/crypto-api/recovery-key.js");
 const { DecryptionFailureCode } = await import("matrix-js-sdk/lib/crypto-api/index.js");
 const { MatrixClient } = await import("./sdk.js");
+
+function makeCryptoApi(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    on: vi.fn(),
+    bootstrapCrossSigning: vi.fn(async () => {}),
+    bootstrapSecretStorage: vi.fn(async () => {}),
+    requestOwnUserVerification: vi.fn(async () => null),
+    ...overrides,
+  };
+}
+
+function makeDeviceVerificationStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    isVerified: () => true,
+    localVerified: true,
+    crossSigningVerified: true,
+    signedByOwner: true,
+    ...overrides,
+  };
+}
+
+function makeKeyBackupInfo(version = "9") {
+  return {
+    algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
+    auth_data: {},
+    version,
+  };
+}
+
+function makeKeyBackupTrust(overrides: Record<string, unknown> = {}) {
+  return {
+    trusted: true,
+    matchesDecryptionKey: true,
+    ...overrides,
+  };
+}
 
 describe("MatrixClient request hardening", () => {
   beforeEach(() => {
@@ -1162,10 +1222,8 @@ describe("MatrixClient request hardening", () => {
   it("maps relations pages back to raw events", async () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
     matrixJsClient.relations = vi.fn(async () => ({
-      originalEvent: new FakeMatrixEvent({
-        roomId: "!room:example.org",
+      originalEvent: makeMatrixEvent({
         eventId: "$poll",
-        sender: "@alice:example.org",
         type: "m.poll.start",
         ts: 1,
         content: {
@@ -1176,8 +1234,7 @@ describe("MatrixClient request hardening", () => {
         },
       }),
       events: [
-        new FakeMatrixEvent({
-          roomId: "!room:example.org",
+        makeMatrixEvent({
           eventId: "$vote",
           sender: "@bob:example.org",
           type: "m.poll.response",
@@ -1577,25 +1634,8 @@ describe("MatrixClient event bridge", () => {
 
     await client.start();
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-    });
-    const decrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.message",
-      ts: Date.now(),
-      content: {
-        msgtype: "m.text",
-        body: "hello",
-      },
-    });
+    const encrypted = makeMatrixEvent();
+    const decrypted = makeDecryptedMessageEvent();
 
     matrixJsClient.emit("event", encrypted);
     expect(messageEvents).toHaveLength(0);
@@ -1625,25 +1665,8 @@ describe("MatrixClient event bridge", () => {
 
     await client.start();
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-    });
-    const decrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.message",
-      ts: Date.now(),
-      content: {
-        msgtype: "m.text",
-        body: "hello",
-      },
-    });
+    const encrypted = makeMatrixEvent();
+    const decrypted = makeDecryptedMessageEvent();
 
     matrixJsClient.emit("event", encrypted);
     encrypted.emit("decrypted", decrypted, new Error("decrypt failed"));
@@ -1665,26 +1688,8 @@ describe("MatrixClient event bridge", () => {
       delivered.push(event.type);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
-    const decrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.message",
-      ts: Date.now(),
-      content: {
-        msgtype: "m.text",
-        body: "hello",
-      },
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
+    const decrypted = makeDecryptedMessageEvent();
 
     matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
       encrypted.emit("decrypted", decrypted);
@@ -1713,26 +1718,8 @@ describe("MatrixClient event bridge", () => {
       delivered.push(event.type);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
-    const decrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.message",
-      ts: Date.now(),
-      content: {
-        msgtype: "m.text",
-        body: "hello",
-      },
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
+    const decrypted = makeDecryptedMessageEvent();
 
     matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
       encrypted.emit("decrypted", decrypted);
@@ -1748,13 +1735,8 @@ describe("MatrixClient event bridge", () => {
     expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(1);
     expect(delivered).toEqual(["m.room.message"]);
 
-    const lateEncrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
+    const lateEncrypted = makeMatrixEvent({
       eventId: "$late",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
       decryptionFailure: true,
     });
     matrixJsClient.emit("event", lateEncrypted);
@@ -1774,14 +1756,7 @@ describe("MatrixClient event bridge", () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
     const delivered: string[] = [];
     let releaseSdkDecryption: (() => void) | undefined;
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$pending",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-    });
+    const encrypted = makeMatrixEvent({ eventId: "$pending" });
     const sdkDecryption = new Promise<void>((resolve) => {
       releaseSdkDecryption = () => {
         encrypted.markDecrypted({
@@ -1822,14 +1797,7 @@ describe("MatrixClient event bridge", () => {
     vi.useFakeTimers();
     const client = new MatrixClient("https://matrix.example.org", "token");
     let rejectSdkDecryption: ((reason?: unknown) => void) | undefined;
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$pending",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-    });
+    const encrypted = makeMatrixEvent({ eventId: "$pending" });
     encrypted.setDecryptionPromise(
       new Promise<void>((_, reject) => {
         rejectSdkDecryption = reject;
@@ -1880,26 +1848,8 @@ describe("MatrixClient event bridge", () => {
       delivered.push(event.type);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
-    const decrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.message",
-      ts: Date.now(),
-      content: {
-        msgtype: "m.text",
-        body: "hello",
-      },
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
+    const decrypted = makeDecryptedMessageEvent();
     encrypted.onAttemptDecryption(() => {
       encrypted.emit("decrypted", decrypted);
     });
@@ -1930,13 +1880,9 @@ describe("MatrixClient event bridge", () => {
       failed.push(error.message);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
+    const encrypted = makeMatrixEvent({
       eventId: "$historical",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
       ts: Date.now() - 60_000,
-      content: {},
       decryptionFailure: true,
       decryptionFailureReason: DecryptionFailureCode.HISTORICAL_MESSAGE_NO_KEY_BACKUP,
     });
@@ -1964,15 +1910,7 @@ describe("MatrixClient event bridge", () => {
       delivered.push(event.type);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
 
     matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
       encrypted.markDecrypted({
@@ -2011,15 +1949,7 @@ describe("MatrixClient event bridge", () => {
       delivered.push(event.type);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
 
     matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
       encrypted.markDecrypted({
@@ -2052,15 +1982,7 @@ describe("MatrixClient event bridge", () => {
       failed.push(error.message);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
 
     matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
       throw new Error("still missing key");
@@ -2106,15 +2028,7 @@ describe("MatrixClient event bridge", () => {
       delivered.push(event.type);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
 
     matrixJsClient.decryptEventIfNeeded = vi.fn(
       async (event: FakeMatrixEvent, options?: { isRetry?: boolean }) => {
@@ -2178,15 +2092,7 @@ describe("MatrixClient event bridge", () => {
       requestOwnUserVerification: vi.fn(async () => null),
     }));
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
 
     await client.start();
     matrixJsClient.emit("event", encrypted);
@@ -2238,26 +2144,8 @@ describe("MatrixClient event bridge", () => {
       delivered.push(event.type);
     });
 
-    const encrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
-    const decrypted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.message",
-      ts: Date.now(),
-      content: {
-        msgtype: "m.text",
-        body: "hello",
-      },
-    });
+    const encrypted = makeMatrixEvent({ decryptionFailure: true });
+    const decrypted = makeDecryptedMessageEvent();
 
     const releaseRetryRef: { current?: () => void } = {};
     encrypted.onAttemptDecryption(
@@ -2301,12 +2189,9 @@ describe("MatrixClient event bridge", () => {
 
     await client.start();
 
-    const inviteMembership = new FakeMatrixEvent({
-      roomId: "!room:example.org",
+    const inviteMembership = makeMatrixEvent({
       eventId: "$invite",
-      sender: "@alice:example.org",
       type: "m.room.member",
-      ts: Date.now(),
       stateKey: "@bot:example.org",
       content: {
         membership: "invite",
@@ -2898,18 +2783,11 @@ describe("MatrixClient crypto bootstrapping", () => {
   it("reports own verification status when crypto marks device as verified", async () => {
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -2930,13 +2808,11 @@ describe("MatrixClient crypto bootstrapping", () => {
     matrixJsClient.getDevices = vi.fn(async () => ({
       devices: [{ device_id: "OTHERDEVICE" }],
     }));
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      getDeviceVerificationStatus: vi.fn(async () => null),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        getDeviceVerificationStatus: vi.fn(async () => null),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -2954,18 +2830,11 @@ describe("MatrixClient crypto bootstrapping", () => {
     matrixJsClient.getDevices = vi.fn(async () => {
       throw new Error("device list unavailable");
     });
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -2993,18 +2862,11 @@ describe("MatrixClient crypto bootstrapping", () => {
         statusCode: 401,
       });
     });
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -3044,18 +2906,16 @@ describe("MatrixClient crypto bootstrapping", () => {
   it("does not treat local-only trust as Matrix identity trust", async () => {
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: false,
-        signedByOwner: false,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        getDeviceVerificationStatus: vi.fn(async () => ({
+          isVerified: () => true,
+          localVerified: true,
+          crossSigningVerified: false,
+          signedByOwner: false,
+        })),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -3076,13 +2936,11 @@ describe("MatrixClient crypto bootstrapping", () => {
       crossSigningVerified: false,
       signedByOwner: false,
     }));
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      getDeviceVerificationStatus,
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        getDeviceVerificationStatus,
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -3168,27 +3026,15 @@ describe("MatrixClient crypto bootstrapping", () => {
         defaultKeyId: "SSSSKEY",
         secretStorageKeyValidityMap: {},
       })),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
+      getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
       checkKeyBackupAndEnable: vi.fn(async () => {}),
       loadSessionBackupPrivateKeyFromSecretStorage: vi.fn(async () => {
         backupKeyLoaded = await consumeMatrixSecretStorageKey();
       }),
       getActiveSessionBackupVersion: vi.fn(async () => (backupKeyLoaded ? "11" : null)),
       getSessionBackupPrivateKey: vi.fn(async () => (backupKeyLoaded ? privateKey : null)),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "11",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("11")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const recoveryDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-verify-used-key-"));
@@ -3276,15 +3122,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       }),
       getActiveSessionBackupVersion: vi.fn(async () => (backupKeyLoaded ? "11" : null)),
       getSessionBackupPrivateKey: vi.fn(async () => (backupKeyLoaded ? privateKey : null)),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "11",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("11")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const recoveryDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-verify-usable-"));
@@ -3314,35 +3153,26 @@ describe("MatrixClient crypto bootstrapping", () => {
 
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      getSecretStorageStatus: vi.fn(async () => ({
-        ready: true,
-        defaultKeyId: "SSSSKEY",
-        secretStorageKeyValidityMap: { SSSSKEY: true },
-      })),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: false,
-        signedByOwner: false,
-      })),
-      checkKeyBackupAndEnable: vi.fn(async () => {}),
-      getActiveSessionBackupVersion: vi.fn(async () => "11"),
-      getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "11",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        getSecretStorageStatus: vi.fn(async () => ({
+          ready: true,
+          defaultKeyId: "SSSSKEY",
+          secretStorageKeyValidityMap: { SSSSKEY: true },
+        })),
+        getDeviceVerificationStatus: vi.fn(async () => ({
+          isVerified: () => true,
+          localVerified: true,
+          crossSigningVerified: false,
+          signedByOwner: false,
+        })),
+        checkKeyBackupAndEnable: vi.fn(async () => {}),
+        getActiveSessionBackupVersion: vi.fn(async () => "11"),
+        getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
+        getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("11")),
+        isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
+      }),
+    );
 
     const recoveryDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-verify-cached-"));
     const recoveryKeyPath = path.join(recoveryDir, "recovery-key.json");
@@ -3403,15 +3233,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       checkKeyBackupAndEnable: vi.fn(async () => {}),
       getActiveSessionBackupVersion: vi.fn(async () => "11"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "11",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("11")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const recoveryDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-verify-invalid-"));
@@ -3471,15 +3294,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       checkKeyBackupAndEnable: vi.fn(async () => {}),
       getActiveSessionBackupVersion: vi.fn(async () => "11"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "11",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("11")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const recoveryDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-verify-restored-"));
@@ -3528,24 +3344,14 @@ describe("MatrixClient crypto bootstrapping", () => {
         defaultKeyId: "SSSSKEY",
         secretStorageKeyValidityMap: { SSSSKEY: true },
       })),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
+      getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
       checkKeyBackupAndEnable: vi.fn(async () => {}),
       getActiveSessionBackupVersion: vi.fn(async () => "11"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "11",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: false,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("11")),
+      isKeyBackupTrusted: vi.fn(async () =>
+        makeKeyBackupTrust({ trusted: false, matchesDecryptionKey: true }),
+      ),
     }));
 
     const recoveryDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-verify-untrusted-"));
@@ -3631,21 +3437,9 @@ describe("MatrixClient crypto bootstrapping", () => {
       on: vi.fn(),
       getActiveSessionBackupVersion: vi.fn(async () => "11"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1, 2, 3])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "11",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("11")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
+      getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -3681,15 +3475,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       getActiveSessionBackupVersion,
       getSessionBackupPrivateKey,
       loadSessionBackupPrivateKeyFromSecretStorage,
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "9",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("9")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -3728,11 +3515,7 @@ describe("MatrixClient crypto bootstrapping", () => {
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
       loadSessionBackupPrivateKeyFromSecretStorage,
       checkKeyBackupAndEnable,
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "49262",
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("49262")),
       isKeyBackupTrusted,
     }));
 
@@ -3763,15 +3546,10 @@ describe("MatrixClient crypto bootstrapping", () => {
       getActiveSessionBackupVersion: vi.fn(async () => null),
       getSessionBackupPrivateKey: vi.fn(async () => null),
       loadSessionBackupPrivateKeyFromSecretStorage,
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "9",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: false,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("9")),
+      isKeyBackupTrusted: vi.fn(async () =>
+        makeKeyBackupTrust({ trusted: true, matchesDecryptionKey: false }),
+      ),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -3803,15 +3581,8 @@ describe("MatrixClient crypto bootstrapping", () => {
         .fn()
         .mockResolvedValueOnce(null)
         .mockResolvedValue(new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "9",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("9")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     };
     matrixJsClient.getCrypto = vi.fn(() => crypto);
 
@@ -3838,15 +3609,10 @@ describe("MatrixClient crypto bootstrapping", () => {
       on: vi.fn(),
       getActiveSessionBackupVersion: vi.fn(async () => "42"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "42",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: false,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("42")),
+      isKeyBackupTrusted: vi.fn(async () =>
+        makeKeyBackupTrust({ trusted: false, matchesDecryptionKey: true }),
+      ),
       restoreKeyBackup,
     }));
 
@@ -3883,15 +3649,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       loadSessionBackupPrivateKeyFromSecretStorage,
       checkKeyBackupAndEnable,
       restoreKeyBackup,
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "5256",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("5256")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     };
     matrixJsClient.getCrypto = vi.fn(() => crypto);
 
@@ -3913,15 +3672,10 @@ describe("MatrixClient crypto bootstrapping", () => {
       on: vi.fn(),
       getActiveSessionBackupVersion: vi.fn(async () => null),
       getSessionBackupPrivateKey: vi.fn(async () => null),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "3",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: false,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("3")),
+      isKeyBackupTrusted: vi.fn(async () =>
+        makeKeyBackupTrust({ trusted: true, matchesDecryptionKey: false }),
+      ),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -3960,11 +3714,7 @@ describe("MatrixClient crypto bootstrapping", () => {
       loadSessionBackupPrivateKeyFromSecretStorage,
       checkKeyBackupAndEnable: vi.fn(async () => {}),
       restoreKeyBackup,
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "49262",
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("49262")),
       isKeyBackupTrusted,
     }));
 
@@ -3992,15 +3742,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       checkKeyBackupAndEnable,
       getActiveSessionBackupVersion: vi.fn(async () => "21869"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "21869",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("21869")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4047,15 +3790,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       getActiveSessionBackupVersion: vi.fn(async () => "21870"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
       getSecretStorageStatus: vi.fn(async () => ({ ready: true, defaultKeyId: "OLD" })),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "21870",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("21870")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4099,11 +3835,7 @@ describe("MatrixClient crypto bootstrapping", () => {
       loadSessionBackupPrivateKeyFromSecretStorage,
       getActiveSessionBackupVersion: vi.fn(async () => "49262"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "49262",
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("49262")),
       isKeyBackupTrusted,
     }));
 
@@ -4136,15 +3868,10 @@ describe("MatrixClient crypto bootstrapping", () => {
       checkKeyBackupAndEnable: vi.fn(async () => {}),
       getActiveSessionBackupVersion: vi.fn(async () => "21868"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "21868",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: false,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("21868")),
+      isKeyBackupTrusted: vi.fn(async () =>
+        makeKeyBackupTrust({ trusted: true, matchesDecryptionKey: false }),
+      ),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4194,15 +3921,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       getSessionBackupPrivateKey,
       getSecretStorageStatus,
       getActiveSessionBackupVersion: vi.fn(async () => "22000"),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "22000",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("22000")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4252,15 +3972,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       loadSessionBackupPrivateKeyFromSecretStorage,
       getActiveSessionBackupVersion,
       getSessionBackupPrivateKey,
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "22001",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("22001")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4310,15 +4023,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       loadSessionBackupPrivateKeyFromSecretStorage,
       getActiveSessionBackupVersion: vi.fn(async () => "22002"),
       getSessionBackupPrivateKey,
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "22002",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("22002")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4348,20 +4054,13 @@ describe("MatrixClient crypto bootstrapping", () => {
   it("reports bootstrap failure when cross-signing keys are not published", async () => {
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      isCrossSigningReady: vi.fn(async () => false),
-      userHasCrossSigningKeys: vi.fn(async () => false),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        isCrossSigningReady: vi.fn(async () => false),
+        userHasCrossSigningKeys: vi.fn(async () => false),
+        getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -4385,31 +4084,17 @@ describe("MatrixClient crypto bootstrapping", () => {
   it("reports bootstrap success when own device is verified and keys are published", async () => {
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      isCrossSigningReady: vi.fn(async () => true),
-      userHasCrossSigningKeys: vi.fn(async () => true),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
-      getActiveSessionBackupVersion: vi.fn(async () => "9"),
-      getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "9",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        isCrossSigningReady: vi.fn(async () => true),
+        userHasCrossSigningKeys: vi.fn(async () => true),
+        getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
+        getActiveSessionBackupVersion: vi.fn(async () => "9"),
+        getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
+        getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("9")),
+        isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -4435,20 +4120,18 @@ describe("MatrixClient crypto bootstrapping", () => {
   it("reports bootstrap failure when the device is only locally trusted", async () => {
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      isCrossSigningReady: vi.fn(async () => true),
-      userHasCrossSigningKeys: vi.fn(async () => true),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: false,
-        signedByOwner: false,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        isCrossSigningReady: vi.fn(async () => true),
+        userHasCrossSigningKeys: vi.fn(async () => true),
+        getDeviceVerificationStatus: vi.fn(async () => ({
+          isVerified: () => true,
+          localVerified: true,
+          crossSigningVerified: false,
+          signedByOwner: false,
+        })),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -4479,23 +4162,11 @@ describe("MatrixClient crypto bootstrapping", () => {
       requestOwnUserVerification: vi.fn(async () => null),
       isCrossSigningReady: vi.fn(async () => true),
       userHasCrossSigningKeys: vi.fn(async () => true),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
+      getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
       getActiveSessionBackupVersion: vi.fn(async () => "7"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "7",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("7")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4535,23 +4206,11 @@ describe("MatrixClient crypto bootstrapping", () => {
       requestOwnUserVerification: vi.fn(async () => null),
       isCrossSigningReady: vi.fn(async () => true),
       userHasCrossSigningKeys: vi.fn(async () => true),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
+      getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
       getActiveSessionBackupVersion: vi.fn(async () => "9"),
       getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "9",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
+      getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("9")),
+      isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
     }));
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
@@ -4587,36 +4246,22 @@ describe("MatrixClient crypto bootstrapping", () => {
     const encoded = encodeRecoveryKey(new Uint8Array(Array.from({ length: 32 }, (_, i) => i + 90)));
     matrixJsClient.getUserId = vi.fn(() => "@bot:example.org");
     matrixJsClient.getDeviceId = vi.fn(() => "DEVICE123");
-    matrixJsClient.getCrypto = vi.fn(() => ({
-      on: vi.fn(),
-      bootstrapCrossSigning: vi.fn(async () => {}),
-      bootstrapSecretStorage: vi.fn(async () => {}),
-      requestOwnUserVerification: vi.fn(async () => null),
-      isCrossSigningReady: vi.fn(async () => true),
-      userHasCrossSigningKeys: vi.fn(async () => true),
-      getSecretStorageStatus: vi.fn(async () => ({
-        ready: true,
-        defaultKeyId: "SSSSKEY",
-        secretStorageKeyValidityMap: { SSSSKEY: true },
-      })),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-        localVerified: true,
-        crossSigningVerified: true,
-        signedByOwner: true,
-      })),
-      getActiveSessionBackupVersion: vi.fn(async () => "12"),
-      getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
-      getKeyBackupInfo: vi.fn(async () => ({
-        algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
-        auth_data: {},
-        version: "12",
-      })),
-      isKeyBackupTrusted: vi.fn(async () => ({
-        trusted: true,
-        matchesDecryptionKey: true,
-      })),
-    }));
+    matrixJsClient.getCrypto = vi.fn(() =>
+      makeCryptoApi({
+        isCrossSigningReady: vi.fn(async () => true),
+        userHasCrossSigningKeys: vi.fn(async () => true),
+        getSecretStorageStatus: vi.fn(async () => ({
+          ready: true,
+          defaultKeyId: "SSSSKEY",
+          secretStorageKeyValidityMap: { SSSSKEY: true },
+        })),
+        getDeviceVerificationStatus: vi.fn(async () => makeDeviceVerificationStatus()),
+        getActiveSessionBackupVersion: vi.fn(async () => "12"),
+        getSessionBackupPrivateKey: vi.fn(async () => new Uint8Array([1])),
+        getKeyBackupInfo: vi.fn(async () => makeKeyBackupInfo("12")),
+        isKeyBackupTrusted: vi.fn(async () => makeKeyBackupTrust()),
+      }),
+    );
 
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
@@ -4668,13 +4313,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       }
     ).exhaustedDecryptRetries;
     const events = Array.from({ length: 513 }, (_unused, index) => {
-      const event = new FakeMatrixEvent({
-        roomId: "!room:example.org",
+      const event = makeMatrixEvent({
         eventId: `$event-${index}`,
-        sender: "@alice:example.org",
-        type: "m.room.encrypted",
-        ts: Date.now(),
-        content: {},
         decryptionFailure: true,
       });
       event.onAttemptDecryption(() => {});
@@ -4716,15 +4356,7 @@ describe("MatrixClient crypto bootstrapping", () => {
       emitFailedDecryption: vi.fn(),
       emitMessage: vi.fn(),
     });
-    const event = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
+    const event = makeMatrixEvent({ decryptionFailure: true });
     event.onAttemptDecryption(() => {});
     (
       bridge as unknown as {
@@ -4777,15 +4409,7 @@ describe("MatrixClient crypto bootstrapping", () => {
       emitFailedDecryption,
       emitMessage,
     });
-    const event = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$event",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-      decryptionFailure: true,
-    });
+    const event = makeMatrixEvent({ decryptionFailure: true });
     event.onAttemptDecryption(
       () =>
         new Promise<void>((resolve) => {
@@ -4842,13 +4466,8 @@ describe("MatrixClient crypto bootstrapping", () => {
       emitFailedDecryption: vi.fn(),
       emitMessage,
     });
-    const exhausted = new FakeMatrixEvent({
-      roomId: "!room:example.org",
+    const exhausted = makeMatrixEvent({
       eventId: "$exhausted",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
       decryptionFailure: true,
     });
     (
@@ -4880,14 +4499,7 @@ describe("MatrixClient crypto bootstrapping", () => {
     await bridge.drainPendingDecryptions("test shutdown");
     listeners.get(CryptoEvent.KeyBackupDecryptionKeyCached)?.();
 
-    const late = new FakeMatrixEvent({
-      roomId: "!room:example.org",
-      eventId: "$late",
-      sender: "@alice:example.org",
-      type: "m.room.encrypted",
-      ts: Date.now(),
-      content: {},
-    });
+    const late = makeMatrixEvent({ eventId: "$late" });
     bridge.attachEncryptedEvent(late as unknown as MatrixEvent, "!room:example.org");
     late.emit("decrypted", late);
     await Promise.resolve();

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -131,6 +131,27 @@ function emitAndClose(child: MockChild, stream: "stdout" | "stderr", data: strin
   });
 }
 
+function makeQmdChild(
+  overrides: {
+    stream?: "stdout" | "stderr";
+    data?: string;
+    code?: number;
+  } = {},
+): MockChild {
+  const output = { stream: "stdout" as const, data: "[]", code: 0, ...overrides };
+  const child = createMockChild({ autoClose: false });
+  emitAndClose(child, output.stream, output.data, output.code);
+  return child;
+}
+
+function makeMcporterChild(results: unknown[] = []): MockChild {
+  return makeQmdChild({ data: JSON.stringify({ results }) });
+}
+
+function makeQmdResults(...results: unknown[]): MockChild {
+  return makeQmdChild({ data: JSON.stringify(results) });
+}
+
 async function waitUntil(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
   const startedAt = Date.now();
   while (!predicate()) {
@@ -473,9 +494,7 @@ describe("QmdMemoryManager", () => {
     await configureMemoryCoreDreamingStateForTests();
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "add") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "permission denied", 1);
-        return child;
+        return makeQmdChild({ stream: "stderr", data: "permission denied", code: 1 });
       }
       return createMockChild();
     });
@@ -511,9 +530,7 @@ describe("QmdMemoryManager", () => {
     await configureMemoryCoreDreamingStateForTests();
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query" || args[0] === "search" || args[0] === "vsearch") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -629,14 +646,10 @@ describe("QmdMemoryManager", () => {
     configureQmd({ sessions: { enabled: true } });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--help") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "Usage: qmd search -c one or more collections");
-        return child;
+        return makeQmdChild({ data: "Usage: qmd search -c one or more collections" });
       }
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -669,14 +682,10 @@ describe("QmdMemoryManager", () => {
     configureQmd({ sessions: { enabled: true } });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--help") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "Usage: qmd search -c one or more collections");
-        return child;
+        return makeQmdChild({ data: "Usage: qmd search -c one or more collections" });
       }
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -718,9 +727,7 @@ describe("QmdMemoryManager", () => {
         return child;
       }
       if (args[0] === "--version") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "qmd 1.0.0");
-        return child;
+        return makeQmdChild({ data: "qmd 1.0.0" });
       }
       return createMockChild();
     });
@@ -764,9 +771,7 @@ describe("QmdMemoryManager", () => {
     );
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -799,24 +804,16 @@ describe("QmdMemoryManager", () => {
       args.filter((token) => token === "-c").length > 1;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--version") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "qmd 1.0.0");
-        return child;
+        return makeQmdChild({ data: "qmd 1.0.0" });
       }
       if (args[0] === "--help") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "Usage: qmd search -c one or more collections");
-        return child;
+        return makeQmdChild({ data: "Usage: qmd search -c one or more collections" });
       }
       if (isCombinedSearch(args)) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "unknown flag: -c", 1);
-        return child;
+        return makeQmdChild({ stream: "stderr", data: "unknown flag: -c", code: 1 });
       }
       if (args[0] === "search" || args[0] === "query" || args[0] === "vsearch") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -1021,9 +1018,7 @@ describe("QmdMemoryManager", () => {
       }
       const output = scenario.outputFor?.(cmd, args);
       if (output) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, output.stream, output.data, output.code);
-        return child;
+        return makeQmdChild(output);
       }
       return createMockChild();
     });
@@ -1094,23 +1089,15 @@ describe("QmdMemoryManager", () => {
     await scenario.configure();
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "--help" && scenario.supportsMultiCollection) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          "-c, --collection <name>    Filter by one or more collections",
-        );
-        return child;
+        return makeQmdChild({
+          data: "-c, --collection <name>    Filter by one or more collections",
+        });
       }
       if (args[0] === "search" && scenario.rejectSearchFlags) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "unknown flag: --json", 2);
-        return child;
+        return makeQmdChild({ stream: "stderr", data: "unknown flag: --json", code: 2 });
       }
       if (args[0] === "search" || args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -1303,9 +1290,7 @@ describe("QmdMemoryManager", () => {
         return child;
       }
       if (args[0] === "search" || args[0] === "query" || args[0] === "vsearch") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -1619,9 +1604,7 @@ describe("QmdMemoryManager", () => {
     );
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -1732,15 +1715,11 @@ describe("QmdMemoryManager", () => {
     const wrongSessionsPath = path.join(stateDir, "agents", agentId, "qmd", "sessions");
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
+        return makeQmdChild({
+          data: JSON.stringify([
             { name: sessionCollectionName, path: wrongSessionsPath, mask: "**/*.md" },
           ]),
-        );
-        return child;
+        });
       }
       return createMockChild();
     });
@@ -1782,13 +1761,9 @@ describe("QmdMemoryManager", () => {
     const sessionCollectionName = `sessions-${agentId}`;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([`workspace-${agentId}`, sessionCollectionName]),
-        );
-        return child;
+        return makeQmdChild({
+          data: JSON.stringify([`workspace-${agentId}`, sessionCollectionName]),
+        });
       }
       return createMockChild();
     });
@@ -1809,15 +1784,13 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          ["workspace-main (qmd://workspace-main/)", "  Pattern:  *.txt", "  Files:    17"].join(
-            "\n",
-          ),
-        );
-        return child;
+        return makeQmdChild({
+          data: [
+            "workspace-main (qmd://workspace-main/)",
+            "  Pattern:  *.txt",
+            "  Files:    17",
+          ].join("\n"),
+        });
       }
       return createMockChild();
     });
@@ -1860,19 +1833,15 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify(
+        return makeQmdChild({
+          data: JSON.stringify(
             [...legacyCollections.entries()].map(([name, info]) => ({
               name,
               path: info.path,
               mask: info.pattern,
             })),
           ),
-        );
-        return child;
+        });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -1931,19 +1900,15 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify(
+        return makeQmdChild({
+          data: JSON.stringify(
             [...listedCollections.entries()].map(([name, info]) => ({
               name,
               path: info.path,
               mask: info.pattern,
             })),
           ),
-        );
-        return child;
+        });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -1999,19 +1964,15 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify(
+        return makeQmdChild({
+          data: JSON.stringify(
             [...listedCollections.entries()].map(([name, info]) => ({
               name,
               path: info.path,
               mask: info.pattern,
             })),
           ),
-        );
-        return child;
+        });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -2060,15 +2021,11 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
         // Name-only rows do not expose path/mask metadata.
-        emitAndClose(child, "stdout", JSON.stringify(["workspace-legacy"]));
-        return child;
+        return makeQmdChild({ data: JSON.stringify(["workspace-legacy"]) });
       }
       if (args[0] === "collection" && args[1] === "add") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "collection already exists", 1);
-        return child;
+        return makeQmdChild({ stream: "stderr", data: "collection already exists", code: 1 });
       }
       return createMockChild();
     });
@@ -2088,10 +2045,8 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
         // Older qmd output may expose only names, so path/pattern matching cannot find this.
-        emitAndClose(child, "stdout", JSON.stringify(["workspace-legacy"]));
-        return child;
+        return makeQmdChild({ data: JSON.stringify(["workspace-legacy"]) });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -2151,9 +2106,7 @@ describe("QmdMemoryManager", () => {
     const addAttempts = new Map<string, number>();
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "temporary qmd list failure", 1);
-        return child;
+        return makeQmdChild({ stream: "stderr", data: "temporary qmd list failure", code: 1 });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -2204,11 +2157,8 @@ describe("QmdMemoryManager", () => {
     const added = new Map<string, string>();
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          [
+        return makeQmdChild({
+          data: [
             "Collections (2):",
             "",
             "memory-dir-main (qmd://memory-dir-main/)",
@@ -2218,8 +2168,7 @@ describe("QmdMemoryManager", () => {
             "  Pattern:  **/*.md",
             "",
           ].join("\n"),
-        );
-        return child;
+        });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -2258,9 +2207,7 @@ describe("QmdMemoryManager", () => {
     const addFlagCalls: string[] = [];
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       if (args[0] === "collection" && args[1] === "add") {
         const child = createMockChild({ autoClose: false });
@@ -2289,11 +2236,8 @@ describe("QmdMemoryManager", () => {
     const addCalls: string[] = [];
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          [
+        return makeQmdChild({
+          data: [
             "Collections (2):",
             "",
             "memory-root (qmd://memory-root/)",
@@ -2303,8 +2247,7 @@ describe("QmdMemoryManager", () => {
             "  Pattern:  **/*.md",
             "",
           ].join("\n"),
-        );
-        return child;
+        });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -2336,13 +2279,9 @@ describe("QmdMemoryManager", () => {
     const removeCalls: string[] = [];
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([{ name: "memory-root", path: differentPath, mask: "MEMORY.md" }]),
-        );
-        return child;
+        return makeQmdChild({
+          data: JSON.stringify([{ name: "memory-root", path: differentPath, mask: "MEMORY.md" }]),
+        });
       }
       if (args[0] === "collection" && args[1] === "remove") {
         const child = createMockChild({ autoClose: false });
@@ -2568,9 +2507,11 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "update") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "SQLiteError: UNIQUE constraint failed: documents.docid", 1);
-        return child;
+        return makeQmdChild({
+          stream: "stderr",
+          data: "SQLiteError: UNIQUE constraint failed: documents.docid",
+          code: 1,
+        });
       }
       return createMockChild();
     });
@@ -2597,14 +2538,11 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "update") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stderr",
-          "ENOTDIR: not a directory, open '/tmp/workspace/MEMORY.md'",
-          1,
-        );
-        return child;
+        return makeQmdChild({
+          stream: "stderr",
+          data: "ENOTDIR: not a directory, open '/tmp/workspace/MEMORY.md'",
+          code: 1,
+        });
       }
       return createMockChild();
     });
@@ -2626,9 +2564,7 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -2719,9 +2655,7 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "not json", 134);
-        return child;
+        return makeQmdChild({ data: "not json", code: 134 });
       }
       return createMockChild();
     });
@@ -2769,9 +2703,7 @@ describe("QmdMemoryManager", () => {
     let addCallsAfterMissing = 0;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       if (args[0] === "collection" && args[1] === "add") {
         if (missingCollectionSeen) {
@@ -2793,17 +2725,13 @@ describe("QmdMemoryManager", () => {
           return child;
         }
         if (collection === "memory-root-main") {
-          const child = createMockChild({ autoClose: false });
-          emitAndClose(
-            child,
-            "stdout",
-            JSON.stringify([{ docid: expectedDocId, score: 1, snippet: "@@ -1,1\nremember this" }]),
-          );
-          return child;
+          return makeQmdChild({
+            data: JSON.stringify([
+              { docid: expectedDocId, score: 1, snippet: "@@ -1,1\nremember this" },
+            ]),
+          });
         }
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -2900,9 +2828,7 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -2936,9 +2862,7 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -2959,9 +2883,7 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -2983,9 +2905,7 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "query" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -3006,14 +2926,10 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "search" });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "unknown flag: --json", 2);
-        return child;
+        return makeQmdChild({ stream: "stderr", data: "unknown flag: --json", code: 2 });
       }
       if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -3044,9 +2960,7 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "query", rerank: false });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -3132,14 +3046,10 @@ describe("QmdMemoryManager", () => {
     configureQmd({ searchMode: "search", rerank: false });
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stderr", "unknown flag: --json", 2);
-        return child;
+        return makeQmdChild({ stream: "stderr", data: "unknown flag: --json", code: 2 });
       }
       if (args[0] === "query") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -3363,13 +3273,10 @@ describe("QmdMemoryManager", () => {
     });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -3399,7 +3306,6 @@ describe("QmdMemoryManager", () => {
 
     const commandPhases: string[] = [];
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
         expect(commandPhases).toEqual(["pause"]);
         // Verify it calls qmd.query (v2) not qmd.deep_search (v1)
@@ -3418,11 +3324,9 @@ describe("QmdMemoryManager", () => {
         expect(callArgs).not.toHaveProperty("minScore");
         expect(callArgs).not.toHaveProperty("collection");
         expect(callArgs).not.toHaveProperty("rerank");
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -3444,7 +3348,6 @@ describe("QmdMemoryManager", () => {
     });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
         expect(args[1]).toBe("qmd.query");
         const callArgs = JSON.parse(requireArgAfter(args, "--args"));
@@ -3458,11 +3361,9 @@ describe("QmdMemoryManager", () => {
           collections: ["workspace-main"],
           rerank: false,
         });
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -3478,14 +3379,11 @@ describe("QmdMemoryManager", () => {
 
     let captured: Record<string, unknown> | null = null;
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
         captured = JSON.parse(requireArgAfter(args, "--args"));
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -3508,7 +3406,6 @@ describe("QmdMemoryManager", () => {
     });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
         expect(args[1]).toBe("qmd.query");
         const callArgs = JSON.parse(requireArgAfter(args, "--args"));
@@ -3517,11 +3414,9 @@ describe("QmdMemoryManager", () => {
           { type: "vec", query: "sqlite vec qmd backend health 2026 05 04 multi agent" },
           { type: "hyde", query: "sqlite vec qmd backend health 2026 05 04 multi agent" },
         ]);
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -3538,16 +3433,13 @@ describe("QmdMemoryManager", () => {
     });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
         expect(args[1]).toBe("qmd.query");
         const callArgs = JSON.parse(requireArgAfter(args, "--args"));
         expect(callArgs.searches).toEqual([{ type: "vec", query: "sqlite vec backend health" }]);
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -3564,16 +3456,13 @@ describe("QmdMemoryManager", () => {
     });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
         // mcporter exits 0 but prints non-JSON to stdout (daemon warning, truncated
         // output, or CLI flag mismatch). Without the guard this throws a raw
         // SyntaxError out of runQmdSearchViaMcporter; the guard wraps it.
-        emitAndClose(child, "stdout", "mcporter: daemon warning: connection unstable\n");
-        return child;
+        return makeQmdChild({ data: "mcporter: daemon warning: connection unstable\n" });
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -4210,9 +4099,7 @@ describe("QmdMemoryManager", () => {
             });
             return child;
           }
-          const child = createMockChild({ autoClose: false });
-          emitAndClose(child, "stdout", "[]");
-          return child;
+          return makeQmdChild();
         });
 
         const { manager } = await createManager();
@@ -4242,13 +4129,10 @@ describe("QmdMemoryManager", () => {
     });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -4277,22 +4161,16 @@ describe("QmdMemoryManager", () => {
 
     let daemonAttempts = 0;
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "daemon") {
         daemonAttempts += 1;
-        if (daemonAttempts === 1) {
-          emitAndClose(child, "stderr", "failed", 1);
-        } else {
-          emitAndClose(child, "stdout", "");
-        }
-        return child;
+        return daemonAttempts === 1
+          ? makeQmdChild({ stream: "stderr", data: "failed", code: 1 })
+          : makeQmdChild({ data: "" });
       }
       if (isMcporterCommand(cmd) && args[0] === "call") {
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -4311,17 +4189,13 @@ describe("QmdMemoryManager", () => {
     });
 
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
-      const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "daemon") {
-        emitAndClose(child, "stdout", "");
-        return child;
+        return makeQmdChild({ data: "" });
       }
       if (isMcporterCommand(cmd) && args[0] === "call") {
-        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
-        return child;
+        return makeMcporterChild();
       }
-      emitAndClose(child, "stdout", "[]");
-      return child;
+      return makeQmdChild();
     });
 
     const { manager } = await createManager();
@@ -4355,27 +4229,15 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search" && args.includes("workspace-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([{ docid: "m1", score: 0.6, snippet: "@@ -1,1\nmemory fact" }]),
-        );
-        return child;
+        return makeQmdResults({ docid: "m1", score: 0.6, snippet: "@@ -1,1\nmemory fact" });
       }
       if (args[0] === "search" && args.includes("sessions-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            { docid: "s1", score: 0.99, snippet: "@@ -1,1\nsession top 1" },
-            { docid: "s2", score: 0.95, snippet: "@@ -1,1\nsession top 2" },
-            { docid: "s3", score: 0.91, snippet: "@@ -1,1\nsession top 3" },
-            { docid: "s4", score: 0.88, snippet: "@@ -1,1\nsession top 4" },
-          ]),
+        return makeQmdResults(
+          { docid: "s1", score: 0.99, snippet: "@@ -1,1\nsession top 1" },
+          { docid: "s2", score: 0.95, snippet: "@@ -1,1\nsession top 2" },
+          { docid: "s3", score: 0.91, snippet: "@@ -1,1\nsession top 3" },
+          { docid: "s4", score: 0.88, snippet: "@@ -1,1\nsession top 4" },
         );
-        return child;
       }
       return createMockChild();
     });
@@ -5645,15 +5507,11 @@ describe("QmdMemoryManager", () => {
     const exactDocid = "abc123";
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            { docid: exactDocid, score: 1, snippet: "@@ -5,2\nremember this\nnext line" },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          docid: exactDocid,
+          score: 1,
+          snippet: "@@ -5,2\nremember this\nnext line",
+        });
       }
       return createMockChild();
     });
@@ -5719,20 +5577,14 @@ describe("QmdMemoryManager", () => {
     const duplicateDocid = "dup-123";
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search" && args.includes("workspace-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            { docid: duplicateDocid, score: 0.9, snippet: "@@ -3,1\nworkspace hit" },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          docid: duplicateDocid,
+          score: 0.9,
+          snippet: "@@ -3,1\nworkspace hit",
+        });
       }
       if (args[0] === "search" && args.includes("notes-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "[]");
-        return child;
+        return makeQmdChild();
       }
       return createMockChild();
     });
@@ -5776,19 +5628,11 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              file: "qmd://workspace-main/notes/welcome.md",
-              score: 0.71,
-              snippet: "@@ -4,1\ntoken unlock",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          file: "qmd://workspace-main/notes/welcome.md",
+          score: 0.71,
+          snippet: "@@ -4,1\ntoken unlock",
+        });
       }
       return createMockChild();
     });
@@ -5822,19 +5666,11 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              file: "qmd://sessions-main/session-1.md",
-              score: 0.84,
-              snippet: "@@ -2,1\nsession canary",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          file: "qmd://sessions-main/session-1.md",
+          score: 0.84,
+          snippet: "@@ -2,1\nsession canary",
+        });
       }
       return createMockChild();
     });
@@ -5907,34 +5743,18 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search" && args.includes("workspace-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              file: "qmd://workspace-main/notes.md",
-              score: 0.99,
-              snippet: "@@ -1,1\nmemory hit",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          file: "qmd://workspace-main/notes.md",
+          score: 0.99,
+          snippet: "@@ -1,1\nmemory hit",
+        });
       }
       if (args[0] === "search" && args.includes("sessions-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              file: "qmd://sessions-main/session-1.md",
-              score: 0.8,
-              snippet: "@@ -2,1\nsession hit",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          file: "qmd://sessions-main/session-1.md",
+          score: 0.8,
+          snippet: "@@ -2,1\nsession hit",
+        });
       }
       return createMockChild();
     });
@@ -5978,34 +5798,18 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search" && args.includes("workspace-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              file: "qmd://workspace-main/memory/facts.md",
-              score: 0.8,
-              snippet: "@@ -2,1\nworkspace fact",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          file: "qmd://workspace-main/memory/facts.md",
+          score: 0.8,
+          snippet: "@@ -2,1\nworkspace fact",
+        });
       }
       if (args[0] === "search" && args.includes("notes-main")) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              file: "qmd://notes-main/guide.md",
-              score: 0.7,
-              snippet: "@@ -1,1\nnotes guide",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          file: "qmd://notes-main/guide.md",
+          score: 0.7,
+          snippet: "@@ -1,1\nnotes guide",
+        });
       }
       return createMockChild();
     });
@@ -6042,9 +5846,7 @@ describe("QmdMemoryManager", () => {
     const noisyPayload = "x".repeat(240_000);
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", noisyPayload);
-        return child;
+        return makeQmdChild({ data: noisyPayload });
       }
       return createMockChild();
     });
@@ -6067,9 +5869,7 @@ describe("QmdMemoryManager", () => {
     for (const testCase of cases) {
       spawnMock.mockImplementation((_cmd: string, args: string[]) => {
         if (args[0] === "search") {
-          const child = createMockChild({ autoClose: false });
-          emitAndClose(child, testCase.stream, testCase.payload);
-          return child;
+          return makeQmdChild({ stream: testCase.stream, data: testCase.payload });
         }
         return createMockChild();
       });
@@ -6086,20 +5886,12 @@ describe("QmdMemoryManager", () => {
   it("uses qmd file hints when docid lookup misses", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              docid: "missing-from-openclaw-index",
-              file: "qmd://workspace-main/notes/welcome.md",
-              score: 0.91,
-              snippet: "@@ -3,1\nQMD activation",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          docid: "missing-from-openclaw-index",
+          file: "qmd://workspace-main/notes/welcome.md",
+          score: 0.91,
+          snippet: "@@ -3,1\nQMD activation",
+        });
       }
       return createMockChild();
     });
@@ -6135,20 +5927,12 @@ describe("QmdMemoryManager", () => {
     const searchDocid = "recovered-doc-after-empty-index";
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "search") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          JSON.stringify([
-            {
-              docid: searchDocid,
-              file: "qmd://workspace-main/notes/welcome.md",
-              score: 0.91,
-              snippet: "@@ -3,1\nQMD activation",
-            },
-          ]),
-        );
-        return child;
+        return makeQmdResults({
+          docid: searchDocid,
+          file: "qmd://workspace-main/notes/welcome.md",
+          score: 0.91,
+          snippet: "@@ -3,1\nQMD activation",
+        });
       }
       return createMockChild();
     });
@@ -6306,9 +6090,7 @@ describe("QmdMemoryManager", () => {
   it("reports vector availability as unavailable when qmd status shows zero vectors", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "status") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "Documents: 12\nVectors: 0\n");
-        return child;
+        return makeQmdChild({ data: "Documents: 12\nVectors: 0\n" });
       }
       return createMockChild();
     });
@@ -6340,9 +6122,7 @@ describe("QmdMemoryManager", () => {
   it("reports vector availability as ready when qmd status shows vectors", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "status") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "Documents: 12\nVectors: 42\n");
-        return child;
+        return makeQmdChild({ data: "Documents: 12\nVectors: 42\n" });
       }
       return createMockChild();
     });
@@ -6379,9 +6159,7 @@ describe("QmdMemoryManager", () => {
   ])("reports vector availability as ready for qmd status %s", async (_name, statusOutput) => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "status") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", statusOutput);
-        return child;
+        return makeQmdChild({ data: statusOutput });
       }
       return createMockChild();
     });
@@ -6403,9 +6181,7 @@ describe("QmdMemoryManager", () => {
   it("does not parse unrelated qmd status vector-like fields", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "status") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", "Documents: 12\nMaxVectors: 42\nVector index: yes\n");
-        return child;
+        return makeQmdChild({ data: "Documents: 12\nMaxVectors: 42\nVector index: yes\n" });
       }
       return createMockChild();
     });
@@ -6562,24 +6338,18 @@ describe("QmdMemoryManager", () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
         // Real qmd: names only, no path/pattern in list output.
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", JSON.stringify([collectionName]));
-        return child;
+        return makeQmdResults(collectionName);
       }
       if (args[0] === "collection" && args[1] === "show" && args[2] === collectionName) {
         // Real qmd `collection show` output — exposes the stale (old) path.
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          [
+        return makeQmdChild({
+          data: [
             `Collection: ${collectionName}`,
             `  Path:     ${oldWorkspaceDir}`,
             `  Pattern:  **/*.md`,
             `  Include:  yes (default)`,
           ].join("\n"),
-        );
-        return child;
+        });
       }
       return createMockChild();
     });
@@ -6622,23 +6392,17 @@ describe("QmdMemoryManager", () => {
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", JSON.stringify([collectionName]));
-        return child;
+        return makeQmdResults(collectionName);
       }
       if (args[0] === "collection" && args[1] === "show" && args[2] === collectionName) {
-        const child = createMockChild({ autoClose: false });
-        emitAndClose(
-          child,
-          "stdout",
-          [
+        return makeQmdChild({
+          data: [
             `Collection: ${collectionName}`,
             `  Path:     ${containerRoot}`,
             `  Pattern:  **/*.md`,
             `  Include:  yes (default)`,
           ].join("\n"),
-        );
-        return child;
+        });
       }
       return createMockChild();
     });

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -5911,7 +5911,7 @@ describe("createTelegramBot", () => {
       makeTelegramConfig(
         {
           dmPolicy: "pairing",
-          botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+          botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" } as never,
         },
         { commands: { native: true } },
       ),

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -133,11 +133,18 @@ const PARTY_EMOJI = "\u{1F389}";
 const HEART_EMOJI = "\u{2764}\u{FE0F}";
 type TelegramChannelConfig = NonNullable<NonNullable<OpenClawConfig["channels"]>["telegram"]>;
 
+function makeTelegramConfig(
+  telegram: TelegramChannelConfig,
+  config: Omit<OpenClawConfig, "channels"> = {},
+): OpenClawConfig {
+  return { ...config, channels: { telegram } };
+}
+
 function mockTelegramConfig(
   telegram: TelegramChannelConfig,
   config: Omit<OpenClawConfig, "channels"> = {},
 ) {
-  loadConfig.mockReturnValue({ ...config, channels: { telegram } } satisfies OpenClawConfig);
+  loadConfig.mockReturnValue(makeTelegramConfig(telegram, config));
 }
 
 type TelegramCallbackQueryOverrides = {
@@ -163,6 +170,14 @@ function makeCallbackQuery(overrides: TelegramCallbackQueryOverrides) {
   };
 }
 
+function makeCallbackQueryContext(overrides: TelegramCallbackQueryOverrides) {
+  return {
+    callbackQuery: makeCallbackQuery(overrides),
+    me: { username: "openclaw_bot" },
+    getFile: getEmptyTelegramFile,
+  };
+}
+
 type TelegramReactionPolicyCase = {
   name: string;
   updateId: number;
@@ -179,6 +194,18 @@ type TelegramPollRegistryEntry = Omit<
   Parameters<typeof recordTelegramPollRegistryEntry>[0],
   "accountId" | "env"
 > & { createdAt: number };
+
+function makeTelegramPollRegistryEntry(
+  overrides: Pick<TelegramPollRegistryEntry, "messageId" | "pollId"> &
+    Partial<Omit<TelegramPollRegistryEntry, "createdAt" | "messageId" | "pollId">>,
+): Omit<TelegramPollRegistryEntry, "createdAt"> {
+  return {
+    chat: { id: 9876, type: "private", first_name: "Ada" },
+    question: "Ready?",
+    options: ["Yes", "No"],
+    ...overrides,
+  };
+}
 
 async function withTelegramSpooledReplayUpdate<T>(
   update: object,
@@ -269,6 +296,109 @@ function createReplyPhotoMessage(text: string) {
       photo: [{ file_id: "reply-photo-1" }],
       from: { first_name: "Ada" },
     },
+  };
+}
+
+function makeExecApprovalTelegramConfig(
+  overrides: TelegramChannelConfig = {},
+): TelegramChannelConfig {
+  return {
+    dmPolicy: "open",
+    allowFrom: ["*"],
+    execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
+    ...overrides,
+  };
+}
+
+function makeDirectTelegramConfig(
+  storePath: string,
+  telegramOverrides: TelegramChannelConfig = {},
+): OpenClawConfig {
+  return {
+    channels: {
+      telegram: {
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        ...telegramOverrides,
+      },
+    },
+    session: { store: storePath },
+  };
+}
+
+function makeModelPickerConfig(
+  storePath: string,
+  overrides: {
+    config?: Omit<OpenClawConfig, "agents" | "channels" | "session">;
+    defaultModel?: string;
+    models?: Record<string, Record<string, never>>;
+    omitModels?: boolean;
+    telegram?: TelegramChannelConfig;
+  } = {},
+): OpenClawConfig {
+  return {
+    ...overrides.config,
+    agents: {
+      defaults: {
+        model: overrides.defaultModel ?? "anthropic/claude-opus-4-6",
+        ...(overrides.omitModels
+          ? {}
+          : {
+              models: overrides.models ?? {
+                "anthropic/claude-opus-4-6": {},
+                "openai/gpt-5.4": {},
+              },
+            }),
+      },
+    },
+    channels: {
+      telegram: overrides.telegram ?? { dmPolicy: "open", allowFrom: ["*"] },
+    },
+    session: { store: storePath },
+  };
+}
+
+type DirectTelegramMessageOverrides = Record<string, unknown> & {
+  chat?: Record<string, unknown>;
+  from?: Record<string, unknown>;
+};
+
+function makeDirectTelegramMessageContext(params: {
+  chatId: number;
+  messageId: number;
+  omitText?: boolean;
+  senderId?: number;
+  message?: DirectTelegramMessageOverrides;
+  context?: Record<string, unknown>;
+}) {
+  const { chat: chatOverrides, from: fromOverrides, ...messageOverrides } = params.message ?? {};
+  const chat = { id: params.chatId, type: "private", ...chatOverrides };
+  const from = {
+    id: params.senderId ?? 202,
+    is_bot: false,
+    first_name: "Kesava",
+    ...fromOverrides,
+  };
+  return {
+    me: { id: 999, username: "openclaw_bot" },
+    getFile: getEmptyTelegramFile,
+    ...params.context,
+    message: {
+      chat,
+      ...(params.omitText ? {} : { text: "continue" }),
+      date: 1_778_474_850,
+      message_id: params.messageId,
+      from,
+      ...messageOverrides,
+    },
+  };
+}
+
+function makeTelegramTransport(fetch: typeof globalThis.fetch) {
+  return {
+    fetch,
+    sourceFetch: fetch,
+    close: async () => {},
   };
 }
 
@@ -797,34 +927,33 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     getChatSpy.mockResolvedValue({ status: "member" });
-    await installTelegramPollRegistryForTests({
-      pollId: "poll-topic-agent",
-      chat: {
-        id: -1001234567890,
-        type: "supergroup",
-        title: "Reviewers",
-        is_forum: true,
-      },
-      messageId: 321,
-      messageThreadId: 99,
-      question: "Escalate?",
-      options: ["Yes", "No"],
-    });
+    await installTelegramPollRegistryForTests(
+      makeTelegramPollRegistryEntry({
+        pollId: "poll-topic-agent",
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Reviewers",
+          is_forum: true,
+        },
+        messageId: 321,
+        messageThreadId: 99,
+        question: "Escalate?",
+      }),
+    );
 
     try {
-      loadConfig.mockReturnValue({
-        channels: {
-          telegram: {
-            groupPolicy: "open",
-            groups: {
-              "-1001234567890": {
-                requireMention: false,
-                topics: { "99": { agentId: "forum-agent", requireMention: false } },
-              },
+      loadConfig.mockReturnValue(
+        makeTelegramConfig({
+          groupPolicy: "open",
+          groups: {
+            "-1001234567890": {
+              requireMention: false,
+              topics: { "99": { agentId: "forum-agent", requireMention: false } },
             },
           },
-        },
-      });
+        }),
+      );
       createTelegramBot({ token: "tok" });
 
       await getTelegramPollAnswerHandlerForTests()({
@@ -856,26 +985,25 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     getChatSpy.mockResolvedValueOnce({ status: "left" });
-    await installTelegramPollRegistryForTests({
-      pollId: "poll-forwarded-group",
-      chat: {
-        id: -1001234567890,
-        type: "supergroup",
-        title: "Reviewers",
-        is_forum: true,
-      },
-      messageId: 324,
-      messageThreadId: 99,
-      question: "Escalate?",
-      options: ["Yes", "No"],
-    });
+    await installTelegramPollRegistryForTests(
+      makeTelegramPollRegistryEntry({
+        pollId: "poll-forwarded-group",
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Reviewers",
+          is_forum: true,
+        },
+        messageId: 324,
+        messageThreadId: 99,
+        question: "Escalate?",
+      }),
+    );
 
     try {
-      loadConfig.mockReturnValue({
-        channels: {
-          telegram: { groupPolicy: "allowlist", groupAllowFrom: ["10"] },
-        },
-      });
+      loadConfig.mockReturnValue(
+        makeTelegramConfig({ groupPolicy: "allowlist", groupAllowFrom: ["10"] }),
+      );
       createTelegramBot({ token: "tok" });
 
       await getTelegramPollAnswerHandlerForTests()({
@@ -898,18 +1026,12 @@ describe("createTelegramBot", () => {
   it("blocks forwarded direct-message poll answers from another user", async () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
-    await installTelegramPollRegistryForTests({
-      pollId: "poll-forwarded-dm",
-      chat: { id: 9876, type: "private", first_name: "Ada" },
-      messageId: 325,
-      question: "Ready?",
-      options: ["Yes", "No"],
-    });
+    await installTelegramPollRegistryForTests(
+      makeTelegramPollRegistryEntry({ pollId: "poll-forwarded-dm", messageId: 325 }),
+    );
 
     try {
-      loadConfig.mockReturnValue({
-        channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      });
+      loadConfig.mockReturnValue(makeTelegramConfig({ dmPolicy: "open", allowFrom: ["*"] }));
       createTelegramBot({ token: "tok" });
 
       await getTelegramPollAnswerHandlerForTests()({
@@ -932,24 +1054,18 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     getChatSpy.mockClear();
-    await installTelegramPollRegistryForTests({
-      pollId: "poll-dm-topic",
-      chat: { id: 9876, type: "private", first_name: "Ada" },
-      messageId: 322,
-      question: "Ready?",
-      options: ["Yes", "No"],
-    });
+    await installTelegramPollRegistryForTests(
+      makeTelegramPollRegistryEntry({ pollId: "poll-dm-topic", messageId: 322 }),
+    );
 
     try {
-      loadConfig.mockReturnValue({
-        channels: {
-          telegram: {
-            dmPolicy: "allowlist",
-            allowFrom: ["9876"],
-            direct: { "9876": { requireTopic: true } },
-          },
-        },
-      });
+      loadConfig.mockReturnValue(
+        makeTelegramConfig({
+          dmPolicy: "allowlist",
+          allowFrom: ["9876"],
+          direct: { "9876": { requireTopic: true } },
+        }),
+      );
       createTelegramBot({ token: "tok" });
 
       await getTelegramPollAnswerHandlerForTests()({
@@ -971,14 +1087,13 @@ describe("createTelegramBot", () => {
   it("routes poll answers to the recorded direct-message topic session", async () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
-    await installTelegramPollRegistryForTests({
-      pollId: "poll-dm-topic",
-      chat: { id: 9876, type: "private", first_name: "Ada" },
-      messageId: 323,
-      messageThreadId: 42,
-      question: "Ready?",
-      options: ["Yes", "No"],
-    });
+    await installTelegramPollRegistryForTests(
+      makeTelegramPollRegistryEntry({
+        pollId: "poll-dm-topic",
+        messageId: 323,
+        messageThreadId: 42,
+      }),
+    );
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1007,13 +1122,9 @@ describe("createTelegramBot", () => {
   it("preserves durable replay for synthetic poll-answer turns", async () => {
     onSpy.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
-    await installTelegramPollRegistryForTests({
-      pollId: "poll-durable-replay",
-      chat: { id: 9876, type: "private", first_name: "Ada" },
-      messageId: 326,
-      question: "Ready?",
-      options: ["Yes", "No"],
-    });
+    await installTelegramPollRegistryForTests(
+      makeTelegramPollRegistryEntry({ pollId: "poll-durable-replay", messageId: 326 }),
+    );
 
     try {
       createTelegramBot({ token: "tok" });
@@ -1067,13 +1178,11 @@ describe("createTelegramBot", () => {
 
   it("retires a closed poll route after the durable replay grace", async () => {
     onSpy.mockClear();
-    const entry: Omit<TelegramPollRegistryEntry, "createdAt"> = {
+    const entry = makeTelegramPollRegistryEntry({
       pollId: "poll-closed",
       chat: { id: 123, type: "private", first_name: "Ada" },
       messageId: 44,
-      question: "Ready?",
-      options: ["Yes", "No"],
-    };
+    });
     const register = vi.fn(async () => {});
     setTelegramPollRegistryRuntimeForTests({
       lookup: async () => entry,
@@ -1331,16 +1440,7 @@ describe("createTelegramBot", () => {
     "$caseName",
     async ({ replyFrom, expectedSender, omitMe, senderBusinessBot, chatId, replyMessageId }) => {
       const storePath = createTelegramTestStorePath(`self-projection-${chatId}`);
-      const cfg = {
-        channels: {
-          telegram: {
-            name: "  Configured Agent  ",
-            dmPolicy: "open",
-            allowFrom: ["*"],
-          },
-        },
-        session: { store: storePath },
-      } satisfies OpenClawConfig;
+      const cfg = makeDirectTelegramConfig(storePath, { name: "  Configured Agent  " });
       loadConfig.mockReturnValue(cfg);
       createTelegramBot({
         token: "tok",
@@ -1476,27 +1576,9 @@ describe("createTelegramBot", () => {
 
   it("blocks DM model-selection callbacks for unpaired users when inline buttons are DM-scoped", async () => {
     const storePath = createTelegramTestStorePath("callback-authz");
-
-    const config = {
-      agents: {
-        defaults: {
-          model: "anthropic/claude-opus-4-6",
-          models: {
-            "anthropic/claude-opus-4-6": {},
-            "openai/gpt-5.4": {},
-          },
-        },
-      },
-      channels: {
-        telegram: {
-          dmPolicy: "pairing",
-          capabilities: { inlineButtons: "dm" },
-        },
-      },
-      session: {
-        store: storePath,
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeModelPickerConfig(storePath, {
+      telegram: { dmPolicy: "pairing", capabilities: { inlineButtons: "dm" } },
+    });
 
     loadConfig.mockReturnValue(config);
     readChannelAllowFromStore.mockResolvedValueOnce([]);
@@ -1524,34 +1606,15 @@ describe("createTelegramBot", () => {
 
   it("blocks group model-selection callbacks for senders who are not authorized for /models", async () => {
     const storePath = createTelegramTestStorePath("group-model-authz");
-
-    const config = {
-      agents: {
-        defaults: {
-          model: "anthropic/claude-opus-4-6",
-          models: {
-            "anthropic/claude-opus-4-6": {},
-            "openai/gpt-5.4": {},
-          },
-        },
+    const config = makeModelPickerConfig(storePath, {
+      config: { commands: { allowFrom: { telegram: ["9"] } } },
+      telegram: {
+        dmPolicy: "open",
+        capabilities: { inlineButtons: "group" },
+        groupPolicy: "open",
+        groups: { "*": { requireMention: false } },
       },
-      commands: {
-        allowFrom: {
-          telegram: ["9"],
-        },
-      },
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          capabilities: { inlineButtons: "group" },
-          groupPolicy: "open",
-          groups: { "*": { requireMention: false } },
-        },
-      },
-      session: {
-        store: storePath,
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    });
 
     loadConfig.mockReturnValue(config);
     createTelegramBot({
@@ -1582,33 +1645,15 @@ describe("createTelegramBot", () => {
     const storePath = createTelegramTestStorePath("group-model-authz-runtime");
 
     try {
-      let currentConfig = {
-        agents: {
-          defaults: {
-            model: "anthropic/claude-opus-4-6",
-            models: {
-              "anthropic/claude-opus-4-6": {},
-              "openai/gpt-5.4": {},
-            },
-          },
+      let currentConfig = makeModelPickerConfig(storePath, {
+        config: { commands: { allowFrom: { telegram: ["999"] } } },
+        telegram: {
+          dmPolicy: "open",
+          capabilities: { inlineButtons: "group" },
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
         },
-        commands: {
-          allowFrom: {
-            telegram: ["999"],
-          },
-        },
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            capabilities: { inlineButtons: "group" },
-            groupPolicy: "open",
-            groups: { "*": { requireMention: false } },
-          },
-        },
-        session: {
-          store: storePath,
-        },
-      } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+      });
 
       loadConfig.mockImplementation(() => currentConfig);
       createTelegramBot({
@@ -1654,17 +1699,13 @@ describe("createTelegramBot", () => {
   it("allows callback_query in groups when group policy authorizes the sender", async () => {
     createTelegramBot({
       token: "tok",
-      config: {
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            capabilities: { inlineButtons: "allowlist" },
-            allowFrom: [],
-            groupPolicy: "open",
-            groups: { "*": { requireMention: false } },
-          },
-        },
-      },
+      config: makeTelegramConfig({
+        dmPolicy: "open",
+        capabilities: { inlineButtons: "allowlist" },
+        allowFrom: [],
+        groupPolicy: "open",
+        groups: { "*": { requireMention: false } },
+      }),
     });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
@@ -1686,17 +1727,13 @@ describe("createTelegramBot", () => {
   });
 
   it("keeps group question callbacks on the configured callback allowlist", async () => {
-    const config = {
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["9"],
-          capabilities: { inlineButtons: "all" },
-          groupPolicy: "open",
-          groups: { "*": { requireMention: false, allowFrom: ["9"] } },
-        },
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeTelegramConfig({
+      dmPolicy: "open",
+      allowFrom: ["9"],
+      capabilities: { inlineButtons: "all" },
+      groupPolicy: "open",
+      groups: { "*": { requireMention: false, allowFrom: ["9"] } },
+    });
     loadConfig.mockReturnValue(config);
     createTelegramBot({ token: "tok", config });
     const callbackHandler = getTelegramCallbackHandlerForTests();
@@ -1718,11 +1755,7 @@ describe("createTelegramBot", () => {
   });
 
   it("replaces legacy approval controls with a visible terminal receipt", async () => {
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
@@ -1778,13 +1811,9 @@ describe("createTelegramBot", () => {
   });
 
   it("allows approval callbacks when exec approvals are enabled even without generic inlineButtons capability", async () => {
-    mockTelegramConfig({
-      botToken: "tok",
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      capabilities: ["vision"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(
+      makeExecApprovalTelegramConfig({ botToken: "tok", capabilities: ["vision"] }),
+    );
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
@@ -1822,11 +1851,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
     const callbackData = buildTelegramApprovalCallbackData({
@@ -1892,11 +1917,7 @@ describe("createTelegramBot", () => {
       },
     });
 
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
     const callbackData = buildTelegramApprovalCallbackData({
       type: "approval",
@@ -1908,8 +1929,8 @@ describe("createTelegramBot", () => {
       throw new Error("Expected typed approval callback data");
     }
 
-    await getTelegramCallbackHandlerForTests()({
-      callbackQuery: makeCallbackQuery({
+    await getTelegramCallbackHandlerForTests()(
+      makeCallbackQueryContext({
         id: "cbq-terminal-edit-fallback",
         data: callbackData,
         message: {
@@ -1917,9 +1938,7 @@ describe("createTelegramBot", () => {
           text: "Approval required.",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     const terminalText = [
       "✅ Approval resolved here",
@@ -1947,15 +1966,11 @@ describe("createTelegramBot", () => {
       handler: pluginHandler as never,
     });
 
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
 
-    await getTelegramCallbackHandlerForTests()({
-      callbackQuery: makeCallbackQuery({
+    await getTelegramCallbackHandlerForTests()(
+      makeCallbackQueryContext({
         id: "cbq-malformed-reserved-approval",
         data: "tga1:e:x:req-1",
         message: {
@@ -1963,9 +1978,7 @@ describe("createTelegramBot", () => {
           text: "Approval required.",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(editMessageTextSpy).toHaveBeenCalledWith(
       1234,
@@ -2055,15 +2068,11 @@ describe("createTelegramBot", () => {
         resolveExecApprovalSpy.mockRejectedValueOnce(secondResolution.value);
       }
 
-      mockTelegramConfig({
-        dmPolicy: "open",
-        allowFrom: ["*"],
-        execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-      });
+      mockTelegramConfig(makeExecApprovalTelegramConfig());
       createTelegramBot({ token: "tok" });
 
-      await getTelegramCallbackHandlerForTests()({
-        callbackQuery: makeCallbackQuery({
+      await getTelegramCallbackHandlerForTests()(
+        makeCallbackQueryContext({
           id: callbackId,
           data: callbackData,
           message: {
@@ -2071,9 +2080,7 @@ describe("createTelegramBot", () => {
             text: "Approval required.",
           },
         }),
-        me: { username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-      });
+      );
 
       expect(resolveExecApprovalSpy).toHaveBeenCalledTimes(2);
       expect(editMessageTextSpy).toHaveBeenCalledWith(
@@ -2096,16 +2103,12 @@ describe("createTelegramBot", () => {
       .mockRejectedValueOnce(alreadyResolved)
       .mockRejectedValueOnce(new Error("gateway unavailable"));
 
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
 
     await expect(
-      getTelegramCallbackHandlerForTests()({
-        callbackQuery: makeCallbackQuery({
+      getTelegramCallbackHandlerForTests()(
+        makeCallbackQueryContext({
           id: "cbq-stale-legacy-retry",
           data: "/approve stale-retry-id deny",
           message: {
@@ -2113,9 +2116,7 @@ describe("createTelegramBot", () => {
             text: "Approval required.",
           },
         }),
-        me: { username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-      }),
+      ),
     ).rejects.toThrow("gateway unavailable");
 
     expect(resolveExecApprovalSpy).toHaveBeenCalledTimes(2);
@@ -2127,11 +2128,7 @@ describe("createTelegramBot", () => {
   it("resolves legacy opaque plugin ids without inferring kind from id spelling", async () => {
     resolveExecApprovalSpy.mockRejectedValueOnce(new Error("unknown or expired approval id"));
 
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
@@ -2173,11 +2170,7 @@ describe("createTelegramBot", () => {
   });
 
   it("terminalizes unowned opaque approval-shaped plugin callbacks", async () => {
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
@@ -2227,11 +2220,7 @@ describe("createTelegramBot", () => {
   it("keeps approval callback resolution failures out of Telegram chat before retry", async () => {
     resolveExecApprovalSpy.mockRejectedValueOnce(new Error("gateway secret detail"));
 
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
@@ -2340,11 +2329,7 @@ describe("createTelegramBot", () => {
       .mockRejectedValueOnce(new Error("unknown or expired approval id"))
       .mockRejectedValueOnce(new Error("unknown or expired approval id"));
 
-    mockTelegramConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-      execApprovals: { enabled: true, approvers: ["9"], target: "dm" },
-    });
+    mockTelegramConfig(makeExecApprovalTelegramConfig());
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
@@ -2393,8 +2378,8 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = getTelegramCallbackHandlerForTests();
 
-    await callbackHandler({
-      callbackQuery: makeCallbackQuery({
+    await callbackHandler(
+      makeCallbackQueryContext({
         id: "cbq-plugin-approve-blocked",
         data: "/approve plugin:138e9b8c allow-once",
         message: {
@@ -2402,9 +2387,7 @@ describe("createTelegramBot", () => {
           text: "Plugin approval required.",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(execApprovalCall()).toMatchObject({
       approvalId: "plugin:138e9b8c",
@@ -2493,15 +2476,11 @@ describe("createTelegramBot", () => {
   });
 
   it("blocks pagination callbacks when allowlist rejects sender", async () => {
-    const config = {
-      channels: {
-        telegram: {
-          dmPolicy: "pairing" as const,
-          capabilities: { inlineButtons: "allowlist" as const },
-          allowFrom: [],
-        },
-      },
-    };
+    const config = makeTelegramConfig({
+      dmPolicy: "pairing",
+      capabilities: { inlineButtons: "allowlist" },
+      allowFrom: [],
+    });
     loadConfig.mockReturnValue(config);
     createTelegramBot({
       token: "tok",
@@ -2545,23 +2524,10 @@ describe("createTelegramBot", () => {
     "$name",
     async ({ callbackId, callbackData, configuredModels, defaultModel, messageId, storeLabel }) => {
       const storePath = createTelegramTestStorePath(storeLabel);
-      const config: OpenClawConfig = {
-        agents: {
-          defaults: {
-            model: defaultModel,
-            ...(configuredModels ? { models: configuredModels } : {}),
-          },
-        },
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            allowFrom: ["*"],
-          },
-        },
-        session: {
-          store: storePath,
-        },
-      } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+      const config = makeModelPickerConfig(storePath, {
+        defaultModel,
+        ...(configuredModels ? { models: configuredModels } : { omitModels: true }),
+      });
 
       loadConfig.mockReturnValue(config);
       createTelegramBot({ token: "tok", config });
@@ -2592,19 +2558,7 @@ describe("createTelegramBot", () => {
 
   it("reports when selecting the default clears an incompatible runtime", async () => {
     const storePath = createTelegramTestStorePath("model-default-runtime");
-    const config = {
-      agents: {
-        defaults: {
-          model: "anthropic/claude-opus-4-6",
-          models: {
-            "anthropic/claude-opus-4-6": {},
-            "openai/gpt-5.4": {},
-          },
-        },
-      },
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies OpenClawConfig;
+    const config = makeModelPickerConfig(storePath);
     const route = resolveTelegramConversationRoute({
       cfg: config,
       accountId: "default",
@@ -2700,24 +2654,18 @@ describe("createTelegramBot", () => {
         editMessageTextSpy.mockClear();
 
         const storePath = createTelegramTestStorePath(`model-auth-${caseId}`);
-        const config = {
-          auth: {
-            profiles: { "team:prod": { provider: "openai", mode: "api_key" } },
+        const config = makeModelPickerConfig(storePath, {
+          config: {
+            auth: { profiles: { "team:prod": { provider: "openai", mode: "api_key" } } },
           },
-          agents: {
-            defaults: {
-              model: `${defaultProvider}/${defaultModel}`,
-              models: {
-                "openai/gpt-4o": {},
-                "openai/gpt-4.1": {},
-                "openai/gpt-5": {},
-                "anthropic/claude-sonnet-4-5": {},
-              },
-            },
+          defaultModel: `${defaultProvider}/${defaultModel}`,
+          models: {
+            "openai/gpt-4o": {},
+            "openai/gpt-4.1": {},
+            "openai/gpt-5": {},
+            "anthropic/claude-sonnet-4-5": {},
           },
-          channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-          session: { store: storePath },
-        } satisfies OpenClawConfig;
+        });
         const route = resolveTelegramConversationRoute({
           cfg: config,
           accountId: "default",
@@ -2795,22 +2743,10 @@ describe("createTelegramBot", () => {
       ]),
     });
 
-    const config = {
-      agents: {
-        defaults: {
-          model: "openai/gpt-5",
-        },
-      },
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-        },
-      },
-      session: {
-        store: storePath,
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeModelPickerConfig(storePath, {
+      defaultModel: "openai/gpt-5",
+      omitModels: true,
+    });
 
     loadConfig.mockReturnValue(config);
     createTelegramBot({
@@ -2848,27 +2784,7 @@ describe("createTelegramBot", () => {
 
   it("formats non-default model selection confirmations with Telegram HTML parse mode", async () => {
     const storePath = createTelegramTestStorePath("model-html");
-
-    const config = {
-      agents: {
-        defaults: {
-          model: "anthropic/claude-opus-4-6",
-          models: {
-            "anthropic/claude-opus-4-6": {},
-            "openai/gpt-5.4": {},
-          },
-        },
-      },
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-        },
-      },
-      session: {
-        store: storePath,
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeModelPickerConfig(storePath);
 
     loadConfig.mockReturnValue(config);
     createTelegramBot({
@@ -3521,37 +3437,23 @@ describe("createTelegramBot", () => {
 
   it("keeps direct Telegram media context when transcript context exists", async () => {
     const storePath = createTelegramTestStorePath("dm-media-context");
-    const config = {
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-        },
-      },
-      session: {
-        store: storePath,
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
 
     loadConfig.mockReturnValue(config);
     createTelegramBot({ token: "tok", config });
     const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-    const baseCtx = {
-      me: { id: 999, username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    };
-
-    await handler({
-      ...baseCtx,
-      message: {
-        chat: { id: 7771, type: "private" },
-        caption: "the reference image",
-        date: 1778474800,
-        message_id: 100,
-        from: { id: 202, is_bot: false, first_name: "Kesava" },
-        photo: [{ file_id: "reference-photo-1", width: 1, height: 1 }],
-      },
-    });
+    await handler(
+      makeDirectTelegramMessageContext({
+        chatId: 7771,
+        messageId: 100,
+        omitText: true,
+        message: {
+          caption: "the reference image",
+          date: 1778474800,
+          photo: [{ file_id: "reference-photo-1", width: 1, height: 1 }],
+        },
+      }),
+    );
 
     await writeDirectTelegramTranscriptContext({
       cfg: config,
@@ -3564,16 +3466,13 @@ describe("createTelegramBot", () => {
     });
 
     replySpy.mockClear();
-    await handler({
-      ...baseCtx,
-      message: {
-        chat: { id: 7771, type: "private" },
-        text: "what about the image above?",
-        date: 1778474850,
-        message_id: 101,
-        from: { id: 202, is_bot: false, first_name: "Kesava" },
-      },
-    });
+    await handler(
+      makeDirectTelegramMessageContext({
+        chatId: 7771,
+        messageId: 101,
+        message: { text: "what about the image above?", date: 1778474850 },
+      }),
+    );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
@@ -3594,10 +3493,7 @@ describe("createTelegramBot", () => {
 
   it("dedupes an unversioned outbound row by its explicit legacy prompt timestamp", async () => {
     const storePath = createTelegramTestStorePath("dm-legacy-dedupe");
-    const config = {
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
     const chatId = 7772;
     const senderId = 202;
     const transcriptTimestampMs = 1_778_474_700_000;
@@ -3630,17 +3526,7 @@ describe("createTelegramBot", () => {
       createTelegramBot({ token: "tok", config });
 
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-      await handler({
-        me: { id: 999, username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "continue",
-          date: 1_778_474_850,
-          message_id: 740,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-        },
-      });
+      await handler(makeDirectTelegramMessageContext({ chatId, messageId: 740, senderId }));
 
       const messages = latestConversationContextMessages();
       expect(messages.filter((message) => message.body === "Legacy answer")).toEqual([
@@ -3657,10 +3543,7 @@ describe("createTelegramBot", () => {
 
   it("does not infer projection provenance from a current markerless outbound row", async () => {
     const storePath = createTelegramTestStorePath("dm-markerless-assistant");
-    const config = {
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
     const chatId = 7771;
     const senderId = 202;
     const transcriptTimestampMs = 1_778_474_700_000;
@@ -3691,17 +3574,7 @@ describe("createTelegramBot", () => {
       createTelegramBot({ token: "tok", config });
 
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-      await handler({
-        me: { id: 999, username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "continue",
-          date: 1_778_474_850,
-          message_id: 739,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-        },
-      });
+      await handler(makeDirectTelegramMessageContext({ chatId, messageId: 739, senderId }));
 
       const messages = latestConversationContextMessages();
       expect(
@@ -3717,17 +3590,7 @@ describe("createTelegramBot", () => {
 
   it("dedupes a Markdown assistant transcript against its complete Telegram projection", async () => {
     const storePath = createTelegramTestStorePath("dm-visible-dedupe");
-    const config = {
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-        },
-      },
-      session: {
-        store: storePath,
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
 
     try {
       loadConfig.mockReturnValue(config);
@@ -3765,27 +3628,26 @@ describe("createTelegramBot", () => {
       });
       createTelegramBot({ token: "tok", config });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-      const baseCtx = {
-        me: { id: 999, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-      };
-      await handler({
-        ...baseCtx,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "still there?",
-          date: 1_778_474_850,
-          message_id: 741,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-          reply_to_message: {
-            chat: { id: chatId, type: "private" },
-            date: telegramReplyDate,
-            from: { id: 999, is_bot: true, first_name: "OpenClaw" },
-            message_id: 736,
-            text: visibleReply,
+      await handler(
+        makeDirectTelegramMessageContext({
+          chatId,
+          messageId: 741,
+          senderId,
+          context: {
+            me: { id: 999, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
           },
-        },
-      });
+          message: {
+            text: "still there?",
+            reply_to_message: {
+              chat: { id: chatId, type: "private" },
+              date: telegramReplyDate,
+              from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+              message_id: 736,
+              text: visibleReply,
+            },
+          },
+        }),
+      );
 
       expect(replySpy).toHaveBeenCalledTimes(1);
       const payload = mockMsgContextArg(
@@ -3846,10 +3708,7 @@ describe("createTelegramBot", () => {
     const storePath = createTelegramTestStorePath(
       `dm-incomplete-projection-${parts[0]?.messageId}`,
     );
-    const config = {
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
     const caseId = parts[0]?.messageId ?? 0;
     const chatId = 10_000 + caseId;
     const senderId = 202;
@@ -3885,17 +3744,9 @@ describe("createTelegramBot", () => {
 
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       replySpy.mockClear();
-      await handler({
-        me: { id: 999, username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "continue",
-          date: 1_778_474_850,
-          message_id: caseId + 100,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-        },
-      });
+      await handler(
+        makeDirectTelegramMessageContext({ chatId, messageId: caseId + 100, senderId }),
+      );
 
       expect(replySpy).toHaveBeenCalledTimes(1);
       const messages = latestConversationContextMessages();
@@ -3918,10 +3769,7 @@ describe("createTelegramBot", () => {
 
   it("preserves cached multipart provenance on a markerless Telegram reply target", async () => {
     const storePath = createTelegramTestStorePath("dm-complete-multipart");
-    const config = {
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
     const chatId = 7783;
     const senderId = 202;
     const transcriptTimestampMs = 1_778_474_700_000;
@@ -3965,24 +3813,22 @@ describe("createTelegramBot", () => {
 
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       replySpy.mockClear();
-      await handler({
-        me: { id: 999, username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "continue",
-          date: 1_778_474_850,
-          message_id: 783,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-          reply_to_message: {
-            chat: { id: chatId, type: "private" },
-            date: transcriptTimestampMs / 1000 + 1,
-            from: { id: 999, is_bot: true, first_name: "OpenClaw" },
-            message_id: 781,
-            text: "Alpha",
+      await handler(
+        makeDirectTelegramMessageContext({
+          chatId,
+          messageId: 783,
+          senderId,
+          message: {
+            reply_to_message: {
+              chat: { id: chatId, type: "private" },
+              date: transcriptTimestampMs / 1000 + 1,
+              from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+              message_id: 781,
+              text: "Alpha",
+            },
           },
-        },
-      });
+        }),
+      );
 
       const messages = latestConversationContextMessages();
       expect(messages).toEqual(
@@ -4004,10 +3850,7 @@ describe("createTelegramBot", () => {
 
   it("keeps an assistant transcript when persisted projection metadata is invalid", async () => {
     const storePath = createTelegramTestStorePath("dm-invalid-projection");
-    const config = {
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
     const chatId = 7784;
     const senderId = 202;
     const transcriptTimestampMs = 1_778_474_700_000;
@@ -4054,17 +3897,7 @@ describe("createTelegramBot", () => {
 
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       replySpy.mockClear();
-      await handler({
-        me: { id: 999, username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "continue",
-          date: 1_778_474_850,
-          message_id: 792,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-        },
-      });
+      await handler(makeDirectTelegramMessageContext({ chatId, messageId: 792, senderId }));
 
       const messages = latestConversationContextMessages();
       expect(messages).toEqual(
@@ -4085,10 +3918,7 @@ describe("createTelegramBot", () => {
 
   it("keeps identical visible replies correlated to distinct transcript identities", async () => {
     const storePath = createTelegramTestStorePath("dm-repeat-projection");
-    const config = {
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
     const chatId = 7781;
     const senderId = 202;
     const transcriptTimestampMs = 1_778_474_700_000;
@@ -4146,17 +3976,7 @@ describe("createTelegramBot", () => {
 
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       replySpy.mockClear();
-      await handler({
-        me: { id: 999, username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "continue",
-          date: 1_778_474_850,
-          message_id: 763,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-        },
-      });
+      await handler(makeDirectTelegramMessageContext({ chatId, messageId: 763, senderId }));
 
       const messages = latestConversationContextMessages();
       expect(
@@ -4175,10 +3995,7 @@ describe("createTelegramBot", () => {
 
   it("does not collapse literal user Markdown into markerless plain cache text", async () => {
     const storePath = createTelegramTestStorePath("dm-user-markdown");
-    const config = {
-      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
-      session: { store: storePath },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
     const chatId = 7782;
     const senderId = 202;
     const timestampMs = 1_778_474_700_000;
@@ -4209,17 +4026,7 @@ describe("createTelegramBot", () => {
 
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       replySpy.mockClear();
-      await handler({
-        me: { id: 999, username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-        message: {
-          chat: { id: chatId, type: "private" },
-          text: "continue",
-          date: 1_778_474_850,
-          message_id: 772,
-          from: { id: senderId, is_bot: false, first_name: "Kesava" },
-        },
-      });
+      await handler(makeDirectTelegramMessageContext({ chatId, messageId: 772, senderId }));
 
       const messages = latestConversationContextMessages();
       expect(messages).toEqual(
@@ -4239,17 +4046,7 @@ describe("createTelegramBot", () => {
 
   it("skips direct transcript context for hard reset messages", async () => {
     const storePath = createTelegramTestStorePath("dm-reset-context");
-    const config = {
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          allowFrom: ["*"],
-        },
-      },
-      session: {
-        store: storePath,
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    const config = makeDirectTelegramConfig(storePath);
 
     loadConfig.mockReturnValue(config);
     createTelegramBot({ token: "tok", config });
@@ -4264,17 +4061,13 @@ describe("createTelegramBot", () => {
     });
 
     const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-    await handler({
-      me: { id: 999, username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-      message: {
-        chat: { id: 7772, type: "private" },
-        text: "/reset summarize my workspace",
-        date: 1778474850,
-        message_id: 101,
-        from: { id: 202, is_bot: false, first_name: "Kesava" },
-      },
-    });
+    await handler(
+      makeDirectTelegramMessageContext({
+        chatId: 7772,
+        messageId: 101,
+        message: { text: "/reset summarize my workspace", date: 1778474850 },
+      }),
+    );
 
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
@@ -4372,11 +4165,7 @@ describe("createTelegramBot", () => {
         token: "tok",
         fetchAbortSignal: botShutdown.signal,
         mediaAbortSignal: mediaAbort.signal,
-        telegramTransport: {
-          fetch: mediaFetch as typeof fetch,
-          sourceFetch: mediaFetch as typeof fetch,
-          close: async () => {},
-        },
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
       });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
 
@@ -4429,11 +4218,7 @@ describe("createTelegramBot", () => {
     try {
       createTelegramBot({
         token: "tok",
-        telegramTransport: {
-          fetch: mediaFetch as typeof fetch,
-          sourceFetch: mediaFetch as typeof fetch,
-          close: async () => {},
-        },
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
       });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
 
@@ -4524,11 +4309,7 @@ describe("createTelegramBot", () => {
     try {
       createTelegramBot({
         token: "tok",
-        telegramTransport: {
-          fetch: mediaFetch as typeof fetch,
-          sourceFetch: mediaFetch as typeof fetch,
-          close: async () => {},
-        },
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
       });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
 
@@ -4657,11 +4438,7 @@ describe("createTelegramBot", () => {
     try {
       createTelegramBot({
         token: "tok",
-        telegramTransport: {
-          fetch: mediaFetch as typeof fetch,
-          sourceFetch: mediaFetch as typeof fetch,
-          close: async () => {},
-        },
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
       });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       const baseCtx = {
@@ -4821,11 +4598,7 @@ describe("createTelegramBot", () => {
       const replyDelivered = waitForReplyCalls(1);
       createTelegramBot({
         token: "tok",
-        telegramTransport: {
-          fetch: mediaFetch as typeof fetch,
-          sourceFetch: mediaFetch as typeof fetch,
-          close: async () => {},
-        },
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
       });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       const chat = { id: -1007, type: "supergroup", title: "Ops", is_forum: true };
@@ -4965,11 +4738,7 @@ describe("createTelegramBot", () => {
           config: startupConfig,
           ...(optionGroupAllowFrom ? { groupAllowFrom: optionGroupAllowFrom } : {}),
           runtime: { log: runtimeLog, error: runtimeError, exit: runtimeExit },
-          telegramTransport: {
-            fetch: mediaFetch as typeof fetch,
-            sourceFetch: mediaFetch as typeof fetch,
-            close: async () => {},
-          },
+          telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
         });
         const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
         const chat = { id: chatId, type: "group", title: "Ops" };
@@ -5082,11 +4851,7 @@ describe("createTelegramBot", () => {
       const replyDelivered = waitForReplyCalls(1);
       createTelegramBot({
         token: "tok",
-        telegramTransport: {
-          fetch: mediaFetch as typeof fetch,
-          sourceFetch: mediaFetch as typeof fetch,
-          close: async () => {},
-        },
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
       });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
 
@@ -5647,15 +5412,11 @@ describe("createTelegramBot", () => {
         pluginId: "smart-replies-plugin",
         namespace: "openclaw-smart-replies",
         handler,
-        config: {
-          channels: {
-            telegram: {
-              dmPolicy: "open",
-              allowFrom: ["*"],
-              capabilities: { inlineButtons: "dm" },
-            },
-          },
-        },
+        config: makeTelegramConfig({
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          capabilities: { inlineButtons: "dm" },
+        }),
       });
       const callbackContext = createTelegramCallbackContext({
         id: "cbq-smart-reply-policy-skip",
@@ -5686,17 +5447,13 @@ describe("createTelegramBot", () => {
         pluginId: "smart-replies-plugin",
         namespace: "openclaw-smart-replies",
         handler: async () => ({ handled: true, submitText: "Investigate topic callback" }),
-        config: {
-          channels: {
-            telegram: {
-              dmPolicy: "open",
-              allowFrom: ["*"],
-              capabilities: { inlineButtons: "group" },
-              groupPolicy: "open",
-              groups: { "*": { requireMention: true } },
-            },
-          },
-        },
+        config: makeTelegramConfig({
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          capabilities: { inlineButtons: "group" },
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+        }),
       });
       await callbackHandler(
         createTelegramCallbackContext({
@@ -5908,21 +5665,15 @@ describe("createTelegramBot", () => {
       return { handled: true };
     });
 
-    const config = {
-      commands: {
-        allowFrom: {
-          telegram: ["111111111"],
-        },
+    const config = makeTelegramConfig(
+      {
+        dmPolicy: "open",
+        capabilities: { inlineButtons: "group" },
+        groupPolicy: "open",
+        groups: { "*": { requireMention: false } },
       },
-      channels: {
-        telegram: {
-          dmPolicy: "open",
-          capabilities: { inlineButtons: "group" },
-          groupPolicy: "open",
-          groups: { "*": { requireMention: false } },
-        },
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+      { commands: { allowFrom: { telegram: ["111111111"] } } },
+    );
     loadConfig.mockReturnValue(config);
 
     const callbackHandler = createTelegramPluginCallbackHandler({
@@ -5995,21 +5746,21 @@ describe("createTelegramBot", () => {
       return { handled: true };
     });
 
-    const config = {
-      accessGroups: {
-        operators: {
-          type: "message.senders",
-          members: { telegram: ["123456789"] },
+    const config = makeTelegramConfig(
+      {
+        dmPolicy: "allowlist",
+        allowFrom: ["accessGroup:operators"],
+        capabilities: { inlineButtons: "dm" },
+      },
+      {
+        accessGroups: {
+          operators: {
+            type: "message.senders",
+            members: { telegram: ["123456789"] },
+          },
         },
       },
-      channels: {
-        telegram: {
-          dmPolicy: "allowlist",
-          allowFrom: ["accessGroup:operators"],
-          capabilities: { inlineButtons: "dm" },
-        },
-      },
-    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    );
     loadConfig.mockReturnValue(config);
 
     const callbackHandler = createTelegramPluginCallbackHandler({
@@ -6156,15 +5907,15 @@ describe("createTelegramBot", () => {
       token: "tok",
       config: startupConfig,
     });
-    loadConfig.mockReturnValue({
-      commands: { native: true },
-      channels: {
-        telegram: {
+    loadConfig.mockReturnValue(
+      makeTelegramConfig(
+        {
           dmPolicy: "pairing",
           botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
         },
-      },
-    });
+        { commands: { native: true } },
+      ),
+    );
     readChannelAllowFromStore.mockResolvedValueOnce(["12345"]);
 
     const handler = commandSpy.mock.calls.find((call) => call[0] === "status")?.[1] as

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -248,6 +248,8 @@ vi.mock("./openrouter-model-capabilities.js", () => ({
 }));
 
 import type { OpenClawConfig, OpenClawConfigInput } from "../../config/config.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.models.js";
+import type { Model } from "../../llm/types.js";
 import { getModelProviderLocalService } from "../provider-local-service.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { buildForwardCompatTemplate } from "./model.forward-compat.test-support.js";
@@ -425,16 +427,156 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0): Record<stri
   return call[0] as Record<string, unknown>;
 }
 
+function mockModelDiscovery(
+  overrides: {
+    provider?: string;
+    modelId?: string;
+    templateModel?: unknown;
+  } = {},
+) {
+  const provider = overrides.provider ?? "openai";
+  const modelId = overrides.modelId ?? "gpt-5.5";
+  mockDiscoveredModel(discoverModels, {
+    provider,
+    modelId,
+    templateModel: overrides.templateModel ?? { provider, ...makeModel(modelId) },
+  });
+}
+
+function mockOpenAIForwardCompatDiscovery(modelId = "gpt-5.4", overrides: Partial<Model> = {}) {
+  const name =
+    modelId === "gpt-5.3-codex-spark"
+      ? "GPT-5.3 Codex Spark"
+      : modelId === "gpt-5.4-mini"
+        ? "GPT-5.4 Mini"
+        : modelId === "gpt-5.5"
+          ? "GPT-5.5"
+          : "GPT-5.4";
+  mockModelDiscovery({
+    provider: "openai",
+    modelId,
+    templateModel: {
+      ...buildOpenAICodexForwardCompatExpectation(modelId),
+      name,
+      ...overrides,
+    },
+  });
+}
+
+function mockMinimalModelDiscovery(
+  provider: string,
+  modelId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  mockModelDiscovery({
+    provider,
+    modelId,
+    templateModel: { ...makeModel(modelId), provider, ...overrides },
+  });
+}
+
+function makeProviderConfig(
+  provider: string,
+  overrides: Record<string, unknown> = {},
+): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        [provider]: { models: [], ...overrides },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+const deepSeekCatalogCompat = {
+  supportsUsageInStreaming: true,
+  supportsReasoningEffort: true,
+  maxTokensField: "max_tokens" as const,
+};
+
+function makeDeepSeekCatalogModel(overrides: Partial<Model> = {}): Model {
+  const { compat, ...modelOverrides } = overrides;
+  return {
+    provider: "deepseek",
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
+    api: "openai-completions",
+    baseUrl: "https://api.deepseek.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: 384_000,
+    ...modelOverrides,
+    ...(compat ? { compat: { ...deepSeekCatalogCompat, ...compat } } : {}),
+  };
+}
+
+function makeMistralCatalogModel(overrides: Partial<Model> = {}): Model {
+  return {
+    provider: "mistral",
+    id: "mistral-medium-3-5",
+    name: "Mistral Medium 3.5",
+    api: "openai-completions",
+    baseUrl: "https://api.mistral.ai/v1",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 262_144,
+    maxTokens: 8_192,
+    ...overrides,
+  };
+}
+
+function makeConfiguredDeepSeekModel(
+  overrides: Partial<ModelDefinitionConfig> = {},
+): ModelDefinitionConfig {
+  const { compat, ...modelOverrides } = overrides;
+  return {
+    id: "deepseek-v4-pro",
+    name: "Custom DeepSeek V4 Pro",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32_768,
+    maxTokens: 4_096,
+    ...modelOverrides,
+    ...(compat ? { compat: { ...compat } } : {}),
+  };
+}
+
+function makeDeepSeekConfig(
+  modelOverrides: Partial<ModelDefinitionConfig> = {},
+  providerOverrides: Partial<ModelProviderConfig> = {},
+): OpenClawConfig {
+  return makeProviderConfig("deepseek", {
+    models: [makeConfiguredDeepSeekModel(modelOverrides)],
+    ...providerOverrides,
+  });
+}
+
+function makeVllmQwenConfig(
+  modelOverrides: Record<string, unknown> = {},
+  providerOverrides: Record<string, unknown> = {},
+): OpenClawConfig {
+  return makeProviderConfig("vllm", {
+    baseUrl: "http://localhost:9000",
+    api: "openai-completions",
+    models: [
+      {
+        id: "Qwen/Qwen3-8B",
+        name: "Qwen/Qwen3-8B",
+        compat: { thinkingFormat: "qwen-chat-template" },
+        ...modelOverrides,
+      },
+    ],
+    ...providerOverrides,
+  });
+}
+
 describe("resolveModel", () => {
   it("reuses agent discovery stores while the agent model files are unchanged", async () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
 
     const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
       runtimeHooks: createRuntimeHooks(),
@@ -450,14 +592,7 @@ describe("resolveModel", () => {
   });
 
   it("looks up the lifecycle owner before applying a derived workspace", async () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
     const cfg = {
       agents: { defaults: { workspace: "/tmp/config-derived-workspace" } },
     } as OpenClawConfig;
@@ -475,14 +610,7 @@ describe("resolveModel", () => {
   });
 
   it("keeps prepared discovery generations separate for agents sharing directories", async () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
 
     const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
       agentId: "agent-a",
@@ -500,14 +628,7 @@ describe("resolveModel", () => {
   });
 
   it("keeps lifecycle discovery stable when request route config changes", async () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
     const providerConfig = (api: "openai-responses" | "openai-completions") =>
       ({
         models: {
@@ -590,14 +711,7 @@ describe("resolveModel", () => {
         ],
       },
     } as unknown as OpenClawConfig;
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
 
     const first = await resolveModelAsync("openai", "gpt-5.5", agentDir, cfg, {
       runtimeHooks: createRuntimeHooks(),
@@ -625,14 +739,7 @@ describe("resolveModel", () => {
     const agentDir = path.join(rootDir, "agent");
     const workspaceDir = path.join(rootDir, "workspace");
     fs.mkdirSync(agentDir, { recursive: true });
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
     const cfg = {
       agents: {
         list: [{ id: "workspace-agent", default: true, agentDir, workspace: workspaceDir }],
@@ -668,14 +775,7 @@ describe("resolveModel", () => {
           },
         },
       } as unknown as OpenClawConfig;
-      mockDiscoveredModel(discoverModels, {
-        provider: "openai",
-        modelId: "gpt-5.5",
-        templateModel: {
-          provider: "openai",
-          ...makeModel("gpt-5.5"),
-        },
-      });
+      mockModelDiscovery();
 
       const options = {
         authStorage,
@@ -703,14 +803,7 @@ describe("resolveModel", () => {
     fs.mkdirSync(mainAgentDir, { recursive: true });
     try {
       await withEnvAsync({ OPENCLAW_STATE_DIR: rootDir }, async () => {
-        mockDiscoveredModel(discoverModels, {
-          provider: "openai",
-          modelId: "gpt-5.5",
-          templateModel: {
-            provider: "openai",
-            ...makeModel("gpt-5.5"),
-          },
-        });
+        mockModelDiscovery();
 
         const first = await resolveModelAsync("openai", "gpt-5.5", agentDir, undefined, {
           runtimeHooks: createRuntimeHooks(),
@@ -748,14 +841,7 @@ describe("resolveModel", () => {
         } as never,
       },
     ]);
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
 
     const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
       runtimeHooks: createRuntimeHooks(),
@@ -773,14 +859,7 @@ describe("resolveModel", () => {
   it("keeps plugin auth overlays inside the lifecycle generation", async () => {
     resolveRuntimeSyntheticAuthProviderRefsMock.mockReturnValue(["runtime-provider"]);
     resolveRuntimeExternalAuthProviderRefsMock.mockReturnValue(["external-provider"]);
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        provider: "openai",
-        ...makeModel("gpt-5.5"),
-      },
-    });
+    mockModelDiscovery();
 
     const first = await resolveModelAsync("openai", "gpt-5.5", "/tmp/agent", undefined, {
       runtimeHooks: createRuntimeHooks(),
@@ -816,18 +895,7 @@ describe("resolveModel", () => {
   });
 
   it("resolves opt-in bundled static catalog rows while skipping agent discovery", async () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "mistral",
-      id: "mistral-medium-3-5",
-      name: "Mistral Medium 3.5",
-      api: "openai-completions",
-      baseUrl: "https://api.mistral.ai/v1",
-      reasoning: true,
-      input: ["text", "image"],
-      cost: { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 262144,
-      maxTokens: 8192,
-    });
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(makeMistralCatalogModel());
 
     const result = await resolveModelAsync(
       "mistral",
@@ -863,18 +931,7 @@ describe("resolveModel", () => {
   });
 
   it("reuses configured static models from the loaded snapshot", async () => {
-    const preparedModel = {
-      provider: "mistral",
-      id: "mistral-medium-3-5",
-      name: "Mistral Medium 3.5",
-      api: "openai-completions" as const,
-      baseUrl: "https://api.mistral.ai/v1",
-      reasoning: true,
-      input: ["text" as const, "image" as const],
-      cost: { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 262144,
-      maxTokens: 8192,
-    };
+    const preparedModel = makeMistralCatalogModel();
 
     preparedSnapshotState.configuredRuntimeModels = [
       {
@@ -907,16 +964,10 @@ describe("resolveModel", () => {
   });
 
   it("resolves configured inline models from one prepared generation", async () => {
-    const cfg = {
-      models: {
-        providers: {
-          deepseek: {
-            api: "openai-completions",
-            models: [{ id: "deepseek-v4-pro", name: "Configured DeepSeek" }],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("deepseek", {
+      api: "openai-completions",
+      models: [{ id: "deepseek-v4-pro", name: "Configured DeepSeek" }],
+    });
     const preparedModelRuntime = {
       agentDir: "/tmp/agent",
       activeProjectKeys: [],
@@ -928,18 +979,7 @@ describe("resolveModel", () => {
         {
           provider: "deepseek",
           modelId: "deepseek-v4-pro",
-          model: {
-            provider: "deepseek",
-            id: "deepseek-v4-pro",
-            name: "DeepSeek V4 Pro",
-            api: "openai-completions",
-            baseUrl: "https://api.deepseek.com",
-            reasoning: true,
-            input: ["text"],
-            cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-            contextWindow: 1_000_000,
-            maxTokens: 384_000,
-          },
+          model: makeDeepSeekCatalogModel(),
         },
       ],
       inlineProviderModels: buildInlineProviderModels(cfg.models?.providers ?? {}),
@@ -964,18 +1004,9 @@ describe("resolveModel", () => {
   });
 
   it("falls back when an opaque prepared handle has no model facts", async () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "mistral",
-      id: "mistral-medium-3-5",
-      name: "Mistral Medium 3.5",
-      api: "openai-completions",
-      baseUrl: "https://api.mistral.ai/v1",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 262_144,
-      maxTokens: 8_192,
-    });
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(
+      makeMistralCatalogModel({ input: ["text"] }),
+    );
 
     const result = await resolveModelAsync(
       "mistral",
@@ -1602,16 +1633,7 @@ describe("resolveModel", () => {
   });
 
   it("includes provider baseUrl in fallback model", () => {
-    const cfg = {
-      models: {
-        providers: {
-          custom: {
-            baseUrl: "http://localhost:9000",
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom", { baseUrl: "http://localhost:9000" });
 
     const result = resolveModelForTest("custom", "missing-model", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1623,16 +1645,9 @@ describe("resolveModel", () => {
   });
 
   it("defaults baseUrl-only Google fallback models to native Gemini transport", () => {
-    const cfg = {
-      models: {
-        providers: {
-          google: {
-            baseUrl: "https://generativelanguage.googleapis.com",
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("google", {
+      baseUrl: "https://generativelanguage.googleapis.com",
+    });
 
     const result = resolveModelForTest("google", "gemini-2.5-flash-lite", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1644,16 +1659,9 @@ describe("resolveModel", () => {
   });
 
   it("defaults baseUrl-only Google Vertex fallback models to native Vertex transport", () => {
-    const cfg = {
-      models: {
-        providers: {
-          "google-vertex": {
-            baseUrl: "https://aiplatform.googleapis.com",
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("google-vertex", {
+      baseUrl: "https://aiplatform.googleapis.com",
+    });
 
     const result = resolveModelForTest("google-vertex", "gemini-2.5-flash", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1677,18 +1685,11 @@ describe("resolveModel", () => {
       contextWindow: 1_048_576,
       maxTokens: 32_000,
     });
-    const cfg = {
-      models: {
-        providers: {
-          "xiaomi-token-plan": {
-            baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1",
-            api: "openai-completions",
-            contextWindow: 16_000,
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("xiaomi-token-plan", {
+      baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1",
+      api: "openai-completions",
+      contextWindow: 16_000,
+    });
 
     const result = resolveModelForTest("xiaomi-token-plan", "mimo-v2.5-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1721,18 +1722,11 @@ describe("resolveModel", () => {
 
   it("marks a provider-level maxTokens override as configured", () => {
     mockDiscoveredGroqModel();
-    const cfg = {
-      models: {
-        providers: {
-          groq: {
-            baseUrl: "https://api.groq.com/openai/v1",
-            api: "openai-completions",
-            maxTokens: 2_048,
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("groq", {
+      baseUrl: "https://api.groq.com/openai/v1",
+      api: "openai-completions",
+      maxTokens: 2_048,
+    });
 
     const result = resolveModelForTest("groq", "llama-3.3-70b-versatile", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1745,23 +1739,17 @@ describe("resolveModel", () => {
 
   it("marks a configured-model top-level maxTokens override as configured", () => {
     mockDiscoveredGroqModel();
-    const cfg = {
-      models: {
-        providers: {
-          groq: {
-            baseUrl: "https://api.groq.com/openai/v1",
-            api: "openai-completions",
-            models: [
-              {
-                id: "llama-3.3-70b-versatile",
-                name: "Llama 3.3 70B",
-                maxTokens: 4_096,
-              },
-            ],
-          },
+    const cfg = makeProviderConfig("groq", {
+      baseUrl: "https://api.groq.com/openai/v1",
+      api: "openai-completions",
+      models: [
+        {
+          id: "llama-3.3-70b-versatile",
+          name: "Llama 3.3 70B",
+          maxTokens: 4_096,
         },
-      },
-    } as unknown as OpenClawConfig;
+      ],
+    });
 
     const result = resolveModelForTest("groq", "llama-3.3-70b-versatile", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1781,21 +1769,10 @@ describe("resolveModel", () => {
     // avoiding HTTP 400 (Param Incorrect) from strict OpenAI-compatible
     // servers whose completion-token ceiling is below the synthesized value.
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce(undefined);
-    const cfg = {
-      models: {
-        providers: {
-          xiaomi: {
-            baseUrl: "https://api.xiaomimimo.com/v1",
-            models: [
-              {
-                id: "mimo-v2.5-pro",
-                name: "mimo-v2.5-pro",
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("xiaomi", {
+      baseUrl: "https://api.xiaomimimo.com/v1",
+      models: [{ id: "mimo-v2.5-pro", name: "mimo-v2.5-pro" }],
+    });
 
     const result = resolveModelForTest("xiaomi", "mimo-v2.5-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1806,46 +1783,10 @@ describe("resolveModel", () => {
   });
 
   it("inherits bundled static transport for configured provider fallback models", () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "DeepSeek V4 Pro",
-      api: "openai-completions",
-      baseUrl: "https://api.deepseek.com",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-      contextWindow: 1_000_000,
-      maxTokens: 384_000,
-      compat: {
-        supportsUsageInStreaming: true,
-        supportsReasoningEffort: true,
-        maxTokensField: "max_tokens",
-      },
-    });
-    const cfg = {
-      models: {
-        providers: {
-          deepseek: {
-            baseUrl: "",
-            models: [
-              {
-                id: "deepseek-v4-pro",
-                name: "Custom DeepSeek V4 Pro",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 32_768,
-                maxTokens: 4_096,
-                compat: {
-                  supportsReasoningEffort: false,
-                },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(
+      makeDeepSeekCatalogModel({ compat: deepSeekCatalogCompat }),
+    );
+    const cfg = makeDeepSeekConfig({ compat: { supportsReasoningEffort: false } }, { baseUrl: "" });
 
     const result = resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -1875,53 +1816,14 @@ describe("resolveModel", () => {
   });
 
   it("fills missing configured provider runtime transport from bundled static metadata", async () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "DeepSeek V4 Pro",
-      api: "openai-completions",
-      baseUrl: "https://api.deepseek.com",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-      contextWindow: 1_000_000,
-      maxTokens: 384_000,
-      compat: {
-        supportsUsageInStreaming: true,
-        supportsReasoningEffort: true,
-        maxTokensField: "max_tokens",
-      },
-    });
-    const cfg = {
-      models: {
-        providers: {
-          deepseek: {
-            models: [
-              {
-                id: "deepseek-v4-pro",
-                name: "Custom DeepSeek V4 Pro",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 32_768,
-                maxTokens: 4_096,
-                thinkingLevelMap: { off: null },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(
+      makeDeepSeekCatalogModel({ compat: deepSeekCatalogCompat }),
+    );
+    const cfg = makeDeepSeekConfig({ thinkingLevelMap: { off: null } });
     const baseRuntimeHooks = createRuntimeHooks();
     const runProviderDynamicModel = vi.fn(() => ({
       provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "Custom DeepSeek V4 Pro",
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 32_768,
-      maxTokens: 4_096,
+      ...makeConfiguredDeepSeekModel(),
     }));
 
     const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
@@ -1951,43 +1853,10 @@ describe("resolveModel", () => {
   });
 
   it("resolves configured DeepSeek probe models through bundled static transport without agent discovery", async () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "DeepSeek V4 Pro",
-      api: "openai-completions",
-      baseUrl: "https://api.deepseek.com",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-      contextWindow: 1_000_000,
-      maxTokens: 384_000,
-      compat: {
-        supportsUsageInStreaming: true,
-        supportsReasoningEffort: true,
-        maxTokensField: "max_tokens",
-      },
-    });
-    const cfg = {
-      models: {
-        providers: {
-          deepseek: {
-            models: [
-              {
-                id: "deepseek-v4-pro",
-                name: "Custom DeepSeek V4 Pro",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 32_768,
-                maxTokens: 4_096,
-                thinkingLevelMap: { off: null },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(
+      makeDeepSeekCatalogModel({ compat: deepSeekCatalogCompat }),
+    );
+    const cfg = makeDeepSeekConfig({ thinkingLevelMap: { off: null } });
 
     const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
       runtimeHooks: createRuntimeHooks(),
@@ -2014,50 +1883,20 @@ describe("resolveModel", () => {
   });
 
   it("keeps provider runtime transport ahead of bundled static fallback metadata", async () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "DeepSeek V4 Pro",
-      api: "openai-completions",
-      baseUrl: "https://api.deepseek.com",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-      contextWindow: 1_000_000,
-      maxTokens: 384_000,
-    });
-    const cfg = {
-      models: {
-        providers: {
-          deepseek: {
-            models: [
-              {
-                id: "deepseek-v4-pro",
-                name: "Custom DeepSeek V4 Pro",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 32_768,
-                maxTokens: 4_096,
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(makeDeepSeekCatalogModel());
+    const cfg = makeDeepSeekConfig();
     const baseRuntimeHooks = createRuntimeHooks();
-    const runProviderDynamicModel = vi.fn(() => ({
-      provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "Runtime DeepSeek V4 Pro",
-      api: "openai-responses" as const,
-      baseUrl: "https://runtime.deepseek.example/v1",
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 32_768,
-      maxTokens: 4_096,
-    }));
+    const runProviderDynamicModel = vi.fn(() =>
+      makeDeepSeekCatalogModel({
+        name: "Runtime DeepSeek V4 Pro",
+        api: "openai-responses",
+        baseUrl: "https://runtime.deepseek.example/v1",
+        reasoning: false,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32_768,
+        maxTokens: 4_096,
+      }),
+    );
 
     const result = await resolveModelAsync("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg, {
       runtimeHooks: {
@@ -2079,41 +1918,17 @@ describe("resolveModel", () => {
   });
 
   it("keeps configured transport overrides ahead of bundled static fallback metadata", () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "DeepSeek V4 Pro",
-      api: "openai-completions",
-      baseUrl: "https://api.deepseek.com",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-      contextWindow: 1_000_000,
-      maxTokens: 384_000,
-    });
-    const cfg = {
-      models: {
-        providers: {
-          deepseek: {
-            baseUrl: "https://deepseek-proxy.example.com/v1",
-            api: "openai-completions",
-            models: [
-              {
-                id: "deepseek-v4-pro",
-                name: "Custom DeepSeek V4 Pro",
-                baseUrl: "https://deepseek-model-proxy.example.com/v1",
-                api: "openai-responses",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 32_768,
-                maxTokens: 4_096,
-              },
-            ],
-          },
-        },
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(makeDeepSeekCatalogModel());
+    const cfg = makeDeepSeekConfig(
+      {
+        baseUrl: "https://deepseek-model-proxy.example.com/v1",
+        api: "openai-responses",
       },
-    } as unknown as OpenClawConfig;
+      {
+        baseUrl: "https://deepseek-proxy.example.com/v1",
+        api: "openai-completions",
+      },
+    );
 
     const result = resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2127,39 +1942,13 @@ describe("resolveModel", () => {
   });
 
   it("keeps bundled static baseUrl when provider api is configured without a baseUrl", () => {
-    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
-      provider: "deepseek",
-      id: "deepseek-v4-pro",
-      name: "DeepSeek V4 Pro",
-      api: "openai-responses",
-      baseUrl: "https://api.deepseek.com",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 1.74, output: 3.48, cacheRead: 0.145, cacheWrite: 0 },
-      contextWindow: 1_000_000,
-      maxTokens: 384_000,
-    });
-    const cfg = {
-      models: {
-        providers: {
-          deepseek: {
-            api: "openai-completions",
-            models: [
-              {
-                id: "deepseek-v4-pro",
-                name: "Custom DeepSeek V4 Pro",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 32_768,
-                maxTokens: 4_096,
-                thinkingLevelMap: { off: null },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(
+      makeDeepSeekCatalogModel({ api: "openai-responses" }),
+    );
+    const cfg = makeDeepSeekConfig(
+      { thinkingLevelMap: { off: null } },
+      { api: "openai-completions" },
+    );
 
     const result = resolveModelForTest("deepseek", "deepseek-v4-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2187,20 +1976,13 @@ describe("resolveModel", () => {
       contextTokens: 500_000,
       maxTokens: 32_000,
     });
-    const cfg = {
-      models: {
-        providers: {
-          "xiaomi-token-plan": {
-            baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1",
-            api: "openai-completions",
-            contextWindow: 100_000,
-            contextTokens: 90_000,
-            maxTokens: 512,
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("xiaomi-token-plan", {
+      baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1",
+      api: "openai-completions",
+      contextWindow: 100_000,
+      contextTokens: 90_000,
+      maxTokens: 512,
+    });
 
     const result = resolveModelForTest("xiaomi-token-plan", "mimo-v2.5-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2213,17 +1995,7 @@ describe("resolveModel", () => {
   });
 
   it("does not synthesize unknown models from timeout-only provider overlays", () => {
-    const cfg = {
-      models: {
-        providers: {
-          openai: {
-            timeoutSeconds: 300,
-            baseUrl: "",
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("openai", { timeoutSeconds: 300, baseUrl: "" });
 
     const result = resolveModelForTest("openai", "typo-model", "/tmp/agent", cfg);
 
@@ -2317,24 +2089,18 @@ describe("resolveModel", () => {
   });
 
   it("preserves normalized inline provider transport when static metadata is merged", () => {
-    const cfg = {
-      models: {
-        providers: {
-          "my-gemini": {
-            api: "google-generative-ai",
-            baseUrl: "https://generativelanguage.googleapis.com",
-            models: [
-              {
-                id: "gemini-pro",
-                name: "Gemini Pro",
-                input: ["text"],
-                contextWindow: 32_768,
-              },
-            ],
-          },
+    const cfg = makeProviderConfig("my-gemini", {
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com",
+      models: [
+        {
+          id: "gemini-pro",
+          name: "Gemini Pro",
+          input: ["text"],
+          contextWindow: 32_768,
         },
-      },
-    } as unknown as OpenClawConfig;
+      ],
+    });
 
     const result = resolveModelForTest("my-gemini", "gemini-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2373,24 +2139,17 @@ describe("resolveModel", () => {
   });
 
   it("attaches provider localService metadata to configured fallback models", () => {
-    const cfg = {
-      models: {
-        providers: {
-          ds4: {
-            baseUrl: "http://127.0.0.1:18000/v1",
-            api: "openai-completions",
-            localService: {
-              command: "/opt/ds4/ds4-server",
-              args: ["--port", "18000"],
-              healthUrl: "http://127.0.0.1:18000/v1/models",
-              readyTimeoutMs: 180_000,
-              idleStopMs: 0,
-            },
-            models: [],
-          },
-        },
+    const cfg = makeProviderConfig("ds4", {
+      baseUrl: "http://127.0.0.1:18000/v1",
+      api: "openai-completions",
+      localService: {
+        command: "/opt/ds4/ds4-server",
+        args: ["--port", "18000"],
+        healthUrl: "http://127.0.0.1:18000/v1/models",
+        readyTimeoutMs: 180_000,
+        idleStopMs: 0,
       },
-    } as unknown as OpenClawConfig;
+    });
 
     const result = resolveModelForTest("ds4", "deepseek-v4-flash", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2440,17 +2199,10 @@ describe("resolveModel", () => {
   });
 
   it("keeps unconfigured qwen3.6-plus suppressed on Coding Plan endpoints", () => {
-    const cfg = {
-      models: {
-        providers: {
-          qwen: {
-            baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-            api: "openai-completions",
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("qwen", {
+      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+      api: "openai-completions",
+    });
 
     const result = resolveModelForTest("qwen", "qwen3.6-plus", "/tmp/agent", cfg);
 
@@ -2492,17 +2244,10 @@ describe("resolveModel", () => {
   });
 
   it("normalizes Google fallback baseUrls for custom providers", () => {
-    const cfg = {
-      models: {
-        providers: {
-          "google-paid": {
-            baseUrl: "https://generativelanguage.googleapis.com",
-            api: "google-generative-ai",
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("google-paid", {
+      baseUrl: "https://generativelanguage.googleapis.com",
+      api: "google-generative-ai",
+    });
 
     const result = resolveModelForTest("google-paid", "missing-model", "/tmp/agent", cfg);
 
@@ -2512,27 +2257,15 @@ describe("resolveModel", () => {
   });
 
   it("normalizes configured Google override baseUrls when provider api is omitted", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "google",
-      modelId: "gemini-2.5-pro",
-      templateModel: {
-        ...makeModel("gemini-2.5-pro"),
-        provider: "google",
-        api: "google-generative-ai",
-        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-      },
+    mockMinimalModelDiscovery("google", "gemini-2.5-pro", {
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     });
 
-    const cfg = {
-      models: {
-        providers: {
-          google: {
-            baseUrl: "https://generativelanguage.googleapis.com",
-            models: [{ id: "gemini-2.5-pro", name: "gemini-2.5-pro" }],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("google", {
+      baseUrl: "https://generativelanguage.googleapis.com",
+      models: [{ id: "gemini-2.5-pro", name: "gemini-2.5-pro" }],
+    });
 
     const result = resolveModelForTest("google", "gemini-2.5-pro", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2542,22 +2275,11 @@ describe("resolveModel", () => {
   });
 
   it("normalizes custom api.openai.com providers to responses transport", () => {
-    const cfg = {
-      models: {
-        providers: {
-          "custom-openai": {
-            baseUrl: "https://api.openai.com/v1",
-            api: "openai-completions",
-            models: [
-              {
-                ...makeModel("gpt-5.4"),
-                provider: "custom-openai",
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom-openai", {
+      baseUrl: "https://api.openai.com/v1",
+      api: "openai-completions",
+      models: [{ ...makeModel("gpt-5.4"), provider: "custom-openai" }],
+    });
 
     const result = resolveModelForTest("custom-openai", "gpt-5.4", "/tmp/agent", cfg);
 
@@ -2570,22 +2292,11 @@ describe("resolveModel", () => {
   });
 
   it("normalizes custom api.x.ai providers to responses transport", () => {
-    const cfg = {
-      models: {
-        providers: {
-          "custom-xai": {
-            baseUrl: "https://api.x.ai/v1",
-            api: "openai-completions",
-            models: [
-              {
-                ...makeModel("grok-4.1-fast"),
-                provider: "custom-xai",
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom-xai", {
+      baseUrl: "https://api.x.ai/v1",
+      api: "openai-completions",
+      models: [{ ...makeModel("grok-4.1-fast"), provider: "custom-xai" }],
+    });
 
     const result = resolveModelForTest("custom-xai", "grok-4.1-fast", "/tmp/agent", cfg);
 
@@ -2605,17 +2316,11 @@ describe("resolveModel", () => {
   });
 
   it("leaves configured GitHub Copilot request identity to runtime auth preparation", () => {
-    const cfg = {
-      models: {
-        providers: {
-          "github-copilot": {
-            baseUrl: "https://api.githubcopilot.com",
-            api: "openai-responses",
-            models: [makeModel("gpt-5.5")],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("github-copilot", {
+      baseUrl: "https://api.githubcopilot.com",
+      api: "openai-responses",
+      models: [makeModel("gpt-5.5")],
+    });
 
     const result = resolveModelForTest("github-copilot", "gpt-5.5", "/tmp/agent", cfg);
     const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
@@ -2624,17 +2329,11 @@ describe("resolveModel", () => {
   });
 
   it("includes provider headers in provider fallback model", () => {
-    const cfg = {
-      models: {
-        providers: {
-          custom: {
-            baseUrl: "http://localhost:9000",
-            headers: { "X-Custom-Auth": "token-123" },
-            models: [makeModel("listed-model")],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom", {
+      baseUrl: "http://localhost:9000",
+      headers: { "X-Custom-Auth": "token-123" },
+      models: [makeModel("listed-model")],
+    });
 
     // Requesting a non-listed model forces the providerCfg fallback branch.
     const result = resolveModelForTest("custom", "missing-model", "/tmp/agent", cfg);
@@ -2646,21 +2345,15 @@ describe("resolveModel", () => {
   });
 
   it("drops SecretRef marker provider headers in fallback models", () => {
-    const cfg = {
-      models: {
-        providers: {
-          custom: {
-            baseUrl: "http://localhost:9000",
-            headers: {
-              Authorization: "secretref-env:OPENAI_HEADER_TOKEN",
-              "X-Managed": "secretref-managed",
-              "X-Custom-Auth": "token-123",
-            },
-            models: [makeModel("listed-model")],
-          },
-        },
+    const cfg = makeProviderConfig("custom", {
+      baseUrl: "http://localhost:9000",
+      headers: {
+        Authorization: "secretref-env:OPENAI_HEADER_TOKEN",
+        "X-Managed": "secretref-managed",
+        "X-Custom-Auth": "token-123",
       },
-    } as unknown as OpenClawConfig;
+      models: [makeModel("listed-model")],
+    });
 
     const result = resolveModelForTest("custom", "missing-model", "/tmp/agent", cfg);
     const model = expectResolvedModel(result) as unknown as { headers?: Record<string, string> };
@@ -2671,17 +2364,11 @@ describe("resolveModel", () => {
   });
 
   it("drops marker headers from discovered models.json entries", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "custom",
-      modelId: "listed-model",
-      templateModel: {
-        ...makeModel("listed-model"),
-        provider: "custom",
-        headers: {
-          Authorization: "secretref-env:OPENAI_HEADER_TOKEN",
-          "X-Managed": "secretref-managed",
-          "X-Static": "tenant-a",
-        },
+    mockMinimalModelDiscovery("custom", "listed-model", {
+      headers: {
+        Authorization: "secretref-env:OPENAI_HEADER_TOKEN",
+        "X-Managed": "secretref-managed",
+        "X-Static": "tenant-a",
       },
     });
 
@@ -2694,27 +2381,13 @@ describe("resolveModel", () => {
   });
 
   it("prefers matching configured model metadata for fallback token limits", () => {
-    const cfg = {
-      models: {
-        providers: {
-          custom: {
-            baseUrl: "http://localhost:9000",
-            models: [
-              {
-                ...makeModel("model-a"),
-                contextWindow: 4096,
-                maxTokens: 1024,
-              },
-              {
-                ...makeModel("model-b"),
-                contextWindow: 262144,
-                maxTokens: 32768,
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom", {
+      baseUrl: "http://localhost:9000",
+      models: [
+        { ...makeModel("model-a"), contextWindow: 4096, maxTokens: 1024 },
+        { ...makeModel("model-b"), contextWindow: 262144, maxTokens: 32768 },
+      ],
+    });
 
     const result = resolveModelForTest("custom", "model-b", "/tmp/agent", cfg);
     const model = expectResolvedModel(result);
@@ -2724,14 +2397,8 @@ describe("resolveModel", () => {
   });
 
   it("merges configured model params with agent defaults for resolved models", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "ollama",
-      modelId: "qwen3:32b",
-      templateModel: {
-        ...makeModel("qwen3:32b"),
-        provider: "ollama",
-        params: { num_ctx: 4096, keep_alive: "1m" },
-      },
+    mockMinimalModelDiscovery("ollama", "qwen3:32b", {
+      params: { num_ctx: 4096, keep_alive: "1m" },
     });
     const cfg = {
       agents: {
@@ -2769,26 +2436,11 @@ describe("resolveModel", () => {
   });
 
   it("applies configured provider params to resolved models", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "ollama",
-      modelId: "qwen3:32b",
-      templateModel: {
-        ...makeModel("qwen3:32b"),
-        provider: "ollama",
-        params: { keep_alive: "1m" },
-      },
+    mockMinimalModelDiscovery("ollama", "qwen3:32b", { params: { keep_alive: "1m" } });
+    const cfg = makeProviderConfig("ollama", {
+      baseUrl: "http://localhost:11434",
+      params: { num_ctx: 65536, top_p: 0.9 },
     });
-    const cfg = {
-      models: {
-        providers: {
-          ollama: {
-            baseUrl: "http://localhost:11434",
-            params: { num_ctx: 65536, top_p: 0.9 },
-            models: [],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
 
     const result = resolveModelForTest("ollama", "qwen3:32b", "/tmp/agent", cfg);
 
@@ -2801,25 +2453,12 @@ describe("resolveModel", () => {
   });
 
   it("resolves provider request timeout metadata for configured provider models", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "ollama",
-      modelId: "qwen3:32b",
-      templateModel: {
-        ...makeModel("qwen3:32b"),
-        provider: "ollama",
-      },
+    mockMinimalModelDiscovery("ollama", "qwen3:32b");
+    const cfg = makeProviderConfig("ollama", {
+      baseUrl: "http://localhost:11434",
+      timeoutSeconds: 300,
+      models: [makeModel("qwen3:32b")],
     });
-    const cfg = {
-      models: {
-        providers: {
-          ollama: {
-            baseUrl: "http://localhost:11434",
-            timeoutSeconds: 300,
-            models: [makeModel("qwen3:32b")],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
 
     const result = resolveModelForTest("ollama", "qwen3:32b", "/tmp/agent", cfg);
 
@@ -2830,14 +2469,7 @@ describe("resolveModel", () => {
   });
 
   it("resolves provider request timeout metadata from built-in provider overlays", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        ...makeModel("gpt-5.5"),
-        provider: "openai",
-      },
-    });
+    mockMinimalModelDiscovery("openai", "gpt-5.5");
     const cfg = {
       models: {
         providers: {
@@ -2862,14 +2494,7 @@ describe("resolveModel", () => {
   });
 
   it("caps oversized provider request timeout metadata at the timer-safe ceiling", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        ...makeModel("gpt-5.5"),
-        provider: "openai",
-      },
-    });
+    mockMinimalModelDiscovery("openai", "gpt-5.5");
     const cfg = {
       models: {
         providers: {
@@ -2894,29 +2519,17 @@ describe("resolveModel", () => {
   });
 
   it("uses provider-level context defaults over discovered metadata", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "ollama",
-      modelId: "qwen3.5:9b",
-      templateModel: {
-        ...makeModel("qwen3.5:9b"),
-        provider: "ollama",
-        contextWindow: 216_000,
-        contextTokens: 216_000,
-        maxTokens: 65_536,
-      },
+    mockMinimalModelDiscovery("ollama", "qwen3.5:9b", {
+      contextWindow: 216_000,
+      contextTokens: 216_000,
+      maxTokens: 65_536,
     });
-    const cfg = {
-      models: {
-        providers: {
-          ollama: {
-            baseUrl: "http://localhost:11434",
-            contextWindow: 8_192,
-            contextTokens: 8_000,
-            models: [{ id: "qwen3.5:9b", name: "qwen3.5:9b" }],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("ollama", {
+      baseUrl: "http://localhost:11434",
+      contextWindow: 8_192,
+      contextTokens: 8_000,
+      models: [{ id: "qwen3.5:9b", name: "qwen3.5:9b" }],
+    });
 
     const result = resolveModelForTest("ollama", "qwen3.5:9b", "/tmp/agent", cfg);
 
@@ -2927,35 +2540,23 @@ describe("resolveModel", () => {
   });
 
   it("keeps per-model context values above provider-level defaults", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "ollama",
-      modelId: "qwen3.5:9b",
-      templateModel: {
-        ...makeModel("qwen3.5:9b"),
-        provider: "ollama",
-        contextWindow: 216_000,
-        maxTokens: 65_536,
-      },
+    mockMinimalModelDiscovery("ollama", "qwen3.5:9b", {
+      contextWindow: 216_000,
+      maxTokens: 65_536,
     });
-    const cfg = {
-      models: {
-        providers: {
-          ollama: {
-            baseUrl: "http://localhost:11434",
-            contextWindow: 8_192,
-            maxTokens: 4_096,
-            models: [
-              {
-                id: "qwen3.5:9b",
-                name: "qwen3.5:9b",
-                contextWindow: 16_384,
-                maxTokens: 12_000,
-              },
-            ],
-          },
+    const cfg = makeProviderConfig("ollama", {
+      baseUrl: "http://localhost:11434",
+      contextWindow: 8_192,
+      maxTokens: 4_096,
+      models: [
+        {
+          id: "qwen3.5:9b",
+          name: "qwen3.5:9b",
+          contextWindow: 16_384,
+          maxTokens: 12_000,
         },
-      },
-    } as unknown as OpenClawConfig;
+      ],
+    });
 
     const result = resolveModelForTest("ollama", "qwen3.5:9b", "/tmp/agent", cfg);
 
@@ -2965,14 +2566,7 @@ describe("resolveModel", () => {
   });
 
   it("applies agent default model params without explicit provider config", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "ollama",
-      modelId: "llama3.2",
-      templateModel: {
-        ...makeModel("llama3.2"),
-        provider: "ollama",
-      },
-    });
+    mockMinimalModelDiscovery("ollama", "llama3.2");
     const cfg = {
       agents: {
         defaults: {
@@ -2994,25 +2588,13 @@ describe("resolveModel", () => {
   });
 
   it("propagates reasoning from matching configured fallback model", () => {
-    const cfg = {
-      models: {
-        providers: {
-          custom: {
-            baseUrl: "http://localhost:9000",
-            models: [
-              {
-                ...makeModel("model-a"),
-                reasoning: false,
-              },
-              {
-                ...makeModel("model-b"),
-                reasoning: true,
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom", {
+      baseUrl: "http://localhost:9000",
+      models: [
+        { ...makeModel("model-a"), reasoning: false },
+        { ...makeModel("model-b"), reasoning: true },
+      ],
+    });
 
     const result = resolveModelForTest("custom", "model-b", "/tmp/agent", cfg);
 
@@ -3020,22 +2602,16 @@ describe("resolveModel", () => {
   });
 
   it("propagates compat from matching configured fallback model", () => {
-    const cfg = {
-      models: {
-        providers: {
-          vllm: {
-            baseUrl: "http://localhost:9000",
-            api: "openai-completions",
-            models: [
-              {
-                ...makeModel("Qwen/Qwen3-8B"),
-                compat: { thinkingFormat: "qwen-chat-template" },
-              },
-            ],
-          },
+    const cfg = makeProviderConfig("vllm", {
+      baseUrl: "http://localhost:9000",
+      api: "openai-completions",
+      models: [
+        {
+          ...makeModel("Qwen/Qwen3-8B"),
+          compat: { thinkingFormat: "qwen-chat-template" },
         },
-      },
-    } as unknown as OpenClawConfig;
+      ],
+    });
 
     const result = resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
 
@@ -3047,35 +2623,13 @@ describe("resolveModel", () => {
   });
 
   it("lets configured vLLM Qwen compat override stale discovered reasoning", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "vllm",
-      modelId: "Qwen/Qwen3-8B",
-      templateModel: {
-        ...makeModel("Qwen/Qwen3-8B"),
-        provider: "vllm",
-        api: "openai-completions",
-        baseUrl: "http://localhost:9000",
-        reasoning: false,
-        compat: { supportsStrictMode: false },
-      },
+    mockMinimalModelDiscovery("vllm", "Qwen/Qwen3-8B", {
+      api: "openai-completions",
+      baseUrl: "http://localhost:9000",
+      reasoning: false,
+      compat: { supportsStrictMode: false },
     });
-    const cfg = {
-      models: {
-        providers: {
-          vllm: {
-            baseUrl: "http://localhost:9000",
-            api: "openai-completions",
-            models: [
-              {
-                id: "Qwen/Qwen3-8B",
-                name: "Qwen/Qwen3-8B",
-                compat: { thinkingFormat: "qwen-chat-template" },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeVllmQwenConfig();
 
     const result = resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
 
@@ -3098,23 +2652,7 @@ describe("resolveModel", () => {
       reasoning: false,
       compat: { supportsStrictMode: false },
     });
-    const cfg = {
-      models: {
-        providers: {
-          vllm: {
-            baseUrl: "http://localhost:9000",
-            api: "openai-completions",
-            models: [
-              {
-                id: "Qwen/Qwen3-8B",
-                name: "Qwen/Qwen3-8B",
-                compat: { thinkingFormat: "qwen-chat-template" },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeVllmQwenConfig();
 
     const result = resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
 
@@ -3125,23 +2663,7 @@ describe("resolveModel", () => {
   });
 
   it("infers reasoning for matching vLLM Qwen compat fallback models", () => {
-    const cfg = {
-      models: {
-        providers: {
-          vllm: {
-            baseUrl: "http://localhost:9000",
-            api: "openai-completions",
-            models: [
-              {
-                id: "Qwen/Qwen3-8B",
-                name: "Qwen/Qwen3-8B",
-                compat: { thinkingFormat: "qwen-chat-template" },
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeVllmQwenConfig();
 
     const result = resolveModelForTest("vllm", "Qwen/Qwen3-8B", "/tmp/agent", cfg);
 
@@ -3150,25 +2672,13 @@ describe("resolveModel", () => {
   });
 
   it("propagates image input capability from matching configured fallback model", () => {
-    const cfg = {
-      models: {
-        providers: {
-          custom: {
-            baseUrl: "http://localhost:9000",
-            models: [
-              {
-                ...makeModel("model-a"),
-                input: ["text"],
-              },
-              {
-                ...makeModel("model-b"),
-                input: ["text", "image"],
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom", {
+      baseUrl: "http://localhost:9000",
+      models: [
+        { ...makeModel("model-a"), input: ["text"] },
+        { ...makeModel("model-b"), input: ["text", "image"] },
+      ],
+    });
 
     const result = resolveModelForTest("custom", "model-b", "/tmp/agent", cfg);
 
@@ -3176,22 +2686,11 @@ describe("resolveModel", () => {
   });
 
   it("propagates image input when configured model ids include the provider prefix", () => {
-    const cfg = {
-      models: {
-        providers: {
-          custom: {
-            baseUrl: "http://localhost:9000",
-            api: "openai-completions",
-            models: [
-              {
-                ...makeModel("custom/vision-model"),
-                input: ["text", "image"],
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("custom", {
+      baseUrl: "http://localhost:9000",
+      api: "openai-completions",
+      models: [{ ...makeModel("custom/vision-model"), input: ["text", "image"] }],
+    });
 
     const result = resolveModelForTest("custom", "vision-model", "/tmp/agent", cfg);
 
@@ -3204,22 +2703,11 @@ describe("resolveModel", () => {
   });
 
   it("does not match provider-prefixed configured model ids through core provider aliases", () => {
-    const cfg = {
-      models: {
-        providers: {
-          volcengine: {
-            baseUrl: "http://localhost:9000",
-            api: "openai-completions",
-            models: [
-              {
-                ...makeModel("volcengine/vision-model"),
-                input: ["text", "image"],
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("volcengine", {
+      baseUrl: "http://localhost:9000",
+      api: "openai-completions",
+      models: [{ ...makeModel("volcengine/vision-model"), input: ["text", "image"] }],
+    });
 
     const result = resolveModelForTest("bytedance", "vision-model", "/tmp/agent", cfg);
 
@@ -3227,23 +2715,11 @@ describe("resolveModel", () => {
   });
 
   it("resolves direct moonshotai refs through manifest-owned provider aliases", () => {
-    const cfg = {
-      models: {
-        providers: {
-          moonshot: {
-            baseUrl: "https://api.moonshot.ai/v1",
-            api: "openai-completions",
-            models: [
-              {
-                ...makeModel("kimi-k2.6"),
-                name: "Kimi K2.6",
-                input: ["text", "image"],
-              },
-            ],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("moonshot", {
+      baseUrl: "https://api.moonshot.ai/v1",
+      api: "openai-completions",
+      models: [{ ...makeModel("kimi-k2.6"), name: "Kimi K2.6", input: ["text", "image"] }],
+    });
 
     const result = resolveModelForTest("moonshotai", "kimi-k2.6", "/tmp/agent", cfg);
 
@@ -3255,17 +2731,11 @@ describe("resolveModel", () => {
   });
 
   it("resolves direct moonshot-ai refs through manifest-owned provider aliases", () => {
-    const cfg = {
-      models: {
-        providers: {
-          moonshot: {
-            baseUrl: "https://api.moonshot.ai/v1",
-            api: "openai-completions",
-            models: [makeModel("kimi-k2.6")],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
+    const cfg = makeProviderConfig("moonshot", {
+      baseUrl: "https://api.moonshot.ai/v1",
+      api: "openai-completions",
+      models: [makeModel("kimi-k2.6")],
+    });
 
     const result = resolveModelForTest("moonshot-ai", "kimi-k2.6", "/tmp/agent", cfg);
 
@@ -3591,15 +3061,7 @@ describe("resolveModel", () => {
   });
 
   it("prefers provider-prefixed configured metadata over discovered text-only models", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "custom",
-      modelId: "vision-model",
-      templateModel: {
-        ...makeModel("vision-model"),
-        provider: "custom",
-        input: ["text"],
-      },
-    });
+    mockMinimalModelDiscovery("custom", "vision-model", { input: ["text"] });
     const cfg = {
       models: {
         providers: {
@@ -3997,16 +3459,10 @@ describe("resolveModel", () => {
   });
 
   it("matches prefixed Hugging Face ids against discovered registry models", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "huggingface",
-      modelId: "deepseek-ai/DeepSeek-R1",
-      templateModel: {
-        ...makeModel("deepseek-ai/DeepSeek-R1"),
-        provider: "huggingface",
-        baseUrl: "https://router.huggingface.co/v1",
-        reasoning: true,
-        input: ["text"],
-      },
+    mockMinimalModelDiscovery("huggingface", "deepseek-ai/DeepSeek-R1", {
+      baseUrl: "https://router.huggingface.co/v1",
+      reasoning: true,
+      input: ["text"],
     });
 
     const result = resolveModelForTest(
@@ -4445,15 +3901,7 @@ describe("resolveModel", () => {
   });
 
   it("rejects stale openai gpt-5.3-codex-spark discovery rows", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.3-codex-spark",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex-spark"),
-        name: "GPT-5.3 Codex Spark",
-        input: ["text"],
-      },
-    });
+    mockOpenAIForwardCompatDiscovery("gpt-5.3-codex-spark", { input: ["text"] });
 
     const result = resolveModelForTest("openai", "gpt-5.3-codex-spark", "/tmp/agent");
 
@@ -4464,16 +3912,10 @@ describe("resolveModel", () => {
   });
 
   it("prefers runtime-resolved openai gpt-5.4 metadata when it has a larger context window", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
-        name: "GPT-5.4",
-        contextWindow: 128_000,
-        contextTokens: 32_000,
-        input: ["text"],
-      },
+    mockOpenAIForwardCompatDiscovery("gpt-5.4", {
+      contextWindow: 128_000,
+      contextTokens: 32_000,
+      input: ["text"],
     });
 
     const result = resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
@@ -4490,14 +3932,7 @@ describe("resolveModel", () => {
   });
 
   it("lets official openai metadata override stale configured model rows", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
-        name: "GPT-5.4",
-      },
-    });
+    mockOpenAIForwardCompatDiscovery();
 
     const cfg = {
       models: {
@@ -4558,15 +3993,9 @@ describe("resolveModel", () => {
   });
 
   it("preserves unmarked manual openai metadata overrides", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.5",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.5"),
-        name: "GPT-5.5",
-        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
-        contextWindow: 400_000,
-      },
+    mockOpenAIForwardCompatDiscovery("gpt-5.5", {
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+      contextWindow: 400_000,
     });
 
     const cfg = {
@@ -4606,15 +4035,9 @@ describe("resolveModel", () => {
   });
 
   it("prefers runtime-resolved openai gpt-5.4 metadata during async resolution too", async () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
-        name: "GPT-5.4",
-        contextWindow: 128_000,
-        contextTokens: 32_000,
-      },
+    mockOpenAIForwardCompatDiscovery("gpt-5.4", {
+      contextWindow: 128_000,
+      contextTokens: 32_000,
     });
 
     const result = await resolveModelAsyncForTest("openai", "gpt-5.4", "/tmp/agent");
@@ -4629,14 +4052,8 @@ describe("resolveModel", () => {
   });
 
   it("normalizes stale discovered openai /backend-api/v1 metadata", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
-        name: "GPT-5.4",
-        baseUrl: "https://chatgpt.com/backend-api/v1",
-      },
+    mockOpenAIForwardCompatDiscovery("gpt-5.4", {
+      baseUrl: "https://chatgpt.com/backend-api/v1",
     });
 
     const result = resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
@@ -4680,15 +4097,7 @@ describe("resolveModel", () => {
   });
 
   it("normalizes discovered openai metadata when api is missing", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
-        name: "GPT-5.4",
-        api: undefined,
-      },
-    });
+    mockOpenAIForwardCompatDiscovery("gpt-5.4", { api: undefined });
 
     const result = resolveModelForTest("openai", "gpt-5.4", "/tmp/agent");
 
@@ -4702,15 +4111,9 @@ describe("resolveModel", () => {
   });
 
   it("passes configured workspaceDir to runtime preference hooks", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
-        name: "GPT-5.4",
-        contextWindow: 128_000,
-        contextTokens: 32_000,
-      },
+    mockOpenAIForwardCompatDiscovery("gpt-5.4", {
+      contextWindow: 128_000,
+      contextTokens: 32_000,
     });
 
     const shouldPreferRuntimeResolvedModel = vi.fn(
@@ -4829,15 +4232,9 @@ describe("resolveModel", () => {
   });
 
   it("resolves discovered openai gpt-5.4-mini rows", () => {
-    mockDiscoveredModel(discoverModels, {
-      provider: "openai",
-      modelId: "gpt-5.4-mini",
-      templateModel: {
-        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4-mini"),
-        name: "GPT-5.4 Mini",
-        contextWindow: 64_000,
-        input: ["text"],
-      },
+    mockOpenAIForwardCompatDiscovery("gpt-5.4-mini", {
+      contextWindow: 64_000,
+      input: ["text"],
     });
 
     const result = resolveModelForTest("openai", "gpt-5.4-mini", "/tmp/agent");

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -36,6 +36,7 @@ import { createStructuredOutputTool } from "./tools/structured-output-tool.js";
 type LifecycleControllerParams = Parameters<typeof createSubagentRegistryLifecycleController>[0];
 type LifecycleController = ReturnType<typeof createSubagentRegistryLifecycleController>;
 type SubagentCompletionParams = Parameters<LifecycleController["completeSubagentRun"]>[0];
+type RestartRecoveryReceipt = NonNullable<SubagentRunRecord["execution"]["restartRecovery"]>;
 
 describe("subagent recovery session-effect ownership", () => {
   it("does not treat an ordinary run generation as a recovery suppression receipt", () => {
@@ -55,13 +56,9 @@ describe("subagent recovery session-effect ownership", () => {
       execution: {
         status: "terminal",
         endedAt: 4_000,
-        restartRecovery: {
-          sessionId: "session-id",
-          sessionMarker: "session-id:1",
-          idempotencyKey: "recovery-run",
+        restartRecovery: makeRestartRecoveryReceipt({
           lifecycleGeneration: "retired-generation",
-          phase: "accepted",
-        },
+        }),
       },
     });
     const legacyKillEntry = createRunEntry({
@@ -200,6 +197,9 @@ type RunEntryOverrides = Omit<Partial<SubagentRunRecord>, "execution"> & {
   endedAt?: number;
   outcome?: SubagentRunRecord["execution"]["outcome"];
 };
+type RunModeCleanupEntryOverrides = Omit<RunEntryOverrides, "execution"> & {
+  execution?: Partial<SubagentRunRecord["execution"]>;
+};
 
 function createRunEntry(overrides: RunEntryOverrides = {}): SubagentRunRecord {
   const { startedAt = 2_000, endedAt, outcome, execution, ...recordOverrides } = overrides;
@@ -221,6 +221,92 @@ function createRunEntry(overrides: RunEntryOverrides = {}): SubagentRunRecord {
           ...(outcome === undefined ? {} : { outcome }),
         },
   };
+}
+
+function makeProvisionalKilledRunEntry(overrides: RunEntryOverrides = {}): SubagentRunRecord {
+  return createRunEntry({
+    endedAt: 4_000,
+    endedReason: SUBAGENT_ENDED_REASON_KILLED,
+    outcome: { status: "error", error: "agent run aborted" },
+    suppressAnnounceReason: "killed",
+    killReconciliation: { killedAt: 4_000 },
+    cleanupHandled: true,
+    cleanupCompletedAt: 4_000,
+    ...overrides,
+  });
+}
+
+function makeRestartRecoveryReceipt(
+  overrides: Partial<RestartRecoveryReceipt> = {},
+): RestartRecoveryReceipt {
+  return {
+    sessionId: "session-id",
+    sessionMarker: "session-id:1",
+    idempotencyKey: "recovery-run",
+    phase: "accepted",
+    ...overrides,
+  };
+}
+
+function makeRunModeCleanupEntry(
+  transcriptSessionId: string,
+  overrides: RunModeCleanupEntryOverrides = {},
+): SubagentRunRecord {
+  const { execution, ...recordOverrides } = overrides;
+  const sessionKeySuffix = transcriptSessionId.replace(/^internal-/u, "");
+  return createRunEntry({
+    cleanup: "delete",
+    spawnMode: "run",
+    ...recordOverrides,
+    execution: {
+      status: "terminal",
+      endedAt: 4_000,
+      transcriptTarget: {
+        agentId: "main",
+        sessionId: transcriptSessionId,
+        sessionKey: `agent:main:internal:${sessionKeySuffix}`,
+        storePath: "/tmp/openclaw-agent.sqlite",
+      },
+      ...execution,
+    },
+  });
+}
+
+function makeSubagentCompletion(
+  entry: SubagentRunRecord,
+  overrides: Omit<Partial<SubagentCompletionParams>, "runId"> = {},
+): SubagentCompletionParams {
+  return {
+    runId: entry.runId,
+    endedAt: 4_000,
+    outcome: { status: "ok" },
+    reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    triggerCleanup: false,
+    ...overrides,
+  };
+}
+
+function makeKilledSubagentCompletion(
+  entry: SubagentRunRecord,
+  overrides: Omit<Partial<SubagentCompletionParams>, "runId"> = {},
+): SubagentCompletionParams {
+  return makeSubagentCompletion(entry, {
+    outcome: { status: "error", error: "agent run aborted" },
+    reason: SUBAGENT_ENDED_REASON_KILLED,
+    ...overrides,
+  });
+}
+
+function makeInterruptedSubagentCompletion(
+  entry: SubagentRunRecord,
+  overrides: Omit<Partial<SubagentCompletionParams>, "runId"> = {},
+): SubagentCompletionParams {
+  return makeSubagentCompletion(entry, {
+    outcome: { status: "error", error: "restart interrupted run" },
+    reason: SUBAGENT_ENDED_REASON_ERROR,
+    recoverInterrupted: true,
+    ...overrides,
+  });
 }
 
 function expectFields(value: unknown, expected: Record<string, unknown>): void {
@@ -326,14 +412,7 @@ function completeRun(
   entry: SubagentRunRecord,
   overrides: Omit<Partial<SubagentCompletionParams>, "runId"> = {},
 ) {
-  return controller.completeSubagentRun({
-    runId: entry.runId,
-    endedAt: 4_000,
-    outcome: { status: "ok" },
-    reason: SUBAGENT_ENDED_REASON_COMPLETE,
-    triggerCleanup: false,
-    ...overrides,
-  });
+  return controller.completeSubagentRun(makeSubagentCompletion(entry, overrides));
 }
 
 async function runNoReplyMirrorScenario(params: {
@@ -384,13 +463,11 @@ async function runNoReplyMirrorScenario(params: {
     captureSubagentCompletionReply: vi.fn(async () => text),
     persist: vi.fn(),
     runSubagentAnnounceFlow,
-  }).completeSubagentRun({
-    runId: entry.runId,
-    endedAt: 4_000,
-    outcome: { status: "ok" },
-    reason: SUBAGENT_ENDED_REASON_COMPLETE,
-    triggerCleanup: true,
-  });
+  }).completeSubagentRun(
+    makeSubagentCompletion(entry, {
+      triggerCleanup: true,
+    }),
+  );
   return entry;
 }
 
@@ -542,14 +619,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry();
     const emitSubagentProgressEndedForRun = vi.fn(async () => {});
     const controller = createLifecycleController({ entry, emitSubagentProgressEndedForRun });
-    const completion = {
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error" as const, error: "restart interrupted run" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: false,
-      recoverInterrupted: true,
-    } satisfies SubagentCompletionParams;
+    const completion = makeInterruptedSubagentCompletion(entry);
 
     await controller.completeSubagentRun(completion);
     await controller.completeSubagentRun(completion);
@@ -585,13 +655,12 @@ describe("subagent registry lifecycle hardening", () => {
     const emitSubagentProgressEndedForRun = vi.fn(async () => {});
     const controller = createLifecycleController({ entry, emitSubagentProgressEndedForRun });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "restart interrupted run" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(
+      makeSubagentCompletion(entry, {
+        outcome: { status: "error", error: "restart interrupted run" },
+        reason: SUBAGENT_ENDED_REASON_ERROR,
+      }),
+    );
 
     expect(lifecycleEventMocks.emitSessionLifecycleEvent).not.toHaveBeenCalled();
     expect(emitSubagentProgressEndedForRun).not.toHaveBeenCalled();
@@ -602,27 +671,20 @@ describe("subagent registry lifecycle hardening", () => {
       execution: {
         status: "running",
         startedAt: 2_000,
-        restartRecovery: {
-          sessionId: "session-id",
-          sessionMarker: "session-id:1",
-          idempotencyKey: "recovery-run",
-          phase: "accepted",
+        restartRecovery: makeRestartRecoveryReceipt({
           lifecycleGeneration: "retired-generation",
-        },
+        }),
       },
     });
     const persistOrThrow = vi.fn();
     const controller = createLifecycleController({ entry, persistOrThrow });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "exact recovery session was lost" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: false,
-      recoverInterrupted: true,
-      suppressSessionEffects: true,
-    });
+    await controller.completeSubagentRun(
+      makeInterruptedSubagentCompletion(entry, {
+        outcome: { status: "error", error: "exact recovery session was lost" },
+        suppressSessionEffects: true,
+      }),
+    );
 
     expect(entry).toMatchObject({
       terminalOwner: "interrupted-recovery",
@@ -646,13 +708,9 @@ describe("subagent registry lifecycle hardening", () => {
       execution: {
         status: "interrupted",
         startedAt: 2_000,
-        restartRecovery: {
-          sessionId: "session-id",
-          sessionMarker: "session-id:1",
-          idempotencyKey: "recovery-run",
-          phase: "accepted",
+        restartRecovery: makeRestartRecoveryReceipt({
           lifecycleGeneration: "retired-generation",
-        },
+        }),
       },
     });
     const runs = new Map([[entry.runId, entry]]);
@@ -666,15 +724,13 @@ describe("subagent registry lifecycle hardening", () => {
       shouldEmitEndedHookForRun: () => true,
     });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "retired Gateway lifecycle" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: true,
-      recoverInterrupted: true,
-      suppressSessionEffects: true,
-    });
+    await controller.completeSubagentRun(
+      makeInterruptedSubagentCompletion(entry, {
+        outcome: { status: "error", error: "retired Gateway lifecycle" },
+        triggerCleanup: true,
+        suppressSessionEffects: true,
+      }),
+    );
     await waitForLifecycleState(() => {
       expect(entry.execution.restartRecovery).toBeUndefined();
     });
@@ -721,23 +777,17 @@ describe("subagent registry lifecycle hardening", () => {
         startedAt: 2_000,
         endedAt: 4_000,
         outcome: { status: "error", error: "restart interrupted run" },
-        restartRecovery: {
-          sessionId: "session-id",
-          sessionMarker: "session-id:1",
-          idempotencyKey: "recovery-run",
-          phase: "accepted",
-        },
+        restartRecovery: makeRestartRecoveryReceipt(),
       },
     });
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_001,
-      outcome: { status: "error", error: "killed" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(
+      makeKilledSubagentCompletion(entry, {
+        endedAt: 4_001,
+        outcome: { status: "error", error: "killed" },
+      }),
+    );
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_KILLED,
@@ -767,23 +817,17 @@ describe("subagent registry lifecycle hardening", () => {
         startedAt: 2_000,
         endedAt: 4_000,
         outcome: { status: "error", error: "restart interrupted run" },
-        restartRecovery: {
-          sessionId: "session-id",
-          sessionMarker: "session-id:1",
-          idempotencyKey: "recovery-run",
-          phase: "accepted",
-        },
+        restartRecovery: makeRestartRecoveryReceipt(),
       },
     });
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_001,
-      outcome: { status: "error", error: "legacy killed" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(
+      makeKilledSubagentCompletion(entry, {
+        endedAt: 4_001,
+        outcome: { status: "error", error: "legacy killed" },
+      }),
+    );
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_KILLED,
@@ -811,13 +855,7 @@ describe("subagent registry lifecycle hardening", () => {
     });
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "ok" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(makeSubagentCompletion(entry));
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
@@ -1031,14 +1069,11 @@ describe("subagent registry lifecycle hardening", () => {
     });
     const providerCompletion = completeRun(controller, entry);
     await waitForLifecycleState(() => expect(finishCapture).toBeTypeOf("function"));
-    const interruptedRecovery = controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_001,
-      outcome: { status: "error", error: "restart interrupted run" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: false,
-      recoverInterrupted: true,
-    });
+    const interruptedRecovery = controller.completeSubagentRun(
+      makeInterruptedSubagentCompletion(entry, {
+        endedAt: 4_001,
+      }),
+    );
 
     finishCapture?.("provider result");
     await Promise.all([providerCompletion, interruptedRecovery]);
@@ -1053,14 +1088,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry();
     const persistOrThrow = vi.fn();
     const controller = createLifecycleController({ entry, persistOrThrow });
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "restart interrupted run" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: false,
-      recoverInterrupted: true,
-    });
+    await controller.completeSubagentRun(makeInterruptedSubagentCompletion(entry));
     const recovered = structuredClone(entry);
 
     await completeRun(controller, entry, { endedAt: 4_001 });
@@ -1093,14 +1121,7 @@ describe("subagent registry lifecycle hardening", () => {
     });
 
     await expect(
-      controller.completeSubagentRun({
-        runId: entry.runId,
-        endedAt: 4_000,
-        outcome: { status: "error", error: "restart interrupted run" },
-        reason: SUBAGENT_ENDED_REASON_ERROR,
-        triggerCleanup: false,
-        recoverInterrupted: true,
-      }),
+      controller.completeSubagentRun(makeInterruptedSubagentCompletion(entry)),
     ).rejects.toThrow("registry store boom");
 
     expect(entry).toEqual(original);
@@ -1120,14 +1141,11 @@ describe("subagent registry lifecycle hardening", () => {
     });
     const original = structuredClone(entry);
     const persistOrThrow = vi.fn();
-    await createLifecycleController({ entry, persistOrThrow }).completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_001,
-      outcome: { status: "error", error: "restart interrupted run" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: false,
-      recoverInterrupted: true,
-    });
+    await createLifecycleController({ entry, persistOrThrow }).completeSubagentRun(
+      makeInterruptedSubagentCompletion(entry, {
+        endedAt: 4_001,
+      }),
+    );
 
     expect(entry).toEqual(original);
     expect(persistOrThrow).not.toHaveBeenCalled();
@@ -1158,14 +1176,11 @@ describe("subagent registry lifecycle hardening", () => {
       const entry = createRunEntry(evidence);
       const original = structuredClone(entry);
       const persistOrThrow = vi.fn();
-      await createLifecycleController({ entry, persistOrThrow }).completeSubagentRun({
-        runId: entry.runId,
-        endedAt: 4_001,
-        outcome: { status: "error", error: "restart interrupted run" },
-        reason: SUBAGENT_ENDED_REASON_ERROR,
-        triggerCleanup: false,
-        recoverInterrupted: true,
-      });
+      await createLifecycleController({ entry, persistOrThrow }).completeSubagentRun(
+        makeInterruptedSubagentCompletion(entry, {
+          endedAt: 4_001,
+        }),
+      );
 
       expect(entry).toEqual(original);
       expect(persistOrThrow).not.toHaveBeenCalled();
@@ -1192,14 +1207,9 @@ describe("subagent registry lifecycle hardening", () => {
       },
     });
     const persistOrThrow = vi.fn();
-    await createLifecycleController({ entry, persistOrThrow }).completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "restart interrupted run" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: false,
-      recoverInterrupted: true,
-    });
+    await createLifecycleController({ entry, persistOrThrow }).completeSubagentRun(
+      makeInterruptedSubagentCompletion(entry),
+    );
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_ERROR,
@@ -1214,15 +1224,7 @@ describe("subagent registry lifecycle hardening", () => {
   });
 
   it("restores a provisional kill when canonical task projection fails", async () => {
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     const original = structuredClone(entry);
     const persistOrThrow = vi.fn();
     taskExecutorMocks.completeTaskRunByRunId.mockImplementation(() => {
@@ -1252,15 +1254,7 @@ describe("subagent registry lifecycle hardening", () => {
 
   it("commits a reconciled task before its canonical registry outcome", async () => {
     taskExecutorMocks.completeTaskRunByRunId.mockReturnValueOnce([{}]);
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     const persistOrThrow = vi.fn();
     const controller = createLifecycleController({
       entry,
@@ -1288,13 +1282,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry({ suppressAnnounceReason: "steer-restart" });
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(makeKilledSubagentCompletion(entry));
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_KILLED,
@@ -1308,13 +1296,7 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry();
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(makeKilledSubagentCompletion(entry));
 
     expectFields(firstCallArg(taskExecutorMocks.failTaskRunByRunId), {
       runId: entry.runId,
@@ -1329,14 +1311,12 @@ describe("subagent registry lifecycle hardening", () => {
     const entry = createRunEntry({ runTimeoutSeconds: 3 });
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      startedAt: 2_000,
-      endedAt: 6_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(
+      makeKilledSubagentCompletion(entry, {
+        startedAt: 2_000,
+        endedAt: 6_000,
+      }),
+    );
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
@@ -1359,14 +1339,12 @@ describe("subagent registry lifecycle hardening", () => {
     });
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      startedAt: 2_000,
-      endedAt: 6_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(
+      makeKilledSubagentCompletion(entry, {
+        startedAt: 2_000,
+        endedAt: 6_000,
+      }),
+    );
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
@@ -1390,13 +1368,11 @@ describe("subagent registry lifecycle hardening", () => {
         runSubagentAnnounceFlow,
       });
 
-      await controller.completeSubagentRun({
-        runId: entry.runId,
-        endedAt: 4_000,
-        outcome: { status: "error", error: "agent run aborted" },
-        reason: SUBAGENT_ENDED_REASON_KILLED,
-        triggerCleanup: true,
-      });
+      await controller.completeSubagentRun(
+        makeKilledSubagentCompletion(entry, {
+          triggerCleanup: true,
+        }),
+      );
 
       expect(entry).toMatchObject({
         endedReason: SUBAGENT_ENDED_REASON_KILLED,
@@ -1423,13 +1399,7 @@ describe("subagent registry lifecycle hardening", () => {
       captureSubagentCompletionReply,
     });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(makeKilledSubagentCompletion(entry));
     expect(entry.completion).toMatchObject({ resultText: null });
 
     await completeRun(controller, entry, { endedAt: 4_001 });
@@ -1458,13 +1428,7 @@ describe("subagent registry lifecycle hardening", () => {
       captureSubagentCompletionReply,
     });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(makeKilledSubagentCompletion(entry));
     expect(entry.completion).toMatchObject({ resultText: null });
 
     await completeRun(controller, entry, {
@@ -1478,15 +1442,9 @@ describe("subagent registry lifecycle hardening", () => {
   });
 
   it("preserves a captured reply when success supersedes a delayed killed lifecycle", async () => {
-    const entry = createRunEntry({
-      endedAt: 4_000,
+    const entry = makeProvisionalKilledRunEntry({
       archiveAtMs: 5_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
       expectsCompletionMessage: true,
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
       completion: {
         required: true,
         resultText: "Already captured final reply.",
@@ -1530,13 +1488,11 @@ describe("subagent registry lifecycle hardening", () => {
     await waitForLifecycleState(() =>
       expect(captureSubagentCompletionReply).toHaveBeenCalledOnce(),
     );
-    const killed = controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_001,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: false,
-    });
+    const killed = controller.completeSubagentRun(
+      makeKilledSubagentCompletion(entry, {
+        endedAt: 4_001,
+      }),
+    );
     releaseCapture?.("Canonical final reply.");
     await Promise.all([success, killed]);
 
@@ -1695,13 +1651,11 @@ describe("subagent registry lifecycle hardening", () => {
       captureSubagentCompletionReply: vi.fn(async () => "Canonical success."),
     });
 
-    const killed = controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: true,
-    });
+    const killed = controller.completeSubagentRun(
+      makeKilledSubagentCompletion(entry, {
+        triggerCleanup: true,
+      }),
+    );
     await waitForLifecycleState(() =>
       expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalledOnce(),
     );
@@ -1725,18 +1679,12 @@ describe("subagent registry lifecycle hardening", () => {
   });
 
   it("keeps requester stop delivery suppressed when provider completion wins", async () => {
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
+    const entry = makeProvisionalKilledRunEntry({
       expectsCompletionMessage: true,
-      suppressAnnounceReason: "killed",
       killReconciliation: {
         killedAt: 4_000,
         suppressTaskDelivery: true,
       },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
     });
     const runSubagentAnnounceFlow = vi.fn<(_params: unknown) => Promise<boolean>>(async () => true);
     const emitSubagentEndedHookForRun = vi.fn(async () => {});
@@ -1782,20 +1730,17 @@ describe("subagent registry lifecycle hardening", () => {
       const entry = createRunEntry();
       const controller = createLifecycleController({ entry });
 
-      await controller.completeSubagentRun({
-        runId: entry.runId,
-        endedAt: 4_000,
-        outcome,
-        reason,
-        triggerCleanup: false,
-      });
-      await controller.completeSubagentRun({
-        runId: entry.runId,
-        endedAt: 4_001,
-        outcome: { status: "error", error: "agent run aborted" },
-        reason: SUBAGENT_ENDED_REASON_KILLED,
-        triggerCleanup: false,
-      });
+      await controller.completeSubagentRun(
+        makeSubagentCompletion(entry, {
+          outcome,
+          reason,
+        }),
+      );
+      await controller.completeSubagentRun(
+        makeKilledSubagentCompletion(entry, {
+          endedAt: 4_001,
+        }),
+      );
 
       expect(entry.execution.outcome?.status).toBe(outcome.status);
       expect(entry.endedReason).toBe(reason);
@@ -1817,15 +1762,8 @@ describe("subagent registry lifecycle hardening", () => {
   ])(
     "restarts cleanup when canonical $name supersedes a killed run",
     async ({ reason, outcome }) => {
-      const entry = createRunEntry({
-        endedAt: 4_000,
-        endedReason: SUBAGENT_ENDED_REASON_KILLED,
-        outcome: { status: "error", error: "agent run aborted" },
+      const entry = makeProvisionalKilledRunEntry({
         expectsCompletionMessage: true,
-        suppressAnnounceReason: "killed",
-        killReconciliation: { killedAt: 4_000 },
-        cleanupHandled: true,
-        cleanupCompletedAt: 4_000,
         delivery: {
           status: "delivered",
           announcedAt: 4_000,
@@ -1834,13 +1772,13 @@ describe("subagent registry lifecycle hardening", () => {
       });
       const controller = createLifecycleController({ entry });
 
-      await controller.completeSubagentRun({
-        runId: entry.runId,
-        endedAt: 4_001,
-        outcome,
-        reason,
-        triggerCleanup: false,
-      });
+      await controller.completeSubagentRun(
+        makeSubagentCompletion(entry, {
+          endedAt: 4_001,
+          outcome,
+          reason,
+        }),
+      );
 
       expect(entry).toMatchObject({
         endedReason: reason,
@@ -1856,15 +1794,7 @@ describe("subagent registry lifecycle hardening", () => {
   );
 
   it("keeps accepted task cancellation canonical over a late provider result", async () => {
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     const controller = createLifecycleController({
       entry,
       resolveSubagentTask: () => ({
@@ -1910,15 +1840,7 @@ describe("subagent registry lifecycle hardening", () => {
   });
 
   it("keeps cancellation canonical when a custom runtime cannot resolve its task", async () => {
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     const controller = createLifecycleController({
       entry,
       resolveSubagentTask: () => ({ lookup: "unavailable" }),
@@ -1939,15 +1861,7 @@ describe("subagent registry lifecycle hardening", () => {
 
   it("accepts provider completion when an opaque custom runtime finalizes it", async () => {
     taskExecutorMocks.completeTaskRunByRunId.mockReturnValueOnce([{}]);
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     const controller = createLifecycleController({
       entry,
       resolveSubagentTask: () => ({ lookup: "unavailable" }),
@@ -1965,15 +1879,7 @@ describe("subagent registry lifecycle hardening", () => {
 
   it("restores an opaque provisional kill when completion persistence fails", async () => {
     taskExecutorMocks.completeTaskRunByRunId.mockReturnValueOnce([{}]);
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     const original = structuredClone(entry);
     const controller = createLifecycleController({
       entry,
@@ -1992,15 +1898,7 @@ describe("subagent registry lifecycle hardening", () => {
   });
 
   it("keeps cancellation that becomes durable during completion capture", async () => {
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     let cancellationStable = false;
     let finishCapture: ((value: string) => void) | undefined;
     const captureSubagentCompletionReply = vi.fn(
@@ -2075,13 +1973,11 @@ describe("subagent registry lifecycle hardening", () => {
       }),
     });
 
-    const killed = controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "agent run aborted" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-      triggerCleanup: true,
-    });
+    const killed = controller.completeSubagentRun(
+      makeKilledSubagentCompletion(entry, {
+        triggerCleanup: true,
+      }),
+    );
     await waitForLifecycleState(() =>
       expect(helperMocks.persistSubagentSessionTiming).toHaveBeenCalled(),
     );
@@ -2099,15 +1995,7 @@ describe("subagent registry lifecycle hardening", () => {
 
   it("accepts a provider result that predates task cancellation", async () => {
     taskExecutorMocks.completeTaskRunByRunId.mockReturnValueOnce([{}]);
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
-    });
+    const entry = makeProvisionalKilledRunEntry();
     const controller = createLifecycleController({
       entry,
       resolveSubagentTask: () => ({
@@ -2134,14 +2022,10 @@ describe("subagent registry lifecycle hardening", () => {
 
   it("lets an explicit timeout deadline predate accepted task cancellation", async () => {
     taskExecutorMocks.failTaskRunByRunId.mockReturnValueOnce([{}]);
-    const entry = createRunEntry({
+    const entry = makeProvisionalKilledRunEntry({
       runTimeoutSeconds: 3,
       endedAt: 5_500,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
       killReconciliation: { killedAt: 5_500 },
-      cleanupHandled: true,
       cleanupCompletedAt: 5_500,
     });
     const controller = createLifecycleController({
@@ -2157,14 +2041,12 @@ describe("subagent registry lifecycle hardening", () => {
       }),
     });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      startedAt: 2_000,
-      endedAt: 6_000,
-      outcome: { status: "ok" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(
+      makeSubagentCompletion(entry, {
+        startedAt: 2_000,
+        endedAt: 6_000,
+      }),
+    );
 
     expect(entry).toMatchObject({
       endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
@@ -2184,14 +2066,7 @@ describe("subagent registry lifecycle hardening", () => {
 
   it("retires an old live completion without touching a newer session generation", async () => {
     taskExecutorMocks.completeTaskRunByRunId.mockReturnValueOnce([{}]);
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
-      killReconciliation: { killedAt: 4_000 },
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
+    const entry = makeProvisionalKilledRunEntry({
       cleanup: "delete",
     });
     const newer = createRunEntry({
@@ -2250,15 +2125,9 @@ describe("subagent registry lifecycle hardening", () => {
   it("keeps the superseded generation boundary through task finalization", async () => {
     taskExecutorMocks.completeTaskRunByRunId.mockReturnValueOnce([{}]);
     const marker = { killedAt: 4_000, supersededAt: 5_000 };
-    const entry = createRunEntry({
+    const entry = makeProvisionalKilledRunEntry({
       runId: "run-after-replacement",
-      endedAt: 4_000,
-      endedReason: SUBAGENT_ENDED_REASON_KILLED,
-      outcome: { status: "error", error: "agent run aborted" },
-      suppressAnnounceReason: "killed",
       killReconciliation: marker,
-      cleanupHandled: true,
-      cleanupCompletedAt: 4_000,
     });
     const observedSupersededAt: Array<number | undefined> = [];
     const resolveSubagentTask = vi.fn((candidate: SubagentRunRecord) => {
@@ -2479,13 +2348,7 @@ describe("subagent registry lifecycle hardening", () => {
     await createLifecycleController({
       entry,
       captureSubagentCompletionReply: vi.fn(async () => reply),
-    }).completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "ok" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-      triggerCleanup: false,
-    });
+    }).completeSubagentRun(makeSubagentCompletion(entry));
 
     const finalArg = firstCallArg(taskExecutorMocks.completeTaskRunByRunId);
     expectFields(finalArg, {
@@ -2933,13 +2796,13 @@ describe("subagent registry lifecycle hardening", () => {
       captureSubagentCompletionReply: vi.fn(async () => ""),
     });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "completed" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: true,
-    });
+    await controller.completeSubagentRun(
+      makeSubagentCompletion(entry, {
+        outcome: { status: "error", error: "completed" },
+        reason: SUBAGENT_ENDED_REASON_ERROR,
+        triggerCleanup: true,
+      }),
+    );
 
     await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
     expect(entry.collectorCompletion).toEqual({ status: "done", structured });
@@ -2961,13 +2824,13 @@ describe("subagent registry lifecycle hardening", () => {
     });
     const controller = createLifecycleController({ entry });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "error", error: "provider failed after tool output" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: true,
-    });
+    await controller.completeSubagentRun(
+      makeSubagentCompletion(entry, {
+        outcome: { status: "error", error: "provider failed after tool output" },
+        reason: SUBAGENT_ENDED_REASON_ERROR,
+        triggerCleanup: true,
+      }),
+    );
 
     await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
     expect(entry.collectorCompletion).toEqual({ status: "failed", structured });
@@ -3215,13 +3078,7 @@ describe("subagent registry lifecycle hardening", () => {
       runSubagentAnnounceFlow: vi.fn(async () => false),
     });
 
-    await controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "ok" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-      triggerCleanup: false,
-    });
+    await controller.completeSubagentRun(makeSubagentCompletion(entry));
 
     expect(captureSubagentCompletionReply).toHaveBeenCalledWith(
       childSessionKey,
@@ -3254,13 +3111,11 @@ describe("subagent registry lifecycle hardening", () => {
     });
 
     await expect(
-      controller.completeSubagentRun({
-        runId: entry.runId,
-        endedAt: 4_000,
-        outcome: { status: "error", error: "All models failed (2): timeout" },
-        reason: SUBAGENT_ENDED_REASON_COMPLETE,
-        triggerCleanup: false,
-      }),
+      controller.completeSubagentRun(
+        makeSubagentCompletion(entry, {
+          outcome: { status: "error", error: "All models failed (2): timeout" },
+        }),
+      ),
     ).resolves.toBeUndefined();
 
     expect(captureSubagentCompletionReply).not.toHaveBeenCalled();
@@ -3825,23 +3680,20 @@ describe("subagent registry lifecycle hardening", () => {
       },
     );
 
-    const firstCompletion = controller.completeSubagentRun({
-      runId: entry.runId,
-      endedAt: 4_000,
-      outcome: { status: "ok" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-      triggerCleanup: true,
-    });
+    const firstCompletion = controller.completeSubagentRun(
+      makeSubagentCompletion(entry, {
+        triggerCleanup: true,
+      }),
+    );
     await firstCleanupEntered;
-    const staleRecovery = controller.completeSubagentRun({
-      runId: entry.runId,
-      expectedEntry: entry,
-      endedAt: 4_001,
-      outcome: { status: "error", error: "stale interrupted recovery" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      triggerCleanup: true,
-      recoverInterrupted: true,
-    });
+    const staleRecovery = controller.completeSubagentRun(
+      makeInterruptedSubagentCompletion(entry, {
+        expectedEntry: entry,
+        endedAt: 4_001,
+        outcome: { status: "error", error: "stale interrupted recovery" },
+        triggerCleanup: true,
+      }),
+    );
     runs.set(entry.runId, successor);
 
     releaseFirstCleanup();
@@ -4023,21 +3875,13 @@ describe("requester settle wake trigger", () => {
       ) => runs.set(successor.runId, successor),
     },
   ])("drops detached cleanup tails after a $name takes ownership", async (scenario) => {
-    const entry = createRunEntry({
+    const entry = makeRunModeCleanupEntry("internal-run-1", {
       generation: 1,
       createdAt: 1_000,
-      spawnMode: "run",
+      cleanup: "keep",
       execution: {
-        status: "terminal",
         startedAt: 2_000,
-        endedAt: 4_000,
         outcome: { status: "ok" },
-        transcriptTarget: {
-          agentId: "main",
-          sessionId: "internal-run-1",
-          sessionKey: "agent:main:internal:run-1",
-          storePath: "/tmp/openclaw-agent.sqlite",
-        },
       },
     });
     const runs = new Map([[entry.runId, entry]]);
@@ -4142,22 +3986,8 @@ describe("requester settle wake trigger", () => {
   });
 
   it("emits cleanup effects when settle retirement wins before detached tails start", async () => {
-    const transcriptTarget = {
-      agentId: "main",
-      sessionId: "internal-settle-retirement",
-      sessionKey: "agent:main:internal:settle-retirement",
-      storePath: "/tmp/openclaw-agent.sqlite",
-    };
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      cleanup: "delete",
-      spawnMode: "run",
-      execution: {
-        status: "terminal",
-        endedAt: 4_000,
-        transcriptTarget,
-      },
-    });
+    const entry = makeRunModeCleanupEntry("internal-settle-retirement");
+    const transcriptTarget = entry.execution.transcriptTarget;
     const runs = new Map([[entry.runId, entry]]);
     const notifyContextEngineSubagentEnded = vi.fn(async () => {});
     const settleWake = vi.fn(async () => false);
@@ -4194,21 +4024,8 @@ describe("requester settle wake trigger", () => {
   });
 
   it("drops settle-retirement effects when a newer child generation takes ownership", async () => {
-    const entry = createRunEntry({
-      endedAt: 4_000,
-      cleanup: "delete",
-      spawnMode: "run",
+    const entry = makeRunModeCleanupEntry("internal-settle-retired-generation", {
       generation: 1,
-      execution: {
-        status: "terminal",
-        endedAt: 4_000,
-        transcriptTarget: {
-          agentId: "main",
-          sessionId: "internal-settle-retired-generation",
-          sessionKey: "agent:main:internal:settle-retired-generation",
-          storePath: "/tmp/openclaw-agent.sqlite",
-        },
-      },
     });
     const runs = new Map([[entry.runId, entry]]);
     const notifyContextEngineSubagentEnded = vi.fn(async () => {});
@@ -4424,20 +4241,7 @@ describe("requester settle wake trigger", () => {
   });
 
   it("restores a suspended delete row without cleanup effects when retirement fails", () => {
-    const entry = createRunEntry({
-      cleanup: "delete",
-      endedAt: 4_000,
-      spawnMode: "run",
-      execution: {
-        status: "terminal",
-        endedAt: 4_000,
-        transcriptTarget: {
-          agentId: "main",
-          sessionId: "internal-failed-retirement",
-          sessionKey: "agent:main:internal:failed-retirement",
-          storePath: "/tmp/openclaw-agent.sqlite",
-        },
-      },
+    const entry = makeRunModeCleanupEntry("internal-failed-retirement", {
       delivery: {
         status: "discarded",
         discardedAt: 5_000,
@@ -4484,22 +4288,8 @@ describe("requester settle wake trigger", () => {
   });
 
   it("emits cleanup effects once after immediate retirement commits", async () => {
-    const transcriptTarget = {
-      agentId: "main",
-      sessionId: "internal-successful-retirement",
-      sessionKey: "agent:main:internal:successful-retirement",
-      storePath: "/tmp/openclaw-agent.sqlite",
-    };
-    const entry = createRunEntry({
-      cleanup: "delete",
-      endedAt: 4_000,
-      spawnMode: "run",
-      execution: {
-        status: "terminal",
-        endedAt: 4_000,
-        transcriptTarget,
-      },
-    });
+    const entry = makeRunModeCleanupEntry("internal-successful-retirement");
+    const transcriptTarget = entry.execution.transcriptTarget;
     const runs = new Map([[entry.runId, entry]]);
     const notifyContextEngineSubagentEnded = vi.fn(async () => {});
     const persistOrThrow = vi.fn();
@@ -4533,21 +4323,8 @@ describe("requester settle wake trigger", () => {
   });
 
   it("drops immediate-retirement effects after a newer child generation takes ownership", async () => {
-    const entry = createRunEntry({
-      cleanup: "delete",
-      endedAt: 4_000,
-      spawnMode: "run",
+    const entry = makeRunModeCleanupEntry("internal-retired-generation", {
       generation: 1,
-      execution: {
-        status: "terminal",
-        endedAt: 4_000,
-        transcriptTarget: {
-          agentId: "main",
-          sessionId: "internal-retired-generation",
-          sessionKey: "agent:main:internal:retired-generation",
-          storePath: "/tmp/openclaw-agent.sqlite",
-        },
-      },
     });
     const runs = new Map([[entry.runId, entry]]);
     const notifyContextEngineSubagentEnded = vi.fn(async () => {});

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -123,16 +123,16 @@ function makeSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
   };
 }
 
-async function makeSessionFixture(
+async function makeSessionFixture<SessionKey extends string = "main">(
   overrides: Partial<SessionEntry> = {},
-  sessionKey = "main",
+  sessionKey: SessionKey = "main" as SessionKey,
 ): Promise<{
   sessionEntry: SessionEntry;
-  sessionStore: Record<string, SessionEntry>;
+  sessionStore: Record<SessionKey, SessionEntry>;
   storePath: string;
 }> {
   const sessionEntry = makeSessionEntry(overrides);
-  const sessionStore = { [sessionKey]: sessionEntry };
+  const sessionStore = { [sessionKey]: sessionEntry } as Record<SessionKey, SessionEntry>;
   const storePath = await createSessionStoreFile(sessionEntry, sessionKey);
   return { sessionEntry, sessionStore, storePath };
 }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -115,12 +115,62 @@ async function createSessionStoreFile(entry: SessionEntry, sessionKey = "main"):
   return storePath;
 }
 
+function makeSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "session",
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+async function makeSessionFixture(
+  overrides: Partial<SessionEntry> = {},
+  sessionKey = "main",
+): Promise<{
+  sessionEntry: SessionEntry;
+  sessionStore: Record<string, SessionEntry>;
+  storePath: string;
+}> {
+  const sessionEntry = makeSessionEntry(overrides);
+  const sessionStore = { [sessionKey]: sessionEntry };
+  const storePath = await createSessionStoreFile(sessionEntry, sessionKey);
+  return { sessionEntry, sessionStore, storePath };
+}
+
 async function readStoredMainSession(storePath: string): Promise<SessionEntry> {
   return requireStoredSessionEntry(storePath);
 }
 
 let modelFallbackModule: typeof import("../../agents/model-fallback-runner.js");
 let onAgentEvent: typeof import("../../infra/agent-events.js").onAgentEvent;
+
+function makeCompletedFallbackRunner(
+  overrides: {
+    provider?: string;
+    model?: string;
+    attempts?: Awaited<
+      ReturnType<typeof modelFallbackModule.runWithModelFallback<unknown>>
+    >["attempts"];
+  } = {},
+) {
+  const provider = overrides.provider ?? "openai";
+  const model = overrides.model ?? "gpt-5.5";
+  const attempts = overrides.attempts ?? [
+    {
+      provider: "lmstudio",
+      model: "gemma-4-e4b-it",
+      error: "Connection error.",
+      reason: "timeout",
+    },
+  ];
+  return async <T>({ run }: Parameters<typeof modelFallbackModule.runWithModelFallback<T>>[0]) => ({
+    outcome: "completed" as const,
+    result: await run(provider, model),
+    provider,
+    model,
+    attempts,
+  });
+}
 
 let runReplyAgentPromise:
   | Promise<(typeof import("./agent-runner.js"))["runReplyAgent"]>
@@ -792,12 +842,7 @@ describe("runReplyAgent active steering", () => {
   });
 
   it("admits an ordinary rejected steering turn with durable recovery state", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const onAdopted = vi.fn(async () => {
       expect((await readStoredMainSession(storePath)).restartRecoveryBeforeAgentReplyState).toBe(
         "admitted",
@@ -1349,10 +1394,7 @@ describe("runReplyAgent pending final delivery capture", () => {
         defaults: { compaction: { memoryFlush: {} } },
       },
     };
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry();
     const sessionStore = { main: sessionEntry };
     const storePath = join(
       tempDirs.make("openclaw-custom-default-agent-"),
@@ -1446,12 +1488,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "private final" }],
       meta: {},
@@ -1472,13 +1509,9 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("does not persist sendPolicy-denied final replies for heartbeat replay", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       sendPolicy: "deny",
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "denied final" }],
       meta: {},
@@ -1498,12 +1531,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("persists only visible non-reasoning final reply text", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "hidden reasoning", isReasoning: true }, { text: "visible final" }],
       meta: {},
@@ -1535,12 +1563,7 @@ describe("runReplyAgent pending final delivery capture", () => {
 
   it("persists canonical SQLite pending final delivery after its intent commits", async () => {
     const sessionKey = "agent:main:main";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { [sessionKey]: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry, sessionKey);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({}, sessionKey);
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "visible canonical final" }],
       meta: {},
@@ -1573,12 +1596,7 @@ describe("runReplyAgent pending final delivery capture", () => {
 
   it("rejects canonical SQLite pending final delivery when its session is deleted", async () => {
     const sessionKey = "agent:main:main";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { [sessionKey]: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry, sessionKey);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({}, sessionKey);
     state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
       await applySessionEntryLifecycleMutation({
         removals: [{ sessionKey }],
@@ -1605,12 +1623,7 @@ describe("runReplyAgent pending final delivery capture", () => {
 
   it("does not persist canonical SQLite pending final delivery on a reset session", async () => {
     const sessionKey = "agent:main:main";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { [sessionKey]: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry, sessionKey);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({}, sessionKey);
     state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
       await replaceSessionEntry(
         { sessionKey, storePath },
@@ -1638,12 +1651,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("persists auto-reply delivery context for restart recovery", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const expectedSourceTurnId = requireBuiltChannelSourceTurnId({
       provider: "discord",
       accountId: "work",
@@ -1709,12 +1717,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("fails closed and retires an unknown terminal receipt when the live run returns", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const expectedSourceTurnId = requireBuiltChannelSourceTurnId({
       provider: "discord",
       conversationId: "channel:24680",
@@ -1776,12 +1779,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("rejects channel recovery admission without a source-keyed user turn", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const { run } = createMinimalRun({
       sessionCtx: {
         Provider: "discord",
@@ -1807,12 +1805,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("does not arm channel recovery without a source turn id", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
       expect((await readStoredMainSession(storePath)).restartRecoveryDeliveryRunId).toBeUndefined();
       return { payloads: [{ text: "visible final" }], meta: {} };
@@ -1837,12 +1830,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("drops a redelivered terminal channel source before hooks or model work", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const sessionCtx = {
       Provider: "discord",
       OriginatingChannel: "discord",
@@ -1912,8 +1900,7 @@ describe("runReplyAgent pending final delivery capture", () => {
       conversationId: "channel:24680",
       messageId: "redelivered-active-message",
     });
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       status: "running",
       restartRecoveryDeliveryRunId: "active-recovery-run",
       restartRecoveryDeliverySourceRunId: sourceTurnId,
@@ -1921,10 +1908,7 @@ describe("runReplyAgent pending final delivery capture", () => {
         channel: "discord",
         to: "channel:24680",
       },
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const onAdopted = vi.fn();
     const duplicate = createMinimalRun({
       isActive: true,
@@ -1971,8 +1955,7 @@ describe("runReplyAgent pending final delivery capture", () => {
       conversationId: "channel:24680",
       messageId: "redelivered-terminal-message",
     });
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       status: "done",
       restartRecoveryDeliveryRunId: "terminal-recovery-run",
       restartRecoveryDeliverySourceRunId: sourceTurnId,
@@ -1980,10 +1963,7 @@ describe("runReplyAgent pending final delivery capture", () => {
         channel: "discord",
         to: "channel:24680",
       },
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const onAdopted = vi.fn();
     const duplicate = createMinimalRun({
       isActive: true,
@@ -2013,7 +1993,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("atomically replaces a terminal stale recovery claim for the next run", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,
       restartRecoveryDeliveryContext: {
         channel: "webchat",
@@ -2021,12 +2001,8 @@ describe("runReplyAgent pending final delivery capture", () => {
       },
       restartRecoveryDeliveryRunId: "stale-run",
       restartRecoveryDeliverySourceRunId: "stale-control-ui-run",
-      sessionId: "session",
       status: "done",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const expectedSourceTurnId = requireBuiltChannelSourceTurnId({
       provider: "discord",
       accountId: "work",
@@ -2089,15 +2065,11 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("admits the next channel turn after a failed recovery became terminal", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: true,
       restartRecoveryTerminalRunIds: ["failed-source-turn"],
-      sessionId: "session",
       status: "failed",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const expectedSourceTurnId = requireBuiltChannelSourceTurnId({
       provider: "discord",
       accountId: "work",
@@ -2152,17 +2124,13 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("migrates a legacy transcript-only claim before preserving its pending final", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,
       restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
       restartRecoveryDeliveryRunId: "msg",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
-      sessionId: "session",
       status: "running",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
       const storedDuringRun = await readStoredMainSession(storePath);
       expect(storedDuringRun.restartRecoveryBeforeAgentReplyState).toBe("admitted");
@@ -2212,19 +2180,15 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("advances a transcript-only admission to pending before running a discovered hook", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,
       restartRecoveryBeforeAgentReplyState: "admitted",
       restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
       restartRecoveryDeliveryRunId: "msg",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
       restartRecoverySourceIngress: "control-ui",
-      sessionId: "session",
       status: "running",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
@@ -2265,18 +2229,14 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("does not rerun a hook after a durable continue checkpoint", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,
       restartRecoveryBeforeAgentReplyState: "continue",
       restartRecoveryDeliveryRunId: "msg",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
       restartRecoverySourceIngress: "control-ui",
-      sessionId: "session",
       status: "running",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
@@ -2302,13 +2262,9 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("does not carry a stale hook checkpoint into a fresh claim", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       restartRecoveryBeforeAgentReplyState: "continue",
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
@@ -2348,16 +2304,12 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("adopts a transcript-only claim by its short id when the full id differs", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,
       restartRecoveryDeliveryRunId: "msg",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
-      sessionId: "session",
       status: "running",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const { run } = createMinimalRun({
       sessionCtx: {
         MessageSid: "msg",
@@ -2382,17 +2334,13 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("rejects a transcript-only claim already aborted for restart", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: true,
       restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
       restartRecoveryDeliveryRunId: "msg",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
-      sessionId: "session",
       status: "running",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const onAdopted = vi.fn();
     const { run } = createMinimalRun({
       opts: { turnAdoptionLifecycle: { onAdopted } },
@@ -2421,17 +2369,13 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("clears an adopted transcript-only claim after user cancellation", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,
       restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
       restartRecoveryDeliveryRunId: "msg",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
-      sessionId: "session",
       status: "running",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const replyOperation = createReplyOperation({
       sessionKey: "main",
       sessionId: "session",
@@ -2475,17 +2419,13 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("preserves an adopted restart claim when the replacement takes the SQLite lease", async () => {
-    const sessionEntry: SessionEntry = {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({
       abortedLastRun: false,
       restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
       restartRecoveryDeliveryRunId: "msg",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
-      sessionId: "session",
       status: "running",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    });
     const replyOperation = createReplyOperation({
       sessionKey: "main",
       sessionId: "session",
@@ -2546,12 +2486,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("fires onAdopted after restart recovery delivery context persist completes", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const expectedSourceTurnId = requireBuiltChannelSourceTurnId({
       provider: "discord",
       accountId: "work",
@@ -2651,12 +2586,7 @@ describe("runReplyAgent pending final delivery capture", () => {
         buildToolContext: () => ({ sameChannelThreadRequired: true }),
       },
     });
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const onAdopted = vi.fn(async () => {
       expect(
         (await readStoredMainSession(storePath)).restartRecoverySameChannelThreadRequired,
@@ -2698,12 +2628,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("runs a deferred before_agent_reply hook only after durable admission", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const expectedSourceTurnId = requireBuiltChannelSourceTurnId({
       provider: "discord",
       conversationId: "channel:24680",
@@ -2776,12 +2701,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("finalizes a hook-handled turn when source delivery is intentionally suppressed", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
@@ -2823,12 +2743,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("checkpoints an unhandled before_agent_reply hook before the model starts", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
@@ -2880,12 +2795,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("fires onAdopted for suppressed-delivery runs before the agent turn", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const events: string[] = [];
     const onAdopted = vi.fn(async () => {
       const storedAtAdoption = await readStoredMainSession(storePath);
@@ -2929,12 +2839,7 @@ describe("runReplyAgent pending final delivery capture", () => {
   });
 
   it("keeps heartbeat replies with real content in pending final delivery", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "Sent daily summary to channel." }],
       meta: {},
@@ -2961,12 +2866,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     // When a heartbeat response contains HEARTBEAT_OK followed by substantive content,
     // the remainder after stripping the token must be persisted for durable delivery.
     // The default ackMaxChars is 300 — any remainder longer than that is treated as real content.
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
-    const sessionStore = { main: sessionEntry };
-    const storePath = await createSessionStoreFile(sessionEntry);
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const longRemainder = "Sent daily digest to channel. ".repeat(12).trimEnd(); // ~360 chars, > 300
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: `HEARTBEAT_OK ${longRemainder}` }],
@@ -3475,13 +3375,11 @@ describe("runReplyAgent typing (heartbeat)", () => {
       { name: "verbose off", verbose: "off" as const },
     ] as const;
     for (const testCase of cases) {
-      const sessionEntry: SessionEntry = {
-        sessionId: "session",
-        updatedAt: Date.now(),
+      const sessionEntry = makeSessionEntry({
         providerOverride: "openai",
         modelOverride: "gpt-5.6-luna",
         modelOverrideSource: "user",
-      };
+      });
       await replaceSessionEntry({ storePath, sessionKey: "main" }, sessionEntry);
       const sessionStore = { main: sessionEntry };
       state.runEmbeddedAgentMock.mockResolvedValueOnce({
@@ -3562,11 +3460,9 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const storePath = join(root, "sessions.json");
     const sessionFile = join(root, "session.jsonl");
     const runId = "run-exhausted-trace";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry({
       traceLevel: "raw",
-    };
+    });
     await replaceSessionEntry({ storePath, sessionKey: "main" }, sessionEntry);
     try {
       state.runEmbeddedAgentMock.mockResolvedValueOnce({
@@ -3873,13 +3769,11 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("does not persist active fallback state for internal subagent announce fallback", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry({
       modelProvider: "openai",
       model: "gpt-5.5",
       responseUsage: "tokens",
-    };
+    });
     const sessionStore = { main: sessionEntry };
     const storeRoot = await mkdtemp(join(tmpdir(), "openclaw-internal-fallback-"));
     const storePath = join(storeRoot, "sessions.json");
@@ -3959,12 +3853,10 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("surfaces empty internal fallback failures without persisting visible fallback state", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry({
       modelProvider: "openai",
       model: "gpt-5.5",
-    };
+    });
     const sessionStore = { main: sessionEntry };
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [],
@@ -4022,10 +3914,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("keeps fallback transition notices when block streaming has no final text", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry();
     const sessionStore = { main: sessionEntry };
     const onBlockReply = vi.fn();
 
@@ -4036,9 +3925,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+        makeCompletedFallbackRunner({
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
           attempts: [
@@ -4072,10 +3959,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("threads fallback notices without consuming the first assistant reply slot", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry();
     const sessionStore = { main: sessionEntry };
 
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
@@ -4085,9 +3969,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+        makeCompletedFallbackRunner({
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
           attempts: [
@@ -4165,22 +4047,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4215,22 +4082,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4257,15 +4109,13 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("surfaces a persisted configured backend failure when the active fallback is silent", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry({
       providerOverride: "openai",
       modelOverride: "gpt-5.5",
       modelOverrideSource: "auto",
       modelOverrideFallbackOriginProvider: "lmstudio",
       modelOverrideFallbackOriginModel: "gemma-4-e4b-it",
-    };
+    });
     const sessionStore = { main: sessionEntry };
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "NO_REPLY" }],
@@ -4303,22 +4153,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4355,22 +4190,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4409,22 +4229,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4460,22 +4265,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4512,22 +4302,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4564,22 +4339,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4612,22 +4372,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementationOnce(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("openai", "gpt-5.5"),
-          provider: "openai",
-          model: "gpt-5.5",
-          attempts: [
-            {
-              provider: "lmstudio",
-              model: "gemma-4-e4b-it",
-              error: "Connection error.",
-              reason: "timeout",
-            },
-          ],
-        }),
-      );
+      .mockImplementationOnce(makeCompletedFallbackRunner());
 
     try {
       const { run } = createMinimalRun({
@@ -4653,34 +4398,27 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("announces model fallback only once per active fallback state", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry();
     const sessionStore = { main: sessionEntry };
 
     state.runEmbeddedAgentMock.mockResolvedValue({
       payloads: [{ text: "final" }],
       meta: {},
     });
-    const fallbackSpy = vi
-      .spyOn(modelFallbackModule, "runWithModelFallback")
-      .mockImplementation(
-        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
-          outcome: "completed" as const,
-          result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
-          provider: "deepinfra",
-          model: "moonshotai/Kimi-K2.5",
-          attempts: [
-            {
-              provider: "fireworks",
-              model: "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
-              error: "Provider fireworks is in cooldown (all profiles unavailable)",
-              reason: "rate_limit",
-            },
-          ],
-        }),
-      );
+    const fallbackSpy = vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementation(
+      makeCompletedFallbackRunner({
+        provider: "deepinfra",
+        model: "moonshotai/Kimi-K2.5",
+        attempts: [
+          {
+            provider: "fireworks",
+            model: "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+            error: "Provider fireworks is in cooldown (all profiles unavailable)",
+            reason: "rate_limit",
+          },
+        ],
+      }),
+    );
     try {
       const { run } = createMinimalRun({
         resolvedVerboseLevel: "on",
@@ -4709,10 +4447,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("re-announces model fallback after returning to selected model", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry();
     const sessionStore = { main: sessionEntry };
     let callCount = 0;
 
@@ -4781,10 +4516,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("announces fallback-cleared once when runtime returns to selected model", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry();
     const sessionStore = { main: sessionEntry };
     let callCount = 0;
 
@@ -4863,10 +4595,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("announces fallback transitions and emits lifecycle events while verbose is off", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-    };
+    const sessionEntry = makeSessionEntry();
     const sessionStore = { main: sessionEntry };
     let callCount = 0;
 
@@ -4961,9 +4690,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     ] as const;
 
     for (const testCase of cases) {
-      const sessionEntry: SessionEntry = {
-        sessionId: "session",
-        updatedAt: Date.now(),
+      const sessionEntry = makeSessionEntry({
         fallbackNotice: {
           kind: "active" as const,
           selectedModel: "anthropic/claude",
@@ -4972,7 +4699,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         },
         modelProvider: "deepinfra",
         model: "moonshotai/Kimi-K2.5",
-      };
+      });
       const sessionStore = { main: sessionEntry };
 
       state.runEmbeddedAgentMock.mockResolvedValue({
@@ -5015,16 +4742,14 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("does not persist fallback state for an equivalent CLI runtime alias", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
+    const sessionEntry = makeSessionEntry({
       fallbackNotice: {
         kind: "active",
         selectedModel: "anthropic/claude-opus-4-7",
         activeModel: "claude-cli/claude-opus-4-7",
         reason: "selected model unavailable",
       },
-    };
+    });
     const sessionStore = { main: sessionEntry };
     const dir = await mkdtemp(join(tmpdir(), "openclaw-agent-runner-cli-alias-"));
     const storePath = join(dir, "sessions.json");

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -120,10 +120,7 @@ function createGatewayReloadHandlers(
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
     stopPostReadySidecars: vi.fn(),
-    reloadPlugins: vi.fn(async () => ({
-      restartChannels: new Set<ChannelKind>(),
-      activeChannels: new Set<ChannelKind>(),
-    })),
+    reloadPlugins: vi.fn(async () => makePluginReloadResult()),
     logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     logChannels: { info: vi.fn(), error: vi.fn() },
     logCron: { error: vi.fn() },
@@ -140,7 +137,9 @@ function createGatewayReloadHandlers(
   });
 }
 
-function createDefaultGatewayReloadState() {
+function createDefaultGatewayReloadState(
+  overrides: Partial<ReturnType<ReloadHandlerParams["getState"]>> = {},
+) {
   return {
     hooksConfig: {} as never,
     hookClientIpConfig: {} as never,
@@ -151,6 +150,7 @@ function createDefaultGatewayReloadState() {
       cronEnabled: false,
     } as never,
     channelHealthMonitor: null,
+    ...overrides,
   };
 }
 
@@ -167,23 +167,15 @@ function startManagedGatewayConfigReloader(params: ManagedReloaderTestParams) {
     setState: vi.fn(),
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
-    reloadPlugins: vi.fn(async () => ({
-      restartChannels: new Set<ChannelKind>(),
-      activeChannels: new Set<ChannelKind>(),
-    })),
+    reloadPlugins: vi.fn(async () => makePluginReloadResult()),
     logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     logChannels: { info: vi.fn(), error: vi.fn() },
     logCron: { error: vi.fn() },
     logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     channelManager: {} as never,
-    activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
-      sourceConfig: config,
-      config,
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    })) as never,
+    activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) =>
+      makePreparedSecretsSnapshot(config),
+    ) as never,
     resolveSharedGatewaySessionGenerationForConfig: () => undefined,
     sharedGatewaySessionGenerationState: { current: undefined, required: null },
     clients: [],
@@ -401,6 +393,61 @@ function createRecordedChannelHandlers(events: string[]) {
   };
 }
 
+function makePreparedSecretsSnapshot(
+  config: OpenClawConfig,
+  overrides: Partial<PreparedSecretsRuntimeSnapshot> = {},
+): PreparedSecretsRuntimeSnapshot {
+  return {
+    sourceConfig: config,
+    config,
+    authStores: [],
+    authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+    warnings: [],
+    webTools: createEmptyRuntimeWebToolsMetadata(),
+    ...overrides,
+  };
+}
+
+function makeActiveTaskBlocker(
+  overrides: Partial<(typeof hoisted.activeTaskBlockers)[number]> = {},
+): (typeof hoisted.activeTaskBlockers)[number] {
+  return {
+    taskId: "task-blocking-reload",
+    status: "running",
+    runtime: "subagent",
+    ...overrides,
+  };
+}
+
+function makePluginReloadResult(
+  overrides: Partial<GatewayPluginReloadResult> = {},
+): GatewayPluginReloadResult {
+  return {
+    restartChannels: new Set(),
+    activeChannels: new Set(),
+    ...overrides,
+  };
+}
+
+function enableChannelReloadsForTest() {
+  const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
+  const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
+  delete process.env.OPENCLAW_SKIP_CHANNELS;
+  delete process.env.OPENCLAW_SKIP_PROVIDERS;
+  return () => {
+    if (previousSkipChannels === undefined) {
+      delete process.env.OPENCLAW_SKIP_CHANNELS;
+    } else {
+      process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
+    }
+    if (previousSkipProviders === undefined) {
+      delete process.env.OPENCLAW_SKIP_PROVIDERS;
+    } else {
+      process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
+    }
+  };
+}
+
 function createTestCronReconciliation() {
   const complete = vi.fn<() => Promise<void>>(async () => {});
   return {
@@ -599,14 +646,7 @@ function createManagedRestartSequenceHarness(
     },
   } as OpenClawConfig;
   setRuntimeConfigSnapshot(initialConfig, initialConfig);
-  activateSecretsRuntimeSnapshot({
-    sourceConfig: initialConfig,
-    config: initialConfig,
-    authStores: [],
-    authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-    warnings: [],
-    webTools: createEmptyRuntimeWebToolsMetadata(),
-  });
+  activateSecretsRuntimeSnapshot(makePreparedSecretsSnapshot(initialConfig));
   const deferredConfig = {
     gateway: {
       port: 18790,
@@ -715,14 +755,7 @@ function createManagedRestartSequenceHarness(
         throw new Error(`required SecretRef ${secretInput.id} is unavailable`);
       }
     }
-    return {
-      sourceConfig: config,
-      config,
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    };
+    return makePreparedSecretsSnapshot(config);
   });
   const requestRecoveryRestart = vi.fn<NonNullable<ReloadHandlerParams["requestRecoveryRestart"]>>(
     () => ({ status: "emitted" }),
@@ -769,16 +802,11 @@ function createManagedRestartSequenceHarness(
     }
     snapshotConfig = config;
     snapshotHash = hash;
-    listener({
-      configPath: "/tmp/openclaw.json",
-      sourceConfig: config,
-      runtimeConfig,
-      persistedHash: hash,
-      revision,
-      fingerprint: `runtime-${hash}`,
-      sourceFingerprint: `source-${hash}`,
-      writtenAtMs: Date.now(),
-    });
+    listener(
+      createConfigWriteNotification(config, hash, revision, `runtime-${hash}`, `source-${hash}`, {
+        runtimeConfig,
+      }),
+    );
   };
 
   return {
@@ -886,14 +914,7 @@ async function runManagedOwnershipScenario(params: {
     },
   } satisfies OpenClawConfig;
   const configB = structuredClone(initialConfig);
-  const snapshot = (config: OpenClawConfig): PreparedSecretsRuntimeSnapshot => ({
-    sourceConfig: config,
-    config,
-    authStores: [],
-    authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-    warnings: [],
-    webTools: createEmptyRuntimeWebToolsMetadata(),
-  });
+  const snapshot = (config: OpenClawConfig) => makePreparedSecretsSnapshot(config);
   const writeListenerRef = createConfigWriteListenerRef();
   let resolveAccepted: (() => void) | undefined;
   const accepted = new Promise<void>((resolve) => {
@@ -1300,26 +1321,22 @@ describe("gateway hot reload model state", () => {
   });
 
   it("restarts when the replacement cron fails after runtime commit", async () => {
-    restartTesting.resetSigusr1State();
-    resetGatewayWorkAdmission();
-    const signalSpy = vi.fn();
-    process.once("SIGUSR1", signalSpy);
-    const logReload = { info: vi.fn(), warn: vi.fn() };
-    hoisted.buildGatewayCronService.mockReturnValueOnce({
-      cron: {
-        start: vi.fn(async () => {
-          throw new Error("cron start failed");
-        }),
-        stop: vi.fn(),
-      },
-      storePath: "/tmp/rebuilt-cron.json",
-      cronEnabled: true,
-      reconcileExitWatchers: vi.fn(async () => {}),
-      stopExitWatchers: vi.fn(),
-    });
-    const { applyHotReload, setState } = createReloadHandlersForTest(logReload);
+    await withGatewayRestartSignal(async (signalSpy) => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      hoisted.buildGatewayCronService.mockReturnValueOnce({
+        cron: {
+          start: vi.fn(async () => {
+            throw new Error("cron start failed");
+          }),
+          stop: vi.fn(),
+        },
+        storePath: "/tmp/rebuilt-cron.json",
+        cronEnabled: true,
+        reconcileExitWatchers: vi.fn(async () => {}),
+        stopExitWatchers: vi.fn(),
+      });
+      const { applyHotReload, setState } = createReloadHandlersForTest(logReload);
 
-    try {
       await expect(
         applyHotReload(createCronRestartPlan(), { cron: { enabled: true } }),
       ).resolves.toBeUndefined();
@@ -1331,11 +1348,7 @@ describe("gateway hot reload model state", () => {
       );
       expect(isGatewayWorkAdmissionClosed()).toBe(true);
       markGatewaySigusr1RestartHandled();
-    } finally {
-      process.removeListener("SIGUSR1", signalSpy);
-      restartTesting.resetSigusr1State();
-      resetGatewayWorkAdmission();
-    }
+    });
   });
 
   it("ignores a delayed cron failure after a newer reload supersedes it", async () => {
@@ -1382,18 +1395,14 @@ describe("gateway hot reload model state", () => {
   });
 
   it("restarts instead of rolling back when cron teardown fails after runtime commit", async () => {
-    restartTesting.resetSigusr1State();
-    resetGatewayWorkAdmission();
-    const signalSpy = vi.fn();
-    process.once("SIGUSR1", signalSpy);
-    const logReload = { info: vi.fn(), warn: vi.fn() };
-    const publish = vi.fn(async (commit: () => Promise<void>) => await commit());
-    const { applyHotReload, cron, setState } = createReloadHandlersForTest(logReload);
-    cron.stop.mockImplementation(() => {
-      throw new Error("cron stop failed");
-    });
+    await withGatewayRestartSignal(async (signalSpy) => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const publish = vi.fn(async (commit: () => Promise<void>) => await commit());
+      const { applyHotReload, cron, setState } = createReloadHandlersForTest(logReload);
+      cron.stop.mockImplementation(() => {
+        throw new Error("cron stop failed");
+      });
 
-    try {
       await expect(
         applyHotReload(
           createCronRestartPlan(),
@@ -1413,11 +1422,7 @@ describe("gateway hot reload model state", () => {
       expect(signalSpy).toHaveBeenCalledOnce();
       expect(isGatewayWorkAdmissionClosed()).toBe(true);
       markGatewaySigusr1RestartHandled();
-    } finally {
-      process.removeListener("SIGUSR1", signalSpy);
-      restartTesting.resetSigusr1State();
-      resetGatewayWorkAdmission();
-    }
+    });
   });
 
   it("resets prepared model runtime state for every hot reload and rewarms after plugin reload", async () => {
@@ -1425,10 +1430,7 @@ describe("gateway hot reload model state", () => {
       hoisted.reloadEvents.push("prepare-plugins");
       await params.commitRuntime();
       hoisted.reloadEvents.push("replace-plugins");
-      return {
-        restartChannels: new Set(),
-        activeChannels: new Set(),
-      };
+      return makePluginReloadResult();
     });
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const { applyHotReload } = createGatewayReloadHandlers({
@@ -2316,11 +2318,9 @@ describe("gateway restart deferral preflight", () => {
     const channels = {
       stop: vi.fn(async () => {}),
       start: vi.fn(async () => {
-        hoisted.activeTaskBlockers.push({
-          taskId: "discord-recovery-blocker",
-          status: "running",
-          runtime: "subagent",
-        });
+        hoisted.activeTaskBlockers.push(
+          makeActiveTaskBlocker({ taskId: "discord-recovery-blocker" }),
+        );
         throw new Error("discord restart failed");
       }),
     };
@@ -2413,11 +2413,9 @@ describe("gateway restart deferral preflight", () => {
     const channels = {
       stop: vi.fn(async () => {}),
       start: vi.fn(async () => {
-        hoisted.activeTaskBlockers.push({
-          taskId: "discord-recovery-clear-blocker",
-          status: "running",
-          runtime: "subagent",
-        });
+        hoisted.activeTaskBlockers.push(
+          makeActiveTaskBlocker({ taskId: "discord-recovery-clear-blocker" }),
+        );
         throw new Error("discord restart failed");
       }),
     };
@@ -2698,10 +2696,7 @@ describe("gateway restart deferral preflight", () => {
   });
 
   it("defers channel hot reload until active embedded work drains", async () => {
-    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
-    const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
-    delete process.env.OPENCLAW_SKIP_CHANNELS;
-    delete process.env.OPENCLAW_SKIP_PROVIDERS;
+    const restoreChannelReloadEnv = enableChannelReloadsForTest();
     const startChannel = vi.fn(async () => {});
     const stopChannel = vi.fn(async () => {});
     const setState = vi.fn();
@@ -2749,16 +2744,7 @@ describe("gateway restart deferral preflight", () => {
       await vi.advanceTimersByTimeAsync(500).catch(() => {});
       vi.useRealTimers();
       await reloadPromise.catch(() => {});
-      if (previousSkipChannels === undefined) {
-        delete process.env.OPENCLAW_SKIP_CHANNELS;
-      } else {
-        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
-      }
-      if (previousSkipProviders === undefined) {
-        delete process.env.OPENCLAW_SKIP_PROVIDERS;
-      } else {
-        process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
-      }
+      restoreChannelReloadEnv();
     }
 
     expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
@@ -2768,10 +2754,7 @@ describe("gateway restart deferral preflight", () => {
   });
 
   it("uses the default channel reload deferral timeout when config omits deferralTimeoutMs", async () => {
-    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
-    const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
-    delete process.env.OPENCLAW_SKIP_CHANNELS;
-    delete process.env.OPENCLAW_SKIP_PROVIDERS;
+    const restoreChannelReloadEnv = enableChannelReloadsForTest();
     const startChannel = vi.fn(async () => {});
     const stopChannel = vi.fn(async () => {});
     const logReload = { info: vi.fn(), warn: vi.fn() };
@@ -2805,16 +2788,7 @@ describe("gateway restart deferral preflight", () => {
       await vi.advanceTimersByTimeAsync(500).catch(() => {});
       vi.useRealTimers();
       await reloadPromise.catch(() => {});
-      if (previousSkipChannels === undefined) {
-        delete process.env.OPENCLAW_SKIP_CHANNELS;
-      } else {
-        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
-      }
-      if (previousSkipProviders === undefined) {
-        delete process.env.OPENCLAW_SKIP_PROVIDERS;
-      } else {
-        process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
-      }
+      restoreChannelReloadEnv();
     }
 
     expect(stopChannel).toHaveBeenCalledWith("telegram", undefined, { manual: false });
@@ -2831,14 +2805,15 @@ describe("gateway restart deferral preflight", () => {
     hoisted.activeTaskCount.value = 1;
     hoisted.activeEmbeddedRunSessionIds.push("session-issue-82433");
     hoisted.activeEmbeddedRunSessionKeys.push("agent:main:issue-82433");
-    hoisted.activeTaskBlockers.push({
-      taskId: "task-nightly",
-      runId: "run-nightly",
-      status: "running",
-      runtime: "cron",
-      label: "nightly sync",
-      title: "refresh all accounts",
-    });
+    hoisted.activeTaskBlockers.push(
+      makeActiveTaskBlocker({
+        taskId: "task-nightly",
+        runId: "run-nightly",
+        runtime: "cron",
+        label: "nightly sync",
+        title: "refresh all accounts",
+      }),
+    );
     const signalSpy = vi.fn();
     process.once("SIGUSR1", signalSpy);
     vi.useFakeTimers();
@@ -2893,11 +2868,7 @@ describe("gateway restart deferral preflight", () => {
     restartTesting.resetSigusr1State();
     const { requestGatewayRestart } = createReloadHandlersForTest();
     hoisted.activeTaskCount.value = 1;
-    hoisted.activeTaskBlockers.push({
-      taskId: "task-running-1",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "task-running-1" }));
     const signalSpy = vi.fn();
     process.once("SIGUSR1", signalSpy);
     vi.useFakeTimers();
@@ -2930,23 +2901,11 @@ describe("gateway channel hot reload handlers", () => {
   }
 
   async function withChannelReloadsEnabled(run: () => Promise<void>) {
-    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
-    const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
-    delete process.env.OPENCLAW_SKIP_CHANNELS;
-    delete process.env.OPENCLAW_SKIP_PROVIDERS;
+    const restoreChannelReloadEnv = enableChannelReloadsForTest();
     try {
       await run();
     } finally {
-      if (previousSkipChannels === undefined) {
-        delete process.env.OPENCLAW_SKIP_CHANNELS;
-      } else {
-        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
-      }
-      if (previousSkipProviders === undefined) {
-        delete process.env.OPENCLAW_SKIP_PROVIDERS;
-      } else {
-        process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
-      }
+      restoreChannelReloadEnv();
     }
   }
 
@@ -3227,10 +3186,7 @@ describe("gateway channel hot reload handlers", () => {
     const reloadPlugins = vi.fn(async (params): Promise<GatewayPluginReloadResult> => {
       await params.beforeReplace(new Set());
       hoisted.activeEmbeddedRunCount.value = 1;
-      return {
-        restartChannels: new Set(),
-        activeChannels: new Set(["discord"]),
-      };
+      return makePluginReloadResult({ activeChannels: new Set(["discord"]) });
     });
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const { applyHotReload } = createReloadHandlersForTest(logReload, channels, reloadPlugins);
@@ -3428,22 +3384,18 @@ describe("gateway Gmail hot reload handlers", () => {
   });
 
   it("restarts when post-ready sidecar teardown fails after runtime commit", async () => {
-    restartTesting.resetSigusr1State();
-    resetGatewayWorkAdmission();
-    const signalSpy = vi.fn();
-    process.once("SIGUSR1", signalSpy);
-    const logReload = { info: vi.fn(), warn: vi.fn() };
-    const stopPostReadySidecars = vi.fn(async () => {
-      throw new Error("sidecar stop failed");
-    });
-    const { applyHotReload, setState } = createReloadHandlersForTest(
-      logReload,
-      undefined,
-      undefined,
-      stopPostReadySidecars,
-    );
+    await withGatewayRestartSignal(async (signalSpy) => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const stopPostReadySidecars = vi.fn(async () => {
+        throw new Error("sidecar stop failed");
+      });
+      const { applyHotReload, setState } = createReloadHandlersForTest(
+        logReload,
+        undefined,
+        undefined,
+        stopPostReadySidecars,
+      );
 
-    try {
       await expect(
         applyHotReload(createGmailReloadPlan(), createGmailConfig("next@example.com")),
       ).resolves.toBeUndefined();
@@ -3456,11 +3408,7 @@ describe("gateway Gmail hot reload handlers", () => {
       expect(signalSpy).toHaveBeenCalledOnce();
       expect(isGatewayWorkAdmissionClosed()).toBe(true);
       markGatewaySigusr1RestartHandled();
-    } finally {
-      process.removeListener("SIGUSR1", signalSpy);
-      restartTesting.resetSigusr1State();
-      resetGatewayWorkAdmission();
-    }
+    });
   });
 
   it("passes a cancellable signal to Gmail watcher restarts", async () => {
@@ -3494,14 +3442,7 @@ describe("gateway Gmail hot reload handlers", () => {
       gateway: { reload: {} },
       messages: { visibleReplies: "message_tool" },
     };
-    const snapshot = (config: OpenClawConfig): PreparedSecretsRuntimeSnapshot => ({
-      sourceConfig: config,
-      config,
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    });
+    const snapshot = (config: OpenClawConfig) => makePreparedSecretsSnapshot(config);
     const failurePublicationEligibility: boolean[] = [];
     let preparationAttempt = 0;
     const activateRuntimeSecrets = vi.fn(
@@ -3531,17 +3472,15 @@ describe("gateway Gmail hot reload handlers", () => {
       initialConfig,
       readSnapshot: vi.fn(async () => createValidConfigSnapshot(nextConfig, "hash-next")) as never,
       subscribeToWrites: captureConfigWriteListener(writeListenerRef),
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: heartbeatRunner as never,
-        cronState: {
-          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
-          storePath: "/tmp/cron.json",
-          cronEnabled: false,
-        } as never,
-        channelHealthMonitor: null,
-      }),
+      getState: () =>
+        createDefaultGatewayReloadState({
+          heartbeatRunner: heartbeatRunner as never,
+          cronState: {
+            cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+            storePath: "/tmp/cron.json",
+            cronEnabled: false,
+          } as never,
+        }),
       activateRuntimeSecrets: activateRuntimeSecrets as never,
       commitTerminalConfig,
       acceptTerminalConfig,
@@ -3608,97 +3547,94 @@ describe("gateway Gmail hot reload handlers", () => {
       path: "tts.providers.elevenlabs.apiKey",
       message: "Text-to-speech remains unavailable.",
     };
-    activateSecretsRuntimeSnapshot({
-      sourceConfig: initialSourceConfig,
-      config: runtimeConfig,
-      authStores: [
-        {
-          agentDir: authAgentDir,
-          store: {
-            version: 1,
-            profiles: {
-              [authProfileId]: {
-                type: "api_key",
-                provider: "openai",
-                key: String(42),
-                keyRef: { source: "env", provider: "default", id: "AUTH_FIRST" },
+    activateSecretsRuntimeSnapshot(
+      makePreparedSecretsSnapshot(initialSourceConfig, {
+        config: runtimeConfig,
+        authStores: [
+          {
+            agentDir: authAgentDir,
+            store: {
+              version: 1,
+              profiles: {
+                [authProfileId]: {
+                  type: "api_key",
+                  provider: "openai",
+                  key: String(42),
+                  keyRef: { source: "env", provider: "default", id: "AUTH_FIRST" },
+                },
               },
             },
           },
-        },
-      ],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [activeWarning],
-      degradedOwners: [
-        {
-          ownerKind: "capability",
-          ownerId: "tts",
-          state: "unavailable",
-          paths: ["tts.providers.elevenlabs.apiKey"],
-          refKeys: ["env:default:TTS_FIRST"],
-          reason: "secret reference was not found",
-        },
-        {
-          ownerKind: "account",
-          ownerId: authOwnerId,
-          state: "unavailable",
-          paths: [`${authAgentDir}.auth-profiles.${authProfileId}.key`],
-          refKeys: ["env:default:AUTH_FIRST"],
-          reason: "secret provider failed",
-        },
-      ],
-      secretOwners: [
-        {
-          ownerKind: "capability",
-          ownerId: "tts",
-          refKeys: ["env:default:TTS_FIRST"],
-          contractDigest: ttsContractDigest,
-        },
-        {
-          ownerKind: "account",
-          ownerId: authOwnerId,
-          refKeys: ["env:default:AUTH_FIRST"],
-        },
-      ],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    });
+        ],
+        warnings: [activeWarning],
+        degradedOwners: [
+          {
+            ownerKind: "capability",
+            ownerId: "tts",
+            state: "unavailable",
+            paths: ["tts.providers.elevenlabs.apiKey"],
+            refKeys: ["env:default:TTS_FIRST"],
+            reason: "secret reference was not found",
+          },
+          {
+            ownerKind: "account",
+            ownerId: authOwnerId,
+            state: "unavailable",
+            paths: [`${authAgentDir}.auth-profiles.${authProfileId}.key`],
+            refKeys: ["env:default:AUTH_FIRST"],
+            reason: "secret provider failed",
+          },
+        ],
+        secretOwners: [
+          {
+            ownerKind: "capability",
+            ownerId: "tts",
+            refKeys: ["env:default:TTS_FIRST"],
+            contractDigest: ttsContractDigest,
+          },
+          {
+            ownerKind: "account",
+            ownerId: authOwnerId,
+            refKeys: ["env:default:AUTH_FIRST"],
+          },
+        ],
+      }),
+    );
     const writeListenerRef = createConfigWriteListenerRef();
-    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig, _params: unknown) => ({
-      sourceConfig: config,
-      config: runtimeConfig,
-      authStores: [
-        {
-          agentDir: authAgentDir,
-          store: {
-            version: 1,
-            profiles: {
-              [authProfileId]: {
-                type: "api_key" as const,
-                provider: "openai",
-                key: String(42),
-                keyRef: { source: "env" as const, provider: "default", id: "AUTH_SECOND" },
+    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig, _params: unknown) =>
+      makePreparedSecretsSnapshot(config, {
+        config: runtimeConfig,
+        authStores: [
+          {
+            agentDir: authAgentDir,
+            store: {
+              version: 1,
+              profiles: {
+                [authProfileId]: {
+                  type: "api_key" as const,
+                  provider: "openai",
+                  key: String(42),
+                  keyRef: { source: "env" as const, provider: "default", id: "AUTH_SECOND" },
+                },
               },
             },
           },
-        },
-      ],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      secretOwners: [
-        {
-          ownerKind: "capability" as const,
-          ownerId: "tts",
-          refKeys: ["env:default:TTS_SECOND"],
-          contractDigest: ttsContractDigest,
-        },
-        {
-          ownerKind: "account" as const,
-          ownerId: authOwnerId,
-          refKeys: ["env:default:AUTH_SECOND"],
-        },
-      ],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    }));
+        ],
+        secretOwners: [
+          {
+            ownerKind: "capability" as const,
+            ownerId: "tts",
+            refKeys: ["env:default:TTS_SECOND"],
+            contractDigest: ttsContractDigest,
+          },
+          {
+            ownerKind: "account" as const,
+            ownerId: authOwnerId,
+            refKeys: ["env:default:AUTH_SECOND"],
+          },
+        ],
+      }),
+    );
     const reloader = startManagedGatewayConfigReloader({
       initialConfig: runtimeConfig,
       readSnapshot: vi.fn(async () => ({
@@ -3733,16 +3669,16 @@ describe("gateway Gmail hot reload handlers", () => {
         ...initialSourceConfig,
         logging: { level: "info" as const },
       };
-      listener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: unrelatedSourceConfig,
-        runtimeConfig,
-        persistedHash: "same-secrets-new-source",
-        revision: 1,
-        fingerprint: "same-runtime",
-        sourceFingerprint: "same-secrets-new-source",
-        writtenAtMs: Date.now(),
-      });
+      listener(
+        createConfigWriteNotification(
+          unrelatedSourceConfig,
+          "same-secrets-new-source",
+          1,
+          "same-runtime",
+          "same-secrets-new-source",
+          { runtimeConfig },
+        ),
+      );
       await vi.runAllTimersAsync();
 
       expect(activateRuntimeSecrets).not.toHaveBeenCalled();
@@ -3762,16 +3698,16 @@ describe("gateway Gmail hot reload handlers", () => {
         },
       ]);
 
-      listener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: nextSourceConfig,
-        runtimeConfig,
-        persistedHash: "same-runtime-next-source",
-        revision: 2,
-        fingerprint: "same-runtime",
-        sourceFingerprint: "next-source",
-        writtenAtMs: Date.now(),
-      });
+      listener(
+        createConfigWriteNotification(
+          nextSourceConfig,
+          "same-runtime-next-source",
+          2,
+          "same-runtime",
+          "next-source",
+          { runtimeConfig },
+        ),
+      );
       await vi.runAllTimersAsync();
 
       expect(activateRuntimeSecrets.mock.calls[0]?.[1]).toMatchObject({
@@ -3809,32 +3745,29 @@ describe("gateway Gmail hot reload handlers", () => {
         }),
       ).toBe("stale");
 
-      activateRuntimeSecrets.mockImplementationOnce(async (config: OpenClawConfig) => ({
-        sourceConfig: config,
-        config: { ...runtimeConfig, logging: { level: "debug" } },
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        secretOwners: [
-          {
-            ownerKind: "capability" as const,
-            ownerId: "tts",
-            refKeys: ["env:default:TTS_THIRD"],
-            contractDigest: ttsContractDigest,
-          },
-        ],
-        webTools: createEmptyRuntimeWebToolsMetadata(),
-      }));
-      listener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: sourceConfig(thirdRef),
-        runtimeConfig,
-        persistedHash: "changed-second-resolution",
-        revision: 2,
-        fingerprint: "same-runtime",
-        sourceFingerprint: "changed-second-resolution",
-        writtenAtMs: Date.now(),
-      });
+      activateRuntimeSecrets.mockImplementationOnce(async (config: OpenClawConfig) =>
+        makePreparedSecretsSnapshot(config, {
+          config: { ...runtimeConfig, logging: { level: "debug" } },
+          secretOwners: [
+            {
+              ownerKind: "capability" as const,
+              ownerId: "tts",
+              refKeys: ["env:default:TTS_THIRD"],
+              contractDigest: ttsContractDigest,
+            },
+          ],
+        }),
+      );
+      listener(
+        createConfigWriteNotification(
+          sourceConfig(thirdRef),
+          "changed-second-resolution",
+          2,
+          "same-runtime",
+          "changed-second-resolution",
+          { runtimeConfig },
+        ),
+      );
       await vi.runAllTimersAsync();
 
       expect(getActiveSecretsRuntimeSnapshot()?.secretOwners).toEqual([
@@ -3862,12 +3795,8 @@ describe("gateway Gmail hot reload handlers", () => {
       activateRuntimeSecrets.mockImplementationOnce(async (config: OpenClawConfig) => {
         markPreparationStarted?.();
         await preparationGate;
-        return {
-          sourceConfig: config,
+        return makePreparedSecretsSnapshot(config, {
           config: runtimeConfig,
-          authStores: [],
-          authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-          warnings: [],
           secretOwners: [
             {
               ownerKind: "capability" as const,
@@ -3876,38 +3805,34 @@ describe("gateway Gmail hot reload handlers", () => {
               contractDigest: ttsContractDigest,
             },
           ],
-          webTools: createEmptyRuntimeWebToolsMetadata(),
-        };
+        });
       });
-      listener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: sourceConfig(thirdRef),
-        runtimeConfig,
-        persistedHash: "superseded-source-owner",
-        revision: 3,
-        fingerprint: "same-runtime",
-        sourceFingerprint: "superseded-source-owner",
-        writtenAtMs: Date.now(),
-      });
+      listener(
+        createConfigWriteNotification(
+          sourceConfig(thirdRef),
+          "superseded-source-owner",
+          3,
+          "same-runtime",
+          "superseded-source-owner",
+          { runtimeConfig },
+        ),
+      );
       await vi.advanceTimersByTimeAsync(0);
       await preparationStarted;
 
       const concurrentSourceConfig = sourceConfig(fourthRef);
-      activateSecretsRuntimeSnapshot({
-        sourceConfig: concurrentSourceConfig,
-        config: runtimeConfig,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        secretOwners: [
-          {
-            ownerKind: "capability",
-            ownerId: "tts",
-            refKeys: ["env:default:TTS_FOURTH"],
-          },
-        ],
-        webTools: createEmptyRuntimeWebToolsMetadata(),
-      });
+      activateSecretsRuntimeSnapshot(
+        makePreparedSecretsSnapshot(concurrentSourceConfig, {
+          config: runtimeConfig,
+          secretOwners: [
+            {
+              ownerKind: "capability",
+              ownerId: "tts",
+              refKeys: ["env:default:TTS_FOURTH"],
+            },
+          ],
+        }),
+      );
       releasePreparation();
       await vi.runAllTimersAsync();
 
@@ -3950,14 +3875,9 @@ describe("gateway Gmail hot reload handlers", () => {
     const writeListenerRef = createConfigWriteListenerRef();
     let snapshotConfig = initialConfig;
     let snapshotHash = "initial";
-    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig) => ({
-      sourceConfig: config,
-      config,
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    }));
+    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig) =>
+      makePreparedSecretsSnapshot(config),
+    );
     const reloader = startManagedGatewayConfigReloader({
       initialConfig,
       readSnapshot: vi.fn(async () =>
@@ -3983,16 +3903,9 @@ describe("gateway Gmail hot reload handlers", () => {
       snapshotConfig = config;
       snapshotHash = hash;
       revision += 1;
-      listener({
-        configPath: "/tmp/openclaw.json",
-        sourceConfig: config,
-        runtimeConfig: config,
-        persistedHash: hash,
-        revision,
-        fingerprint: `runtime-${hash}`,
-        sourceFingerprint: `source-${hash}`,
-        writtenAtMs: Date.now(),
-      });
+      listener(
+        createConfigWriteNotification(config, hash, revision, `runtime-${hash}`, `source-${hash}`),
+      );
     };
 
     try {
@@ -4107,24 +4020,10 @@ describe("gateway Gmail hot reload handlers", () => {
       if (config.gateway?.port === rejectedConfig.gateway?.port) {
         throw new Error("restart secrets preflight failed");
       }
-      return {
-        sourceConfig: config,
-        config,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        webTools: createEmptyRuntimeWebToolsMetadata(),
-      };
+      return makePreparedSecretsSnapshot(config);
     });
     const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
-    activateSecretsRuntimeSnapshot({
-      sourceConfig: initialConfig,
-      config: initialConfig,
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    });
+    activateSecretsRuntimeSnapshot(makePreparedSecretsSnapshot(initialConfig));
     const reloader = startManagedGatewayConfigReloader({
       initialConfig,
       readSnapshot: vi.fn(async () =>
@@ -4207,11 +4106,7 @@ describe("gateway Gmail hot reload handlers", () => {
   it("cancels a deferred restart when a newer config fails required SecretRef preflight", async () => {
     vi.useFakeTimers();
     const harness = createManagedRestartSequenceHarness();
-    hoisted.activeTaskBlockers.push({
-      taskId: "restart-sequence-blocker",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "restart-sequence-blocker" }));
 
     try {
       const deferredPromotion = harness.nextPromotion();
@@ -4298,14 +4193,7 @@ describe("gateway Gmail hot reload handlers", () => {
     harness.activateRuntimeSecrets.mockImplementationOnce(async (config: OpenClawConfig) => {
       markPreflightStarted?.();
       await preflightBlocked;
-      return {
-        sourceConfig: config,
-        config,
-        authStores: [],
-        authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-        warnings: [],
-        webTools: createEmptyRuntimeWebToolsMetadata(),
-      };
+      return makePreparedSecretsSnapshot(config);
     });
 
     harness.writeConfig(harness.deferredConfig, "shutdown-restart", 1);
@@ -4343,11 +4231,7 @@ describe("gateway Gmail hot reload handlers", () => {
         diffConfigPaths(harness.deferredConfig, invalidConfig),
       );
       expect(invalidPlan.restartGateway).toBe(false);
-      hoisted.activeTaskBlockers.push({
-        taskId: "hot-noop-secret-blocker",
-        status: "running",
-        runtime: "subagent",
-      });
+      hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "hot-noop-secret-blocker" }));
 
       try {
         const deferredPromotion = harness.nextPromotion();
@@ -4431,11 +4315,9 @@ describe("gateway Gmail hot reload handlers", () => {
   it("revalidates deferred restart SecretRefs again before emission and retry", async () => {
     vi.useFakeTimers();
     const harness = createManagedRestartSequenceHarness();
-    hoisted.activeTaskBlockers.push({
-      taskId: "restart-emission-preflight-blocker",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(
+      makeActiveTaskBlocker({ taskId: "restart-emission-preflight-blocker" }),
+    );
 
     try {
       const promotion = harness.nextPromotion();
@@ -4485,11 +4367,7 @@ describe("gateway Gmail hot reload handlers", () => {
       }
       return await originalActivateRuntimeSecrets(...args);
     });
-    hoisted.activeTaskBlockers.push({
-      taskId: "restart-pre-emit-blocker",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "restart-pre-emit-blocker" }));
 
     try {
       const deferredPromotion = harness.nextPromotion();
@@ -4522,11 +4400,7 @@ describe("gateway Gmail hot reload handlers", () => {
   it("revalidates paused restart secrets before rearming an exact config revert", async () => {
     vi.useFakeTimers();
     const harness = createManagedRestartSequenceHarness();
-    hoisted.activeTaskBlockers.push({
-      taskId: "restart-sequence-blocker",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "restart-sequence-blocker" }));
 
     try {
       const deferredPromotion = harness.nextPromotion();
@@ -4571,11 +4445,7 @@ describe("gateway Gmail hot reload handlers", () => {
   it("lets a newer valid restart config replace the deferred restart owner", async () => {
     vi.useFakeTimers();
     const harness = createManagedRestartSequenceHarness();
-    hoisted.activeTaskBlockers.push({
-      taskId: "restart-sequence-blocker",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "restart-sequence-blocker" }));
 
     try {
       const deferredPromotion = harness.nextPromotion();
@@ -4618,14 +4488,7 @@ describe("gateway Gmail hot reload handlers", () => {
       gateway: { reload: {} },
       hooks: { enabled: true, token: "test-token", path: "/next" },
     } as OpenClawConfig;
-    const initialSnapshot: PreparedSecretsRuntimeSnapshot = {
-      sourceConfig: initialConfig,
-      config: initialConfig,
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    };
+    const initialSnapshot = makePreparedSecretsSnapshot(initialConfig);
     const refreshedSnapshot: PreparedSecretsRuntimeSnapshot = {
       ...initialSnapshot,
       authStores: [
@@ -4665,14 +4528,7 @@ describe("gateway Gmail hot reload handlers", () => {
             ),
           ).toBe(true);
         }
-        return {
-          sourceConfig: config,
-          config,
-          authStores: [],
-          authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-          warnings: [],
-          webTools: createEmptyRuntimeWebToolsMetadata(),
-        };
+        return makePreparedSecretsSnapshot(config);
       }),
       { activatePreparedSnapshotIfCurrent },
     );
@@ -4798,14 +4654,7 @@ describe("gateway Gmail hot reload handlers", () => {
       models: { providers: {} },
     };
     const logReload = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    activateSecretsRuntimeSnapshot({
-      sourceConfig: initialConfig,
-      config: initialConfig,
-      authStores: [],
-      authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-      warnings: [],
-      webTools: createEmptyRuntimeWebToolsMetadata(),
-    });
+    activateSecretsRuntimeSnapshot(makePreparedSecretsSnapshot(initialConfig));
     hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("start failed"));
     const reloader = startManagedGatewayConfigReloader({
       initialConfig,
@@ -4857,14 +4706,7 @@ describe("gateway Gmail hot reload handlers", () => {
       activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => {
         secretsEntered?.();
         await releaseSecretsPromise;
-        return {
-          sourceConfig: config,
-          config,
-          authStores: [],
-          authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
-          warnings: [],
-          webTools: {},
-        };
+        return makePreparedSecretsSnapshot(config, { webTools: {} });
       }) as never,
     });
     const registeredWriteListener = writeListenerRef.current;
@@ -5064,10 +4906,10 @@ describe("gateway plugin hot reload handlers", () => {
         events.push(`lookup:${params.env[envKey]}:${targetEnv[envKey]}`);
         await params.commitRuntime();
         events.push(`plugin:${targetEnv[envKey]}`);
-        return {
+        return makePluginReloadResult({
           restartChannels: new Set(["discord"]),
           activeChannels: new Set(["discord"]),
-        };
+        });
       },
     );
     const reloader = startManagedGatewayConfigReloader({
@@ -5113,7 +4955,7 @@ describe("gateway plugin hot reload handlers", () => {
         await params.beforeReplace(new Set(["discord"]));
         await params.commitRuntime();
         events.push("registry:replace");
-        return { restartChannels: new Set(), activeChannels: new Set() };
+        return makePluginReloadResult();
       },
     );
     const handlers = createReloadHandlersForTest(
@@ -5159,34 +5001,30 @@ describe("gateway plugin hot reload handlers", () => {
   });
 
   it("keeps a committed plugin generation when a later channel restart fails", async () => {
-    restartTesting.resetSigusr1State();
-    resetGatewayWorkAdmission();
-    const signalSpy = vi.fn();
-    process.once("SIGUSR1", signalSpy);
-    const logReload = { info: vi.fn(), warn: vi.fn() };
-    const reloadPlugins = vi.fn(
-      async (params: {
-        commitRuntime: () => Promise<void>;
-      }): Promise<GatewayPluginReloadResult> => {
-        await params.commitRuntime();
-        return {
-          restartChannels: new Set(["discord"]),
-          activeChannels: new Set(["discord"]),
-        };
-      },
-    );
-    const handlers = createReloadHandlersForTest(
-      logReload,
-      {
-        start: vi.fn(async () => {
-          throw new Error("start failed");
-        }),
-        stop: vi.fn(async () => {}),
-      },
-      reloadPlugins,
-    );
+    await withGatewayRestartSignal(async (signalSpy) => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const reloadPlugins = vi.fn(
+        async (params: {
+          commitRuntime: () => Promise<void>;
+        }): Promise<GatewayPluginReloadResult> => {
+          await params.commitRuntime();
+          return makePluginReloadResult({
+            restartChannels: new Set(["discord"]),
+            activeChannels: new Set(["discord"]),
+          });
+        },
+      );
+      const handlers = createReloadHandlersForTest(
+        logReload,
+        {
+          start: vi.fn(async () => {
+            throw new Error("start failed");
+          }),
+          stop: vi.fn(async () => {}),
+        },
+        reloadPlugins,
+      );
 
-    try {
       await expect(
         handlers.applyHotReload(
           createPluginReloadPlan(),
@@ -5202,30 +5040,22 @@ describe("gateway plugin hot reload handlers", () => {
       expect(signalSpy).toHaveBeenCalledOnce();
       expect(isGatewayWorkAdmissionClosed()).toBe(true);
       markGatewaySigusr1RestartHandled();
-    } finally {
-      process.removeListener("SIGUSR1", signalSpy);
-      restartTesting.resetSigusr1State();
-      resetGatewayWorkAdmission();
-    }
+    });
   });
 
   it("restarts instead of rolling back when plugin swap throws after runtime commit", async () => {
-    restartTesting.resetSigusr1State();
-    resetGatewayWorkAdmission();
-    const signalSpy = vi.fn();
-    process.once("SIGUSR1", signalSpy);
-    const logReload = { info: vi.fn(), warn: vi.fn() };
-    const publish = vi.fn(async (commit: () => Promise<void>) => await commit());
-    const handlers = createReloadHandlersForTest(
-      logReload,
-      undefined,
-      vi.fn(async (params: { commitRuntime: () => Promise<void> }) => {
-        await params.commitRuntime();
-        throw new Error("swap failed");
-      }),
-    );
+    await withGatewayRestartSignal(async (signalSpy) => {
+      const logReload = { info: vi.fn(), warn: vi.fn() };
+      const publish = vi.fn(async (commit: () => Promise<void>) => await commit());
+      const handlers = createReloadHandlersForTest(
+        logReload,
+        undefined,
+        vi.fn(async (params: { commitRuntime: () => Promise<void> }) => {
+          await params.commitRuntime();
+          throw new Error("swap failed");
+        }),
+      );
 
-    try {
       await expect(
         handlers.applyHotReload(
           createPluginReloadPlan(),
@@ -5242,11 +5072,7 @@ describe("gateway plugin hot reload handlers", () => {
       expect(signalSpy).toHaveBeenCalledOnce();
       expect(isGatewayWorkAdmissionClosed()).toBe(true);
       markGatewaySigusr1RestartHandled();
-    } finally {
-      process.removeListener("SIGUSR1", signalSpy);
-      restartTesting.resetSigusr1State();
-      resetGatewayWorkAdmission();
-    }
+    });
   });
 
   it.each([
@@ -5340,7 +5166,7 @@ describe("gateway plugin hot reload handlers", () => {
       }): Promise<GatewayPluginReloadResult> => {
         await params.beforeReplace(new Set(["discord"]));
         await params.commitRuntime();
-        return { restartChannels: new Set(), activeChannels: new Set(["discord"]) };
+        return makePluginReloadResult({ activeChannels: new Set(["discord"]) });
       },
     );
     const handlers = createReloadHandlersForTest(
@@ -5377,7 +5203,7 @@ describe("gateway plugin hot reload handlers", () => {
       }): Promise<GatewayPluginReloadResult> => {
         await params.beforeReplace(new Set(["discord"]));
         expect(params.isAborted?.()).toBe(false);
-        return { restartChannels: new Set(), activeChannels: new Set(), cancelled: true };
+        return makePluginReloadResult({ cancelled: true });
       },
     );
     const handlers = createReloadHandlersForTest(
@@ -5402,15 +5228,8 @@ describe("gateway plugin hot reload handlers", () => {
   });
 
   it("rolls back stopped channels when plugin pre-replace stop fails", async () => {
-    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
-    const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
-    delete process.env.OPENCLAW_SKIP_CHANNELS;
-    delete process.env.OPENCLAW_SKIP_PROVIDERS;
-    const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
-    const heartbeatRunner = {
-      stop: vi.fn(),
-      updateConfig: vi.fn(),
-    };
+    const restoreChannelReloadEnv = enableChannelReloadsForTest();
+    const gatewayState = createDefaultGatewayReloadState();
     const setState = vi.fn();
     const logChannels = { info: vi.fn(), error: vi.fn() };
     const events: string[] = [];
@@ -5432,20 +5251,11 @@ describe("gateway plugin hot reload handlers", () => {
         events.push("reload:start");
         await params.beforeReplace(new Set(["telegram", "discord"]));
         events.push("registry:replace");
-        return {
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        };
+        return makePluginReloadResult();
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: heartbeatRunner as never,
-        cronState: { cron, storePath: "/tmp/cron.json", cronEnabled: false } as never,
-        channelHealthMonitor: null,
-      }),
+      getState: () => gatewayState,
       setState,
       startChannel,
       stopChannel,
@@ -5467,16 +5277,7 @@ describe("gateway plugin hot reload handlers", () => {
       ).rejects.toThrow("failed to stop channels before plugin reload: discord");
     } finally {
       root?.release();
-      if (previousSkipChannels === undefined) {
-        delete process.env.OPENCLAW_SKIP_CHANNELS;
-      } else {
-        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
-      }
-      if (previousSkipProviders === undefined) {
-        delete process.env.OPENCLAW_SKIP_PROVIDERS;
-      } else {
-        process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
-      }
+      restoreChannelReloadEnv();
     }
 
     expect(events).toEqual([
@@ -5496,15 +5297,8 @@ describe("gateway plugin hot reload handlers", () => {
   });
 
   it("stops removed channel plugins from broad activation before swapping plugin runtime", async () => {
-    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
-    const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
-    delete process.env.OPENCLAW_SKIP_CHANNELS;
-    delete process.env.OPENCLAW_SKIP_PROVIDERS;
-    const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
-    const heartbeatRunner = {
-      stop: vi.fn(),
-      updateConfig: vi.fn(),
-    };
+    const restoreChannelReloadEnv = enableChannelReloadsForTest();
+    const gatewayState = createDefaultGatewayReloadState();
     const setState = vi.fn();
     const startChannel = vi.fn(async () => {});
     const events: string[] = [];
@@ -5518,20 +5312,11 @@ describe("gateway plugin hot reload handlers", () => {
         events.push("reload:start");
         await params.beforeReplace(new Set(["discord"]));
         events.push("registry:replace");
-        return {
-          restartChannels: new Set(),
-          activeChannels: new Set(),
-        };
+        return makePluginReloadResult();
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: heartbeatRunner as never,
-        cronState: { cron, storePath: "/tmp/cron.json", cronEnabled: false } as never,
-        channelHealthMonitor: null,
-      }),
+      getState: () => gatewayState,
       setState,
       startChannel,
       stopChannel,
@@ -5545,16 +5330,7 @@ describe("gateway plugin hot reload handlers", () => {
         },
       });
     } finally {
-      if (previousSkipChannels === undefined) {
-        delete process.env.OPENCLAW_SKIP_CHANNELS;
-      } else {
-        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
-      }
-      if (previousSkipProviders === undefined) {
-        delete process.env.OPENCLAW_SKIP_PROVIDERS;
-      } else {
-        process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
-      }
+      restoreChannelReloadEnv();
     }
 
     const [reloadParams] = reloadPlugins.mock.calls.at(-1) ?? [];
@@ -5574,15 +5350,8 @@ describe("gateway plugin hot reload handlers", () => {
   });
 
   it("stops manually started channels before plugin replacement while autostart is suppressed", async () => {
-    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
-    const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
-    delete process.env.OPENCLAW_SKIP_CHANNELS;
-    delete process.env.OPENCLAW_SKIP_PROVIDERS;
-    const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
-    const heartbeatRunner = {
-      stop: vi.fn(),
-      updateConfig: vi.fn(),
-    };
+    const restoreChannelReloadEnv = enableChannelReloadsForTest();
+    const gatewayState = createDefaultGatewayReloadState();
     const setState = vi.fn();
     const logChannels = { info: vi.fn(), error: vi.fn() };
     const events: string[] = [];
@@ -5599,20 +5368,14 @@ describe("gateway plugin hot reload handlers", () => {
         events.push("reload:start");
         await params.beforeReplace(new Set(["discord"]));
         events.push("registry:replace");
-        return {
+        return makePluginReloadResult({
           restartChannels: new Set(["discord"]),
           activeChannels: new Set(["discord"]),
-        };
+        });
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
-      getState: () => ({
-        hooksConfig: {} as never,
-        hookClientIpConfig: {} as never,
-        heartbeatRunner: heartbeatRunner as never,
-        cronState: { cron, storePath: "/tmp/cron.json", cronEnabled: false } as never,
-        channelHealthMonitor: null,
-      }),
+      getState: () => gatewayState,
       setState,
       startChannel,
       stopChannel,
@@ -5631,16 +5394,7 @@ describe("gateway plugin hot reload handlers", () => {
         },
       });
     } finally {
-      if (previousSkipChannels === undefined) {
-        delete process.env.OPENCLAW_SKIP_CHANNELS;
-      } else {
-        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
-      }
-      if (previousSkipProviders === undefined) {
-        delete process.env.OPENCLAW_SKIP_PROVIDERS;
-      } else {
-        process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
-      }
+      restoreChannelReloadEnv();
     }
 
     expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
@@ -5691,11 +5445,7 @@ describe("deferred channel reload abort generation", () => {
     };
     const { applyHotReload } = createTestHandlers(logChannels, channels);
 
-    hoisted.activeTaskBlockers.push({
-      taskId: "task-blocking-reload",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker());
     vi.useFakeTimers();
 
     try {
@@ -5727,11 +5477,9 @@ describe("deferred channel reload abort generation", () => {
     };
     const reloadPlugins: NonNullable<ReloadHandlerParams["reloadPlugins"]> = async (params) => {
       await params.beforeReplace(new Set(["whatsapp"]));
-      return {
-        restartChannels: new Set(),
-        activeChannels: new Set(),
+      return makePluginReloadResult({
         cancelled: params.isAborted?.() === true,
-      };
+      });
     };
     const { applyHotReload } = createTestHandlers(logChannels, channels, { reloadPlugins });
 
@@ -5754,11 +5502,9 @@ describe("deferred channel reload abort generation", () => {
     };
     const reloadPlugins: NonNullable<ReloadHandlerParams["reloadPlugins"]> = async (params) => {
       await params.beforeReplace(new Set(["whatsapp"]));
-      return {
-        restartChannels: new Set(),
-        activeChannels: new Set(),
+      return makePluginReloadResult({
         cancelled: params.isAborted?.() === true,
-      };
+      });
     };
     const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
     const { applyHotReload } = createTestHandlers(logChannels, channels, {
@@ -5785,11 +5531,9 @@ describe("deferred channel reload abort generation", () => {
     };
     const reloadPlugins: NonNullable<ReloadHandlerParams["reloadPlugins"]> = async (params) => {
       await params.beforeReplace(new Set(["whatsapp"]));
-      return {
-        restartChannels: new Set(),
-        activeChannels: new Set(),
+      return makePluginReloadResult({
         cancelled: true,
-      };
+      });
     };
     const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
     const { applyHotReload } = createTestHandlers(logChannels, channels, {
@@ -5813,11 +5557,9 @@ describe("deferred channel reload abort generation", () => {
       stop: vi.fn(async () => {}),
     };
     const { applyHotReload } = createTestHandlers(logChannels, channels);
-    hoisted.activeTaskBlockers.push({
-      taskId: "task-blocking-superseded-reload",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(
+      makeActiveTaskBlocker({ taskId: "task-blocking-superseded-reload" }),
+    );
     let transactionCurrent = true;
     vi.useFakeTimers();
 
@@ -5887,11 +5629,7 @@ describe("deferred channel reload abort generation", () => {
     if (!registeredWriteListener) {
       throw new Error("Expected config write listener to be registered");
     }
-    hoisted.activeTaskBlockers.push({
-      taskId: "managed-reload-blocker",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "managed-reload-blocker" }));
     vi.useFakeTimers();
     let reloaderStopped = false;
 
@@ -5939,11 +5677,7 @@ describe("deferred channel reload abort generation", () => {
     // Create gen 2 — should not carry over the abort from gen 1
     const h2 = createTestHandlers(logChannels, channels);
 
-    hoisted.activeTaskBlockers.push({
-      taskId: "task-blocking-reload-g2",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker({ taskId: "task-blocking-reload-g2" }));
     vi.useFakeTimers();
 
     try {
@@ -5989,9 +5723,9 @@ describe("deferred channel reload abort generation", () => {
         await params.beforeReplace(new Set(["whatsapp"]));
         if (params.isAborted?.()) {
           reloadWasCancelled = true;
-          return { restartChannels: new Set(), activeChannels: new Set(), cancelled: true };
+          return makePluginReloadResult({ cancelled: true });
         }
-        return { restartChannels: new Set(), activeChannels: new Set() };
+        return makePluginReloadResult();
       },
     );
     const { applyHotReload } = createGatewayReloadHandlers({
@@ -6003,11 +5737,7 @@ describe("deferred channel reload abort generation", () => {
 
     const pluginReloadPlan: GatewayReloadPlan = createPluginReloadPlan();
 
-    hoisted.activeTaskBlockers.push({
-      taskId: "task-blocking-reload",
-      status: "running",
-      runtime: "subagent",
-    });
+    hoisted.activeTaskBlockers.push(makeActiveTaskBlocker());
     vi.useFakeTimers();
 
     try {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -4706,7 +4706,7 @@ describe("gateway Gmail hot reload handlers", () => {
       activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => {
         secretsEntered?.();
         await releaseSecretsPromise;
-        return makePreparedSecretsSnapshot(config, { webTools: {} });
+        return makePreparedSecretsSnapshot(config, { webTools: {} as never });
       }) as never,
     });
     const registeredWriteListener = writeListenerRef.current;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -321,7 +321,7 @@ function makeMainSessionParams(overrides: Record<string, unknown> = {}) {
 }
 
 function makeMainMessageParams(messageId: string) {
-  return makeMainSessionParams({ messageId });
+  return { sessionKey: "main", messageId };
 }
 
 function makeChatSendParams(overrides: ChatSendParamOverrides) {
@@ -337,7 +337,7 @@ function makeMainSessionScope(storePath: string | undefined) {
   };
 }
 
-function makeGatewayWebchatClient(id = GATEWAY_CLIENT_NAMES.CONTROL_UI) {
+function makeGatewayWebchatClient(id: string = GATEWAY_CLIENT_NAMES.CONTROL_UI) {
   return {
     client: {
       id,
@@ -5047,7 +5047,7 @@ describe("gateway server chat", () => {
       await prepareMainHistoryHarness({ ws, createSessionDir });
       const historyMaxBytes = getMaxChatHistoryMessagesBytes();
       const baseText = "s".repeat(100_000);
-      const lines = Array.from({ length: 70 }, (_, index) =>
+      const lines: unknown[] = Array.from({ length: 70 }, (_, index) =>
         createTextTranscriptEvent("user", `small-${index}:${baseText}`, {
           timestamp: Date.now() + index,
         }),

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -311,6 +311,102 @@ function createControlUiClient(
   } as never;
 }
 
+type ChatSendParamOverrides = {
+  idempotencyKey: string;
+  [key: string]: unknown;
+};
+
+function makeMainSessionParams(overrides: Record<string, unknown> = {}) {
+  return { sessionKey: "main", ...overrides };
+}
+
+function makeMainMessageParams(messageId: string) {
+  return makeMainSessionParams({ messageId });
+}
+
+function makeChatSendParams(overrides: ChatSendParamOverrides) {
+  return makeMainSessionParams({ message: "hello", ...overrides });
+}
+
+function makeMainSessionScope(storePath: string | undefined) {
+  return {
+    agentId: "main",
+    sessionId: "sess-main",
+    sessionKey: "agent:main:main",
+    storePath,
+  };
+}
+
+function makeGatewayWebchatClient(id = GATEWAY_CLIENT_NAMES.CONTROL_UI) {
+  return {
+    client: {
+      id,
+      version: "1.0.0",
+      platform: "web",
+      mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+    },
+  };
+}
+
+function makeTuiClient() {
+  return {
+    connId: "conn-tui",
+    connect: {
+      client: { id: GATEWAY_CLIENT_NAMES.TUI, mode: GATEWAY_CLIENT_MODES.UI },
+      scopes: ["operator.write", "operator.admin"],
+    },
+  } as never;
+}
+
+function makeTranscriptTextEvent(
+  text: string,
+  overrides: {
+    role?: "assistant" | "toolResult" | "user";
+    message?: Record<string, unknown>;
+    [key: string]: unknown;
+  } = {},
+) {
+  const { role = "assistant", message = {}, ...event } = overrides;
+  return {
+    ...event,
+    message: { role, content: [{ type: "text", text }], ...message },
+  };
+}
+
+function makeClaudeCliSessionEntry(
+  sessionDir: string,
+  sessionId: string,
+  cliSessionId: string,
+): StoredSessionEntry {
+  return {
+    sessionId,
+    sessionFile: testSessionFilePath(sessionDir, sessionId),
+    updatedAt: futureFixtureUpdatedAt(),
+    modelProvider: "claude-cli",
+    model: "claude-sonnet-4-6",
+    cliSessionBindings: { "claude-cli": { sessionId: cliSessionId } },
+  };
+}
+
+function makeDoneSessionEntry(overrides: StoredSessionEntry = {}): StoredSessionEntry {
+  return { status: "done", ...overrides };
+}
+
+type CapturedChatResult = { ok: boolean; payload?: unknown };
+type CapturedChatResponse = CapturedChatResult & { error?: unknown };
+
+function captureChatResult(results: CapturedChatResult[]): RespondFn {
+  return (ok, payload) => {
+    results.push({ ok, payload });
+  };
+}
+
+function captureChatResponse(responses: CapturedChatResponse[]): RespondFn {
+  return (ok, payload, error) => {
+    responses.push({ ok, payload, error });
+  };
+}
+
 async function sendControlUiChat(params: {
   authenticatedUserId?: string;
   authenticatedUserProfile?: {
@@ -325,14 +421,13 @@ async function sendControlUiChat(params: {
   respond: RespondFn;
   onAdmissionOwned?: () => Promise<boolean>;
 }): Promise<void> {
-  const requestParams = {
-    sessionKey: "main",
+  const requestParams = makeChatSendParams({
     message: params.message,
     idempotencyKey: params.idempotencyKey,
     ...(params.expectedSessionRoutingContract
       ? { expectedSessionRoutingContract: params.expectedSessionRoutingContract }
       : {}),
-  };
+  });
   const options: GatewayRequestHandlerOptions = {
     req: {
       type: "req",
@@ -379,11 +474,10 @@ test("chat.send replays a cached result after the session is archived", async ()
     await callDirectChat("chat.send", {
       id: "cached",
       req: { type: "req", id: "cached", method: "chat.send" },
-      params: {
-        sessionKey: "main",
+      params: makeChatSendParams({
         message: "retry completed send",
         idempotencyKey: runId,
-      },
+      }),
       respond: ((ok, payload, error, meta) => {
         responses.push({ ok, payload, error, meta });
       }) as RespondFn,
@@ -420,11 +514,14 @@ async function fetchHistoryMessages(
     maxChars?: number;
   },
 ): Promise<unknown[]> {
-  const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
-    sessionKey: "main",
-    limit: params?.limit ?? 1000,
-    ...(typeof params?.maxChars === "number" ? { maxChars: params.maxChars } : {}),
-  });
+  const historyRes = await rpcReq<{ messages?: unknown[] }>(
+    ws,
+    "chat.history",
+    makeMainSessionParams({
+      limit: params?.limit ?? 1000,
+      ...(typeof params?.maxChars === "number" ? { maxChars: params.maxChars } : {}),
+    }),
+  );
   expect(historyRes.ok).toBe(true);
   return historyRes.payload?.messages ?? [];
 }
@@ -511,8 +608,8 @@ describe("gateway server chat", () => {
         const responses: Array<{ ok: boolean; payload?: unknown }> = [];
         await callDirectChat(method, {
           id: method,
-          params: { sessionKey: "main" },
-          respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+          params: makeMainSessionParams(),
+          respond: captureChatResult(responses),
           context,
         });
 
@@ -632,8 +729,8 @@ describe("gateway server chat", () => {
         const responses: Array<{ ok: boolean; payload?: unknown }> = [];
         await callDirectChat(method, {
           id: method,
-          params: { sessionKey: "main" },
-          respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+          params: makeMainSessionParams(),
+          respond: captureChatResult(responses),
           context,
         });
 
@@ -731,10 +828,8 @@ describe("gateway server chat", () => {
       });
       await callDirectChat("chat.history", {
         id: "history-no-catalog",
-        params: { sessionKey: "main" },
-        respond: ((ok, payload, error) => {
-          responses.push({ ok, payload, error });
-        }) as RespondFn,
+        params: makeMainSessionParams(),
+        respond: captureChatResponse(responses),
         context,
       });
 
@@ -803,7 +898,7 @@ describe("gateway server chat", () => {
           model?: string | null;
           contextTokens?: number | null;
         };
-      }>(ws, "chat.history", { sessionKey: "main" });
+      }>(ws, "chat.history", makeMainSessionParams());
 
       expect(persisted.ok).toBe(true);
       expect(persisted.payload?.defaults?.modelProvider).toBeTruthy();
@@ -828,7 +923,7 @@ describe("gateway server chat", () => {
           model?: string | null;
           contextTokens?: number | null;
         };
-      }>(ws, "chat.history", { sessionKey: "main" });
+      }>(ws, "chat.history", makeMainSessionParams());
 
       expect(synthetic.ok).toBe(true);
       expect(synthetic.payload?.defaults?.modelProvider).toBeTruthy();
@@ -889,7 +984,7 @@ describe("gateway server chat", () => {
         };
         messages?: unknown[];
         sessionInfo?: { key?: string; sessionId?: string };
-      }>(ws, "chat.startup", { sessionKey: "main" });
+      }>(ws, "chat.startup", makeMainSessionParams());
 
       expect(startup.ok).toBe(true);
       expect(startup.payload?.agentsList?.defaultId).toBe("main");
@@ -953,7 +1048,7 @@ describe("gateway server chat", () => {
       await callDirectChat("chat.startup", {
         id: "startup-fallback-owner",
         params: { sessionKey: "agent:work:main" },
-        respond: ((ok, payload, error) => responses.push({ ok, payload, error })) as RespondFn,
+        respond: captureChatResponse(responses),
         context,
       });
 
@@ -981,10 +1076,8 @@ describe("gateway server chat", () => {
       });
       await callDirectChat("chat.startup", {
         id: "startup-slow-catalog",
-        params: { sessionKey: "main" },
-        respond: ((ok, payload, error) => {
-          responses.push({ ok, payload, error });
-        }) as RespondFn,
+        params: makeMainSessionParams(),
+        respond: captureChatResponse(responses),
         context,
       });
 
@@ -1026,8 +1119,8 @@ describe("gateway server chat", () => {
       });
       await callDirectChat("chat.history", {
         id: "history-slow-catalog",
-        params: { sessionKey: "main" },
-        respond: ((ok, payload, error) => responses.push({ ok, payload, error })) as RespondFn,
+        params: makeMainSessionParams(),
+        respond: captureChatResponse(responses),
         context,
       });
 
@@ -1311,9 +1404,7 @@ describe("gateway server chat", () => {
           await callDirectChat("chat.startup", {
             id: "startup-dual-route-catalog",
             params: { sessionKey: "agent:work:main" },
-            respond: ((ok, payload, error) => {
-              responses.push({ ok, payload, error });
-            }) as RespondFn,
+            respond: captureChatResponse(responses),
             context,
           });
 
@@ -1424,7 +1515,7 @@ describe("gateway server chat", () => {
 
       const startup = await rpcReq<{
         metadata?: { models?: Array<{ id?: string; provider?: string }> };
-      }>(ws, "chat.startup", { sessionKey: "main" });
+      }>(ws, "chat.startup", makeMainSessionParams());
 
       expect(startup.ok).toBe(true);
       expect(startup.payload?.metadata?.models).toEqual(
@@ -1529,9 +1620,7 @@ describe("gateway server chat", () => {
       await callDirectChat("chat.startup", {
         id: "startup-agent-scoped-metadata",
         params: { sessionKey: "agent:work:main" },
-        respond: ((ok, payload, error) => {
-          responses.push({ ok, payload, error });
-        }) as RespondFn,
+        respond: captureChatResponse(responses),
         context,
       });
 
@@ -1736,8 +1825,7 @@ describe("gateway server chat", () => {
 
       const pngB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
-      const params = {
-        sessionKey: "main",
+      const params = makeChatSendParams({
         message: "see image",
         idempotencyKey: "idem-attachment-race",
         attachments: [
@@ -1748,7 +1836,7 @@ describe("gateway server chat", () => {
             content: pngB64,
           },
         ],
-      };
+      });
       const callSend = (id: string) =>
         callDirectChat("chat.send", {
           id,
@@ -1831,8 +1919,7 @@ describe("gateway server chat", () => {
 
       const pngB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
-      const params = {
-        sessionKey: "main",
+      const params = makeChatSendParams({
         message: "abort this image",
         idempotencyKey: "idem-attachment-abort",
         attachments: [
@@ -1843,7 +1930,7 @@ describe("gateway server chat", () => {
             content: pngB64,
           },
         ],
-      };
+      });
       const client = {
         connId: "conn-owner",
         connect: {
@@ -1869,11 +1956,9 @@ describe("gateway server chat", () => {
 
       await callDirectChat("chat.abort", {
         id: "abort",
-        params: { sessionKey: "main", runId: "idem-attachment-abort" },
+        params: makeMainSessionParams({ runId: "idem-attachment-abort" }),
         client,
-        respond: ((ok, payload, error) => {
-          abortResponses.push({ ok, payload, error });
-        }) as RespondFn,
+        respond: captureChatResponse(abortResponses),
         context,
       });
 
@@ -1974,11 +2059,10 @@ describe("gateway server chat", () => {
         payload: { runId: `pending:${runId}`, status: "ok" },
       };
       context.dedupe.set(collidingFinalKey, collidingFinalEntry);
-      const params = {
-        sessionKey: "main",
+      const params = makeChatSendParams({
         message: "do not dispatch",
         idempotencyKey: runId,
-      };
+      });
       const client = {
         connId: "conn-owner",
         connect: {
@@ -1991,9 +2075,7 @@ describe("gateway server chat", () => {
           id: "send",
           params,
           client,
-          respond: ((ok, payload, error) => {
-            sendResponses.push({ ok, payload, error });
-          }) as RespondFn,
+          respond: captureChatResponse(sendResponses),
           context,
         }),
       );
@@ -2008,9 +2090,7 @@ describe("gateway server chat", () => {
         id: "retry",
         params,
         client,
-        respond: ((ok, payload, error) => {
-          retryResponses.push({ ok, payload, error });
-        }) as RespondFn,
+        respond: captureChatResponse(retryResponses),
         context,
       });
       expect(retryResponses).toEqual([
@@ -2024,11 +2104,9 @@ describe("gateway server chat", () => {
 
       await callDirectChat("chat.abort", {
         id: "abort",
-        params: { sessionKey: "main", runId },
+        params: makeMainSessionParams({ runId }),
         client,
-        respond: ((ok, payload, error) => {
-          abortResponses.push({ ok, payload, error });
-        }) as RespondFn,
+        respond: captureChatResponse(abortResponses),
         context,
       });
       releaseMutation.resolve();
@@ -2084,18 +2162,15 @@ describe("gateway server chat", () => {
       const sendResponses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
       const context = createDirectChatContext();
       const runId = "idem-stale-lifecycle";
-      const params = {
-        sessionKey: "main",
+      const params = makeChatSendParams({
         message: "do not resume after restart",
         idempotencyKey: runId,
-      };
+      });
       const send = Promise.resolve(
         callDirectChat("chat.send", {
           id: "send",
           params,
-          respond: ((ok, payload, error) => {
-            sendResponses.push({ ok, payload, error });
-          }) as RespondFn,
+          respond: captureChatResponse(sendResponses),
           context,
         }),
       );
@@ -2185,11 +2260,10 @@ describe("gateway server chat", () => {
       }> = [];
       const context = createDirectChatContext();
       const runId = "idem-deleted-during-admission";
-      const params = {
-        sessionKey: "main",
+      const params = makeChatSendParams({
         message: "do not recreate the deleted session",
         idempotencyKey: runId,
-      };
+      });
       const send = Promise.resolve(
         callDirectChat("chat.send", {
           id: "send",
@@ -2248,18 +2322,15 @@ describe("gateway server chat", () => {
       const sendResponses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
       const context = createDirectChatContext();
       const runId = "idem-reset-during-admission";
-      const params = {
-        sessionKey: "main",
+      const params = makeChatSendParams({
         message: "do not enter the replacement session",
         idempotencyKey: runId,
-      };
+      });
       const send = Promise.resolve(
         callDirectChat("chat.send", {
           id: "send",
           params,
-          respond: ((ok, payload, error) => {
-            sendResponses.push({ ok, payload, error });
-          }) as RespondFn,
+          respond: captureChatResponse(sendResponses),
           context,
         }),
       );
@@ -2308,18 +2379,15 @@ describe("gateway server chat", () => {
       const context = createDirectChatContext();
       const runId = "idem-replaced-reservation";
       const pendingKey = pendingChatSendDedupeKey(runId);
-      const params = {
-        sessionKey: "main",
+      const params = makeChatSendParams({
         message: "only the replacement may run",
         idempotencyKey: runId,
-      };
+      });
       const send = Promise.resolve(
         callDirectChat("chat.send", {
           id: "send",
           params,
-          respond: ((ok, payload, error) => {
-            sendResponses.push({ ok, payload, error });
-          }) as RespondFn,
+          respond: captureChatResponse(sendResponses),
           context,
         }),
       );
@@ -2366,19 +2434,16 @@ describe("gateway server chat", () => {
       await terminalMutationStarted.promise;
       const terminalRunId = "idem-terminal-replacement";
       const terminalPendingKey = pendingChatSendDedupeKey(terminalRunId);
-      const terminalParams = {
-        sessionKey: "main",
+      const terminalParams = makeChatSendParams({
         message: "preserve the replacement result",
         idempotencyKey: terminalRunId,
-      };
+      });
       const terminalResponses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
       const terminalSend = Promise.resolve(
         callDirectChat("chat.send", {
           id: "terminal-send",
           params: terminalParams,
-          respond: ((ok, payload, error) => {
-            terminalResponses.push({ ok, payload, error });
-          }) as RespondFn,
+          respond: captureChatResponse(terminalResponses),
           context,
         }),
       );
@@ -2479,8 +2544,7 @@ describe("gateway server chat", () => {
         const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
         await callDirectChat("chat.send", {
           id: `configured-image-model-${id}`,
-          params: {
-            sessionKey: "main",
+          params: makeChatSendParams({
             message: "see image",
             idempotencyKey: `idem-configured-image-model-${id}`,
             attachments: [
@@ -2491,10 +2555,8 @@ describe("gateway server chat", () => {
                 content: pngB64,
               },
             ],
-          },
-          respond: ((ok, payload, error) => {
-            responses.push({ ok, payload, error });
-          }) as RespondFn,
+          }),
+          respond: captureChatResponse(responses),
           context,
         });
 
@@ -2522,9 +2584,7 @@ describe("gateway server chat", () => {
     const { storePath } = openDirectChatSession();
     const dispatchRelease = createDeferred();
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const context = createDirectChatContext();
       dispatchInboundMessageMock.mockImplementationOnce(async () => dispatchRelease.promise);
       let snapshotAtAck:
@@ -2542,12 +2602,7 @@ describe("gateway server chat", () => {
           if (!ok || (payload as { status?: unknown } | undefined)?.status !== "started") {
             return;
           }
-          const scope = {
-            agentId: "main",
-            sessionId: "sess-main",
-            sessionKey: "agent:main:main",
-            storePath,
-          };
+          const scope = makeMainSessionScope(storePath);
           snapshotAtAck = {
             entry: loadSessionEntry(scope),
             events: loadTranscriptEventsSync(scope),
@@ -2593,9 +2648,7 @@ describe("gateway server chat", () => {
   test("chat.send persists optional connection identity per turn", async () => {
     openDirectChatSession();
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const context = createDirectChatContext();
       const send = async (params: {
         authenticatedUserId?: string;
@@ -2644,12 +2697,9 @@ describe("gateway server chat", () => {
         message: "prompt without identity",
       });
 
-      const transcriptEvents = loadTranscriptEventsSync({
-        agentId: "main",
-        sessionId: "sess-main",
-        sessionKey: "agent:main:main",
-        storePath: testState.sessionStorePath,
-      });
+      const transcriptEvents = loadTranscriptEventsSync(
+        makeMainSessionScope(testState.sessionStorePath),
+      );
       expect(transcriptEvents).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -2695,13 +2745,14 @@ describe("gateway server chat", () => {
     const priorRunId = "idem-prior-terminal-claim";
     const nextRunId = "idem-after-terminal-claim";
     try {
-      await writeStoredMainSession({
-        status: "done",
-        abortedLastRun: false,
-        restartRecoveryDeliveryRunId: priorRunId,
-        restartRecoveryDeliverySourceRunId: priorRunId,
-        restartRecoveryTerminalRunIds: ["idem-older-terminal-claim"],
-      });
+      await writeStoredMainSession(
+        makeDoneSessionEntry({
+          abortedLastRun: false,
+          restartRecoveryDeliveryRunId: priorRunId,
+          restartRecoveryDeliverySourceRunId: priorRunId,
+          restartRecoveryTerminalRunIds: ["idem-older-terminal-claim"],
+        }),
+      );
       const context = createDirectChatContext();
       dispatchInboundMessageMock.mockImplementationOnce(async () => dispatchRelease.promise);
       let snapshotAtAck: ReturnType<typeof loadSessionEntry>;
@@ -2770,9 +2821,7 @@ describe("gateway server chat", () => {
     const dispatchRelease = createDeferred();
     const runId = "idem-concurrent-admission-owner";
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const context = createDirectChatContext();
       dispatchInboundMessageMock.mockImplementationOnce(async () => dispatchRelease.promise);
       const firstAdmission = vi.fn(async () => true);
@@ -2818,9 +2867,7 @@ describe("gateway server chat", () => {
     const releaseCallback = createDeferred();
     const runId = "idem-visible-during-admission-callback";
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const context = createDirectChatContext({ chatQueuedTurns: new Map() });
       const sendResponses: Array<{ ok: boolean; payload?: unknown }> = [];
       const sendPromise = sendControlUiChat({
@@ -2832,7 +2879,7 @@ describe("gateway server chat", () => {
           await releaseCallback.promise;
           return true;
         },
-        respond: ((ok, payload) => sendResponses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(sendResponses),
       });
       await callbackEntered.promise;
       expect(context.chatAbortControllers.get(runId)?.controlUiVisible).not.toBe(false);
@@ -2840,10 +2887,10 @@ describe("gateway server chat", () => {
       const abortResponses: Array<{ ok: boolean; payload?: unknown }> = [];
       await callDirectChat("chat.abort", {
         id: "abort-visible-replacement",
-        params: { sessionKey: "main" },
+        params: makeMainSessionParams(),
         client: createControlUiClient(),
         isWebchatConnect: () => true,
-        respond: ((ok, payload) => abortResponses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(abortResponses),
         context,
       });
 
@@ -2884,15 +2931,8 @@ describe("gateway server chat", () => {
     const releaseLock = createDeferred();
     let lockPromise: Promise<void> | undefined;
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
-      const scope = {
-        agentId: "main",
-        sessionId: "sess-main",
-        sessionKey: "agent:main:main",
-        storePath,
-      };
+      await writeStoredMainSession(makeDoneSessionEntry());
+      const scope = makeMainSessionScope(storePath);
       lockPromise = withTranscriptWriteLock(scope, async () => {
         lockEntered.resolve(undefined);
         await releaseLock.promise;
@@ -2904,7 +2944,7 @@ describe("gateway server chat", () => {
         context,
         idempotencyKey: runId,
         message: "persist, then stop",
-        respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(responses),
       });
       await waitForFast(
         () => expect(context.chatAbortControllers.get(runId)).toBeDefined(),
@@ -2976,7 +3016,7 @@ describe("gateway server chat", () => {
         context: retryContext,
         idempotencyKey: runId,
         message: "persist, then stop",
-        respond: ((ok, payload) => retryResponses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(retryResponses),
       });
       expect(retryResponses).toEqual([
         {
@@ -3067,7 +3107,7 @@ describe("gateway server chat", () => {
         context,
         idempotencyKey,
         message: "already admitted",
-        respond: ((ok, payload, error) => responses.push({ ok, payload, error })) as RespondFn,
+        respond: captureChatResponse(responses),
       });
 
       expect(responses).toEqual([
@@ -3129,7 +3169,7 @@ describe("gateway server chat", () => {
         context,
         idempotencyKey,
         message: "already admitted",
-        respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(responses),
       });
 
       expect(responses).toEqual([
@@ -3157,9 +3197,7 @@ describe("gateway server chat", () => {
     const releaseMutation = createDeferred();
     let mutation: Promise<void> | undefined;
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const mutationStarted = createDeferred();
       mutation = runExclusiveSessionLifecycleMutation({
         scope: storePath,
@@ -3225,7 +3263,7 @@ describe("gateway server chat", () => {
         context,
         idempotencyKey,
         message: "must stay archived",
-        respond: ((ok, payload, error) => responses.push({ ok, payload, error })) as RespondFn,
+        respond: captureChatResponse(responses),
       });
 
       expect(responses).toEqual([
@@ -3271,7 +3309,7 @@ describe("gateway server chat", () => {
         context,
         idempotencyKey,
         message: "must not dispatch replacement ownership",
-        respond: ((ok, payload, error) => responses.push({ ok, payload, error })) as RespondFn,
+        respond: captureChatResponse(responses),
       });
 
       expect(responses).toEqual([
@@ -3307,7 +3345,7 @@ describe("gateway server chat", () => {
         context,
         idempotencyKey,
         message: "already handled",
-        respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(responses),
       });
 
       expect(responses).toEqual([
@@ -3326,9 +3364,7 @@ describe("gateway server chat", () => {
     const { storePath } = openDirectChatSession();
     const runId = "idem-restart-safe-dispatch-error";
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const context = createDirectChatContext();
       const responses: Array<{ ok: boolean; payload?: unknown }> = [];
       dispatchInboundMessageMock.mockRejectedValueOnce(new Error("dispatch rejected"));
@@ -3337,7 +3373,7 @@ describe("gateway server chat", () => {
         context,
         idempotencyKey: runId,
         message: "retry me after dispatch failure",
-        respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(responses),
       });
       expect(responses).toEqual([
         {
@@ -3363,7 +3399,7 @@ describe("gateway server chat", () => {
         context: collisionContext,
         idempotencyKey: runId,
         message: "changed text under the same run id",
-        respond: ((ok, payload) => collisionResponses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(collisionResponses),
       });
       expect(collisionResponses).toEqual([
         {
@@ -3384,7 +3420,7 @@ describe("gateway server chat", () => {
         context: retryContext,
         idempotencyKey: runId,
         message: "retry me after dispatch failure",
-        respond: ((ok, payload) => retryResponses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(retryResponses),
       });
       expect(retryResponses).toEqual([
         {
@@ -3413,9 +3449,7 @@ describe("gateway server chat", () => {
     const { storePath } = openDirectChatSession();
     const runId = "idem-restart-safe-setup-error";
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const context = createDirectChatContext();
       const responses: Array<{ ok: boolean; payload?: unknown }> = [];
       let responseCount = 0;
@@ -3451,9 +3485,7 @@ describe("gateway server chat", () => {
     const { storePath } = openDirectChatSession();
     const runId = "idem-restart-safe-routing-change";
     try {
-      await writeStoredMainSession({
-        status: "done",
-      });
+      await writeStoredMainSession(makeDoneSessionEntry());
       const context = createDirectChatContext();
       const initialRuntimeConfig = getRuntimeConfig();
       const changedRuntimeConfig = {
@@ -3475,7 +3507,7 @@ describe("gateway server chat", () => {
         expectedSessionRoutingContract: resolveSessionRoutingContract(initialRuntimeConfig),
         idempotencyKey: runId,
         message: "retry me after routing changes",
-        respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(responses),
       });
       expect(responses).toEqual([{ ok: false, payload: undefined }]);
       expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
@@ -3494,7 +3526,7 @@ describe("gateway server chat", () => {
         context: retryContext,
         idempotencyKey: runId,
         message: "retry me after routing changes",
-        respond: ((ok, payload) => retryResponses.push({ ok, payload })) as RespondFn,
+        respond: captureChatResult(retryResponses),
       });
       expect(retryResponses).toEqual([
         {
@@ -3543,11 +3575,12 @@ describe("gateway server chat", () => {
   ])("chat.send leaves $caseName outside restart-safe admission", async ({ entry, runId }) => {
     const { storePath } = openDirectChatSession();
     try {
-      await writeStoredMainSession({
-        status: "done",
-        ...entry,
-        updatedAt: Date.now(),
-      });
+      await writeStoredMainSession(
+        makeDoneSessionEntry({
+          ...entry,
+          updatedAt: Date.now(),
+        }),
+      );
       const context = createDirectChatContext();
       dispatchInboundMessageMock.mockResolvedValueOnce(undefined);
       const ackSnapshot: { entry: ReturnType<typeof loadSessionEntry> } = { entry: undefined };
@@ -3596,13 +3629,12 @@ describe("gateway server chat", () => {
         systemProvenanceReceipt?: string,
         thinking = "low",
       ) => {
-        const params = {
-          sessionKey: "main",
-          message: "?",
+        const params = makeChatSendParams({
           idempotencyKey,
+          message: "?",
           thinking,
           ...(systemProvenanceReceipt ? { systemProvenanceReceipt } : {}),
-        };
+        });
         return callDirectChat("chat.send", {
           id,
           params,
@@ -3773,12 +3805,11 @@ describe("gateway server chat", () => {
 
       await callDirectChat("chat.send", {
         id: "suppressed-command",
-        params: {
-          sessionKey: "main",
+        params: makeChatSendParams({
           message: "/reset examples",
           suppressCommandInterpretation: true,
           idempotencyKey: "idem-suppressed-command",
-        },
+        }),
         client: createControlUiClient(),
         isWebchatConnect: () => true,
         respond: ((ok, payload, error) => {
@@ -3838,11 +3869,7 @@ describe("gateway server chat", () => {
       const callSend = (id: string, message: string, idempotencyKey: string) =>
         callDirectChat("chat.send", {
           id,
-          params: {
-            sessionKey: "main",
-            message,
-            idempotencyKey,
-          },
+          params: makeChatSendParams({ idempotencyKey, message }),
           client: createControlUiClient(["operator.write"]),
           isWebchatConnect: () => true,
           respond: ((ok, payload, error) => {
@@ -3930,21 +3957,11 @@ describe("gateway server chat", () => {
 
       await callDirectChat("chat.send", {
         id: "queued-followup",
-        params: {
-          sessionKey: "main",
+        params: makeChatSendParams({
           message: "queued prompt",
           idempotencyKey: "idem-queued-followup",
-        },
-        client: {
-          connId: "conn-tui",
-          connect: {
-            client: {
-              id: GATEWAY_CLIENT_NAMES.TUI,
-              mode: GATEWAY_CLIENT_MODES.UI,
-            },
-            scopes: ["operator.write", "operator.admin"],
-          },
-        } as never,
+        }),
+        client: makeTuiClient(),
         isWebchatConnect: () => true,
         respond: vi.fn() as RespondFn,
         context,
@@ -3994,18 +4011,11 @@ describe("gateway server chat", () => {
       const replayRespond = vi.fn() as RespondFn;
       await callDirectChat("chat.send", {
         id: "queued-followup-replay",
-        params: {
-          sessionKey: "main",
+        params: makeChatSendParams({
           message: "queued prompt",
           idempotencyKey: "idem-queued-followup",
-        },
-        client: {
-          connId: "conn-tui",
-          connect: {
-            client: { id: GATEWAY_CLIENT_NAMES.TUI, mode: GATEWAY_CLIENT_MODES.UI },
-            scopes: ["operator.write", "operator.admin"],
-          },
-        } as never,
+        }),
+        client: makeTuiClient(),
         isWebchatConnect: () => true,
         respond: replayRespond,
         context,
@@ -4040,21 +4050,11 @@ describe("gateway server chat", () => {
       });
       await callDirectChat("chat.send", {
         id: "queued-followup-post-error",
-        params: {
-          sessionKey: "main",
+        params: makeChatSendParams({
           message: "accepted before dispatch error",
           idempotencyKey: "idem-queued-followup-post-error",
-        },
-        client: {
-          connId: "conn-tui",
-          connect: {
-            client: {
-              id: GATEWAY_CLIENT_NAMES.TUI,
-              mode: GATEWAY_CLIENT_MODES.UI,
-            },
-            scopes: ["operator.write", "operator.admin"],
-          },
-        } as never,
+        }),
+        client: makeTuiClient(),
         isWebchatConnect: () => true,
         respond: vi.fn() as RespondFn,
         context,
@@ -4105,16 +4105,13 @@ describe("gateway server chat", () => {
 
       await callDirectChat("chat.send", {
         id: "operator-timing",
-        params: {
-          sessionKey: "main",
+        params: makeChatSendParams({
           message: "measure",
           idempotencyKey: "idem-server-timing",
-        },
+        }),
         client: createControlUiClient(["operator.write"], { connId: "conn-control-ui" }),
         isWebchatConnect: () => true,
-        respond: ((ok, payload, error) => {
-          responses.push({ ok, payload, error });
-        }) as RespondFn,
+        respond: captureChatResponse(responses),
         context,
       });
 
@@ -4209,16 +4206,13 @@ describe("gateway server chat", () => {
 
       await callDirectChat("chat.send", {
         id: "operator-direct-timing",
-        params: {
-          sessionKey: "main",
+        params: makeChatSendParams({
           message: "measure direct",
           idempotencyKey: "idem-direct-server-timing",
-        },
+        }),
         client: createControlUiClient(["operator.write"], { connId: "conn-control-ui" }),
         isWebchatConnect: () => true,
-        respond: ((ok, payload, error) => {
-          responses.push({ ok, payload, error });
-        }) as RespondFn,
+        respond: captureChatResponse(responses),
         context,
       });
 
@@ -4339,25 +4333,16 @@ describe("gateway server chat", () => {
       );
       setTestEnvValue("HOME", homeDir);
       try {
-        await writeStoredMainSession({
-          sessionId,
-          sessionFile: testSessionFilePath(sessionDir, sessionId),
-          updatedAt: futureFixtureUpdatedAt(),
-          modelProvider: "claude-cli",
-          model: "claude-sonnet-4-6",
-          cliSessionBindings: {
-            "claude-cli": {
-              sessionId: cliSessionId,
-            },
-          },
-        });
+        await writeStoredMainSession(
+          makeClaudeCliSessionEntry(sessionDir, sessionId, cliSessionId),
+        );
         const history = await rpcReq<{
           messages?: Array<{ __openclaw?: { id?: string } }>;
           hasMore?: boolean;
           nextOffset?: number;
           totalMessages?: number;
           completeSnapshot?: boolean;
-        }>(ws, "chat.history", { sessionKey: "main", limit: 100 });
+        }>(ws, "chat.history", makeMainSessionParams({ limit: 100 }));
         expect(history.ok).toBe(true);
         const messages = history.payload?.messages ?? [];
         expect(messages).toHaveLength(107);
@@ -4415,23 +4400,16 @@ describe("gateway server chat", () => {
       );
       setTestEnvValue("HOME", homeDir);
       try {
-        await writeStoredMainSession({
-          sessionId,
-          sessionFile: testSessionFilePath(sessionDir, sessionId),
-          updatedAt: futureFixtureUpdatedAt(),
-          modelProvider: "claude-cli",
-          model: "claude-sonnet-4-6",
-          cliSessionBindings: { "claude-cli": { sessionId: cliSessionId } },
-        });
+        await writeStoredMainSession(
+          makeClaudeCliSessionEntry(sessionDir, sessionId, cliSessionId),
+        );
         await writeMainSessionTranscript(
           Array.from({ length: 70 }, (_, index) =>
-            JSON.stringify({
-              message: {
-                role: index % 2 === 0 ? "user" : "assistant",
-                content: [{ type: "text", text: `local-only message ${index + 1}` }],
-                timestamp: Date.parse("2026-03-27T00:00:00.000Z") + index,
-              },
-            }),
+            createTextTranscriptEvent(
+              index % 2 === 0 ? "user" : "assistant",
+              `local-only message ${index + 1}`,
+              { timestamp: Date.parse("2026-03-27T00:00:00.000Z") + index },
+            ),
           ),
           sessionId,
         );
@@ -4442,7 +4420,7 @@ describe("gateway server chat", () => {
           nextOffset?: number;
           totalMessages?: number;
           completeSnapshot?: boolean;
-        }>(ws, "chat.history", { sessionKey: "main", limit: 2 });
+        }>(ws, "chat.history", makeMainSessionParams({ limit: 2 }));
         expect(history.ok).toBe(true);
         expect(history.payload?.totalMessages).toBe(72);
         expect(history.payload?.hasMore).toBe(false);
@@ -4476,25 +4454,16 @@ describe("gateway server chat", () => {
       const homeEnvSnapshot = captureEnv(["HOME"]);
       setTestEnvValue("HOME", path.join(sessionDir, "empty-home"));
       try {
-        await writeStoredMainSession({
-          sessionId,
-          sessionFile: testSessionFilePath(sessionDir, sessionId),
-          updatedAt: futureFixtureUpdatedAt(),
-          modelProvider: "claude-cli",
-          model: "claude-sonnet-4-6",
-          cliSessionBindings: {
-            "claude-cli": { sessionId: "missing-cli-session" },
-          },
-        });
+        await writeStoredMainSession(
+          makeClaudeCliSessionEntry(sessionDir, sessionId, "missing-cli-session"),
+        );
         await writeMainSessionTranscript(
           Array.from({ length: 5 }, (_, index) =>
-            JSON.stringify({
-              message: {
-                role: index % 2 === 0 ? "user" : "assistant",
-                content: [{ type: "text", text: `local message ${index + 1}` }],
-                timestamp: Date.now() + index,
-              },
-            }),
+            createTextTranscriptEvent(
+              index % 2 === 0 ? "user" : "assistant",
+              `local message ${index + 1}`,
+              { timestamp: Date.now() + index },
+            ),
           ),
           sessionId,
         );
@@ -4504,7 +4473,7 @@ describe("gateway server chat", () => {
           hasMore?: boolean;
           nextOffset?: number;
           totalMessages?: number;
-        }>(ws, "chat.history", { sessionKey: "main", limit: 2 });
+        }>(ws, "chat.history", makeMainSessionParams({ limit: 2 }));
         expect(firstPage.ok).toBe(true);
         expect(firstPage.payload?.messages?.map(readOpenClawSeq)).toEqual([4, 5]);
         expect(firstPage.payload?.hasMore).toBe(true);
@@ -4515,11 +4484,14 @@ describe("gateway server chat", () => {
           messages?: Array<{ __openclaw?: { seq?: number } }>;
           hasMore?: boolean;
           nextOffset?: number;
-        }>(ws, "chat.history", {
-          sessionKey: "main",
-          limit: 2,
-          offset: firstPage.payload?.nextOffset,
-        });
+        }>(
+          ws,
+          "chat.history",
+          makeMainSessionParams({
+            limit: 2,
+            offset: firstPage.payload?.nextOffset,
+          }),
+        );
         expect(secondPage.ok).toBe(true);
         expect(secondPage.payload?.messages?.map(readOpenClawSeq)).toEqual([2, 3]);
         expect(secondPage.payload?.hasMore).toBe(true);
@@ -4565,16 +4537,9 @@ describe("gateway server chat", () => {
       );
       setTestEnvValue("HOME", homeDir);
       try {
-        await writeStoredMainSession({
-          sessionId,
-          sessionFile: testSessionFilePath(sessionDir, sessionId),
-          updatedAt: futureFixtureUpdatedAt(),
-          modelProvider: "claude-cli",
-          model: "claude-sonnet-4-6",
-          cliSessionBindings: {
-            "claude-cli": { sessionId: cliSessionId },
-          },
-        });
+        await writeStoredMainSession(
+          makeClaudeCliSessionEntry(sessionDir, sessionId, cliSessionId),
+        );
         // The two import copies are the oldest local records; 45 newer
         // local-only records push them past the limit-1 tail window (40 raw
         // messages), so the tail merge incorporates the import while the full
@@ -4586,13 +4551,11 @@ describe("gateway server chat", () => {
               timestamp: dupBaseMs + 1000,
             }),
             ...Array.from({ length: 45 }, (_, index) =>
-              JSON.stringify({
-                message: {
-                  role: index % 2 === 0 ? "user" : "assistant",
-                  content: [{ type: "text", text: `local-only message ${index + 1}` }],
-                  timestamp: dupBaseMs + 60_000 + index,
-                },
-              }),
+              createTextTranscriptEvent(
+                index % 2 === 0 ? "user" : "assistant",
+                `local-only message ${index + 1}`,
+                { timestamp: dupBaseMs + 60_000 + index },
+              ),
             ),
           ],
           sessionId,
@@ -4603,7 +4566,7 @@ describe("gateway server chat", () => {
           hasMore?: boolean;
           nextOffset?: number;
           totalMessages?: number;
-        }>(ws, "chat.history", { sessionKey: "main", limit: 1 });
+        }>(ws, "chat.history", makeMainSessionParams({ limit: 1 }));
         expect(history.ok).toBe(true);
         expect(history.payload?.totalMessages).toBe(47);
         expect(history.payload?.hasMore).toBe(true);
@@ -4642,19 +4605,12 @@ describe("gateway server chat", () => {
             },
           },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("stale announce reply", {
           timestamp: "2026-05-16T16:00:33.000Z",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "stale announce reply" }],
-          },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("fresh turn", {
+          role: "user",
           timestamp: "2026-05-23T04:03:10.000Z",
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "fresh turn" }],
-          },
         }),
       ]);
 
@@ -4689,12 +4645,8 @@ describe("gateway server chat", () => {
             provenance: announce,
           },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("older stale announce reply", {
           timestamp: "2026-05-16T16:00:30.000Z",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "older stale announce reply" }],
-          },
         }),
         JSON.stringify({
           timestamp: "2026-05-16T16:00:31.000Z",
@@ -4705,19 +4657,12 @@ describe("gateway server chat", () => {
             provenance: announce,
           },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("newer stale announce reply", {
           timestamp: "2026-05-16T16:00:33.000Z",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "newer stale announce reply" }],
-          },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("fresh turn", {
+          role: "user",
           timestamp: "2026-05-23T04:03:10.000Z",
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "fresh turn" }],
-          },
         }),
       ]);
 
@@ -4743,12 +4688,9 @@ describe("gateway server chat", () => {
         sessionStartedAt,
       });
       await writeMainSessionTranscript([
-        JSON.stringify({
+        makeTranscriptTextEvent("older visible turn", {
+          role: "user",
           timestamp: "2026-05-23T04:03:10.000Z",
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "older visible turn" }],
-          },
         }),
         JSON.stringify({
           timestamp: "2026-05-16T16:00:31.000Z",
@@ -4759,19 +4701,11 @@ describe("gateway server chat", () => {
             provenance: announce,
           },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("stale announce reply", {
           timestamp: "2026-05-16T16:00:33.000Z",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "stale announce reply" }],
-          },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("latest visible reply", {
           timestamp: "2026-05-23T04:03:20.000Z",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "latest visible reply" }],
-          },
         }),
       ]);
 
@@ -4779,12 +4713,15 @@ describe("gateway server chat", () => {
         messages?: Array<{ __openclaw?: { seq?: number } }>;
         nextOffset?: number;
         hasMore?: boolean;
-      }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: 1,
-        offset: 1,
-        maxChars: 100,
-      });
+      }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: 1,
+          offset: 1,
+          maxChars: 100,
+        }),
+      );
       expect(page.ok).toBe(true);
       expect(page.payload?.messages).toEqual([]);
       expect(JSON.stringify(page.payload)).not.toContain("stale announce reply");
@@ -4799,24 +4736,9 @@ describe("gateway server chat", () => {
       await createSessionDir();
       await writeStoredMainSession({});
       await writeMainSessionTranscript([
-        JSON.stringify({
-          message: {
-            role: "user",
-            content: [{ type: "text", text: HEARTBEAT_PROMPT }],
-          },
-        }),
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "heartbeat run output" }],
-          },
-        }),
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "newest output" }],
-          },
-        }),
+        makeTranscriptTextEvent(HEARTBEAT_PROMPT, { role: "user" }),
+        makeTranscriptTextEvent("heartbeat run output"),
+        makeTranscriptTextEvent("newest output"),
       ]);
 
       const page = await rpcReq<{
@@ -4824,11 +4746,14 @@ describe("gateway server chat", () => {
           content?: Array<{ text?: string }>;
           __openclaw?: { turnBoundary?: boolean };
         }>;
-      }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: 1,
-        offset: 1,
-      });
+      }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: 1,
+          offset: 1,
+        }),
+      );
 
       expect(page.ok).toBe(true);
       expect(page.payload?.messages).toHaveLength(1);
@@ -4852,11 +4777,13 @@ describe("gateway server chat", () => {
           return undefined;
         });
 
-        const sendRes = await rpcReq(ws, "chat.send", {
-          sessionKey: "main",
-          message: "hello",
-          idempotencyKey: "idem-block-streaming",
-        });
+        const sendRes = await rpcReq(
+          ws,
+          "chat.send",
+          makeChatSendParams({
+            idempotencyKey: "idem-block-streaming",
+          }),
+        );
         expect(sendRes.ok).toBe(true);
 
         await waitForFast(() => {
@@ -4881,24 +4808,19 @@ describe("gateway server chat", () => {
       await withGatewayChatHarness(
         async ({ ws, createSessionDir }) => {
           const spy = getReplyFromConfig;
-          await connectOk(ws, {
-            client: {
-              id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-              version: "1.0.0",
-              platform: "web",
-              mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-            },
-          });
+          await connectOk(ws, makeGatewayWebchatClient());
 
           await createSessionDir();
           await writeMainSessionStore();
           mockGetReplyFromConfigOnce(async () => undefined);
 
-          const sendRes = await rpcReq(ws, "chat.send", {
-            sessionKey: "main",
-            message: "hello",
-            idempotencyKey: "idem-timeline",
-          });
+          const sendRes = await rpcReq(
+            ws,
+            "chat.send",
+            makeChatSendParams({
+              idempotencyKey: "idem-timeline",
+            }),
+          );
           expect(sendRes.ok).toBe(true);
           expect(sendRes.payload).toMatchObject({
             runId: "idem-timeline",
@@ -4959,24 +4881,19 @@ describe("gateway server chat", () => {
   test("chat.send omits ACK server timing for public WebChat clients", async () => {
     await withGatewayChatHarness(
       async ({ ws, createSessionDir }) => {
-        await connectOk(ws, {
-          client: {
-            id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
-            version: "1.0.0",
-            platform: "web",
-            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          },
-        });
+        await connectOk(ws, makeGatewayWebchatClient(GATEWAY_CLIENT_NAMES.WEBCHAT_UI));
 
         await createSessionDir();
         await writeMainSessionStore();
         mockGetReplyFromConfigOnce(async () => undefined);
 
-        const sendRes = await rpcReq(ws, "chat.send", {
-          sessionKey: "main",
-          message: "hello",
-          idempotencyKey: "idem-public-webchat",
-        });
+        const sendRes = await rpcReq(
+          ws,
+          "chat.send",
+          makeChatSendParams({
+            idempotencyKey: "idem-public-webchat",
+          }),
+        );
 
         expect(sendRes.ok).toBe(true);
         expect(sendRes.payload).toMatchObject({
@@ -4996,22 +4913,18 @@ describe("gateway server chat", () => {
   test("chat.send rejects Control UI reconnect resume marker from public WebChat clients", async () => {
     await withGatewayChatHarness(
       async ({ ws }) => {
-        await connectOk(ws, {
-          client: {
-            id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
-            version: "1.0.0",
-            platform: "web",
-            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          },
-        });
+        await connectOk(ws, makeGatewayWebchatClient(GATEWAY_CLIENT_NAMES.WEBCHAT_UI));
 
-        const sendRes = await rpcReq(ws, "chat.send", {
-          sessionKey: "main",
-          sessionId: "sess-main",
-          __controlUiReconnectResume: true,
-          message: "hello after reconnect",
-          idempotencyKey: "idem-public-webchat-resume",
-        });
+        const sendRes = await rpcReq(
+          ws,
+          "chat.send",
+          makeChatSendParams({
+            sessionId: "sess-main",
+            __controlUiReconnectResume: true,
+            message: "hello after reconnect",
+            idempotencyKey: "idem-public-webchat-resume",
+          }),
+        );
         expect(sendRes.ok).toBe(false);
       },
       {
@@ -5024,14 +4937,7 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(
       async ({ ws, createSessionDir }) => {
         const spy = getReplyFromConfig;
-        await connectOk(ws, {
-          client: {
-            id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-            version: "1.0.0",
-            platform: "web",
-            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          },
-        });
+        await connectOk(ws, makeGatewayWebchatClient());
 
         await createSessionDir();
         await writeMainSessionStore();
@@ -5041,13 +4947,16 @@ describe("gateway server chat", () => {
           return undefined;
         });
 
-        const sendRes = await rpcReq(ws, "chat.send", {
-          sessionKey: "main",
-          sessionId: "sess-main",
-          __controlUiReconnectResume: true,
-          message: "hello after reconnect",
-          idempotencyKey: "idem-requested-session-id",
-        });
+        const sendRes = await rpcReq(
+          ws,
+          "chat.send",
+          makeChatSendParams({
+            sessionId: "sess-main",
+            __controlUiReconnectResume: true,
+            message: "hello after reconnect",
+            idempotencyKey: "idem-requested-session-id",
+          }),
+        );
         expect(sendRes.ok).toBe(true);
 
         await waitForFast(() => {
@@ -5067,14 +4976,7 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(
       async ({ ws, createSessionDir }) => {
         const spy = getReplyFromConfig;
-        await connectOk(ws, {
-          client: {
-            id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-            version: "1.0.0",
-            platform: "web",
-            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-          },
-        });
+        await connectOk(ws, makeGatewayWebchatClient());
 
         await createSessionDir();
         await writeMainSessionStore();
@@ -5084,12 +4986,15 @@ describe("gateway server chat", () => {
           return undefined;
         });
 
-        const sendRes = await rpcReq(ws, "chat.send", {
-          sessionKey: "main",
-          message: "steer this turn",
-          queueMode: "steer",
-          idempotencyKey: "idem-queue-mode-override",
-        });
+        const sendRes = await rpcReq(
+          ws,
+          "chat.send",
+          makeChatSendParams({
+            message: "steer this turn",
+            queueMode: "steer",
+            idempotencyKey: "idem-queue-mode-override",
+          }),
+        );
         expect(sendRes.ok).toBe(true);
 
         await waitForFast(() => {
@@ -5143,12 +5048,8 @@ describe("gateway server chat", () => {
       const historyMaxBytes = getMaxChatHistoryMessagesBytes();
       const baseText = "s".repeat(100_000);
       const lines = Array.from({ length: 70 }, (_, index) =>
-        JSON.stringify({
-          message: {
-            role: "user",
-            timestamp: Date.now() + index,
-            content: [{ type: "text", text: `small-${index}:${baseText}` }],
-          },
+        createTextTranscriptEvent("user", `small-${index}:${baseText}`, {
+          timestamp: Date.now() + index,
         }),
       );
       lines.push(
@@ -5184,10 +5085,8 @@ describe("gateway server chat", () => {
       const historyMaxBytes = getMaxChatHistoryMessagesBytes();
       await writeMainSessionTranscript([
         createTextTranscriptEvent("user", "reachable older message", { timestamp: Date.now() }),
-        JSON.stringify({
+        makeTranscriptTextEvent("NO_REPLY", {
           message: {
-            role: "assistant",
-            content: [{ type: "text", text: "NO_REPLY" }],
             padding: "x".repeat(historyMaxBytes * 2 + 1024),
             timestamp: Date.now() + 1,
           },
@@ -5198,7 +5097,7 @@ describe("gateway server chat", () => {
         messages?: unknown[];
         nextOffset?: number;
         hasMore?: boolean;
-      }>(ws, "chat.history", { sessionKey: "main", limit: 1 });
+      }>(ws, "chat.history", makeMainSessionParams({ limit: 1 }));
       expect(firstPage.ok).toBe(true);
       expect(firstPage.payload?.messages).toEqual([]);
       expect(firstPage.payload?.hasMore).toBe(true);
@@ -5207,7 +5106,7 @@ describe("gateway server chat", () => {
       const olderPage = await rpcReq<{ messages?: unknown[]; hasMore?: boolean }>(
         ws,
         "chat.history",
-        { sessionKey: "main", limit: 1, offset: firstPage.payload?.nextOffset },
+        makeMainSessionParams({ limit: 1, offset: firstPage.payload?.nextOffset }),
       );
       expect(olderPage.ok).toBe(true);
       expect(JSON.stringify(olderPage.payload?.messages)).toContain("reachable older message");
@@ -5223,11 +5122,9 @@ describe("gateway server chat", () => {
       await writeMainSessionStore();
 
       await writeMainSessionTranscript([
-        JSON.stringify({
+        makeTranscriptTextEvent("hello", {
           message: {
-            role: "assistant",
             timestamp: Date.now(),
-            content: [{ type: "text", text: "hello" }],
             usage: {
               input: 12,
               output: 5,
@@ -5300,22 +5197,20 @@ describe("gateway server chat", () => {
             timestamp: 1,
           },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("Updated src/a.ts", {
+          role: "toolResult",
           message: {
-            role: "toolResult",
             toolCallId: "call-edit",
             toolName: "edit",
-            content: [{ type: "text", text: "Updated src/a.ts" }],
             details: { diff: fullDiff, internal: "not for display" },
             timestamp: 2,
           },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("contents of b", {
+          role: "toolResult",
           message: {
-            role: "toolResult",
             toolCallId: "call-read",
             toolName: "read",
-            content: [{ type: "text", text: "contents of b" }],
             timestamp: 3,
           },
         }),
@@ -5354,14 +5249,8 @@ describe("gateway server chat", () => {
       await writeMainSessionStore();
 
       const lines = [
-        JSON.stringify({
-          message: {
-            role: "assistant",
-            content: [
-              { type: "text", text: "Hello [[reply_to_current]] world [[audio_as_voice]]" },
-            ],
-            timestamp: Date.now(),
-          },
+        makeTranscriptTextEvent("Hello [[reply_to_current]] world [[audio_as_voice]]", {
+          message: { timestamp: Date.now() },
         }),
         JSON.stringify({
           message: {
@@ -5428,12 +5317,11 @@ describe("gateway server chat", () => {
             timestamp: 2,
           },
         }),
-        JSON.stringify({
+        makeTranscriptTextEvent("file contents", {
+          role: "toolResult",
           message: {
-            role: "toolResult",
             toolCallId: "call-read",
             toolName: "read",
-            content: [{ type: "text", text: "file contents" }],
             timestamp: 3,
           },
         }),
@@ -5477,19 +5365,25 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await prepareMainHistoryHarness({ ws, createSessionDir });
 
-      const zeroRes = await rpcReq(ws, "chat.history", {
-        sessionKey: "main",
-        maxChars: 0,
-      });
+      const zeroRes = await rpcReq(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          maxChars: 0,
+        }),
+      );
       expect(zeroRes.ok).toBe(false);
       expect((zeroRes.error as { message?: string } | undefined)?.message ?? "").toMatch(
         /invalid chat\.history params/i,
       );
 
-      const tooLargeRes = await rpcReq(ws, "chat.history", {
-        sessionKey: "main",
-        maxChars: 500_001,
-      });
+      const tooLargeRes = await rpcReq(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          maxChars: 500_001,
+        }),
+      );
       expect(tooLargeRes.ok).toBe(false);
       expect((tooLargeRes.error as { message?: string } | undefined)?.message ?? "").toMatch(
         /invalid chat\.history params/i,
@@ -5507,10 +5401,7 @@ describe("gateway server chat", () => {
       const historyMessages = await fetchHistoryMessages(ws, { maxChars: 5 });
       expect(JSON.stringify(historyMessages)).toContain("abcde\\n...(truncated)...");
 
-      const full = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-full-assistant",
-      });
+      const full = await fetchChatMessage(ws, makeMainMessageParams("msg-full-assistant"));
       expect(full.ok).toBe(true);
       expect(full.unavailableReason).toBeUndefined();
       expect(JSON.stringify(full.message)).toContain("abcdefghij");
@@ -5538,10 +5429,7 @@ describe("gateway server chat", () => {
       const historyMessages = await fetchHistoryMessages(ws, { maxChars: 12 });
       expect(JSON.stringify(historyMessages)).toContain("archive abcd\\n...(truncated)...");
 
-      const full = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-archive-full-assistant",
-      });
+      const full = await fetchChatMessage(ws, makeMainMessageParams("msg-archive-full-assistant"));
       expect(full.ok).toBe(true);
       expect(full.unavailableReason).toBeUndefined();
       expect(JSON.stringify(full.message)).toContain("archive abcdefghij");
@@ -5589,24 +5477,18 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionId = "sess-oversized-archive";
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir, sessionId });
-      const oversizedLine = JSON.stringify({
-        id: "msg-oversized",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "x".repeat(300 * 1024) }],
-          timestamp: Date.now(),
-        },
-      });
+      const oversizedLine = JSON.stringify(
+        createTextTranscriptEvent("assistant", "x".repeat(300 * 1024), {
+          id: "msg-oversized",
+        }),
+      );
       await fs.writeFile(
         `${testSessionFilePath(sessionDir, sessionId)}.reset.2026-02-16T22-26-34.000Z`,
         [JSON.stringify({ type: "session", version: 1, id: sessionId }), oversizedLine].join("\n"),
         "utf-8",
       );
 
-      const full = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-oversized",
-      });
+      const full = await fetchChatMessage(ws, makeMainMessageParams("msg-oversized"));
       expect(full.ok).toBe(false);
       expect(full.unavailableReason).toBe("oversized");
       expect(full.message).toBeUndefined();
@@ -5621,10 +5503,7 @@ describe("gateway server chat", () => {
         createTextTranscriptEvent("assistant", oversizedText, { id: "msg-oversized-sqlite" }),
       ]);
 
-      const full = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-oversized-sqlite",
-      });
+      const full = await fetchChatMessage(ws, makeMainMessageParams("msg-oversized-sqlite"));
       expect(full.ok).toBe(true);
       expect(JSON.stringify(full.message)).toContain(oversizedText.slice(0, 256));
     });
@@ -5659,24 +5538,15 @@ describe("gateway server chat", () => {
         path: path.join(sessionDir, "openclaw-agent.sqlite"),
       });
 
-      const stale = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-stale",
-      });
+      const stale = await fetchChatMessage(ws, makeMainMessageParams("msg-stale"));
       expect(stale.ok).toBe(false);
       expect(stale.unavailableReason).toBe("not_found");
 
-      const sideDelivery = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-side-delivery",
-      });
+      const sideDelivery = await fetchChatMessage(ws, makeMainMessageParams("msg-side-delivery"));
       expect(sideDelivery.ok).toBe(false);
       expect(sideDelivery.unavailableReason).toBe("not_found");
 
-      const active = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-active",
-      });
+      const active = await fetchChatMessage(ws, makeMainMessageParams("msg-active"));
       expect(active.ok).toBe(true);
       expect(JSON.stringify(active.message)).toContain("active branch");
       expect(JSON.stringify(await fetchHistoryMessages(ws))).not.toContain("side delivery");
@@ -5694,14 +5564,10 @@ describe("gateway server chat", () => {
         },
       });
       await writeMainSessionTranscript([
-        JSON.stringify({
+        createTextTranscriptEvent("user", "announce", {
           id: "msg-announce",
-          message: {
-            role: "user",
-            provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
-            content: [{ type: "text", text: "announce" }],
-            timestamp: sessionStartedAt - 2_000,
-          },
+          timestamp: sessionStartedAt - 2_000,
+          message: { provenance: { kind: "inter_session", sourceTool: "subagent_announce" } },
         }),
         createTextTranscriptEvent("assistant", "hidden pre-session reply", {
           id: "msg-hidden-assistant",
@@ -5713,17 +5579,11 @@ describe("gateway server chat", () => {
         }),
       ]);
 
-      const hidden = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-hidden-assistant",
-      });
+      const hidden = await fetchChatMessage(ws, makeMainMessageParams("msg-hidden-assistant"));
       expect(hidden.ok).toBe(false);
       expect(hidden.unavailableReason).toBe("not_found");
 
-      const visible = await fetchChatMessage(ws, {
-        sessionKey: "main",
-        messageId: "msg-visible-assistant",
-      });
+      const visible = await fetchChatMessage(ws, makeMainMessageParams("msg-visible-assistant"));
       expect(visible.ok).toBe(true);
       expect(JSON.stringify(visible.message)).toContain("visible reply");
     });
@@ -5775,15 +5635,18 @@ describe("gateway server chat", () => {
         .prepare("UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?")
         .run("sess-main");
 
-      const rebuilding = await rpcReq(ws, "chat.history", { sessionKey: "main", limit: 1 });
+      const rebuilding = await rpcReq(ws, "chat.history", makeMainSessionParams({ limit: 1 }));
       expect(rebuilding.ok).toBe(false);
       expect(rebuilding.error).toMatchObject({ code: "UNAVAILABLE", retryable: true });
 
       await waitForSessionTranscriptIndexReconcile(databaseOptions);
-      const ready = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: 1,
-      });
+      const ready = await rpcReq<{ messages?: unknown[] }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: 1,
+        }),
+      );
       expect(ready.ok).toBe(true);
       expect(JSON.stringify(ready.payload?.messages)).toContain("ready after rebuild");
     });
@@ -5805,12 +5668,15 @@ describe("gateway server chat", () => {
         nextOffset?: number;
         hasMore?: boolean;
         totalMessages?: number;
-      }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: 2,
-        offset: 0,
-        maxChars: 100,
-      });
+      }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: 2,
+          offset: 0,
+          maxChars: 100,
+        }),
+      );
       expect(firstPage.ok).toBe(true);
       expect(firstPage.payload?.messages?.map(readOpenClawSeq)).toEqual([3, 5]);
       expect(firstPage.payload?.nextOffset).toBe(3);
@@ -5821,12 +5687,15 @@ describe("gateway server chat", () => {
         messages?: Array<{ __openclaw?: { seq?: number } }>;
         hasMore?: boolean;
         nextOffset?: number;
-      }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: 2,
-        offset: firstPage.payload?.nextOffset,
-        maxChars: 100,
-      });
+      }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: 2,
+          offset: firstPage.payload?.nextOffset,
+          maxChars: 100,
+        }),
+      );
       expect(secondPage.ok).toBe(true);
       expect(secondPage.payload?.messages?.map(readOpenClawSeq)).toEqual([1, 2]);
       expect(JSON.stringify(secondPage.payload?.messages)).not.toContain("visible boundary");
@@ -5840,13 +5709,11 @@ describe("gateway server chat", () => {
       await prepareMainHistoryHarness({ ws, createSessionDir });
       await writeMainSessionTranscript(
         Array.from({ length: 7 }, (_, index) =>
-          JSON.stringify({
-            message: {
-              role: index % 2 === 0 ? "user" : "assistant",
-              content: [{ type: "text", text: `message ${index + 1}` }],
-              timestamp: Date.now() + index,
-            },
-          }),
+          createTextTranscriptEvent(
+            index % 2 === 0 ? "user" : "assistant",
+            `message ${index + 1}`,
+            { timestamp: Date.now() + index },
+          ),
         ),
       );
 
@@ -5859,11 +5726,14 @@ describe("gateway server chat", () => {
       const pages: HistoryPage[] = [];
       let offset: number | undefined;
       do {
-        const page = await rpcReq<HistoryPage>(ws, "chat.history", {
-          sessionKey: "main",
-          limit: 2,
-          ...(offset !== undefined ? { offset } : {}),
-        });
+        const page = await rpcReq<HistoryPage>(
+          ws,
+          "chat.history",
+          makeMainSessionParams({
+            limit: 2,
+            ...(offset !== undefined ? { offset } : {}),
+          }),
+        );
         expect(page.ok).toBe(true);
         pages.push(page.payload ?? {});
         offset = page.payload?.nextOffset;
@@ -5894,12 +5764,7 @@ describe("gateway server chat", () => {
       if (!storePath) {
         throw new Error("session store path was not initialized");
       }
-      const scope = {
-        agentId: "main",
-        sessionId: "sess-main",
-        sessionKey: "agent:main:main",
-        storePath,
-      };
+      const scope = makeMainSessionScope(storePath);
       let parentId: string | null = null;
       for (let index = 1; index <= 5; index += 1) {
         const messageId = `message-${index}`;
@@ -5929,11 +5794,14 @@ describe("gateway server chat", () => {
       const pages: HistoryPage[] = [];
       let offset: number | undefined;
       do {
-        const page = await rpcReq<HistoryPage>(ws, "chat.history", {
-          sessionKey: "main",
-          limit: 2,
-          ...(offset !== undefined ? { offset } : {}),
-        });
+        const page = await rpcReq<HistoryPage>(
+          ws,
+          "chat.history",
+          makeMainSessionParams({
+            limit: 2,
+            ...(offset !== undefined ? { offset } : {}),
+          }),
+        );
         expect(page.ok).toBe(true);
         pages.push(page.payload ?? {});
         offset = page.payload?.nextOffset;
@@ -5962,22 +5830,14 @@ describe("gateway server chat", () => {
         throw new Error("session store path was not initialized");
       }
       for (let index = 0; index < 7; index += 1) {
-        await appendTranscriptMessage(
-          {
-            agentId: "main",
-            sessionId: "sess-main",
-            sessionKey: "agent:main:main",
-            storePath,
+        await appendTranscriptMessage(makeMainSessionScope(storePath), {
+          eventId: `message-${index + 1}`,
+          message: {
+            role: index % 2 === 0 ? "user" : "assistant",
+            content: [{ type: "text", text: `message ${index + 1} ${"x".repeat(700)}` }],
+            timestamp: Date.now() + index,
           },
-          {
-            eventId: `message-${index + 1}`,
-            message: {
-              role: index % 2 === 0 ? "user" : "assistant",
-              content: [{ type: "text", text: `message ${index + 1} ${"x".repeat(700)}` }],
-              timestamp: Date.now() + index,
-            },
-          },
-        );
+        });
       }
       await waitForSessionTranscriptIndexReconcile({
         agentId: "main",
@@ -5990,13 +5850,16 @@ describe("gateway server chat", () => {
         nextOffset?: number;
         offset?: number;
         totalMessages?: number;
-      }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: 3,
-        messageId: "message-3",
-        sessionId: "sess-main",
-        maxChars: 100,
-      });
+      }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: 3,
+          messageId: "message-3",
+          sessionId: "sess-main",
+          maxChars: 100,
+        }),
+      );
 
       expect(history.ok).toBe(true);
       expect(history.payload?.messages?.map(readOpenClawSeq)).toEqual([2, 3, 4]);
@@ -6052,12 +5915,15 @@ describe("gateway server chat", () => {
 
       const history = await rpcReq<{
         messages?: Array<{ content?: string }>;
-      }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: 3,
-        messageId: "archived-2",
-        sessionId: "sess-before-reset",
-      });
+      }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: 3,
+          messageId: "archived-2",
+          sessionId: "sess-before-reset",
+        }),
+      );
 
       expect(history.ok).toBe(true);
       expect(history.payload?.messages?.map((message) => message.content)).toEqual([
@@ -6071,11 +5937,14 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await prepareMainHistoryHarness({ ws, createSessionDir });
 
-      const history = await rpcReq(ws, "chat.history", {
-        sessionKey: "main",
-        offset: 0,
-        messageId: "message-1",
-      });
+      const history = await rpcReq(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          offset: 0,
+          messageId: "message-1",
+        }),
+      );
 
       expect(history.ok).toBe(false);
       expect((history.error as { message?: string } | undefined)?.message).toContain(
@@ -6088,11 +5957,14 @@ describe("gateway server chat", () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await prepareMainHistoryHarness({ ws, createSessionDir });
 
-      const history = await rpcReq(ws, "chat.history", {
-        sessionKey: "main",
-        messageId: "message-1",
-        sessionId: "unknown-session",
-      });
+      const history = await rpcReq(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          messageId: "message-1",
+          sessionId: "unknown-session",
+        }),
+      );
 
       expect(history.ok).toBe(false);
       expect((history.error as { message?: string } | undefined)?.message).toContain(
@@ -6107,13 +5979,11 @@ describe("gateway server chat", () => {
       const messageCount = 70;
       await writeMainSessionTranscript(
         Array.from({ length: messageCount }, (_, index) =>
-          JSON.stringify({
-            message: {
-              role: index % 2 === 0 ? "user" : "assistant",
-              content: [{ type: "text", text: `message ${index + 1} ${"x".repeat(100_000)}` }],
-              timestamp: Date.now() + index,
-            },
-          }),
+          createTextTranscriptEvent(
+            index % 2 === 0 ? "user" : "assistant",
+            `message ${index + 1} ${"x".repeat(100_000)}`,
+            { timestamp: Date.now() + index },
+          ),
         ),
       );
 
@@ -6122,12 +5992,15 @@ describe("gateway server chat", () => {
         nextOffset?: number;
         hasMore?: boolean;
         totalMessages?: number;
-      }>(ws, "chat.history", {
-        sessionKey: "main",
-        limit: messageCount,
-        offset: 0,
-        maxChars: 100_000,
-      });
+      }>(
+        ws,
+        "chat.history",
+        makeMainSessionParams({
+          limit: messageCount,
+          offset: 0,
+          maxChars: 100_000,
+        }),
+      );
       expect(firstPage.ok).toBe(true);
       const sequences = firstPage.payload?.messages?.map(readOpenClawSeq) ?? [];
       expect(sequences.length).toBeGreaterThan(0);
@@ -6182,12 +6055,15 @@ describe("gateway server chat", () => {
           nextOffset?: number;
           hasMore?: boolean;
         };
-        const firstPage = await rpcReq<HistoryPage>(ws, "chat.history", {
-          sessionKey: "main",
-          limit: projectedSiblingCount + 1,
-          offset: 0,
-          maxChars: 100_000,
-        });
+        const firstPage = await rpcReq<HistoryPage>(
+          ws,
+          "chat.history",
+          makeMainSessionParams({
+            limit: projectedSiblingCount + 1,
+            offset: 0,
+            maxChars: 100_000,
+          }),
+        );
         expect(firstPage.ok).toBe(true);
         const firstPageSequences = firstPage.payload?.messages?.map(readOpenClawSeq) ?? [];
         expect(firstPageSequences.length).toBeGreaterThan(0);
@@ -6201,11 +6077,14 @@ describe("gateway server chat", () => {
         let offset = expectDefined(firstPage.payload?.nextOffset, "second page offset");
         const olderMessages: unknown[] = [];
         for (let pageIndex = 0; pageIndex < 3; pageIndex += 1) {
-          const page = await rpcReq<HistoryPage>(ws, "chat.history", {
-            sessionKey: "main",
-            limit: 2,
-            offset,
-          });
+          const page = await rpcReq<HistoryPage>(
+            ws,
+            "chat.history",
+            makeMainSessionParams({
+              limit: 2,
+              offset,
+            }),
+          );
           expect(page.ok).toBe(true);
           olderMessages.push(...(page.payload?.messages ?? []));
           const nextOffset = page.payload?.nextOffset;
@@ -6254,12 +6133,15 @@ describe("gateway server chat", () => {
       });
 
       const sendResP = onceMessage(ws, (o) => o.type === "res" && o.id === "send-abort-1", 2_000);
-      sendReq(ws, "send-abort-1", "chat.send", {
-        sessionKey: "main",
-        message: "hello",
-        idempotencyKey: "idem-abort-1",
-        timeoutMs: 30_000,
-      });
+      sendReq(
+        ws,
+        "send-abort-1",
+        "chat.send",
+        makeChatSendParams({
+          idempotencyKey: "idem-abort-1",
+          timeoutMs: 30_000,
+        }),
+      );
 
       const sendRes = await sendResP;
       expect(sendRes.ok).toBe(true);
@@ -6267,18 +6149,23 @@ describe("gateway server chat", () => {
         expect(spy.mock.calls.length).toBeGreaterThan(0);
       }, FAST_WAIT_OPTS);
 
-      const inFlight = await rpcReq<{ status?: string }>(ws, "chat.send", {
-        sessionKey: "main",
-        message: "hello",
-        idempotencyKey: "idem-abort-1",
-      });
+      const inFlight = await rpcReq<{ status?: string }>(
+        ws,
+        "chat.send",
+        makeChatSendParams({
+          idempotencyKey: "idem-abort-1",
+        }),
+      );
       expect(inFlight.ok).toBe(true);
       expect(["started", "in_flight", "ok"]).toContain(inFlight.payload?.status ?? "");
 
-      const abortRes = await rpcReq<{ aborted?: boolean }>(ws, "chat.abort", {
-        sessionKey: "main",
-        runId: "idem-abort-1",
-      });
+      const abortRes = await rpcReq<{ aborted?: boolean }>(
+        ws,
+        "chat.abort",
+        makeMainSessionParams({
+          runId: "idem-abort-1",
+        }),
+      );
       expect(abortRes.ok).toBe(true);
       expect(abortRes.payload?.aborted).toBe(true);
       await waitForFast(() => {
@@ -6288,19 +6175,23 @@ describe("gateway server chat", () => {
       spy.mockClear();
       spy.mockResolvedValueOnce(undefined);
 
-      const completeRes = await rpcReq<{ status?: string }>(ws, "chat.send", {
-        sessionKey: "main",
-        message: "hello",
-        idempotencyKey: "idem-complete-1",
-      });
+      const completeRes = await rpcReq<{ status?: string }>(
+        ws,
+        "chat.send",
+        makeChatSendParams({
+          idempotencyKey: "idem-complete-1",
+        }),
+      );
       expect(completeRes.ok).toBe(true);
 
       await waitForFast(async () => {
-        const again = await rpcReq<{ status?: string }>(ws, "chat.send", {
-          sessionKey: "main",
-          message: "hello",
-          idempotencyKey: "idem-complete-1",
-        });
+        const again = await rpcReq<{ status?: string }>(
+          ws,
+          "chat.send",
+          makeChatSendParams({
+            idempotencyKey: "idem-complete-1",
+          }),
+        );
         expect(again.ok).toBe(true);
         expect(again.payload?.status).toBe("ok");
       }, FAST_WAIT_OPTS);


### PR DESCRIPTION
Related: #120124

AI-assisted: yes

## What Problem This Solves

An audit of every `*.test.ts` file at least 1,500 LOC found eight eligible files with 1,537–1,650 exact repeated eligible lines each after the campaign, directory-ownership, and worker-priority exclusions were applied. Their repeated arrange objects obscured scenario-specific inputs and made fixture-wide changes unnecessarily risky.

## Why This Change Was Made

This batch adds local, domain-named `make*` builders with dominant defaults and explicit overrides at each owning test boundary. Nested values are merged where required, and capability-absent negative fixtures remain explicit. No production code, shared helper surface, baseline, snapshot, test title, assertion contract, or test order changed.

The eight selected files were committed independently, with four tiny file-scoped type-contract follow-ups from the changed gate. The final test-only diff removes 2,353 net LOC.

## User Impact

None. This is a behavior-neutral test-maintenance refactor. Future cases can express only their meaningful differences while retaining the same runtime coverage.

## Evidence

The batch-2-compatible census used exact trimmed physical lines at least 15 characters long, excluded complete import declarations and comment-only lines, retained strings occurring at least three times, and ranked `sum(frequency - 1)`. The selected files contained 12,780 repeated lines in aggregate; every file exceeded Worker A's 30% self-repetition threshold.

Mechanical Vitest `list --json` title multisets were identical before and after:

- subagent registry lifecycle: 276 routed entries
- embedded-agent model resolution: 298
- Telegram bot: 137
- reply-agent E2E: 139
- Matrix SDK: 139
- QMD manager: 165
- Gateway chat: 94
- Gateway reload handlers: 210

Focused Vitest proof, serialized in this worktree:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/subagent-registry-lifecycle.test.ts
# 138 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts
# 149 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts
# 137 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts --configLoader runner src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
# 139 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk.test.ts
# 139 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts
# 165 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts
# 94 passed

OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/gateway/server-reload-handlers.test.ts
# 210 passed
```

Static proof:

```text
pnpm format <all eight paths>
# passed

node scripts/run-oxlint.mjs <all eight paths>
# passed

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs
# passed: guards, format, dead exports, core/extension test typechecks, core/extension lint

git diff --check 5e477aff2adc0...HEAD
# passed

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
# clean: no accepted/actionable findings for the full eight-file diff

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
# clean: no accepted/actionable findings for the type-contract follow-ups
```

The initial delegated `node scripts/check-changed.mjs` attempt recorded Crabbox run `run_e5d4bd79dc48`; Blacksmith doctor failed, Daytona timed out, and Azure rejected its brokered image selector with `admin_required`. The trusted-source local fallback above is the final green changed gate.

Production-vs-test numstat against the requested base `5e477aff2adc0`:

```text
production: +0 / -0
tests:      +2664 / -5017
net tests:  -2353 LOC
```
