### PR TITLE
fix(e2e): model managed upgrade restarts

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/gateway-start.sh
+++ b/scripts/e2e/lib/upgrade-survivor/gateway-start.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+UPGRADE_SURVIVOR_GATEWAY_MIGRATION_REFUSAL="OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory."
+UPGRADE_SURVIVOR_GATEWAY_MIGRATION_RESTART_MARKER="[upgrade-survivor] restarting direct gateway after migration convergence refusal"
+
+upgrade_survivor_attempt_log_has_migration_refusal() {
+  local log_path="$1"
+  local launch_offset="$2"
+  local refusal="$UPGRADE_SURVIVOR_GATEWAY_MIGRATION_REFUSAL"
+  tail -c +"$((launch_offset + 1))" "$log_path" 2>/dev/null |
+    awk -v refusal="$refusal" '$0 == refusal { found = 1 } END { exit found ? 0 : 1 }'
+}
+
+# Reuse the exact launch command and retry only the convergence refusal emitted
+# by this attempt. The ready child PID remains the caller-owned gateway PID.
+upgrade_survivor_start_direct_gateway() {
+  local log_path="$1"
+  local attempts="$2"
+  local port="$3"
+  local readiness_mode="${4:-strict}"
+  shift 4
+  if [ "${1:-}" = "--" ]; then
+    shift
+  fi
+  if [ "$#" -eq 0 ]; then
+    echo "missing direct gateway launch command" >&2
+    return 2
+  fi
+
+  : >"$log_path"
+  local attempt
+  for attempt in 1 2; do
+    local launch_offset
+    launch_offset="$(wc -c <"$log_path")"
+    launch_offset="${launch_offset//[[:space:]]/}"
+    if command -v setsid >/dev/null 2>&1; then
+      setsid "$@" >>"$log_path" 2>&1 &
+    else
+      "$@" >>"$log_path" 2>&1 &
+    fi
+    gateway_pid="$!"
+    OPENCLAW_E2E_GATEWAY_PID="$gateway_pid"
+
+    if openclaw_e2e_wait_gateway_ready \
+      "$gateway_pid" \
+      "$log_path" \
+      "$attempts" \
+      "$port" \
+      "$readiness_mode" \
+      "$launch_offset"; then
+      return 0
+    fi
+
+    if [ "$attempt" -eq 1 ] &&
+      [ "${OPENCLAW_E2E_GATEWAY_EXIT_STATUS:-}" = "1" ] &&
+      upgrade_survivor_attempt_log_has_migration_refusal "$log_path" "$launch_offset"; then
+      printf '%s\n' "$UPGRADE_SURVIVOR_GATEWAY_MIGRATION_RESTART_MARKER" >>"$log_path"
+      continue
+    fi
+    return 1
+  done
+}

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -2,6 +2,10 @@
 set -Eeuo pipefail
 
 source scripts/lib/openclaw-e2e-instance.sh
+# shellcheck disable=SC1091
+source scripts/e2e/lib/upgrade-survivor/gateway-start.sh
+# shellcheck disable=SC1091
+source scripts/e2e/lib/upgrade-survivor/systemctl-shim.sh
 
 SCENARIO="${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}"
 
@@ -230,10 +234,13 @@ cleanup() {
   if [ -n "${plugin_registry_pid:-}" ]; then
     kill "$plugin_registry_pid" >/dev/null 2>&1 || true
   fi
+  if [ -s "$SYSTEMCTL_SHIM_PID_FILE.supervisor.pid" ] || [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
+    systemctl --user stop openclaw-gateway.service >/dev/null 2>&1 || true
+  fi
   openclaw_e2e_terminate_gateways "${gateway_pid:-}"
-  if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
+  if [ -s "$SYSTEMCTL_SHIM_PID_FILE.supervisor.pid" ]; then
     local shim_pid
-    shim_pid="$(cat "$SYSTEMCTL_SHIM_PID_FILE" 2>/dev/null || true)"
+    shim_pid="$(cat "$SYSTEMCTL_SHIM_PID_FILE.supervisor.pid" 2>/dev/null || true)"
     if [[ "$shim_pid" =~ ^[0-9]+$ ]] && [ "$shim_pid" -gt 1 ]; then
       openclaw_e2e_terminate_gateways "$shim_pid"
     fi
@@ -693,7 +700,11 @@ rm_rf_retry() {
 
 reset_run_state() {
   rm_rf_retry "$npm_config_prefix" "$TMPDIR" "$OPENCLAW_TEST_STATE_TMPDIR" "$STATE_HOME_ROOT"
-  rm -f "$SYSTEMCTL_SHIM_PID_FILE" "$SYSTEMCTL_SHIM_DAEMON_LOG"
+  rm -f \
+    "$SYSTEMCTL_SHIM_PID_FILE" \
+    "$SYSTEMCTL_SHIM_PID_FILE.supervisor.pid" \
+    "$SYSTEMCTL_SHIM_PID_FILE.supervisor.mjs" \
+    "$SYSTEMCTL_SHIM_DAEMON_LOG"
   mkdir -p "$npm_config_prefix" "$npm_config_cache" "$TMPDIR" "$OPENCLAW_TEST_STATE_TMPDIR"
 }
 
@@ -772,172 +783,6 @@ validate_baseline_config() {
     openclaw_e2e_print_log "$BASELINE_CONFIG_VALIDATE_LOG" >&2
     return 1
   fi
-}
-
-install_update_restart_systemctl_shim() {
-  local shim_dir="$npm_config_prefix/bin"
-  mkdir -p "$shim_dir"
-  cat >"$shim_dir/systemctl" <<'SHIM'
-#!/usr/bin/env bash
-set -euo pipefail
-
-log_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG:-/tmp/openclaw-systemctl-shim.log}"
-pid_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE:-/tmp/openclaw-systemctl-shim.pid}"
-daemon_log="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG:-/tmp/openclaw-systemctl-shim-gateway.log}"
-printf '%s\n' "$*" >>"$log_file"
-
-filtered=()
-system_scope=1
-property=""
-for ((i = 1; i <= $#; i++)); do
-  arg="${!i}"
-  case "$arg" in
-    --user)
-      system_scope=0
-      ;;
-    --quiet | --no-page | --now | --value)
-      ;;
-    --property)
-      i=$((i + 1))
-      property="${!i}"
-      ;;
-    --property=*)
-      property="${arg#--property=}"
-      ;;
-    *)
-      filtered+=("$arg")
-      ;;
-  esac
-done
-
-command="${filtered[0]:-status}"
-
-is_running() {
-  [ -s "$pid_file" ] || return 1
-  local pid
-  pid="$(cat "$pid_file" 2>/dev/null || true)"
-  [ -n "$pid" ] || return 1
-  kill -0 "$pid" >/dev/null 2>&1
-}
-
-stop_gateway() {
-  [ -s "$pid_file" ] || return 0
-  local pid
-  pid="$(cat "$pid_file" 2>/dev/null || true)"
-  if [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ] && kill -0 "$pid" >/dev/null 2>&1; then
-    kill "$pid" >/dev/null 2>&1 || true
-    for _ in $(seq 1 100); do
-      kill -0 "$pid" >/dev/null 2>&1 || break
-      sleep 0.1
-    done
-    kill -9 "$pid" >/dev/null 2>&1 || true
-  fi
-  rm -f "$pid_file"
-}
-
-unit_path() {
-  printf '%s/.config/systemd/user/openclaw-gateway.service\n' "${HOME:?missing HOME}"
-}
-
-load_unit_environment() {
-  local unit="$1"
-  while IFS= read -r line; do
-    case "$line" in
-      EnvironmentFile=*)
-        local spec="${line#EnvironmentFile=}"
-        for token in $spec; do
-          local file="${token#-}"
-          [ -f "$file" ] || continue
-          set -a
-          # shellcheck disable=SC1090
-          . "$file"
-          set +a
-        done
-        ;;
-      Environment=*)
-        local assignment="${line#Environment=}"
-        assignment="${assignment#\"}"
-        assignment="${assignment%\"}"
-        export "$assignment"
-        ;;
-    esac
-  done <"$unit"
-}
-
-start_gateway() {
-  local unit
-  local exec_start
-  unit="$(unit_path)"
-  exec_start="$(sed -n 's/^ExecStart=//p' "$unit" | tail -n 1)"
-  [ -n "$exec_start" ] || {
-    echo "systemctl shim could not find ExecStart in $unit" >&2
-    return 1
-  }
-  (
-    load_unit_environment "$unit"
-    nohup bash -lc "exec $exec_start" >>"$daemon_log" 2>&1 &
-    printf '%s\n' "$!" >"$pid_file"
-  )
-}
-
-case "$command" in
-  daemon-reload | enable | disable)
-    exit 0
-    ;;
-  status)
-    is_running && exit 0
-    exit 0
-    ;;
-  stop)
-    stop_gateway
-    exit 0
-    ;;
-  restart | start)
-    stop_gateway
-    start_gateway
-    exit 0
-    ;;
-  is-enabled)
-    exit 0
-    ;;
-  is-active)
-    is_running && exit 0
-    exit 3
-    ;;
-  show)
-    if [ "$system_scope" = "1" ]; then
-      case "$property" in
-        LoadState)
-          printf 'not-found\n'
-          ;;
-        UnitPath)
-          printf '/etc/systemd/system /usr/lib/systemd/system\n'
-          ;;
-        *)
-          echo "systemctl shim unsupported system-scope show: $*" >&2
-          exit 1
-          ;;
-      esac
-      exit 0
-    fi
-    if is_running; then
-      printf 'ActiveState=active\nSubState=running\nMainPID=%s\nExecMainStatus=0\nExecMainCode=0\n' "$(cat "$pid_file")"
-    else
-      printf 'ActiveState=inactive\nSubState=dead\nMainPID=0\nExecMainStatus=0\nExecMainCode=0\n'
-    fi
-    exit 0
-    ;;
-  *)
-    echo "systemctl shim unsupported command: $*" >&2
-    exit 1
-    ;;
-esac
-SHIM
-  chmod +x "$shim_dir/systemctl"
-  export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG="$SYSTEMCTL_SHIM_LOG"
-  export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE="$SYSTEMCTL_SHIM_PID_FILE"
-  export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG="$SYSTEMCTL_SHIM_DAEMON_LOG"
-  export PATH="$shim_dir:$PATH"
 }
 
 install_update_restart_service_unit() {
@@ -1247,12 +1092,17 @@ start_gateway() {
   local start_epoch
   local ready_epoch
   start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-  env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured >"$GATEWAY_LOG" 2>&1 &
-  gateway_pid="$!"
+  upgrade_survivor_start_direct_gateway \
+    "$GATEWAY_LOG" \
+    360 \
+    "$port" \
+    "${1:-strict}" \
+    -- \
+    env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD \
+    openclaw gateway --port "$port" --bind loopback --allow-unconfigured
   if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
     printf '%s\n' "$gateway_pid" >"$SYSTEMCTL_SHIM_PID_FILE"
   fi
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "${1:-strict}"
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   if [ "$start_seconds" -gt "$budget" ]; then

--- a/scripts/e2e/lib/upgrade-survivor/systemctl-shim.sh
+++ b/scripts/e2e/lib/upgrade-survivor/systemctl-shim.sh
@@ -1,0 +1,616 @@
+#!/usr/bin/env bash
+
+install_update_restart_systemctl_shim() {
+  local shim_dir="$npm_config_prefix/bin"
+  export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG:-${SYSTEMCTL_SHIM_LOG:-/tmp/openclaw-systemctl-shim.log}}"
+  export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE:-${SYSTEMCTL_SHIM_PID_FILE:-/tmp/openclaw-systemctl-shim.pid}}"
+  export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG:-${SYSTEMCTL_SHIM_DAEMON_LOG:-/tmp/openclaw-systemctl-shim-gateway.log}}"
+  mkdir -p "$shim_dir"
+  cat >"$shim_dir/systemctl" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG:-/tmp/openclaw-systemctl-shim.log}"
+pid_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE:-/tmp/openclaw-systemctl-shim.pid}"
+daemon_log="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG:-/tmp/openclaw-systemctl-shim-gateway.log}"
+supervisor_pid_file="${pid_file}.supervisor.pid"
+supervisor_script="${pid_file}.supervisor.mjs"
+supervisor_ready_file="${pid_file}.supervisor.ready"
+supervisor_error_file="${pid_file}.supervisor.error"
+child_init_file="${pid_file}.child.init"
+printf '%s\n' "$*" >>"$log_file"
+
+filtered=()
+system_scope=1
+property=""
+for ((i = 1; i <= $#; i++)); do
+  arg="${!i}"
+  case "$arg" in
+    --user)
+      system_scope=0
+      ;;
+    --quiet | --no-page | --now | --value)
+      ;;
+    --property)
+      i=$((i + 1))
+      property="${!i}"
+      ;;
+    --property=*)
+      property="${arg#--property=}"
+      ;;
+    *)
+      filtered+=("$arg")
+      ;;
+  esac
+done
+
+command="${filtered[0]:-status}"
+
+pid_is_running() {
+  local pid="${1:-}"
+  local process_state=""
+  [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ] || return 1
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  if [ -r "/proc/$pid/stat" ]; then
+    process_state="$(awk '{ print $3 }' "/proc/$pid/stat" 2>/dev/null || true)"
+  else
+    process_state="$(ps -o stat= -p "$pid" 2>/dev/null | cut -c1 || true)"
+  fi
+  [ "$process_state" != "Z" ]
+}
+
+process_group_is_running() {
+  local pgid="${1:-}"
+  local process_group=""
+  local process_state=""
+  local stat_file=""
+  [[ "$pgid" =~ ^[0-9]+$ ]] && [ "$pgid" -gt 1 ] || return 1
+  kill -0 -- "-$pgid" >/dev/null 2>&1 || return 1
+  if [ -d /proc ]; then
+    for stat_file in /proc/[0-9]*/stat; do
+      [ -r "$stat_file" ] || continue
+      read -r process_state _ process_group _ <<<"$(sed 's/^.*) //' "$stat_file" 2>/dev/null || true)"
+      if [ "$process_group" = "$pgid" ] && [ "$process_state" != "Z" ] && [ "$process_state" != "X" ]; then
+        return 0
+      fi
+    done
+    return 1
+  fi
+}
+
+signal_process_group() {
+  local pgid="${1:-}"
+  local signal="$2"
+  process_group_is_running "$pgid" || return 0
+  kill "-$signal" -- "-$pgid" >/dev/null 2>&1 || true
+}
+
+read_pid_file() {
+  local file="$1"
+  [ -s "$file" ] || return 1
+  cat "$file" 2>/dev/null
+}
+
+child_is_running() {
+  local pid=""
+  pid="$(read_pid_file "$pid_file" || true)"
+  pid_is_running "$pid"
+}
+
+supervisor_is_running() {
+  local pid=""
+  pid="$(read_pid_file "$supervisor_pid_file" || true)"
+  pid_is_running "$pid"
+}
+
+service_is_running() {
+  child_is_running
+}
+
+cleanup_stale_supervisor_state() {
+  local supervisor_pid=""
+  supervisor_pid="$(read_pid_file "$supervisor_pid_file" || true)"
+  if [ -n "$supervisor_pid" ] && ! pid_is_running "$supervisor_pid"; then
+    rm -f \
+      "$supervisor_pid_file" \
+      "$supervisor_script" \
+      "$supervisor_ready_file" \
+      "$supervisor_error_file" \
+      "$child_init_file"
+  fi
+  if [ -s "$pid_file" ] && ! process_group_is_running "$(read_pid_file "$pid_file" || true)"; then
+    rm -f "$pid_file"
+  fi
+}
+
+stop_gateway() {
+  local child_pid=""
+  local supervisor_pid=""
+  child_pid="$(read_pid_file "$pid_file" || true)"
+  supervisor_pid="$(read_pid_file "$supervisor_pid_file" || true)"
+
+  if pid_is_running "$supervisor_pid"; then
+    kill "$supervisor_pid" >/dev/null 2>&1 || true
+  elif process_group_is_running "$child_pid"; then
+    signal_process_group "$child_pid" TERM
+  fi
+
+  for ((attempt = 0; attempt < 350; attempt++)); do
+    if ! pid_is_running "$supervisor_pid" && ! process_group_is_running "$child_pid"; then
+      break
+    fi
+    sleep 0.1
+  done
+  process_group_is_running "$child_pid" && signal_process_group "$child_pid" KILL
+  pid_is_running "$supervisor_pid" && kill -9 "$supervisor_pid" >/dev/null 2>&1 || true
+  for ((attempt = 0; attempt < 50; attempt++)); do
+    if ! pid_is_running "$supervisor_pid" && ! process_group_is_running "$child_pid"; then
+      break
+    fi
+    sleep 0.1
+  done
+  if pid_is_running "$supervisor_pid" || process_group_is_running "$child_pid"; then
+    echo "systemctl shim could not stop gateway supervisor or process group" >&2
+    return 1
+  fi
+  rm -f \
+    "$pid_file" \
+    "$supervisor_pid_file" \
+    "$supervisor_script" \
+    "$supervisor_ready_file" \
+    "$supervisor_error_file" \
+    "$child_init_file"
+}
+
+unit_path() {
+  printf '%s/.config/systemd/user/openclaw-gateway.service\n' "${HOME:?missing HOME}"
+}
+
+start_gateway() {
+  local unit
+  local exec_start
+  local supervisor_pid
+  unit="$(unit_path)"
+  exec_start="$(sed -n 's/^ExecStart=//p' "$unit" | tail -n 1)"
+  [ -n "$exec_start" ] || {
+    echo "systemctl shim could not find ExecStart in $unit" >&2
+    return 1
+  }
+
+  rm -f \
+    "$pid_file" \
+    "$supervisor_pid_file" \
+    "$supervisor_script" \
+    "$supervisor_ready_file" \
+    "$supervisor_error_file" \
+    "$child_init_file"
+  cat >"$supervisor_script" <<'SUPERVISOR'
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+
+const command = process.env.OPENCLAW_SYSTEMCTL_SHIM_EXEC_START;
+const daemonLog = process.env.OPENCLAW_SYSTEMCTL_SHIM_DAEMON_LOG;
+const unitPath = process.env.OPENCLAW_SYSTEMCTL_SHIM_UNIT_PATH;
+const childPidFile = process.env.OPENCLAW_SYSTEMCTL_SHIM_CHILD_PID_FILE;
+const supervisorPidFile = process.env.OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_PID_FILE;
+const supervisorScript = process.env.OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_SCRIPT;
+const supervisorReadyFile = process.env.OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_READY_FILE;
+const supervisorErrorFile = process.env.OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_ERROR_FILE;
+const childInitFile = process.env.OPENCLAW_SYSTEMCTL_SHIM_CHILD_INIT_FILE;
+if (
+  !command ||
+  !daemonLog ||
+  !unitPath ||
+  !childPidFile ||
+  !supervisorPidFile ||
+  !supervisorReadyFile ||
+  !supervisorErrorFile ||
+  !childInitFile
+) {
+  process.exit(2);
+}
+fs.writeFileSync(supervisorPidFile, `${process.pid}\n`);
+
+const readPositiveInt = (name, fallback) => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+};
+
+let restartDelayMs;
+let startLimitBurst;
+let startLimitIntervalMs;
+let stopTimeoutMs;
+let output;
+let inheritedEnv;
+try {
+  restartDelayMs = readPositiveInt(
+    "OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_RESTART_SEC_MS",
+    5_000,
+  );
+  startLimitBurst = readPositiveInt(
+    "OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_START_LIMIT_BURST",
+    5,
+  );
+  startLimitIntervalMs = readPositiveInt(
+    "OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_START_LIMIT_INTERVAL_MS",
+    60_000,
+  );
+  stopTimeoutMs = readPositiveInt(
+    "OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_STOP_TIMEOUT_MS",
+    30_000,
+  );
+  output = fs.openSync(daemonLog, "a");
+  inheritedEnv = { ...process.env };
+  for (const key of Object.keys(inheritedEnv)) {
+    if (
+      key.startsWith("OPENCLAW_UPDATE_") ||
+      key.startsWith("OPENCLAW_SYSTEMCTL_SHIM_") ||
+      key.startsWith("OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_")
+    ) {
+      delete inheritedEnv[key];
+    }
+  }
+  delete inheritedEnv.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+} catch (error) {
+  fs.writeFileSync(supervisorErrorFile, `${String(error)}\n`);
+  process.exit(1);
+}
+
+const childLoader = `
+set -euo pipefail
+unit="$1"
+exec_start="$2"
+child_init_file="$3"
+while IFS= read -r line; do
+  case "$line" in
+    EnvironmentFile=*)
+      spec="\${line#EnvironmentFile=}"
+      for token in $spec; do
+        file="\${token#-}"
+        file="\${file#\\\"}"
+        file="\${file%\\\"}"
+        [ -f "$file" ] || continue
+        set -a
+        . "$file"
+        set +a
+      done
+      ;;
+    Environment=*)
+      assignment="\${line#Environment=}"
+      assignment="\${assignment#\\\"}"
+      assignment="\${assignment%\\\"}"
+      export "$assignment"
+      ;;
+  esac
+done <"$unit"
+printf '%s\\n' "$$" >"$child_init_file"
+exec bash -lc "exec $exec_start"
+`;
+
+let child;
+let finished = false;
+let startupFailure = "";
+let startupPoll;
+let startupReady = false;
+let stopping = false;
+let stopTimer;
+let forceDrainTimer;
+let groupPoll;
+let terminatingPgid;
+const startTimes = [];
+
+const removeChildState = () => {
+  try {
+    fs.rmSync(childPidFile, { force: true });
+  } catch {}
+};
+
+const finish = (status = 0, options = {}) => {
+  if (finished) return;
+  finished = true;
+  if (stopTimer) clearTimeout(stopTimer);
+  if (forceDrainTimer) clearTimeout(forceDrainTimer);
+  if (groupPoll) clearInterval(groupPoll);
+  if (startupPoll) clearInterval(startupPoll);
+  if (!options.preserveChildState) removeChildState();
+  try {
+    if (output !== undefined) fs.closeSync(output);
+  } catch {}
+  process.exit(status);
+};
+
+const processGroupIsRunning = (pgid) => {
+  if (!Number.isSafeInteger(pgid) || pgid <= 1) return false;
+  try {
+    process.kill(-pgid, 0);
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+  if (process.platform !== "linux") return true;
+  for (const entry of fs.readdirSync("/proc")) {
+    if (!/^[0-9]+$/u.test(entry)) continue;
+    try {
+      const stat = fs.readFileSync(`/proc/${entry}/stat`, "utf8");
+      const fields = stat.slice(stat.lastIndexOf(") ") + 2).trim().split(/\s+/u);
+      const state = fields[0];
+      const processGroup = Number(fields[2]);
+      if (processGroup === pgid && state !== "Z" && state !== "X") return true;
+    } catch {}
+  }
+  return false;
+};
+
+const signalProcessGroup = (pgid, signal) => {
+  try {
+    process.kill(-pgid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+};
+
+const terminateProcessGroup = (pgid, callback) => {
+  if (!processGroupIsRunning(pgid)) return callback();
+  if (terminatingPgid === pgid) return;
+  if (terminatingPgid !== undefined) {
+    throw new Error(`already terminating process group ${terminatingPgid}`);
+  }
+  terminatingPgid = pgid;
+  const complete = (error) => {
+    if (groupPoll) clearInterval(groupPoll);
+    if (stopTimer) clearTimeout(stopTimer);
+    if (forceDrainTimer) clearTimeout(forceDrainTimer);
+    groupPoll = undefined;
+    stopTimer = undefined;
+    forceDrainTimer = undefined;
+    terminatingPgid = undefined;
+    if (!error) child = undefined;
+    callback(error);
+  };
+  signalProcessGroup(pgid, "SIGTERM");
+  groupPoll = setInterval(() => {
+    if (!processGroupIsRunning(pgid)) complete();
+  }, 10);
+  stopTimer = setTimeout(() => {
+    signalProcessGroup(pgid, "SIGKILL");
+    forceDrainTimer = setTimeout(() => {
+      if (!processGroupIsRunning(pgid)) return complete();
+      complete(new Error(`process group ${pgid} remained active after SIGKILL`));
+    }, Math.min(stopTimeoutMs, 5_000));
+    forceDrainTimer.unref();
+  }, stopTimeoutMs);
+  stopTimer.unref();
+};
+
+const failStartup = (error) => {
+  if (startupFailure || startupReady || finished) return;
+  startupFailure = String(error);
+  fs.writeFileSync(supervisorErrorFile, `${startupFailure}\n`);
+  if (output !== undefined) {
+    fs.writeSync(output, `[systemctl-shim] startup failed: ${startupFailure}\n`);
+  }
+  stopping = true;
+  if (!child) return finish(1);
+  terminateProcessGroup(child.pid, (error) =>
+    finish(1, { preserveChildState: error !== undefined }),
+  );
+};
+
+const stop = () => {
+  if (stopping || finished) return;
+  stopping = true;
+  if (!child) return finish();
+  terminateProcessGroup(child.pid, (error) => {
+    if (error) fs.writeSync(output, `[systemctl-shim] ${String(error)}\n`);
+    finish(error ? 1 : 0, { preserveChildState: error !== undefined });
+  });
+};
+
+const start = () => {
+  if (stopping || finished) return finish();
+  const now = Date.now();
+  while (startTimes.length > 0 && now - startTimes[0] >= startLimitIntervalMs) {
+    startTimes.shift();
+  }
+  if (startTimes.length >= startLimitBurst) {
+    fs.writeSync(
+      output,
+      `[systemctl-shim] start limit hit: ${startLimitBurst} starts in ${startLimitIntervalMs}ms\n`,
+    );
+    return finish(1);
+  }
+  startTimes.push(now);
+  fs.rmSync(childInitFile, { force: true });
+  child = spawn(
+    "bash",
+    [
+      "--noprofile",
+      "--norc",
+      "-c",
+      childLoader,
+      "systemctl-shim-child",
+      unitPath,
+      command,
+      childInitFile,
+    ],
+    {
+      detached: true,
+      env: inheritedEnv,
+      stdio: ["ignore", output, output],
+    },
+  );
+  child.once("spawn", () => {
+    fs.writeFileSync(childPidFile, `${child.pid}\n`);
+    if (startupReady) return;
+    startupPoll = setInterval(() => {
+      let initializedPid = "";
+      try {
+        initializedPid = fs.readFileSync(childInitFile, "utf8").trim();
+      } catch {
+        return;
+      }
+      if (initializedPid !== String(child?.pid) || child?.exitCode !== null) return;
+      startupReady = true;
+      clearInterval(startupPoll);
+      startupPoll = undefined;
+      fs.writeFileSync(supervisorReadyFile, `${initializedPid}\n`);
+    }, 5);
+  });
+  child.on("error", (error) => {
+    fs.writeSync(output, `[systemctl-shim] gateway spawn failed: ${String(error)}\n`);
+    if (!startupReady) failStartup(error);
+  });
+  child.once("close", (code) => {
+    const pgid = child?.pid;
+    if (startupPoll) {
+      clearInterval(startupPoll);
+      startupPoll = undefined;
+    }
+    try {
+      fs.rmSync(childPidFile, { force: true });
+      fs.rmSync(childInitFile, { force: true });
+    } catch {}
+    if (terminatingPgid === pgid) return;
+    child = undefined;
+    if (stopping) return finish(startupFailure ? 1 : 0);
+    if (!startupReady) {
+      return failStartup(`gateway exited before startup initialization (code ${code ?? "signal"})`);
+    }
+    terminateProcessGroup(pgid, (error) => {
+      if (error) {
+        fs.writeSync(output, `[systemctl-shim] ${String(error)}\n`);
+        return finish(1, { preserveChildState: true });
+      }
+      if (code === 78) return finish();
+      setTimeout(start, restartDelayMs);
+    });
+  });
+};
+
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);
+process.on("SIGHUP", stop);
+start();
+SUPERVISOR
+
+  OPENCLAW_SYSTEMCTL_SHIM_EXEC_START="$exec_start" \
+    OPENCLAW_SYSTEMCTL_SHIM_DAEMON_LOG="$daemon_log" \
+    OPENCLAW_SYSTEMCTL_SHIM_UNIT_PATH="$unit" \
+    OPENCLAW_SYSTEMCTL_SHIM_CHILD_PID_FILE="$pid_file" \
+    OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_PID_FILE="$supervisor_pid_file" \
+    OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_SCRIPT="$supervisor_script" \
+    OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_READY_FILE="$supervisor_ready_file" \
+    OPENCLAW_SYSTEMCTL_SHIM_SUPERVISOR_ERROR_FILE="$supervisor_error_file" \
+    OPENCLAW_SYSTEMCTL_SHIM_CHILD_INIT_FILE="$child_init_file" \
+    nohup node "$supervisor_script" </dev/null >/dev/null 2>&1 &
+  supervisor_pid="$!"
+  for ((attempt = 0; attempt < 1000; attempt++)); do
+    if [ -s "$supervisor_pid_file" ]; then
+      if [ "$(cat "$supervisor_pid_file")" != "$supervisor_pid" ]; then
+        stop_gateway || true
+        echo "systemctl shim supervisor published an unexpected PID" >&2
+        return 1
+      fi
+    fi
+    if [ -s "$supervisor_error_file" ]; then
+      local startup_error
+      startup_error="$(cat "$supervisor_error_file")"
+      for ((exit_attempt = 0; exit_attempt < 500; exit_attempt++)); do
+        pid_is_running "$supervisor_pid" || break
+        sleep 0.01
+      done
+      if pid_is_running "$supervisor_pid"; then
+        stop_gateway || true
+      else
+        cleanup_stale_supervisor_state
+      fi
+      echo "systemctl shim supervisor startup failed: $startup_error" >&2
+      return 1
+    fi
+    if [ -s "$supervisor_ready_file" ]; then
+      local child_pid
+      child_pid="$(cat "$supervisor_ready_file")"
+      if [ "$child_pid" = "$(read_pid_file "$pid_file" || true)" ] && pid_is_running "$child_pid"; then
+        rm -f "$supervisor_ready_file" "$supervisor_error_file" "$child_init_file"
+        return 0
+      fi
+    fi
+    if ! pid_is_running "$supervisor_pid"; then
+      local supervisor_status=0
+      wait "$supervisor_pid" || supervisor_status=$?
+      cleanup_stale_supervisor_state
+      echo "systemctl shim supervisor exited before startup completed (status $supervisor_status)" >&2
+      return 1
+    fi
+    sleep 0.01
+  done
+  stop_gateway || true
+  echo "systemctl shim supervisor did not complete startup" >&2
+  return 1
+}
+
+cleanup_stale_supervisor_state
+
+case "$command" in
+  daemon-reload | enable | disable)
+    exit 0
+    ;;
+  status)
+    service_is_running && exit 0
+    exit 0
+    ;;
+  stop)
+    stop_gateway
+    exit 0
+    ;;
+  restart | start)
+    stop_gateway
+    start_gateway
+    exit 0
+    ;;
+  is-enabled)
+    exit 0
+    ;;
+  is-active)
+    service_is_running && exit 0
+    exit 3
+    ;;
+  show)
+    if [ "$system_scope" = "1" ]; then
+      case "$property" in
+        LoadState)
+          printf 'not-found\n'
+          ;;
+        UnitPath)
+          printf '/etc/systemd/system /usr/lib/systemd/system\n'
+          ;;
+        *)
+          echo "systemctl shim unsupported system-scope show: $*" >&2
+          exit 1
+          ;;
+      esac
+      exit 0
+    fi
+    if service_is_running; then
+      main_pid=0
+      child_is_running && main_pid="$(cat "$pid_file")"
+      printf 'ActiveState=active\nSubState=running\nMainPID=%s\nExecMainStatus=0\nExecMainCode=0\n' "$main_pid"
+    else
+      printf 'ActiveState=inactive\nSubState=dead\nMainPID=0\nExecMainStatus=0\nExecMainCode=0\n'
+    fi
+    exit 0
+    ;;
+  *)
+    echo "systemctl shim unsupported command: $*" >&2
+    exit 1
+    ;;
+esac
+SHIM
+  chmod +x "$shim_dir/systemctl"
+  export PATH="$shim_dir:$PATH"
+}

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -1,167 +1,10 @@
 #!/usr/bin/env bash
 
-install_update_restart_systemctl_shim() {
-  local shim_dir="$npm_config_prefix/bin"
-  mkdir -p "$shim_dir"
-  cat >"$shim_dir/systemctl" <<'SHIM'
-#!/usr/bin/env bash
-set -euo pipefail
-
-log_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG:-/tmp/openclaw-systemctl-shim.log}"
-pid_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE:-/tmp/openclaw-systemctl-shim.pid}"
-daemon_log="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG:-/tmp/openclaw-systemctl-shim-gateway.log}"
-printf '%s\n' "$*" >>"$log_file"
-
-filtered=()
-system_scope=1
-property=""
-for ((i = 1; i <= $#; i++)); do
-  arg="${!i}"
-  case "$arg" in
-    --user)
-      system_scope=0
-      ;;
-    --quiet | --no-page | --now | --value)
-      ;;
-    --property)
-      i=$((i + 1))
-      property="${!i}"
-      ;;
-    --property=*)
-      property="${arg#--property=}"
-      ;;
-    *)
-      filtered+=("$arg")
-      ;;
-  esac
-done
-
-command="${filtered[0]:-status}"
-
-is_running() {
-  [ -s "$pid_file" ] || return 1
-  local pid
-  pid="$(cat "$pid_file" 2>/dev/null || true)"
-  [ -n "$pid" ] || return 1
-  kill -0 "$pid" >/dev/null 2>&1
-}
-
-stop_gateway() {
-  [ -s "$pid_file" ] || return 0
-  local pid
-  pid="$(cat "$pid_file" 2>/dev/null || true)"
-  if [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ] && kill -0 "$pid" >/dev/null 2>&1; then
-    kill "$pid" >/dev/null 2>&1 || true
-    for _ in $(seq 1 100); do
-      kill -0 "$pid" >/dev/null 2>&1 || break
-      sleep 0.1
-    done
-    kill -9 "$pid" >/dev/null 2>&1 || true
-  fi
-  rm -f "$pid_file"
-}
-
-unit_path() {
-  printf '%s/.config/systemd/user/openclaw-gateway.service\n' "${HOME:?missing HOME}"
-}
-
-load_unit_environment() {
-  local unit="$1"
-  while IFS= read -r line; do
-    case "$line" in
-      EnvironmentFile=*)
-        local spec="${line#EnvironmentFile=}"
-        for token in $spec; do
-          local file="${token#-}"
-          [ -f "$file" ] || continue
-          set -a
-          # shellcheck disable=SC1090
-          . "$file"
-          set +a
-        done
-        ;;
-      Environment=*)
-        local assignment="${line#Environment=}"
-        assignment="${assignment#\"}"
-        assignment="${assignment%\"}"
-        export "$assignment"
-        ;;
-    esac
-  done <"$unit"
-}
-
-start_gateway() {
-  local unit
-  local exec_start
-  unit="$(unit_path)"
-  exec_start="$(sed -n 's/^ExecStart=//p' "$unit" | tail -n 1)"
-  [ -n "$exec_start" ] || {
-    echo "systemctl shim could not find ExecStart in $unit" >&2
-    return 1
-  }
-  (
-    load_unit_environment "$unit"
-    nohup bash -lc "exec $exec_start" >>"$daemon_log" 2>&1 &
-    printf '%s\n' "$!" >"$pid_file"
-  )
-}
-
-case "$command" in
-  daemon-reload | enable | disable)
-    exit 0
-    ;;
-  status)
-    is_running && exit 0
-    exit 0
-    ;;
-  stop)
-    stop_gateway
-    exit 0
-    ;;
-  restart | start)
-    stop_gateway
-    start_gateway
-    exit 0
-    ;;
-  is-enabled)
-    exit 0
-    ;;
-  is-active)
-    is_running && exit 0
-    exit 3
-    ;;
-  show)
-    if [ "$system_scope" = "1" ]; then
-      case "$property" in
-        LoadState)
-          printf 'not-found\n'
-          ;;
-        UnitPath)
-          printf '/etc/systemd/system /usr/lib/systemd/system\n'
-          ;;
-        *)
-          echo "systemctl shim unsupported system-scope show: $*" >&2
-          exit 1
-          ;;
-      esac
-      exit 0
-    fi
-    if is_running; then
-      printf 'ActiveState=active\nSubState=running\nMainPID=%s\nExecMainStatus=0\nExecMainCode=0\n' "$(cat "$pid_file")"
-    else
-      printf 'ActiveState=inactive\nSubState=dead\nMainPID=0\nExecMainStatus=0\nExecMainCode=0\n'
-    fi
-    exit 0
-    ;;
-  *)
-    echo "systemctl shim unsupported command: $*" >&2
-    exit 1
-    ;;
-esac
-SHIM
-  chmod +x "$shim_dir/systemctl"
-  export PATH="$shim_dir:$PATH"
-}
+# Both package paths use one trusted shim so restart behavior cannot drift.
+# shellcheck disable=SC1091
+source scripts/e2e/lib/upgrade-survivor/systemctl-shim.sh
+# shellcheck disable=SC1091
+source scripts/e2e/lib/upgrade-survivor/gateway-start.sh
 
 seed_update_restart_probe_device_auth() {
   node --input-type=module <<'NODE'
@@ -279,10 +122,15 @@ prepare_update_restart_probe_current_install() {
     return 1
   fi
   start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-  env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured >"$log_file" 2>&1 &
-  gateway_pid="$!"
+  upgrade_survivor_start_direct_gateway \
+    "$log_file" \
+    360 \
+    "$port" \
+    strict \
+    -- \
+    env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD \
+    openclaw gateway --port "$port" --bind loopback --allow-unconfigured
   printf '%s\n' "$gateway_pid" >"$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE"
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port"
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   write_update_restart_service_auth_env

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 HARNESS_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$HARNESS_ROOT_DIR}" && pwd)"
+DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"
 source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh"
@@ -213,6 +214,7 @@ docker_e2e_run_with_harness \
   "$IMAGE_NAME" \
   timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" bash -lc 'set -euo pipefail
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/upgrade-survivor/gateway-start.sh
 
 export npm_config_loglevel=error
 export npm_config_fund=false
@@ -268,9 +270,14 @@ cleanup() {
   if [ -n "${plugin_registry_pid:-}" ]; then
     kill "$plugin_registry_pid" >/dev/null 2>&1 || true
   fi
+  if [ -s "$SYSTEMCTL_SHIM_PID_FILE.supervisor.pid" ] || [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
+    systemctl --user stop openclaw-gateway.service >/dev/null 2>&1 || true
+  fi
   openclaw_e2e_terminate_gateways "${gateway_pid:-}"
-  if [ -s "$SYSTEMCTL_SHIM_PID_FILE" ]; then
-    openclaw_e2e_terminate_gateways "$(cat "$SYSTEMCTL_SHIM_PID_FILE" 2>/dev/null || true)"
+  if [ -s "$SYSTEMCTL_SHIM_PID_FILE.supervisor.pid" ]; then
+    openclaw_e2e_terminate_gateways "$(
+      cat "$SYSTEMCTL_SHIM_PID_FILE.supervisor.pid" 2>/dev/null || true
+    )"
   fi
 }
 trap cleanup EXIT
@@ -435,6 +442,8 @@ if [ "$update_status" -ne 0 ]; then
   echo "openclaw update failed" >&2
   openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.err >&2
   openclaw_e2e_print_log /tmp/openclaw-upgrade-survivor-update.json >&2
+  openclaw_e2e_print_log "$SYSTEMCTL_SHIM_LOG" >&2
+  openclaw_e2e_print_log "$SYSTEMCTL_SHIM_DAEMON_LOG" >&2
   exit "$update_status"
 fi
 
@@ -464,9 +473,13 @@ if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
 else
   echo "Starting gateway from upgraded state..."
   start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-  openclaw gateway --port "$PORT" --bind loopback --allow-unconfigured >"$GATEWAY_LOG" 2>&1 &
-  gateway_pid="$!"
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$PORT"
+  upgrade_survivor_start_direct_gateway \
+    "$GATEWAY_LOG" \
+    360 \
+    "$PORT" \
+    strict \
+    -- \
+    openclaw gateway --port "$PORT" --bind loopback --allow-unconfigured
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   if [ "$start_seconds" -gt "$START_BUDGET" ]; then

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -264,13 +264,14 @@ docker_e2e_cleanup_container_cidfile() {
 }
 
 docker_e2e_harness_mount_args() {
+  local harness_root="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}"
   DOCKER_E2E_HARNESS_ARGS=(
-    -v "$ROOT_DIR/scripts/e2e:/app/scripts/e2e:ro"
-    -v "$ROOT_DIR/scripts/lib:/app/scripts/lib:ro"
-    -v "$ROOT_DIR/packages/normalization-core/src:/app/packages/normalization-core/src:ro"
-    -v "$ROOT_DIR/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"
-    -v "$ROOT_DIR/test/helpers:/app/test/helpers:ro"
-    -v "$ROOT_DIR/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"
+    -v "$harness_root/scripts/e2e:/app/scripts/e2e:ro"
+    -v "$harness_root/scripts/lib:/app/scripts/lib:ro"
+    -v "$harness_root/packages/normalization-core/src:/app/packages/normalization-core/src:ro"
+    -v "$harness_root/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"
+    -v "$harness_root/test/helpers:/app/test/helpers:ro"
+    -v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"
   )
 }
 

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -94,6 +94,9 @@ const UPGRADE_SURVIVOR_SCENARIOS = [
   "cron-scheduled-authority",
 ];
 
+// The representative OpenAI route uses this version-bound runtime package.
+const UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES = ["@openclaw/codex"];
+
 const UPGRADE_SURVIVOR_SCENARIO_ALIASES = new Map([
   ["reported-issues", UPGRADE_SURVIVOR_SCENARIOS],
   ["far-reaching", UPGRADE_SURVIVOR_SCENARIOS],
@@ -674,16 +677,20 @@ function configuredChannelIdsForLane(poolLane, scenario) {
 
 export function requiredPrepublishPluginPackagesForLanes(poolLanes) {
   const configuredChannelIds = new Set();
+  const requiredPackages = new Set();
   for (const poolLane of poolLanes) {
     const scenario = upgradeSurvivorScenarioForLane(poolLane);
     if (!scenario) {
       continue;
     }
+    for (const packageName of UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES) {
+      requiredPackages.add(packageName);
+    }
     for (const channelId of configuredChannelIdsForLane(poolLane, scenario)) {
       configuredChannelIds.add(channelId);
     }
   }
-  return (officialExternalChannelCatalog.entries ?? [])
+  for (const packageName of (officialExternalChannelCatalog.entries ?? [])
     .filter((entry) => {
       const channelId = entry.openclaw?.channel?.id;
       const install = entry.openclaw?.install;
@@ -694,8 +701,10 @@ export function requiredPrepublishPluginPackagesForLanes(poolLanes) {
         install?.npmSpec === entry.name
       );
     })
-    .map((entry) => entry.name)
-    .toSorted((a, b) => a.localeCompare(b));
+    .map((entry) => entry.name)) {
+    requiredPackages.add(packageName);
+  }
+  return [...requiredPackages].toSorted((a, b) => a.localeCompare(b));
 }
 
 function buildPlanJson(params) {

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -393,11 +393,16 @@ openclaw_e2e_gateway_log_port_from_text() {
 }
 openclaw_e2e_wait_gateway_ready() {
   local pid="$1" log="$2" attempts="${3:-300}" ready_port="${4:-}" readiness_mode="${5:-strict}" _ saw_ready_log=false
-  local ready_scan_offset=0 ready_scan_carry="" ready_scan_carry_chars=256
+  local ready_scan_offset="${6:-0}" ready_scan_carry="" ready_scan_carry_chars=256
+  OPENCLAW_E2E_GATEWAY_EXIT_STATUS=""
   for _ in $(seq 1 "$attempts"); do
     ! kill -0 "$pid" >/dev/null 2>&1 && {
       echo "Gateway exited before becoming ready"
-      wait "$pid" || true
+      if wait "$pid"; then
+        OPENCLAW_E2E_GATEWAY_EXIT_STATUS=0
+      else
+        OPENCLAW_E2E_GATEWAY_EXIT_STATUS=$?
+      fi
       tail -n 120 "$log" 2>/dev/null || true
       return 1
     }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -94,6 +94,7 @@ const RELEASE_TYPED_ONBOARDING_SCENARIO_PATH =
 const RELEASE_USER_JOURNEY_DOCKER_E2E_PATH = "scripts/e2e/release-user-journey-docker.sh";
 const RELEASE_USER_JOURNEY_SCENARIO_PATH = "scripts/e2e/lib/release-user-journey/scenario.sh";
 const UPGRADE_SURVIVOR_RUN_SCRIPT = "scripts/e2e/lib/upgrade-survivor/run.sh";
+const UPGRADE_SURVIVOR_GATEWAY_START_PATH = "scripts/e2e/lib/upgrade-survivor/gateway-start.sh";
 const UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH =
   "scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh";
 const GATEWAY_NETWORK_DOCKER_E2E_PATH = "scripts/e2e/gateway-network-docker.sh";
@@ -2423,6 +2424,7 @@ docker_e2e_docker_run_cmd run demo
     expect(upgradeSurvivor).toContain(
       'ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$HARNESS_ROOT_DIR}" && pwd)"',
     );
+    expect(upgradeSurvivor).toContain('DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"');
     expect(upgradeSurvivor).toContain(
       '-v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro"',
     );
@@ -2506,10 +2508,12 @@ fi
   it("bounds upgrade survivor foreground OpenClaw CLI calls", () => {
     const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
     const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+    const gatewayStart = readFileSync(UPGRADE_SURVIVOR_GATEWAY_START_PATH, "utf8");
     const updateRestartAuth = readFileSync(UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH, "utf8");
 
     expectTextToIncludeAll(runner, [
       'source "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh"',
+      "source scripts/e2e/lib/upgrade-survivor/gateway-start.sh",
       'START_BUDGET_SECONDS="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS 90)"',
       'STATUS_BUDGET_SECONDS="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS 30)"',
       '-e OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS="$START_BUDGET_SECONDS"',
@@ -2523,7 +2527,7 @@ fi
       'openclaw_e2e_maybe_timeout "$command_timeout" openclaw doctor --fix --non-interactive',
       'openclaw_e2e_maybe_timeout "$command_timeout" openclaw config validate',
       'openclaw_e2e_maybe_timeout "$command_timeout" openclaw gateway status',
-      'openclaw gateway --port "$PORT" --bind loopback --allow-unconfigured',
+      "upgrade_survivor_start_direct_gateway",
       'PROBE_TIMEOUT_MS="$(openclaw_e2e_read_nonnegative_int_env OPENCLAW_UPGRADE_SURVIVOR_PROBE_TIMEOUT_MS 60000)"',
       "openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_PROBE_ATTEMPT_TIMEOUT_MS 5000",
       "openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_PROBE_MAX_BODY_BYTES 1048576",
@@ -2571,11 +2575,9 @@ fi
     expect(publishedRunner).toContain(
       'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw gateway status',
     );
-    expect(publishedRunner).toContain('openclaw gateway --port "$port" --bind loopback');
+    expect(publishedRunner).toContain("upgrade_survivor_start_direct_gateway");
     expect(publishedRunner).toContain("start_gateway legacy-ready-log-ok");
-    expect(publishedRunner).toContain(
-      'openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "${1:-strict}"',
-    );
+    expect(publishedRunner).toContain("source scripts/e2e/lib/upgrade-survivor/gateway-start.sh");
 
     expect(updateRestartAuth).toContain(
       'command_timeout="${OPENCLAW_UPGRADE_SURVIVOR_COMMAND_TIMEOUT:-900s}"',
@@ -2583,10 +2585,15 @@ fi
     expect(updateRestartAuth).toContain(
       'openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN',
     );
-    expect(updateRestartAuth).toContain('openclaw gateway --port "$port" --bind loopback');
-    expect(updateRestartAuth).toContain(
-      'openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port"',
-    );
+    expect(updateRestartAuth).toContain("upgrade_survivor_start_direct_gateway");
+    expect(updateRestartAuth).toContain("source scripts/e2e/lib/upgrade-survivor/gateway-start.sh");
+    expectTextToIncludeAll(gatewayStart, [
+      'UPGRADE_SURVIVOR_GATEWAY_MIGRATION_REFUSAL="OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory."',
+      "for attempt in 1 2; do",
+      '[ "${OPENCLAW_E2E_GATEWAY_EXIT_STATUS:-}" = "1" ]',
+      'upgrade_survivor_attempt_log_has_migration_refusal "$log_path" "$launch_offset"',
+      'OPENCLAW_E2E_GATEWAY_PID="$gateway_pid"',
+    ]);
   });
 
   it("keeps upgrade survivor auto-auth success summary set -u safe", () => {
@@ -3723,10 +3730,11 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     const helper = readFileSync(DOCKER_E2E_PACKAGE_HELPER_PATH, "utf8");
     expectTextToIncludeAll(helper, [
       "--allow-unreleased-changelog",
-      '-v "$ROOT_DIR/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"',
-      '-v "$ROOT_DIR/packages/normalization-core/src:/app/packages/normalization-core/src:ro"',
-      '-v "$ROOT_DIR/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"',
-      '-v "$ROOT_DIR/test/helpers:/app/test/helpers:ro"',
+      'local harness_root="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}"',
+      '-v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"',
+      '-v "$harness_root/packages/normalization-core/src:/app/packages/normalization-core/src:ro"',
+      '-v "$harness_root/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"',
+      '-v "$harness_root/test/helpers:/app/test/helpers:ro"',
     ]);
   });
 

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1654,7 +1654,10 @@ describe("scripts/lib/docker-e2e-plan", () => {
 
   it("derives prerelease npm companions from selected survivor recipes", () => {
     const basePlan = planFor({ selectedLaneNames: ["published-upgrade-survivor"] });
-    expect(basePlan.requiredPrepublishPluginPackages).toEqual(["@openclaw/discord"]);
+    expect(basePlan.requiredPrepublishPluginPackages).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+    ]);
     expect(basePlan.needs.prepublishPluginRegistry).toBe(true);
 
     const feishuPlan = planFor({
@@ -1663,21 +1666,28 @@ describe("scripts/lib/docker-e2e-plan", () => {
       upgradeSurvivorScenarios: "base feishu-channel",
     });
     expect(feishuPlan.requiredPrepublishPluginPackages).toEqual([
+      "@openclaw/codex",
       "@openclaw/discord",
       "@openclaw/feishu",
     ]);
     expect(
       planFor({ selectedLaneNames: ["root-managed-vps-upgrade"] }).requiredPrepublishPluginPackages,
-    ).toEqual(["@openclaw/discord"]);
+    ).toEqual(["@openclaw/codex", "@openclaw/discord"]);
     expect(
       planFor({ selectedLaneNames: ["update-migration"] }).requiredPrepublishPluginPackages,
-    ).toEqual(["@openclaw/discord"]);
+    ).toEqual(["@openclaw/codex", "@openclaw/discord"]);
+    expect(
+      planFor({ selectedLaneNames: ["update-restart-auth"] }).requiredPrepublishPluginPackages,
+    ).toEqual(["@openclaw/codex", "@openclaw/discord"]);
     const legacyFeishuPlan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
       upgradeSurvivorBaselines: "2026.3.13",
       upgradeSurvivorScenarios: "feishu-channel",
     });
-    expect(legacyFeishuPlan.requiredPrepublishPluginPackages).toEqual(["@openclaw/discord"]);
+    expect(legacyFeishuPlan.requiredPrepublishPluginPackages).toEqual([
+      "@openclaw/codex",
+      "@openclaw/discord",
+    ]);
     const selfUpgradeLane = findLaneByName("update-run-package-self-upgrade");
     expect(selfUpgradeLane).toBeDefined();
     expect(requiredPrepublishPluginPackagesForLanes([selfUpgradeLane!])).toEqual([]);

--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -355,6 +355,31 @@ describe("scripts/lib/openclaw-e2e-instance.sh", () => {
     });
   });
 
+  it("reports the reaped gateway status and ignores ready logs before the launch offset", () => {
+    withTempDir("openclaw-e2e-ready-offset-", (tempDir) => {
+      const logPath = path.join(tempDir, "gateway.log");
+      const result = runBashWithHelper(
+        [
+          "openclaw_e2e_probe_http() { return 0; }",
+          `printf '[gateway] ready ws://127.0.0.1:23456\\n' >${shellQuote(logPath)}`,
+          `launch_offset="$(wc -c <${shellQuote(logPath)})"`,
+          `(sleep 0.1; printf 'current launch failed\\n' >>${shellQuote(logPath)}; exit 1) &`,
+          'gateway_pid="$!"',
+          `if openclaw_e2e_wait_gateway_ready "$gateway_pid" ${shellQuote(logPath)} 4 23456 strict "$launch_offset"; then`,
+          '  echo "stale ready log satisfied current launch" >&2',
+          "  exit 1",
+          "fi",
+          '[ "$OPENCLAW_E2E_GATEWAY_EXIT_STATUS" = "1" ]',
+        ],
+        {},
+        5_000,
+      );
+
+      expectShellSuccess(result);
+      expect(result.stdout).toContain("Gateway exited before becoming ready");
+    });
+  });
+
   it("wraps package installs with the configured timeout", () => {
     withTempDir("openclaw-e2e-instance-", (tempDir) => {
       const fixture = createPackageInstallFixture(tempDir);

--- a/test/scripts/upgrade-survivor-gateway-start.test.ts
+++ b/test/scripts/upgrade-survivor-gateway-start.test.ts
@@ -1,0 +1,182 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const instanceHelperPath = path.resolve("scripts/lib/openclaw-e2e-instance.sh");
+const gatewayStartPath = path.resolve("scripts/e2e/lib/upgrade-survivor/gateway-start.sh");
+const refusal =
+  "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory.";
+const restartMarker =
+  "[upgrade-survivor] restarting direct gateway after migration convergence refusal";
+const tempRoots: string[] = [];
+
+type Attempt = {
+  args: string[];
+  config: unknown;
+  cwd: string;
+  env: Record<string, string | undefined>;
+  pid: number;
+};
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+function runScenario(sequence: string, initialLog = "") {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "upgrade-survivor-gateway-start-"));
+  tempRoots.push(root);
+  const fixturePath = path.join(root, "gateway.mjs");
+  const tracePath = path.join(root, "attempts.jsonl");
+  const configPath = path.join(root, "openclaw.json");
+  const logPath = path.join(root, "gateway.log");
+  const stateDir = path.join(root, "state");
+  fs.mkdirSync(stateDir);
+  fs.writeFileSync(configPath, `${JSON.stringify({ gateway: { mode: "local" } })}\n`);
+  fs.writeFileSync(logPath, initialLog);
+  fs.writeFileSync(
+    fixturePath,
+    `
+import fs from "node:fs";
+const tracePath = process.env.OPENCLAW_FAKE_GATEWAY_TRACE;
+const countPath = tracePath + ".count";
+let attempt = 1;
+try { attempt = Number(fs.readFileSync(countPath, "utf8")) + 1; } catch {}
+fs.writeFileSync(countPath, String(attempt));
+fs.appendFileSync(tracePath, JSON.stringify({
+  args: process.argv.slice(2),
+  config: JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8")),
+  cwd: process.cwd(),
+  env: Object.fromEntries(["HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR", "OPENCLAW_TEST_LAUNCH_ID"].map((key) => [key, process.env[key]])),
+  pid: process.pid,
+}) + "\\n");
+const action = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[attempt - 1] || "ready";
+const refusal = ${JSON.stringify(refusal)};
+if (action === "refuse") { process.stderr.write(refusal + "\\n"); process.exit(1); }
+if (action === "near") { process.stderr.write(refusal.replace("convergence;", "convergence:") + "\\n"); process.exit(1); }
+if (action === "prefixed") { process.stderr.write("prefix " + refusal + "\\n"); process.exit(1); }
+if (action === "suffixed") { process.stderr.write(refusal + " extra\\n"); process.exit(1); }
+if (action === "status2") { process.stderr.write(refusal + "\\n"); process.exit(2); }
+if (action === "signal") { process.stderr.write(refusal + "\\n"); process.kill(process.pid, "SIGTERM"); }
+if (action === "unrelated") { process.stderr.write("unrelated startup failure\\n"); process.exit(1); }
+process.stdout.write("[gateway] ready ws://127.0.0.1:23456\\n");
+process.on("SIGTERM", () => process.exit(0));
+setInterval(() => {}, 1_000);
+`,
+  );
+
+  const script = `
+set -u
+source ${shellQuote(instanceHelperPath)}
+source ${shellQuote(gatewayStartPath)}
+openclaw_e2e_probe_http() { return 0; }
+set +e
+upgrade_survivor_start_direct_gateway \
+  ${shellQuote(logPath)} \
+  20 \
+  23456 \
+  strict \
+  -- \
+  env \
+    HOME=${shellQuote(root)} \
+    OPENCLAW_CONFIG_PATH=${shellQuote(configPath)} \
+    OPENCLAW_STATE_DIR=${shellQuote(stateDir)} \
+    OPENCLAW_TEST_LAUNCH_ID=stable-launch \
+    OPENCLAW_FAKE_GATEWAY_TRACE=${shellQuote(tracePath)} \
+    OPENCLAW_FAKE_GATEWAY_SEQUENCE=${shellQuote(sequence)} \
+    ${shellQuote(process.execPath)} \
+    ${shellQuote(fixturePath)} \
+    gateway \
+    --port \
+    23456 \
+    "argument with spaces"
+status="$?"
+set -e
+printf 'result=%s pid=%s\\n' "$status" "\${gateway_pid:-}"
+if [ "$status" -eq 0 ]; then
+  openclaw_e2e_stop_process "$gateway_pid"
+fi
+`;
+  const result = spawnSync("/bin/bash", ["-c", script], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  const attempts = fs.existsSync(tracePath)
+    ? fs
+        .readFileSync(tracePath, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Attempt)
+    : [];
+  return {
+    attempts,
+    log: fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "",
+    result,
+  };
+}
+
+describe("upgrade survivor direct gateway convergence", () => {
+  it("retries one exact refusal with identical launch state and retains the ready PID", () => {
+    const { attempts, log, result } = runScenario("refuse,ready");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(`result=0 pid=${attempts[1]?.pid}`);
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]?.pid).not.toBe(attempts[1]?.pid);
+    expect({ ...attempts[0], pid: 0 }).toEqual({ ...attempts[1], pid: 0 });
+    expect(log).toContain(refusal);
+    expect(log).toContain(restartMarker);
+  });
+
+  it.each(["near", "prefixed", "suffixed", "status2", "signal", "unrelated"])(
+    "keeps %s refusal lookalikes terminal",
+    (action) => {
+      const { attempts, log, result } = runScenario(`${action},ready`);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("result=1 pid=");
+      expect(attempts).toHaveLength(1);
+      expect(log).not.toContain(restartMarker);
+    },
+  );
+
+  it("does not reuse the first attempt refusal for a later unrelated exit", () => {
+    const { attempts, log, result } = runScenario("refuse,unrelated,ready");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("result=1 pid=");
+    expect(attempts).toHaveLength(2);
+    expect(log.split(restartMarker)).toHaveLength(2);
+  });
+
+  it("ignores an exact refusal left in the log before the current launch", () => {
+    const { attempts, log, result } = runScenario("unrelated,ready", `${refusal}\n`);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("result=1 pid=");
+    expect(attempts).toHaveLength(1);
+    expect(log).not.toContain(refusal);
+    expect(log).not.toContain(restartMarker);
+  });
+
+  it("fails a second exact refusal without spawning a third gateway", () => {
+    const { attempts, log, result } = runScenario("refuse,refuse,ready");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("result=1 pid=");
+    expect(attempts).toHaveLength(2);
+    expect(log.split(restartMarker)).toHaveLength(2);
+    expect(
+      log.match(/OpenClaw plugin migration inputs changed during startup convergence;/gu),
+    ).toHaveLength(2);
+  });
+});

--- a/test/scripts/upgrade-survivor-systemctl-shim.test.ts
+++ b/test/scripts/upgrade-survivor-systemctl-shim.test.ts
@@ -1,0 +1,429 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const SHIM_HELPER_PATH = "scripts/e2e/lib/upgrade-survivor/systemctl-shim.sh";
+const SYSTEMD_UNIT_PATH = "src/daemon/systemd-unit.ts";
+const PUBLISHED_RUNNER_PATH = "scripts/e2e/lib/upgrade-survivor/run.sh";
+const UPDATE_RESTART_AUTH_PATH = "scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh";
+
+type Fixture = {
+  childPidFile: string;
+  envFile: string;
+  gatewayRunsFile: string;
+  shim: string;
+  shimEnv: NodeJS.ProcessEnv;
+  supervisorPidFile: string;
+  workerAliveAtRestartFile: string;
+  workerPidFile: string;
+  workerTermFile: string;
+};
+
+async function waitFor(predicate: () => boolean, message: string, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(20);
+  }
+  throw new Error(message);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    const state = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], {
+      encoding: "utf8",
+    }).stdout.trim();
+    return state !== "" && !state.startsWith("Z");
+  } catch {
+    return false;
+  }
+}
+
+function readLines(file: string): string[] {
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8").trim().split("\n").filter(Boolean);
+}
+
+function createFixture(
+  mode:
+    | "stay-running"
+    | "with-descendant"
+    | "restart-with-stubborn-descendant"
+    | "restart-once"
+    | "always-fail"
+    | "exit-78",
+): Fixture {
+  const root = tempDirs.make("openclaw-systemctl-shim-");
+  const home = join(root, "home");
+  const prefix = join(root, "prefix");
+  const state = join(root, "state");
+  const unitDir = join(home, ".config/systemd/user");
+  const gateway = join(root, "gateway.sh");
+  const envFile = join(root, "service.env");
+  const gatewayRunsFile = join(root, "gateway-runs.log");
+  const workerAliveAtRestartFile = join(root, "worker-alive-at-restart");
+  const workerPidFile = join(root, "worker.pid");
+  const workerTermFile = join(root, "worker-term");
+  const childPidFile = join(state, "gateway.pid");
+  const supervisorPidFile = `${childPidFile}.supervisor.pid`;
+  const daemonLog = join(state, "gateway.log");
+  mkdirSync(unitDir, { recursive: true });
+  mkdirSync(state, { recursive: true });
+
+  writeFileSync(
+    gateway,
+    `#!/usr/bin/env bash
+set -euo pipefail
+count_file="$TEST_RUN_DIR/count"
+count=0
+[ ! -f "$count_file" ] || count="$(cat "$count_file")"
+count=$((count + 1))
+printf '%s\\n' "$count" >"$count_file"
+printf '%s|%s|%s\\n' "$$" "\${OPENCLAW_UPDATE_IN_PROGRESS-unset}" "\${OPENCLAW_UPDATE_UNIT_DEFINED-unset}" >>"$TEST_RUN_DIR/gateway-runs.log"
+case "$TEST_MODE" in
+  stay-running)
+    trap 'exit 0' INT TERM
+    while true; do sleep 1; done
+    ;;
+  with-descendant)
+    (
+      trap 'exit 0' INT TERM
+      while true; do sleep 1; done
+    ) &
+    printf '%s\\n' "$!" >"$TEST_RUN_DIR/worker.pid"
+    trap 'exit 0' INT TERM
+    while true; do sleep 1; done
+    ;;
+  restart-with-stubborn-descendant)
+    if [ "$count" -eq 1 ]; then
+      (
+        trap 'printf "%s\\n" TERM >"$TEST_RUN_DIR/worker-term"' TERM
+        while true; do sleep 1; done
+      ) &
+      printf '%s\\n' "$!" >"$TEST_RUN_DIR/worker.pid"
+      sleep 0.05
+      exit 1
+    fi
+    old_worker_pid="$(cat "$TEST_RUN_DIR/worker.pid")"
+    old_worker_state="$(ps -o stat= -p "$old_worker_pid" 2>/dev/null | cut -c1 || true)"
+    if kill -0 "$old_worker_pid" >/dev/null 2>&1 &&
+      [ -n "$old_worker_state" ] &&
+      [ "$old_worker_state" != "Z" ]; then
+      printf '%s\\n' "$old_worker_pid" >"$TEST_RUN_DIR/worker-alive-at-restart"
+    fi
+    trap 'exit 0' INT TERM
+    while true; do sleep 1; done
+    ;;
+  restart-once)
+    if [ "$count" -eq 1 ]; then sleep 0.2; exit 1; fi
+    trap 'exit 0' INT TERM
+    while true; do sleep 1; done
+    ;;
+  always-fail)
+    sleep 0.05
+    exit 1
+    ;;
+  exit-78)
+    sleep 0.05
+    exit 78
+    ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    envFile,
+    `TEST_RUN_DIR=${root}
+TEST_MODE=${mode}
+OPENCLAW_UPDATE_UNIT_DEFINED=unit-one
+`,
+  );
+  writeFileSync(
+    join(unitDir, "openclaw-gateway.service"),
+    `[Unit]
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+[Service]
+ExecStart=${gateway}
+Restart=always
+RestartSec=5
+RestartPreventExitStatus=78
+EnvironmentFile=-${envFile}
+`,
+  );
+
+  const installEnv = {
+    ...process.env,
+    HOME: home,
+    npm_config_prefix: prefix,
+    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(state, "systemctl.log"),
+    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: childPidFile,
+    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG: daemonLog,
+  };
+  execFileSync(
+    "bash",
+    [
+      "--noprofile",
+      "--norc",
+      "-c",
+      `source "$1"; install_update_restart_systemctl_shim`,
+      "install-systemctl-shim",
+      SHIM_HELPER_PATH,
+    ],
+    { env: installEnv },
+  );
+
+  return {
+    childPidFile,
+    envFile,
+    gatewayRunsFile,
+    shim: join(prefix, "bin/systemctl"),
+    shimEnv: {
+      ...installEnv,
+      OPENCLAW_UPDATE_IN_PROGRESS: "caller-update",
+      OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_RESTART_SEC_MS: "50",
+      OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_START_LIMIT_BURST: "5",
+      OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_START_LIMIT_INTERVAL_MS: "2000",
+      OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_STOP_TIMEOUT_MS: "500",
+    },
+    supervisorPidFile,
+    workerAliveAtRestartFile,
+    workerPidFile,
+    workerTermFile,
+  };
+}
+
+function runSystemctl(fixture: Fixture, args: string[]): string {
+  return execFileSync(fixture.shim, args, {
+    encoding: "utf8",
+    env: fixture.shimEnv,
+  });
+}
+
+function runSystemctlResult(fixture: Fixture, args: string[]) {
+  return spawnSync(fixture.shim, args, {
+    encoding: "utf8",
+    env: fixture.shimEnv,
+  });
+}
+
+describe("upgrade survivor systemctl shim", () => {
+  it("is the single supervisor implementation used by both package paths", () => {
+    const helper = readFileSync(SHIM_HELPER_PATH, "utf8");
+    const productionUnit = readFileSync(SYSTEMD_UNIT_PATH, "utf8");
+    for (const file of [PUBLISHED_RUNNER_PATH, UPDATE_RESTART_AUTH_PATH]) {
+      const script = readFileSync(file, "utf8");
+      expect(script).toContain("source scripts/e2e/lib/upgrade-survivor/systemctl-shim.sh");
+      expect(script).not.toContain('cat >"$shim_dir/systemctl"');
+    }
+    for (const contract of [
+      ["Restart=always", "5_000"],
+      ["RestartSec=5", "5_000"],
+      ["RestartPreventExitStatus=78", "code === 78"],
+      ["StartLimitBurst=5", "5"],
+      ["StartLimitIntervalSec=60", "60_000"],
+      ["TimeoutStopSec=30", "30_000"],
+      ["KillMode=control-group", "detached: true"],
+    ]) {
+      expect(productionUnit).toContain(contract[0]);
+      expect(helper).toContain(contract[1]);
+    }
+  });
+
+  it("restarts failures with fresh unit env and reports the gateway child as MainPID", async () => {
+    const fixture = createFixture("restart-once");
+    fixture.shimEnv.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_RESTART_SEC_MS = "1000";
+    runSystemctl(fixture, ["--user", "start", "openclaw-gateway.service"]);
+
+    await waitFor(
+      () => readLines(fixture.gatewayRunsFile).length === 1,
+      "first gateway did not run",
+    );
+    const supervisorPid = Number(readFileSync(fixture.supervisorPidFile, "utf8").trim());
+    await waitFor(
+      () => !existsSync(fixture.childPidFile),
+      "gateway child PID remained during restart delay",
+    );
+    const inactive = runSystemctlResult(fixture, [
+      "--user",
+      "is-active",
+      "openclaw-gateway.service",
+    ]);
+    expect(inactive.status).toBe(3);
+    const delayedShow = runSystemctl(fixture, [
+      "--user",
+      "show",
+      "--property=MainPID",
+      "openclaw-gateway.service",
+    ]);
+    expect(delayedShow).toContain("ActiveState=inactive");
+    expect(delayedShow).toContain("MainPID=0");
+    expect(processIsAlive(supervisorPid)).toBe(true);
+    expect(existsSync(fixture.supervisorPidFile)).toBe(true);
+
+    writeFileSync(
+      fixture.envFile,
+      `${readFileSync(fixture.envFile, "utf8").replace("unit-one", "unit-two")}`,
+    );
+    await waitFor(
+      () => readLines(fixture.gatewayRunsFile).length === 2,
+      "failed gateway was not restarted",
+    );
+
+    const runs = readLines(fixture.gatewayRunsFile);
+    expect(runs[0]?.split("|").slice(1)).toEqual(["unset", "unit-one"]);
+    expect(runs[1]?.split("|").slice(1)).toEqual(["unset", "unit-two"]);
+
+    const show = runSystemctl(fixture, [
+      "--user",
+      "show",
+      "--property=MainPID",
+      "openclaw-gateway.service",
+    ]);
+    const mainPid = Number(/^MainPID=(\d+)$/mu.exec(show)?.[1]);
+    expect(mainPid).toBe(Number(runs[1]?.split("|")[0]));
+    expect(mainPid).not.toBe(supervisorPid);
+    expect(processIsAlive(mainPid)).toBe(true);
+    expect(processIsAlive(supervisorPid)).toBe(true);
+
+    runSystemctl(fixture, ["--user", "stop", "openclaw-gateway.service"]);
+    await waitFor(
+      () => !processIsAlive(mainPid) && !processIsAlive(supervisorPid),
+      "stop left the supervisor or gateway alive",
+    );
+    expect(existsSync(fixture.childPidFile)).toBe(false);
+    expect(existsSync(fixture.supervisorPidFile)).toBe(false);
+    expect(existsSync(`${fixture.childPidFile}.supervisor.mjs`)).toBe(false);
+  });
+
+  it("returns from start only after a live child is visible as MainPID", () => {
+    const fixture = createFixture("stay-running");
+    runSystemctl(fixture, ["--user", "start", "openclaw-gateway.service"]);
+
+    const childPid = Number(readFileSync(fixture.childPidFile, "utf8").trim());
+    const show = runSystemctl(fixture, [
+      "--user",
+      "show",
+      "--property=MainPID",
+      "openclaw-gateway.service",
+    ]);
+    expect(show).toContain("ActiveState=active");
+    expect(show).toContain(`MainPID=${childPid}`);
+    expect(processIsAlive(childPid)).toBe(true);
+
+    runSystemctl(fixture, ["--user", "stop", "openclaw-gateway.service"]);
+    expect(processIsAlive(childPid)).toBe(false);
+  });
+
+  it("stops descendants in the managed gateway process group", async () => {
+    const fixture = createFixture("with-descendant");
+    runSystemctl(fixture, ["--user", "start", "openclaw-gateway.service"]);
+    await waitFor(() => existsSync(fixture.workerPidFile), "gateway worker did not start");
+
+    const childPid = Number(readFileSync(fixture.childPidFile, "utf8").trim());
+    const workerPid = Number(readFileSync(fixture.workerPidFile, "utf8").trim());
+    expect(processIsAlive(childPid)).toBe(true);
+    expect(processIsAlive(workerPid)).toBe(true);
+
+    runSystemctl(fixture, ["--user", "stop", "openclaw-gateway.service"]);
+    await waitFor(
+      () => !processIsAlive(childPid) && !processIsAlive(workerPid),
+      "stop left the gateway or descendant worker alive",
+    );
+  });
+
+  it("drains a failed leader's process group before restarting", async () => {
+    const fixture = createFixture("restart-with-stubborn-descendant");
+    fixture.shimEnv.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_RESTART_SEC_MS = "50";
+    fixture.shimEnv.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_STOP_TIMEOUT_MS = "100";
+    runSystemctl(fixture, ["--user", "start", "openclaw-gateway.service"]);
+
+    await waitFor(() => existsSync(fixture.workerPidFile), "gateway worker did not start");
+    const workerPid = Number(readFileSync(fixture.workerPidFile, "utf8").trim());
+    await waitFor(
+      () => readLines(fixture.gatewayRunsFile).length === 2,
+      "gateway did not restart after draining its old process group",
+    );
+
+    expect(readFileSync(fixture.workerTermFile, "utf8").trim()).toBe("TERM");
+    expect(processIsAlive(workerPid)).toBe(false);
+    expect(existsSync(fixture.workerAliveAtRestartFile)).toBe(false);
+
+    runSystemctl(fixture, ["--user", "stop", "openclaw-gateway.service"]);
+  });
+
+  it("returns nonzero when supervisor timing validation fails", () => {
+    const fixture = createFixture("stay-running");
+    fixture.shimEnv.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_RESTART_SEC_MS = "invalid";
+
+    const result = runSystemctlResult(fixture, ["--user", "start", "openclaw-gateway.service"]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_RESTART_SEC_MS must be a positive integer",
+    );
+    expect(existsSync(fixture.childPidFile)).toBe(false);
+    expect(existsSync(fixture.supervisorPidFile)).toBe(false);
+  });
+
+  it("returns nonzero when the first child cannot initialize its unit environment", () => {
+    const fixture = createFixture("stay-running");
+    writeFileSync(fixture.envFile, "BROKEN='unterminated\n");
+
+    const result = runSystemctlResult(fixture, ["--user", "start", "openclaw-gateway.service"]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("gateway exited before startup initialization");
+    expect(existsSync(fixture.childPidFile)).toBe(false);
+    expect(existsSync(fixture.supervisorPidFile)).toBe(false);
+  });
+
+  it("stops after five starts inside the production burst interval", async () => {
+    const fixture = createFixture("always-fail");
+    runSystemctl(fixture, ["--user", "start", "openclaw-gateway.service"]);
+    const supervisorPid = Number(readFileSync(fixture.supervisorPidFile, "utf8").trim());
+
+    await waitFor(
+      () => readLines(fixture.gatewayRunsFile).length === 5,
+      "gateway did not reach the five-start limit",
+    );
+    await waitFor(
+      () => !processIsAlive(supervisorPid),
+      "supervisor process stayed alive after the start limit",
+    );
+    expect(existsSync(fixture.supervisorPidFile)).toBe(true);
+    expect(
+      runSystemctlResult(fixture, ["--user", "is-active", "openclaw-gateway.service"]).status,
+    ).toBe(3);
+    await delay(150);
+    expect(readLines(fixture.gatewayRunsFile)).toHaveLength(5);
+    expect(existsSync(fixture.childPidFile)).toBe(false);
+    expect(existsSync(fixture.supervisorPidFile)).toBe(false);
+    expect(existsSync(`${fixture.childPidFile}.supervisor.mjs`)).toBe(false);
+  });
+
+  it("does not restart exit status 78", async () => {
+    const fixture = createFixture("exit-78");
+    runSystemctl(fixture, ["--user", "start", "openclaw-gateway.service"]);
+    const supervisorPid = Number(readFileSync(fixture.supervisorPidFile, "utf8").trim());
+
+    await waitFor(() => readLines(fixture.gatewayRunsFile).length === 1, "gateway did not run");
+    await waitFor(
+      () => !processIsAlive(supervisorPid),
+      "supervisor process stayed alive after exit 78",
+    );
+    expect(existsSync(fixture.supervisorPidFile)).toBe(true);
+    expect(
+      runSystemctlResult(fixture, ["--user", "is-active", "openclaw-gateway.service"]).status,
+    ).toBe(3);
+    await delay(150);
+    expect(readLines(fixture.gatewayRunsFile)).toHaveLength(1);
+    expect(existsSync(fixture.childPidFile)).toBe(false);
+    expect(existsSync(fixture.supervisorPidFile)).toBe(false);
+    expect(existsSync(`${fixture.childPidFile}.supervisor.mjs`)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #120297

Related: #120300
Related: #120086

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Package Acceptance could reject a healthy candidate during
the authenticated update/restart lane because the release harness ran stale
candidate scripts, modeled the managed Gateway as a one-shot process, omitted a
version-bound runtime companion, and treated the documented one-restart
migration-convergence contract as an immediate terminal failure.

## Why This Change Was Made

The trusted harness is now mounted independently from the package source,
prepublishes every fixture-owned companion at the candidate version, models the
generated systemd unit's bounded restart behavior, and retries a direct Gateway
launch exactly once only for exit status 1 plus the exact migration-convergence
refusal. Package self-update remains separate.

This supersedes the overlapping drafts in #120300 and #120086. Their branches
cannot accept maintainer edits, and the landed diff must differ to address the
reviewed restart timing, PID ownership, environment reload, start-limit,
split-root, and exact-refusal requirements. Peter Steinberger's contribution is
preserved in the commit co-author trailer.

## User Impact

Release operators get deterministic package/update validation that follows the
installed service contract instead of false-failing a healthy candidate.
Product runtime impact: none.

## Evidence

- Reproduced the original pre-ready convergence refusal in the
  `update-restart-auth` Docker path before the fake systemd supervisor was
  invoked.
- The repaired direct launcher retries once, then correctly fails a second
  independent refusal. That diagnostic also confirmed raw direct runs need the
  candidate-version prepublish registry supplied by Package Acceptance.
- Focused tests: 10/10 direct Gateway convergence cases and 7/7 systemd-shim
  behavior cases.
- Fresh exact-head autoreview: clean, no accepted/actionable P0-P2 findings.
- Blacksmith Testbox `check:changed`: passed on exact head `209cc1d63b` in
  https://github.com/openclaw/openclaw/actions/runs/31207673047.
- Fresh `source=ref` Package Acceptance and native PR landing gates remain hard
  pre-merge requirements.

AI-assisted: yes. No agent transcript is included.

Punchcard-Session: brisk-harbor-lantern-f3
