### PR TITLE
fix(ui): preserve slow build-link navigation

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -48,6 +48,15 @@ const AGENT_VALUE_PREFIX = "agent:";
 const COMMAND_VALUE_PREFIX = "command:";
 const LINK_VALUE_PREFIX = "link:";
 
+// Nested overlays bubble lifecycle events through the dropdown. Only the
+// owner's completed hide may remove its menu or consume its Escape state.
+function closeMenuAfterOwnDropdownHide(event: Event, onClose: (restoreFocus?: boolean) => void) {
+  if (event.target !== event.currentTarget) {
+    return;
+  }
+  onClose(consumeDropdownKeyboardDismissal(event));
+}
+
 type AgentMenuAgent = {
   id: string;
   name?: string;
@@ -285,7 +294,7 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
         }}
         @keydown=${(event: KeyboardEvent) =>
           trackDropdownKeyboardDismissal(event, params.onTabAway)}
-        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
+        @wa-after-hide=${(event: Event) => closeMenuAfterOwnDropdownHide(event, params.onClose)}
       >
         <button
           slot="trigger"
@@ -425,7 +434,7 @@ export function renderSidebarIdentityMenu(params: SidebarIdentityMenuParams) {
         }}
         @keydown=${(event: KeyboardEvent) =>
           trackDropdownKeyboardDismissal(event, params.onTabAway)}
-        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
+        @wa-after-hide=${(event: Event) => closeMenuAfterOwnDropdownHide(event, params.onClose)}
       >
         <button
           slot="trigger"

--- a/ui/src/e2e/build-info-unicode.e2e.test.ts
+++ b/ui/src/e2e/build-info-unicode.e2e.test.ts
@@ -69,16 +69,21 @@ async function openBuildDetails(page: Page) {
   if (!buildLinkHandle) {
     throw new Error("Expected the identity-menu build link to be attached");
   }
-  await Promise.all([
-    tooltip.evaluate(
-      (element) =>
-        new Promise<void>((resolve) => {
-          element.addEventListener("wa-after-hide", () => resolve(), { once: true });
-        }),
-    ),
-    page.mouse.down(),
-  ]);
+  const afterHideMarker = "data-openclaw-test-after-hide";
+  await tooltip.evaluate((element, marker) => {
+    element.removeAttribute(marker);
+    element.addEventListener("wa-after-hide", () => element.setAttribute(marker, ""), {
+      once: true,
+    });
+  }, afterHideMarker);
+  await page.mouse.down();
+  await expect
+    .poll(() =>
+      tooltip.evaluate((element, marker) => element.hasAttribute(marker), afterHideMarker),
+    )
+    .toBe(true);
   expect(await buildLinkHandle.evaluate((element) => element.isConnected)).toBe(true);
+  await tooltip.evaluate((element, marker) => element.removeAttribute(marker), afterHideMarker);
   await page.mouse.up();
   await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/about");
 }

--- a/ui/src/e2e/build-info-unicode.e2e.test.ts
+++ b/ui/src/e2e/build-info-unicode.e2e.test.ts
@@ -62,7 +62,24 @@ async function openBuildDetails(page: Page) {
   expect(compactText).not.toContain("�");
   expect(containsBrokenSurrogate(compactText)).toBe(false);
 
-  await buildLink.click();
+  await buildLink.hover();
+  const tooltip = sidebar.locator("openclaw-sidebar-build-chip openclaw-tooltip wa-tooltip");
+  await expect.poll(() => tooltip.evaluate((element) => element.hasAttribute("open"))).toBe(true);
+  const buildLinkHandle = await buildLink.elementHandle();
+  if (!buildLinkHandle) {
+    throw new Error("Expected the identity-menu build link to be attached");
+  }
+  await Promise.all([
+    tooltip.evaluate(
+      (element) =>
+        new Promise<void>((resolve) => {
+          element.addEventListener("wa-after-hide", () => resolve(), { once: true });
+        }),
+    ),
+    page.mouse.down(),
+  ]);
+  expect(await buildLinkHandle.evaluate((element) => element.isConnected)).toBe(true);
+  await page.mouse.up();
   await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/about");
 }
 
@@ -78,7 +95,7 @@ async function assertFullBranchLabel(page: Page) {
 }
 
 suite.define(() => {
-  it("renders intact emoji at compact and metadata boundaries across navigation and reload", async () => {
+  it("keeps slow build-link navigation intact across Unicode boundaries and reload", async () => {
     await suite.withPage(
       {
         locale: "en-US",


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted: yes. The change has been reviewed and its behavior validated.

## What Problem This Solves

Fixes an issue where users opening the build details link from the Control UI sidebar could get no visible outcome when using a slow click. After pointer-down, the nested build tooltip hid and its bubbling `wa-after-hide` lifecycle event was handled as though the identity dropdown itself had finished hiding. That closed the dropdown and detached the link before pointer-up, so the click never completed and navigation did not occur.

## Why This Change Was Made

The identity and agent dropdowns now close only for their own `wa-after-hide` lifecycle events, leaving nested overlay events with the nested overlay that owns them. This repairs the owner boundary without changing tooltip or link behavior, and protects both dropdowns that share the lifecycle handler.

The existing browser test now performs the real slow pointer ordering: hover to open the nested tooltip, press the pointer, wait for the tooltip's hide lifecycle event, prove the build link remains connected, then release the pointer and verify navigation to `/settings/about`.

## User Impact

The sidebar build link now reliably opens Settings > About even when a user presses and releases slowly enough for the tooltip to hide between pointer-down and pointer-up. The action once again ends in visible navigation instead of silently doing nothing.

Release-note context: Control UI build-link navigation now remains reliable during slow pointer interactions while nested tooltips hide.

## Evidence

- Focused browser E2E (`build-info-unicode.e2e.test.ts`): 1/1 passed.
- Settings sidebar component test: 11/11 passed.
- Exact `check:changed` planned lanes: passed locally. Remote Crabbox/Testbox delegation was unavailable, so the exact planned lanes ran through the documented local fallback and passed.
- `pnpm ui:build`: passed.
- Mandatory autoreview of the uncommitted patch: clean, with no accepted or actionable findings.
- `git diff --check`: passed after rebasing onto current `origin/main`.
- Production delta: +11/-2 (net +9). Tests: +19/-2 (net +17).
