### PR TITLE
fix(agents): apply per-agent contextTokens cap to embedded run context budget

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -395,7 +395,7 @@ describe("context-window-guard", () => {
     ).toContain("This looks like a local model endpoint.");
   });
 
-  it("points config-backed block remediation at agents.defaults.contextTokens", () => {
+  it("points agent-cap block remediation at the agent contextTokens setting", () => {
     const guard = evaluateContextWindowGuard({
       info: { tokens: 8_000, source: "agentContextTokens" },
     });
@@ -405,7 +405,12 @@ describe("context-window-guard", () => {
       runtimeBaseUrl: "http://127.0.0.1:11434/v1",
     });
 
-    expect(message).toContain("OpenClaw is capped by agents.defaults.contextTokens.");
+    // A per-agent contextTokens overrides the default, so the remediation must
+    // name the agent setting. resolveAgentConfig reads both roster shapes, so it
+    // must name agents.list[] and agents.entries.*, not just defaults (#118678).
+    expect(message).toContain("agents.list[].contextTokens");
+    expect(message).toContain("agents.entries.<id>.contextTokens");
+    expect(message).toContain("agents.defaults.contextTokens");
     expect(message).not.toContain("choose a larger model");
   });
 

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -158,8 +158,9 @@ export function formatContextWindowWarningMessage(params: {
   }
   if (params.guard.source === "agentContextTokens") {
     return (
-      `${base}; OpenClaw is capped by agents.defaults.contextTokens, so raise that cap ` +
-      `if you want to use more of the model context window`
+      `${base}; OpenClaw is capped by the agent's contextTokens setting ` +
+      `(agents.list[].contextTokens or agents.entries.<id>.contextTokens, else agents.defaults.contextTokens), ` +
+      `so raise that cap if you want to use more of the model context window`
     );
   }
   if (params.guard.source === "modelsConfig") {
@@ -187,7 +188,11 @@ export function formatContextWindowBlockMessage(params: {
     return base;
   }
   if (params.guard.source === "agentContextTokens") {
-    return `${base} OpenClaw is capped by agents.defaults.contextTokens. Raise that cap.`;
+    return (
+      `${base} OpenClaw is capped by the agent's contextTokens setting ` +
+      `(agents.list[].contextTokens or agents.entries.<id>.contextTokens, else agents.defaults.contextTokens). ` +
+      `Raise that cap.`
+    );
   }
   if (params.guard.source === "modelsConfig") {
     return (

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -859,6 +859,49 @@ describe("runEmbeddedAgent", () => {
     expect("contextWindowInfo" in attempt).toBe(false);
   });
 
+  it("applies the selected agent's contextTokens cap to the embedded precheck budget", async () => {
+    // Regression for #118678: a per-agent contextTokens cap must reach the
+    // embedded run's context budget, not silently fall back to
+    // agents.defaults.contextTokens. The model window (272000) stays above both
+    // caps so the difference between 200000 and the 128000 default is visible.
+    const sessionFile = nextSessionCompatibilityKey();
+    const cfg = {
+      ...createEmbeddedAgentRunnerOpenAiConfig([]),
+      agents: {
+        list: [{ id: "capped", contextTokens: 200_000 }],
+        defaults: { contextTokens: 128_000 },
+      },
+    };
+    resolveModelAsyncMock.mockImplementationOnce(async (provider: string, modelId: string) => {
+      const resolved = createResolvedEmbeddedRunnerModel(provider, modelId);
+      return { ...resolved, model: { ...resolved.model, contextWindow: 272_000 } };
+    });
+    mockSuccessfulEmbeddedAttempt();
+
+    const result = await runEmbeddedAgent({
+      sessionId: "per-agent-context-cap",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      agentId: "capped",
+      runId: nextRunId("per-agent-context-cap"),
+      enqueue: immediateEnqueue,
+    });
+
+    const attempt = firstRunEmbeddedAttemptParams() as {
+      contextTokenBudget?: number;
+      model?: { contextWindow?: number };
+    };
+    expect(attempt.contextTokenBudget).toBe(200_000);
+    expect(attempt.model?.contextWindow).toBe(200_000);
+    expect(result.meta.agentMeta?.contextTokens).toBe(200_000);
+  });
+
   it("does not apply outer context-overflow recovery to a locked Codex harness", async () => {
     const sessionFile = nextSessionCompatibilityKey();
     runEmbeddedAttemptMock.mockResolvedValueOnce(

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -538,6 +538,7 @@ async function compactResolvedContextEngine(
     provider: ceContextConfigProvider,
     modelId: ceModelId,
     model: effectiveRuntimeModel,
+    agentId: runtimeTarget.agentId,
     requestedTokenBudget: params.contextTokenBudget,
   });
   const contextEngineRuntimeContext = buildCompactionContextEngineRuntimeContext({

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -9,6 +9,7 @@ import { createProcessSessionFixture } from "../bash-process-registry.test-helpe
 import { resetProcessRegistryForTests } from "../bash-process-registry.test-support.js";
 import {
   buildEmbeddedCompactionRuntimeContext,
+  resolveCompactionContextTokenBudget,
   resolveCompactionHarnessRuntime,
   resolveEmbeddedCompactionThinkingLevel,
   resolveEmbeddedCompactionTarget,
@@ -16,6 +17,44 @@ import {
 import { buildContextEngineCompactionSessionTarget } from "./run/session-bootstrap.js";
 
 const compactionTempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("resolveCompactionContextTokenBudget", () => {
+  const cfg = {
+    agents: {
+      list: [{ id: "capped", contextTokens: 200_000 }],
+      defaults: { contextTokens: 128_000 },
+    },
+  } as unknown as OpenClawConfig;
+  it.each([
+    { requested: 500_000, modelWindow: 500_000, expected: 200_000 },
+    { requested: 100_000, modelWindow: 500_000, expected: 100_000 },
+    { requested: 500_000, modelWindow: 64_000, expected: 64_000 },
+  ])(
+    "caps requested=$requested by agent and model ceilings to $expected",
+    ({ requested, modelWindow, expected }) => {
+      const budget = resolveCompactionContextTokenBudget({
+        config: cfg,
+        provider: "openai",
+        modelId: "mock-model",
+        model: { contextWindow: modelWindow },
+        agentId: "capped",
+        requestedTokenBudget: requested,
+      });
+      expect(budget).toBe(expected);
+    },
+  );
+
+  it("falls back to the default cap when no agent id is given", () => {
+    const budget = resolveCompactionContextTokenBudget({
+      config: cfg,
+      provider: "openai",
+      modelId: "mock-model",
+      model: { contextWindow: 272_000 },
+      requestedTokenBudget: 200_000,
+    });
+    expect(budget).toBe(128_000);
+  });
+});
 
 describe("resolveEmbeddedCompactionThinkingLevel", () => {
   it("lets the compaction override replace the inherited session level", () => {

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -25,6 +25,8 @@ describe("resolveCompactionContextTokenBudget", () => {
       defaults: { contextTokens: 128_000 },
     },
   } as unknown as OpenClawConfig;
+  const modelWithWindow = (contextWindow: number) =>
+    ({ contextWindow }) as Parameters<typeof resolveCompactionContextTokenBudget>[0]["model"];
   it.each([
     { requested: 500_000, modelWindow: 500_000, expected: 200_000 },
     { requested: 100_000, modelWindow: 500_000, expected: 100_000 },
@@ -36,7 +38,7 @@ describe("resolveCompactionContextTokenBudget", () => {
         config: cfg,
         provider: "openai",
         modelId: "mock-model",
-        model: { contextWindow: modelWindow },
+        model: modelWithWindow(modelWindow),
         agentId: "capped",
         requestedTokenBudget: requested,
       });
@@ -49,7 +51,7 @@ describe("resolveCompactionContextTokenBudget", () => {
       config: cfg,
       provider: "openai",
       modelId: "mock-model",
-      model: { contextWindow: 272_000 },
+      model: modelWithWindow(272_000),
       requestedTokenBudget: 200_000,
     });
     expect(budget).toBe(128_000);

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -6,6 +6,7 @@ import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
+import { resolveAgentConfig } from "../agent-scope.js";
 import {
   listActiveProcessSessionReferences,
   type ActiveProcessSessionReference,
@@ -307,9 +308,14 @@ export function resolveCompactionContextTokenBudget(params: {
   provider: string;
   modelId: string;
   model?: ProviderRuntimeModel;
+  agentId?: string;
   requestedTokenBudget?: number;
   fallbackTokenBudget?: number;
 }) {
+  // Caller budgets stay bounded by the selected agent and model ceilings.
+  const agentContextTokens = params.agentId
+    ? resolveAgentConfig(params.config ?? {}, params.agentId)?.contextTokens
+    : undefined;
   const resolvedBudget =
     normalizeContextTokenBudget(
       resolveContextWindowInfo({
@@ -318,6 +324,7 @@ export function resolveCompactionContextTokenBudget(params: {
         modelId: params.modelId,
         modelContextTokens: readAgentModelContextTokens(params.model),
         modelContextWindow: params.model?.contextWindow,
+        agentContextTokens,
         defaultTokens: DEFAULT_CONTEXT_TOKENS,
       }).tokens,
     ) ?? DEFAULT_CONTEXT_TOKENS;

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -175,6 +175,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
         provider,
         modelId,
         model: effectiveModel,
+        contextTokenBudget,
         agentId: sessionAgentId,
         sessionId: params.sessionId,
         sessionKey: params.sessionKey ?? sandboxSessionKey,

--- a/src/agents/embedded-agent-runner/extensions.test.ts
+++ b/src/agents/embedded-agent-runner/extensions.test.ts
@@ -53,6 +53,30 @@ function expectSafeguardRuntime(
 }
 
 describe("buildEmbeddedExtensionFactories", () => {
+  it("uses the prepared context budget for safeguard sizing", () => {
+    const sessionManager = {} as SessionManager;
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: {
+        agents: {
+          list: [{ id: "capped", contextTokens: 200_000 }],
+          defaults: { contextTokens: 128_000, compaction: { mode: "safeguard" } },
+        },
+      } as OpenClawConfig,
+      sessionManager,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+      model: {
+        id: "claude-sonnet-4-20250514",
+        contextWindow: 272_000,
+        contextTokens: 272_000,
+      } as Model,
+      contextTokenBudget: 128_000,
+      agentId: "capped",
+    });
+    expect(factories).toContain(compactionSafeguardExtension);
+    expect(getCompactionSafeguardRuntime(sessionManager)?.contextWindowTokens).toBe(128_000);
+  });
+
   it("enables quality-guard retries by default in safeguard mode", () => {
     const cfg = {
       agents: {

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -127,6 +127,7 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  contextTokenBudget?: number;
   agentId?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -136,16 +137,20 @@ export function buildEmbeddedExtensionFactories(params: {
   if (resolveEffectiveCompactionMode(params.cfg) === "safeguard") {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
     const qualityGuardCfg = compactionCfg?.qualityGuard;
-    const contextWindowInfo = resolveContextWindowInfo({
-      cfg: params.cfg,
-      provider: params.provider,
-      modelId: params.modelId,
-      modelContextTokens: params.model?.contextTokens,
-      modelContextWindow: params.model?.contextWindow,
-      defaultTokens: DEFAULT_CONTEXT_TOKENS,
-    });
+    // Prepared runs carry the canonical policy budget; fallback resolution is
+    // only for callers that do not own a prepared attempt.
+    const contextWindowTokens =
+      params.contextTokenBudget ??
+      resolveContextWindowInfo({
+        cfg: params.cfg,
+        provider: params.provider,
+        modelId: params.modelId,
+        modelContextTokens: params.model?.contextTokens,
+        modelContextWindow: params.model?.contextWindow,
+        defaultTokens: DEFAULT_CONTEXT_TOKENS,
+      }).tokens;
     setCompactionSafeguardRuntime(params.sessionManager, {
-      contextWindowTokens: contextWindowInfo.tokens,
+      contextWindowTokens,
       identifierPolicy: compactionCfg?.identifierPolicy,
       qualityGuardEnabled: qualityGuardCfg?.enabled ?? true,
       qualityGuardMaxRetries: qualityGuardCfg?.maxRetries,

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -205,6 +205,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       provider: contextConfigProvider,
       modelId,
       model: runtimeModelWithContext,
+      agentId: effectiveSkillAgentId,
       requestedTokenBudget: params.contextTokenBudget,
       fallbackTokenBudget: params.tokenBudget,
     });

--- a/src/agents/embedded-agent-runner/run/attempt-session.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.ts
@@ -84,6 +84,7 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
     provider: attempt.provider,
     modelId: attempt.modelId,
     model: attempt.model,
+    contextTokenBudget: attempt.contextTokenBudget,
     agentId: input.sessionAgentId,
     sessionId: attempt.sessionId,
     sessionKey: attempt.sessionKey ?? attempt.sandboxSessionKey,

--- a/src/agents/embedded-agent-runner/run/model-harness.ts
+++ b/src/agents/embedded-agent-runner/run/model-harness.ts
@@ -1,4 +1,5 @@
 import type { Model } from "../../../llm/types.js";
+import { resolveAgentConfig, resolveSessionAgentIds } from "../../agent-scope.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
@@ -31,6 +32,15 @@ export function resolveEmbeddedRunEffectiveModel(
     nativeModelOwned: boolean;
   },
 ) {
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.runParams.sessionKey,
+    config: params.runParams.config,
+    agentId: params.runParams.agentId,
+  });
+  const agentContextTokens = resolveAgentConfig(
+    params.runParams.config ?? {},
+    sessionAgentId,
+  )?.contextTokens;
   return resolveEmbeddedRuntimeModelPolicy({
     cfg: params.runParams.config,
     provider: params.provider,
@@ -42,6 +52,7 @@ export function resolveEmbeddedRunEffectiveModel(
     modelId: params.modelId,
     runtimeModel: params.runtimeModel,
     nativeModelOwned: params.nativeModelOwned,
+    agentContextTokens,
   });
 }
 

--- a/src/agents/embedded-agent-runner/run/setup.ts
+++ b/src/agents/embedded-agent-runner/run/setup.ts
@@ -210,6 +210,7 @@ function resolveEffectiveRuntimeModel(params: {
   contextConfigProvider?: string;
   modelId: string;
   runtimeModel: ProviderRuntimeModel;
+  agentContextTokens?: number;
 }): {
   ctxInfo: ContextWindowInfo;
   effectiveModel: ProviderRuntimeModel;
@@ -220,6 +221,7 @@ function resolveEffectiveRuntimeModel(params: {
     modelId: params.modelId,
     modelContextTokens: readAgentModelContextTokens(params.runtimeModel),
     modelContextWindow: params.runtimeModel.contextWindow,
+    agentContextTokens: params.agentContextTokens,
     defaultTokens: DEFAULT_CONTEXT_TOKENS,
   });
 
@@ -273,6 +275,7 @@ export function resolveEmbeddedRuntimeModelPolicy(params: {
   modelId: string;
   runtimeModel: ProviderRuntimeModel;
   nativeModelOwned: boolean;
+  agentContextTokens?: number;
 }): {
   contextWindowInfo?: ContextWindowInfo;
   contextTokenBudget?: number;


### PR DESCRIPTION
## What Problem This Solves

Embedded runs ignored the selected agent's `contextTokens` ceiling. The run instead fell back to `agents.defaults.contextTokens`, so prompt prechecks, compaction, and session metadata could disagree with the per-agent limit the operator configured.

## Why This Change Was Made

The selected session agent is now resolved before OpenClaw-owned model policy and its configured ceiling is applied to the prepared attempt budget. That prepared budget is then carried into the effective model, normal and compaction session safeguard extensions, and result metadata instead of re-resolving mutable policy at each consumer.

Standalone queued/direct compaction resolves the canonical session agent when no prepared attempt exists. Caller budgets remain ceilings within the configured agent cap and model window:

| Requested | Agent cap | Model window | Effective |
|---:|---:|---:|---:|
| 500,000 | 200,000 | 500,000 | 200,000 |
| 100,000 | 200,000 | 500,000 | 100,000 |
| 500,000 | 200,000 | 64,000 | 64,000 |

Native model-owned harnesses still return before OpenClaw context policy. Codex therefore continues to own its own model context window and automatic/manual compaction.

## Best-Fix Decision

This PR is the canonical fix rather than #119277. A per-agent `contextTokens` value is an operator-configured ceiling, so a larger request must not override it. The broader durable-session and hot-reload provenance question in #118678 remains intentionally out of scope.

Production LOC: +47/-12 (net +35) | Tests: +115/-2 (net +113). The production growth establishes one selected-agent ownership boundary and carries the prepared fact to consumers; the rewrite removes the incoming duplicate safeguard-policy resolution.

## Evidence

- Focused context guard, embedded setup, extension, compaction-runtime, and overflow-compaction shards: 94 tests passed.
- The typed compaction fixture correction reran its 40-test shard successfully.
- Regression coverage asserts the 200,000-token attempt budget, effective model window, and result metadata, plus the precedence table above.
- Existing overflow-compaction coverage proves the same 200,000-token budget reaches recovery compaction; no duplicate lifecycle test was added.
- `git diff --check`: passed.
- Maintainer autoreview of both the rewrite delta and full branch: no accepted/actionable findings.
- The local E2E shard could not start in the fresh worktree because its stale-dist setup requires an unavailable UI workspace dependency; exact-head hosted CI/Testbox is required before merge.

## Codex Ownership Audit

Verified against `openai/codex` commit `c2bcb9a26b5bdbdc66c48cf3bc3bb382568e800c`:

- `codex-rs/protocol/src/openai_models.rs:416-424,463-479` owns model context and automatic-compaction thresholds.
- `codex-rs/models-manager/src/model_info.rs:25-37` applies context and compaction overrides.
- `codex-rs/core/src/session/context_window.rs:23-79` decides native context-window pressure and compaction.
- `codex-rs/core/src/session/handlers.rs:444-448` and `codex-rs/core/src/tasks/compact.rs:19-84` own manual compaction.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:988-998` and `codex-rs/app-server/src/request_processors/thread_processor.rs:1913-1924` show `thread/compact/start` accepts only the thread id and delegates to native `Op::Compact`.

Refs: #118678

Co-authored-by: harjoth <harjoth.khara@gmail.com>
