### PR TITLE
fix(routing): preserve fallback safety for pinned sessions

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -307,14 +307,16 @@ describe("resolveAgentConfig", () => {
         hasSessionModelOverride: true,
         modelOverrideSource: "user",
       }),
-    ).toStrictEqual([]);
+      // User pins now inherit the fallback chain as a terminal safety net
+      // (pin stays primary) so a provider outage fails over instead of dying.
+    ).toEqual(["openai/gpt-5.4"]);
     expect(
       resolveEffectiveModelFallbacks({
         cfg,
         agentId: "linus",
         hasSessionModelOverride: true,
       }),
-    ).toStrictEqual([]);
+    ).toEqual(["openai/gpt-5.4"]);
     expect(
       resolveEffectiveModelFallbacks({
         cfg,
@@ -331,7 +333,7 @@ describe("resolveAgentConfig", () => {
         modelOverrideSource: "user",
         hasAutoFallbackProvenance: true,
       }),
-    ).toStrictEqual([]);
+    ).toEqual(["openai/gpt-5.4"]);
     expect(
       resolveEffectiveModelFallbacks({
         cfg: cfgNoOverride,
@@ -364,6 +366,69 @@ describe("resolveAgentConfig", () => {
         agentId: "linus",
         hasSessionModelOverride: true,
         modelOverrideSource: "auto",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps a user-pinned session resilient via the default fallback safety net", () => {
+    // Recovery contract: a user pins a model whose provider is temporarily
+    // unavailable (e.g. OpenAI usage-capped). The pin must stay primary, but
+    // the session must still inherit the global fallback chain so failover
+    // reaches a healthy provider instead of surfacing "all models rate-limited".
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-8",
+            fallbacks: ["anthropic/claude-sonnet-4-6", "ollama/qwen3:8b", "local/free-chat"],
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    };
+
+    // User explicitly pinned a model on this session.
+    expect(
+      resolveEffectiveModelFallbacks({
+        cfg,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        hasSessionModelOverride: true,
+        modelOverrideSource: "user",
+      }),
+    ).toEqual(["anthropic/claude-sonnet-4-6", "ollama/qwen3:8b", "local/free-chat"]);
+
+    // Auto-selected override behaves identically (unchanged).
+    expect(
+      resolveEffectiveModelFallbacks({
+        cfg,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        hasSessionModelOverride: true,
+        modelOverrideSource: "auto",
+      }),
+    ).toEqual(["anthropic/claude-sonnet-4-6", "ollama/qwen3:8b", "local/free-chat"]);
+
+    // Opt-out preserved: an explicit empty fallbacks list makes a pin exclusive
+    // (no substitution), e.g. for cost control or model-specific evaluation.
+    const cfgExclusive: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-8",
+            fallbacks: [],
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    };
+    expect(
+      resolveEffectiveModelFallbacks({
+        cfg: cfgExclusive,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        hasSessionModelOverride: true,
+        modelOverrideSource: "user",
       }),
     ).toStrictEqual([]);
   });
@@ -944,7 +1009,9 @@ describe("resolveAgentConfig", () => {
         hasSessionModelOverride: true,
         modelOverrideSource: "user",
       }),
-    ).toStrictEqual([]);
+      // User-pinned subagent also inherits its subagent fallback chain as a
+      // safety net (matches the auto-selected case above).
+    ).toEqual(["openai-codex/gpt-5.4", "zai/glm-5"]);
     expect(
       resolveEffectiveModelFallbacks({
         cfg,

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -541,12 +541,19 @@ export function resolveEffectiveModelFallbacks(params: {
   if (!params.hasSessionModelOverride) {
     return agentFallbacksOverride;
   }
-  const canUseConfiguredFallbacks =
-    params.modelOverrideSource === "auto" ||
-    (params.modelOverrideSource === undefined && params.hasAutoFallbackProvenance === true);
-  if (!canUseConfiguredFallbacks) {
-    return [];
-  }
+  // A session model override keeps the pinned model as the *primary* candidate
+  // (it is always attempted first, preserving user intent), but still inherits
+  // the configured fallback chain as a terminal safety net. This ensures a
+  // provider outage — rate limit, auth cooldown, or quota exhaustion — fails
+  // over to the next healthy provider instead of hard-failing the session with
+  // "all models rate-limited". This holds for both auto-selected overrides and
+  // explicit user pins; previously user pins returned [] and were left with no
+  // recovery path when their provider went down.
+  //
+  // Operators who want a strictly exclusive pin (no substitution, e.g. for cost
+  // control or model-specific evaluation) opt out by configuring an empty
+  // fallbacks list (agents.defaults.model.fallbacks: [] or per-agent
+  // model.fallbacks: []), which resolves to [] here and is respected.
   const subagentFallbacksOverride = isSubagentSessionKey(params.sessionKey)
     ? resolveSubagentSpawnModelFallbacksOverride(params.cfg, params.agentId)
     : undefined;

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -48,6 +48,25 @@ describe("resolveCronFallbacksOverride", () => {
     ).toEqual(["openai/gpt-5.4", "google/gemini-3-pro"]);
   });
 
+  it("keeps an isolated cron job resilient when its pinned provider is down", () => {
+    // Recovery invariant (parallels the session-pin safety net in
+    // resolveEffectiveModelFallbacks): a scheduled job pinned to a model whose
+    // provider is temporarily unavailable must still inherit the configured
+    // fallback chain — including the local terminal fallback — so the run fails
+    // over to a healthy provider instead of dying with "all models rate-limited".
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: makeConfig(["anthropic/claude-sonnet-4-6", "ollama/qwen3:8b", "local/free-chat"]),
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "nightly report",
+          model: "openai/gpt-5.5", // pinned to a provider that may be usage-capped
+        }),
+      }),
+    ).toEqual(["anthropic/claude-sonnet-4-6", "ollama/qwen3:8b", "local/free-chat"]);
+  });
+
   it("returns an empty override for payload model overrides without configured fallbacks", () => {
     expect(
       resolveCronFallbacksOverride({


### PR DESCRIPTION
## Summary

Improves OpenClaw routing resilience when a user explicitly pins a model/session.

## What Problem This Solves

A user-pinned model previously could become a single-provider dead end.

If that provider became rate-limited, usage-capped, temporarily unavailable, or entered an authentication cooldown, the pinned session could resolve to no usable fallback path and fail with errors such as "all models temporarily rate-limited."

This change preserves the user's explicit model choice as the primary model while retaining the configured fallback chain as an emergency safety net.

The pinned model is always attempted first. Fallbacks engage only if the selected provider cannot complete the request.

## Changes

- User-pinned sessions retain the configured fallback safety net.
- The user's pinned model remains primary.
- Provider outages and rate limits can fail over rather than terminating the session.
- Adds regression coverage for pinned-session fallback behavior.
- Adds cron/isolated-agent fallback safety coverage.

## Evidence

- Regression coverage was added in `src/agents/agent-scope.test.ts`.
- Cron/isolated-agent recovery coverage was added in `src/cron/isolated-agent/run-fallback-policy.test.ts`.
- Focused routing tests were run successfully during local implementation.
- The recovery test explicitly models a pinned provider becoming temporarily unavailable and verifies that the configured fallback chain remains available.
- The implementation preserves explicit exclusive-pin behavior when an operator intentionally configures an empty fallback list.

## Safety

This PR is intended to contain only the pinned-session routing fix and its regression coverage.

Uncommitted local OpenClaw/OCOS files are not part of this PR.