### PR TITLE
fix(qa): stabilize runtime tool evidence

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -254,6 +254,9 @@ export function buildQaToolSearchArgs(
       ].join("\n"),
     };
   }
+  if (failureMode && targetTool === "sessions_spawn") {
+    return { task: "" };
+  }
   if (failureMode) {
     return { __qaFailureMode: "denied-input" };
   }

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -5597,6 +5597,26 @@ Update and merge these partial structured summaries.`,
     expect(String(toolPlanOutput.arguments)).toContain("OPENCLAW_QA_WEB_SEARCH_DENIED_INPUT");
   });
 
+  it("plans sessions_spawn failure calls with an explicit empty task", async () => {
+    const server = await startMockServer();
+
+    const response = await expectNonStreamingResponses(server, {
+      tools: [SESSIONS_SPAWN_TOOL],
+      input: [
+        makeUserInput(
+          'QA routing marker: tool search qa failure target=sessions_spawn. Call sessions_spawn directly exactly once with task="". Do not repair, omit, replace, or retry the empty task.',
+        ),
+      ],
+    });
+
+    const payload = await response.json();
+    expect(outputItem(payload)).toMatchObject({
+      type: "function_call",
+      name: "sessions_spawn",
+    });
+    expect(outputToolArgs(payload)).toEqual({ task: "" });
+  });
+
   it.each([
     {
       label: "workspace-local happy",

--- a/extensions/qa-lab/src/runtime-tool-fixture.test.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.test.ts
@@ -722,8 +722,8 @@ describe("runtime tool fixture", () => {
     });
 
     expect(promptEvidence).toEqual([
-      { transcriptToolName: undefined, requireSuccessfulTranscriptToolResult: undefined },
-      { transcriptToolName: undefined, requireSuccessfulTranscriptToolResult: undefined },
+      { transcriptToolName: "apply_patch", requireSuccessfulTranscriptToolResult: true },
+      { transcriptToolName: "apply_patch", requireSuccessfulTranscriptToolResult: undefined },
     ]);
     expect(details).toContain("apply_patch live provider happy planned args");
     expect(details).toContain("runtime-tool-fixture-patch.txt");
@@ -762,8 +762,8 @@ describe("runtime tool fixture", () => {
     ).resolves.toContain("apply_patch live provider happy planned args");
 
     expect(promptEvidence).toEqual([
-      { transcriptToolName: undefined, requireSuccessfulTranscriptToolResult: undefined },
-      { transcriptToolName: undefined, requireSuccessfulTranscriptToolResult: undefined },
+      { transcriptToolName: "apply_patch", requireSuccessfulTranscriptToolResult: true },
+      { transcriptToolName: "apply_patch", requireSuccessfulTranscriptToolResult: undefined },
     ]);
   });
 

--- a/extensions/qa-lab/src/runtime-tool-fixture.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.ts
@@ -1000,9 +1000,7 @@ export async function runRuntimeToolFixture(
         sessionKey: happySessionKey,
         message: happyPrompt,
         timeoutMs: liveTurnTimeoutMs(env, 45_000),
-        ...(happyPathOutputRequired &&
-        requireTranscriptEvidence &&
-        !requireNativePatchTranscriptEvidence
+        ...(happyPathOutputRequired && requireTranscriptEvidence
           ? { transcriptToolName: toolName, requireSuccessfulTranscriptToolResult: true }
           : {}),
       });
@@ -1045,9 +1043,7 @@ export async function runRuntimeToolFixture(
         sessionKey: failureSessionKey,
         message: failurePrompt,
         timeoutMs: liveTurnTimeoutMs(env, 45_000),
-        ...(requireTranscriptEvidence && !requireNativePatchTranscriptEvidence
-          ? { transcriptToolName: toolName }
-          : {}),
+        ...(requireTranscriptEvidence ? { transcriptToolName: toolName } : {}),
       });
     if (toolName !== "apply_patch") {
       return runFailurePrompt();

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -545,6 +545,20 @@ describe("qa scenario catalog", () => {
       },
     });
     expect(readQaScenarioExecutionConfig(sessionsSpawn.id)).not.toHaveProperty("knownHarnessGap");
+    const sessionsSpawnConfig = readQaScenarioExecutionConfig(sessionsSpawn.id);
+    expect(sessionsSpawnConfig?.happyPrompt).toContain("sessions_spawn directly exactly once");
+    expect(sessionsSpawnConfig?.happyPrompt).toContain(
+      'task="Runtime tool fixture subagent: reply exactly RUNTIME-TOOL-FIXTURE."',
+    );
+    expect(sessionsSpawnConfig?.happyPrompt).toContain('label="runtime-tool-fixture"');
+    expect(sessionsSpawnConfig?.happyPrompt).toContain('mode="run"');
+    expect(sessionsSpawnConfig?.happyPrompt).toContain("thread=false");
+    expect(sessionsSpawnConfig?.failurePrompt).toContain(
+      'sessions_spawn directly exactly once with task=""',
+    );
+    expect(sessionsSpawnConfig?.failurePrompt).toContain(
+      "Do not repair, omit, replace, or retry the empty task",
+    );
     const webFetchConfig = readQaScenarioExecutionConfig(webFetch.id);
     expect(webFetchConfig?.happyPrompt).toContain("Call web_fetch exactly once");
     expect(webFetchConfig?.happyPrompt).toContain("call it directly without tool_search");

--- a/qa/scenarios/runtime/tools/sessions-spawn.yaml
+++ b/qa/scenarios/runtime/tools/sessions-spawn.yaml
@@ -23,6 +23,18 @@ scenario:
     summary: Exercise the sessions_spawn runtime tool family.
     config:
       toolName: sessions_spawn
+      happyPrompt: >-
+        QA routing marker: tool search qa check target=sessions_spawn. Call
+        sessions_spawn directly exactly once with task="Runtime tool fixture
+        subagent: reply exactly RUNTIME-TOOL-FIXTURE.",
+        label="runtime-tool-fixture", mode="run", and thread=false. Do not call
+        tool_search. Wait for sessions_spawn to return, then summarize the
+        actual result.
+      failurePrompt: >-
+        QA routing marker: tool search qa failure target=sessions_spawn. Call
+        sessions_spawn directly exactly once with task="". Do not repair,
+        omit, replace, or retry the empty task. Do not call tool_search.
+        Summarize the actual rejection.
       toolCoverage:
         family: sessions_spawn
         actualTool: sessions_spawn


### PR DESCRIPTION
Related: #80319

## What Problem This Solves

Resolves two QA evidence defects in the runtime-tool parity fixtures.

First, native Codex `apply_patch` behavior could complete before its projected transcript result was durably observable. The fixture's native-patch-specific exclusions bypassed the existing persisted-transcript wait, so parity capture could inspect the session before the authoritative tool result appeared.

Second, the generic `sessions_spawn` prompts were ambiguous under Codex's automatic tool choice and non-strict function schema. The failure mock also used a generic denied-input marker instead of the real invalid contract, an empty `task`, allowing the model or mock path to repair, omit, or retry the intended failure call.

## Why This Change Was Made

The native patch fixture now reuses the existing bounded transcript poll in `suite-runtime-agent-process.ts`. The happy path waits for a linked successful `apply_patch` result, while the failure path waits for a linked completed result without requiring success. Mock-only patch behavior remains unchanged.

The `sessions_spawn` scenario now directs exactly one call with stable happy-path arguments and exactly one failure call with `task=""`, explicitly forbidding repair, omission, replacement, or retry. The mock provider now emits the same empty-task failure arguments.

No Codex `tool_choice`, harness timeout, report-only status, provider policy, or model-specific production behavior changed. The repair stays within the QA fixture and evidence-persistence owners.

## User Impact

Runtime-pair QA now captures completed native patch evidence deterministically and exercises the actual `sessions_spawn` invalid-input contract instead of depending on model interpretation.

## Evidence

Commits:

- `79078d95d71959e52239ecfacef12e5570dd4048` - `fix(qa): wait for native patch transcript completion`
- `0d724d4b3db8f07ef173c42af46eadf1c42c231d` - `fix(qa): make sessions spawn fixtures deterministic`

Focused validation:

- Requested four-file Vitest command: 418 passing tests.
- Native patch fixture suite: 62 passing tests.
- Touched runtime-tool catalog assertion: passing.
- Targeted `oxfmt`, targeted `oxlint`, and `git diff --check`: clean.
- Autoreview: clean, with no accepted or actionable findings.

Current-main failure, not touched by this PR:

- The prior catalog mismatch was fixed on main by #120335; the focused rerun passes.
- The repo oxlint wrapper stops during package-boundary preparation on the unchanged `packages/terminal-core/src/ansi.ts:194` type error. Targeted lint of the changed TypeScript files is clean.

Direct Codex dependency evidence was audited at `rust-v0.146.1` (`79b4f03d35962b005b007a015113b38930711665`):

- `codex-rs/app-server/README.md:1467`, `codex-rs/app-server/README.md:1478`, and `codex-rs/app-server/README.md:1553` define the `fileChange` and authoritative `item/completed` lifecycle.
- `codex-rs/core/src/client.rs:907` constructs Responses requests with automatic tool choice.
- `codex-rs/core/src/tools/handlers/multi_agents_spec.rs:83` defines the spawn tool as non-strict.
- `codex-rs/tools/src/responses_api.rs:25` and `codex-rs/tools/src/responses_api.rs:127` serialize the strict field and preserve non-strict converted tools.

LOC:

- Product runtime: `0`
- QA harness non-test: `+5/-6`
- Tests and scenarios: `+50/-4`

Punchcard-Session: golden-valley-workshop-br
Provenance: #113420, #113484, and #114907 are merged lineage. #80319 remains the canonical umbrella.

