### PR TITLE
fix(cron): isolated heartbeat recovers after session archival

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -186,6 +186,25 @@ describe("resolveCronSession", () => {
     expect(result.sessionEntry.heartbeatIsolatedBaseSessionKey).toBeUndefined();
   });
 
+  it("keeps an initializing isolated heartbeat blocked during forced rollover", () => {
+    expect(() =>
+      resolveWithStoredEntry({
+        sessionKey: "agent:main:main:heartbeat",
+        entry: {
+          sessionId: "initializing-heartbeat-session-id",
+          updatedAt: NOW_MS - 1000,
+          archivedAt: NOW_MS,
+          initializationPending: true,
+          heartbeatIsolatedBaseSessionKey: "agent:main:main",
+        },
+        forceNew: true,
+      }),
+    ).toThrow(
+      'Session "agent:main:main:heartbeat" is still initializing. Retry after initialization completes.',
+    );
+    expect(clearBootstrapSnapshot).not.toHaveBeenCalled();
+  });
+
   it("keeps an archived isolated heartbeat read-only without forceNew", () => {
     expect(() =>
       resolveWithStoredEntry({

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -167,6 +167,41 @@ describe("resolveCronSession", () => {
     expect(clearBootstrapSnapshot).not.toHaveBeenCalled();
   });
 
+  it("rolls an archived isolated heartbeat session into a fresh run", () => {
+    const result = resolveWithStoredEntry({
+      sessionKey: "agent:main:main:heartbeat",
+      entry: {
+        sessionId: "archived-heartbeat-session-id",
+        updatedAt: NOW_MS - 1000,
+        archivedAt: NOW_MS,
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      },
+      forceNew: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.previousSessionId).toBe("archived-heartbeat-session-id");
+    expect(result.sessionEntry.sessionId).not.toBe("archived-heartbeat-session-id");
+    expect(result.sessionEntry.archivedAt).toBeUndefined();
+    expect(result.sessionEntry.heartbeatIsolatedBaseSessionKey).toBeUndefined();
+  });
+
+  it("keeps an archived isolated heartbeat read-only without forceNew", () => {
+    expect(() =>
+      resolveWithStoredEntry({
+        sessionKey: "agent:main:main:heartbeat",
+        entry: {
+          sessionId: "archived-heartbeat-session-id",
+          updatedAt: NOW_MS - 1000,
+          archivedAt: NOW_MS,
+          heartbeatIsolatedBaseSessionKey: "agent:main:main",
+        },
+      }),
+    ).toThrow(
+      'Session "agent:main:main:heartbeat" is archived. Restore it before starting new work.',
+    );
+  });
+
   // New tests for session reuse behavior (#18027)
   describe("session reuse for webhooks/cron", () => {
     it("reuses existing sessionId when session is fresh", () => {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -161,17 +161,17 @@ export function resolveCronSession(params: {
   const sourceSessionDiffers = Boolean(sourceSessionKey && sourceSessionKey !== params.sessionKey);
   const targetEntry = store[params.sessionKey];
   const entry = store[sourceSessionKey || params.sessionKey];
-  // Guard the run's target row: archived sessions stay read-only even when a
-  // differing source session seeds the carried preferences. The one exception
-  // is an isolated heartbeat row that forceNew will replace with a fresh
-  // synthetic run; maintenance may archive that row between heartbeat ticks.
+  // Guard the run's target row even when a differing source session seeds the
+  // carried preferences. A forced isolated heartbeat may replace its archived
+  // synthetic row, but trusted initialization must still finish first.
   const canRollArchivedHeartbeat =
-    params.forceNew === true && Boolean(targetEntry?.heartbeatIsolatedBaseSessionKey?.trim());
-  const archivedSessionError = canRollArchivedHeartbeat
-    ? undefined
-    : resolveSessionWorkStartError(params.sessionKey, targetEntry);
-  if (archivedSessionError) {
-    throw new Error(archivedSessionError);
+    params.forceNew === true &&
+    targetEntry?.archivedAt !== undefined &&
+    targetEntry.initializationPending !== true &&
+    Boolean(targetEntry.heartbeatIsolatedBaseSessionKey?.trim());
+  const sessionWorkStartError = resolveSessionWorkStartError(params.sessionKey, targetEntry);
+  if (sessionWorkStartError && !canRollArchivedHeartbeat) {
+    throw new Error(sessionWorkStartError);
   }
 
   let sessionId: string;

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -162,8 +162,14 @@ export function resolveCronSession(params: {
   const targetEntry = store[params.sessionKey];
   const entry = store[sourceSessionKey || params.sessionKey];
   // Guard the run's target row: archived sessions stay read-only even when a
-  // differing source session seeds the carried preferences.
-  const archivedSessionError = resolveSessionWorkStartError(params.sessionKey, targetEntry);
+  // differing source session seeds the carried preferences. The one exception
+  // is an isolated heartbeat row that forceNew will replace with a fresh
+  // synthetic run; maintenance may archive that row between heartbeat ticks.
+  const canRollArchivedHeartbeat =
+    params.forceNew === true && Boolean(targetEntry?.heartbeatIsolatedBaseSessionKey?.trim());
+  const archivedSessionError = canRollArchivedHeartbeat
+    ? undefined
+    : resolveSessionWorkStartError(params.sessionKey, targetEntry);
   if (archivedSessionError) {
     throw new Error(archivedSessionError);
   }

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -163,6 +163,49 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
     });
   });
 
+  it("recovers an archived isolated session on the next heartbeat tick", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const nowMs = Date.now();
+      await seedSessionStore(storePath, isolatedSessionKey, {
+        sessionId: "archived-heartbeat-session-id",
+        updatedAt: nowMs - 1000,
+        archivedAt: nowMs - 500,
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+1555",
+      });
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "interval",
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const store = readSessionStoreForTest<{
+        archivedAt?: number;
+        heartbeatIsolatedBaseSessionKey?: string;
+        sessionId?: string;
+      }>(storePath);
+      expect(store[isolatedSessionKey]).toMatchObject({
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+      });
+      expect(store[isolatedSessionKey]?.archivedAt).toBeUndefined();
+      expect(store[isolatedSessionKey]?.sessionId).not.toBe("archived-heartbeat-session-id");
+    });
+  });
+
   it("stays stable even with multiply-accumulated suffixes", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);


### PR DESCRIPTION
Closes #120311

AI-assisted: implemented with Codex. I reviewed the affected session lifecycle, heartbeat caller, sibling marker handling, and the final diff.

## What Problem This Solves

Fixes an issue where operators using isolated heartbeat sessions could lose future heartbeat runs after session maintenance archived the synthetic heartbeat row. Each later tick tried to start fresh but was rejected by the archived-session guard.

## Why This Change Was Made

Allow `forceNew` rollover only when the archived target carries OpenClaw's internal isolated-heartbeat marker. Ordinary archived sessions remain read-only, and marked heartbeat sessions are still rejected without `forceNew`.

## User Impact

Isolated heartbeats recover automatically on the next tick after their synthetic session is archived. This does not restore or mutate archived ordinary conversation sessions.

## Evidence

- [Patch-identical runtime trace](https://github.com/openclaw/openclaw/pull/120314#issuecomment-5227417055): a source dev Gateway with isolated state created the marked row on a real scheduled monitor tick; the row was archived through the running Gateway; the next scheduled tick replaced it with a new generation, cleared archived state, retained the internal marker, completed its synthetic response, and left the monitor status `ok`. The PR was subsequently rebased without changing the three-file patch.
- Focused tests on rebased head `018ab67c51591a68c71406d78a82755c5c4b17e6`: 35 passed across `src/cron/isolated-agent/session.test.ts` and `src/infra/heartbeat-runner.isolated-key-stability.test.ts`.
- Regression-first proof: the new focused resolver case fails before the fix with `Session "agent:main:main:heartbeat" is archived. Restore it before starting new work.`
- The ordinary archived-session, marked-without-`forceNew`, and initializing-session rejection cases remain covered.
