### PR TITLE
refactor(core): adopt normalization-core leaf helpers across production

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -1,15 +1,9 @@
 // Memory Host SDK module implements embeddings remote fetch behavior.
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { postJson } from "./post-json.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
 
 // Fetches and validates OpenAI-compatible embedding responses.
-
-/** Narrow unknown JSON payloads to plain objects. */
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 /** Build the common malformed embedding response error. */
 function malformedEmbeddingResponse(errorPrefix: string): Error {
@@ -31,7 +25,7 @@ function readEmbeddingVector(value: unknown, errorPrefix: string): number[] {
 
 /** Resolve expected response count from the request body when input is an array. */
 function resolveExpectedEmbeddingCount(body: unknown): number | undefined {
-  const input = asRecord(body)?.input;
+  const input = asOptionalRecord(body)?.input;
   return Array.isArray(input) ? input.length : undefined;
 }
 
@@ -54,7 +48,7 @@ export async function fetchRemoteEmbeddingVectors(params: {
     body: params.body,
     errorPrefix: params.errorPrefix,
     parse: (payload) => {
-      const root = asRecord(payload);
+      const root = asOptionalRecord(payload);
       if (!root || !Array.isArray(root.data)) {
         throw malformedEmbeddingResponse(params.errorPrefix);
       }
@@ -63,7 +57,7 @@ export async function fetchRemoteEmbeddingVectors(params: {
         throw malformedEmbeddingResponse(params.errorPrefix);
       }
       return root.data.map((entry) => {
-        const record = asRecord(entry);
+        const record = asOptionalRecord(entry);
         if (!record) {
           throw malformedEmbeddingResponse(params.errorPrefix);
         }

--- a/packages/memory-host-sdk/src/host/qmd-query-parser.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK module implements qmd query parser behavior.
+import { asPositiveSafeInteger as parseQmdLineNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "./error-utils.js";
@@ -122,11 +123,6 @@ function parseQmdQueryResultArray(raw: string): QmdQueryResult[] | null {
   } catch {
     return null;
   }
-}
-
-/** Normalize qmd line numbers, rejecting zero, negative, and non-integer values. */
-function parseQmdLineNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
 }
 
 /** Extract the first complete, standalone JSON result array from noisy stdout. */

--- a/packages/memory-host-sdk/src/host/secret-input-utils.ts
+++ b/packages/memory-host-sdk/src/host/secret-input-utils.ts
@@ -1,6 +1,9 @@
 // Secret input parsing shared by memory provider config and gateway-resolved snapshots.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
+import {
+  hasNonEmptyString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 
 /** Supported secret reference backing stores. */
 type SecretRefSource = "env" | "file" | "exec";
@@ -17,15 +20,6 @@ const ENV_SECRET_REF_ID_RE = /^[A-Z][A-Z0-9_]{0,127}$/;
 const LEGACY_SECRETREF_ENV_MARKER_PREFIX = "secretref-env:";
 const ENV_SECRET_TEMPLATE_RE = /^\$\{([A-Z][A-Z0-9_]{0,127})\}$/;
 const SECRET_REF_SOURCES = new Set<SecretRefSource>(["env", "file", "exec"]);
-
-/** Normalize literal secret strings and reject empty placeholders. */
-function normalizeSecretInputString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
 
 /** Narrow a string to a supported SecretRef source. */
 function hasSecretRefSource(value: unknown): value is SecretRefSource {
@@ -111,7 +105,7 @@ function coerceSecretRef(value: unknown): SecretRef | null {
 
 /** Return true when a secret input has either a literal value or resolvable reference shape. */
 export function hasConfiguredMemorySecretInputValue(value: unknown): boolean {
-  if (normalizeSecretInputString(value)) {
+  if (normalizeOptionalString(value)) {
     return true;
   }
   return coerceSecretRef(value) !== null;
@@ -139,7 +133,7 @@ export function normalizeResolvedMemorySecretInputString(params: {
   value: unknown;
   path: string;
 }): string | undefined {
-  const normalized = normalizeSecretInputString(params.value);
+  const normalized = normalizeOptionalString(params.value);
   if (normalized) {
     return normalized;
   }
@@ -152,5 +146,5 @@ export function normalizeResolvedMemorySecretInputString(params: {
 
 /** Normalize env-provided secret values before use. */
 export function normalizeEnvSecretInputString(value: unknown): string | undefined {
-  return normalizeSecretInputString(value);
+  return normalizeOptionalString(value);
 }

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -1,4 +1,5 @@
 // Model Catalog Core helper module supports model catalog normalize behavior.
+import { asFiniteNumber as normalizeFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -125,10 +126,6 @@ function normalizeModelCatalogInputs(value: unknown): ModelCatalogInput[] | unde
 
 function normalizeNonNegativeNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
-}
-
-function normalizeFiniteNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function normalizeStringOrNumber(value: unknown): string | number | undefined {

--- a/packages/net-policy/package.json
+++ b/packages/net-policy/package.json
@@ -44,6 +44,7 @@
     "build": "tsdown src/index.ts src/ip.ts src/ipv4.ts src/redact-sensitive-url.ts src/url-protocol.ts src/url-userinfo.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   },
   "dependencies": {
+    "@openclaw/normalization-core": "workspace:*",
     "ipaddr.js": "2.4.0"
   }
 }

--- a/packages/net-policy/src/ip.ts
+++ b/packages/net-policy/src/ip.ts
@@ -1,17 +1,9 @@
 // Network Policy module implements ip behavior.
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import ipaddr from "ipaddr.js";
-
-function normalizeOptionalString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed || undefined;
-}
-
-function normalizeLowercaseStringOrEmpty(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
-}
 
 /** Parsed IP address value returned by the net-policy parsing helpers. */
 export type ParsedIpAddress = ipaddr.IPv4 | ipaddr.IPv6;

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -1,11 +1,9 @@
 // Network Policy module implements redact sensitive url behavior.
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
 type ConfigUiHintTags = {
   tags?: string[];
 };
-
-function normalizeLowercaseStringOrEmpty(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
-}
 
 /** Config UI hint tag for URL-like values that may embed credentials or tokens. */
 export const SENSITIVE_URL_HINT_TAG = "url-secret";

--- a/packages/normalization-core/src/utf16-slice.test.ts
+++ b/packages/normalization-core/src/utf16-slice.test.ts
@@ -4,6 +4,7 @@ import {
   avoidTrailingHighSurrogateBreak,
   sliceUtf16Safe,
   truncateUtf16Safe,
+  truncateWithMarker,
 } from "./utf16-slice.js";
 
 describe("avoidTrailingHighSurrogateBreak", () => {
@@ -103,5 +104,54 @@ describe("truncateUtf16Safe", () => {
   it("returns empty string when truncating at surrogate pair boundary", () => {
     const input = "👨👩";
     expect(truncateUtf16Safe(input, 1)).toBe("");
+  });
+});
+
+describe("truncateWithMarker", () => {
+  it.each([
+    {
+      name: "returns values at the boundary unchanged",
+      value: "hello",
+      max: 5,
+      options: { marker: "...", reserve: 3, trimEnd: false },
+      expected: "hello",
+    },
+    {
+      name: "reserves marker width",
+      value: "hello world",
+      max: 8,
+      options: { marker: "...", reserve: 3, trimEnd: false },
+      expected: "hello...",
+    },
+    {
+      name: "supports markers outside the limit",
+      value: "hello world",
+      max: 5,
+      options: { marker: "...", reserve: 0, trimEnd: false },
+      expected: "hello...",
+    },
+    {
+      name: "trims only the truncated prefix",
+      value: "hello   world",
+      max: 9,
+      options: { marker: "...", reserve: 3, trimEnd: true },
+      expected: "hello...",
+    },
+    {
+      name: "keeps surrogate pairs well formed",
+      value: "ab🚀tail",
+      max: 4,
+      options: { marker: "…", reserve: 1, trimEnd: false },
+      expected: "ab…",
+    },
+    {
+      name: "preserves marker output at zero limits",
+      value: "hello",
+      max: 0,
+      options: { marker: "…", reserve: 1, trimEnd: false },
+      expected: "…",
+    },
+  ] as const)("$name", ({ value, max, options, expected }) => {
+    expect(truncateWithMarker(value, max, options)).toBe(expected);
   });
 });

--- a/packages/normalization-core/src/utf16-slice.ts
+++ b/packages/normalization-core/src/utf16-slice.ts
@@ -62,3 +62,16 @@ export function truncateUtf16Safe(input: string, maxLen: number): string {
   }
   return sliceUtf16Safe(input, 0, limit);
 }
+
+/** Truncates text and appends a marker while preserving the caller's reserved width contract. */
+export function truncateWithMarker(
+  value: string,
+  max: number,
+  options: { marker: string; reserve: number; trimEnd: boolean },
+): string {
+  if (value.length <= max) {
+    return value;
+  }
+  const prefix = truncateUtf16Safe(value, max - options.reserve);
+  return `${options.trimEnd ? prefix.trimEnd() : prefix}${options.marker}`;
+}

--- a/packages/plugin-package-contract/package.json
+++ b/packages/plugin-package-contract/package.json
@@ -5,5 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@openclaw/normalization-core": "workspace:*"
   }
 }

--- a/packages/plugin-package-contract/package.json
+++ b/packages/plugin-package-contract/package.json
@@ -5,8 +5,5 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
-  },
-  "dependencies": {
-    "@openclaw/normalization-core": "workspace:*"
   }
 }

--- a/packages/plugin-package-contract/src/index.ts
+++ b/packages/plugin-package-contract/src/index.ts
@@ -1,4 +1,6 @@
 // External code plugin package.json compatibility and validation contracts.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 /** JSON object shape accepted by package contract helpers. */
 export type JsonObject = Record<string, unknown>;
@@ -28,20 +30,6 @@ export const EXTERNAL_CODE_PLUGIN_REQUIRED_FIELD_PATHS = [
   "openclaw.compat.pluginApi",
   "openclaw.build.openclawVersion",
 ] as const;
-
-/** Narrow unknown values to plain records. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-/** Normalize optional package metadata strings. */
-function normalizeOptionalString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-}
 
 /** Read OpenClaw package.json blocks without trusting caller input shape. */
 function readOpenClawBlock(packageJson: unknown) {

--- a/packages/plugin-package-contract/src/index.ts
+++ b/packages/plugin-package-contract/src/index.ts
@@ -1,6 +1,6 @@
 // External code plugin package.json compatibility and validation contracts.
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isRecord } from "../../normalization-core/src/record-coerce.js";
+import { normalizeOptionalString } from "../../normalization-core/src/string-coerce.js";
 
 /** JSON object shape accepted by package contract helpers. */
 export type JsonObject = Record<string, unknown>;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,6 +19,7 @@
     "build": "tsdown src/index.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   },
   "dependencies": {
-    "@openclaw/gateway-client": "workspace:*"
+    "@openclaw/gateway-client": "workspace:*",
+    "@openclaw/normalization-core": "workspace:*"
   }
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,5 +1,6 @@
 // OpenClaw SDK module implements client behavior.
 import { randomUUID } from "node:crypto";
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { EventHub } from "./event-hub.js";
 import { normalizeGatewayEvent } from "./normalize.js";
 import { GatewayClientTransport, isConnectableTransport } from "./transport.js";
@@ -221,10 +222,6 @@ type ChatProjection = {
   state: ChatProjectionState;
   payload: Record<string, unknown>;
 };
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
 
 function hasArtifactQueryScope(params: unknown): params is ArtifactQuery {
   const record = asRecord(params);

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -1,17 +1,10 @@
 // OpenClaw SDK helper module supports normalize behavior.
+import { asFiniteNumber as readNumber } from "@openclaw/normalization-core/number-coercion";
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayEvent, JsonObject, OpenClawEvent, OpenClawEventType } from "./types.js";
-
-// Normalize raw Gateway events into stable SDK event types and common metadata.
-function asRecord(value: unknown): JsonObject {
-  return typeof value === "object" && value !== null ? (value as JsonObject) : {};
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function readNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function readLowerString(value: unknown): string | undefined {

--- a/packages/tool-call-repair/src/promote.ts
+++ b/packages/tool-call-repair/src/promote.ts
@@ -1,3 +1,4 @@
+import { asOptionalObjectRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { PlainTextToolCallProtectedRangeResolver } from "./contracts.js";
 // Tool Call Repair module implements promote behavior.
 import { parseStandalonePlainTextToolCallBlocks, type PlainTextToolCallBlock } from "./payload.js";
@@ -43,10 +44,6 @@ export function createPromotedPlainTextToolCallBlock(
     arguments: block.arguments,
     partialArgs: JSON.stringify(block.arguments),
   };
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
 
 /** Emits the complete provider-neutral lifecycle for promoted tool-call blocks. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2322,11 +2322,7 @@ importers:
         specifier: 1.3.6
         version: 1.3.6
 
-  packages/plugin-package-contract:
-    dependencies:
-      '@openclaw/normalization-core':
-        specifier: workspace:*
-        version: link:../normalization-core
+  packages/plugin-package-contract: {}
 
   packages/plugin-sdk: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2306,6 +2306,9 @@ importers:
 
   packages/net-policy:
     dependencies:
+      '@openclaw/normalization-core':
+        specifier: workspace:*
+        version: link:../normalization-core
       ipaddr.js:
         specifier: 2.4.0
         version: 2.4.0
@@ -2319,7 +2322,11 @@ importers:
         specifier: 1.3.6
         version: 1.3.6
 
-  packages/plugin-package-contract: {}
+  packages/plugin-package-contract:
+    dependencies:
+      '@openclaw/normalization-core':
+        specifier: workspace:*
+        version: link:../normalization-core
 
   packages/plugin-sdk: {}
 
@@ -2330,6 +2337,9 @@ importers:
       '@openclaw/gateway-client':
         specifier: workspace:*
         version: link:../gateway-client
+      '@openclaw/normalization-core':
+        specifier: workspace:*
+        version: link:../normalization-core
 
   packages/session-url-contract: {}
 

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -10,6 +10,7 @@ import {
   type AnyMessage,
 } from "@agentclientprotocol/sdk";
 import type { AcpServerOptions } from "@openclaw/acp-core/types";
+import { isRecord as isJsonObject } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   GATEWAY_CLIENT_CAPS,
@@ -287,10 +288,6 @@ function normalizeAcpInitializeProtocolVersion(message: AnyMessage): AnyMessage 
       protocolVersion: PROTOCOL_VERSION,
     },
   } as AnyMessage;
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isUint16Integer(value: unknown): value is number {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -35,6 +35,7 @@ import { defaultAcpSessionStore, type AcpSessionStore } from "@openclaw/acp-core
 import { toAcpSessionLineageMeta } from "@openclaw/acp-core/session-lineage-meta";
 import type { AcpServerOptions } from "@openclaw/acp-core/types";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import { normalizeLowercaseStringOrEmpty as normalizedChatSendAckStatus } from "@openclaw/normalization-core/string-coerce";
 import {
   normalizeFastMode,
   normalizeOptionalString,
@@ -112,10 +113,6 @@ type ChatSendAck = {
   runId?: unknown;
   status?: unknown;
 };
-
-function normalizedChatSendAckStatus(status: unknown): string {
-  return typeof status === "string" ? status.trim().toLowerCase() : "";
-}
 
 function isTerminalChatSendAckFailure(status: unknown): boolean {
   const normalized = normalizedChatSendAckStatus(status);

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -1,7 +1,12 @@
 /** Relays child ACP session stream updates back into the requester parent session. */
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  sliceUtf16Safe,
+  truncateUtf16Safe,
+  truncateWithMarker,
+} from "@openclaw/normalization-core/utf16-slice";
 import {
   isAcpTagVisible,
   resolveAcpProjectionSettings,
@@ -58,7 +63,7 @@ function truncate(value: string, maxChars: number): string {
   if (maxChars <= 1) {
     return truncateUtf16Safe(value, maxChars);
   }
-  return `${truncateUtf16Safe(value, maxChars - 1)}…`;
+  return truncateWithMarker(value, maxChars, { marker: "…", reserve: 1, trimEnd: false });
 }
 
 function normalizeStringArray(value: unknown): string[] {
@@ -73,12 +78,6 @@ function formatProxyEnvSummary(keys: string[]): string {
     return "proxy env: none";
   }
   return `proxy env: ${keys.join(", ")}`;
-}
-
-function asObjectRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function mergeStreamingConfig(base: unknown, override: unknown): unknown {

--- a/src/agents/agent-command-restart-recovery.ts
+++ b/src/agents/agent-command-restart-recovery.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../config/sessions/restart-recovery-types.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -12,10 +13,6 @@ import {
   type AgentDeliveryEvidence,
 } from "./embedded-agent-runner/delivery-evidence.js";
 import { mergeAttemptToolMediaPayloads } from "./embedded-agent-runner/run/tool-media-payloads.js";
-
-function normalizeOptionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 function normalizeOptionalThreadId(value: unknown): string | undefined {
   return (

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -1,4 +1,5 @@
 /** Normalizes agent run wait/liveness/timeout metadata into sticky terminal outcomes. */
+import { asFiniteNumber as asFiniteTimestamp } from "@openclaw/normalization-core/number-coercion";
 import {
   formatAbandonedLivenessError,
   formatBlockedLivenessError,
@@ -460,10 +461,6 @@ type AgentRunLifecycleTerminalData = Omit<AgentRunTerminalWaitInput, "status"> &
 export const AGENT_RUN_TERMINAL_RETRY_GRACE_MS = 15_000;
 
 const HARD_TIMEOUT_PHASES = new Set<AgentRunTimeoutPhase>(["preflight", "provider", "post_turn"]);
-
-function asFiniteTimestamp(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
 
 function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;

--- a/src/agents/auth-profiles/read-only-availability.ts
+++ b/src/agents/auth-profiles/read-only-availability.ts
@@ -1,4 +1,5 @@
 /** Pure, non-resolving credential availability checks shared by status and route selection. */
+import { hasNonEmptyString as hasSecret } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   isSecretRef,
@@ -19,10 +20,6 @@ import { hasUsableOAuthCredential, resolveTokenExpiryState } from "./credential-
 import type { AuthProfileCredential } from "./types.js";
 
 type ReadOnlyCredentialAvailability = boolean | undefined;
-
-function hasSecret(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 export function hasMalformedSecretInputSyntax(value: unknown): boolean {
   if (typeof value !== "string") {

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -6,6 +6,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
 import { sha256HexPrefix } from "../../infra/crypto-digest.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
@@ -85,11 +86,7 @@ function parseJsonCell(raw: string | null | undefined): unknown {
   if (!raw) {
     return null;
   }
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    return null;
-  }
+  return safeParseJson(raw) ?? null;
 }
 
 type PersistedAuthProfileStoreInspection =

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -12,6 +12,7 @@ import {
   resolveExpiresAtMsFromEpochSeconds,
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { cancelUnreadResponseBody } from "../../infra/http-body.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { readProviderJsonResponse } from "../provider-http-errors.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
@@ -251,12 +252,6 @@ function applyWhamCooldownResult(params: {
       resolveUsageWindowUntil(params.now, params.whamResult.cooldownMs),
     ),
   };
-}
-
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
 }
 
 async function probeWhamForCooldown(

--- a/src/agents/bash-process-references.ts
+++ b/src/agents/bash-process-references.ts
@@ -3,7 +3,7 @@
  * These references are surfaced in agent context so follow-up turns can
  * reconnect to prior long-running work.
  */
-import { truncateUtf16Safe } from "../utils.js";
+import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { listRunningSessions } from "./bash-process-registry.js";
 import { deriveSessionName } from "./bash-tools.shared.js";
 
@@ -31,7 +31,7 @@ function truncate(value: string, maxChars: number): string {
   if (maxChars <= 1) {
     return truncateUtf16Safe(value, maxChars);
   }
-  return `${truncateUtf16Safe(value, Math.max(0, maxChars - 3))}...`;
+  return truncateWithMarker(value, maxChars, { marker: "...", reserve: 3, trimEnd: false });
 }
 
 /** List active background process sessions for one scope key, newest first. */

--- a/src/agents/bash-tools.exec-host-node-failure.ts
+++ b/src/agents/bash-tools.exec-host-node-failure.ts
@@ -1,4 +1,5 @@
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString as readString } from "@openclaw/normalization-core/string-coerce";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import { renderExecUpdateText } from "./bash-tools.exec-output.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -26,10 +27,6 @@ type NodeInvokeFailure =
 type NodeSystemRunInvokeResult =
   | { ok: true; raw: unknown }
   | { ok: false; failure: NodeInvokeFailure };
-
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 /** Only NOT_CONNECTED plus explicit pre-dispatch provenance proves a retry cannot duplicate work. */
 function classifyNodeInvokeFailure(error: unknown): NodeInvokeFailure {

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -5,6 +5,7 @@
 import { randomBytes } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
+import { cancelUnreadResponseBody } from "../infra/http-body.js";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
 import { buildOAuthRequestSignal } from "../llm/utils/oauth/abort.js";
@@ -100,12 +101,6 @@ function resolveChutesExpiresAt(value: unknown, now: number): number | undefined
     bufferMs: DEFAULT_EXPIRES_BUFFER_MS,
     minRemainingMs: 30_000,
   });
-}
-
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
 }
 
 async function fetchChutesUserInfo(params: {

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -3,7 +3,7 @@
  */
 import { safeParseJson } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import { hasNonEmptyString, readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import {
   isMessageToolConversationCreateActionName,
@@ -32,29 +32,22 @@ const BROADCAST_SEND_ENVELOPE_KEYS = ["payload", "result", "sendResult", "toolRe
 const PARTIAL_DELIVERY_ENVELOPE_KEYS = [...RESULT_ENVELOPE_KEYS, "error", "cause"];
 const SESSIONS_SEND_DELIVERY_STATUSES = new Set(["accepted", "ok"]);
 const BARE_OK_DELIVERY_STATUS = "ok";
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
 
 function resultConfirmsCurrentSourceRoute(value: unknown): boolean {
-  return asRecord(asRecord(value).details).sourceReplyRoute === "current-source";
-}
-
-function hasStringValue(value: unknown): boolean {
-  return typeof value === "string" && value.trim().length > 0;
+  return (
+    (asOptionalRecord(asOptionalRecord(value)?.details) ?? {}).sourceReplyRoute === "current-source"
+  );
 }
 
 function hasConversationIdValue(value: unknown): boolean {
-  return hasStringValue(value) || (typeof value === "number" && Number.isFinite(value));
+  return hasNonEmptyString(value) || (typeof value === "number" && Number.isFinite(value));
 }
 
 function hasExplicitMessageRoute(args: Record<string, unknown>): boolean {
-  if (EXPLICIT_MESSAGE_ROUTE_KEYS.some((key) => hasStringValue(args[key]))) {
+  if (EXPLICIT_MESSAGE_ROUTE_KEYS.some((key) => hasNonEmptyString(args[key]))) {
     return true;
   }
-  return Array.isArray(args.targets) && args.targets.some((value) => hasStringValue(value));
+  return Array.isArray(args.targets) && args.targets.some((value) => hasNonEmptyString(value));
 }
 
 function isMessageToolSourceReplyActionName(action: unknown): boolean {
@@ -73,7 +66,7 @@ function isMessageToolSourceReplyActionName(action: unknown): boolean {
 
 /** Read the visible text delivered by a source-reply message action. */
 export function readMessageToolSourceReplyText(args: unknown): string | undefined {
-  const record = asRecord(args);
+  const record = asOptionalRecord(args) ?? {};
   if (!isMessageToolSourceReplyActionName(record.action)) {
     return undefined;
   }
@@ -110,7 +103,7 @@ function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {
     const normalized = normalizeStatus(value);
     return Boolean(normalized && !NON_DELIVERY_MESSAGE_IDS.has(normalized));
   };
-  const message = asRecord(record.message);
+  const message = asOptionalRecord(record.message) ?? {};
   if (
     hasDeliveredId(record.messageId) ||
     hasDeliveredId(record.pollId) ||
@@ -504,7 +497,7 @@ export function isDeliveredMessagingToolResult(params: {
   hookResult?: unknown;
   isError?: boolean;
 }): boolean {
-  const args = asRecord(params.args);
+  const args = asOptionalRecord(params.args) ?? {};
   const action = normalizeStatus(args.action);
   if (
     args.dryRun === true ||
@@ -595,7 +588,7 @@ export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   if (normalizeToolName(params.toolName) !== MESSAGE_TOOL_NAME) {
     return false;
   }
-  const args = asRecord(params.args);
+  const args = asOptionalRecord(params.args) ?? {};
   const sourceRouteReplyAction =
     (params.allowExplicitSourceRoute === true || confirmedCurrentSourceRoute) &&
     isMessageToolSourceReplyActionName(args.action);

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -1,3 +1,4 @@
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeMediaReferenceForComparison } from "../../media/media-reference-comparison.js";
 /**
  * Extracts visible delivery evidence from embedded-agent run results.
@@ -95,10 +96,6 @@ export function hasCompletedTerminalDeliveryEvidence(
     (explicitFinal === undefined && hasVisibleOutboundDeliveryEvidence(result)) ||
     result.didSendDeterministicApprovalPrompt === true
   );
-}
-
-function hasNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 function hasNonEmptyArray(value: unknown): boolean {

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -2,6 +2,7 @@
  * Builds extension factories available to embedded-agent runtime sessions.
  */
 import { randomUUID } from "node:crypto";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { normalizeAcceptedSessionSpawnResult } from "../accepted-session-spawn.js";
@@ -31,14 +32,8 @@ type AgentToolResultEvent = {
   isError?: boolean;
 };
 
-function recordFromUnknown(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
 function snapshotToolSendReceipt(details: unknown): unknown {
-  const toolSend = recordFromUnknown(details).toolSend;
+  const toolSend = (asOptionalRecord(details) ?? {}).toolSend;
   return toolSend && typeof toolSend === "object" && !Array.isArray(toolSend)
     ? { ...(toolSend as Record<string, unknown>) }
     : toolSend;
@@ -66,7 +61,7 @@ function buildAgentToolResultMiddlewareFactory(
   });
   return (agent) => {
     agent.on("tool_result", async (rawEvent: unknown, ctx: { cwd?: string }) => {
-      const event = recordFromUnknown(rawEvent) as AgentToolResultEvent;
+      const event = (asOptionalRecord(rawEvent) ?? {}) as AgentToolResultEvent;
       if (!event.toolName) {
         return undefined;
       }
@@ -94,7 +89,7 @@ function buildAgentToolResultMiddlewareFactory(
         turnId: event.turnId,
         toolCallId,
         toolName: event.toolName,
-        args: recordFromUnknown(adjustedInput ?? event.input),
+        args: asOptionalRecord(adjustedInput ?? event.input) ?? {},
         cwd: ctx.cwd,
         isError: event.isError,
         result: current,

--- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
@@ -16,7 +16,7 @@ import {
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { parseGeminiAuth } from "../../infra/gemini-auth.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
-import { readResponseWithLimit } from "../../infra/http-body.js";
+import { cancelUnreadResponseBody, readResponseWithLimit } from "../../infra/http-body.js";
 import { streamWithPayloadPatch } from "../../llm/providers/stream-wrappers/stream-payload-utils.js";
 import type { Model } from "../../llm/types.js";
 import { isSecretValueRegisteredForRedaction } from "../../logging/secret-redaction-registry.js";
@@ -284,12 +284,6 @@ function buildManagedContextForCachedContent(context: GooglePromptCacheContext) 
     systemPrompt: undefined,
     tools: undefined,
   };
-}
-
-async function cancelUnreadResponseBody(response: Response | undefined): Promise<void> {
-  if (response && !response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
 }
 
 /**

--- a/src/agents/embedded-agent-runner/message-visibility.ts
+++ b/src/agents/embedded-agent-runner/message-visibility.ts
@@ -1,3 +1,4 @@
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import {
   isSilentReplyPayloadText,
   isSilentReplyText,
@@ -23,10 +24,6 @@ type PayloadVisibilityOptions = {
   includeReasoningPayloads?: boolean;
   includeSilentReplyPayloads?: boolean;
 };
-
-function hasNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some(hasNonEmptyString);

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord as readModelParams } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ModelCompatConfig, ModelMediaInputConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -226,13 +227,6 @@ export function hasConfiguredFallbackSurface(params: {
     return true;
   }
   return Boolean(params.providerConfig?.baseUrl?.trim());
-}
-
-function readModelParams(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  return value as Record<string, unknown>;
 }
 
 function mergeModelParams(

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
@@ -19,7 +19,7 @@
  */
 
 import { formatErrorMessage } from "../../infra/errors.js";
-import { readResponseWithLimit } from "../../infra/http-body.js";
+import { cancelUnreadResponseBody, readResponseWithLimit } from "../../infra/http-body.js";
 import { resolveProxyFetchFromEnv } from "../../infra/net/proxy-fetch.js";
 import { parseStrictFiniteNumber } from "../../infra/parse-finite-number.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -175,12 +175,6 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
       cacheWrite: (parseStrictFiniteNumber(model.pricing?.input_cache_write) ?? 0) * 1_000_000,
     },
   };
-}
-
-async function cancelUnreadResponseBody(response: Response | undefined): Promise<void> {
-  if (response && !response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -2,6 +2,7 @@
  * Sanitizes and validates replayed session history before model calls.
  */
 import { isDeepStrictEqual } from "node:util";
+import { asFiniteNumber as toFiniteCostNumber } from "@openclaw/normalization-core/number-coercion";
 import { stripInternalMetadataForDisplay } from "../../auto-reply/reply/display-text-sanitize.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -520,10 +521,6 @@ function normalizeAssistantUsageCost(usage: unknown): AssistantUsageSnapshot["co
   // turns a real zero-dollar total back into a local estimate during later accounting.
   const totalOrigin = cost.totalOrigin === "provider-billed" ? cost.totalOrigin : undefined;
   return { input, output, cacheRead, cacheWrite, total, ...(totalOrigin ? { totalOrigin } : {}) };
-}
-
-function toFiniteCostNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[] {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -2,7 +2,10 @@
  * Normalizes tool-call names, ids, and standalone text calls for providers.
  */
 import { randomUUID } from "node:crypto";
-import { normalizeLowercaseStringOrEmpty } from "../../../../packages/normalization-core/src/string-coerce.js";
+import {
+  hasNonEmptyString as replayToolCallNonEmptyString,
+  normalizeLowercaseStringOrEmpty,
+} from "../../../../packages/normalization-core/src/string-coerce.js";
 import { normalizeStringEntries } from "../../../../packages/normalization-core/src/string-normalization.js";
 import {
   createPromotedPlainTextToolCallEvents,
@@ -334,10 +337,6 @@ function collectFollowingToolResults(
     sawNonToolResult = true;
   }
   return { ids, displaced };
-}
-
-function replayToolCallNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 function resolveReplayToolCallName(

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -4,6 +4,7 @@
 import type { LlmRuntime } from "@openclaw/ai";
 import { stripSystemPromptCacheBoundary } from "@openclaw/ai/internal/shared";
 import { createBoundaryAwareStreamFnForModel } from "@openclaw/ai/transports";
+import { hasNonEmptyString as hasResolvedRuntimeApiKey } from "@openclaw/normalization-core/string-coerce";
 import { getStreamLlmRuntime } from "../../llm/model-runtime-binding.js";
 import "../ai-transport-runtime-host.js";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
@@ -67,10 +68,6 @@ function isDefaultOpenClawStreamFnForModel(
   }
   const provider = llmRuntime.registry.getApiProvider(api as never);
   return streamFn === provider?.streamSimple || streamFn === provider?.stream;
-}
-
-function hasResolvedRuntimeApiKey(apiKey: string | undefined): boolean {
-  return typeof apiKey === "string" && apiKey.trim().length > 0;
 }
 
 function isOpenAICodexResponsesModel(model: EmbeddedRunAttemptParams["model"]): boolean {

--- a/src/agents/harness/native-hook-relay-utils.ts
+++ b/src/agents/harness/native-hook-relay-utils.ts
@@ -1,4 +1,4 @@
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import type {
   JsonValue,
   NativeHookRelayEvent,
@@ -213,8 +213,5 @@ function snapshotString(value: string, state: { remainingStringLength: number })
 }
 
 export function truncateText(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
-    return value;
-  }
-  return `${truncateUtf16Safe(value, Math.max(0, maxLength - 3))}...`;
+  return truncateWithMarker(value, maxLength, { marker: "...", reserve: 3, trimEnd: false });
 }

--- a/src/agents/harness/support.ts
+++ b/src/agents/harness/support.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeOptionalString as readStringParam } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveMergedModelProviderConfig,
   resolveMergedModelProviderModels,
@@ -256,10 +257,6 @@ function isSupportedHarness(entry: {
   support: AgentHarnessSupport & { supported: true };
 } {
   return entry.support.supported;
-}
-
-function readStringParam(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function normalizeModelId(provider: string, modelId: string): string {

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -4,6 +4,7 @@ import {
   normalizeProviderId,
   normalizeProviderIdForAuth,
 } from "@openclaw/model-catalog-core/provider-id";
+import { hasNonEmptyString as hasSecret } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveMergedModelProviderConfig } from "../config/model-provider-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -127,10 +128,6 @@ type AuthSourceEvaluation = Pick<
   ModelAuthAvailabilityEvaluation,
   "availability" | "selectedAuthMode" | "evidence" | "selectedProfileId"
 >;
-
-function hasSecret(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 function modeAllowed(provider: string, target: AuthTarget, mode: string | undefined): boolean {
   const requirement = resolveProviderModelRouteAuthRequirement(mode);

--- a/src/agents/model-compat-catalog.ts
+++ b/src/agents/model-compat-catalog.ts
@@ -1,13 +1,10 @@
+import { normalizeLowercaseStringOrEmpty as normalizeApi } from "@openclaw/normalization-core/string-coerce";
 import type { ModelCompatConfig } from "../config/types.models.js";
 
 type ModelTransportRoute = {
   api?: unknown;
   baseUrl?: unknown;
 };
-
-function normalizeApi(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
-}
 
 function normalizeBaseUrl(value: unknown): string {
   if (typeof value !== "string") {

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -20,6 +20,7 @@ import {
 import pMap from "p-map";
 import { Type } from "typebox";
 import { formatErrorMessage } from "../infra/errors.js";
+import { cancelUnreadResponseBody } from "../infra/http-body.js";
 /**
  * Scans remote provider model catalogs for configured providers.
  */
@@ -284,9 +285,7 @@ async function fetchOpenRouterModels(
       "OpenRouter model scan",
     );
   } finally {
-    if (res && !res.bodyUsed) {
-      await res.body?.cancel().catch(() => undefined);
-    }
+    await cancelUnreadResponseBody(res);
   }
 }
 

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -3,6 +3,8 @@
  * store preserves typed columns for hot delivery state while retaining the
  * normalized payload JSON for forward-compatible record hydration.
  */
+import { safeParseJson } from "@openclaw/normalization-core";
+import { asFiniteNumber as normalizeFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sql, type Insertable, type Selectable, type Updateable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -82,19 +84,11 @@ function parseJson(raw: string | null): unknown {
   if (!raw) {
     return undefined;
   }
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(raw);
 }
 
 function boolToSqlite(value: boolean | undefined): number | null {
   return value === undefined ? null : value ? 1 : 0;
-}
-
-function normalizeFiniteNumber(value: number | null): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 /** Rehydrates one sqlite row into the normalized subagent run record shape. */

--- a/src/agents/tool-schema-quarantine-health.ts
+++ b/src/agents/tool-schema-quarantine-health.ts
@@ -1,6 +1,7 @@
 // Persists runtime tool-schema quarantines in the shared SQLite-backed core
 // plugin-state store so health surfaces can see failures from any live
 // runtime process.
+import { hasNonEmptyString as isNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import {
   createRuntimeHealthRecordEnvelope,
   createRuntimeHealthStore,
@@ -19,10 +20,6 @@ type PersistedRuntimeToolSchemaQuarantineRecord = RuntimeHealthRecordEnvelope & 
   owner?: string;
   reason: string;
 };
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 const quarantineStore = createRuntimeHealthStore<PersistedRuntimeToolSchemaQuarantineRecord>({
   ownerId: "core:runtime-tool-quarantine-health",

--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -4,6 +4,7 @@
  * Recovers flat or partial model/tool inputs into the structured cron job/patch shape.
  */
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import { hasNonEmptyString as isNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import { isRecord } from "../../utils.js";
 import { isStringOption } from "../../utils/string-readers.js";
 
@@ -73,10 +74,6 @@ function isCronScheduleKind(value: unknown): value is (typeof CRON_SCHEDULE_KIND
 
 function isCronPayloadKind(value: unknown): value is (typeof CRON_PAYLOAD_KINDS)[number] {
   return value === "systemEvent" || value === "agentTurn" || value === "script";
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 function isStringArrayOrNull(value: unknown): boolean {

--- a/src/agents/tools/cron-tool-context.ts
+++ b/src/agents/tools/cron-tool-context.ts
@@ -1,7 +1,7 @@
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 /** Reminder-context projection for cron tool job creation. */
 import { getRuntimeConfig } from "../../config/config.js";
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
-import { truncateUtf16Safe } from "../../utils.js";
 import { REMINDER_CONTEXT_MESSAGES_MAX } from "./cron-tool-schema.js";
 import type { ChatMessage, GatewayToolCaller } from "./cron-tool.types.js";
 import type { GatewayCallOptions } from "./gateway.js";
@@ -20,11 +20,7 @@ export function stripExistingContext(text: string) {
 }
 
 function truncateText(input: string, maxLen: number) {
-  if (input.length <= maxLen) {
-    return input;
-  }
-  const truncated = truncateUtf16Safe(input, Math.max(0, maxLen - 3)).trimEnd();
-  return `${truncated}...`;
+  return truncateWithMarker(input, maxLen, { marker: "...", reserve: 3, trimEnd: true });
 }
 
 function extractMessageText(message: ChatMessage): { role: string; text: string } | null {

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -4,6 +4,7 @@
  * Manages live capture, manual import, summarization, and process-local transcript sessions.
  */
 import path from "node:path";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { Type } from "typebox";
 import { resolveStateDir } from "../../config/paths.js";
@@ -57,12 +58,6 @@ function ownsTranscriptSession(
   // Shipped rows predate agent attribution. Treat them as operator-owned legacy
   // state: main can curate them, but isolated agents cannot claim them.
   return ctx.agentId === "main";
-}
-
-function asParamsRecord(params: unknown): Record<string, unknown> {
-  return params && typeof params === "object" && !Array.isArray(params)
-    ? (params as Record<string, unknown>)
-    : {};
 }
 
 const TranscriptsSchema = Type.Object(
@@ -356,7 +351,7 @@ export function createTranscriptsTool(options?: {
       if (!config.enabled) {
         throw new Error("transcripts are disabled");
       }
-      const params = asParamsRecord(rawParams);
+      const params = asOptionalRecord(rawParams) ?? {};
       const action = readStringParam(params, "action", { required: true, trim: true });
       const store = createStore(ctx);
       switch (action) {

--- a/src/agents/tools/web-search-output.ts
+++ b/src/agents/tools/web-search-output.ts
@@ -7,6 +7,7 @@
  * re-wrapped here unconditionally, so no provider-controlled metadata can
  * spoof the trust marker and transport-specific extras never reach the model.
  */
+import { asFiniteNumber as readFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Static } from "typebox";
@@ -117,10 +118,6 @@ type WebSearchOutputBudget = { remaining: number; truncated: boolean };
 
 function unwrapEnvelopes(value: string): string {
   return value.replace(ENVELOPE_OPEN_RE, "").replace(ENVELOPE_END_RE, "").trim();
-}
-
-function readFiniteNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 // URLs are emitted canonicalized (percent-encoded), so whitespace or readable

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -22,6 +22,7 @@ import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import { cancelUnreadResponseBody } from "../../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { APP_NAME, getBinDir } from "../config.js";
 import { readProviderJsonResponse } from "../provider-http-errors.js";
@@ -35,12 +36,6 @@ const MAX_ARCHIVE_ENTRIES = 1_000;
 const ARCHIVE_EXTRACT_TIMEOUT_MS = 60_000;
 const CONTENT_LENGTH_RE = /^\d+$/;
 const GITHUB_RELEASE_JSON_MAX_BYTES = 1024 * 1024;
-
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
-}
 
 function isOfflineModeEnabled(): boolean {
   return isTruthyEnvValue(process.env.OPENCLAW_OFFLINE);

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -2,7 +2,6 @@
 // unintentionally breaking on newlines. Using [\s\S] keeps newlines inside
 // the chunk so messages are only split when they truly exceed the limit.
 
-import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import {
   findFenceSpanAt,
   isSafeFenceBreak,
@@ -16,6 +15,7 @@ import { normalizeAccountId } from "../routing/session-key.js";
 import {
   avoidTrailingHighSurrogateBreak,
   chunkTextByBreakResolver,
+  normalizeChunkLimit,
 } from "../shared/text-chunking.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 
@@ -32,11 +32,6 @@ export type ChunkMode = "length" | "newline";
 
 const DEFAULT_CHUNK_LIMIT = 4000;
 const DEFAULT_CHUNK_MODE: ChunkMode = "length";
-
-function normalizeChunkLimit(limit: number): number {
-  // String slicing truncates fractional indexes, so positive limits need an integer progress step.
-  return Number.isFinite(limit) && limit > 0 ? resolveIntegerOption(limit, 1, { min: 1 }) : limit;
-}
 
 type ProviderChunkConfig = {
   textChunkLimit?: number;

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -4,7 +4,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAcpToolTerminalOutcome } from "../../acp/tool-status.js";
 import { EmbeddedBlockChunker } from "../../agents/embedded-agent-block-chunker.js";
 import { formatToolSummary, resolveToolDisplay } from "../../agents/tool-display.js";
@@ -53,7 +53,7 @@ function truncateText(input: string, maxChars: number): string {
   if (maxChars <= 1) {
     return truncateUtf16Safe(input, maxChars);
   }
-  return `${truncateUtf16Safe(input, maxChars - 1)}…`;
+  return truncateWithMarker(input, maxChars, { marker: "…", reserve: 1, trimEnd: false });
 }
 
 function hashText(text: string): string {

--- a/src/auto-reply/reply/agent-runner-command-output.ts
+++ b/src/auto-reply/reply/agent-runner-command-output.ts
@@ -1,15 +1,11 @@
+import { asFiniteNumber as readFiniteNumberValue } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord as readRecordValue } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { GetReplyOptions } from "../types.js";
-
-function readRecordValue(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 /**
  * CLI backends report a tool result as its raw content: a string, or the text
@@ -30,10 +26,6 @@ function readToolResultText(value: unknown): string | undefined {
     .join("\n")
     .trim();
   return text || undefined;
-}
-
-function readFiniteNumberValue(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function readNullableNumberValue(value: unknown): number | null | undefined {

--- a/src/auto-reply/reply/commands-acp/shared.ts
+++ b/src/auto-reply/reply/commands-acp/shared.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { toAcpRuntimeErrorText } from "@openclaw/acp-core/runtime/error-text";
 import type { AcpRuntimeSessionMode } from "@openclaw/acp-core/runtime/types";
+import type { Result } from "@openclaw/normalization-core/result";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -183,7 +184,7 @@ function resolveDefaultSpawnThreadMode(params: HandleCommandsParams): AcpSpawnTh
 export function parseSpawnInput(
   params: HandleCommandsParams,
   tokens: string[],
-): { ok: true; value: ParsedSpawnInput } | { ok: false; error: string } {
+): Result<ParsedSpawnInput, string> {
   const normalizedTokens = tokens.map((token) => normalizeAcpOptionToken(token));
   let mode: AcpRuntimeSessionMode = "persistent";
   let thread = resolveDefaultSpawnThreadMode(params);
@@ -323,9 +324,7 @@ export function parseSpawnInput(
   };
 }
 
-export function parseSteerInput(
-  tokens: string[],
-): { ok: true; value: ParsedSteerInput } | { ok: false; error: string } {
+export function parseSteerInput(tokens: string[]): Result<ParsedSteerInput, string> {
   const normalizedTokens = tokens.map((token) => normalizeAcpOptionToken(token));
   let sessionToken: string | undefined;
   const instructionTokens: string[] = [];
@@ -372,7 +371,7 @@ export function parseSteerInput(
 export function parseSingleValueCommandInput(
   tokens: string[],
   usage: string,
-): { ok: true; value: ParsedSingleValueCommandInput } | { ok: false; error: string } {
+): Result<ParsedSingleValueCommandInput, string> {
   const value = normalizeOptionalString(tokens[0]) ?? "";
   if (!value) {
     return { ok: false, error: usage };
@@ -390,9 +389,7 @@ export function parseSingleValueCommandInput(
   };
 }
 
-export function parseSetCommandInput(
-  tokens: string[],
-): { ok: true; value: ParsedSetCommandInput } | { ok: false; error: string } {
+export function parseSetCommandInput(tokens: string[]): Result<ParsedSetCommandInput, string> {
   const key = normalizeOptionalString(tokens[0]) ?? "";
   const value = normalizeOptionalString(tokens[1]) ?? "";
   if (!key || !value) {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -1,6 +1,7 @@
 import { type FSWatcher, readFileSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
+import { isRecord as isPlainObject } from "@openclaw/normalization-core/record-coerce";
 import { createDedupeCache } from "../../infra/dedupe.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { DEFAULT_USAGE_BAR_TEMPLATE } from "./default-template.js";
@@ -29,10 +30,6 @@ function expandPath(p: string): string {
     return resolve(homedir(), p.slice(2));
   }
   return isAbsolute(p) ? p : resolve(p);
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function hasPieces(value: unknown): boolean {

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -1,14 +1,12 @@
 import {
   asSafeIntegerInRange,
   expectDefined,
+  isRecord as isObject,
   parseStrictInteger,
 } from "@openclaw/normalization-core";
 export type UsageBarTemplate = Record<string, unknown>;
 export type UsageContract = Record<string, unknown>;
 type Vocab = Record<string, unknown>;
-
-const isObject = (v: unknown): v is Record<string, unknown> =>
-  typeof v === "object" && v !== null && !Array.isArray(v);
 
 function toGlyphs(scale: unknown): string[] {
   if (Array.isArray(scale)) {

--- a/src/channels/plugins/dm-access.ts
+++ b/src/channels/plugins/dm-access.ts
@@ -3,6 +3,7 @@
  *
  * Reads, writes, migrates, and normalizes direct-message policy and allowFrom fields.
  */
+import { asNullableRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 
 /**
@@ -50,12 +51,6 @@ export function normalizeChannelDmPolicy(value: string | undefined): ChannelDmPo
   return value === "pairing" || value === "allowlist" || value === "open" || value === "disabled"
     ? value
     : undefined;
-}
-
-function asObjectRecord(value: unknown): DmAccessRecord | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as DmAccessRecord)
-    : null;
 }
 
 function cloneDm(entry: DmAccessRecord): DmAccessRecord | null {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 // Channel streaming config normalization and progress-draft formatting helpers.
+import { asNullableRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import {
@@ -39,12 +40,6 @@ export type {
 export type { SlackChannelStreamingConfig } from "../config/types.slack.js";
 
 // Runtime reads are nested-only; doctor migrates legacy streaming spellings.
-
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function asInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) ? value : undefined;

--- a/src/cli/capability-cli/tts-runtime.ts
+++ b/src/cli/capability-cli/tts-runtime.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -399,10 +400,6 @@ function buildTtsConfigWithHydratedProvider(params: {
     tts.providers = providers;
   }
   return tts;
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function ttsProviderConfigHasApiKey(value: unknown): boolean {

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { toErrorObject } from "../infra/errors.js";
+import { cancelUnreadResponseBody } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
 import { resolveCliName } from "./cli-name.js";
@@ -80,12 +81,6 @@ type CameraClipPayload = {
   durationMs: number;
   hasAudio: boolean;
 };
-
-async function cancelIgnoredResponseBody(response: Response | undefined): Promise<void> {
-  if (response?.bodyUsed !== true) {
-    await response?.body?.cancel().catch(() => undefined);
-  }
-}
 
 /** Validate and normalize an unknown camera still-image payload. */
 export function parseCameraSnapPayload(value: unknown): CameraSnapPayload {
@@ -170,13 +165,13 @@ async function writeUrlToFile(filePath: string, url: string, opts: { expectedHos
     const res = guarded.response;
     const finalUrl = new URL(guarded.finalUrl);
     if (normalizeHostname(finalUrl.hostname) !== expectedHost) {
-      await cancelIgnoredResponseBody(res);
+      await cancelUnreadResponseBody(res);
       throw new Error(
         `writeUrlToFile: redirect host ${finalUrl.hostname} must match node host ${opts.expectedHost}`,
       );
     }
     if (!res.ok) {
-      await cancelIgnoredResponseBody(res);
+      await cancelUnreadResponseBody(res);
       throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
     }
 
@@ -184,11 +179,11 @@ async function writeUrlToFile(filePath: string, url: string, opts: { expectedHos
     try {
       contentLength = parseMediaContentLength(res.headers.get("content-length"));
     } catch (err) {
-      await cancelIgnoredResponseBody(res);
+      await cancelUnreadResponseBody(res);
       throw err;
     }
     if (contentLength !== null && contentLength > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
-      await cancelIgnoredResponseBody(res);
+      await cancelUnreadResponseBody(res);
       throw new Error(
         `writeUrlToFile: content-length ${contentLength} exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
       );
@@ -196,7 +191,7 @@ async function writeUrlToFile(filePath: string, url: string, opts: { expectedHos
 
     const body = res.body;
     if (!body) {
-      await cancelIgnoredResponseBody(res);
+      await cancelUnreadResponseBody(res);
       throw new Error(`failed to download ${url}: empty response body`);
     }
 

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -2,7 +2,7 @@
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -24,7 +24,7 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${truncateUtf16Safe(value, maxChars - 1)}…`;
+  return truncateWithMarker(value, maxChars, { marker: "…", reserve: 1, trimEnd: false });
 }
 
 function safe(value: string): string {

--- a/src/commands/doctor/cron/scheduled-tool-policy-migration.ts
+++ b/src/commands/doctor/cron/scheduled-tool-policy-migration.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   createAccountCronScheduledToolPolicy,
@@ -34,12 +35,6 @@ export function createScheduledToolPolicyMigrationCollector() {
       return result.mutated;
     },
   };
-}
-
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function usesToolRuntime(raw: Record<string, unknown>): boolean {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.refs.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.refs.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { normalizeLowercaseStringOrEmpty as normalizeString } from "@openclaw/normalization-core/string-coerce";
 import { splitTrailingAuthProfile } from "../../../agents/model-ref-profile.js";
 import { ensureRecord, getRecord } from "../../../config/legacy.shared.js";
 import { normalizeAgentModelRefForConfig } from "../../../config/model-input.js";
@@ -12,10 +13,6 @@ import { isBlockedObjectKey } from "../../../infra/prototype-keys.js";
 
 export function hasOwnDefinedProperty(record: Record<string, unknown>, key: string): boolean {
   return Object.hasOwn(record, key) && record[key] !== undefined;
-}
-
-function normalizeString(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
 function preferredClaudeSeparator(provider: string | undefined): "." | "-" {

--- a/src/commands/doctor/shared/object.ts
+++ b/src/commands/doctor/shared/object.ts
@@ -1,7 +1,2 @@
 // Shared nullable record guard for doctor config walkers.
-export function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
+export { asNullableRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -1,7 +1,7 @@
 /** CLI commands for listing, inspecting, and cancelling TaskFlow records. */
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { truncateToVisibleWidth, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
@@ -38,7 +38,7 @@ function truncate(value: string, maxChars: number) {
   if (maxChars <= 1) {
     return truncateUtf16Safe(value, maxChars);
   }
-  return `${truncateUtf16Safe(value, maxChars - 1)}…`;
+  return truncateWithMarker(value, maxChars, { marker: "…", reserve: 1, trimEnd: false });
 }
 
 function safeFlowDisplayText(value: string | undefined, maxChars?: number): string {

--- a/src/commands/models/list.persisted-catalog.ts
+++ b/src/commands/models/list.persisted-catalog.ts
@@ -1,6 +1,7 @@
 /** Reads persisted generated catalogs without constructing a model registry. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString as readString } from "@openclaw/normalization-core/string-coerce";
 import type { ModelCatalogEntry, ModelInputType } from "../../agents/model-catalog.types.js";
 import {
   filterGeneratedPluginModelCatalogProviders,
@@ -12,10 +13,6 @@ import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snaps
 
 const modelApis = new Set<string>(MODEL_APIS);
 const modelInputs = new Set<ModelInputType>(["text", "image", "audio", "video", "document"]);
-
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 function readPositiveNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -4,6 +4,7 @@
  * It selects active or requested sessions, renders recent trajectory events,
  * and can follow newly appended SQLite trajectory rows.
  */
+import { normalizeOptionalString as toOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
@@ -77,10 +78,6 @@ function parseTailCount(value: string | number | undefined): number | null {
     return DEFAULT_TAIL_COUNT;
   }
   return parseStrictNonNegativeInteger(value) ?? null;
-}
-
-function toOptionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function formatTimestamp(ts: string): string {

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -1,6 +1,7 @@
 // Gateway log-tail helpers for status diagnostics.
 // Summaries compact repeated auth/runtime failures while preserving enough context for operators.
 
+import { safeParseJson } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { classifyOAuthRefreshFailureReason } from "../../agents/auth-profiles/oauth-refresh-failure.js";
@@ -108,15 +109,9 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
       const block = consumeJsonBlock(lines, i);
       if (block) {
         i = block.endIndex;
-        const parsed = (() => {
-          try {
-            return JSON.parse(block.json) as {
-              error?: { code?: string; message?: string };
-            };
-          } catch {
-            return null;
-          }
-        })();
+        const parsed = (safeParseJson(block.json) ?? null) as {
+          error?: { code?: string; message?: string };
+        } | null;
         const code = normalizeOptionalString(parsed?.error?.code) ?? null;
         const msg = normalizeOptionalString(parsed?.error?.message) ?? null;
         const refreshReason = classifyOAuthRefreshFailureReason(msg ?? "");

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -3,7 +3,7 @@
 
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -206,7 +206,9 @@ function truncate(value: string, maxChars: number) {
   if (value.length <= maxChars) {
     return value;
   }
-  return maxChars <= 0 ? "" : `${truncateUtf16Safe(value, maxChars - 1)}…`;
+  return maxChars <= 0
+    ? ""
+    : truncateWithMarker(value, maxChars, { marker: "…", reserve: 1, trimEnd: false });
 }
 
 function shortToken(value: string | undefined, maxChars = ID_PAD): string {

--- a/src/config/channel-compat-normalization.ts
+++ b/src/config/channel-compat-normalization.ts
@@ -1,10 +1,12 @@
 // Normalizes channel config compatibility fields during config loading.
+import { asNullableRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLegacyDmAliases,
   type CompatMutationResult,
 } from "../channels/plugins/dm-access.js";
 
 export { normalizeLegacyDmAliases };
+export { asObjectRecord };
 export type { CompatMutationResult };
 
 /** Resolved streaming values a channel doctor supplies while migrating legacy aliases. */
@@ -40,13 +42,6 @@ export type RetiredChannelKeyRemoval = {
   key: string;
   pathPrefix: string;
 };
-
-/** Narrows unknown config JSON values to mutable object records. */
-export function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 function parseAliasStreamingMode(value: unknown): "off" | "partial" | "block" | "progress" | null {
   if (typeof value !== "string") {

--- a/src/config/mcp-config-normalize.ts
+++ b/src/config/mcp-config-normalize.ts
@@ -1,4 +1,5 @@
 // Normalizes MCP config records into canonical runtime shape.
+import { normalizeLowercaseStringOrEmpty as normalizeMcpString } from "@openclaw/normalization-core/string-coerce";
 import { isRecord } from "../utils.js";
 
 type ConfigMcpServers = Record<string, Record<string, unknown>>;
@@ -10,10 +11,6 @@ const CLI_MCP_TYPE_TO_OPENCLAW_TRANSPORT: Record<string, OpenClawMcpHttpTranspor
   sse: "sse",
   stdio: "stdio",
 };
-
-function normalizeMcpString(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
-}
 
 /** Maps CLI-native MCP type aliases to OpenClaw HTTP transport names. */
 export function resolveOpenClawMcpTransportAlias(

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ProviderRouteOverridePresence } from "../plugin-sdk/provider-model-types.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "./types.models.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
@@ -34,12 +35,6 @@ function normalizeModelId(provider: string, modelId: string): string {
     normalizeProviderId(trimmed.slice(0, slashIndex)) === normalizeProviderId(provider)
     ? trimmed.slice(slashIndex + 1).trim()
     : trimmed;
-}
-
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function hasNonEmptyRecord(value: unknown): boolean {

--- a/src/config/sessions/conversation-identity.ts
+++ b/src/config/sessions/conversation-identity.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString as normalizeText } from "@openclaw/normalization-core/string-coerce";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
@@ -34,10 +35,6 @@ export type ConversationIdentity = {
   label?: string;
   metadata?: Record<string, unknown>;
 };
-
-function normalizeText(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 function normalizeThreadId(value: unknown): string | undefined {
   if (typeof value === "number" && Number.isFinite(value)) {

--- a/src/config/sessions/restart-recovery-state.ts
+++ b/src/config/sessions/restart-recovery-state.ts
@@ -1,4 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
+import { normalizeOptionalString as normalizeRunId } from "@openclaw/normalization-core/string-coerce";
 import {
   normalizeDeliveryContext,
   type DeliveryContext,
@@ -16,10 +17,6 @@ type RestartRecoveryChannelAuthority = {
   deliveryContext: DeliveryContext & { channel: string; to: string };
   sourceTurnId: string;
 };
-
-function normalizeRunId(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 /** Resolves only a complete durable channel claim; session-route fallbacks carry no authority. */
 export function resolveRestartRecoveryChannelAuthority(

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -1,6 +1,6 @@
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 /** Name, agent id, and payload text normalization helpers for cron service ops. */
 import { normalizeOptionalAgentId } from "../../routing/session-key.js";
-import { truncateUtf16Safe } from "../../utils.js";
 import type { CronPayload } from "../types.js";
 
 /** Normalizes a required cron job name and throws the public validation error when absent. */
@@ -16,10 +16,7 @@ export function normalizeRequiredName(raw: unknown) {
 }
 
 function truncateText(input: string, maxLen: number) {
-  if (input.length <= maxLen) {
-    return input;
-  }
-  return `${truncateUtf16Safe(input, Math.max(0, maxLen - 1)).trimEnd()}…`;
+  return truncateWithMarker(input, maxLen, { marker: "…", reserve: 1, trimEnd: true });
 }
 
 /** Normalizes optional cron agent ids through the canonical session-key agent id rules. */

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -1,4 +1,5 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeLowercaseStringOrEmpty as normalizeErrorSignal } from "@openclaw/normalization-core/string-coerce";
 import { isContextOverflowError } from "../agents/embedded-agent-helpers/context-overflow.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
@@ -87,10 +88,6 @@ type ChatDisplayProjectionResult = {
 const GATEWAY_ASSISTANT_ERROR_FALLBACK_TEXT = "The agent run failed before producing a reply.";
 const GATEWAY_ASSISTANT_CONTEXT_OVERFLOW_FALLBACK_TEXT =
   "Context overflow: this conversation is too large for the model. Try /compact, use /new to start a fresh session, or retry the command with a tighter output limit.";
-
-function normalizeErrorSignal(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
-}
 
 function isContextOverflowErrorSignal(value: unknown): boolean {
   if (typeof value !== "string") {

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.ts
@@ -1,6 +1,7 @@
 // CLI backend live probe helpers run cron/MCP/image probes through the gateway
 // CLI backend and poll for externally visible live results.
 import { randomUUID } from "node:crypto";
+import { asNullableRecord as asLoopbackSchemaRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { renderCatFacePngBase64 } from "../../test/helpers/live-image-probe.js";
 import { AUTOMATIONS_TOOL_NAME } from "../agents/tools/automations-tool-name.js";
@@ -124,12 +125,6 @@ function parsePositiveInt(value: string | undefined, fallback: number, name: str
     throw new Error(`invalid ${name}: ${value}`);
   }
   return parsed;
-}
-
-function asLoopbackSchemaRecord(schema: unknown): Record<string, unknown> | null {
-  return schema && typeof schema === "object" && !Array.isArray(schema)
-    ? (schema as Record<string, unknown>)
-    : null;
 }
 
 function assertLoopbackObjectSchemasHaveProperties(params: {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -1,6 +1,7 @@
 // Gateway webhook helpers for external hook dispatch into agents and wake flows.
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage } from "node:http";
+import type { Result } from "@openclaw/normalization-core/result";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -175,7 +176,7 @@ export function extractHookToken(req: IncomingMessage): string | undefined {
 export async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
-): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+): Promise<Result<unknown, string>> {
   const result = await readJsonBodyWithLimit(req, { maxBytes, emptyObjectOnEmpty: true });
   if (result.ok) {
     return result;
@@ -209,9 +210,7 @@ export function normalizeHookHeaders(req: IncomingMessage) {
 /** Validate a hook wake payload. */
 export function normalizeWakePayload(
   payload: Record<string, unknown>,
-):
-  | { ok: true; value: { text: string; mode: "now" | "next-heartbeat" } }
-  | { ok: false; error: string } {
+): Result<{ text: string; mode: "now" | "next-heartbeat" }, string> {
   const normalizedText = normalizeOptionalString(payload.text) ?? "";
   if (!normalizedText) {
     return { ok: false, error: "text required" };
@@ -287,12 +286,10 @@ function normalizeHookAgentDelivery(params: {
   channel: unknown;
   to: unknown;
   accountId: unknown;
-}):
-  | {
-      ok: true;
-      value: Pick<HookAgentPayload, "deliver" | "channel" | "to" | "accountId" | "delivery">;
-    }
-  | { ok: false; error: string } {
+}): Result<
+  Pick<HookAgentPayload, "deliver" | "channel" | "to" | "accountId" | "delivery">,
+  string
+> {
   const deliver = resolveHookDeliver(params.deliver);
   if (!deliver) {
     return {
@@ -449,7 +446,7 @@ export function resolveHookSessionKey(params: {
   source: HookSessionKeySource;
   sessionKey?: string;
   idFactory?: () => string;
-}): { ok: true; value: string } | { ok: false; error: string } {
+}): Result<string, string> {
   const requested = resolveSessionKey(params.sessionKey);
   if (requested) {
     if (
@@ -526,12 +523,9 @@ export function normalizeHookDispatchSessionKey(params: {
 }
 
 /** Validate and normalize a hook agent payload before policy/session resolution. */
-export function normalizeAgentPayload(payload: Record<string, unknown>):
-  | {
-      ok: true;
-      value: HookAgentPayload;
-    }
-  | { ok: false; error: string } {
+export function normalizeAgentPayload(
+  payload: Record<string, unknown>,
+): Result<HookAgentPayload, string> {
   const message = normalizeOptionalString(payload.message) ?? "";
   if (!message) {
     return { ok: false, error: "message required" };

--- a/src/gateway/node-plugin-tool-snapshot.ts
+++ b/src/gateway/node-plugin-tool-snapshot.ts
@@ -1,4 +1,5 @@
 /** Connected node-hosted plugin tools available to agent tool resolution. */
+import { asOptionalRecord as normalizeRecord } from "@openclaw/normalization-core/record-coerce";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/schema/nodes.js";
 import { NODE_MCP_TOOLS_CALL_COMMAND } from "../infra/node-commands.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -42,12 +43,6 @@ function bumpSnapshotVersion(): void {
 
 function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
-}
-
-function normalizeRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function defaultParameters(): Record<string, unknown> {

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -1,4 +1,5 @@
 // Transcript persistence and source-reply rewrites shared by chat send and abort.
+import { asOptionalRecord as transcriptEventRecord } from "@openclaw/normalization-core/record-coerce";
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import {
   findTranscriptEvent,
@@ -65,12 +66,6 @@ export function assistantTranscriptScope(
     ...(params.storePath ? { storePath: params.storePath } : {}),
     ...(params.agentId ? { agentId: params.agentId } : {}),
   };
-}
-
-function transcriptEventRecord(event: TranscriptEvent): Record<string, unknown> | undefined {
-  return event && typeof event === "object" && !Array.isArray(event)
-    ? (event as Record<string, unknown>)
-    : undefined;
 }
 
 function transcriptEventId(event: TranscriptEvent): string | undefined {

--- a/src/gateway/server-methods/fs.ts
+++ b/src/gateway/server-methods/fs.ts
@@ -1,6 +1,7 @@
 // Host directory browsing for the new-session folder picker. operator.admin
 // only (see core-descriptors): listing arbitrary host paths carries the same
 // trust as starting a session with an explicit cwd.
+import { safeParseJson } from "@openclaw/normalization-core";
 import {
   ErrorCodes,
   errorShape,
@@ -14,11 +15,7 @@ import type { GatewayRequestHandlers } from "./types.js";
 
 function parseNodePayload(payload: unknown, payloadJSON?: string | null): unknown {
   if (payloadJSON) {
-    try {
-      return JSON.parse(payloadJSON) as unknown;
-    } catch {
-      return undefined;
-    }
+    return safeParseJson(payloadJSON);
   }
   return payload;
 }

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -1,6 +1,7 @@
 // Model list result building resolves visible model catalogs for an agent and
 // strips runtime-only provider params before sending the browse API payload.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { asPositiveSafeInteger as resolvePositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import {
   resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
@@ -77,10 +78,6 @@ let loggedSlowModelsListCatalog = false;
 function resolveModelsListView(params: Record<string, unknown>): ModelsListView {
   const view = params.view;
   return view === "configured" || view === "provider-config" || view === "all" ? view : "default";
-}
-
-function resolvePositiveSafeInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
 }
 
 // Project explicitly onto the public protocol shape. Concrete route, base URL,

--- a/src/gateway/server-methods/terminal.ts
+++ b/src/gateway/server-methods/terminal.ts
@@ -1,3 +1,4 @@
+import { safeParseJson } from "@openclaw/normalization-core";
 import {
   GATEWAY_CLIENT_CAPS,
   hasGatewayClientCap,
@@ -68,11 +69,7 @@ function parseNodePayload(payload: unknown, payloadJSON?: string | null): unknow
   if (!payloadJSON) {
     return payload;
   }
-  try {
-    return JSON.parse(payloadJSON) as unknown;
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(payloadJSON);
 }
 
 async function stageNodeTerminalUpload(

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -1,5 +1,6 @@
 // Gateway session lifecycle state projection.
 // Converts agent run lifecycle events into session row/store status updates.
+import { normalizeOptionalString as normalizeLifecycleRunId } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SessionRunStatus } from "../../packages/gateway-protocol/src/schema/sessions-row.js";
 import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
@@ -243,10 +244,6 @@ export function deriveGatewaySessionLifecycleProjectionPatch(params: {
     ...patch
   } = derivePersistedSessionLifecyclePatch(params);
   return patch;
-}
-
-function normalizeLifecycleRunId(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 export function isRestartRecoveryLifecycleEvent(params: {

--- a/src/gateway/watch-node-http.ts
+++ b/src/gateway/watch-node-http.ts
@@ -2,6 +2,7 @@
 // Apple Watch cannot use generic WebSockets on-device, so node events use bounded HTTPS polls.
 import { randomBytes, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { isRecord as isStringRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -172,10 +173,6 @@ function resolveWatchClientAddress(
     ...(clientIp ? { clientIp } : {}),
     rateLimitKey: clientIp ?? buildRateLimitIdentityKey("watch-client", "unknown"),
   };
-}
-
-function isStringRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function trackResponseLifecycle(res: ServerResponse): ResponseLifecycle {

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -1,6 +1,7 @@
 // Hook workspace helpers resolve hook roots and workspace-local hook files.
 import fs from "node:fs";
 import path from "node:path";
+import { safeParseJson } from "@openclaw/normalization-core";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -44,11 +45,7 @@ function readHookPackageManifest(dir: string): HookPackageManifest | null {
   if (raw === null) {
     return null;
   }
-  try {
-    return JSON.parse(raw) as HookPackageManifest;
-  } catch {
-    return null;
-  }
+  return (safeParseJson(raw) as HookPackageManifest | undefined) ?? null;
 }
 
 function resolvePackageHooks(manifest: HookPackageManifest): string[] {

--- a/src/infra/advertised-lan-host.ts
+++ b/src/infra/advertised-lan-host.ts
@@ -1,5 +1,6 @@
 // Resolves the LAN host OpenClaw should advertise to nearby devices.
 import { isRfc1918Ipv4Address } from "@openclaw/net-policy/ip";
+import { normalizeLowercaseStringOrEmpty as normalizeInterfaceName } from "@openclaw/normalization-core/string-coerce";
 import { runCommandWithTimeout as defaultRunCommandWithTimeout } from "../process/exec.js";
 import {
   listExternalInterfaceAddresses,
@@ -55,10 +56,6 @@ type RankedWindowsRouteRow = {
   interfaceMetric: number;
   order: number;
 };
-
-function normalizeInterfaceName(name: unknown): string {
-  return typeof name === "string" ? name.trim().toLowerCase() : "";
-}
 
 function normalizeMetric(value: unknown): number {
   if (typeof value === "number" && Number.isFinite(value)) {

--- a/src/infra/clawhub-skill-security.ts
+++ b/src/infra/clawhub-skill-security.ts
@@ -1,4 +1,5 @@
 // Shared owner-qualified ClawHub security verdict resolution.
+import { asOptionalRecord as readObject } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import pLimit from "p-limit";
 import {
@@ -74,12 +75,6 @@ function partitionCompatibleBatches(
     batch.legacyKeys.add(legacyKey);
   }
   return batches.map((batch) => batch.items);
-}
-
-function readObject(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function readOptionalStringField(value: unknown, field: string): string | undefined {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { isRecord as isJsonObject } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -850,10 +851,6 @@ function createClawHubBodyLimitError(
   return new Error(
     `ClawHub ${resourceLabel} exceeded ${maxBytes} bytes (${size} bytes ${measurement})`,
   );
-}
-
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function optionalStringField(

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -2,6 +2,7 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  cancelUnreadResponseBody,
   readResponseTextPrefix,
   readResponseTextSnippet,
   readResponseWithLimit,
@@ -102,6 +103,37 @@ async function expectReadResponseWithLimitFailureCase(params: {
     readResponseWithLimit(params.response, params.maxBytes, params.options),
   ).rejects.toThrow(params.expectedError);
 }
+
+describe("cancelUnreadResponseBody", () => {
+  it("cancels unread bodies and ignores cancellation failures", async () => {
+    const cancel = vi.fn(() => {
+      throw new Error("already closed");
+    });
+    const response = new Response(makeStallingStream([], cancel));
+
+    await expect(cancelUnreadResponseBody(response)).resolves.toBeUndefined();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("leaves consumed and absent bodies alone", async () => {
+    const cancel = vi.fn();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("done"));
+          controller.close();
+        },
+        cancel,
+      }),
+    );
+    await response.text();
+
+    await cancelUnreadResponseBody(response);
+    await cancelUnreadResponseBody(undefined);
+
+    expect(cancel).not.toHaveBeenCalled();
+  });
+});
 
 describe("readResponseWithLimit", () => {
   beforeEach(() => {

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -10,6 +10,13 @@ import { parseStrictNonNegativeInteger } from "./parse-finite-number.js";
 
 export { readChunkWithIdleTimeout } from "./http-response-body-timeout.js";
 
+/** Cancels a response body only when no consumer has started reading it. */
+export async function cancelUnreadResponseBody(response: Response | undefined): Promise<void> {
+  if (response && !response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined);
+  }
+}
+
 export const DEFAULT_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 export const DEFAULT_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 

--- a/src/infra/outbound/delivery-queue-media-spool.ts
+++ b/src/infra/outbound/delivery-queue-media-spool.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isPassThroughRemoteMediaSource } from "@openclaw/media-core/media-source-url";
+import { hasNonEmptyString as isNonEmptyMediaSource } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveDeliveryQueueMediaDir } from "../../config/paths.js";
 import {
@@ -36,10 +37,6 @@ function openSpoolStore(stateDir: string | undefined, maxBytes?: number) {
 function resolveArtifactExtension(source: string): string {
   const extension = path.extname(source.split("?")[0] ?? "");
   return ARTIFACT_EXT_RE.test(extension) ? extension.toLowerCase() : "";
-}
-
-function isNonEmptyMediaSource(source: unknown): source is string {
-  return typeof source === "string" && Boolean(source.trim());
 }
 
 function payloadMediaSources(payload: ReplyPayload): string[] {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1,5 +1,6 @@
 // Message-action runner normalizes tool params, resolves channel/target/media,
 // applies policies, and dispatches send/poll/plugin actions.
+import { asOptionalRecord as asResultRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -282,12 +283,6 @@ export function getToolResult(
   result: MessageActionRunResult,
 ): AgentToolResult<unknown> | undefined {
   return "toolResult" in result ? result.toolResult : undefined;
-}
-
-function asResultRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function withSendNormalization(

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -3,9 +3,9 @@ import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
+import { cancelUnreadResponseBody } from "./http-body.js";
 import {
   buildUsageHttpErrorSnapshot,
-  discardUsageResponseBody,
   fetchJson,
   parseUsageResetAt,
   readUsageJson,
@@ -159,7 +159,7 @@ async function fetchClaudeWebUsage(
     fetchFn,
   );
   if (!orgRes.ok) {
-    await discardUsageResponseBody(orgRes);
+    await cancelUnreadResponseBody(orgRes);
     return null;
   }
 
@@ -180,7 +180,7 @@ async function fetchClaudeWebUsage(
     fetchFn,
   );
   if (!usageRes.ok) {
-    await discardUsageResponseBody(usageRes);
+    await cancelUnreadResponseBody(usageRes);
     return null;
   }
 

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -1,9 +1,9 @@
 // Fetches Codex provider usage windows.
 import { resolveProviderRequestHeaders } from "../agents/provider-request-config.js";
+import { cancelUnreadResponseBody } from "./http-body.js";
 import { parseStrictFiniteNumber } from "./parse-finite-number.js";
 import {
   buildUsageHttpErrorSnapshot,
-  discardUsageResponseBody,
   fetchJson,
   readUsageJson,
 } from "./provider-usage.fetch.shared.js";
@@ -89,7 +89,7 @@ export async function fetchCodexUsage(
   );
 
   if (!res.ok) {
-    await discardUsageResponseBody(res);
+    await cancelUnreadResponseBody(res);
     return buildUsageHttpErrorSnapshot({
       provider: "openai",
       status: res.status,

--- a/src/infra/provider-usage.fetch.deepseek.ts
+++ b/src/infra/provider-usage.fetch.deepseek.ts
@@ -1,8 +1,8 @@
 // Fetches and normalizes DeepSeek provider usage records.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { cancelUnreadResponseBody } from "./http-body.js";
 import {
   buildUsageHttpErrorSnapshot,
-  discardUsageResponseBody,
   fetchJson,
   parseFiniteNumber,
   readUsageJson,
@@ -75,7 +75,7 @@ export async function fetchDeepSeekUsage(
   );
 
   if (!res.ok) {
-    await discardUsageResponseBody(res);
+    await cancelUnreadResponseBody(res);
     return buildUsageHttpErrorSnapshot({
       provider: "deepseek",
       status: res.status,

--- a/src/infra/provider-usage.fetch.gemini.ts
+++ b/src/infra/provider-usage.fetch.gemini.ts
@@ -2,9 +2,9 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // Fetches Gemini provider usage windows.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { cancelUnreadResponseBody } from "./http-body.js";
 import {
   buildUsageHttpErrorSnapshot,
-  discardUsageResponseBody,
   fetchJson,
   readUsageJson,
 } from "./provider-usage.fetch.shared.js";
@@ -36,7 +36,7 @@ export async function fetchGeminiUsage(
   );
 
   if (!res.ok) {
-    await discardUsageResponseBody(res);
+    await cancelUnreadResponseBody(res);
     return buildUsageHttpErrorSnapshot({
       provider,
       status: res.status,

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -4,9 +4,9 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { isRecord } from "../utils.js";
 import { readTrimmedStringAlias } from "../utils/string-readers.js";
+import { cancelUnreadResponseBody } from "./http-body.js";
 import {
   buildUsageHttpErrorSnapshot,
-  discardUsageResponseBody,
   fetchJson,
   parseFiniteNumber,
 } from "./provider-usage.fetch.shared.js";
@@ -544,7 +544,7 @@ export async function fetchMinimaxUsage(
   );
 
   if (!res.ok) {
-    await discardUsageResponseBody(res);
+    await cancelUnreadResponseBody(res);
     return buildUsageHttpErrorSnapshot({
       provider: "minimax",
       status: res.status,

--- a/src/infra/provider-usage.fetch.shared.test.ts
+++ b/src/infra/provider-usage.fetch.shared.test.ts
@@ -5,7 +5,6 @@ import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import {
   buildUsageErrorSnapshot,
   buildUsageHttpErrorSnapshot,
-  discardUsageResponseBody,
   fetchJson,
   parseFiniteNumber,
   readUsageJson,
@@ -157,15 +156,6 @@ describe("provider usage fetch shared helpers", () => {
     await fetchJson("https://example.com/usage", {}, MAX_TIMER_TIMEOUT_MS + 1_000_000, fetchFn);
 
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
-  });
-
-  it("cancels unread response bodies when discarding usage responses", async () => {
-    const response = new Response("not needed", { status: 429 });
-    const cancel = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
-
-    await discardUsageResponseBody(response);
-
-    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("maps configured status codes to token expired", () => {

--- a/src/infra/provider-usage.fetch.shared.ts
+++ b/src/infra/provider-usage.fetch.shared.ts
@@ -23,12 +23,6 @@ export async function fetchJson(
   return await fetchFn(url, { ...init, signal });
 }
 
-export async function discardUsageResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
-}
-
 export function parseFiniteNumber(value: unknown): number | undefined {
   return parseFiniteNumberish(value);
 }

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -2,9 +2,9 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { cancelUnreadResponseBody } from "./http-body.js";
 import {
   buildUsageHttpErrorSnapshot,
-  discardUsageResponseBody,
   fetchJson,
   parseUsageResetAt,
   readUsageJson,
@@ -80,7 +80,7 @@ export async function fetchZaiUsage(
   );
 
   if (!res.ok) {
-    await discardUsageResponseBody(res);
+    await cancelUnreadResponseBody(res);
     return buildUsageHttpErrorSnapshot({
       provider: "zai",
       status: res.status,

--- a/src/infra/restart-sentinel-store.ts
+++ b/src/infra/restart-sentinel-store.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -356,11 +357,7 @@ function parseRequiredJson(value: string | null): unknown {
   if (value === null) {
     return undefined;
   }
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(value);
 }
 
 function decodeRestartSentinelRow(row: {

--- a/src/infra/state-migrations.tui-last-session.ts
+++ b/src/infra/state-migrations.tui-last-session.ts
@@ -1,6 +1,7 @@
 // Doctor-only import for the retired TUI last-session JSON store.
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -60,10 +61,6 @@ function assertLegacySourceUnchanged(sourcePath: string, expected: LegacySourceS
     label: "TUI last-session",
     followSymlinks: true,
   });
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function isHeartbeatSessionKey(sessionKey: string): boolean {

--- a/src/infra/update-check-package-target.ts
+++ b/src/infra/update-check-package-target.ts
@@ -1,3 +1,4 @@
+import { normalizeNullableString as toOptionalTrimmedString } from "@openclaw/normalization-core/string-coerce";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
@@ -5,6 +6,7 @@ import {
   type OpenClawSchemaVersions,
 } from "../state/openclaw-schema-versions.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
+import { cancelUnreadResponseBody } from "./http-body.js";
 
 type NpmPackageTargetStatus = {
   target: string;
@@ -27,10 +29,6 @@ export type NpmMetadataCommandRunner = (
   stderr: string;
   code: number | null;
 }>;
-
-function toOptionalTrimmedString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
 
 function parseNpmPackageTargetMetadata(raw: string): {
   version: string | null;
@@ -135,9 +133,7 @@ async function fetchNpmPackageTargetStatusFromRegistry(params: {
   } catch (err) {
     return { target: params.target, version: null, nodeEngine: null, error: String(err) };
   } finally {
-    if (res?.bodyUsed !== true) {
-      await res?.body?.cancel().catch(() => undefined);
-    }
+    await cancelUnreadResponseBody(res);
     cleanup();
   }
 }

--- a/src/infra/windows-gateway-firewall-diagnostics.ts
+++ b/src/infra/windows-gateway-firewall-diagnostics.ts
@@ -1,4 +1,5 @@
 // Read-only diagnostics for Windows LAN Gateway reachability.
+import { safeParseJson } from "@openclaw/normalization-core";
 import { runCommandWithTimeout as defaultRunCommandWithTimeout } from "../process/exec.js";
 import { getWindowsPowerShellExePath } from "./windows-install-roots.js";
 
@@ -246,11 +247,7 @@ function parseJsonPayload(stdout: string): unknown {
   if (!trimmed) {
     return null;
   }
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    return null;
-  }
+  return safeParseJson(trimmed) ?? null;
 }
 
 function stringField(row: Record<string, unknown>, key: string): string {

--- a/src/llm/providers/stream-wrappers/moonshot-thinking.ts
+++ b/src/llm/providers/stream-wrappers/moonshot-thinking.ts
@@ -1,4 +1,5 @@
 // Moonshot thinking wrapper normalizes reasoning output from Moonshot streams.
+import { asOptionalRecord as asPayloadRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { StreamFn } from "../../../agents/runtime/index.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
@@ -75,12 +76,6 @@ function isPinnedToolChoice(toolChoice: unknown): boolean {
   }
   const typeValue = (toolChoice as Record<string, unknown>).type;
   return typeValue === "tool" || typeValue === "function";
-}
-
-function asPayloadRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function ensureMoonshotToolCallReasoningContent(payloadObj: Record<string, unknown>): void {

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -5,6 +5,10 @@ import {
   mimeTypeFromFilePath,
   normalizeMimeType,
 } from "@openclaw/media-core/mime";
+import {
+  asFiniteNumberInRange,
+  asPositiveSafeInteger as normalizePositiveInteger,
+} from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { PromptImageOrderEntry } from "./prompt-image-order.js";
 
@@ -37,7 +41,7 @@ export type MediaFactInput = {
 const RUNTIME_PROMPT_MEDIA_FACTS = Symbol.for("openclaw.runtimePromptMediaFacts");
 
 function normalizeNonNegativeNumber(value: number | null | undefined): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+  return asFiniteNumberInRange(value, { min: 0 });
 }
 
 /** Attaches facts to a runtime prompt message without changing serialized/model-visible bytes. */
@@ -320,10 +324,6 @@ type MediaFactDefaults<TInput extends MediaFactInput = MediaFactInput> = {
   workspaceDir?: string;
   transcribed?: (media: TInput, index: number) => boolean;
 };
-
-function normalizePositiveInteger(value: number | null | undefined): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
 
 export type MediaFactLegacyProjection = {
   /** @deprecated Use `media[0]?.path`. */

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 import type { MediaKind } from "@openclaw/media-core/constants";
+import {
+  asPositiveSafeInteger as parsePositiveInteger,
+  asSafeIntegerInRange,
+} from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
@@ -38,10 +43,6 @@ type MediaProbeBatchOptions = {
 
 type FfprobeSource = { kind: "fileDescriptor"; fd: number } | { kind: "buffer"; buffer: Buffer };
 
-function parsePositiveInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined;
-}
-
 function parseDurationMs(value: unknown): number | undefined {
   if (typeof value !== "number" && typeof value !== "string") {
     return undefined;
@@ -53,12 +54,6 @@ function parseDurationMs(value: unknown): number | undefined {
   return parsePositiveInteger(Math.round(seconds * 1000));
 }
 
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
 function normalizeCodecName(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -68,7 +63,7 @@ function normalizeCodecName(value: unknown): string | undefined {
 }
 
 function parseStreamIndex(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+  return asSafeIntegerInRange(value, { min: 0 });
 }
 
 function selectPlaybackStream(

--- a/src/meeting-bot/node-invoke-policy.ts
+++ b/src/meeting-bot/node-invoke-policy.ts
@@ -1,3 +1,4 @@
+import { asSafeIntegerInRange } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
   OpenClawPluginNodeInvokePolicy,
@@ -39,7 +40,7 @@ function readPositiveNumber(value: unknown): number | undefined {
 }
 
 function readOutputGeneration(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+  return asSafeIntegerInRange(value, { min: 0 });
 }
 
 function copyCommand(command: string[] | undefined): string[] | undefined {

--- a/src/meeting-bot/realtime-engine-support.ts
+++ b/src/meeting-bot/realtime-engine-support.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString as readLogString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   RealtimeTranscriptionProviderPlugin,
@@ -92,10 +93,6 @@ export function buildMeetingSpeakExactUserMessage(text: string): string {
     "Speak this exact OpenClaw answer to the meeting, without adding, removing, or rephrasing words.",
     `Answer: ${JSON.stringify(text)}`,
   ].join("\n");
-}
-
-function readLogString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function formatLogValue(value: string | undefined): string {

--- a/src/node-host/plugin-node-host.ts
+++ b/src/node-host/plugin-node-host.ts
@@ -1,4 +1,5 @@
 /** Plugin node-host bridge for loading plugin registry commands and dispatching node capabilities. */
+import { asOptionalRecord as normalizeRecord } from "@openclaw/normalization-core/record-coerce";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/schema/nodes.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
@@ -112,12 +113,6 @@ export function watchRegisteredNodeHostCommandAvailability(
 
 function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
-}
-
-function normalizeRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function isProviderSafeToolName(value: string): boolean {

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -1,4 +1,5 @@
 // Channel policy helpers evaluate plugin channel runtime policy and operator-facing warnings.
+import { asNullableRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeStringEntries,
   uniqueStrings,
@@ -103,12 +104,6 @@ type StandardAllowlistScope = {
   prefix: string;
   account: Record<string, unknown>;
 };
-
-function asObjectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
 
 /** Collect the common account, nested-DM, and group/room allowlist paths for doctor warnings. */
 export function collectStandardAllowlistLists(

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -34,6 +34,7 @@ import {
 import { resolveManagedSecretRefRuntimeProviderAuth } from "../agents/model-auth-runtime-config.js";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { cancelUnreadResponseBody } from "../infra/http-body.js";
 import { logWarn } from "../logger.js";
 import {
   DEFAULT_GITHUB_COPILOT_DOMAIN,
@@ -271,12 +272,6 @@ function parseCopilotTokenResponse(value: unknown): {
   }
 
   return { token, expiresAt: expiresAtMs };
-}
-
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
 }
 
 /** @deprecated GitHub Copilot provider-owned helper; do not use from third-party plugins. */

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -1,5 +1,5 @@
 import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
-import { readResponseWithLimit } from "../infra/http-body.js";
+import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
 import { retainSafeHeadersForCrossOriginRedirect } from "../infra/net/redirect-headers.js";
 import type {
   ProviderCatalogContext,
@@ -196,12 +196,6 @@ function buildHeaders(
     headers.set("accept", "application/json");
   }
   return headers;
-}
-
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
 }
 
 async function readLiveModelCatalogJson(response: Response, timeoutMs: number): Promise<unknown> {

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -1,5 +1,6 @@
 /** Builds installed-index records from normalized plugin manifest registry entries. */
 import path from "node:path";
+import { normalizeOptionalString as normalizeStringField } from "@openclaw/normalization-core/string-coerce";
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginCompatCode } from "./compat/registry.js";
@@ -167,14 +168,6 @@ function describePackageInstallSource(
   return describePluginInstallSource(install, {
     expectedPackageName: candidate?.packageName,
   });
-}
-
-function normalizeStringField(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.trim();
-  return normalized ? normalized : undefined;
 }
 
 function normalizePackageChannel(

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -1,6 +1,7 @@
 /** Reads installed-index records back into manifest registry records. */
 import fs from "node:fs";
 import path from "node:path";
+import { safeParseJson } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
@@ -432,11 +433,7 @@ type InstalledPluginIndexRecordRow = {
 };
 
 function parseJsonColumn(value: string): unknown {
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(value);
 }
 
 function readPersistedInstalledPluginIndexForRecords(

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -1,6 +1,7 @@
 /** Persists, inspects, and refreshes the installed plugin index in the state database. */
 import { existsSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
 import { z } from "zod";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
@@ -222,11 +223,7 @@ function assertWritableInstalledPluginIndexStoreOptions(
 }
 
 function parseJsonColumn(value: string): unknown {
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(value);
 }
 
 function parseInstalledPluginIndexSqliteRow(

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -1,5 +1,6 @@
 // Structured plugin catalog and lifecycle operations shared by Gateway-facing surfaces.
 import path from "node:path";
+import { asSafeIntegerInRange } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
@@ -415,7 +416,7 @@ function normalizeCatalogMetadata(
 }
 
 function normalizeFeaturedAt(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+  return asSafeIntegerInRange(value, { min: 0 });
 }
 
 function resolveCatalogInstallAction(params: {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -5,7 +5,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { readResponseWithLimit } from "../infra/http-body.js";
+import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
 import { isRecord } from "../utils.js";
 import type {
   PluginManifestCatalog,
@@ -1329,9 +1329,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       now: currentTime(),
     });
   } finally {
-    if (response?.bodyUsed !== true) {
-      await response?.body?.cancel().catch(() => undefined);
-    }
+    await cancelUnreadResponseBody(response);
     await release?.().catch(() => undefined);
   }
 }

--- a/src/plugins/provider-openai-chatgpt-oauth-tls.ts
+++ b/src/plugins/provider-openai-chatgpt-oauth-tls.ts
@@ -6,6 +6,7 @@ import { asNullableObjectRecord } from "@openclaw/normalization-core/record-coer
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { cancelUnreadResponseBody } from "../infra/http-body.js";
 
 const OPENAI_AUTH_PROBE_URL =
   "https://auth.openai.com/oauth/authorize?response_type=code&client_id=openclaw-preflight&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&scope=openid+profile+email";
@@ -112,9 +113,7 @@ export async function runOpenAIOAuthTlsPreflight(options?: {
       message: failure.message,
     };
   } finally {
-    if (response?.bodyUsed !== true) {
-      await response?.body?.cancel().catch(() => undefined);
-    }
+    await cancelUnreadResponseBody(response);
   }
 }
 

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -27,6 +27,7 @@ import {
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 // Builds setup metadata for self-hosted provider plugins.
+import { cancelUnreadResponseBody } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -117,12 +118,6 @@ async function readSelfHostedDiscoveryJson<T>(response: Response, label: string)
   return await readProviderJsonResponse<T>(response, `${label} discovery`, {
     maxBytes: SELF_HOSTED_DISCOVERY_JSON_MAX_BYTES,
   });
-}
-
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
 }
 
 function resolveLlamaCppPropsUrl(baseUrl: string, modelId?: string): string {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -4,7 +4,7 @@ import {
   normalizeBuiltInProviderModelId,
   stripSelfProviderModelPrefix,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
-import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { asFiniteNumber, asFiniteNumberInRange } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { splitTrailingAuthProfile } from "../../agents/model-ref-profile.js";
 import { normalizeModelRef } from "../../agents/model-ref-shared.js";
@@ -212,7 +212,7 @@ function buildMessages(params: {
 }
 
 function readFiniteNonNegativeNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+  return asFiniteNumberInRange(value, { min: 0 });
 }
 
 function readExplicitCostUsd(raw: unknown): number | undefined {

--- a/src/security/channel-metadata.ts
+++ b/src/security/channel-metadata.ts
@@ -1,6 +1,6 @@
 // Extracts channel metadata used by security audit findings.
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { wrapExternalContent } from "./external-content.js";
 
 const DEFAULT_MAX_CHARS = 800;
@@ -14,11 +14,7 @@ function truncateText(value: string, maxChars: number): string {
   if (maxChars <= 0) {
     return "";
   }
-  if (value.length <= maxChars) {
-    return value;
-  }
-  const trimmed = truncateUtf16Safe(value, Math.max(0, maxChars - 3)).trimEnd();
-  return `${trimmed}...`;
+  return truncateWithMarker(value, maxChars, { marker: "...", reserve: 3, trimEnd: true });
 }
 
 /**

--- a/src/security/install-policy.ts
+++ b/src/security/install-policy.ts
@@ -1,7 +1,7 @@
 // Checks install policy constraints for package and plugin operations.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig, SecurityConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -343,7 +343,7 @@ async function assertSecurePolicyScriptArg(params: {
 }
 
 function truncateText(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${truncateUtf16Safe(value, maxChars)}...`;
+  return truncateWithMarker(value, maxChars, { marker: "...", reserve: 0, trimEnd: false });
 }
 
 function createPolicyChildEnv(sourceEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -1,5 +1,6 @@
 /** Best-effort shared-state registry for adopted upstream sessions. */
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
 import type { Selectable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
@@ -42,11 +43,7 @@ function parseJson(value: string | null): SessionUpstreamJsonValue | null {
   if (value === null) {
     return null;
   }
-  try {
-    return JSON.parse(value) as SessionUpstreamJsonValue;
-  } catch {
-    return null;
-  }
+  return (safeParseJson(value) as SessionUpstreamJsonValue | undefined) ?? null;
 }
 
 function rowToSessionUpstreamLink(row: SessionUpstreamLinkRow): SessionUpstreamLink {

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -5,7 +5,7 @@ export { avoidTrailingHighSurrogateBreak };
 
 const CJK_PUNCTUATION_BREAK_AFTER_RE = /[、。，．！？；：）］｝〉》」』】〕〗〙]/u;
 
-function normalizeChunkLimit(limit: number): number {
+export function normalizeChunkLimit(limit: number): number {
   // String slicing truncates fractional indexes, so positive limits need an integer progress step.
   return Number.isFinite(limit) && limit > 0 ? resolveIntegerOption(limit, 1, { min: 1 }) : limit;
 }

--- a/src/skills/lifecycle/clawhub-store.ts
+++ b/src/skills/lifecycle/clawhub-store.ts
@@ -1,5 +1,6 @@
 import fsSync from "node:fs";
 import path from "node:path";
+import { normalizeOptionalString as normalizeOptionalStringValue } from "@openclaw/normalization-core/string-coerce";
 import {
   CLAWHUB_SKILLS_SH_TRUST_STATE,
   type ClawHubDownloadResult,
@@ -9,6 +10,8 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { readJsonIfExists, tryReadJson, writeJson } from "../../infra/json-files.js";
 import { normalizeTrackedSkillSlug, validateRequestedSkillSlug } from "./archive-install.js";
+
+export { normalizeOptionalStringValue };
 
 const DOT_DIR = ".clawhub";
 const LEGACY_DOT_DIR = ".clawdhub";
@@ -154,10 +157,6 @@ export function formatClawHubSkillRef(ref: ClawHubSkillRef): string {
 export function normalizeStoredRegistry(registry: string): string {
   const trimmed = registry.trim();
   return trimmed.replace(/\/+$/, "") || trimmed;
-}
-
-export function normalizeOptionalStringValue(raw: unknown): string | undefined {
-  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
 
 export function normalizeGitHubCommitSegment(raw: unknown): string | undefined {

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -1,4 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { normalizeNullableString as migratedText } from "@openclaw/normalization-core/string-coerce";
 import type { SessionRunStatus } from "../../packages/gateway-protocol/src/schema/sessions-row.js";
 import {
   ensureMemoryChunkProvenance,
@@ -332,12 +334,8 @@ function migratedObjectField(
     : null;
 }
 
-function migratedText(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
 function migratedNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+  return asFiniteNumber(value) ?? null;
 }
 
 function migratedChatType(value: unknown): "direct" | "group" | "channel" | null {

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -28,11 +28,11 @@ const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
 const ERROR_OWNED_FIELDS = new Set(["cause", "message", "name", "stack"]);
 
 function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
   const message = String(error);
-  if (
-    error instanceof Error ||
-    ((typeof error !== "object" || error === null) && typeof error !== "function")
-  ) {
+  if ((typeof error !== "object" || error === null) && typeof error !== "function") {
     return toErrorObject(error, message);
   }
   const details = Object.fromEntries(

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -2,6 +2,7 @@ import { fork, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { toErrorObject } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   confirmOpenClawAgentDatabaseIntegrity,
@@ -26,7 +27,7 @@ const log = createSubsystemLogger("state/database-verify");
 const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
 
 function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
+  return toErrorObject(error, String(error));
 }
 
 function resolveDatabaseVerifyWorkerUrl(currentModuleUrl = import.meta.url): URL {

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -25,9 +25,28 @@ export const OPENCLAW_DATABASE_VERIFY_INTERVAL_MS = 24 * 60 * 60_000;
 
 const log = createSubsystemLogger("state/database-verify");
 const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
+const ERROR_OWNED_FIELDS = new Set(["cause", "message", "name", "stack"]);
 
 function toError(error: unknown): Error {
-  return toErrorObject(error, String(error));
+  const message = String(error);
+  if (
+    error instanceof Error ||
+    ((typeof error !== "object" || error === null) && typeof error !== "function")
+  ) {
+    return toErrorObject(error, message);
+  }
+  const details = Object.fromEntries(
+    Reflect.ownKeys(error)
+      .filter(
+        (key) =>
+          (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
+          Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
+      )
+      .map((key) => [key, Reflect.get(error, key)]),
+  );
+  const normalized = toErrorObject(details, message);
+  normalized.cause = error;
+  return normalized;
 }
 
 function resolveDatabaseVerifyWorkerUrl(currentModuleUrl = import.meta.url): URL {

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -42,7 +42,13 @@ function toError(error: unknown): Error {
           (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
           Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
       )
-      .map((key) => [key, Reflect.get(error, key)]),
+      .flatMap((key): [PropertyKey, unknown][] => {
+        try {
+          return [[key, Reflect.get(error, key)]];
+        } catch {
+          return [];
+        }
+      }),
   );
   const normalized = toErrorObject(details, message);
   normalized.cause = error;

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -26,6 +26,7 @@ export const OPENCLAW_DATABASE_VERIFY_INTERVAL_MS = 24 * 60 * 60_000;
 const log = createSubsystemLogger("state/database-verify");
 const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
 const ERROR_OWNED_FIELDS = new Set(["cause", "message", "name", "stack"]);
+const PROTOTYPE_MUTATING_FIELDS = new Set(["__proto__", "constructor", "prototype"]);
 
 function toError(error: unknown): Error {
   if (error instanceof Error) {
@@ -38,22 +39,24 @@ function toError(error: unknown): Error {
   const normalized = toErrorObject({}, message);
   normalized.cause = error;
   try {
-    const details = Object.fromEntries(
-      Reflect.ownKeys(error)
-        .filter(
-          (key) =>
-            (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
-            Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
-        )
-        .flatMap((key): [PropertyKey, unknown][] => {
-          try {
-            return [[key, Reflect.get(error, key)]];
-          } catch {
-            return [];
-          }
-        }),
+    const detailKeys = Reflect.ownKeys(error).filter(
+      (key) =>
+        (typeof key !== "string" ||
+          (!ERROR_OWNED_FIELDS.has(key) && !PROTOTYPE_MUTATING_FIELDS.has(key))) &&
+        Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
     );
-    Object.assign(normalized, details);
+    for (const key of detailKeys) {
+      try {
+        Object.defineProperty(normalized, key, {
+          value: Reflect.get(error, key),
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+      } catch {
+        // Skip fields whose getters or property definitions reject access.
+      }
+    }
   } catch {
     // Opaque proxies may reject enumeration; preserve the original failure as the cause.
   }

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -35,23 +35,28 @@ function toError(error: unknown): Error {
   if ((typeof error !== "object" || error === null) && typeof error !== "function") {
     return toErrorObject(error, message);
   }
-  const details = Object.fromEntries(
-    Reflect.ownKeys(error)
-      .filter(
-        (key) =>
-          (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
-          Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
-      )
-      .flatMap((key): [PropertyKey, unknown][] => {
-        try {
-          return [[key, Reflect.get(error, key)]];
-        } catch {
-          return [];
-        }
-      }),
-  );
-  const normalized = toErrorObject(details, message);
+  const normalized = toErrorObject({}, message);
   normalized.cause = error;
+  try {
+    const details = Object.fromEntries(
+      Reflect.ownKeys(error)
+        .filter(
+          (key) =>
+            (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
+            Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
+        )
+        .flatMap((key): [PropertyKey, unknown][] => {
+          try {
+            return [[key, Reflect.get(error, key)]];
+          } catch {
+            return [];
+          }
+        }),
+    );
+    Object.assign(normalized, details);
+  } catch {
+    // Opaque proxies may reject enumeration; preserve the original failure as the cause.
+  }
   return normalized;
 }
 

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -48,7 +48,51 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
   });
 });
 
+async function captureDatabaseVerifyWorkerSendFailure(failure: unknown): Promise<Error> {
+  return await runDatabaseVerifyWorker([], {
+    onWorker: (worker) => {
+      if (!worker) {
+        return;
+      }
+      worker.send = ((...args: unknown[]) => {
+        const callback = args.at(-1);
+        if (typeof callback === "function") {
+          callback(failure);
+        }
+        return true;
+      }) as ChildProcess["send"];
+    },
+  }).then(
+    () => {
+      throw new Error("expected database verification worker failure");
+    },
+    (rejection: unknown) => rejection as Error,
+  );
+}
+
 describe("database verification error coercion", () => {
+  it("preserves existing Error identity without invoking custom toString", async () => {
+    class ThrowingToStringError extends Error {
+      override toString(): string {
+        throw new Error("unexpected stringification");
+      }
+    }
+    const cause = { code: "SQLITE_IOERR" };
+    const failure = new ThrowingToStringError("database failed", { cause });
+    failure.name = "DatabaseFailure";
+    const originalStack = failure.stack;
+
+    const error = await captureDatabaseVerifyWorkerSendFailure(failure);
+
+    expect(error).toBe(failure);
+    expect(error).toMatchObject({
+      cause,
+      message: "database failed",
+      name: "DatabaseFailure",
+      stack: originalStack,
+    });
+  });
+
   it("preserves adapter-owned Error fields when structured failure fields collide", async () => {
     const detailKey = Symbol("detail");
     let reservedReads = 0;
@@ -74,25 +118,7 @@ describe("database verification error coercion", () => {
       [detailKey]: "symbol detail",
     };
 
-    const error = await runDatabaseVerifyWorker([], {
-      onWorker: (worker) => {
-        if (!worker) {
-          return;
-        }
-        worker.send = ((...args: unknown[]) => {
-          const callback = args.at(-1);
-          if (typeof callback === "function") {
-            callback(failure);
-          }
-          return true;
-        }) as ChildProcess["send"];
-      },
-    }).then(
-      () => {
-        throw new Error("expected database verification worker failure");
-      },
-      (rejection: unknown) => rejection as Error,
-    );
+    const error = await captureDatabaseVerifyWorkerSendFailure(failure);
 
     expect(reservedReads).toBe(0);
     expect(error.message).toBe("[object Object]");

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -45,6 +45,62 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
         cleanup();
       }
     }
+  });
+});
+
+describe("database verification error coercion", () => {
+  it("preserves adapter-owned Error fields when structured failure fields collide", async () => {
+    const detailKey = Symbol("detail");
+    let reservedReads = 0;
+    const failure = {
+      get name() {
+        reservedReads += 1;
+        return "SpoofedError";
+      },
+      get message() {
+        reservedReads += 1;
+        return "spoofed message";
+      },
+      get cause() {
+        reservedReads += 1;
+        return "spoofed cause";
+      },
+      get stack() {
+        reservedReads += 1;
+        return "spoofed stack";
+      },
+      code: "SQLITE_IOERR",
+      details: { database: "state" },
+      [detailKey]: "symbol detail",
+    };
+
+    const error = await runDatabaseVerifyWorker([], {
+      onWorker: (worker) => {
+        if (!worker) {
+          return;
+        }
+        worker.send = ((...args: unknown[]) => {
+          const callback = args.at(-1);
+          if (typeof callback === "function") {
+            callback(failure);
+          }
+          return true;
+        }) as ChildProcess["send"];
+      },
+    }).then(
+      () => {
+        throw new Error("expected database verification worker failure");
+      },
+      (rejection: unknown) => rejection as Error,
+    );
+
+    expect(reservedReads).toBe(0);
+    expect(error.message).toBe("[object Object]");
+    expect(error.cause).toBe(failure);
+    expect(error.name).toBe("Error");
+    expect(error.stack).toContain("Error: [object Object]");
+    expect(error).toMatchObject({ code: "SQLITE_IOERR", details: { database: "state" } });
+    expect(Reflect.get(error, detailKey)).toBe("symbol detail");
   });
 });
 

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -93,6 +93,20 @@ describe("database verification error coercion", () => {
     });
   });
 
+  it("skips structured fields whose getters throw", async () => {
+    const failure = {
+      get details(): never {
+        throw new Error("unexpected structured field read");
+      },
+      code: "SQLITE_IOERR",
+    };
+
+    const error = await captureDatabaseVerifyWorkerSendFailure(failure);
+
+    expect(error).toMatchObject({ code: "SQLITE_IOERR" });
+    expect(error).not.toHaveProperty("details");
+  });
+
   it("preserves adapter-owned Error fields when structured failure fields collide", async () => {
     const detailKey = Symbol("detail");
     let reservedReads = 0;

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -173,6 +173,21 @@ describe("database verification error coercion", () => {
     expect(error).toMatchObject({ code: "SQLITE_IOERR", details: { database: "state" } });
     expect(Reflect.get(error, detailKey)).toBe("symbol detail");
   });
+
+  it("rejects prototype-mutating structured failure fields", async () => {
+    const failure = { constructor: { polluted: true }, prototype: { polluted: true } };
+    Object.defineProperty(failure, "__proto__", {
+      value: { polluted: true },
+      enumerable: true,
+    });
+
+    const error = await captureDatabaseVerifyWorkerSendFailure(failure);
+
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+    expect(Object.hasOwn(error, "constructor")).toBe(false);
+    expect(Object.hasOwn(error, "prototype")).toBe(false);
+  });
 });
 
 function createUnsafeIndexDrift(databasePath: string): void {

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -107,6 +107,37 @@ describe("database verification error coercion", () => {
     expect(error).not.toHaveProperty("details");
   });
 
+  it("preserves the base Error when structured enumeration traps throw", async () => {
+    const handlers: ProxyHandler<{ code: string; status: number }>[] = [
+      {
+        ownKeys() {
+          throw new Error("unexpected ownKeys call");
+        },
+      },
+      {
+        ownKeys() {
+          return ["code", "status"];
+        },
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "status") {
+            throw new Error("unexpected descriptor read");
+          }
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      },
+    ];
+
+    for (const handler of handlers) {
+      const failure = new Proxy({ code: "SQLITE_IOERR", status: 10 }, handler);
+      const error = await captureDatabaseVerifyWorkerSendFailure(failure);
+
+      expect(error).toMatchObject({ name: "Error", message: "[object Object]" });
+      expect(error.cause).toBe(failure);
+      expect(error).not.toHaveProperty("code");
+      expect(error).not.toHaveProperty("status");
+    }
+  });
+
   it("preserves adapter-owned Error fields when structured failure fields collide", async () => {
     const detailKey = Symbol("detail");
     let reservedReads = 0;

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -1,6 +1,7 @@
 // Builds the status summary used by human and JSON status output.
 // It aggregates sessions, tasks, heartbeat, channel summary, and model/runtime metadata.
 
+import { normalizeLowercaseStringOrEmpty as normalizeStatusModelPart } from "@openclaw/normalization-core/string-coerce";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { getRuntimeConfig, projectConfigOntoRuntimeSourceSnapshot } from "../config/config.js";
@@ -150,10 +151,6 @@ function hasUserPinnedModelSelection(entry: SessionEntry | undefined): boolean {
     return false;
   }
   return !hasSessionAutoModelFallbackProvenance(entry);
-}
-
-function normalizeStatusModelPart(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
 function resolveTrustedSessionContextTokens(params: {

--- a/src/system-agent/rescue-message.ts
+++ b/src/system-agent/rescue-message.ts
@@ -4,6 +4,7 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { hasNonEmptyString as isNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import type { CommandContext } from "../auto-reply/reply/commands-types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
@@ -122,10 +123,6 @@ function hasExactKeys(
 
 function hasOptionalString(value: Record<string, unknown>, key: string): boolean {
   return !Object.hasOwn(value, key) || isNonEmptyString(value[key]);
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 function parsePendingOperation(value: unknown): SystemAgentOperation | null {

--- a/src/system-agent/setup-app-recommendations.ts
+++ b/src/system-agent/setup-app-recommendations.ts
@@ -1,3 +1,4 @@
+import { safeParseJson } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import pLimit from "p-limit";
@@ -292,11 +293,7 @@ function parseMatcherJson(text: string): unknown {
   if (start === -1 || end <= start) {
     return null;
   }
-  try {
-    return JSON.parse(text.slice(start, end + 1));
-  } catch {
-    return null;
-  }
+  return safeParseJson(text.slice(start, end + 1)) ?? null;
 }
 
 function buildMatcherPrompt(groups: SetupAppCandidateGroup[]): string {

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -1,5 +1,6 @@
 // Persists managed task-flow records through the OpenClaw SQLite state database.
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
 import type { Insertable, Selectable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
@@ -45,11 +46,7 @@ function parseJsonValue(raw: string | null): JsonValue | undefined {
   if (!raw?.trim()) {
     return undefined;
   }
-  try {
-    return JSON.parse(raw) as JsonValue;
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(raw) as JsonValue | undefined;
 }
 
 function rowToSyncMode(row: FlowRegistryRow): TaskFlowSyncMode {

--- a/src/tasks/task-registry.sqlite.shared.ts
+++ b/src/tasks/task-registry.sqlite.shared.ts
@@ -1,4 +1,5 @@
 // Shares SQLite row mapping helpers between task registry persistence modules.
+import { safeParseJson } from "@openclaw/normalization-core";
 import { isRecord } from "../utils.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
@@ -8,11 +9,7 @@ function parseSqliteJsonValue<T>(raw: string | null): T | undefined {
   if (!raw?.trim()) {
     return undefined;
   }
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(raw) as T | undefined;
 }
 
 export function parseDeliveryContextJson(raw: string | null): DeliveryContext | undefined {

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -1,5 +1,6 @@
 // Persists task registry records and events through the OpenClaw SQLite state database.
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
 import type { Insertable, Selectable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { assertSqliteTableIntegrity } from "../infra/sqlite-integrity.js";
@@ -94,11 +95,7 @@ function parseJsonValue(raw: string | null): JsonValue | undefined {
   if (!raw?.trim()) {
     return undefined;
   }
-  try {
-    return JSON.parse(raw) as JsonValue;
-  } catch {
-    return undefined;
-  }
+  return safeParseJson(raw) as JsonValue | undefined;
 }
 
 function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {

--- a/src/tts/speaker.ts
+++ b/src/tts/speaker.ts
@@ -1,10 +1,8 @@
 // Speaker-selection compatibility helpers for plugins that renamed voice fields
 // over time but still need one normalized config object.
-type SpeakerSelectionConfig = Record<string, unknown>;
+import { normalizeOptionalString as readString } from "@openclaw/normalization-core/string-coerce";
 
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
+type SpeakerSelectionConfig = Record<string, unknown>;
 
 /** Populate canonical and legacy speaker voice fields together. */
 export function withSpeakerSelectionCompat(

--- a/src/tts/tts-synthesis-support.ts
+++ b/src/tts/tts-synthesis-support.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString as readTtsResultString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig, ResolvedTtsPersona, TtsProvider } from "../config/types.js";
 import { logVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -405,10 +406,6 @@ export async function executeTtsProviderAttempts<TSynthesis, TResult>(params: {
   }
 
   return buildTtsFailureResult(errors, attemptedProviders, attempts, persona?.id);
-}
-
-function readTtsResultString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function resolveTtsResultModel(

--- a/src/tts/voice-models.ts
+++ b/src/tts/voice-models.ts
@@ -1,5 +1,6 @@
 // Voice model catalog helpers shared by TTS and realtime voice plugins.
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { normalizeOptionalString as normalizeString } from "@openclaw/normalization-core/string-coerce";
 
 type VoiceModelCapability = "tts" | "realtime_transcription" | "realtime_voice";
 
@@ -47,10 +48,6 @@ type VoiceModelConfig =
       fallbacks?: unknown;
       timeoutMs?: unknown;
     };
-
-function normalizeString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 function normalizeLowercaseString(value: unknown): string | undefined {
   return normalizeString(value)?.toLowerCase();

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import type { Component, OverlayHandle, SelectItem, TUI } from "@earendil-works/pi-tui";
 import type { Result } from "@openclaw/normalization-core/result";
+import { normalizeLowercaseStringOrEmpty as normalizedChatSendAckStatus } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { modelKey } from "../agents/model-ref-shared.js";
 import { shouldForwardModelCommandToServer } from "../auto-reply/commands-registry.shared.js";
@@ -105,10 +106,6 @@ function isBtwCommand(text: string): boolean {
 function isSlashStopCommand(text: string): boolean {
   const trimmed = text.trim();
   return trimmed.startsWith("/") && isChatStopCommandText(trimmed);
-}
-
-function normalizedChatSendAckStatus(status: unknown): string {
-  return typeof status === "string" ? status.trim().toLowerCase() : "";
 }
 
 function isTerminalChatSendAckFailure(status: unknown): boolean {

--- a/src/tui/tui-last-session.ts
+++ b/src/tui/tui-last-session.ts
@@ -1,6 +1,7 @@
 // Stores and resolves the last TUI session per workspace.
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { normalizeLowercaseStringOrEmpty as normalizeMarker } from "@openclaw/normalization-core/string-coerce";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -35,10 +36,6 @@ export function buildTuiLastSessionScopeKey(params: {
     .update(`${params.sessionScope}\n${agentId}\n${connectionUrl}`)
     .digest("hex")
     .slice(0, 32);
-}
-
-function normalizeMarker(value: unknown): string {
-  return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
 function isHeartbeatSessionKey(sessionKey: string): boolean {

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -6,6 +6,7 @@ import type {
   WorkerProtocolCloseReason,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { BackoffPolicy } from "../infra/backoff.js";
+import { toErrorObject } from "../infra/errors.js";
 
 const FENCED_CLOSE_REASONS = new Set<WorkerProtocolCloseReason>([
   "credential-replaced",
@@ -95,5 +96,5 @@ export function resolvePositiveTimeout(value: number | undefined, fallback: numb
 }
 
 export function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
+  return toErrorObject(error, String(error));
 }

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -12,6 +12,7 @@ const FENCED_CLOSE_REASONS = new Set<WorkerProtocolCloseReason>([
   "credential-replaced",
   "owner-epoch-mismatch",
 ]);
+const ERROR_OWNED_FIELDS = new Set(["cause", "message", "name", "stack"]);
 
 export type WorkerFencedReason = "credential-replaced" | "owner-epoch-mismatch";
 
@@ -96,5 +97,23 @@ export function resolvePositiveTimeout(value: number | undefined, fallback: numb
 }
 
 export function toError(error: unknown): Error {
-  return toErrorObject(error, String(error));
+  const message = String(error);
+  if (
+    error instanceof Error ||
+    ((typeof error !== "object" || error === null) && typeof error !== "function")
+  ) {
+    return toErrorObject(error, message);
+  }
+  const details = Object.fromEntries(
+    Reflect.ownKeys(error)
+      .filter(
+        (key) =>
+          (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
+          Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
+      )
+      .map((key) => [key, Reflect.get(error, key)]),
+  );
+  const normalized = toErrorObject(details, message);
+  normalized.cause = error;
+  return normalized;
 }

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -97,11 +97,11 @@ export function resolvePositiveTimeout(value: number | undefined, fallback: numb
 }
 
 export function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
   const message = String(error);
-  if (
-    error instanceof Error ||
-    ((typeof error !== "object" || error === null) && typeof error !== "function")
-  ) {
+  if ((typeof error !== "object" || error === null) && typeof error !== "function") {
     return toErrorObject(error, message);
   }
   const details = Object.fromEntries(

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -111,7 +111,13 @@ export function toError(error: unknown): Error {
           (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
           Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
       )
-      .map((key) => [key, Reflect.get(error, key)]),
+      .flatMap((key): [PropertyKey, unknown][] => {
+        try {
+          return [[key, Reflect.get(error, key)]];
+        } catch {
+          return [];
+        }
+      }),
   );
   const normalized = toErrorObject(details, message);
   normalized.cause = error;

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -104,22 +104,27 @@ export function toError(error: unknown): Error {
   if ((typeof error !== "object" || error === null) && typeof error !== "function") {
     return toErrorObject(error, message);
   }
-  const details = Object.fromEntries(
-    Reflect.ownKeys(error)
-      .filter(
-        (key) =>
-          (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
-          Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
-      )
-      .flatMap((key): [PropertyKey, unknown][] => {
-        try {
-          return [[key, Reflect.get(error, key)]];
-        } catch {
-          return [];
-        }
-      }),
-  );
-  const normalized = toErrorObject(details, message);
+  const normalized = toErrorObject({}, message);
   normalized.cause = error;
+  try {
+    const details = Object.fromEntries(
+      Reflect.ownKeys(error)
+        .filter(
+          (key) =>
+            (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
+            Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
+        )
+        .flatMap((key): [PropertyKey, unknown][] => {
+          try {
+            return [[key, Reflect.get(error, key)]];
+          } catch {
+            return [];
+          }
+        }),
+    );
+    Object.assign(normalized, details);
+  } catch {
+    // Opaque proxies may reject enumeration; preserve the original failure as the cause.
+  }
   return normalized;
 }

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -13,6 +13,7 @@ const FENCED_CLOSE_REASONS = new Set<WorkerProtocolCloseReason>([
   "owner-epoch-mismatch",
 ]);
 const ERROR_OWNED_FIELDS = new Set(["cause", "message", "name", "stack"]);
+const PROTOTYPE_MUTATING_FIELDS = new Set(["__proto__", "constructor", "prototype"]);
 
 export type WorkerFencedReason = "credential-replaced" | "owner-epoch-mismatch";
 
@@ -107,22 +108,24 @@ export function toError(error: unknown): Error {
   const normalized = toErrorObject({}, message);
   normalized.cause = error;
   try {
-    const details = Object.fromEntries(
-      Reflect.ownKeys(error)
-        .filter(
-          (key) =>
-            (typeof key !== "string" || !ERROR_OWNED_FIELDS.has(key)) &&
-            Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
-        )
-        .flatMap((key): [PropertyKey, unknown][] => {
-          try {
-            return [[key, Reflect.get(error, key)]];
-          } catch {
-            return [];
-          }
-        }),
+    const detailKeys = Reflect.ownKeys(error).filter(
+      (key) =>
+        (typeof key !== "string" ||
+          (!ERROR_OWNED_FIELDS.has(key) && !PROTOTYPE_MUTATING_FIELDS.has(key))) &&
+        Reflect.getOwnPropertyDescriptor(error, key)?.enumerable,
     );
-    Object.assign(normalized, details);
+    for (const key of detailKeys) {
+      try {
+        Object.defineProperty(normalized, key, {
+          value: Reflect.get(error, key),
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+      } catch {
+        // Skip fields whose getters or property definitions reject access.
+      }
+    }
   } catch {
     // Opaque proxies may reject enumeration; preserve the original failure as the cause.
   }

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -13,6 +13,7 @@ import type {
   WorkerInferenceEventFrame,
   WorkerInferenceTerminalFrame,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { toError } from "./worker-connection-contract.js";
 import { WorkerConnectionFrameDispatcher } from "./worker-connection-frames.js";
 import { createWorkerConnection, type WorkerConnectionState } from "./worker-connection.js";
 
@@ -129,6 +130,18 @@ function installThrowingThenHealthyListeners(connection: ReturnType<typeof creat
   });
   return { observed, throwingCalls: () => throwingCalls };
 }
+
+describe("worker connection error coercion", () => {
+  it("preserves structured non-Error causes", () => {
+    const cause = { code: "ECONNRESET", status: 503 };
+
+    const error = toError(cause);
+
+    expect(error.message).toBe("[object Object]");
+    expect(error.cause).toBe(cause);
+    expect(error).toMatchObject(cause);
+  });
+});
 
 describe("WorkerConnection state listener isolation", () => {
   it("settles stop and reaches later listeners when an earlier listener throws", async () => {

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -141,6 +141,42 @@ describe("worker connection error coercion", () => {
     expect(error.cause).toBe(cause);
     expect(error).toMatchObject(cause);
   });
+
+  it("preserves adapter-owned Error fields when structured cause fields collide", () => {
+    const detailKey = Symbol("detail");
+    let reservedReads = 0;
+    const cause = {
+      get name() {
+        reservedReads += 1;
+        return "SpoofedError";
+      },
+      get message() {
+        reservedReads += 1;
+        return "spoofed message";
+      },
+      get cause() {
+        reservedReads += 1;
+        return "spoofed cause";
+      },
+      get stack() {
+        reservedReads += 1;
+        return "spoofed stack";
+      },
+      code: "ECONNRESET",
+      details: { retryable: true },
+      [detailKey]: "symbol detail",
+    };
+
+    const error = toError(cause);
+
+    expect(reservedReads).toBe(0);
+    expect(error.message).toBe("[object Object]");
+    expect(error.cause).toBe(cause);
+    expect(error.name).toBe("Error");
+    expect(error.stack).toContain("Error: [object Object]");
+    expect(error).toMatchObject({ code: "ECONNRESET", details: { retryable: true } });
+    expect(Reflect.get(error, detailKey)).toBe("symbol detail");
+  });
 });
 
 describe("WorkerConnection state listener isolation", () => {

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -132,6 +132,28 @@ function installThrowingThenHealthyListeners(connection: ReturnType<typeof creat
 }
 
 describe("worker connection error coercion", () => {
+  it("preserves existing Error identity without invoking custom toString", () => {
+    class ThrowingToStringError extends Error {
+      override toString(): string {
+        throw new Error("unexpected stringification");
+      }
+    }
+    const cause = { code: "ECONNRESET" };
+    const original = new ThrowingToStringError("worker failed", { cause });
+    original.name = "WorkerFailure";
+    const originalStack = original.stack;
+
+    const error = toError(original);
+
+    expect(error).toBe(original);
+    expect(error).toMatchObject({
+      cause,
+      message: "worker failed",
+      name: "WorkerFailure",
+      stack: originalStack,
+    });
+  });
+
   it("preserves structured non-Error causes", () => {
     const cause = { code: "ECONNRESET", status: 503 };
 

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -164,6 +164,22 @@ describe("worker connection error coercion", () => {
     expect(error).toMatchObject(cause);
   });
 
+  it("skips structured fields whose getters throw", () => {
+    const cause = {
+      get details(): never {
+        throw new Error("unexpected structured field read");
+      },
+      code: "ECONNRESET",
+    };
+    let error: Error | undefined;
+
+    expect(() => {
+      error = toError(cause);
+    }).not.toThrow();
+    expect(error).toMatchObject({ code: "ECONNRESET" });
+    expect(error).not.toHaveProperty("details");
+  });
+
   it("preserves adapter-owned Error fields when structured cause fields collide", () => {
     const detailKey = Symbol("detail");
     let reservedReads = 0;

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -180,6 +180,37 @@ describe("worker connection error coercion", () => {
     expect(error).not.toHaveProperty("details");
   });
 
+  it("preserves the base Error when structured enumeration traps throw", () => {
+    const handlers: ProxyHandler<{ code: string; status: number }>[] = [
+      {
+        ownKeys() {
+          throw new Error("unexpected ownKeys call");
+        },
+      },
+      {
+        ownKeys() {
+          return ["code", "status"];
+        },
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "status") {
+            throw new Error("unexpected descriptor read");
+          }
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      },
+    ];
+
+    for (const handler of handlers) {
+      const cause = new Proxy({ code: "ECONNRESET", status: 503 }, handler);
+      const error = toError(cause);
+
+      expect(error).toMatchObject({ name: "Error", message: "[object Object]" });
+      expect(error.cause).toBe(cause);
+      expect(error).not.toHaveProperty("code");
+      expect(error).not.toHaveProperty("status");
+    }
+  });
+
   it("preserves adapter-owned Error fields when structured cause fields collide", () => {
     const detailKey = Symbol("detail");
     let reservedReads = 0;

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -246,6 +246,21 @@ describe("worker connection error coercion", () => {
     expect(error).toMatchObject({ code: "ECONNRESET", details: { retryable: true } });
     expect(Reflect.get(error, detailKey)).toBe("symbol detail");
   });
+
+  it("rejects prototype-mutating structured cause fields", () => {
+    const cause = { constructor: { polluted: true }, prototype: { polluted: true } };
+    Object.defineProperty(cause, "__proto__", {
+      value: { polluted: true },
+      enumerable: true,
+    });
+
+    const error = toError(cause);
+
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+    expect(Object.hasOwn(error, "constructor")).toBe(false);
+    expect(Object.hasOwn(error, "prototype")).toBe(false);
+  });
 });
 
 describe("WorkerConnection state listener isolation", () => {

--- a/ui/src/app/custom-theme.ts
+++ b/ui/src/app/custom-theme.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as readThemeRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Control UI module implements custom theme behavior.
 import { normalizeOptionalString } from "../lib/string-coerce.ts";
@@ -100,12 +101,6 @@ export type ImportedCustomTheme = {
 // Shape checks are intentionally shallow: normalizeStoredTokenMap and
 // resolveModeVar re-validate every token (presence, length, safe CSS) and
 // throw on anything off, so no schema library is needed at this boundary.
-function readThemeRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 type TweakcnThemeResolution = {
   sourceUrl: string;
   fetchUrl: string;

--- a/ui/src/app/question-prompt.ts
+++ b/ui/src/app/question-prompt.ts
@@ -1,5 +1,6 @@
 // Control UI module owns transient operator question state.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeNullableString as readNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import type {
   Question,
   QuestionAnswers,
@@ -58,14 +59,6 @@ type QuestionPromptState = QuestionClientResolutionOwner & {
 type QuestionAnswerValues = Record<string, string[]>;
 
 const REFRESH_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
-
-function readNonEmptyString(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
-}
 
 function readTimestamp(value: unknown): number | null {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null;

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -30,6 +30,7 @@ type PersistedUiSettings = Omit<UiSettings, "token" | "sessionKey" | "lastActive
   sessionsByGateway?: Record<string, ScopedSessionSelection>;
 };
 
+import { safeParseJson } from "@openclaw/normalization-core";
 import {
   DEFAULT_SIDEBAR_ENTRIES,
   normalizeSidebarEntries,
@@ -291,11 +292,7 @@ function parsePersistedSettings(raw: string | null): PersistedUiSettings | null 
   if (!raw) {
     return null;
   }
-  try {
-    return JSON.parse(raw) as PersistedUiSettings;
-  } catch {
-    return null;
-  }
+  return (safeParseJson(raw) as PersistedUiSettings | undefined) ?? null;
 }
 
 function settingsMatchGatewayTarget(parsed: PersistedUiSettings, targetUrl: string): boolean {

--- a/ui/src/build-info-normalizers.ts
+++ b/ui/src/build-info-normalizers.ts
@@ -1,5 +1,7 @@
 // Shared build identity normalization for the runtime artifact and Vite config.
 // Vite loads this module before source-package aliases exist, so use the canonical source path.
+import { asRecord } from "../../packages/normalization-core/src/record-coerce.js";
+import { normalizeNullableString } from "../../packages/normalization-core/src/string-coerce.js";
 import { truncateUtf16Safe } from "../../packages/normalization-core/src/utf16-slice.js";
 import type { ControlUiBuildInfo } from "./build-info-types.ts";
 
@@ -12,22 +14,18 @@ const FULL_GIT_SHA = /^[0-9a-f]{40}$/u;
 const UTC_BUILD_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u;
 const BUILD_ID_MAX_LENGTH = 96;
 
-function normalizeOptionalString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
 function normalizeControlUiCommit(value: unknown): string | null {
-  const commit = normalizeOptionalString(value)?.toLowerCase() ?? null;
+  const commit = normalizeNullableString(value)?.toLowerCase() ?? null;
   return commit && FULL_GIT_SHA.test(commit) ? commit : null;
 }
 
 function normalizeControlUiBranch(value: unknown): string | null {
-  const branch = normalizeOptionalString(value);
+  const branch = normalizeNullableString(value);
   return branch && branch !== "HEAD" ? truncateUtf16Safe(branch, 100) : null;
 }
 
 function normalizeControlUiBuildTimestamp(value: unknown): string | null {
-  const timestamp = normalizeOptionalString(value);
+  const timestamp = normalizeNullableString(value);
   if (!timestamp || !UTC_BUILD_TIMESTAMP.test(timestamp)) {
     return null;
   }
@@ -42,7 +40,7 @@ function normalizeControlUiBuildTimestamp(value: unknown): string | null {
 }
 
 function normalizeControlUiBuildId(value: unknown): string {
-  const normalized = normalizeOptionalString(value)?.replace(/[^a-zA-Z0-9._-]+/g, "-");
+  const normalized = normalizeNullableString(value)?.replace(/[^a-zA-Z0-9._-]+/g, "-");
   return normalized?.slice(0, BUILD_ID_MAX_LENGTH) || "dev";
 }
 
@@ -59,10 +57,8 @@ function deriveControlUiBuildId(info: ControlUiBuildMetadata): string {
 }
 
 export function normalizeControlUiBuildInfo(value: unknown): ControlUiBuildInfo {
-  const record = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-  const optionalString = (candidate: unknown) =>
-    typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
-  const version = optionalString(record.version);
+  const record = asRecord(value);
+  const version = normalizeNullableString(record.version);
   const commit = normalizeControlUiCommit(record.commit);
   const builtAt = normalizeControlUiBuildTimestamp(record.builtAt);
   const release = record.release === true;

--- a/ui/src/components/config-form.constraints.ts
+++ b/ui/src/components/config-form.constraints.ts
@@ -3,6 +3,7 @@ import {
   isJsonSchemaValueValid,
   jsonSchemaValuesEqual,
 } from "@openclaw/normalization-core/json-schema";
+import { asFiniteNumber as finiteNumber } from "@openclaw/normalization-core/number-coercion";
 import { decimalRational } from "./config-form.numeric.ts";
 import { schemaType, type JsonSchema } from "./config-form.shared.ts";
 
@@ -15,10 +16,6 @@ export function isSupportedConfigValueValid(schema: JsonSchema, value: unknown):
 function ownPropertySchema(schema: JsonSchema, key: string): JsonSchema | undefined {
   const properties = schema.properties;
   return properties && Object.hasOwn(properties, key) ? properties[key] : undefined;
-}
-
-function finiteNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function decimalPlaces(value: number): number {

--- a/ui/src/lib/chat/follow-up-mode.ts
+++ b/ui/src/lib/chat/follow-up-mode.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord as record } from "@openclaw/normalization-core/record-coerce";
 import type { QueueMode } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { normalizeQueueMode } from "../../../../src/auto-reply/reply/queue/normalize.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../../../src/utils/message-channel-constants.js";
@@ -11,12 +12,6 @@ type ServerQueueModeSources = {
   sessionMetadataLoaded?: boolean;
   sessionMode?: unknown;
 };
-
-function record(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 function normalizedQueueMode(value: unknown): QueueMode | undefined {
   return typeof value === "string" ? normalizeQueueMode(value) : undefined;

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -3,7 +3,7 @@
  */
 
 import { mediaKindFromMime } from "@openclaw/media-core/constants";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { asRecord as asMessageRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
 import {
@@ -16,16 +16,6 @@ import { parseInlineDirectives } from "../../../../src/utils/directive-tags.js";
 import { getMediaFileExtension } from "../media-file-extension.ts";
 import type { NormalizedMessage, MessageContentItem } from "./chat-types.ts";
 import { formatSenderLabel, normalizeSenderIdentity } from "./sender-label.ts";
-
-// These normalizers take `unknown` gateway/transcript data. A malformed or
-// absent entry can arrive as null/undefined (e.g. a transcript row without a
-// `message`), and `typeof m.role` still throws "reading 'role'" when `m` itself
-// is undefined — the typeof only guards the property, not the object. Coercing
-// a non-object to `{}` keeps every downstream `typeof m.<field>` check working
-// and yields role "unknown" instead of crashing the gateway event handler.
-function asMessageRecord(message: unknown): Record<string, unknown> {
-  return message && typeof message === "object" ? (message as Record<string, unknown>) : {};
-}
 
 // Older gateways baked sender labels as "name (<profile uuid>)" into transcript
 // text. The UUID is machine noise in a human label but it is also the row's
@@ -71,6 +61,8 @@ export function normalizeRoleForGrouping(role: string): string {
 }
 
 export function isToolResultMessage(message: unknown): boolean {
+  // Malformed transcript entries coerce to an empty record so property reads
+  // degrade to role "unknown" instead of crashing the event handler.
   const m = asMessageRecord(message);
   const role = typeof m.role === "string" ? m.role.toLowerCase() : "";
   return role === "toolresult" || role === "tool_result";

--- a/ui/src/lib/chat/sender-label.ts
+++ b/ui/src/lib/chat/sender-label.ts
@@ -1,3 +1,5 @@
+import { normalizeNullableString as normalizeLabelPart } from "@openclaw/normalization-core/string-coerce";
+
 export type SenderIdentity = {
   id?: string;
   name?: string;
@@ -11,10 +13,6 @@ type SenderIdentityInput = {
   username?: unknown;
   profileAvatarUrl?: unknown;
 };
-
-function normalizeLabelPart(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
 
 /** Formats durable sender identity without assuming ids will always be email addresses. */
 export function formatSenderLabel(sender: SenderIdentity | null | undefined): string | null {

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -1,6 +1,9 @@
 // Control UI runtime config capability and shared config-domain mutations.
 import { ErrorCodes } from "@openclaw/gateway-client/browser";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  asNullableRecord as asConfigRecord,
+  isRecord,
+} from "@openclaw/normalization-core/record-coerce";
 import {
   GatewayRequestError,
   type GatewayBrowserClient,
@@ -420,13 +423,6 @@ function applyConfigSchema(state: ConfigState, res: ConfigSchemaResponse) {
   state.configSchema = res.schema ?? null;
   state.configUiHints = res.uiHints ?? {};
   state.configSchemaVersion = res.version ?? null;
-}
-
-function asConfigRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
 }
 
 export function resolveEditableSnapshotConfig(

--- a/ui/src/lib/nodes/inventory.ts
+++ b/ui/src/lib/nodes/inventory.ts
@@ -1,3 +1,4 @@
+import { asFiniteNumber as optionalNumber } from "@openclaw/normalization-core/number-coercion";
 import type { PresenceEntry } from "../../api/types.ts";
 // Builds the unified nodes/devices inventory shown on the Nodes page.
 // The gateway exposes two overlapping views of the same machines: paired device
@@ -67,10 +68,6 @@ const NODE_APPROVAL_STATES: ReadonlySet<string> = new Set([
   "pending-reapproval",
   "unapproved",
 ]);
-
-function optionalNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
 
 function stringList(value: unknown): string[] {
   if (!Array.isArray(value)) {

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -1,4 +1,5 @@
 import { asNullableRecord as recordOrNull } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString as stringValue } from "@openclaw/normalization-core/string-coerce";
 import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../../api/types.ts";
 import { isSessionRunActive } from "../session-run-state.ts";
 import {
@@ -213,10 +214,6 @@ function sessionAgentId(
 
 function recordValue(record: Record<string, unknown>, key: string): unknown {
   return Object.hasOwn(record, key) ? record[key] : undefined;
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function sessionRunStatus(value: unknown): SessionRunStatus | null {

--- a/ui/src/lib/sessions/swarm-activity.ts
+++ b/ui/src/lib/sessions/swarm-activity.ts
@@ -1,4 +1,5 @@
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString as normalizedString } from "@openclaw/normalization-core/string-coerce";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 
 // Lifecycle notes are transient UI state, so bound them for long-lived board tabs.
@@ -12,10 +13,6 @@ type SwarmDisplayCarrier = {
   swarmLog?: string;
   swarmPhase?: string;
 };
-
-function normalizedString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 function setBounded<K, V>(map: Map<K, V>, key: K, value: V, limit: number): void {
   map.delete(key);

--- a/ui/src/lib/tasks/data.ts
+++ b/ui/src/lib/tasks/data.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString as optionalString } from "@openclaw/normalization-core/string-coerce";
 import { Value } from "typebox/value";
 import {
   TasksCancelResultSchema,
@@ -19,10 +20,6 @@ type TaskEventPayload =
   | { action: "upserted"; task: TaskSummary }
   | { action: "deleted"; taskId: string }
   | { action: "restored" };
-
-function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
 
 const STATUS_LABEL_KEYS = {
   queued: "tasksPage.status.queued",

--- a/ui/src/lib/workboard/card-state.ts
+++ b/ui/src/lib/workboard/card-state.ts
@@ -1,3 +1,4 @@
+import { normalizeNullableString as normalizeString } from "@openclaw/normalization-core/string-coerce";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type {
   WorkboardCard,
@@ -7,6 +8,8 @@ import type {
   WorkboardStatus,
   WorkboardUiState,
 } from "./types.ts";
+
+export { normalizeString };
 
 const WORKBOARD_STALE_SESSION_MS = 30 * 60 * 1000;
 
@@ -178,8 +181,4 @@ export function workboardCardSessionKey(card: WorkboardCard): string | undefined
 
 export function workboardCardRunId(card: WorkboardCard): string | undefined {
   return card.runId ?? card.execution?.runId;
-}
-
-export function normalizeString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
 }

--- a/ui/src/pages/activity/tool-activity.ts
+++ b/ui/src/pages/activity/tool-activity.ts
@@ -1,4 +1,6 @@
 // Control UI module implements activity model behavior.
+import { asNullableObjectRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeNullableString as toTrimmedString } from "@openclaw/normalization-core/string-coerce";
 import { formatUnknownText, truncateText } from "../../lib/format.ts";
 
 const ACTIVITY_ENTRY_LIMIT = 100;
@@ -65,18 +67,6 @@ const SECRET_PATTERNS: Array<[RegExp, string]> = [
     "$1[redacted path]",
   ],
 ];
-
-function toTrimmedString(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
-}
-
-function readRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
-}
 
 export function parseActivityEvent(
   payload: unknown,

--- a/ui/src/pages/agents/memory/dreaming.ts
+++ b/ui/src/pages/agents/memory/dreaming.ts
@@ -1,4 +1,5 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/normalization-core/string-coerce";
 import type {
   DoctorMemoryDreamActionPayload,
   DoctorMemoryDreamDiaryPayload,
@@ -284,14 +285,6 @@ function buildDreamDiaryActionSuccessMessage(
       });
   }
   return t("dreaming.actions.complete");
-}
-
-function normalizeTrimmedString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function resolveSelectedAgentId(state: DreamingState): string | null {

--- a/ui/src/pages/chat/components/chat-composer-context.ts
+++ b/ui/src/pages/chat/components/chat-composer-context.ts
@@ -1,3 +1,4 @@
+import { asNullableObjectRecord as readCostRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import type { GatewaySessionRow } from "../../../api/types.ts";
 import { normalizeBasePath } from "../../../app-route-paths.ts";
@@ -33,10 +34,6 @@ type ProviderCostStats = {
   provider: string | null;
   model: string | null;
 };
-
-function readCostRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
-}
 
 function readCostValue(
   cost: Record<string, unknown> | null,

--- a/ui/src/pages/chat/steered-chip.ts
+++ b/ui/src/pages/chat/steered-chip.ts
@@ -1,3 +1,4 @@
+import { hasNonEmptyString as hasString } from "@openclaw/normalization-core/string-coerce";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 
 type SteerState = { sendState: "steering" } | { sendState?: undefined; pendingRunId: string };
@@ -5,10 +6,6 @@ type SteeredQueueItem = ChatQueueItem & { kind: "steered" };
 type SteeredChip = ChatQueueItem & { kind: "steered"; sendRunId: string } & SteerState;
 type InflightSteerChip = SteeredChip & { sendState: "steering" };
 type AckedSteeredChip = SteeredChip & { sendState?: undefined; pendingRunId: string };
-
-function hasString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
 
 export function isSteeredQueueItem(item: ChatQueueItem): item is SteeredQueueItem {
   return item.kind === "steered";

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -1,4 +1,6 @@
 // Control UI module implements app tool stream behavior.
+import { asNullableObjectRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeNullableString as toTrimmedString } from "@openclaw/normalization-core/string-coerce";
 import { stripInlineDirectiveTagsForDelivery } from "../../../../src/utils/directive-tags.js";
 import type { ExecApprovalRequest } from "../../app/exec-approval.ts";
 import type { ChatQueueItem, ChatStreamSegment } from "../../lib/chat/chat-types.ts";
@@ -74,14 +76,6 @@ type ToolStreamHost = {
   requestUpdate?: () => void;
   sessions: Pick<SessionCapability, "setModelOverride">;
 };
-
-function toTrimmedString(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
-}
 
 function resolveModelLabel(provider: unknown, model: unknown): string | null {
   const modelValue = toTrimmedString(model);
@@ -210,10 +204,6 @@ function formatToolOutput(value: unknown): string | null {
     return truncated.text;
   }
   return `${truncated.text}\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`;
-}
-
-function readRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
 }
 
 function resolveSessionStatusModelOverride(result: unknown): string | null | undefined {

--- a/ui/src/pages/config/memory-schema.ts
+++ b/ui/src/pages/config/memory-schema.ts
@@ -164,10 +164,6 @@ export function resolveMemoryBackend(configObject: Record<string, unknown>): Mem
 
 type JsonRecord = Record<string, unknown>;
 
-function asJsonRecord(value: unknown): JsonRecord | null {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
-}
-
 // One narrowed schema object per (source schema, key set): the config view caches
 // its schema analysis by object identity, so a fresh clone per render would
 // re-analyze the whole tree on every update.
@@ -178,9 +174,9 @@ const narrowedMemorySchemas = new WeakMap<JsonRecord, Map<string, unknown>>();
  * page can host several tabs over disjoint slices of the same schema section.
  */
 export function narrowMemorySchema(schema: unknown, keys: readonly string[]): unknown {
-  const root = asJsonRecord(schema);
-  const memorySchema = asJsonRecord(asJsonRecord(root?.properties)?.memory);
-  const memoryProperties = asJsonRecord(memorySchema?.properties);
+  const root = asConfigRecord(schema);
+  const memorySchema = asConfigRecord(asConfigRecord(root?.properties)?.memory);
+  const memoryProperties = asConfigRecord(memorySchema?.properties);
   if (!root || !memorySchema || !memoryProperties) {
     return schema;
   }

--- a/ui/src/pages/config/talk-schema.ts
+++ b/ui/src/pages/config/talk-schema.ts
@@ -1,6 +1,8 @@
 // Config-facts module for the curated Talk settings page. No lit imports: like
 // memory-schema.ts, settings search evaluates these facts from the startup
 // chunk and must not pull settings UI code in with them.
+import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeNullableString as readTrimmedString } from "@openclaw/normalization-core/string-coerce";
 
 /** Normalized model/voice pair from one `talk.realtime.providers.<id>` entry. */
 type TalkProviderEntryValues = {
@@ -20,20 +22,6 @@ export type TalkRealtimeSelection = {
   /** Per-provider fallback values keyed by the raw config map key. */
   providerEntries: Record<string, TalkProviderEntryValues>;
 };
-
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function readTrimmedString(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
-}
 
 /**
  * Raw talk.realtime picks plus each provider entry's fallback values. Which

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html } from "lit";
 import { GatewayRequestError, type GatewayEventFrame } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
@@ -142,12 +143,6 @@ const CHANNEL_AUTH_STATUS_KEYS = [
   "signingSecretStatus",
   "userTokenStatus",
 ] as const;
-
-function asRecord(value: unknown): UnknownRecord | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as UnknownRecord)
-    : null;
-}
 
 function hasUnavailableAuth(account: UnknownRecord): boolean {
   return CHANNEL_AUTH_STATUS_KEYS.some((key) => account[key] === "configured_unavailable");

--- a/ui/src/pages/custodian/structured-question.ts
+++ b/ui/src/pages/custodian/structured-question.ts
@@ -1,4 +1,5 @@
 import type { SystemAgentChatQuestion } from "@openclaw/gateway-protocol";
+import { normalizeNullableString as nonEmptyString } from "@openclaw/normalization-core/string-coerce";
 
 export type CustodianStructuredQuestion = {
   id: string;
@@ -8,10 +9,6 @@ export type CustodianStructuredQuestion = {
   isOther: boolean;
   skipAction?: "exit";
 };
-
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
 
 /**
  * Sanitize the typed `question` field from `openclaw.chat`. The gateway owns

--- a/ui/src/pages/new-session/cloud-recovery.ts
+++ b/ui/src/pages/new-session/cloud-recovery.ts
@@ -1,3 +1,4 @@
+import { hasNonEmptyString as isNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionCreateParams } from "../../lib/sessions/create.ts";
 
 export type CloudSessionCreateParams = SessionCreateParams & {
@@ -26,10 +27,6 @@ const STORAGE_PREFIX = "openclaw.new-session.cloud-recovery.v1:";
 
 function storageKey(gatewayUrl: string, recoveryScope: string): string {
   return `${STORAGE_PREFIX}${gatewayUrl}:${recoveryScope}`;
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
 }
 
 const CLOUD_CREATE_STRING_FIELDS = [


### PR DESCRIPTION
## What Problem This Solves

OpenClaw still carried many private copies of record, string, number, JSON, UTF-16 truncation, HTTP response cleanup, error, and Result helpers. Those copies duplicated policy and made sibling call sites vulnerable to drifting semantics.

## Why This Change Was Made

This sweep moves byte-equivalent call sites onto the canonical normalization-core leaf helpers, adds one optionized `truncateWithMarker` owner, centralizes unread response-body cancellation in `src/infra/http-body.ts`, and reuses the shared text chunk limit normalization.

The audit preserved divergent contracts instead of forcing them through a superficially similar helper. In particular, array-rejecting object helpers use `asNullableRecord` (not the array-accepting object-record variant), whitespace-preserving string readers remain local, and the proposed Promise-like consolidation was skipped because current implementations differ on function thenables, proxy traps, non-callable `then`, and throwing getters and there is no normalization-core owner.

## User Impact

Normal behavior is unchanged except for the two error-coercion fixes listed below. Production code is smaller and coercion/truncation/response cleanup policy now has fewer independent implementations.

## Evidence

- Focused Vitest: 1,386 tests passed across 21 routed shards; the HTTP-body shard's 27 tests passed again after the final lint fix.
- `node scripts/check-changed.mjs`: remote providers were unavailable, so the repository-authorized local fallback ran the complete `all` plan. Typecheck, lint, Plugin SDK API/export/surface checks, package-lock validation, dead-export scan, plugin boundaries, database-first guard, and runtime import-cycle checks all passed.
- `node scripts/run-oxlint.mjs <changed TypeScript paths>`: passed.
- Autoreview: `autoreview clean: no accepted/actionable findings reported` (`overall: patch is correct (0.94)`).
- Exact failed CI shard reproduced and fixed: `test/scripts/release-wrapper-scripts.test.ts` now proves the source-consumed plugin contract remains resolvable from a historical release-target cwd.
- Production numstat: +324 / -837, net -513 lines.
- Test numstat: +95 / -10, net +85 lines.

### After-fix runtime proof

Scratch-only plain-Node harness command (run from the repository root at the exact PR head; the harness imported the real worker, database-verifier, and shared binary-response code paths):

```sh
node --import tsx /tmp/openclaw-pr120350-runtime-proof.D8iL8s/runtime-proof.mjs
```

Redacted captured stdout (exit 0; no credentials or external services involved):

```json
{"head":"c9821c8c3f37a81c26c3b68d2d3524260ec801e5","node":"v24.19.0","workerConnectionContract":{"throwingError":{"noThrow":true,"sameIdentity":true,"isError":true,"name":"ThrowingToStringError","message":"worker failure","causeIsInput":false,"reservedCausePreserved":true,"stackPreserved":true,"code":"E_RUNTIME_PROOF","toStringCalls":0},"plainObject":{"isError":true,"legacyMessage":"[object Object]","message":"[object Object]","causeIsOriginalObject":true,"originalCauseReachable":true,"code":"E_WORKER"}},"databaseVerify":{"throwingError":{"noThrow":true,"sameIdentity":true,"isError":true,"name":"ThrowingToStringError","message":"database failure","causeIsInput":false,"reservedCausePreserved":true,"stackPreserved":true,"code":"E_RUNTIME_PROOF","toStringCalls":0},"plainObject":{"isError":true,"legacyMessage":"[object Object]","message":"[object Object]","causeIsOriginalObject":true,"originalCauseReachable":true,"code":"E_DATABASE"}},"responseCleanup":{"jsonContentGuard":{"before":{"bodyUsed":false,"locked":false},"after":{"bodyUsed":true,"locked":false},"errorName":"Error","errorMessage":"runtime proof: malformed audio response"},"originalErrorPropagation":{"before":{"bodyUsed":false,"locked":false},"after":{"bodyUsed":true,"locked":false},"sameIdentity":true,"errorName":"Error","errorMessage":"runtime proof headers failure"}}}
```

This is a direct runtime harness, not a unit-test or live-provider claim. It shows both coercers avoid the hostile `toString()`, preserve Error identity/reserved fields, retain the legacy plain-object message while exposing the original object as `cause` and its structured `code`, and shows real JSON `Response` bodies transition from `bodyUsed:false/locked:false` to `bodyUsed:true/locked:false` through the shared binary guard while the original thrown error still propagates by identity.

## Intentional behavior fixes

- `src/worker/worker-connection-contract.ts`: non-Error objects keep the existing `String(error)` message and now preserve the original value as `cause` plus enumerable structured fields.
- `src/state/openclaw-database-verify.impl.ts`: the same cause/structured-field preservation now applies to database verification worker failures.

The listed `worker.runtime.ts` and prepared-model-runtime helpers were not migrated: their current fallback-message/cause contracts differ, and changing them would exceed the explicitly authorized behavior fixes.

`packages/plugin-package-contract` also retains source-level normalization imports rather than an `@openclaw/normalization-core` workspace dependency. Release planning imports this private source module while running from historical target directories where sibling `dist/` output is intentionally absent; CI covers that runtime contract.
