### PR TITLE
fix(ci): accept neutral draft gate runs

### DIFF
--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -316,7 +316,7 @@ function isGateProvenInProgressRun(run, ciGateJobs, nowMs) {
 function preferredCiRun(runs, nowMs) {
   const scheduledRuns = runs.filter((run) => run.event === "pull_request");
   const latestScheduledRun = latestRun(scheduledRuns);
-  const latestDecisiveScheduledRun = latestRun(
+  const latestDecision = latestRun(
     scheduledRuns.filter(
       (run) => run.status === "completed" && !["cancelled", "skipped"].includes(run.conclusion),
     ),
@@ -325,11 +325,11 @@ function preferredCiRun(runs, nowMs) {
 
   // Manual proof may replace stale scheduled success or a pending run,
   // never an unresolved terminal non-success.
-  if (latestDecisiveScheduledRun && latestDecisiveScheduledRun.conclusion !== "success") {
-    return latestDecisiveScheduledRun;
+  if (latestDecision && latestDecision.conclusion !== "success") {
+    return latestDecision;
   }
-  if (isSuccessfulRecentRun(latestDecisiveScheduledRun, nowMs)) {
-    return latestDecisiveScheduledRun;
+  if (latestScheduledRun?.status === "completed" && isSuccessfulRecentRun(latestDecision, nowMs)) {
+    return latestDecision;
   }
   return latestManualRun ?? latestScheduledRun;
 }

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -328,8 +328,8 @@ function preferredCiRun(runs, nowMs) {
   if (latestDecisiveScheduledRun && latestDecisiveScheduledRun.conclusion !== "success") {
     return latestDecisiveScheduledRun;
   }
-  if (isSuccessfulRecentRun(latestScheduledRun, nowMs)) {
-    return latestScheduledRun;
+  if (isSuccessfulRecentRun(latestDecisiveScheduledRun, nowMs)) {
+    return latestDecisiveScheduledRun;
   }
   return latestManualRun ?? latestScheduledRun;
 }

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -316,17 +316,19 @@ function isGateProvenInProgressRun(run, ciGateJobs, nowMs) {
 function preferredCiRun(runs, nowMs) {
   const scheduledRuns = runs.filter((run) => run.event === "pull_request");
   const latestScheduledRun = latestRun(scheduledRuns);
-  const latestCompletedScheduledRun = latestRun(
-    scheduledRuns.filter((run) => run.status === "completed"),
+  const latestDecisiveScheduledRun = latestRun(
+    scheduledRuns.filter(
+      (run) => run.status === "completed" && !["cancelled", "skipped"].includes(run.conclusion),
+    ),
   );
   const latestManualRun = latestRun(runs.filter((run) => run.event === "workflow_dispatch"));
 
   // Manual proof may replace stale scheduled success or a pending run,
   // never an unresolved terminal non-success.
-  if (latestCompletedScheduledRun && latestCompletedScheduledRun.conclusion !== "success") {
-    return latestCompletedScheduledRun;
+  if (latestDecisiveScheduledRun && latestDecisiveScheduledRun.conclusion !== "success") {
+    return latestDecisiveScheduledRun;
   }
-  if (latestScheduledRun?.status === "completed" && isRecentRun(latestScheduledRun, nowMs)) {
+  if (isSuccessfulRecentRun(latestScheduledRun, nowMs)) {
     return latestScheduledRun;
   }
   return latestManualRun ?? latestScheduledRun;

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -120,8 +120,10 @@ function matchingAuthoritativeRuns(runs, workflowName, sha, allowManual = true) 
 }
 
 function latestRun(runs) {
-  return runs.toSorted((left, right) =>
-    String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? "")),
+  // GitHub run_number is creation order; updated_at moves as jobs finish.
+  return runs.toSorted(
+    (left, right) =>
+      Number(right.run_number ?? right.id ?? 0) - Number(left.run_number ?? left.id ?? 0),
   )[0];
 }
 
@@ -327,6 +329,9 @@ function preferredCiRun(runs, nowMs) {
   // never an unresolved terminal non-success.
   if (latestDecision && latestDecision.conclusion !== "success") {
     return latestDecision;
+  }
+  if (latestScheduledRun && latestScheduledRun.status !== "completed") {
+    return latestRun([latestScheduledRun, latestManualRun].filter(Boolean));
   }
   if (latestScheduledRun?.status === "completed" && isSuccessfulRecentRun(latestDecision, nowMs)) {
     return latestDecision;

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -1020,10 +1020,15 @@ describe("verify-pr-hosted-gates", () => {
     (conclusion) => {
       const success = successfulRun("CI", 1, "2026-06-17T10:47:00Z");
       const neutral = { ...successfulRun("CI", 2, "2026-06-17T10:48:00Z"), conclusion };
-      expect(collectHostedGateEvidence({ sha, workflowRuns: [success, neutral] })).toEqual({
+      const collect = () => collectHostedGateEvidence({ sha, workflowRuns: [success, neutral] });
+      expect(collect()).toEqual({
         headSha: sha,
         workflows: [expect.objectContaining({ name: "CI", id: 1 })],
       });
+      for (const status of ["queued", "in_progress"]) {
+        Object.assign(neutral, { status, conclusion: null });
+        expect(collect).toThrow("Missing successful recent CI workflow");
+      }
     },
   );
 

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -992,6 +992,8 @@ describe("verify-pr-hosted-gates", () => {
       },
     ],
     ["stale", successfulRun("CI", 1, "2026-06-16T10:54:59Z")],
+    ["cancelled", { ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"), conclusion: "cancelled" }],
+    ["skipped", { ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"), conclusion: "skipped" }],
   ])("prefers a fresh exact release gate while scheduled CI is %s", (_state, scheduledRun) => {
     expect(
       collectHostedGateEvidence({
@@ -1002,6 +1004,15 @@ describe("verify-pr-hosted-gates", () => {
       headSha: sha,
       workflows: [expect.objectContaining({ name: `CI release gate ${sha}`, id: 2 })],
     });
+  });
+
+  it.each(["cancelled", "skipped"])("rejects neutral-only scheduled CI (%s)", (conclusion) => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [{ ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"), conclusion }],
+      }),
+    ).toThrow("Missing successful recent CI workflow");
   });
 
   it("rejects a completed scheduled CI failure even when a fallback passed", () => {
@@ -1022,6 +1033,22 @@ describe("verify-pr-hosted-gates", () => {
       }),
     ).toThrow("Missing successful recent CI workflow");
   });
+
+  it.each(["cancelled", "skipped"])(
+    "keeps an older scheduled failure blocking after a newer neutral run (%s)",
+    (conclusion) => {
+      expect(() =>
+        collectHostedGateEvidence({
+          sha,
+          workflowRuns: [
+            { ...successfulRun("CI", 1, "2026-06-17T10:47:00Z"), conclusion: "failure" },
+            { ...successfulRun("CI", 2, "2026-06-17T10:48:00Z"), conclusion },
+            releaseGateRun(3, "2026-06-17T10:49:00Z"),
+          ],
+        }),
+      ).toThrow("Missing successful recent CI workflow");
+    },
+  );
 
   it("does not mask a failed CI run with a queued rerun and release-gate fallback", () => {
     expect(() =>

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -30,6 +30,7 @@ const requiredCliArgs = [
 
 type WorkflowRunFixture = {
   id: number;
+  run_number: number;
   name: string;
   event: string;
   status: string;
@@ -48,6 +49,7 @@ type WorkflowRunFixture = {
 function successfulRun(name: string, id: number, updatedAt: string): WorkflowRunFixture {
   return {
     id,
+    run_number: id,
     name,
     event: "pull_request",
     status: "completed",
@@ -69,6 +71,10 @@ function releaseGateRun(id: number, updatedAt: string) {
     event: "workflow_dispatch",
     display_title: `CI release gate ${sha}`,
   };
+}
+
+function pendingCiRun(id: number, updatedAt: string, status = "queued") {
+  return { ...successfulRun("CI", id, updatedAt), status, conclusion: null };
 }
 
 function queuedBuildArtifactFallbackRuns() {
@@ -983,14 +989,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it.each([
-    [
-      "queued",
-      {
-        ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
-        status: "queued",
-        conclusion: null,
-      },
-    ],
     ["stale", successfulRun("CI", 1, "2026-06-16T10:54:59Z")],
     ["cancelled", { ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"), conclusion: "cancelled" }],
     ["skipped", { ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"), conclusion: "skipped" }],
@@ -1031,6 +1029,60 @@ describe("verify-pr-hosted-gates", () => {
       }
     },
   );
+
+  it.each([
+    [
+      "queued over older manual",
+      [releaseGateRun(1, "2026-06-17T10:49:00Z"), pendingCiRun(2, "2026-06-17T10:50:00Z")],
+      null,
+    ],
+    [
+      "in-progress over older manual",
+      [
+        releaseGateRun(1, "2026-06-17T10:49:00Z"),
+        pendingCiRun(2, "2026-06-17T10:50:00Z", "in_progress"),
+      ],
+      null,
+    ],
+    [
+      "pending over neutral and manual",
+      [
+        { ...successfulRun("CI", 1, "2026-06-17T10:48:00Z"), conclusion: "skipped" },
+        releaseGateRun(2, "2026-06-17T10:49:00Z"),
+        pendingCiRun(3, "2026-06-17T10:50:00Z"),
+      ],
+      null,
+    ],
+    [
+      "newer manual over older pending",
+      [
+        pendingCiRun(1, "2026-06-17T10:48:00Z", "in_progress"),
+        releaseGateRun(2, "2026-06-17T10:49:00Z"),
+      ],
+      2,
+    ],
+  ])("applies the %s policy", (_case, workflowRuns, expectedId) => {
+    const collect = () => collectHostedGateEvidence({ sha, workflowRuns });
+    if (expectedId === null) {
+      expect(collect).toThrow("Missing successful recent CI workflow");
+      return;
+    }
+    expect(collect()).toEqual({
+      headSha: sha,
+      workflows: [expect.objectContaining({ name: `CI release gate ${sha}`, id: expectedId })],
+    });
+  });
+
+  it("orders runs by creation sequence when completion updates invert", () => {
+    const olderSuccess = successfulRun("CI", 1, "2026-06-17T10:54:00Z");
+    const newerFailure = {
+      ...successfulRun("CI", 2, "2026-06-17T10:49:00Z"),
+      conclusion: "failure",
+    };
+    expect(() =>
+      collectHostedGateEvidence({ sha, workflowRuns: [olderSuccess, newerFailure] }),
+    ).toThrow("Missing successful recent CI workflow");
+  });
 
   it("rejects a completed scheduled CI failure even when a fallback passed", () => {
     expect(() =>

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -1015,6 +1015,18 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow("Missing successful recent CI workflow");
   });
 
+  it.each(["cancelled", "skipped"])(
+    "retains a recent scheduled success after a newer neutral run (%s)",
+    (conclusion) => {
+      const success = successfulRun("CI", 1, "2026-06-17T10:47:00Z");
+      const neutral = { ...successfulRun("CI", 2, "2026-06-17T10:48:00Z"), conclusion };
+      expect(collectHostedGateEvidence({ sha, workflowRuns: [success, neutral] })).toEqual({
+        headSha: sha,
+        workflows: [expect.objectContaining({ name: "CI", id: 1 })],
+      });
+    },
+  );
+
   it("rejects a completed scheduled CI failure even when a fallback passed", () => {
     expect(() =>
       collectHostedGateEvidence({


### PR DESCRIPTION
Related: #120246

## What Problem This Solves

Fixes an issue where release maintainers could not reuse a successful exact-SHA manual CI release gate when the scheduled pull-request run was skipped because the PR was still a draft.

## Why This Change Was Made

Treats completed `skipped` and `cancelled` scheduled CI runs as neutral while preserving decisive results and pending-run authority. Run precedence follows GitHub's workflow creation sequence, so completion updates cannot reorder attempts.

## User Impact

Release preparation can accept valid manual exact-head proof after neutral scheduled outcomes without masking a real failure or a newer queued/in-progress scheduled run.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts` - 67 tests passed
- `OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs -- scripts/verify-pr-hosted-gates.mjs test/scripts/verify-pr-hosted-gates.test.ts` - passed on Testbox `tbx_01kzet10qrv7rwmef8wpwksfwx`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/31210151522
- `pnpm exec oxfmt --check --no-error-on-unmatched-pattern -- scripts/verify-pr-hosted-gates.mjs test/scripts/verify-pr-hosted-gates.test.ts` - passed
- `git diff --check` - passed
- Production LOC: +15/-8; tests: +104/-8
