### PR TITLE
docs(plugins): include Agent Plugins in the plugins page read-when hints

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -3,7 +3,7 @@ summary: "Install, configure, and manage OpenClaw plugins"
 read_when:
   - Installing or configuring plugins
   - Understanding plugin discovery and load rules
-  - Working with Codex/Claude-compatible plugin bundles
+  - Working with Agent Plugins, Codex, Claude, or Cursor-compatible plugin bundles
 title: "Plugins"
 sidebarTitle: "Getting Started"
 doc-schema-version: 1


### PR DESCRIPTION
## What Problem This Solves

One frontmatter read_when bullet in docs/tools/plugin.md still said only Codex/Claude-compatible bundles after Agent Plugins support landed (#120115, #120214, #120303).

## Why This Change Was Made

Keeps the page discovery hints aligned with the four supported bundle formats; every other docs surface was already updated.

## User Impact

Docs-only, one line.

## Evidence

git diff --check clean; docs-only change, no runtime surface.