### PR TITLE
fix(android): open camera for chat video button

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -47,6 +47,20 @@ internal fun loadPickedMediaOrDocumentAttachment(
   return loadSharedAttachment(resolver, SharedAttachment(uri = uri, kind = kind, mimeType = requireNotNull(mimeType)))
 }
 
+/** Stages a camera-recorded clip; provider MIME may be missing for FileProvider cache files. */
+internal fun loadCapturedVideoAttachment(
+  resolver: ContentResolver,
+  uri: Uri,
+): PendingAttachment =
+  loadSharedAttachment(
+    resolver,
+    SharedAttachment(
+      uri = uri,
+      kind = SharedAttachmentKind.Video,
+      mimeType = CHAT_VIDEO_CAPTURE_MIME_TYPE,
+    ),
+  )
+
 /** Revalidates provider MIME metadata while the sender grant is live, then loads bounded bytes. */
 internal fun loadSharedAttachment(
   resolver: ContentResolver,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -153,6 +154,7 @@ import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -496,6 +498,46 @@ fun ChatScreen(
         )
       }
     }
+  val videoCaptureOwnerCheckpoint =
+    rememberSaveable(saver = ChatComposerMediaCheckpoint.Saver) { ChatComposerMediaCheckpoint() }
+  var pendingVideoCapture by remember { mutableStateOf<ChatVideoCaptureTarget?>(null) }
+  val captureVideo =
+    rememberLauncherForActivityResult(CaptureVideoToUri()) { success ->
+      val lease = videoCaptureOwnerCheckpoint.clear() ?: return@rememberLauncherForActivityResult
+      val target = pendingVideoCapture
+      pendingVideoCapture = null
+      if (!success || target == null) {
+        composerState.cancelMediaAcquisition(lease.authorizationId)
+        deleteChatVideoCaptureTarget(target)
+        return@rememberLauncherForActivityResult
+      }
+      val importOwner =
+        if (shouldMigrateComposerDraft(lease.owner, currentPickerOwner, currentPickerMainSessionKey)) {
+          currentPickerOwner
+        } else {
+          lease.owner
+        }
+      viewModel.importChatComposerAttachments(
+        owner = importOwner,
+        mediaAuthorizationId = lease.authorizationId,
+        mainSessionKey = currentPickerMainSessionKey,
+        expectedCount = 1,
+      ) {
+        try {
+          listOfNotNull(
+            try {
+              loadCapturedVideoAttachment(resolver, target.uri)
+            } catch (err: CancellationException) {
+              throw err
+            } catch (_: Throwable) {
+              null
+            },
+          )
+        } finally {
+          deleteChatVideoCaptureTarget(target)
+        }
+      }
+    }
 
   LaunchedEffect(composerOwner) {
     dictationController.cancel()
@@ -820,7 +862,41 @@ fun ChatScreen(
         filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
         pickMediaOrDocument.launch(SHARED_AUDIO_DOCUMENT_MIME_TYPES)
       },
-      onPickVideo = {
+      onRecordVideo = {
+        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+        if (!canLaunchSystemVideoCapture(context)) {
+          val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+          filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+          pickMediaOrDocument.launch(SHARED_VIDEO_MIME_TYPES)
+          return@ChatComposer
+        }
+        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+        val target =
+          try {
+            createChatVideoCaptureTarget(context)
+          } catch (_: Throwable) {
+            composerState.cancelMediaAcquisition(authorizationId)
+            val fallbackAuthorizationId =
+              composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+            filePickerOwnerCheckpoint.begin(composerOwner, fallbackAuthorizationId)
+            pickMediaOrDocument.launch(SHARED_VIDEO_MIME_TYPES)
+            return@ChatComposer
+          }
+        videoCaptureOwnerCheckpoint.begin(composerOwner, authorizationId)
+        pendingVideoCapture = target
+        try {
+          captureVideo.launch(target.uri)
+        } catch (_: Throwable) {
+          pendingVideoCapture = null
+          videoCaptureOwnerCheckpoint.clear()
+          deleteChatVideoCaptureTarget(target)
+          composerState.cancelMediaAcquisition(authorizationId)
+          val retryAuthorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+          filePickerOwnerCheckpoint.begin(composerOwner, retryAuthorizationId)
+          pickMediaOrDocument.launch(SHARED_VIDEO_MIME_TYPES)
+        }
+      },
+      onPickExistingVideo = {
         if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
         val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
         filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
@@ -2076,7 +2152,8 @@ private fun ChatComposer(
   onOpenModelPicker: () -> Unit,
   onPickImages: () -> Unit,
   onPickAudioOrDocument: () -> Unit,
-  onPickVideo: () -> Unit,
+  onRecordVideo: () -> Unit,
+  onPickExistingVideo: () -> Unit,
   onRemoveAttachment: (String) -> Unit,
   voiceNoteState: VoiceNoteRecorderState,
   voiceNoteElapsedMs: Long,
@@ -2195,7 +2272,8 @@ private fun ChatComposer(
           onValueChange = onValueChange,
           onPickImages = onPickImages,
           onPickAudioOrDocument = onPickAudioOrDocument,
-          onPickVideo = onPickVideo,
+          onRecordVideo = onRecordVideo,
+          onPickExistingVideo = onPickExistingVideo,
           onStartVoiceNote = onStartVoiceNote,
           recordVoiceNoteEnabled = recordVoiceNoteEnabled,
           dictationActive = dictationActive,
@@ -2640,7 +2718,8 @@ private fun ChatInputPill(
   onValueChange: (String) -> Unit,
   onPickImages: () -> Unit,
   onPickAudioOrDocument: () -> Unit,
-  onPickVideo: () -> Unit,
+  onRecordVideo: () -> Unit,
+  onPickExistingVideo: () -> Unit,
   onStartVoiceNote: () -> Unit,
   recordVoiceNoteEnabled: Boolean,
   dictationActive: Boolean,
@@ -2653,6 +2732,8 @@ private fun ChatInputPill(
   modifier: Modifier = Modifier,
 ) {
   val hardwareEnterHandler = remember { PhysicalChatSendKeyHandler() }
+  val recordVideoLabel = nativeString("Record video")
+  val attachExistingVideoLabel = nativeString("Attach video")
 
   Surface(
     modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
@@ -2676,9 +2757,23 @@ private fun ChatInputPill(
           Icon(imageVector = Icons.Default.AttachFile, contentDescription = nativeString("Attachment"), modifier = Modifier.size(20.dp))
         }
       }
-      Surface(onClick = onPickVideo, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
+      Surface(
+        modifier =
+          Modifier
+            .size(ClawTheme.spacing.touchTarget)
+            .combinedClickable(
+              onClickLabel = recordVideoLabel,
+              onLongClickLabel = attachExistingVideoLabel,
+              role = Role.Button,
+              onClick = onRecordVideo,
+              onLongClick = onPickExistingVideo,
+            ),
+        shape = CircleShape,
+        color = ClawTheme.colors.surfaceRaised,
+        contentColor = ClawTheme.colors.text,
+      ) {
         Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Default.Videocam, contentDescription = nativeString("Attach video"), modifier = Modifier.size(20.dp))
+          Icon(imageVector = Icons.Default.Videocam, contentDescription = recordVideoLabel, modifier = Modifier.size(20.dp))
         }
       }
       Box(modifier = Modifier.weight(1f)) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatVideoCapture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatVideoCapture.kt
@@ -1,0 +1,74 @@
+package ai.openclaw.app.ui.chat
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.content.FileProvider
+import java.io.File
+
+internal const val CHAT_VIDEO_CAPTURE_CACHE_DIR = "chat-captures"
+internal const val CHAT_VIDEO_CAPTURE_MIME_TYPE = "video/mp4"
+
+/** Output target for system video capture that the composer can stage as an attachment. */
+internal data class ChatVideoCaptureTarget(
+  val file: File,
+  val uri: Uri,
+)
+
+/** True when a handler for [MediaStore.ACTION_VIDEO_CAPTURE] is installed. */
+internal fun canLaunchSystemVideoCapture(context: Context): Boolean {
+  val intent = Intent(MediaStore.ACTION_VIDEO_CAPTURE)
+  return intent.resolveActivity(context.packageManager) != null
+}
+
+/** Creates a cache FileProvider destination for one camera recording. */
+internal fun createChatVideoCaptureTarget(context: Context): ChatVideoCaptureTarget {
+  val dir = File(context.cacheDir, CHAT_VIDEO_CAPTURE_CACHE_DIR).apply { mkdirs() }
+  val file = File(dir, "capture-${System.currentTimeMillis()}.mp4")
+  val uri =
+    FileProvider.getUriForFile(
+      context,
+      "${context.packageName}.fileprovider",
+      file,
+    )
+  return ChatVideoCaptureTarget(file = file, uri = uri)
+}
+
+/** Best-effort cleanup for cancelled or failed capture outputs. */
+internal fun deleteChatVideoCaptureTarget(target: ChatVideoCaptureTarget?) {
+  if (target == null) return
+  runCatching { if (target.file.exists()) target.file.delete() }
+}
+
+/**
+ * System camera video capture into a FileProvider URI.
+ *
+ * Grants write/read access to every resolved camera activity so OEM handlers can write the clip.
+ */
+internal class CaptureVideoToUri : ActivityResultContract<Uri, Boolean>() {
+  override fun createIntent(
+    context: Context,
+    input: Uri,
+  ): Intent {
+    val intent =
+      Intent(MediaStore.ACTION_VIDEO_CAPTURE)
+        .putExtra(MediaStore.EXTRA_OUTPUT, input)
+        .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    val flags = Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
+    context.packageManager
+      .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+      .forEach { resolveInfo ->
+        context.grantUriPermission(resolveInfo.activityInfo.packageName, input, flags)
+      }
+    return intent
+  }
+
+  override fun parseResult(
+    resultCode: Int,
+    intent: Intent?,
+  ): Boolean = resultCode == Activity.RESULT_OK
+}

--- a/apps/android/app/src/main/res/xml/file_paths.xml
+++ b/apps/android/app/src/main/res/xml/file_paths.xml
@@ -3,4 +3,5 @@
     <cache-path name="apk_updates" path="updates/" />
     <cache-path name="widget_exports" path="exports/" />
     <cache-path name="workspace_files" path="workspace-files/" />
+    <cache-path name="chat_captures" path="chat-captures/" />
 </paths>

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatVideoCaptureTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatVideoCaptureTest.kt
@@ -1,0 +1,16 @@
+package ai.openclaw.app.ui.chat
+
+import android.app.Activity
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatVideoCaptureTest {
+  @Test
+  fun captureContractMapsResultCodes() {
+    val contract = CaptureVideoToUri()
+    assertTrue(contract.parseResult(Activity.RESULT_OK, null))
+    assertFalse(contract.parseResult(Activity.RESULT_CANCELED, null))
+    assertFalse(contract.parseResult(Activity.RESULT_FIRST_USER, null))
+  }
+}


### PR DESCRIPTION
## Summary
- Tap the Android Chat composer **videocam** control now launches system `ACTION_VIDEO_CAPTURE` into a FileProvider cache file and stages the recorded clip as a chat attachment.
- Long-press keeps the existing document picker path for attaching stored video.
- If no camera capture handler is available (or capture setup fails), the button falls back to the existing video document picker.

## Why
The videocam icon previously only opened `OpenDocument` with video MIME types, so phones jumped straight to Files/Documents instead of the camera.

## Test plan
- [x] `./gradlew :app:compilePlayDebugKotlin` (Play debug)
- [ ] On device: tap videocam → system camera opens in video mode → record → clip appears in composer attachment strip → send
- [ ] Long-press videocam → existing video document picker still works
- [ ] Cancel camera capture → no orphan attachment / no crash
- [ ] Device without video-capture handler falls back to document picker

## Rollout
This lands in the Android app source. Users get it via the next Play/APK release channel (not a gateway-only update). After merge + release, update/install the Android app on devices.