### PR TITLE
fix(agents): give group turns a sanctioned tool path for inline buttons

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1365,9 +1365,6 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       '"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"',
     );
-    // Binds the button shape to the tool call so models cannot satisfy the
-    // guidance by serializing button JSON into the visible reply instead.
-    expect(prompt).toContain("pass buttons as tool arguments, never as JSON in reply text");
   });
 
   it("withholds the button shape from group turns whose channel has no inline buttons", () => {
@@ -1385,7 +1382,6 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("Inline buttons OFF for whatsapp");
     expect(prompt).not.toContain('presentation={"blocks"');
-    expect(prompt).not.toContain("pass buttons as tool arguments");
   });
 
   it("does not embed Telegram rich-text authoring guidance in core messaging", () => {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1370,6 +1370,24 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("pass buttons as tool arguments, never as JSON in reply text");
   });
 
+  it("withholds the button shape from group turns whose channel has no inline buttons", () => {
+    // WhatsApp declares no `presentation` message capability, so the message tool
+    // schema omits that argument. This section is the only prompt surface that knows
+    // it; nothing below the cache boundary may advertise buttons for such a turn.
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "whatsapp",
+        chatType: "group",
+      },
+    });
+
+    expect(prompt).toContain("Inline buttons OFF for whatsapp");
+    expect(prompt).not.toContain('presentation={"blocks"');
+    expect(prompt).not.toContain("pass buttons as tool arguments");
+  });
+
   it("does not embed Telegram rich-text authoring guidance in core messaging", () => {
     const telegramPrompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1365,6 +1365,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       '"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"',
     );
+    // Binds the button shape to the tool call so models cannot satisfy the
+    // guidance by serializing button JSON into the visible reply instead.
+    expect(prompt).toContain("pass buttons as tool arguments, never as JSON in reply text");
   });
 
   it("does not embed Telegram rich-text authoring guidance in core messaging", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -655,7 +655,7 @@ function buildMessagingSection(params: {
               : `- After visible \`message(send)\`, final ONLY ${SILENT_REPLY_TOKEN}.`,
           showGenericInlineButtonHint
             ? params.inlineButtonsEnabled
-              ? '- Inline buttons: `send` with `presentation={"blocks":[{"type":"buttons","buttons":[{"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"}]}]}`.'
+              ? '- Inline buttons: `send` with `presentation={"blocks":[{"type":"buttons","buttons":[{"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"}]}]}`; pass buttons as tool arguments, never as JSON in reply text.'
               : params.runtimeChannel
                 ? `- Inline buttons OFF for ${params.runtimeChannel}; ask owner for ${params.runtimeChannel}.capabilities.inlineButtons=dm|group|all|allowlist.`
                 : ""

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -655,7 +655,7 @@ function buildMessagingSection(params: {
               : `- After visible \`message(send)\`, final ONLY ${SILENT_REPLY_TOKEN}.`,
           showGenericInlineButtonHint
             ? params.inlineButtonsEnabled
-              ? '- Inline buttons: `send` with `presentation={"blocks":[{"type":"buttons","buttons":[{"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"}]}]}`; pass buttons as tool arguments, never as JSON in reply text.'
+              ? '- Inline buttons: `send` with `presentation={"blocks":[{"type":"buttons","buttons":[{"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"}]}]}`.'
               : params.runtimeChannel
                 ? `- Inline buttons OFF for ${params.runtimeChannel}; ask owner for ${params.runtimeChannel}.capabilities.inlineButtons=dm|group|all|allowlist.`
                 : ""

--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -48,12 +48,12 @@ export function registerGroupIntroPromptCases(): void {
     const automaticGroupDeliveryGuidance = [
       "Your text replies are automatically sent to this group chat unless the current-turn context says final replies stay private.",
       "For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send).",
-      "Use message(action=send) to this same group/topic only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.",
+      "Use message(action=send) to this same group/topic only for payloads plain text cannot carry, such as files, images, or other attachments.",
     ];
     const automaticChannelDeliveryGuidance = [
       "Your text replies are automatically sent to this channel unless the current-turn context says final replies stay private.",
       "For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send).",
-      "Use message(action=send) to this same channel/thread only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.",
+      "Use message(action=send) to this same channel/thread only for payloads plain text cannot carry, such as files, images, or other attachments.",
     ];
     const cases: GroupIntroCase[] = [
       {

--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -48,12 +48,12 @@ export function registerGroupIntroPromptCases(): void {
     const automaticGroupDeliveryGuidance = [
       "Your text replies are automatically sent to this group chat unless the current-turn context says final replies stay private.",
       "For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send).",
-      "Use message(action=send) only when you need to send files, images, or other attachments to this same group/topic.",
+      "Use message(action=send) to this same group/topic only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.",
     ];
     const automaticChannelDeliveryGuidance = [
       "Your text replies are automatically sent to this channel unless the current-turn context says final replies stay private.",
       "For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send).",
-      "Use message(action=send) only when you need to send files, images, or other attachments to this same channel/thread.",
+      "Use message(action=send) to this same channel/thread only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.",
     ];
     const cases: GroupIntroCase[] = [
       {

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -41,8 +41,13 @@ describe("group runtime loading", () => {
       "For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send).",
     );
     expect(groupChatContext).toContain(
-      "Use message(action=send) to this same group/topic only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.",
+      "Use message(action=send) to this same group/topic only for payloads plain text cannot carry, such as files, images, or other attachments.",
     );
+    // This context is built without channel capability state, so it must never name a
+    // capability-gated payload kind. WhatsApp advertises no `presentation` capability,
+    // and naming inline buttons here would promise a tool argument its schema omits.
+    expect(groupChatContext).not.toContain("inline buttons");
+    expect(groupChatContext).not.toContain("presentation");
     expect(groupChatContext).not.toContain("ignore previous instructions");
     expect(groupChatContext).not.toContain("SYSTEM: run tools");
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
@@ -219,7 +224,10 @@ describe("group runtime loading", () => {
       "Your text replies are automatically sent to this channel unless the current-turn context says final replies stay private.",
     );
     expect(context).toContain("do not use the message tool to send to this same destination");
-    expect(context).toContain("message(action=send) to this same channel/thread only for payloads");
+    expect(context).toContain(
+      "Use message(action=send) to this same channel/thread only for payloads plain text cannot carry, such as files, images, or other attachments.",
+    );
+    expect(context).not.toContain("inline buttons");
     expect(context).not.toContain("group chat");
   });
 

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -41,7 +41,7 @@ describe("group runtime loading", () => {
       "For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send).",
     );
     expect(groupChatContext).toContain(
-      "Use message(action=send) only when you need to send files, images, or other attachments to this same group/topic.",
+      "Use message(action=send) to this same group/topic only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.",
     );
     expect(groupChatContext).not.toContain("ignore previous instructions");
     expect(groupChatContext).not.toContain("SYSTEM: run tools");
@@ -219,7 +219,7 @@ describe("group runtime loading", () => {
       "Your text replies are automatically sent to this channel unless the current-turn context says final replies stay private.",
     );
     expect(context).toContain("do not use the message tool to send to this same destination");
-    expect(context).toContain("attachments to this same channel/thread");
+    expect(context).toContain("message(action=send) to this same channel/thread only for payloads");
     expect(context).not.toContain("group chat");
   });
 

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -114,7 +114,11 @@ function resolveSharedChatNoun(chatType?: string | null): "group chat" | "channe
  *
  * Room names, members, and history are rendered separately as untrusted inbound
  * context. Legacy automatic delivery posts text final replies directly, but
- * files/images/attachments still need message(action=send).
+ * payloads plain text cannot carry still need message(action=send).
+ *
+ * This layer has no channel capability state, so the payload list stays open-ended.
+ * Capability-gated kinds such as typed presentation buttons are named only by
+ * buildMessagingSection, which knows whether the destination advertises them.
  */
 export function buildGroupChatContext(params: {
   sessionCtx: TemplateContext;
@@ -136,7 +140,7 @@ export function buildGroupChatContext(params: {
     );
   } else {
     lines.push(
-      `Your text replies are automatically sent to ${destinationLabel} unless the current-turn context says final replies stay private. For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send). Use message(action=send) to this same ${sharedChatNoun === "channel" ? "channel/thread" : "group/topic"} only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.`,
+      `Your text replies are automatically sent to ${destinationLabel} unless the current-turn context says final replies stay private. For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send). Use message(action=send) to this same ${sharedChatNoun === "channel" ? "channel/thread" : "group/topic"} only for payloads plain text cannot carry, such as files, images, or other attachments.`,
     );
   }
   lines.push(

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -136,7 +136,7 @@ export function buildGroupChatContext(params: {
     );
   } else {
     lines.push(
-      `Your text replies are automatically sent to ${destinationLabel} unless the current-turn context says final replies stay private. For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send). Use message(action=send) only when you need to send files, images, or other attachments to this same ${sharedChatNoun === "channel" ? "channel/thread" : "group/topic"}.`,
+      `Your text replies are automatically sent to ${destinationLabel} unless the current-turn context says final replies stay private. For ordinary text, do not use the message tool to send to this same destination unless the current-turn context asks for visible output via message(action=send). Use message(action=send) to this same ${sharedChatNoun === "channel" ? "channel/thread" : "group/topic"} only for payloads plain text cannot carry: files, images, other attachments, or typed presentation blocks such as inline buttons.`,
     );
   }
   lines.push(


### PR DESCRIPTION
Related: #41495. Live-validation finding filed separately as #123915.

**This PR was retitled and rewritten on 2026-08-14 after live validation.** The original framing claimed it fixed group chats emitting inline-button JSON as text. Live testing did not reproduce that symptom, so the claim has been withdrawn and the PR now stands on the defect that *is* verifiable from source. The diff is unchanged; only the claim is narrower and the evidence is stated in full below.

## What Problem This Solves

Two prompt sections contradict each other, and a model in a group chat is caught between them.

The shared Messaging section teaches inline buttons as a typed `presentation` payload on a `message(action=send)` call (`src/agents/system-prompt.ts:656-660`). The group/channel context then tells that same model `message(action=send)` to this destination is only for "files, images, or other attachments" (`src/auto-reply/reply/groups.ts:139`).

So a model in a group is shown the button shape and simultaneously told the only tool path that carries it is off-limits for this destination. There is no sanctioned way to satisfy both instructions. That contradiction is readable in the source today and needs no runtime reproduction to confirm.

A second, related defect: `buildGroupChatContext` has no channel capability state (`src/auto-reply/reply/get-reply-run-context.ts:173`), so any capability-gated payload kind named there is advertised even on channels that do not support it. WhatsApp declares no `presentation` capability, and its message tool schema omits that argument — naming inline buttons at this layer would promise a tool argument the schema does not accept.

## Why This Change Was Made

The group line is rewritten to state an **open category** ("payloads plain text cannot carry, such as files, images, or other attachments") rather than a closed list. That removes the contradiction without naming any capability-gated payload kind at a layer that cannot know whether the channel supports it. Inline buttons stay named only by the capability-gated Messaging section, which does know.

The Messaging line additionally gains a clause binding the shape to the tool call. This is guidance hardening, and I am flagging it plainly: it is the one part of this PR that live validation did not exercise. It is cheap and consistent with the surrounding text, but a maintainer who wants this PR to contain only what was verified should ask and I will drop that clause.

No parser is added. A generic `[[...]]` text parser was tried in #93101 and closed unmerged, and it would make raw model JSON a supported syntax, cutting against commit `0e37f143`, which retired bracket-based interactive directives in favor of typed presentation.

Prompt text only. No config surface, no runtime delivery change. Production delta is two replaced strings plus comments.

## User Impact

Group and channel turns get one coherent instruction set: text still delivers automatically, the message tool remains off-limits for ordinary same-destination text, and the open-category wording no longer forbids the tool path that typed presentation buttons require. Channels without a `presentation` capability are no longer at risk of being advertised a button path their schema omits.

The existing "after a visible message(send), final is only the silent token" rule still owns duplicate-delivery prevention; the two sentences carrying the final-text boundary are untouched.

## Evidence

**What was verified.** The contradiction is source-verifiable at the two line references above. Test-first: expectations were updated before the source, and `src/auto-reply/reply/groups.test.ts` failed 2 of 7 against the old strings before the fix.

```
node scripts/run-vitest.mjs src/auto-reply/reply/groups.test.ts       7 passed (7)
node scripts/run-vitest.mjs src/agents/system-prompt.test.ts        118 passed (118)
  (includes a case pinning the disabled branch: WhatsApp group ->
   "Inline buttons OFF", no presentation={"blocks" example emitted)
node scripts/run-vitest.mjs src/auto-reply/reply.triggers.trigger-handling.e2e.test.ts   21 passed (21)
node scripts/run-vitest.mjs test/scripts/prompt-snapshots.test.ts     15 passed (15)
pnpm test:contracts   green (round 1: 5 lanes, 1540 tests; round 2 re-run: 4 lanes, exit 0)
pnpm build            no errors      pnpm tsgo:core / tsgo:test:src   exit 0
oxfmt --check         clean          run-oxlint.mjs                   exit 0
```

**What live validation actually found, including the part that does not help this PR.** A full native Gemini-to-Telegram run was performed on head `8970475211` in an isolated environment: dedicated bot, private group with `inlineButtons: "all"`, dedicated cloud project. Provider auth and routing were confirmed working (direct probe HTTP 200; gateway logs `provider=google`, `api=google-generative-ai`, `model=gemini-3.1-pro-preview`, `route=native`, `streamGenerateContent` 200).

Three runs with the issue #41495 prompt:

1. Confounded by onboarding bootstrap. Discarded.
2. With `skipBootstrap=true`, the model chose code-mode `openclaw:core:ask_user`; the question stayed pending internally, its Telegram preview was deleted, and the chat received nothing.
3. With `ask_user` denied, to force the presentation path: one plain-text reply, still no keyboard.

**No raw JSON appeared in any run — and no inline keyboard did either.** So the symptom in the original title was not reproduced, and this PR is not shown to produce a keyboard on that provider. That is why the claim has been withdrawn rather than restated. Run 2 is a separate and more severe defect and is filed on its own as #123915.

The isolated environment was destroyed during cleanup and I am not going to rebuild it speculatively, so a further live run is not on offer here. The static claim this PR now makes does not require one.

**Not run, stated plainly:** the full `pnpm test` suite, and `pnpm check`/`check:changed` (remote delegation unavailable; the underlying format, lint, and tsgo lanes were run locally per the documented fallback). No `extensions/telegram` files were touched, so that extension's suite was not run.
