### PR TITLE
fix(ci): adopt dispatched release validation runs

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -479,6 +479,32 @@ jobs:
             gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
           }
 
+          validate_child_run() {
+            local candidate_run_id="$1"
+            local candidate_run_json
+            candidate_run_json="$(
+              gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}"
+            )"
+            if ! jq -e \
+              --argjson id "$candidate_run_id" \
+              --argjson workflow_id "$expected_workflow_id" \
+              --arg title "$dispatch_run_name" \
+              --arg branch "$CHILD_WORKFLOW_REF" \
+              --arg head_sha "$PARENT_WORKFLOW_SHA" \
+              '(.id == $id)
+                and (.workflow_id == $workflow_id)
+                and (.display_title == $title)
+                and (.head_branch == $branch)
+                and (.head_sha == $head_sha)
+                and (.event == "workflow_dispatch")' \
+              <<< "$candidate_run_json" >/dev/null; then
+              echo "::error::Refusing to adopt unvalidated ${workflow} run ${candidate_run_id}." >&2
+              jq '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
+                <<< "$candidate_run_json" >&2
+              return 1
+            fi
+          }
+
           fetch_child_jobs() {
             if [[ "$workflow" == "npm-telegram-beta-e2e.yml" || "$workflow" == "openclaw-performance.yml" ]]; then
               gh_with_retry run view "$run_id" --json jobs --jq '.jobs[]'
@@ -491,7 +517,6 @@ jobs:
             local field="$1"
             if [[ "$workflow" == "npm-telegram-beta-e2e.yml" || "$workflow" == "openclaw-performance.yml" ]]; then
               case "$field" in
-                head_sha) field=headSha ;;
                 html_url) field=url ;;
               esac
               gh_with_retry run view "$run_id" --json "$field" --jq ".${field} // \"\""
@@ -544,7 +569,7 @@ jobs:
             local workflow="$1"
             local dispatch_run_name="$2"
             shift 2
-            local dispatch_output dispatch_status matches_json match_count run_id status conclusion url poll_count run_json jobs_json child_head_sha encoded_workflow_ref current_workflow_sha
+            local dispatch_output dispatch_status dispatch_run_ids matches_json match_count run_id status conclusion url poll_count run_json jobs_json encoded_workflow_ref current_workflow_sha expected_workflow_id
 
             encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
             current_workflow_sha="$(
@@ -554,8 +579,12 @@ jobs:
               echo "::error::Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch." >&2
               return 1
             fi
+            expected_workflow_id="$(
+              gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}" --jq .id
+            )"
 
-            # A failed dispatch POST can still create a run. Never retry it; recover only by exact run name.
+            # The dispatch POST is one-shot: adopt its returned identity when available.
+            # If absent or ambiguous, exact-name recovery avoids a duplicate child.
             set +e
             dispatch_output="$(gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1)"
             dispatch_status=$?
@@ -567,30 +596,42 @@ jobs:
             fi
 
             run_id=""
-            for _ in $(seq 1 60); do
-              if matches_json="$(
-                DISPATCH_RUN_NAME="$dispatch_run_name" CHILD_WORKFLOW_REF="$CHILD_WORKFLOW_REF" \
-                  gh_with_retry api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \
-                  -F event=workflow_dispatch \
-                  -F per_page=100 \
-                  --jq '[.workflow_runs[] | select(.display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF) | .id]'
-              )"; then
-                match_count="$(jq 'length' <<< "$matches_json")"
-                if (( match_count > 1 )); then
-                  echo "::error::Multiple runs matched ${dispatch_run_name}; refusing to guess." >&2
-                  exit 1
+            dispatch_run_ids="$(
+              sed -nE "s#^https://github[.]com/${GITHUB_REPOSITORY}/actions/runs/([0-9]+)\$#\1#p" \
+                <<< "$dispatch_output" | sort -u
+            )"
+            if [[ "$dispatch_run_ids" == *$'\n'* ]]; then
+              echo "::error::${workflow} dispatch returned multiple run identities; refusing to guess." >&2
+              exit 1
+            elif [[ -n "$dispatch_run_ids" ]]; then
+              run_id="$dispatch_run_ids"
+            else
+              for _ in $(seq 1 60); do
+                if matches_json="$(
+                  DISPATCH_RUN_NAME="$dispatch_run_name" CHILD_WORKFLOW_REF="$CHILD_WORKFLOW_REF" \
+                    gh_with_retry api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \
+                    -F event=workflow_dispatch \
+                    -F per_page=100 \
+                    --jq '[.workflow_runs[] | select(.display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF) | .id]'
+                )"; then
+                  match_count="$(jq 'length' <<< "$matches_json")"
+                  if (( match_count > 1 )); then
+                    echo "::error::Multiple runs matched ${dispatch_run_name}; refusing to guess." >&2
+                    exit 1
+                  fi
+                  if (( match_count == 1 )); then
+                    run_id="$(jq -r '.[0]' <<< "$matches_json")"
+                    break
+                  fi
                 fi
-                if (( match_count == 1 )); then
-                  run_id="$(jq -r '.[0]' <<< "$matches_json")"
-                  break
-                fi
-              fi
-              sleep 5
-            done
+                sleep 5
+              done
+            fi
             if [[ -z "$run_id" ]]; then
               echo "::error::Could not find exact dispatched run ${dispatch_run_name}; dispatch status ${dispatch_status}. The dispatch was not retried to avoid creating a duplicate child." >&2
               exit 1
             fi
+            validate_child_run "$run_id"
             if [[ "$dispatch_status" -ne 0 ]]; then
               echo "::warning::${workflow} dispatch returned status ${dispatch_status}; adopted exact run ${run_id}." >&2
             fi
@@ -607,14 +648,6 @@ jobs:
             active_child_workflow="$workflow"
             active_child_run_id="$run_id"
             trap cancel_child EXIT INT TERM
-
-            child_head_sha="$(read_child_run_field head_sha)"
-            if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
-              echo "::error::${workflow} child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}."
-              cancel_child
-              trap - EXIT INT TERM
-              exit 1
-            fi
 
             fail_fast_failed_jobs() {
               if [[ "$FAIL_FAST" != "true" ]]; then

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -482,6 +482,10 @@ jobs:
           validate_child_run() {
             local candidate_run_id="$1"
             local candidate_run_json
+            if [[ ! "$candidate_run_id" =~ ^[0-9]+$ ]]; then
+              echo "::error::Refusing to adopt invalid ${workflow} run ID ${candidate_run_id}." >&2
+              return 1
+            fi
             candidate_run_json="$(
               gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}"
             )"
@@ -490,12 +494,10 @@ jobs:
               --argjson workflow_id "$expected_workflow_id" \
               --arg title "$dispatch_run_name" \
               --arg branch "$CHILD_WORKFLOW_REF" \
-              --arg head_sha "$PARENT_WORKFLOW_SHA" \
               '(.id == $id)
                 and (.workflow_id == $workflow_id)
                 and (.display_title == $title)
                 and (.head_branch == $branch)
-                and (.head_sha == $head_sha)
                 and (.event == "workflow_dispatch")' \
               <<< "$candidate_run_json" >/dev/null; then
               echo "::error::Refusing to adopt unvalidated ${workflow} run ${candidate_run_id}." >&2
@@ -503,6 +505,7 @@ jobs:
                 <<< "$candidate_run_json" >&2
               return 1
             fi
+            printf '%s\n' "$candidate_run_json"
           }
 
           fetch_child_jobs() {
@@ -569,7 +572,7 @@ jobs:
             local workflow="$1"
             local dispatch_run_name="$2"
             shift 2
-            local dispatch_output dispatch_status dispatch_run_ids matches_json match_count run_id status conclusion url poll_count run_json jobs_json encoded_workflow_ref current_workflow_sha expected_workflow_id
+            local dispatch_output dispatch_status dispatch_run_ids matches_json match_count run_id status conclusion url poll_count run_json jobs_json child_head_sha encoded_workflow_ref current_workflow_sha expected_workflow_id
 
             encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
             current_workflow_sha="$(
@@ -631,12 +634,6 @@ jobs:
               echo "::error::Could not find exact dispatched run ${dispatch_run_name}; dispatch status ${dispatch_status}. The dispatch was not retried to avoid creating a duplicate child." >&2
               exit 1
             fi
-            validate_child_run "$run_id"
-            if [[ "$dispatch_status" -ne 0 ]]; then
-              echo "::warning::${workflow} dispatch returned status ${dispatch_status}; adopted exact run ${run_id}." >&2
-            fi
-            echo "Dispatched ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
-            echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
 
             cancel_child() {
               if [[ -n "${active_child_run_id:-}" ]]; then
@@ -644,10 +641,26 @@ jobs:
                 gh run cancel "$active_child_run_id" >/dev/null 2>&1 || true
               fi
             }
+            run_json="$(validate_child_run "$run_id")"
+            # Identity fields prove cancellation ownership before workflow-SHA validation.
             # EXIT traps run after function locals unwind; preserve only adopted child identity.
             active_child_workflow="$workflow"
             active_child_run_id="$run_id"
             trap cancel_child EXIT INT TERM
+
+            child_head_sha="$(jq -r '.head_sha // ""' <<< "$run_json")"
+            if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::${workflow} child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}." >&2
+              cancel_child
+              trap - EXIT INT TERM
+              exit 1
+            fi
+
+            if [[ "$dispatch_status" -ne 0 ]]; then
+              echo "::warning::${workflow} dispatch returned status ${dispatch_status}; adopted exact run ${run_id}." >&2
+            fi
+            echo "Dispatched ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+            echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
 
             fail_fast_failed_jobs() {
               if [[ "$FAIL_FAST" != "true" ]]; then

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1946,6 +1946,7 @@ describe("package acceptance workflow", () => {
       expect(
         calls.some(({ args }) => args.some((value) => value.endsWith("/actions/runs/101"))),
       ).toBe(true);
+      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
     },
   );
 
@@ -1967,7 +1968,6 @@ describe("package acceptance workflow", () => {
     ["workflow", { MOCK_GH_RUN_WORKFLOW_ID: "790" }],
     ["title", { MOCK_GH_RUN_TITLE: "Unrelated workflow run" }],
     ["head branch", { MOCK_GH_RUN_HEAD_BRANCH: "other" }],
-    ["head SHA", { MOCK_GH_CHILD_SHA: "c".repeat(40) }],
     ["event", { MOCK_GH_RUN_EVENT: "push" }],
   ] as const)("refuses a returned run URL with the wrong %s", (_label, overrides) => {
     const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
@@ -1981,6 +1981,20 @@ describe("package acceptance workflow", () => {
       calls.some(({ args }) =>
         args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
       ),
+    ).toBe(false);
+    expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
+  });
+
+  it("refuses a nonnumeric exact-name candidate without cancellation ownership", () => {
+    const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
+      MOCK_GH_DISPATCH_OUTPUT: "",
+      MOCK_GH_MATCHES: '["not-a-run-id"]',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Refusing to adopt invalid ci.yml run ID not-a-run-id");
+    expect(
+      calls.some(({ args }) => args.some((value) => value.endsWith("/actions/runs/not-a-run-id"))),
     ).toBe(false);
     expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
   });
@@ -2057,15 +2071,18 @@ describe("package acceptance workflow", () => {
   );
 
   it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "refuses the $jobName child when its workflow SHA differs",
+    "cancels exactly the identified $jobName child when its workflow SHA differs",
     (child) => {
       const { calls, result } = runFullReleaseChildDispatch(child, {
         MOCK_GH_CHILD_SHA: "c".repeat(40),
+        MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
       });
 
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain(`Refusing to adopt unvalidated ${child.workflow} run 101`);
-      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
+      expect(result.stderr).toContain("expected parent workflow SHA");
+      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toEqual([
+        expect.objectContaining({ args: ["run", "cancel", "101"] }),
+      ]);
     },
   );
 
@@ -4051,7 +4068,7 @@ describe("package artifact reuse", () => {
       'dispatch_and_wait npm-telegram-beta-e2e.yml "$dispatch_run_name" "${args[@]}"',
       ".display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF",
       "The dispatch was not retried to avoid creating a duplicate child.",
-      "and (.head_sha == $head_sha)",
+      'if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then',
       '-f harness_ref="$TARGET_SHA"',
       'args=(-f package_spec="$PACKAGE_SPEC"',
       'args+=(-f scenario="$SCENARIO")',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -272,11 +272,13 @@ if (args[0] === "workflow" && args[1] === "run") {
     console.error(env.MOCK_GH_DISPATCH_ERROR);
     process.exit(1);
   }
-  console.log("Created workflow_dispatch event.");
+  console.log(env.MOCK_GH_DISPATCH_OUTPUT);
 } else if (args[0] === "api" && args.some((value) => value.includes("/commits/"))) {
   console.log(env.MOCK_GH_CURRENT_SHA);
 } else if (args[0] === "api" && args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs"))) {
   console.log(env.MOCK_GH_MATCHES);
+} else if (args[0] === "api" && args.some((value) => value.includes("/actions/workflows/"))) {
+  console.log(env.MOCK_GH_WORKFLOW_ID);
 } else if (args[0] === "api" && args.some((value) => value.includes("/jobs?"))) {
   if (env.MOCK_GH_JOBS_ERROR) {
     console.error(env.MOCK_GH_JOBS_ERROR);
@@ -290,9 +292,15 @@ if (args[0] === "workflow" && args[1] === "run") {
   }
   console.log(JSON.stringify({
     conclusion,
+    display_title: env.MOCK_GH_RUN_TITLE,
+    event: env.MOCK_GH_RUN_EVENT,
+    head_branch: env.MOCK_GH_RUN_HEAD_BRANCH,
     head_sha: env.MOCK_GH_CHILD_SHA,
     html_url: url,
+    id: Number(env.MOCK_GH_RUN_ID),
+    path: env.MOCK_GH_RUN_PATH,
     status: nextStatus(),
+    workflow_id: Number(env.MOCK_GH_RUN_WORKFLOW_ID),
   }));
 } else if (args[0] === "run" && args[1] === "view") {
   const field = args[args.indexOf("--json") + 1];
@@ -390,10 +398,21 @@ if (args[0] === "workflow" && args[1] === "run") {
       MOCK_GH_CHILD_SHA: parentSha,
       MOCK_GH_CONCLUSION: "success",
       MOCK_GH_CURRENT_SHA: parentSha,
+      MOCK_GH_DISPATCH_OUTPUT: "Created workflow_dispatch event.",
       MOCK_GH_JOBS: JSON.stringify(defaultJobs),
       MOCK_GH_MATCHES: "[101]",
+      MOCK_GH_RUN_EVENT: "workflow_dispatch",
+      MOCK_GH_RUN_HEAD_BRANCH:
+        overrides.MOCK_GH_RUN_HEAD_BRANCH ??
+        overrides.CHILD_WORKFLOW_REF ??
+        stepEnv.CHILD_WORKFLOW_REF,
+      MOCK_GH_RUN_ID: "101",
+      MOCK_GH_RUN_PATH: `.github/workflows/${child.workflow}`,
+      MOCK_GH_RUN_TITLE: `${child.runName} full-release-validation-77-2${child.nonceSuffix}`,
+      MOCK_GH_RUN_WORKFLOW_ID: "789",
       MOCK_GH_STATUSES: '["completed"]',
       MOCK_GH_STATUS_POLLS: statusPath,
+      MOCK_GH_WORKFLOW_ID: "789",
       PATH: `${workdir}:${process.env.PATH}`,
       ...overrides,
     },
@@ -1807,7 +1826,7 @@ describe("package acceptance workflow", () => {
       expect(script.match(/gh workflow run/gu)).toHaveLength(1);
       expect(script).not.toContain("gh_with_retry workflow run");
       expectTextToIncludeAll(script, [
-        "A failed dispatch POST can still create a run. Never retry it",
+        "The dispatch POST is one-shot",
         'encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF"',
         'gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha',
         '"$current_workflow_sha" != "$PARENT_WORKFLOW_SHA"',
@@ -1816,6 +1835,8 @@ describe("package acceptance workflow", () => {
         "dispatch_status=$?",
         'if [[ "$dispatch_status" -ne 0 && ! "$dispatch_output" =~ $GH_TRANSIENT_SERVER_OR_NETWORK_PATTERN ]]',
         "dispatch failed with non-ambiguous status ${dispatch_status}; refusing adoption polling.",
+        'sed -nE "s#^https://github[.]com/${GITHUB_REPOSITORY}/actions/runs/([0-9]+)\\$#\\1#p"',
+        'validate_child_run "$run_id"',
         'DISPATCH_RUN_NAME="$dispatch_run_name" CHILD_WORKFLOW_REF="$CHILD_WORKFLOW_REF"',
         ".display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF",
         "Multiple runs matched ${dispatch_run_name}; refusing to guess.",
@@ -1909,6 +1930,62 @@ describe("package acceptance workflow", () => {
   });
 
   it.each(FULL_RELEASE_CHILD_DISPATCHES)(
+    "adopts and validates the run URL returned for $jobName without listing runs",
+    (child) => {
+      const { calls, result } = runFullReleaseChildDispatch(child, {
+        MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
+      expect(
+        calls.filter(({ args }) =>
+          args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
+        ),
+      ).toHaveLength(0);
+      expect(
+        calls.some(({ args }) => args.some((value) => value.endsWith("/actions/runs/101"))),
+      ).toBe(true);
+    },
+  );
+
+  it("recovers by exact name when a successful dispatch returns no run URL", () => {
+    const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
+      MOCK_GH_DISPATCH_OUTPUT: "",
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
+    expect(
+      calls.filter(({ args }) =>
+        args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    ["workflow", { MOCK_GH_RUN_WORKFLOW_ID: "790" }],
+    ["title", { MOCK_GH_RUN_TITLE: "Unrelated workflow run" }],
+    ["head branch", { MOCK_GH_RUN_HEAD_BRANCH: "other" }],
+    ["head SHA", { MOCK_GH_CHILD_SHA: "c".repeat(40) }],
+    ["event", { MOCK_GH_RUN_EVENT: "push" }],
+  ] as const)("refuses a returned run URL with the wrong %s", (_label, overrides) => {
+    const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
+      MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
+      ...overrides,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Refusing to adopt unvalidated ci.yml run 101");
+    expect(
+      calls.some(({ args }) =>
+        args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
+      ),
+    ).toBe(false);
+    expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
+  });
+
+  it.each(FULL_RELEASE_CHILD_DISPATCHES)(
     "rejects moved workflow refs before dispatching $jobName",
     (child) => {
       const { calls, result } = runFullReleaseChildDispatch(child, {
@@ -1980,17 +2057,15 @@ describe("package acceptance workflow", () => {
   );
 
   it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "cancels exactly the adopted $jobName child when its workflow SHA differs",
+    "refuses the $jobName child when its workflow SHA differs",
     (child) => {
       const { calls, result } = runFullReleaseChildDispatch(child, {
         MOCK_GH_CHILD_SHA: "c".repeat(40),
       });
 
       expect(result.status).toBe(1);
-      expect(result.stdout).toContain("expected parent workflow SHA");
-      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toEqual([
-        expect.objectContaining({ args: ["run", "cancel", "101"] }),
-      ]);
+      expect(result.stderr).toContain(`Refusing to adopt unvalidated ${child.workflow} run 101`);
+      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
     },
   );
 
@@ -3976,7 +4051,7 @@ describe("package artifact reuse", () => {
       'dispatch_and_wait npm-telegram-beta-e2e.yml "$dispatch_run_name" "${args[@]}"',
       ".display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF",
       "The dispatch was not retried to avoid creating a duplicate child.",
-      'if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then',
+      "and (.head_sha == $head_sha)",
       '-f harness_ref="$TARGET_SHA"',
       'args=(-f package_spec="$PACKAGE_SPEC"',
       'args+=(-f scenario="$SCENARIO")',

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -319,9 +319,17 @@ describe("release validation no-push transport", () => {
       ["performance", "Dispatch and monitor OpenClaw Performance"],
     ] as const) {
       const dispatch = step(job(full, jobName), stepName);
+      const dispatchRun = dispatch.run ?? "";
       expect(dispatch.env?.PARENT_WORKFLOW_SHA, jobName).toBe("${{ github.sha }}");
-      expect(dispatch.run, jobName).toContain('"$child_head_sha" != "$PARENT_WORKFLOW_SHA"');
-      expect(dispatch.run, jobName).toContain("expected parent workflow SHA");
+      expect(dispatchRun, jobName).toContain('--arg head_sha "$PARENT_WORKFLOW_SHA"');
+      expect(dispatchRun, jobName).toContain("and (.head_sha == $head_sha)");
+      expect(dispatchRun, jobName).not.toContain('"$child_head_sha" != "$PARENT_WORKFLOW_SHA"');
+      expect(dispatchRun.indexOf('validate_child_run "$run_id"'), jobName).toBeLessThan(
+        dispatchRun.indexOf('active_child_run_id="$run_id"'),
+      );
+      expect(dispatchRun.indexOf('active_child_run_id="$run_id"'), jobName).toBeLessThan(
+        dispatchRun.indexOf("trap cancel_child EXIT INT TERM"),
+      );
     }
 
     const verify = step(job(full, "summary"), "Verify child workflow results");

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -309,7 +309,7 @@ describe("release validation no-push transport", () => {
     expect(releaseHelper.with?.["persist-credentials"]).toBe(false);
   });
 
-  it("rejects every child whose workflow SHA differs from the parent workflow SHA", () => {
+  it("owns identified children before rejecting a mismatched workflow SHA", () => {
     const full = readWorkflow(FULL_RELEASE);
     for (const [jobName, stepName] of [
       ["normal_ci", "Dispatch and monitor CI"],
@@ -321,15 +321,29 @@ describe("release validation no-push transport", () => {
       const dispatch = step(job(full, jobName), stepName);
       const dispatchRun = dispatch.run ?? "";
       expect(dispatch.env?.PARENT_WORKFLOW_SHA, jobName).toBe("${{ github.sha }}");
-      expect(dispatchRun, jobName).toContain('--arg head_sha "$PARENT_WORKFLOW_SHA"');
-      expect(dispatchRun, jobName).toContain("and (.head_sha == $head_sha)");
-      expect(dispatchRun, jobName).not.toContain('"$child_head_sha" != "$PARENT_WORKFLOW_SHA"');
-      expect(dispatchRun.indexOf('validate_child_run "$run_id"'), jobName).toBeLessThan(
-        dispatchRun.indexOf('active_child_run_id="$run_id"'),
+      expect(dispatchRun, jobName).toContain(
+        'if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then',
       );
+      expect(dispatchRun.match(/\.head_sha == \$head_sha/gu), jobName).toBeNull();
+      expect(dispatchRun, jobName).toContain('run_json="$(validate_child_run "$run_id")"');
+      expect(dispatchRun, jobName).toContain('active_child_run_id="$run_id"');
+      expect(dispatchRun, jobName).toContain("trap cancel_child EXIT INT TERM");
+      expect(
+        dispatchRun.indexOf('run_json="$(validate_child_run "$run_id")"'),
+        jobName,
+      ).toBeLessThan(dispatchRun.indexOf('active_child_run_id="$run_id"'));
       expect(dispatchRun.indexOf('active_child_run_id="$run_id"'), jobName).toBeLessThan(
         dispatchRun.indexOf("trap cancel_child EXIT INT TERM"),
       );
+      expect(dispatchRun.indexOf("trap cancel_child EXIT INT TERM"), jobName).toBeLessThan(
+        dispatchRun.indexOf('if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]'),
+      );
+      const shaMismatch = dispatchRun.slice(
+        dispatchRun.indexOf('if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]'),
+        dispatchRun.indexOf("fail_fast_failed_jobs()"),
+      );
+      expect(shaMismatch, jobName).toContain("cancel_child");
+      expect(shaMismatch, jobName).toContain("trap - EXIT INT TERM");
     }
 
     const verify = step(job(full, "summary"), "Verify child workflow results");


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-blocking problem where Full Release Validation could fail after successfully dispatching a child workflow because the parent discarded the exact run URL and depended only on an eventually consistent run listing. During the 2026.8.1 beta validation, the CI child existed and ran, but the parent timed out without recording its run ID.

## Why This Change Was Made

The parent now adopts the exact child run identity returned by GitHub CLI when available, validates the run's workflow, title, branch, workflow SHA, and event before taking ownership, and keeps exact-name polling only for legacy empty responses or ambiguous transient dispatch errors. The dispatch POST remains one-shot, so recovery cannot create duplicate children.

GitHub CLI v2.97's `workflow run` command requests run details and prints the run URL on non-TTY stdout when the API supports it; older 204 responses remain supported by the polling recovery path.

This PR is AI-assisted. I reviewed the implementation and the upstream GitHub CLI contract, and Codex-backed autoreview reported no actionable finding.

## User Impact

Release operators can run Full Release Validation without a successfully created child being lost to list-API propagation delay. There is no product-runtime behavior change.

## Evidence

- Original failed parent: https://github.com/openclaw/openclaw/actions/runs/31125954087
- Successfully created but unadopted CI child: https://github.com/openclaw/openclaw/actions/runs/31129806068
- GitHub CLI v2.97 implementation: https://github.com/cli/cli/blob/v2.97.0/pkg/cmd/workflow/run/run.go#L333-L392
- `node scripts/run-vitest.mjs test/scripts/release-no-push-workflow.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/ci-workflow-guards.test.ts` — 285 passed, 2 skipped
- `node scripts/check-workflows.mjs` — passed
- `actionlint .github/workflows/full-release-validation.yml` — passed
- `git diff --check` — passed
- Final exact-head CI: https://github.com/openclaw/openclaw/actions/runs/31224778844 — green
- Current main security gate is green via https://github.com/openclaw/openclaw/pull/120368; the rebased branch inherits `nanoid@3.3.18` and has no lockfile delta
- Three Codex `gpt-5.6-sol` autoreview passes after implementation, the stale-guard follow-up, and the cancellation-order repair — clean, no accepted/actionable findings
- ClawSweeper exact-head run: https://github.com/openclaw/clawsweeper/actions/runs/31224900190 — reviewed `d0fe3cc0eaacdd810532bbf202abc9a4a857745d`, found no code finding, and left only the maintainer proof-sufficiency decision
- Maintainer decision: the pinned GitHub CLI v2.97 source contract, historical parent/child incident, shell-backed regression coverage, and exact-head CI are sufficient; a separate post-fix dispatch trace is not required before landing
