### PR TITLE
feat(models): add auth cooldown recovery command

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -154,6 +154,7 @@ openclaw models auth login --provider <id>
 openclaw models auth login --provider openai --profile-id openai:work
 openclaw models auth login-github-copilot
 openclaw models auth logout <profileId> [--yes]
+openclaw models auth clear-cooldown <profileId>
 openclaw models auth paste-api-key --provider <id>
 openclaw models auth setup-token --provider <id>
 openclaw models auth paste-token --provider <id>
@@ -170,9 +171,11 @@ openclaw models auth order clear --provider <id>
 
 `models auth logout <profileId>` removes one saved auth profile from the selected agent auth store. Use the profile id shown by `models auth list`. It also drops that profile from `auth.profiles` and from every `auth.order` list in your config, so no stale reference is left behind, and it deletes an `auth.order.<provider>` entry that would otherwise be emptied (an authored empty order means "select no profiles" and would disable the provider). It prompts for confirmation on a TTY; pass `--yes` for scripts and agents. Logout refuses when the profile is not in the store, or when a `models.providers.<id>.apiKey` entry names it — change that config value first.
 
+`models auth clear-cooldown <profileId>` clears OpenClaw's locally stored cooldown and disable state for one profile without changing its credentials or contacting the provider. Use it only after confirming that the provider account has recovered, such as after a subscription limit reset. Find the profile id with `models auth list`.
+
 `models auth login-github-copilot` is a shortcut for `models auth login --provider github-copilot --method device` (GitHub device flow); it accepts `--yes` to overwrite an existing profile without prompting.
 
-Use `openclaw models auth --agent <id> <subcommand>` to write auth results to a specific configured agent store. The parent `--agent` flag is honored by `add`, `list`, `login`, `logout`, `paste-api-key`, `setup-token`, `paste-token`, `login-github-copilot`, and `order get`/`set`/`clear`.
+Use `openclaw models auth --agent <id> <subcommand>` to write auth results to a specific configured agent store. The parent `--agent` flag is honored by `add`, `list`, `login`, `logout`, `clear-cooldown`, `paste-api-key`, `setup-token`, `paste-token`, `login-github-copilot`, and `order get`/`set`/`clear`.
 
 For OpenAI models, `--provider openai` defaults to ChatGPT/Codex account login. Use `--method api-key` only when you want to add an OpenAI API-key profile, usually as a backup for Codex subscription limits. Run `openclaw doctor --fix` to migrate older legacy OpenAI Codex prefix auth/profile state to `openai`.
 
@@ -183,6 +186,7 @@ openclaw models auth login --provider openai --set-default
 openclaw models auth login --provider openai --method api-key
 openclaw models auth paste-api-key --provider openai
 openclaw models auth list --provider openai
+openclaw models auth clear-cooldown openai:default
 openclaw models auth logout openai:manual --yes
 ```
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -359,6 +359,20 @@ export function registerModelsCli(program: Command) {
     });
 
   auth
+    .command("clear-cooldown")
+    .description("Clear stored auth cooldown state after provider account recovery")
+    .argument("<profileId>", "Auth profile id (e.g. openai:default)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .action(async (profileId: string, opts, command) => {
+      await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
+        const agent = resolveModelAgentOption(command, opts);
+        const { modelsAuthClearCooldownCommand } =
+          await import("../commands/models/auth-clear-cooldown.js");
+        await modelsAuthClearCooldownCommand({ profileId, agent }, defaultRuntime);
+      });
+    });
+
+  auth
     .command("login")
     .description("Run a provider plugin auth flow (OAuth/API key)")
     .option("--provider <id>", "Provider id registered by a plugin")

--- a/src/commands/models/auth-clear-cooldown.test.ts
+++ b/src/commands/models/auth-clear-cooldown.test.ts
@@ -1,0 +1,110 @@
+// Covers explicit clearing of locally stored auth-profile cooldown state.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  clearAuthProfileCooldown: vi.fn(async () => undefined),
+  ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(),
+  loadModelsConfig: vi.fn(),
+  refreshRunningGatewayAuthState: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  clearAuthProfileCooldown: mocks.clearAuthProfileCooldown,
+  ensureAuthProfileStoreWithoutExternalProfiles:
+    mocks.ensureAuthProfileStoreWithoutExternalProfiles,
+}));
+
+vi.mock("./auth-refresh.js", () => ({
+  refreshRunningGatewayAuthState: mocks.refreshRunningGatewayAuthState,
+}));
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfig: mocks.loadModelsConfig,
+}));
+
+vi.mock("./shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./shared.js")>();
+  return {
+    ...actual,
+    resolveModelsTargetAgent: (_cfg: OpenClawConfig, rawAgentId?: string) => ({
+      agentId: rawAgentId ?? "main",
+      agentDir: `/tmp/agent-${rawAgentId ?? "main"}`,
+    }),
+  };
+});
+
+const { modelsAuthClearCooldownCommand } = await import("./auth-clear-cooldown.js");
+
+function createRuntime(): RuntimeEnv & { logs: string[] } {
+  const logs: string[] = [];
+  return {
+    logs,
+    log: (message: string) => {
+      logs.push(message);
+    },
+    error: () => {},
+  } as unknown as RuntimeEnv & { logs: string[] };
+}
+
+describe("models auth clear-cooldown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadModelsConfig.mockResolvedValue({} as OpenClawConfig);
+    mocks.ensureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai:default": { type: "oauth", provider: "openai", access: "token" },
+      },
+      usageStats: {
+        "openai:default": { blockedUntil: Date.now() + 60_000 },
+      },
+    } satisfies AuthProfileStore);
+  });
+
+  it("clears stored state for the selected agent and refreshes the gateway", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthClearCooldownCommand(
+      { profileId: "openai:default", agent: "planner" },
+      runtime,
+    );
+
+    expect(mocks.clearAuthProfileCooldown).toHaveBeenCalledWith({
+      store: expect.any(Object),
+      profileId: "openai:default",
+      agentDir: "/tmp/agent-planner",
+    });
+    expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledOnce();
+    expect(runtime.logs).toContain("Agent: planner");
+    expect(runtime.logs).toContain(
+      "Cleared stored cooldown and disable state for auth profile: openai:default",
+    );
+  });
+
+  it("reports when no stored state exists without refreshing the gateway", async () => {
+    mocks.ensureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai:default": { type: "oauth", provider: "openai", access: "token" },
+      },
+    } satisfies AuthProfileStore);
+    const runtime = createRuntime();
+
+    await modelsAuthClearCooldownCommand({ profileId: "openai:default" }, runtime);
+
+    expect(mocks.clearAuthProfileCooldown).not.toHaveBeenCalled();
+    expect(mocks.refreshRunningGatewayAuthState).not.toHaveBeenCalled();
+    expect(runtime.logs).toContain(
+      "No stored cooldown or disable state for auth profile: openai:default",
+    );
+  });
+
+  it("requires a profile id", async () => {
+    await expect(
+      modelsAuthClearCooldownCommand({ profileId: "  " }, createRuntime()),
+    ).rejects.toThrow("Missing profile id");
+  });
+});

--- a/src/commands/models/auth-clear-cooldown.ts
+++ b/src/commands/models/auth-clear-cooldown.ts
@@ -1,0 +1,41 @@
+/** Command for clearing locally stored auth-profile cooldown state. */
+import {
+  clearAuthProfileCooldown,
+  ensureAuthProfileStoreWithoutExternalProfiles,
+} from "../../agents/auth-profiles.js";
+import { formatCliCommand } from "../../cli/command-format.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { refreshRunningGatewayAuthState } from "./auth-refresh.js";
+import { loadModelsConfig } from "./load-config.js";
+import { resolveModelsTargetAgent } from "./shared.js";
+
+/**
+ * Clears locally stored cooldown/disable state after an operator has confirmed
+ * the provider account has recovered (for example, after a subscription reset).
+ */
+export async function modelsAuthClearCooldownCommand(
+  opts: { profileId: string; agent?: string },
+  runtime: RuntimeEnv,
+) {
+  const profileId = opts.profileId?.trim();
+  if (!profileId) {
+    throw new Error(
+      `Missing profile id. Run ${formatCliCommand("openclaw models auth list")} to see saved profile ids.`,
+    );
+  }
+
+  const cfg = await loadModelsConfig({ commandName: "models auth clear-cooldown", runtime });
+  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
+  const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir);
+  if (!store.usageStats?.[profileId]) {
+    runtime.log(`Agent: ${agentId}`);
+    runtime.log(`No stored cooldown or disable state for auth profile: ${profileId}`);
+    return;
+  }
+
+  await clearAuthProfileCooldown({ store, profileId, agentDir });
+  await refreshRunningGatewayAuthState();
+
+  runtime.log(`Agent: ${agentId}`);
+  runtime.log(`Cleared stored cooldown and disable state for auth profile: ${profileId}`);
+}


### PR DESCRIPTION
## Summary
- add `openclaw models auth clear-cooldown <profileId>` for explicit recovery after a confirmed provider account reset
- refresh a running gateway after local auth state changes
- document the workflow and cover command behavior with focused tests

## Why
OpenClaw correctly persists provider cooldowns to avoid repeated failing requests. When an account recovers on the provider side (for example, after a subscription reset), there is no direct operator command to clear that local state without re-authenticating or editing the auth store. This command clears only local cooldown/disable state; it does not change credentials or contact the provider.

## Test plan
- `pnpm exec vitest run src/commands/models/auth-clear-cooldown.test.ts src/commands/models/auth-list.test.ts src/commands/models/auth-logout.test.ts`
- `pnpm exec oxfmt --check src/cli/models-cli.ts src/commands/models/auth-clear-cooldown.ts src/commands/models/auth-clear-cooldown.test.ts docs/cli/models.md`
- `pnpm exec oxlint src/cli/models-cli.ts src/commands/models/auth-clear-cooldown.ts src/commands/models/auth-clear-cooldown.test.ts`