### PR TITLE
fix(config): limit cleanOrphanBackups to numbered ring slots (#120253)

### DIFF
--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -90,6 +90,13 @@ async function cleanOrphanBackups(configPath: string, ioFs: BackupRotationFs): P
       continue;
     }
     const suffix = entry.slice(bakPrefix.length);
+    // Restrict the cleanup to files that this module actually creates: a
+    // pure integer suffix indicates a numbered ring slot. Anything else
+    // (e.g. `.bak-manual-20260808`, `.bak.pre-update`) is user-authored
+    // and must be left alone (#120253).
+    if (!/^[0-9]+$/.test(suffix)) {
+      continue;
+    }
     if (validSuffixes.has(suffix)) {
       continue;
     }

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -68,7 +68,7 @@ describe("config backup rotation", () => {
       const configPath = resolveConfigPathFromTempState();
       await fs.writeFile(configPath, JSON.stringify({ token: "secret" }), { mode: 0o600 });
       await fs.writeFile(`${configPath}.bak`, "previous", { mode: 0o644 });
-      await fs.writeFile(`${configPath}.bak.orphan`, "old");
+      await fs.writeFile(`${configPath}.bak.99`, "stale-ring-slot");
 
       await maintainConfigBackups(configPath, fs);
 
@@ -84,8 +84,25 @@ describe("config backup rotation", () => {
         const primaryBackupStat = await fs.stat(`${configPath}.bak`);
         expectPosixMode(primaryBackupStat.mode, 0o600);
       }
-      // Out-of-ring orphan gets pruned.
-      await expectPathMissing(`${configPath}.bak.orphan`);
+      // Out-of-ring numbered slot (escaped stale ring slot) gets pruned.
+      await expectPathMissing(`${configPath}.bak.99`);
+    });
+  });
+
+  it("cleanOrphanBackups preserves user-authored non-integer .bak.* files (#120253)", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+      await fs.writeFile(configPath, JSON.stringify({ token: "secret" }), { mode: 0o600 });
+      const userManualBackup = `${configPath}.bak-manual-20260808`;
+      const userLabeledBackup = `${configPath}.bak.pre-edit`;
+      await fs.writeFile(userManualBackup, "manual snapshot");
+      await fs.writeFile(userLabeledBackup, "pre-edit snapshot");
+
+      await maintainConfigBackups(configPath, fs);
+
+      // User-authored backups must survive cleanup untouched.
+      await expect(fs.readFile(userManualBackup, "utf-8")).resolves.toBe("manual snapshot");
+      await expect(fs.readFile(userLabeledBackup, "utf-8")).resolves.toBe("pre-edit snapshot");
     });
   });
 
@@ -194,7 +211,9 @@ describe("config backup rotation", () => {
       logVerboseMock.mockClear();
       const configPath = resolveConfigPathFromTempState();
       await fs.writeFile(configPath, JSON.stringify({ token: "secret" }), { mode: 0o600 });
-      const lockedOrphan = `${configPath}.bak.orphan`;
+      // Use a stale numbered ring slot (.bak.99, outside the active 1..4 ring)
+      // so the cleanup still considers it an orphan candidate.
+      const lockedOrphan = `${configPath}.bak.99`;
       await fs.writeFile(lockedOrphan, "orphan");
 
       // A locked/undeletable orphan: unlink rejects for this entry only, so rotate/copy/harden


### PR DESCRIPTION
## Summary

`cleanOrphanBackups()` in `src/config/backup-rotation.ts` walks the config directory and unlinks any file matching the `.bak.*` prefix that is not one of the active ring slots `.bak.1`–`.bak.4`. With the current implementation, that includes user-authored manual backups such as `openclaw.json.bak.pre-edit` or `openclaw.json.bak.manual-20260808` — the user copies they made before editing the config disappear on the next gateway restart with no log entry, no warning, and no recovery path.

This PR narrows the cleanup to entries whose suffix after `.bak.` is a pure non-negative integer. Stale numbered ring slots (`.bak.0`, `.bak.5`, `.bak.99`, ...) are still pruned; anything else is treated as user-authored and preserved.

## Behavior

| Filename | Before | After |
|---|---|---|
| `openclaw.json.bak` (active primary) | rotated, kept | rotated, kept |
| `openclaw.json.bak.1` – `.bak.4` (active ring) | kept | kept |
| `openclaw.json.bak.0` / `.bak.5` / `.bak.99` (stale slots) | pruned | pruned |
| `openclaw.json.bak.pre-edit` (user) | **silently deleted** | kept |
| `openclaw.json.bak.manual-20260808` (user) | **silently deleted** | kept |
| `openclaw.json.bak.orphan` (user) | **silently deleted** | kept |

## Reproduction

```bash
cp ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.bak.pre-edit
# trigger cleanup (config change or gateway restart)
ls ~/.openclaw/openclaw.json.bak.pre-edit   # gone, silently
```

With the fix, the manual backup survives `maintainConfigBackups` untouched.

## Root cause and fix shape

`cleanOrphanBackups` was scoped by `validSuffixes` (the 1..4 ring) but never asserted that the entry's suffix *was* an integer at all. A second `continue` guard — `if (!/^[0-9]+$/.test(suffix)) continue;` — closes that gap without altering any existing prune contract. Stale ring-slot detection still fires for any pure-integer suffix outside the active set, and the existing log-on-unlink-failure behavior (#105199) is unchanged.

## Test changes

- `config.backup-rotation.test.ts`: two existing cases ("compose rotate/copy/harden/prune flow" and "logs an orphan backup cleanup failure instead of swallowing it") updated to use `.bak.99` as the stale-slot fixture instead of `.bak.orphan`. The new fixture stays in the prune-eligible set, so the existing assertions continue to exercise the same code paths.
- New case "cleanOrphanBackups preserves user-authored non-integer .bak.* files" covers the scope-restriction contract directly.

## Verification

`pnpm vitest` is blocked in this sandbox (Node 18 lacks `node:util.styleText` that rolldown pulls in via vitest 4 — same blocker as #118888). A standalone reproducer at `/tmp/verify-clean-orphan-backups.mts` exercises the patched `cleanOrphanBackups` against an in-memory fs shim with the same scenarios the vitest suite covers:

- **Unpatched (parent commit)**: 3 of 11 checks fail — `.bak.pre-edit`, `.bak.orphan`, and the empty-suffix edge case `.bak.` are wrongly pruned. This is the bug.
- **Patched (this branch)**: 11 of 11 pass — user-authored non-integer suffixes are preserved, numbered ring slots are pruned or kept per their integer status, and the empty-suffix edge case is left alone.

```text
# Scenario 1: user-authored non-integer .bak.* files are preserved
  ok  exists: openclaw.json.bak-manual-20260808
  ok  exists: openclaw.json.bak.pre-edit
  ok  exists: openclaw.json.bak.orphan

# Scenario 2: stale numbered ring slots (.bak.N for N >= 5 or N == 0) are pruned
  ok  pruned: openclaw.json.bak.99
  ok  pruned: openclaw.json.bak.5
  ok  pruned: openclaw.json.bak.0

# Scenario 3: active ring slots (.bak.1..4) are preserved
  ok  exists: openclaw.json.bak.1
  ok  exists: openclaw.json.bak.2
  ok  exists: openclaw.json.bak.3
  ok  exists: openclaw.json.bak.4

# Scenario 4: empty suffix (just `.bak.`) is left alone
  ok  exists: openclaw.json.bak.

11 passed, 0 failed
```

## Risk

Production change is +7 lines in a single helper; no new dependencies, no new exports, no API surface change. The two updated test cases use a different stale-slot fixture (integer suffix `.bak.99` instead of the deliberately-arbitrary `.bak.orphan`) which keeps the prune-eligible contract unchanged while making the test name and fixture match the bug class.

Closes #120253