### PR TITLE
fix(agents): keep tool args when CLI sends input on the start block

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2782,6 +2782,50 @@ describe("createCliJsonlStreamingParser", () => {
     ]);
   });
 
+  it("keeps complete tool input from content_block_start when no json deltas arrive", () => {
+    const starts: CliToolUseStartDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    // Backends that send the whole input on the start block emit no
+    // input_json_delta chunks, so the streamed parts stay empty.
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "Bash",
+              input: { command: "ls -la" },
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([
+      { toolCallId: "toolu_1", name: "Bash", kind: "tool_use", args: { command: "ls -la" } },
+    ]);
+  });
+
   it("frames coalesced Claude image and PDF lines before omitting retained binary bytes", () => {
     const results: CliToolResultDelta[] = [];
     const pluginLines: string[] = [];

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2826,6 +2826,56 @@ describe("createCliJsonlStreamingParser", () => {
     ]);
   });
 
+  it("keeps an explicit empty streamed input over a populated start snapshot", () => {
+    const starts: CliToolUseStartDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onToolUseStart: (delta) => starts.push(delta),
+    });
+
+    // A no-argument invocation is serialized as an explicit `{}` delta. The
+    // streamed value is authoritative, so the start snapshot must not win.
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "toolu_2",
+              name: "Bash",
+              input: { command: "stale --from-start-block" },
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: "{}" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(starts).toEqual([{ toolCallId: "toolu_2", name: "Bash", kind: "tool_use", args: {} }]);
+  });
+
   it("frames coalesced Claude image and PDF lines before omitting retained binary bytes", () => {
     const results: CliToolResultDelta[] = [];
     const pluginLines: string[] = [];

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -833,6 +833,13 @@ type PendingToolUse = {
   name: string;
   kind: CliToolUseStartDelta["kind"];
   inputJsonParts: string[];
+  /**
+   * Complete input carried on `content_block_start`. Some CLI backends send the
+   * whole tool input there and never emit `input_json_delta` chunks, so without
+   * this the start event reports empty args and the later complete copy is
+   * dropped by the `startedIds` dedup in `emitToolStartOnce`.
+   */
+  blockInput?: Record<string, unknown>;
 };
 
 type ToolUseTracker = {
@@ -942,6 +949,7 @@ function dispatchClaudeCliStreamingToolEvent(params: {
             name,
             kind: block.type,
             inputJsonParts: [],
+            ...(isRecord(block.input) ? { blockInput: block.input } : {}),
           });
         }
       } else if (isClaudeAssistantToolResultBlockType(block.type)) {
@@ -972,12 +980,17 @@ function dispatchClaudeCliStreamingToolEvent(params: {
       const pending = tracker.pendingByIndex.get(event.index);
       tracker.pendingByIndex.delete(event.index);
       if (pending) {
+        const streamedArgs = parseToolInputJson(pending.inputJsonParts);
+        const args =
+          Object.keys(streamedArgs).length > 0
+            ? streamedArgs
+            : (pending.blockInput ?? streamedArgs);
         emitToolStartOnce(
           tracker,
           pending.toolCallId,
           pending.name,
           pending.kind,
-          parseToolInputJson(pending.inputJsonParts),
+          args,
           params.onToolUseStart,
         );
       }

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -980,11 +980,14 @@ function dispatchClaudeCliStreamingToolEvent(params: {
       const pending = tracker.pendingByIndex.get(event.index);
       tracker.pendingByIndex.delete(event.index);
       if (pending) {
-        const streamedArgs = parseToolInputJson(pending.inputJsonParts);
+        // Delta presence, not key count, decides which input wins. An empty tool
+        // invocation is serialized as an explicit `{}` delta, so keying on key
+        // count would let a populated start snapshot overwrite a real no-argument
+        // call. Received deltas are authoritative whenever any arrived.
         const args =
-          Object.keys(streamedArgs).length > 0
-            ? streamedArgs
-            : (pending.blockInput ?? streamedArgs);
+          pending.inputJsonParts.length > 0
+            ? parseToolInputJson(pending.inputJsonParts)
+            : (pending.blockInput ?? {});
         emitToolStartOnce(
           tracker,
           pending.toolCallId,


### PR DESCRIPTION
## What Problem This Solves

Related: #120306.

Completed tool rows in the Discord progress draft render as icon plus tool name only, dropping the resolved command, while TUI and web show the same calls correctly. The reporter attached a redacted capture and traced it to source.

The root cause is upstream of Discord, in the CLI stream parser. On `content_block_start`, `src/agents/cli-output.ts` records the tool call id, name and kind but ignores `block.input`, and arguments are assembled only from later `input_json_delta` chunks. A backend that sends the whole tool input on the start block emits no deltas at all, so `parseToolInputJson([])` returns `{}` and the tool-start event goes out with empty args. The complete copy that arrives later in the `assistant` record cannot repair it, because `emitToolStartOnce` dedups on `startedIds` and drops the second description of the same call.

With empty args there is no `detail` for the draft line to render, so the row falls through to the name-only branch. Any consumer of `onToolUseStart` sees the same empty args, so this is not Discord-specific.

## Why This Change Was Made

The fix belongs at the producer. The parser is the only place that ever sees `block.input`, and once it drops that value every downstream renderer is guessing.

`PendingToolUse` now carries `blockInput` when `content_block_start` includes a record input, and `content_block_stop` prefers the streamed parts when they parsed to something, falling back to the start-block input when they did not. Backends that do stream `input_json_delta` chunks are unaffected, since the streamed value still wins.

I deliberately did not touch `src/channels/streaming.ts`. The issue proposes a second, defense-in-depth change there so `mergeProgressDraftLineUpdate` carries a richer `detail` forward for `kind === "tool"`. That file is already owned by #118062 (`fix(channels): preserve command privacy in progress drafts`), and putting a competing diff in it would cost a comparison nobody asked for. This PR is the producer repair only, and it stands alone: with args present, the merge path has something to render. If maintainers want the streaming.ts hardening too, it belongs on top of #118062 rather than in here.

I also left `emitToolStartOnce` alone. The issue suggests letting it upgrade a previously-empty emit, but with the start-block input preserved the first emit is no longer empty on this path, so changing dedup semantics would be unneeded risk.

## User Impact

Tool rows in channel progress drafts keep their resolved command when the CLI backend delivers input on the start block, instead of degrading to a bare tool name. Same fix applies to every `onToolUseStart` consumer, not just Discord.

No config, schema, or public surface changes.

## Evidence

Fault sites confirmed byte-identical to the report on current `main` (`c691f2e41cd`): `content_block_start` at `cli-output.ts:931-946` never reads `block.input`, and `emitToolStartOnce` at `:854-869` returns early on a repeated `toolCallId`.

Regression in `src/agents/cli-output.test.ts`: a `claude-stream-json` parse of `content_block_start` carrying complete `input` with no `input_json_delta` chunks, asserting the start delta keeps `args: { command: "ls -la" }`.

Confirmed the test pins the fix by reverting the fallback to the streamed value and rerunning:

```
× keeps complete tool input from content_block_start when no json deltas arrive
AssertionError: expected [ { toolCallId: 'toolu_1', …(3) } ] to deeply equal [ ... ]
```

then restored for 128/128. Worth noting I caught my first attempt at that break silently not applying, because oxfmt had split the ternary across lines, so the run was green for the wrong reason. The result above is from the corrected break.

`tsgo -p tsconfig.core.json` and `tsgo -p test/tsconfig/tsconfig.core.test.json` are clean, oxlint is clean on both changed files, `git diff --check` is clean. Production delta is +14/-1 in one file, most of it the comment on the new field.

One gap stated plainly: I verified this at the parser boundary, not by driving a live Discord draft. The reporter's capture plus the byte-identical source is what establishes the channel-visible symptom. If a Discord capture after the fix is a merge gate, say so and I will set one up rather than assume the render follows.

AI-assisted: written with AI assistance. I read the parser, the dedup, the pending-record lifecycle, and #118062's file list myself before choosing this scope.
