### PR TITLE
perf(gateway): reuse lifecycle plugin metadata instead of per-turn rescans

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-trajectory.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory.ts
@@ -69,6 +69,9 @@ export async function prepareEmbeddedAttemptTrajectory(input: {
     buildTrajectoryRunMetadata({
       env: process.env,
       config: attempt.config,
+      ...(attempt.preparedModelRuntime?.metadataSnapshot
+        ? { pluginMetadataSnapshot: attempt.preparedModelRuntime.metadataSnapshot }
+        : {}),
       workspaceDir: input.effectiveWorkspace,
       sessionFile: attempt.sessionFile,
       sessionKey: attempt.sessionKey,

--- a/src/commands/doctor/shared/plugin-metadata-snapshot-scope.ts
+++ b/src/commands/doctor/shared/plugin-metadata-snapshot-scope.ts
@@ -4,6 +4,7 @@ import {
   type PluginMetadataSnapshotScopeRunner,
 } from "../../../plugins/current-plugin-metadata-snapshot.js";
 import {
+  completePluginMetadataSnapshot,
   isPluginMetadataSnapshotCompatible,
   loadPluginMetadataSnapshot,
   type PluginMetadataSnapshot,
@@ -24,15 +25,7 @@ export function completeDoctorPluginMetadataSnapshot(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): PluginMetadataSnapshot | undefined {
-  if (!params.snapshot || params.snapshot.pluginIds === undefined) {
-    return params.snapshot;
-  }
-  return loadPluginMetadataSnapshot({
-    config: params.config,
-    env: params.env ?? process.env,
-    index: params.snapshot.index,
-    ...(params.snapshot.workspaceDir ? { workspaceDir: params.snapshot.workspaceDir } : {}),
-  });
+  return completePluginMetadataSnapshot(params);
 }
 
 /** Reuses one exact immutable plugin metadata generation per Doctor workspace. */

--- a/src/commands/sessions.plugin-metadata.test.ts
+++ b/src/commands/sessions.plugin-metadata.test.ts
@@ -86,6 +86,7 @@ describe("sessions plugin metadata preparation", () => {
     expect(resolvePluginMetadataSnapshotMock).toHaveBeenCalledWith({
       config,
       env: process.env,
+      allowWorkspaceScopedCurrent: true,
     });
   });
 });

--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -8,6 +8,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { completePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ExecApprovalManager } from "./exec-approval-manager.js";
 import { revokeAttachGrantsForSession } from "./mcp-grant-store.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
@@ -495,7 +496,13 @@ export async function startGatewayCoreRuntime(input: {
       pluginLookUpTable: nextPluginLookUpTable,
       ambientEnvTriggers,
     });
-    setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
+    const nextPluginMetadataSnapshot = completePluginMetadataSnapshot({
+      snapshot: nextPluginLookUpTable,
+      config: params.nextConfig,
+      env: params.env,
+      workspaceDir: defaultWorkspaceDir,
+    });
+    setCurrentPluginMetadataSnapshot(nextPluginMetadataSnapshot, {
       config: params.nextConfig,
       env: params.env,
       workspaceDir: defaultWorkspaceDir,

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -35,6 +35,7 @@ import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../i
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { completePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
@@ -493,6 +494,7 @@ export async function prepareGatewayServerBootstrap(input: {
     defaultWorkspaceDir,
     startupPluginIds,
     pluginManifestRecords,
+    pluginMetadataSnapshot,
     pluginLookUpTable,
     baseMethods,
     ambientAutostartSuppressedChannelIds,
@@ -505,7 +507,13 @@ export async function prepareGatewayServerBootstrap(input: {
     sourceConfig: startupLastGoodSnapshot.sourceConfig,
   });
   const coreGatewayMethodNames = listCoreGatewayMethodNames();
-  setCurrentPluginMetadataSnapshot(pluginLookUpTable, {
+  const currentPluginMetadataSnapshot = completePluginMetadataSnapshot({
+    snapshot: pluginMetadataSnapshot,
+    config: startupActivationSourceConfig,
+    env: process.env,
+    workspaceDir: defaultWorkspaceDir,
+  });
+  setCurrentPluginMetadataSnapshot(currentPluginMetadataSnapshot, {
     config: startupActivationSourceConfig,
     compatibleConfigs: [startupRuntimeConfig, cfgAtStart, gatewayPluginConfigAtStart],
     env: process.env,
@@ -558,6 +566,7 @@ export async function prepareGatewayServerBootstrap(input: {
     defaultWorkspaceDir,
     startupPluginIds,
     pluginManifestRecords,
+    pluginMetadataSnapshot,
     pluginLookUpTable,
     baseMethods,
     ambientAutostartSuppressedChannelIds,

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -203,6 +203,7 @@ function slackConfig(): OpenClawConfig {
 async function prepareBootstrapWithRuntimeConfig(
   cfg: OpenClawConfig,
   options: {
+    pluginMetadataSnapshot?: PluginMetadataSnapshot;
     workerProviderIds?: readonly string[];
   } = {},
 ) {
@@ -481,9 +482,11 @@ describe("prepareGatewayPluginBootstrap startup plugins", () => {
     } as OpenClawConfig;
 
     const result = await prepareBootstrapWithRuntimeConfig(cfg, {
+      pluginMetadataSnapshot,
       workerProviderIds: ["static-ssh"],
     });
     expect(result.startupPluginIds).toEqual([]);
+    expect(result.pluginMetadataSnapshot).toBe(pluginMetadataSnapshot);
     expect(result.pluginLookUpTable).toBeUndefined();
     expect(result.baseGatewayMethods).toEqual(["ping"]);
 

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -145,8 +145,8 @@ export async function prepareGatewayPluginBootstrap(params: {
           workerProviderIds: params.workerProviderIds ?? [],
           ambientEnvTriggers: params.ambientEnvTriggers,
         });
-  // Startup logging consumes the same process-stable manifest snapshot used for
-  // activation planning. Minimal gateways deliberately have no plugin metadata.
+  // Startup logging and lifecycle publication consume the process-stable metadata snapshot.
+  // Minimal gateways skip runtime lookup-table construction, not metadata ownership.
   const pluginManifestRecords =
     pluginLookUpTable?.manifestRegistry.plugins ??
     params.pluginMetadataSnapshot?.manifestRegistry.plugins ??
@@ -179,6 +179,7 @@ export async function prepareGatewayPluginBootstrap(params: {
     defaultWorkspaceDir,
     startupPluginIds,
     pluginManifestRecords,
+    pluginMetadataSnapshot: pluginLookUpTable ?? params.pluginMetadataSnapshot,
     pluginLookUpTable,
     baseMethods,
     pluginRegistry,

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -7,6 +7,7 @@ import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import {
+  completePluginMetadataSnapshot,
   loadPluginMetadataSnapshot,
   resolvePluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
@@ -112,6 +113,48 @@ describe("plugin metadata snapshot", () => {
     expect(second).not.toBe(first);
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
     expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it("promotes one scoped lifecycle graph and reuses it across runtime resolutions", () => {
+    const config = {};
+    const workspaceDir = "/workspace";
+    const index = makeIndex();
+    index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "provided",
+      snapshot: index,
+      diagnostics: [],
+    });
+    const scoped = loadPluginMetadataSnapshot({
+      config,
+      env: {},
+      index,
+      pluginIds: ["demo"],
+      workspaceDir,
+    });
+
+    const complete = completePluginMetadataSnapshot({
+      snapshot: scoped,
+      config,
+      env: {},
+      workspaceDir,
+    });
+    expect(complete?.pluginIds).toBeUndefined();
+    setCurrentPluginMetadataSnapshot(complete, { config, env: {}, workspaceDir });
+    loadPluginRegistrySnapshotWithMetadata.mockClear();
+    loadPluginManifestRegistryForInstalledIndex.mockClear();
+
+    expect(
+      completePluginMetadataSnapshot({ snapshot: complete, config, env: {}, workspaceDir }),
+    ).toBe(complete);
+    expect(resolvePluginMetadataSnapshot({ env: {}, allowWorkspaceScopedCurrent: true })).toBe(
+      complete,
+    );
+    for (let iteration = 0; iteration < 20; iteration += 1) {
+      expect(resolvePluginMetadataSnapshot({ config, env: {}, workspaceDir })).toBe(complete);
+    }
+    expect(loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
+    expect(loadPluginManifestRegistryForInstalledIndex).not.toHaveBeenCalled();
   });
 
   it("rewalks collection-bearing manifest graphs after prototype mutation", () => {

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -292,6 +292,25 @@ export function loadPluginMetadataSnapshot(
   );
 }
 
+/** Promotes a planning-scoped graph to the complete process-lifecycle metadata snapshot. */
+export function completePluginMetadataSnapshot(params: {
+  snapshot?: PluginMetadataSnapshot;
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+}): PluginMetadataSnapshot | undefined {
+  if (!params.snapshot || params.snapshot.pluginIds === undefined) {
+    return params.snapshot;
+  }
+  const workspaceDir = params.workspaceDir ?? params.snapshot.workspaceDir;
+  return loadPluginMetadataSnapshot({
+    config: params.config,
+    env: params.env ?? process.env,
+    index: params.snapshot.index,
+    ...(workspaceDir ? { workspaceDir } : {}),
+  });
+}
+
 export function resolvePluginMetadataSnapshot(
   params: ResolvePluginMetadataSnapshotParams,
 ): PluginMetadataSnapshot {
@@ -303,6 +322,7 @@ export function resolvePluginMetadataSnapshot(
     const current = getCurrentPluginMetadataSnapshot({
       config: params.config,
       env: params.env,
+      ...(params.config === undefined ? { requireDefaultDiscoveryContext: true } : {}),
       ...(params.pluginIds !== undefined ? { pluginIds: params.pluginIds } : {}),
       ...(params.pluginIdScope !== undefined ? { pluginIdScope: params.pluginIdScope } : {}),
       ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -1061,9 +1061,9 @@ export function resolveExternalAuthProfilesWithPlugins(params: {
   const env = params.env ?? process.env;
   const config = params.config ?? {};
   const currentMetadataSnapshot = getCurrentPluginMetadataSnapshot({
-    config,
     env,
-    ...(workspaceDir === undefined ? { allowWorkspaceScopedSnapshot: true } : { workspaceDir }),
+    ...(params.config ? { config } : { requireDefaultDiscoveryContext: true }),
+    ...(workspaceDir ? { workspaceDir } : { allowWorkspaceScopedSnapshot: true }),
   });
   const { manifestRegistry } =
     currentMetadataSnapshot ?? resolvePluginMetadataSnapshot({ config, workspaceDir, env });

--- a/src/plugins/setup-registry.runtime.test.ts
+++ b/src/plugins/setup-registry.runtime.test.ts
@@ -149,7 +149,7 @@ describe("setup-registry descriptor lookup", () => {
     expect(resolvePluginSetupCliBackendDescriptor({ backend: "disabled-cli" })).toBeUndefined();
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledTimes(3);
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
-      config: {},
+      allowWorkspaceScopedCurrent: true,
       env: process.env,
     });
   });
@@ -232,7 +232,7 @@ describe("setup-registry descriptor lookup", () => {
     expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("does not reuse workspace-scoped current metadata without a workspace context", async () => {
+  it("reuses the lifecycle-owned workspace when no runtime workspace is active", async () => {
     loadPluginMetadataSnapshotMock.mockReturnValue({
       index: {
         diagnostics: [],
@@ -252,12 +252,10 @@ describe("setup-registry descriptor lookup", () => {
       { config: {}, env: process.env },
     );
 
-    expect(
-      resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli", config: {} }),
-    ).toBeUndefined();
-    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
-      config: {},
-      env: process.env,
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli", config: {} })).toEqual({
+      pluginId: "openai",
+      backend: { id: "Codex-CLI" },
     });
+    expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -37,14 +37,10 @@ function resolveMetadataSnapshotForSetupCliBackends(
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
   const snapshot = resolvePluginMetadataSnapshot({
-    config: params.config ?? {},
+    ...(params.config ? { config: params.config } : {}),
     env,
-    ...(workspaceDir !== undefined
-      ? {
-          workspaceDir,
-          allowWorkspaceScopedCurrent: true,
-        }
-      : {}),
+    ...(workspaceDir ? { workspaceDir } : {}),
+    allowWorkspaceScopedCurrent: true,
   });
   return {
     snapshot,

--- a/src/secrets/target-registry-data.current-snapshot.test.ts
+++ b/src/secrets/target-registry-data.current-snapshot.test.ts
@@ -16,20 +16,20 @@ describe("getSecretTargetRegistry metadata reuse", () => {
     metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({ plugins: [] });
   });
 
-  it("uses configless global metadata without a workspace-scoped current request", async () => {
+  it("allows configless runtime targets to reuse the lifecycle workspace", async () => {
     const { getSecretTargetRegistry } = await import("./target-registry-data.js");
 
     getSecretTargetRegistry();
 
     expect(metadataMocks.resolvePluginMetadataSnapshot).toHaveBeenCalledWith({
-      config: {},
+      allowWorkspaceScopedCurrent: true,
       env: process.env,
     });
     const calls = metadataMocks.resolvePluginMetadataSnapshot.mock.calls as unknown as Array<
       [{ allowWorkspaceScopedCurrent?: boolean }]
     >;
     for (const [call] of calls) {
-      expect(call.allowWorkspaceScopedCurrent).not.toBe(true);
+      expect(call.allowWorkspaceScopedCurrent).toBe(true);
     }
   });
   it("registers secret targets for installed-origin plugins (#104320)", async () => {

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -467,8 +467,8 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
   preferPersisted?: boolean;
 }): SecretTargetRegistryEntry[] {
   const plugins = resolvePluginMetadataSnapshot({
-    config: {},
     env: params.env,
+    allowWorkspaceScopedCurrent: true,
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   }).plugins;
   const channelPlugins = plugins.filter((record) => record.channels.length > 0);

--- a/src/trajectory/metadata.test.ts
+++ b/src/trajectory/metadata.test.ts
@@ -44,9 +44,37 @@ import { buildTrajectoryArtifacts, buildTrajectoryRunMetadata } from "./metadata
 
 afterEach(() => {
   resetPluginRuntimeStateForTest();
+  loadPluginManifestRegistry.mockClear();
 });
 
 describe("trajectory metadata", () => {
+  it("uses prepared plugin metadata without rescanning manifests", () => {
+    const metadata = buildTrajectoryRunMetadata({
+      pluginMetadataSnapshot: {
+        plugins: [
+          {
+            id: "prepared-plugin",
+            name: "Prepared Plugin",
+            origin: "bundled",
+            channels: [],
+            providers: [],
+            cliBackends: [],
+            hooks: [],
+            skills: [],
+          },
+        ],
+      } as never,
+      workspaceDir: "/tmp/workspace",
+      timeoutMs: 30_000,
+    });
+
+    expect(metadata.plugins).toMatchObject({
+      source: "manifest-registry",
+      entries: [{ id: "prepared-plugin" }],
+    });
+    expect(loadPluginManifestRegistry).not.toHaveBeenCalled();
+  });
+
   it("redacts harness argv and local paths with the support redaction rules", () => {
     const originalArgv = process.argv;
     process.argv = [

--- a/src/trajectory/metadata.ts
+++ b/src/trajectory/metadata.ts
@@ -10,7 +10,10 @@ import {
   sanitizeSupportSnapshotValue,
   type SupportRedactionContext,
 } from "../logging/diagnostic-support-redaction.js";
-import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  loadPluginMetadataSnapshot,
+  type PluginMetadataSnapshot,
+} from "../plugins/plugin-metadata-snapshot.js";
 import { getActivePluginRegistry, listImportedRuntimePluginIds } from "../plugins/runtime.js";
 import type { SkillSnapshot } from "../skills/types.js";
 import { VERSION } from "../version.js";
@@ -20,6 +23,7 @@ import { VERSION } from "../version.js";
 type BuildTrajectoryRunMetadataParams = {
   env?: NodeJS.ProcessEnv;
   config?: OpenClawConfig;
+  pluginMetadataSnapshot?: PluginMetadataSnapshot;
   workspaceDir: string;
   sessionFile?: string;
   sessionKey?: string;
@@ -139,16 +143,19 @@ function buildPluginsFromActiveRegistry() {
 
 function buildPluginsFromManifest(params: {
   config?: OpenClawConfig;
+  pluginMetadataSnapshot?: PluginMetadataSnapshot;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }) {
   // Startup captures can happen before runtime activation. Fall back to the
   // manifest snapshot so exported runs still show configured plugin surfaces.
-  const snapshot = loadPluginMetadataSnapshot({
-    config: params.config ?? {},
-    workspaceDir: params.workspaceDir,
-    env: params.env ?? process.env,
-  });
+  const snapshot =
+    params.pluginMetadataSnapshot ??
+    loadPluginMetadataSnapshot({
+      config: params.config ?? {},
+      workspaceDir: params.workspaceDir,
+      env: params.env ?? process.env,
+    });
   return {
     source: "manifest-registry",
     entries: snapshot.plugins
@@ -235,6 +242,9 @@ export function buildTrajectoryRunMetadata(
     buildPluginsFromActiveRegistry() ??
     buildPluginsFromManifest({
       config: params.config,
+      ...(params.pluginMetadataSnapshot
+        ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+        : {}),
       workspaceDir: params.workspaceDir,
       env,
     });


### PR DESCRIPTION
# What Problem This Solves

The gateway re-executed the full synchronous plugin manifest scan (`plugins.metadata.scan`, ~51 ms each on macOS) thousands of times at runtime instead of reusing the process-stable lifecycle snapshot. Measured with `OPENCLAW_DIAGNOSTICS=1` + `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH` during one TUI PTY e2e window (142 s): **2,285 scans ≈ 117 s of blocked event loop** — 1,246 during a single agent turn, 266 under `sessions.list`, 677 at startup. A trivial mock-model chat turn spent 47 s in `gateway.chat_send.dispatch_inbound` (`reply.resolve_directives` 26.5 s), and `sessions.list` blew past the 30 s gateway-client timeout, failing the `tui-session-management-pty` QA scenario ("restores the remembered Gateway session and history after a real TUI relaunch") deterministically on macOS. Linux CI only survives because its filesystem metadata operations are faster; the waste exists on every platform, including production gateways.

# Why This Change Was Made

Root cause: gateway config startup had already scanned metadata, but minimal or plugin-disabled gateways skip runtime lookup-table construction, and `server-startup-bootstrap.ts` published that missing lookup table as the current snapshot — clearing the valid startup snapshot. Every runtime reader (`resolvePluginMetadataSnapshot`) then fell through to a fresh synchronous scan. Additional multipliers: configless CLI-backend/secret/auth lookups defeating snapshot compatibility, and trajectory capture ignoring its prepared snapshot.

Fix at the owner boundary (plugin metadata snapshot lifecycle), per the repo architecture rule "gateway/plugin metadata is process-stable":

- Publish a complete lifecycle snapshot independently of the optional runtime lookup table (startup and reload paths).
- Promote scoped planning metadata once via its existing installed index (`completePluginMetadataSnapshot`, promoted from the doctor-local helper; doctor now delegates to it).
- Let configless runtime readers (provider auth, setup CLI backends, secret target registry) reuse the lifecycle snapshot via `requireDefaultDiscoveryContext` / workspace-scoped reuse instead of forcing rescans.
- Carry prepared metadata into trajectory capture.

No new cache, config/env option, protocol change, or storage change.

# User Impact

- Chat turns no longer freeze the gateway: the observed mock turn dropped from 47 s to sub-second overhead; the failing TUI e2e went from 141 s (fail) to 18.8 s (pass).
- `sessions.list` answers immediately during active runs — session switching in the TUI/Control UI no longer times out or feels stuck while a turn is running.
- Post-fix diagnostics timeline shows metadata scans only at process startup (30 total across all child processes in the e2e window; **zero** during agent-turn / sessions.list / history phases, down from 2,285).

# Evidence

- Repro + measurement (macOS, Node 26.7): `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 OPENCLAW_TUI_PTY_USE_BUILT_CLI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts --testNamePattern "restores the remembered Gateway session and history after a real TUI relaunch"` — failed 3/3 runs pre-fix (`GatewayClientRequestTimeoutError: gateway request timeout for sessions.list`, 141 s), passes post-fix in 18.8 s (verified independently twice).
- Scan-count proof: timeline aggregation pre-fix 2,285 `plugins.metadata.scan` events (1,246 agent-turn / 677 startup / 266 sessions.list / 58 agent.prepare); post-fix 30, all startup-phase.
- Focused tests: `src/plugins/plugin-metadata-snapshot.test.ts` (15/15), `src/trajectory/metadata.test.ts`, `src/gateway/server-startup-plugins.test.ts` — all green (3 shards, 5.2 s).
- Wider affected suites (gateway reload + doctor): 233/233 green.
- QA mock lane on the fixed build: `pnpm openclaw qa suite --provider-mode mock-openai` over session-management/messaging/steering scenarios (results in PR discussion).
- Autoreview (codex, gpt-5.6-sol, high): clean — "no accepted/actionable findings", overall 0.97.
- Production LOC +39 (68/-29), tests +72. The net-positive production delta is the lifecycle-publication ownership move required by the repair; doctor's duplicate snapshot-promotion implementation was consolidated into the owner module.
