### PR TITLE
fix(codex): keep Slack turns running when a plugin is disabled

### DIFF
--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -20,6 +20,7 @@ import {
   type RpcRequest,
   type RpcResponse,
 } from "./protocol.js";
+import { CodexAppServerRpcError } from "./rpc-error.js";
 import { createStdioTransport } from "./transport-stdio.js";
 import { createWebSocketTransport } from "./transport-websocket.js";
 import {
@@ -66,20 +67,7 @@ export function resolveCodexAppServerClientInstanceId(client: object): string {
   return getInstanceId?.call(client) ?? getCodexAppServerClientInstanceId(client);
 }
 
-/** RPC error wrapper that preserves app-server error code and data. */
-export class CodexAppServerRpcError extends Error {
-  readonly code?: number;
-  readonly data?: JsonValue;
-  readonly method: string;
-
-  constructor(error: { code?: number; message: string; data?: JsonValue }, method: string) {
-    super(formatCodexAppServerRpcErrorMessage(error, method));
-    this.name = "CodexAppServerRpcError";
-    this.code = error.code;
-    this.data = error.data;
-    this.method = method;
-  }
-}
+export { CodexAppServerRpcError } from "./rpc-error.js";
 
 class CodexAppServerLocalRequestCancellationError extends Error {
   readonly code = "CODEX_APP_SERVER_LOCAL_REQUEST_CANCELLED";
@@ -165,32 +153,6 @@ export function isCodexAppServerIndeterminateTransportError(error: unknown): err
     "mayHaveWritten" in error &&
     error.mayHaveWritten === true
   );
-}
-
-function formatCodexAppServerRpcErrorMessage(
-  error: { message: string; data?: JsonValue },
-  method: string,
-): string {
-  const message = error.message || `${method} failed`;
-  const detail = readCodexAppServerRpcReloginDetail(error.data);
-  return detail && !message.includes(detail) ? `${message}: ${detail}` : message;
-}
-
-function readCodexAppServerRpcReloginDetail(data: JsonValue | undefined): string | undefined {
-  const record = isJsonObject(data) ? data : undefined;
-  const nested = isJsonObject(record?.error) ? record.error : record;
-  if (!nested) {
-    return undefined;
-  }
-  const isRelogin =
-    nested.action === "relogin" ||
-    (nested.reason === "cloudRequirements" && nested.errorCode === "Auth");
-  const detail = typeof nested.detail === "string" ? nested.detail.trim() : "";
-  return isRelogin && detail ? detail : undefined;
-}
-
-function isJsonObject(value: unknown): value is { [key: string]: JsonValue } {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 /** Returns true for errors that mean the app-server transport is closed. */

--- a/extensions/codex/src/app-server/plugin-activation.test.ts
+++ b/extensions/codex/src/app-server/plugin-activation.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover plugin activation plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { CodexAppInventoryCache } from "./app-inventory-cache.js";
+import { CodexAppServerRpcError } from "./client.js";
 import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
@@ -297,6 +298,82 @@ describe("Codex plugin activation", () => {
       "hooks/list",
       "config/mcpServer/reload",
     ]);
+  });
+
+  it("converts an admin-disabled remote plugin install rejection into an activation failure", async () => {
+    const calls: string[] = [];
+    const remoteSummary = pluginSummary("google-calendar@openai-curated-remote", {
+      name: "google-calendar",
+      remotePluginId: "plugin_connector_google_calendar",
+      installed: false,
+      enabled: false,
+    });
+    const result = await ensureCodexPluginActivation({
+      identity: identity("google-calendar"),
+      request: async (method, params) => {
+        calls.push(method);
+        if (method === "plugin/list") {
+          return {
+            marketplaces: [
+              {
+                name: "openai-curated-remote",
+                path: null,
+                interface: null,
+                plugins: [remoteSummary],
+              },
+            ],
+            marketplaceLoadErrors: [],
+            featuredPluginIds: [],
+          } satisfies v2.PluginListResponse;
+        }
+        if (method === "plugin/install") {
+          expect(params).toEqual({
+            remoteMarketplaceName: "openai-curated-remote",
+            pluginName: "plugin_connector_google_calendar",
+          });
+          throw new CodexAppServerRpcError(
+            {
+              code: -32600,
+              message: "remote plugin plugin_connector_google_calendar is disabled by admin",
+            },
+            "plugin/install",
+          );
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expectActivationResult(result, {
+      ok: false,
+      reason: "install_failed",
+      installAttempted: true,
+    });
+    expect(result.diagnostics).toEqual([
+      {
+        message:
+          "Codex plugin install failed: remote plugin plugin_connector_google_calendar is disabled by admin",
+      },
+    ]);
+    expect(calls).toEqual(["plugin/list", "plugin/install"]);
+  });
+
+  it("does not hide non-RPC plugin install failures", async () => {
+    await expect(
+      ensureCodexPluginActivation({
+        identity: identity("google-calendar"),
+        request: async (method) => {
+          if (method === "plugin/list") {
+            return pluginList([
+              pluginSummary("google-calendar", { installed: false, enabled: false }),
+            ]);
+          }
+          if (method === "plugin/install") {
+            throw new Error("plugin/install transport failed");
+          }
+          throw new Error(`unexpected request ${method}`);
+        },
+      }),
+    ).rejects.toThrow("plugin/install transport failed");
   });
 
   it("does not install a remote curated plugin without its opaque remote id", async () => {

--- a/extensions/codex/src/app-server/plugin-activation.test.ts
+++ b/extensions/codex/src/app-server/plugin-activation.test.ts
@@ -300,61 +300,117 @@ describe("Codex plugin activation", () => {
     ]);
   });
 
-  it("converts an admin-disabled remote plugin install rejection into an activation failure", async () => {
-    const calls: string[] = [];
+  it.each([
+    {
+      rejectionMessage: "remote plugin plugin_connector_google_calendar is disabled by admin",
+    },
+    {
+      rejectionMessage:
+        "remote plugin plugin_connector_google_calendar is not available for install",
+    },
+  ])(
+    "converts an exact terminal remote plugin rejection into an activation failure ($rejectionMessage)",
+    async ({ rejectionMessage }) => {
+      const calls: string[] = [];
+      const remoteSummary = pluginSummary("google-calendar@openai-curated-remote", {
+        name: "google-calendar",
+        remotePluginId: "plugin_connector_google_calendar",
+        installed: false,
+        enabled: false,
+        availability: "AVAILABLE",
+        installPolicy: "AVAILABLE",
+      });
+      const result = await ensureCodexPluginActivation({
+        identity: identity("google-calendar"),
+        request: async (method, params) => {
+          calls.push(method);
+          if (method === "plugin/list") {
+            return {
+              marketplaces: [
+                {
+                  name: "openai-curated-remote",
+                  path: null,
+                  interface: null,
+                  plugins: [remoteSummary],
+                },
+              ],
+              marketplaceLoadErrors: [],
+              featuredPluginIds: [],
+            } satisfies v2.PluginListResponse;
+          }
+          if (method === "plugin/install") {
+            expect(params).toEqual({
+              remoteMarketplaceName: "openai-curated-remote",
+              pluginName: "plugin_connector_google_calendar",
+            });
+            throw new CodexAppServerRpcError(
+              {
+                code: -32600,
+                message: rejectionMessage,
+              },
+              "plugin/install",
+            );
+          }
+          throw new Error(`unexpected request ${method}`);
+        },
+      });
+
+      expectActivationResult(result, {
+        ok: false,
+        reason: "install_failed",
+        installAttempted: true,
+      });
+      expect(result.diagnostics).toEqual([
+        {
+          message: `Codex plugin install failed: ${rejectionMessage}`,
+        },
+      ]);
+      expect(calls).toEqual(["plugin/list", "plugin/install"]);
+    },
+  );
+
+  it.each([
+    {
+      code: -32_001,
+      message: "remote plugin plugin_connector_google_calendar is disabled by admin",
+    },
+    { code: -32_600, message: "plugin service temporarily unavailable" },
+  ])("does not hide unrelated plugin install RPC failures ($code)", async ({ code, message }) => {
+    const error = new CodexAppServerRpcError({ code, message }, "plugin/install");
     const remoteSummary = pluginSummary("google-calendar@openai-curated-remote", {
       name: "google-calendar",
       remotePluginId: "plugin_connector_google_calendar",
       installed: false,
       enabled: false,
-    });
-    const result = await ensureCodexPluginActivation({
-      identity: identity("google-calendar"),
-      request: async (method, params) => {
-        calls.push(method);
-        if (method === "plugin/list") {
-          return {
-            marketplaces: [
-              {
-                name: "openai-curated-remote",
-                path: null,
-                interface: null,
-                plugins: [remoteSummary],
-              },
-            ],
-            marketplaceLoadErrors: [],
-            featuredPluginIds: [],
-          } satisfies v2.PluginListResponse;
-        }
-        if (method === "plugin/install") {
-          expect(params).toEqual({
-            remoteMarketplaceName: "openai-curated-remote",
-            pluginName: "plugin_connector_google_calendar",
-          });
-          throw new CodexAppServerRpcError(
-            {
-              code: -32600,
-              message: "remote plugin plugin_connector_google_calendar is disabled by admin",
-            },
-            "plugin/install",
-          );
-        }
-        throw new Error(`unexpected request ${method}`);
-      },
+      availability: "DISABLED_BY_ADMIN",
+      installPolicy: "NOT_AVAILABLE",
     });
 
-    expectActivationResult(result, {
-      ok: false,
-      reason: "install_failed",
-      installAttempted: true,
-    });
-    expect(result.diagnostics).toEqual([
-      {
-        message:
-          "Codex plugin install failed: remote plugin plugin_connector_google_calendar is disabled by admin",
-      },
-    ]);
-    expect(calls).toEqual(["plugin/list", "plugin/install"]);
+    await expect(
+      ensureCodexPluginActivation({
+        identity: identity("google-calendar"),
+        request: async (method) => {
+          if (method === "plugin/list") {
+            return {
+              marketplaces: [
+                {
+                  name: "openai-curated-remote",
+                  path: null,
+                  interface: null,
+                  plugins: [remoteSummary],
+                },
+              ],
+              marketplaceLoadErrors: [],
+              featuredPluginIds: [],
+            } satisfies v2.PluginListResponse;
+          }
+          if (method === "plugin/install") {
+            throw error;
+          }
+          throw new Error(`unexpected request ${method}`);
+        },
+      }),
+    ).rejects.toBe(error);
   });
 
   it("does not hide non-RPC plugin install failures", async () => {

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -3,6 +3,7 @@
  * marketplaces outside OpenClaw's install authority.
  */
 import type { CodexAppInventoryCache, CodexAppInventoryRequest } from "./app-inventory-cache.js";
+import { CodexAppServerRpcError } from "./client.js";
 import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
@@ -25,6 +26,7 @@ type CodexPluginActivationReason =
   | "disabled"
   | "marketplace_missing"
   | "plugin_missing"
+  | "install_failed"
   | "auth_required"
   | "refresh_failed";
 
@@ -104,15 +106,38 @@ export async function ensureCodexPluginActivation(
     };
   }
 
-  const installResponse = (await params.request(
-    "plugin/install",
-    pluginReadParams(
-      resolved.marketplace,
-      resolved.marketplace.remoteMarketplaceName && resolved.summary.remotePluginId
-        ? resolved.summary.remotePluginId
-        : params.identity.pluginName,
-    ) satisfies v2.PluginInstallParams,
-  )) as v2.PluginInstallResponse;
+  let installResponse: v2.PluginInstallResponse;
+  try {
+    installResponse = (await params.request(
+      "plugin/install",
+      pluginReadParams(
+        resolved.marketplace,
+        resolved.marketplace.remoteMarketplaceName && resolved.summary.remotePluginId
+          ? resolved.summary.remotePluginId
+          : params.identity.pluginName,
+      ) satisfies v2.PluginInstallParams,
+    )) as v2.PluginInstallResponse;
+  } catch (error) {
+    if (!(error instanceof CodexAppServerRpcError)) {
+      throw error;
+    }
+    // An application-level install rejection belongs to this plugin. Keep the
+    // plugin fail-closed without aborting setup for the thread's other apps.
+    return {
+      identity: params.identity,
+      ok: false,
+      reason: "install_failed",
+      installAttempted: true,
+      marketplace: resolved.marketplace,
+      diagnostics: [
+        {
+          message: `Codex plugin install failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        },
+      ],
+    };
+  }
   if (params.metadataCache && params.appCacheKey) {
     params.metadataCache.invalidate(params.appCacheKey);
   }

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -3,7 +3,6 @@
  * marketplaces outside OpenClaw's install authority.
  */
 import type { CodexAppInventoryCache, CodexAppInventoryRequest } from "./app-inventory-cache.js";
-import { CodexAppServerRpcError } from "./client.js";
 import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
@@ -18,6 +17,7 @@ import {
 } from "./plugin-inventory.js";
 import type { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import type { CodexAppServerRequestResult, v2 } from "./protocol.js";
+import { CodexAppServerRpcError } from "./rpc-error.js";
 
 /** Terminal reason reported after trying to activate one Codex plugin policy. */
 type CodexPluginActivationReason =

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -106,23 +106,30 @@ export async function ensureCodexPluginActivation(
     };
   }
 
+  const remotePluginId = resolved.marketplace.remoteMarketplaceName
+    ? resolved.summary.remotePluginId
+    : undefined;
   let installResponse: v2.PluginInstallResponse;
   try {
     installResponse = (await params.request(
       "plugin/install",
       pluginReadParams(
         resolved.marketplace,
-        resolved.marketplace.remoteMarketplaceName && resolved.summary.remotePluginId
-          ? resolved.summary.remotePluginId
-          : params.identity.pluginName,
+        remotePluginId ?? params.identity.pluginName,
       ) satisfies v2.PluginInstallParams,
     )) as v2.PluginInstallResponse;
   } catch (error) {
-    if (!(error instanceof CodexAppServerRpcError)) {
+    if (
+      !(error instanceof CodexAppServerRpcError) ||
+      error.code !== -32600 ||
+      !remotePluginId ||
+      (error.message !== `remote plugin ${remotePluginId} is disabled by admin` &&
+        error.message !== `remote plugin ${remotePluginId} is not available for install`)
+    ) {
       throw error;
     }
-    // An application-level install rejection belongs to this plugin. Keep the
-    // plugin fail-closed without aborting setup for the thread's other apps.
+    // The catalog can be stale by install time. Isolate only Codex's exact
+    // terminal remote-install contract; unrelated RPC failures abort the turn.
     return {
       identity: params.identity,
       ok: false,

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppInventoryCache, defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import { codexAppInventoryResponse } from "./app-inventory.test-helpers.js";
+import { CodexAppServerRpcError } from "./client.js";
 import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
@@ -2302,6 +2303,119 @@ describe("Codex plugin thread config", () => {
     expect(config.diagnostics[0]?.message).toBe(
       "Codex plugin runtime refresh failed after install: skills/list unavailable",
     );
+  });
+
+  it("isolates an admin-disabled remote plugin and keeps unaffected plugin apps available", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async (method, params) =>
+        codexAppInventoryResponse(
+          method,
+          [appInfo("calendar-app", true), appInfo("github-app", true)],
+          params,
+        ),
+    });
+    const calendar = pluginSummary("calendar@openai-curated-remote", {
+      name: "calendar",
+      remotePluginId: "plugins~Plugin_calendar",
+      installed: false,
+      enabled: false,
+      availability: "DISABLED_BY_ADMIN",
+    });
+    const github = pluginSummary("github@openai-curated-remote", {
+      name: "github",
+      remotePluginId: "plugins~Plugin_github",
+      installed: true,
+      enabled: true,
+    });
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config/read") {
+        return { config: {}, layers: [] };
+      }
+      if (method === "plugin/installed" || method === "plugin/list") {
+        return method === "plugin/installed"
+          ? pluginInstalled([calendar, github], { name: "openai-curated-remote", path: null })
+          : pluginList([calendar, github], { name: "openai-curated-remote", path: null });
+      }
+      if (method === "plugin/read") {
+        const pluginName = (params as v2.PluginReadParams).pluginName;
+        return pluginName === "plugins~Plugin_calendar"
+          ? pluginDetail("calendar", [appSummary("calendar-app")], [], {
+              marketplaceName: "openai-curated-remote",
+              marketplacePath: null,
+            })
+          : pluginDetail("github", [appSummary("github-app")], ["github"], {
+              marketplaceName: "openai-curated-remote",
+              marketplacePath: null,
+            });
+      }
+      if (method === "plugin/install") {
+        expect(params).toEqual({
+          remoteMarketplaceName: "openai-curated-remote",
+          pluginName: "plugins~Plugin_calendar",
+        });
+        throw new CodexAppServerRpcError(
+          {
+            code: -32600,
+            message: "remote plugin plugins~Plugin_calendar is disabled by admin",
+          },
+          "plugin/install",
+        );
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            calendar: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "calendar",
+              allow_destructive_actions: false,
+            },
+            github: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "github",
+              allow_destructive_actions: "ask",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request,
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+        "github-app": {
+          enabled: true,
+          destructive_enabled: true,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
+          approvals_reviewer: "user",
+        },
+      },
+    });
+    expect(config.provisionalAppIds).toEqual(["github-app"]);
+    expect(config.policyContext.pluginAppIds).toEqual({ github: ["github-app"] });
+    expect(config.policyContext.apps).not.toHaveProperty("calendar-app");
+    expect(config.diagnostics).toContainEqual({
+      code: "plugin_activation_failed",
+      plugin: expect.objectContaining({ configKey: "calendar", pluginName: "calendar" }),
+      message:
+        "Codex plugin install failed: remote plugin plugins~Plugin_calendar is disabled by admin",
+    });
   });
 
   it("fails closed when the initial app inventory refresh fails", async () => {

--- a/extensions/codex/src/app-server/rpc-error.ts
+++ b/extensions/codex/src/app-server/rpc-error.ts
@@ -1,0 +1,42 @@
+import type { JsonValue } from "./protocol.js";
+
+/** RPC error wrapper that preserves app-server error code and data. */
+export class CodexAppServerRpcError extends Error {
+  readonly code?: number;
+  readonly data?: JsonValue;
+  readonly method: string;
+
+  constructor(error: { code?: number; message: string; data?: JsonValue }, method: string) {
+    super(formatCodexAppServerRpcErrorMessage(error, method));
+    this.name = "CodexAppServerRpcError";
+    this.code = error.code;
+    this.data = error.data;
+    this.method = method;
+  }
+}
+
+function formatCodexAppServerRpcErrorMessage(
+  error: { message: string; data?: JsonValue },
+  method: string,
+): string {
+  const message = error.message || `${method} failed`;
+  const detail = readCodexAppServerRpcReloginDetail(error.data);
+  return detail && !message.includes(detail) ? `${message}: ${detail}` : message;
+}
+
+function readCodexAppServerRpcReloginDetail(data: JsonValue | undefined): string | undefined {
+  const record = isJsonObject(data) ? data : undefined;
+  const nested = isJsonObject(record?.error) ? record.error : record;
+  if (!nested) {
+    return undefined;
+  }
+  const isRelogin =
+    nested.action === "relogin" ||
+    (nested.reason === "cloudRequirements" && nested.errorCode === "Auth");
+  const detail = typeof nested.detail === "string" ? nested.detail.trim() : "";
+  return isRelogin && detail ? detail : undefined;
+}
+
+function isJsonObject(value: unknown): value is { [key: string]: JsonValue } {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/extensions/codex/src/migration/apply-report.ts
+++ b/extensions/codex/src/migration/apply-report.ts
@@ -13,6 +13,7 @@ export function codexPluginActivationReportState(result: CodexPluginActivationRe
     case "auth_required":
       return { installed: true, enabled: false };
     case "disabled":
+    case "install_failed":
     case "marketplace_missing":
     case "plugin_missing":
       return { installed: false, enabled: false };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Slack conversation could stop before the ordinary model turn when one configured remote Codex plugin was rejected as disabled by an administrator.

## Why This Change Was Made

The two terminal remote-install rejections defined by the Codex protocol are now recorded as a failure for that plugin instead of escaping the thread-config build. Classification requires the typed RPC error, code `-32600`, the opaque remote plugin ID, and the exact upstream disabled-by-admin or not-available message. Unrelated RPC and transport failures still propagate. The failed plugin remains unavailable while existing default-deny app policy, destructive-action controls, exact-thread app attestation, and unrelated active plugins continue through the canonical startup path.

## User Impact

Users can continue a normal Slack conversation when an optional configured remote plugin is administratively disabled. That plugin and its apps remain unavailable, while unaffected configured plugins can still be used.

## Evidence

- Added focused activation regressions for both upstream terminal `-32600` rejections, including stale `AVAILABLE` inventory, plus guards proving unrelated `-32600`, other RPC codes, and non-RPC transport failures still propagate.
- Added a multi-plugin thread-config regression proving the failed app is omitted, the unaffected app remains enabled, default deny remains in force, destructive approvals remain user-reviewed, and only the unaffected app is provisionally attested.
- Added a guard regression proving non-RPC transport failures still propagate.
- Verified the upstream Codex contract at [`plugins.rs:1625-1633`](https://github.com/openai/codex/blob/204389afcc09301945f0b81a418ffd6145b8dadb/codex-rs/app-server/src/request_processors/plugins.rs#L1625-L1633): disabled-by-admin and not-available install attempts are final invalid-request RPC rejections. Its regression at [`plugin_install.rs:595-645`](https://github.com/openai/codex/blob/204389afcc09301945f0b81a418ffd6145b8dadb/codex-rs/app-server/tests/suite/v2/plugin_install.rs#L595-L645) pins code `-32600` and proves no bundle download or install request occurs.
- Kept the boundary deliberately narrow: only exact terminal remote `plugin/install` rejections become per-plugin diagnostics, while unrelated RPC, transport, and cancellation failures still abort startup.
- `git diff --check` passed.
- Three-file `oxfmt --check` passed using the existing read-only formatter binary after the linked-worktree hook reported no local `node_modules`.
- Structured autoreview passed its TruffleHog scan and reported no accepted/actionable findings.
- Initial exact-head CI caught the missing exhaustive migration-report mapping for `install_failed`; that sibling consumer is now updated and its one-line follow-up passed formatter and autoreview checks.
- Initial CI also exposed an import-order regression from importing the full app-server client only for its RPC error class. The class now lives in a lightweight owner module and remains re-exported from `client.ts`; the three previously failing hook/context files pass locally.
- Local focused Vitest passed 170/170 tests across the two changed regression files, the three import-order regression files, and `client.test.ts` under Node `24.15.0`.
- Previous-head GitHub CI at `62ae67d525a9b0706706aa7b789dce631c1b0d46` completed green, including the full compact Node matrix, production/test types, lint, security, dependency, and boundary checks. Exact-head CI is running for `6ec8b63d334c62da61f07269f9a9dad8595512e3`.
- Exact-head focused Vitest passed 75/75, `pnpm build` passed, `git diff --check` passed, structured autoreview was clean, and an independent repair review found no actionable issue.
- A foreground local Gateway proof on exact-head source injected the upstream-shaped disabled-by-admin RPC rejection and completed the same Slack-context run while hiding Calendar and retaining GitHub plus its approval policy.

## Real behavior proof

- Behavior or issue addressed: A configured remote Codex plugin rejected by `plugin/install` as disabled by admin no longer aborts thread configuration or prevents the ordinary Slack-context model turn; the rejected plugin remains fail-closed and unaffected plugins remain available.
- Real environment tested: The patched branch ran in an isolated temporary OpenClaw workspace on macOS under supported Node `24.15.0`. A foreground local Gateway used the real Codex harness and a stdio app-server fixture that advertised Calendar as `DISABLED_BY_ADMIN`, returned JSON-RPC `-32600` from `plugin/install`, and kept GitHub active. The agent command selected `--channel slack` without delivering to a real Slack workspace.
- Exact steps or command run after this patch: Created a fresh isolated workspace with `.mem/integ/scripts/setup_tmp_integ_workspace.mjs disabled-admin-plugin-e2e-p2 --port 19895`; started exact-head `pnpm openclaw gateway --port 19895 --bind loopback --allow-unconfigured` in the foreground with the isolated config; ran exact-head `pnpm openclaw agent --agent main --session-key agent:main:disabled-admin-plugin-e2e-p2 --channel slack --message "Reply exactly: E2E_DISABLED_PLUGIN_TURN_CONTINUED" --json`; ran the proof-local transcript validator.
- Evidence after fix: The app-server transcript records `plugin/install`, the `-32600` disabled-by-admin response, then `thread/start`, app attestation, `turn/start`, and `turn/completed` in that order. The actual `thread/start` apps config contains `_default` with normal, destructive, and open-world access disabled; contains `github-app` with `approvals_reviewer=user`; and does not contain `calendar-app`. The gateway agent command returned status `ok` and text `E2E_DISABLED_PLUGIN_TURN_CONTINUED`. All eight deterministic proof assertions passed.
- Observed result after fix: The disabled Calendar activation was isolated, Calendar and its app were not exposed, GitHub remained available with destructive actions requiring user review, default-deny remained intact, exact-thread app attestation ran, and the ordinary model turn completed. The foreground gateway was stopped after capture.
- What was not tested: No message was delivered through a real Slack workspace, and the real Codex app-server was not connected to an administrator-disabled tenant. The injected JSON-RPC shape is pinned to the inspected upstream Codex contract.
