### PR TITLE
fix(ci): align hosted gates with workflow applicability

### DIFF
--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -8,6 +8,7 @@ on:
         description: "Testbox session ID"
         required: true
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - ".github/workflows/**"
 

--- a/.github/workflows/ci-check-arm-testbox.yml
+++ b/.github/workflows/ci-check-arm-testbox.yml
@@ -7,6 +7,7 @@ on:
         description: "Testbox session ID"
         required: true
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - ".github/workflows/**"
 

--- a/scripts/verify-pr-hosted-gates.d.mts
+++ b/scripts/verify-pr-hosted-gates.d.mts
@@ -12,6 +12,7 @@ export function parseWorkflowRunPage(raw: unknown): {
   workflowRuns: unknown;
 };
 export function workflowRunPageCount(totalCount: unknown): number;
+export function notApplicableScheduledHostedWorkflows(changedPaths: string[]): string[];
 export function collectHostedGateEvidence({
   sha,
   pr,
@@ -21,6 +22,7 @@ export function collectHostedGateEvidence({
   pullRequestHeadRepository,
   workflowRuns,
   ciGateJobs,
+  notApplicableScheduledWorkflows,
   changelogOnly,
   nowMs,
 }: {
@@ -32,6 +34,7 @@ export function collectHostedGateEvidence({
   pullRequestHeadRepository?: string;
   workflowRuns: Array<Record<string, unknown>>;
   ciGateJobs?: Array<Record<string, unknown>>;
+  notApplicableScheduledWorkflows?: string[];
   changelogOnly?: boolean | undefined;
   nowMs?: number | undefined;
 }): {
@@ -54,6 +57,7 @@ export function collectHostedGateEvidence({
     coveredBy: string;
     reason: string;
   }[];
+  notApplicableWorkflows?: string[];
 };
 export function compareCommitPageCount(totalCommits: number): number;
 export function workflowRunQueryPaths(

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -1,17 +1,20 @@
 #!/usr/bin/env node
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { minimatch } from "minimatch";
+import { parse } from "yaml";
 import { booleanFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mjs";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { execGhApiRead, plainGhEnv } from "./lib/plain-gh.mjs";
 
-export const SCHEDULED_HOSTED_WORKFLOWS = [
-  "Blacksmith Testbox",
-  "Blacksmith ARM Testbox",
-  "Blacksmith Build Artifacts Testbox",
-  "Workflow Sanity",
-];
+const SCHEDULED_HOSTED_WORKFLOW_PATHS = new Map([
+  ["Blacksmith Testbox", ".github/workflows/ci-check-testbox.yml"],
+  ["Blacksmith ARM Testbox", ".github/workflows/ci-check-arm-testbox.yml"],
+  ["Blacksmith Build Artifacts Testbox", ".github/workflows/ci-build-artifacts-testbox.yml"],
+  ["Workflow Sanity", ".github/workflows/workflow-sanity.yml"],
+]);
+export const SCHEDULED_HOSTED_WORKFLOWS = [...SCHEDULED_HOSTED_WORKFLOW_PATHS.keys()];
 const CI_WORKFLOW_PATH = ".github/workflows/ci.yml";
 const BUILD_ARTIFACTS_WORKFLOW = "Blacksmith Build Artifacts Testbox";
 const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
@@ -31,6 +34,7 @@ const HOSTED_GATE_CLOCK_SKEW_MS = 5 * 60 * 1_000;
 const MAX_CI_REUSE_CANDIDATES = 5;
 const CI_REUSE_RUN_LIST_LIMIT = 50;
 const GIT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+const PATH_GLOB_OPTIONS = { dot: true, nocomment: true, nonegate: true };
 
 export function parseArgs(argv) {
   const args = {
@@ -85,6 +89,56 @@ export function parseArgs(argv) {
     );
   }
   return args;
+}
+
+function matchesOrderedPathPatterns(changedPath, patterns) {
+  let included = false;
+  for (const declaredPattern of patterns ?? []) {
+    const excluded = declaredPattern.startsWith("!");
+    const pattern = excluded ? declaredPattern.slice(1) : declaredPattern;
+    if (minimatch(changedPath, pattern, PATH_GLOB_OPTIONS)) {
+      included = !excluded;
+    }
+  }
+  return included;
+}
+
+function pullRequestPathFilterApplies(pullRequest, changedPaths) {
+  if (changedPaths.length === 0) {
+    return false;
+  }
+  const includedPatterns = pullRequest.paths ?? [];
+  if (includedPatterns.length > 0) {
+    return changedPaths.some((changedPath) =>
+      matchesOrderedPathPatterns(changedPath, includedPatterns),
+    );
+  }
+  const ignoredPatterns = pullRequest["paths-ignore"] ?? [];
+  if (ignoredPatterns.length > 0) {
+    return changedPaths.some((changedPath) =>
+      ignoredPatterns.every((pattern) => !minimatch(changedPath, pattern, PATH_GLOB_OPTIONS)),
+    );
+  }
+  return true;
+}
+
+export function notApplicableScheduledHostedWorkflows(changedPaths) {
+  return [...SCHEDULED_HOSTED_WORKFLOW_PATHS]
+    .filter(([expectedName, workflowPath]) => {
+      const workflow = parse(readFileSync(workflowPath, "utf8"));
+      if (workflow?.name !== expectedName) {
+        throw new Error(`${workflowPath} must declare workflow name ${expectedName}.`);
+      }
+      if (!Object.hasOwn(workflow?.on ?? {}, "pull_request")) {
+        throw new Error(`${workflowPath} must declare a pull_request trigger.`);
+      }
+      const pullRequest = workflow.on.pull_request ?? {};
+      if (Object.hasOwn(pullRequest, "branches") || Object.hasOwn(pullRequest, "branches-ignore")) {
+        throw new Error(`${workflowPath} pull_request branch filters are not supported.`);
+      }
+      return !pullRequestPathFilterApplies(pullRequest, changedPaths);
+    })
+    .map(([workflowName]) => workflowName);
 }
 
 function formatObservedRuns(runs) {
@@ -406,12 +460,21 @@ function runBelongsToPullRequest(
   );
 }
 
-function canCoverQueuedBuildArtifacts(workflowRuns, sha, nowMs) {
+function canCoverQueuedBuildArtifacts(
+  workflowRuns,
+  sha,
+  nowMs,
+  notApplicableScheduledWorkflowNames,
+) {
   if (!hasSuccessfulRecentReleaseGate(workflowRuns, sha, nowMs)) {
     return false;
   }
   const supportingGatesPassed = ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS.every((workflowName) => {
-    const run = latestRun(matchingAuthoritativeRuns(workflowRuns, workflowName, sha, false));
+    const matchingRuns = matchingAuthoritativeRuns(workflowRuns, workflowName, sha, false);
+    if (matchingRuns.length === 0 && notApplicableScheduledWorkflowNames?.has(workflowName)) {
+      return true;
+    }
+    const run = latestRun(matchingRuns);
     return isSuccessfulRecentRun(run, nowMs);
   });
   if (!supportingGatesPassed) {
@@ -465,12 +528,17 @@ export function collectHostedGateEvidence({
   ciGateJobs = [],
   loadCiReuseCandidates = () => [],
   execGit = runGit,
+  notApplicableScheduledWorkflows,
   changelogOnly = false,
   nowMs = Date.now(),
 }) {
   if (!Array.isArray(workflowRuns)) {
     throw new Error("workflowRuns must be an array.");
   }
+  const notApplicableScheduledWorkflowNames =
+    notApplicableScheduledWorkflows === undefined
+      ? undefined
+      : new Set(notApplicableScheduledWorkflows);
   const pullRequestCommitShaSet = new Set(pullRequestCommitShas);
 
   const collectForSha = (
@@ -497,13 +565,23 @@ export function collectHostedGateEvidence({
         evidenceSha,
         allowManual,
       );
-      if (matchingRuns.length === 0 && !requiredScheduledWorkflows.has(workflowName)) {
+      if (
+        matchingRuns.length === 0 &&
+        !requiredScheduledWorkflows.has(workflowName) &&
+        (notApplicableScheduledWorkflowNames === undefined ||
+          notApplicableScheduledWorkflowNames.has(workflowName))
+      ) {
         continue;
       }
       if (
         allowManual &&
         workflowName === BUILD_ARTIFACTS_WORKFLOW &&
-        canCoverQueuedBuildArtifacts(workflowRuns, evidenceSha, nowMs)
+        canCoverQueuedBuildArtifacts(
+          workflowRuns,
+          evidenceSha,
+          nowMs,
+          notApplicableScheduledWorkflowNames,
+        )
       ) {
         fallbackCoveredWorkflows.push({
           name: workflowName,
@@ -562,6 +640,8 @@ export function collectHostedGateEvidence({
     const targetScheduledWorkflows = new Set(
       SCHEDULED_HOSTED_WORKFLOWS.filter(
         (workflowName) =>
+          (notApplicableScheduledWorkflowNames !== undefined &&
+            !notApplicableScheduledWorkflowNames.has(workflowName)) ||
           matchingAuthoritativeRuns(workflowRuns, workflowName, sha, false).length > 0,
       ),
     );
@@ -631,6 +711,13 @@ export function collectHostedGateEvidence({
   }
   if (selected.fallbackCoveredWorkflows.length > 0) {
     evidence.fallbackCoveredWorkflows = selected.fallbackCoveredWorkflows;
+  }
+  const notApplicableWorkflows = (notApplicableScheduledWorkflows ?? []).filter(
+    (workflowName) =>
+      matchingAuthoritativeRuns(workflowRuns, workflowName, sha, false).length === 0,
+  );
+  if (notApplicableWorkflows.length > 0) {
+    evidence.notApplicableWorkflows = notApplicableWorkflows;
   }
   return evidence;
 }
@@ -761,6 +848,13 @@ function loadPullRequestCommitShas(repo, { baseSha, headSha }) {
   return shas;
 }
 
+function loadPullRequestChangedPaths(baseSha, headSha) {
+  return runGit(["diff", "--name-only", `${baseSha}...${headSha}`])
+    .trim()
+    .split(/\r?\n/u)
+    .filter(Boolean);
+}
+
 function loadCiGateJobs(repo, workflowRuns, sha, nowMs = Date.now()) {
   // Only an in-progress exact-head CI run can benefit from gate proof.
   const candidates = workflowRuns.filter(
@@ -834,6 +928,7 @@ function main(argv = process.argv.slice(2)) {
   if (headSha !== args.sha) {
     throw new Error(`PR #${args.pr} head changed from ${args.sha} to ${headSha}.`);
   }
+  const changedPaths = loadPullRequestChangedPaths(baseSha, headSha);
   const workflowRuns = loadWorkflowRuns(args.repo, args.sha, args.recentSha, headBranch);
   const evidence = collectHostedGateEvidence({
     sha: args.sha,
@@ -845,6 +940,7 @@ function main(argv = process.argv.slice(2)) {
     workflowRuns,
     ciGateJobs: loadCiGateJobs(args.repo, workflowRuns, args.sha),
     loadCiReuseCandidates: () => loadCiReuseCandidateRuns(args.repo, headBranch),
+    notApplicableScheduledWorkflows: notApplicableScheduledHostedWorkflows(changedPaths),
     changelogOnly: args.changelogOnly,
   });
   const evidenceHeadSha = evidence.evidenceHeadSha ?? args.sha;
@@ -879,7 +975,11 @@ function main(argv = process.argv.slice(2)) {
   console.log(
     `Hosted gates passed for PR #${args.pr} at ${args.sha} using ${evidenceHeadSha}: ${manifest.workflows
       .map((workflow) => `${workflow.name}#${workflow.id}`)
-      .join(", ")}`,
+      .join(", ")}${
+      manifest.notApplicableWorkflows?.length
+        ? `; not applicable: ${manifest.notApplicableWorkflows.join(", ")}`
+        : ""
+    }`,
   );
 }
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1302,6 +1302,25 @@ NODE
     });
   });
 
+  it("keeps every path-filtered hosted gate runnable on landing-relevant events", () => {
+    const workflows = [
+      [".github/workflows/ci-check-testbox.yml", "check"],
+      [".github/workflows/ci-check-arm-testbox.yml", "check-arm"],
+      [".github/workflows/ci-build-artifacts-testbox.yml", "build-artifacts"],
+    ] as const;
+
+    for (const [workflowPath, jobName] of workflows) {
+      const workflow = readWorkflow(workflowPath);
+      expect(workflow.on.pull_request).toEqual({
+        types: ["opened", "reopened", "synchronize", "ready_for_review"],
+        paths: [".github/workflows/**"],
+      });
+      expect(workflow.jobs[jobName].if).toBe(
+        "${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}",
+      );
+    }
+  });
+
   it("pins every external GitHub Action reference to a full commit SHA", () => {
     expect(findUnpinnedExternalActions()).toEqual([]);
   });

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -4,6 +4,7 @@ import {
   collectHostedGateEvidence as collectHostedGateEvidenceRaw,
   compareCommitPageCount,
   HOSTED_GATE_MAX_AGE_HOURS,
+  notApplicableScheduledHostedWorkflows,
   parseArgs,
   parseWorkflowRunPage,
   SCHEDULED_HOSTED_WORKFLOWS,
@@ -173,6 +174,82 @@ function patchReuseOptions(
 }
 
 describe("verify-pr-hosted-gates", () => {
+  it("derives hosted-gate applicability from declared workflow path filters", () => {
+    expect(notApplicableScheduledHostedWorkflows([".github/workflows/ci.yml"])).toEqual([]);
+    expect(
+      notApplicableScheduledHostedWorkflows(["test/e2e/qa-lab/runtime/script-evidence.ts"]),
+    ).toEqual([
+      "Blacksmith Testbox",
+      "Blacksmith ARM Testbox",
+      "Blacksmith Build Artifacts Testbox",
+    ]);
+    expect(notApplicableScheduledHostedWorkflows(["CHANGELOG.md"])).toEqual(
+      SCHEDULED_HOSTED_WORKFLOWS,
+    );
+  });
+
+  it("requires an authoritative ARM run when declared workflow paths apply", () => {
+    const workflowRuns = [
+      successfulRun("CI", 1, "2026-06-17T10:47:00Z"),
+      successfulRun("Blacksmith Testbox", 2, "2026-06-17T10:48:00Z"),
+      successfulRun("Blacksmith Build Artifacts Testbox", 3, "2026-06-17T10:49:00Z"),
+      successfulRun("Workflow Sanity", 4, "2026-06-17T10:50:00Z"),
+    ];
+
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns,
+        notApplicableScheduledWorkflows: [],
+      }),
+    ).toThrow(`Missing successful recent Blacksmith ARM Testbox workflow for ${sha}`);
+  });
+
+  it("records path-filtered hosted gates as not applicable for QA-only changes", () => {
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns: [
+        successfulRun("CI", 1, "2026-06-17T10:47:00Z"),
+        successfulRun("Workflow Sanity", 2, "2026-06-17T10:48:00Z"),
+      ],
+      notApplicableScheduledWorkflows: [
+        "Blacksmith Testbox",
+        "Blacksmith ARM Testbox",
+        "Blacksmith Build Artifacts Testbox",
+      ],
+    });
+
+    expect(evidence.workflows).toEqual([
+      expect.objectContaining({ name: "CI", id: 1 }),
+      expect.objectContaining({ name: "Workflow Sanity", id: 2 }),
+    ]);
+    expect(evidence.notApplicableWorkflows).toEqual([
+      "Blacksmith Testbox",
+      "Blacksmith ARM Testbox",
+      "Blacksmith Build Artifacts Testbox",
+    ]);
+  });
+
+  it("does not require path-inapplicable ARM proof for queued artifact fallback", () => {
+    const workflowRuns = queuedBuildArtifactFallbackRuns().filter(
+      (run) => run.name !== "Blacksmith ARM Testbox",
+    );
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns,
+      notApplicableScheduledWorkflows: ["Blacksmith ARM Testbox"],
+    });
+
+    expect(evidence.fallbackCoveredWorkflows).toEqual([
+      {
+        name: BUILD_ARTIFACTS_WORKFLOW,
+        coveredBy: "CI release gate",
+        reason: "scheduled workflow is queued",
+      },
+    ]);
+    expect(evidence.notApplicableWorkflows).toEqual(["Blacksmith ARM Testbox"]);
+  });
+
   it("reuses successful recent CI from a patch-identical pre-rebase head", () => {
     const candidate = priorSuccessfulCiRun();
     const evidence = collectHostedGateEvidence({


### PR DESCRIPTION
Related: #120281
Related: #120286

## What Problem This Solves

Fixes a hosted landing-gate contract where a mandatory exact-head workflow could be impossible to satisfy: draft workflow changes did not rerun ARM or Build Artifacts when marked ready, while path-filtered workflows could also be required for pull requests that could never trigger them.

## Why This Change Was Made

Workflow YAML is now the single applicability owner. The hosted-gate verifier parses each scheduled workflow's declared `pull_request` path filters and evaluates them against the exact three-dot PR diff:

- Applicable workflows require an authoritative `pull_request` run.
- Path-filtered workflows that do not apply are recorded explicitly as not applicable.
- The queued Build Artifacts fallback uses the same applicability result instead of an unconditional ARM dependency.

ARM Testbox and Build Artifacts Testbox now explicitly listen for `opened`, `reopened`, `synchronize`, and `ready_for_review`, matching the existing regular Testbox contract. Jobs, runners, permissions, concurrency, path filters, and manual Testbox dispatch behavior are otherwise unchanged.

This PR was intentionally opened ready for review because the previous default-branch ARM workflow could not bootstrap itself from a draft-to-ready transition.

## User Impact

Maintainers can obtain every mandatory exact-head hosted gate without empty commits or close/reopen cycles, while QA-only and other path-inapplicable pull requests prepare cleanly without fake ARM runs or manual bypasses.

## Evidence

- Targeted CI recovery reran only failed Node shard 8; attempt 2 passed: https://github.com/openclaw/openclaw/actions/runs/31205640842/attempts/2
- `node scripts/run-vitest.mjs test/scripts/verify-pr-hosted-gates.test.ts test/scripts/ci-workflow-guards.test.ts`: 59 verifier tests passed; 102 workflow/tooling tests passed, 2 skipped.
- `actionlint .github/workflows/ci-check-arm-testbox.yml .github/workflows/ci-build-artifacts-testbox.yml`: passed.
- `pnpm check:script-declarations`: 254 declaration contracts passed.
- `git diff --check`: passed.
- Live workflow-relevant proof on prior #120313 head required and found CI, Testbox, ARM, Build Artifacts, and Workflow Sanity.
- Live QA-only proof on #120286 passed with CI https://github.com/openclaw/openclaw/actions/runs/31204520580 and Workflow Sanity https://github.com/openclaw/openclaw/actions/runs/31195343953; Testbox, ARM, and Build Artifacts were explicitly recorded not applicable.
- Autoreview: clean, no accepted/actionable findings; overall 0.98.
- Production/tooling LOC: +118/-12; tests: +96/-0.
- AI-assisted.

## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

> **User:** Create and land a separate narrow CI repair for the ARM bootstrap hole, then extend the same owner fix when #120286 proved QA-only changes could not trigger the unconditionally required ARM gate.

> **Assistant:** Checked gitcrawl first; its configured cloud archive was unavailable because the remote token was absent, then completed live GitHub duplicate discovery. #120310 changes manual CI fallback selection and does not overlap this trigger/applicability contract.

> **Assistant:** Inspected the ARM, regular Testbox, Build Artifacts, and Workflow Sanity triggers; the hosted-gate verifier; changed-path helpers; tests; and history. The violated invariant was one owner boundary: every mandatory exact-head gate must be runnable and applicable.

> **Assistant:** Kept workflow YAML authoritative. The verifier now consumes declared path filters rather than copying globs, requires every applicable workflow, records path-filtered workflows as not applicable, and uses the same result for queued artifact fallback. ARM and Build Artifacts receive the missing `ready_for_review` trigger.

> **Assistant:** Focused tests, actionlint, declaration checks, diff checks, live relevant/QA-only probes, and autoreview passed. The published exact head is `b4c3d2fdaa18a9477cfa88dd2b29e75c07be98da`.

</details>
<!-- agent-transcript:end -->
