### PR TITLE
fix(tasks): prevent task list pagination from skipping active tasks

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1542,6 +1542,20 @@ public struct McpAppViewExpiredErrorDetails: Codable, Sendable {
     }
 }
 
+public struct TasksListCursorStaleErrorDetails: Codable, Sendable {
+    public let code: String
+
+    public init(
+        code: String)
+    {
+        self.code = code
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+    }
+}
+
 public struct UnknownAgentIdErrorDetails: Codable, Sendable {
     public let code: String
     public let agentid: String
@@ -18116,6 +18130,7 @@ public enum BoardCommand: Codable, Sendable {
 public enum GatewayErrorDetails: Codable, Sendable {
     case missingScope(MissingScopeErrorDetails)
     case mcpAppViewExpired(McpAppViewExpiredErrorDetails)
+    case tasksListCursorStale(TasksListCursorStaleErrorDetails)
     case unknownAgentId(UnknownAgentIdErrorDetails)
     case wizardNotFound(WizardNotFoundErrorDetails)
 
@@ -18133,6 +18148,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         switch self {
         case .missingScope(let value): value.code
         case .mcpAppViewExpired(let value): value.code
+        case .tasksListCursorStale(let value): value.code
         case .unknownAgentId(let value): value.code
         case .wizardNotFound(let value): value.code
         }
@@ -18158,6 +18174,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         switch discriminator {
         case "MISSING_SCOPE": self = try .missingScope(MissingScopeErrorDetails(from: decoder))
         case "MCP_APP_VIEW_EXPIRED": self = try .mcpAppViewExpired(McpAppViewExpiredErrorDetails(from: decoder))
+        case "TASKS_LIST_CURSOR_STALE": self = try .tasksListCursorStale(TasksListCursorStaleErrorDetails(from: decoder))
         case "UNKNOWN_AGENT_ID": self = try .unknownAgentId(UnknownAgentIdErrorDetails(from: decoder))
         case "WIZARD_NOT_FOUND": self = try .wizardNotFound(WizardNotFoundErrorDetails(from: decoder))
         default:
@@ -18173,6 +18190,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         switch self {
         case .missingScope(let value): try value.encode(to: encoder)
         case .mcpAppViewExpired(let value): try value.encode(to: encoder)
+        case .tasksListCursorStale(let value): try value.encode(to: encoder)
         case .unknownAgentId(let value): try value.encode(to: encoder)
         case .wizardNotFound(let value): try value.encode(to: encoder)
         }

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -875,6 +875,11 @@ return sanitized task summaries, not raw runtime state.
     optional `agentId`, optional `sessionKey`, optional `limit` from `1` to
     `500`, and optional string `cursor`.
   - Result: `{ "tasks": TaskSummary[], "nextCursor"?: string }`.
+  - Cursors are opaque and bound to the normalized query and filtered task order.
+    If task activity changes that order between pages, the Gateway returns
+    `INVALID_REQUEST` with detail code `TASKS_LIST_CURSOR_STALE`. Discard any
+    partial pages and restart the traversal without a cursor; retrying the same
+    stale cursor cannot succeed.
 - `tasks.get` requires `operator.read`.
   - Params: `{ "taskId": string }`.
   - Result: `{ "task": TaskSummary }`.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -878,8 +878,7 @@ return sanitized task summaries, not raw runtime state.
   - Cursors are opaque and bound to the normalized query and filtered task order.
     If task activity changes that order between pages, the Gateway returns
     `INVALID_REQUEST` with detail code `TASKS_LIST_CURSOR_STALE`. Discard any
-    partial pages and restart the traversal without a cursor; retrying the same
-    stale cursor cannot succeed.
+    partial pages and restart the traversal without a cursor.
 - `tasks.get` requires `operator.read`.
   - Params: `{ "taskId": string }`.
   - Result: `{ "task": TaskSummary }`.

--- a/packages/gateway-protocol/src/gateway-error-details.ts
+++ b/packages/gateway-protocol/src/gateway-error-details.ts
@@ -24,6 +24,7 @@ export const GatewayErrorDetailCodes = {
   MISSING_SCOPE: "MISSING_SCOPE",
   MCP_APP_VIEW_EXPIRED: "MCP_APP_VIEW_EXPIRED",
   SESSION_COMPANION_BUSY: "SESSION_COMPANION_BUSY",
+  TASKS_LIST_CURSOR_STALE: "TASKS_LIST_CURSOR_STALE",
   UNKNOWN_AGENT_ID: "UNKNOWN_AGENT_ID",
   WIZARD_NOT_FOUND: "WIZARD_NOT_FOUND",
 } as const;
@@ -37,6 +38,10 @@ export type MissingScopeErrorDetails = {
 
 export type McpAppViewExpiredErrorDetails = {
   code: typeof GatewayErrorDetailCodes.MCP_APP_VIEW_EXPIRED;
+};
+
+export type TasksListCursorStaleErrorDetails = {
+  code: typeof GatewayErrorDetailCodes.TASKS_LIST_CURSOR_STALE;
 };
 
 /** Unknown agent details carried by agent-scoped method validation failures. */
@@ -54,6 +59,7 @@ export type WizardNotFoundErrorDetails = {
 export type GatewayErrorDetails =
   | MissingScopeErrorDetails
   | McpAppViewExpiredErrorDetails
+  | TasksListCursorStaleErrorDetails
   | UnknownAgentIdErrorDetails
   | WizardNotFoundErrorDetails;
 

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -21,6 +21,7 @@ export type {
   GatewayErrorDetails,
   McpAppViewExpiredErrorDetails,
   MissingScopeErrorDetails,
+  TasksListCursorStaleErrorDetails,
   WizardNotFoundErrorDetails,
 } from "./schema/error-codes.js";
 export * from "./schema/board.js";

--- a/packages/gateway-protocol/src/schema/error-codes.test.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.test.ts
@@ -10,6 +10,7 @@ import {
   missingScopeErrorShape,
   readMissingScopeError,
   readMissingScopeErrorDetails,
+  TasksListCursorStaleErrorDetailsSchema,
   UnknownAgentIdErrorDetailsSchema,
   WizardNotFoundErrorDetailsSchema,
 } from "./error-codes.js";
@@ -35,6 +36,15 @@ describe("gateway error details", () => {
     expect(Value.Check(GatewayErrorDetailsSchema, details)).toBe(true);
     expect(isMcpAppViewExpiredError({ details })).toBe(true);
     expect(isMcpAppViewExpiredError(new Error("upstream token expired"))).toBe(false);
+  });
+
+  it("validates stale task cursor details", () => {
+    const details = { code: GatewayErrorDetailCodes.TASKS_LIST_CURSOR_STALE };
+    expect(Value.Check(TasksListCursorStaleErrorDetailsSchema, details)).toBe(true);
+    expect(Value.Check(GatewayErrorDetailsSchema, details)).toBe(true);
+    expect(Value.Check(TasksListCursorStaleErrorDetailsSchema, { ...details, offset: 2 })).toBe(
+      false,
+    );
   });
 
   it("validates unknown-agent details", () => {

--- a/packages/gateway-protocol/src/schema/error-codes.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.ts
@@ -17,6 +17,7 @@ export {
   type GatewayErrorDetails,
   type McpAppViewExpiredErrorDetails,
   type MissingScopeErrorDetails,
+  type TasksListCursorStaleErrorDetails,
   type UnknownAgentIdErrorDetails,
   type WizardNotFoundErrorDetails,
   isMcpAppViewExpiredError,
@@ -35,6 +36,10 @@ export const McpAppViewExpiredErrorDetailsSchema = closedObject({
   code: Type.Literal(GatewayErrorDetailCodes.MCP_APP_VIEW_EXPIRED),
 });
 
+export const TasksListCursorStaleErrorDetailsSchema = closedObject({
+  code: Type.Literal(GatewayErrorDetailCodes.TASKS_LIST_CURSOR_STALE),
+});
+
 export const UnknownAgentIdErrorDetailsSchema = closedObject({
   code: Type.Literal(GatewayErrorDetailCodes.UNKNOWN_AGENT_ID),
   agentId: NonEmptyString,
@@ -48,6 +53,7 @@ export const WizardNotFoundErrorDetailsSchema = closedObject({
 export const GatewayErrorDetailsSchema = Type.Union([
   MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetailsSchema,
+  TasksListCursorStaleErrorDetailsSchema,
   UnknownAgentIdErrorDetailsSchema,
   WizardNotFoundErrorDetailsSchema,
 ]);

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-transport.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-transport.ts
@@ -18,6 +18,7 @@ export const TransportProtocolSchemas = {
   ErrorShape: frames.ErrorShapeSchema,
   MissingScopeErrorDetails: errorCodes.MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetails: errorCodes.McpAppViewExpiredErrorDetailsSchema,
+  TasksListCursorStaleErrorDetails: errorCodes.TasksListCursorStaleErrorDetailsSchema,
   UnknownAgentIdErrorDetails: errorCodes.UnknownAgentIdErrorDetailsSchema,
   WizardNotFoundErrorDetails: errorCodes.WizardNotFoundErrorDetailsSchema,
   GatewayErrorDetails: errorCodes.GatewayErrorDetailsSchema,

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -71,13 +71,13 @@ export const TasksListParamsSchema = closedObject({
   agentId: Type.Optional(NonEmptyString),
   sessionKey: Type.Optional(NonEmptyString),
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
-  cursor: Type.Optional(Type.String()),
+  cursor: Type.Optional(Type.String({ maxLength: 1024 })),
 });
 
 /** Task list page response. */
 export const TasksListResultSchema = closedObject({
   tasks: Type.Array(TaskSummarySchema),
-  nextCursor: Type.Optional(Type.String()),
+  nextCursor: Type.Optional(Type.String({ maxLength: 1024 })),
 });
 
 /** Lookup request for one task id. */

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -631,6 +631,7 @@ function emitDiscriminatedUnionCompatibility(name: string): string[] {
     "        switch self {",
     "        case .missingScope(let value): value.code",
     "        case .mcpAppViewExpired(let value): value.code",
+    "        case .tasksListCursorStale(let value): value.code",
     "        case .unknownAgentId(let value): value.code",
     "        case .wizardNotFound(let value): value.code",
     "        }",

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -250,15 +250,107 @@ describe("tasks gateway handlers", () => {
     const page1 = await runTaskHandler("tasks.list", { limit: 2 });
     expect(page1.calls[0]?.[0]).toBe(true);
     expect(page1.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(0, 2));
-    expect(page1.payload?.nextCursor).toBe("2");
+    expect(page1.payload?.nextCursor).toEqual(expect.any(String));
 
-    const page2 = await runTaskHandler("tasks.list", { limit: 2, cursor: "2" });
+    const page2 = await runTaskHandler("tasks.list", {
+      limit: 2,
+      cursor: page1.payload?.nextCursor,
+    });
     expect(page2.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(2, 4));
-    expect(page2.payload?.nextCursor).toBe("4");
+    expect(page2.payload?.nextCursor).toEqual(expect.any(String));
 
-    const page3 = await runTaskHandler("tasks.list", { limit: 2, cursor: "4" });
+    const page3 = await runTaskHandler("tasks.list", {
+      limit: 2,
+      cursor: page2.payload?.nextCursor,
+    });
     expect(page3.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(4));
     expect(page3.payload?.nextCursor).toBeUndefined();
+  });
+
+  it("rejects a continuation when task activity reorders the ledger", async () => {
+    const snapshots = [
+      createSnapshotTask({ taskId: "task-a", runId: "run-a", lastEventAt: 4_000 }),
+      createSnapshotTask({ taskId: "task-b", runId: "run-b", lastEventAt: 3_000 }),
+      createSnapshotTask({ taskId: "task-c", runId: "run-c", lastEventAt: 2_000 }),
+      createSnapshotTask({ taskId: "task-d", runId: "run-d", lastEventAt: 1_000 }),
+    ];
+    saveTaskRegistryStateToSqlite({
+      tasks: new Map(snapshots.map((task) => [task.taskId, task])),
+      deliveryStates: new Map(),
+    });
+    reloadTaskRegistryFromStore();
+
+    const page1 = await runTaskHandler("tasks.list", { limit: 2 });
+    expect(page1.calls[0]?.[0]).toBe(true);
+    expect(page1.payload?.tasks?.map((task) => task.id)).toEqual(["task-a", "task-b"]);
+    expect(page1.payload?.nextCursor).toEqual(expect.any(String));
+
+    markTaskTerminalById({
+      taskId: "task-c",
+      status: "succeeded",
+      endedAt: Date.now(),
+      terminalSummary: "Task C moved ahead of the first page",
+    });
+
+    const page2 = await runTaskHandler("tasks.list", {
+      limit: 2,
+      cursor: page1.payload?.nextCursor,
+    });
+    expect(page2.calls[0]?.[0]).toBe(false);
+    expect(page2.calls[0]?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      details: { code: "TASKS_LIST_CURSOR_STALE" },
+    });
+  });
+
+  it("rejects legacy numeric task cursors", async () => {
+    const result = await runTaskHandler("tasks.list", { cursor: "2" });
+
+    expect(result.calls[0]?.[0]).toBe(false);
+    expect(result.calls[0]?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: "invalid tasks.list cursor",
+    });
+  });
+
+  it("rejects oversized task cursors before decoding", async () => {
+    const result = await runTaskHandler("tasks.list", { cursor: "a".repeat(1_025) });
+
+    expect(result.calls[0]?.[0]).toBe(false);
+    expect(result.calls[0]?.[2]).toMatchObject({ code: "INVALID_REQUEST" });
+  });
+
+  it("rejects a task cursor reused with different filters", async () => {
+    createTaskRecord({
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      task: "Running task",
+      status: "running",
+      deliveryStatus: "pending",
+    });
+    createTaskRecord({
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      task: "Second running task",
+      status: "running",
+      deliveryStatus: "pending",
+    });
+
+    const page1 = await runTaskHandler("tasks.list", { limit: 1 });
+    const page2 = await runTaskHandler("tasks.list", {
+      limit: 1,
+      status: "running",
+      cursor: page1.payload?.nextCursor,
+    });
+
+    expect(page2.calls[0]?.[0]).toBe(false);
+    expect(page2.calls[0]?.[2]).toMatchObject({
+      details: { code: "TASKS_LIST_CURSOR_STALE" },
+    });
   });
 
   it("uses task id as the stable activity-order tie break", async () => {
@@ -305,7 +397,7 @@ describe("tasks gateway handlers", () => {
       const { payload } = await runTaskHandler("tasks.list", { limit: 2 });
 
       expect(payload?.tasks).toHaveLength(2);
-      expect(payload?.nextCursor).toBe("2");
+      expect(payload?.nextCursor).toEqual(expect.any(String));
       expect(cloneSpy).toHaveBeenCalledTimes(2);
     } finally {
       cloneSpy.mockRestore();

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -303,8 +303,19 @@ describe("tasks gateway handlers", () => {
     });
   });
 
-  it("rejects legacy numeric task cursors", async () => {
-    const result = await runTaskHandler("tasks.list", { cursor: "2" });
+  it.each(["2", " 002 "])("treats a legacy numeric task cursor %j as stale", async (cursor) => {
+    const result = await runTaskHandler("tasks.list", { cursor });
+
+    expect(result.calls[0]?.[0]).toBe(false);
+    expect(result.calls[0]?.[2]).toMatchObject({
+      code: "INVALID_REQUEST",
+      message: "stale tasks.list cursor",
+      details: { code: "TASKS_LIST_CURSOR_STALE" },
+    });
+  });
+
+  it("rejects malformed task cursors as invalid input", async () => {
+    const result = await runTaskHandler("tasks.list", { cursor: "2x" });
 
     expect(result.calls[0]?.[0]).toBe(false);
     expect(result.calls[0]?.[2]).toMatchObject({

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -1,8 +1,10 @@
 // Task gateway methods expose detached task list/get/cancel operations with
 // bounded public summaries over the runtime task registry.
+import { stableStringify } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
+  GatewayErrorDetailCodes,
   errorShape,
   type TaskSummary,
   type TasksListParams,
@@ -17,6 +19,7 @@ import {
   retrySubagentCompletionDelivery,
 } from "../../agents/subagent-completion-delivery.js";
 import { canonicalizeMainSessionAlias } from "../../config/sessions.js";
+import { sha256Base64Url } from "../../infra/crypto-digest.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { getTaskById, listTaskRecordPage } from "../../tasks/runtime-internal.js";
 import type { TaskStatus } from "../../tasks/task-registry.types.js";
@@ -26,6 +29,7 @@ import { assertValidParams } from "./validation.js";
 
 const DEFAULT_TASKS_LIST_LIMIT = 100;
 const MAX_TASKS_LIST_LIMIT = 500;
+const MAX_TASKS_LIST_CURSOR_LENGTH = 1024;
 
 type TaskLedgerStatus = TaskSummary["status"];
 
@@ -46,17 +50,65 @@ function normalizeTaskStatusFilter(status: TasksListParams["status"]): Set<TaskS
   return new Set(statuses.flatMap((value) => LEDGER_STATUS_TO_TASK_STATUSES[value] ?? []));
 }
 
-// Cursor strings are offsets, not opaque tokens; reject malformed values so a
-// client cannot silently restart pagination at the first page.
-function parseCursor(cursor: string | undefined): number | null {
+type TasksListCursor = {
+  v: 1;
+  offset: number;
+  revision: string;
+  query: string;
+};
+
+function encodeCursor(cursor: TasksListCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function parseCursor(cursor: string | undefined): TasksListCursor | null | undefined {
   if (!cursor) {
-    return 0;
+    return undefined;
   }
-  if (!/^\d+$/.test(cursor.trim())) {
+  const normalized = cursor.trim();
+  if (
+    !normalized ||
+    normalized.length > MAX_TASKS_LIST_CURSOR_LENGTH ||
+    !/^[A-Za-z0-9_-]+$/.test(normalized)
+  ) {
     return null;
   }
-  const parsed = Number(cursor);
-  return Number.isSafeInteger(parsed) ? parsed : null;
+  try {
+    const decoded = JSON.parse(Buffer.from(normalized, "base64url").toString("utf8")) as unknown;
+    if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+      return null;
+    }
+    const candidate = decoded as Partial<TasksListCursor>;
+    if (
+      candidate.v !== 1 ||
+      !Number.isSafeInteger(candidate.offset) ||
+      (candidate.offset ?? -1) < 0 ||
+      typeof candidate.revision !== "string" ||
+      !candidate.revision ||
+      typeof candidate.query !== "string" ||
+      !candidate.query
+    ) {
+      return null;
+    }
+    const parsed = candidate as TasksListCursor;
+    return encodeCursor(parsed) === normalized ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveQueryFingerprint(params: {
+  statuses?: readonly TaskStatus[];
+  agentId?: string;
+  sessionKey?: string;
+}): string {
+  return `sha256:${sha256Base64Url(
+    stableStringify({
+      statuses: params.statuses?.toSorted() ?? [],
+      agentId: normalizeOptionalString(params.agentId) ?? null,
+      sessionKey: normalizeOptionalString(params.sessionKey) ?? null,
+    }),
+  )}`;
 }
 
 // Control UI task methods expose the stable gateway protocol shape; helpers
@@ -90,20 +142,46 @@ export const tasksHandlers: GatewayRequestHandlers = {
         sessionKey: requestedSessionKey,
       });
     }
-    // The ledger pages by last activity so an old long-running task that just
-    // finished still surfaces first. Selection stays inside the registry so
-    // only the bounded wire page pays for defensive record cloning.
-    const page = listTaskRecordPage({
-      offset: cursor,
-      limit,
-      statuses: statusFilter ? [...statusFilter] : undefined,
+    const statuses = statusFilter ? [...statusFilter] : undefined;
+    const queryFingerprint = resolveQueryFingerprint({
+      statuses,
       agentId: params.agentId,
       sessionKey,
     });
-    const nextOffset = cursor + page.tasks.length;
+    // The ledger pages by last activity so an old long-running task that just
+    // finished still surfaces first. Selection stays inside the registry so
+    // only the bounded wire page pays for defensive record cloning.
+    const offset = cursor?.offset ?? 0;
+    const page = listTaskRecordPage({
+      offset,
+      limit,
+      statuses,
+      agentId: params.agentId,
+      sessionKey,
+    });
+    if (cursor && (cursor.revision !== page.revision || cursor.query !== queryFingerprint)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "stale tasks.list cursor", {
+          details: { code: GatewayErrorDetailCodes.TASKS_LIST_CURSOR_STALE },
+        }),
+      );
+      return;
+    }
+    const nextOffset = offset + page.tasks.length;
     respond(true, {
       tasks: page.tasks.map((task) => mapTaskSummary(task)),
-      ...(page.hasMore ? { nextCursor: String(nextOffset) } : {}),
+      ...(page.hasMore
+        ? {
+            nextCursor: encodeCursor({
+              v: 1,
+              offset: nextOffset,
+              revision: page.revision,
+              query: queryFingerprint,
+            }),
+          }
+        : {}),
     });
   },
   "tasks.get": ({ params, respond }) => {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -61,16 +61,21 @@ function encodeCursor(cursor: TasksListCursor): string {
   return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
 }
 
-function parseCursor(cursor: string | undefined): TasksListCursor | null | undefined {
+function parseCursor(cursor: string | undefined): TasksListCursor | "legacy" | null | undefined {
   if (!cursor) {
     return undefined;
   }
   const normalized = cursor.trim();
-  if (
-    !normalized ||
-    normalized.length > MAX_TASKS_LIST_CURSOR_LENGTH ||
-    !/^[A-Za-z0-9_-]+$/.test(normalized)
-  ) {
+  if (!normalized || normalized.length > MAX_TASKS_LIST_CURSOR_LENGTH) {
+    return null;
+  }
+  // The previous Gateway emitted decimal offsets. Never resume one against the
+  // mutable task order, but preserve its upgrade path through the stale-cursor
+  // response that clients already know how to restart.
+  if (/^\d+$/.test(normalized) && Number.isSafeInteger(Number(normalized))) {
+    return "legacy";
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(normalized)) {
     return null;
   }
   try {
@@ -124,6 +129,16 @@ export const tasksHandlers: GatewayRequestHandlers = {
         false,
         undefined,
         errorShape(ErrorCodes.INVALID_REQUEST, "invalid tasks.list cursor"),
+      );
+      return;
+    }
+    if (cursor === "legacy") {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "stale tasks.list cursor", {
+          details: { code: GatewayErrorDetailCodes.TASKS_LIST_CURSOR_STALE },
+        }),
       );
       return;
     }

--- a/src/gateway/tasks-pagination.e2e.test.ts
+++ b/src/gateway/tasks-pagination.e2e.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { TasksListResult } from "../../packages/gateway-protocol/src/index.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { resetConfigOverrides } from "../config/runtime-overrides.js";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { markTaskTerminalById } from "../tasks/runtime-internal.js";
+import { reloadTaskRegistryFromStore } from "../tasks/task-registry.js";
+import { saveTaskRegistryStateToSqlite } from "../tasks/task-registry.store.sqlite.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+
+const ISOLATED_ENV_KEYS = [
+  "HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function resetGatewayState(): void {
+  resetConfigOverrides();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  clearSessionStoreCacheForTest();
+  resetTaskRegistryForTests({ persist: false });
+  closeOpenClawAgentDatabasesForTest();
+}
+
+function snapshotTask(taskId: string, lastEventAt: number): TaskRecord {
+  return {
+    taskId,
+    runtime: "cli",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    runId: `run-${taskId}`,
+    task: `Task ${taskId}`,
+    status: "running",
+    deliveryStatus: "pending",
+    notifyPolicy: "done_only",
+    createdAt: lastEventAt,
+    startedAt: lastEventAt,
+    lastEventAt,
+  };
+}
+
+async function listEveryTask(
+  client: Awaited<ReturnType<typeof startGatewayWithClient>>["client"],
+  limit: number,
+): Promise<string[]> {
+  const taskIds: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await client.request<TasksListResult>("tasks.list", {
+      limit,
+      ...(cursor ? { cursor } : {}),
+    });
+    taskIds.push(...page.tasks.map((task) => task.id));
+    cursor = page.nextCursor;
+  } while (cursor);
+  return taskIds;
+}
+
+describe("Gateway task pagination", () => {
+  beforeEach(resetGatewayState);
+  afterEach(resetGatewayState);
+
+  it(
+    "restarts a traversal instead of returning mixed task order",
+    { timeout: 120_000 },
+    async () => {
+      const envSnapshot = captureEnv([...ISOLATED_ENV_KEYS]);
+      const tempHome = tempDirs.make("openclaw-task-pagination-");
+      const stateDir = path.join(tempHome, ".openclaw");
+      const bundledPluginsDir = path.join(tempHome, "empty-bundled-plugins");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const token = `task-pagination-${process.pid}`;
+      let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+      try {
+        await Promise.all([
+          fs.mkdir(stateDir, { recursive: true }),
+          fs.mkdir(bundledPluginsDir, { recursive: true }),
+        ]);
+        for (const [key, value] of Object.entries({
+          HOME: tempHome,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_GATEWAY_TOKEN: token,
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+          OPENCLAW_SKIP_CRON: "1",
+          OPENCLAW_SKIP_CANVAS_HOST: "1",
+          OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+          OPENCLAW_SKIP_PROVIDERS: "1",
+          OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        })) {
+          setTestEnvValue(key, value);
+        }
+
+        const initialTasks = [
+          snapshotTask("task-a", 4_000),
+          snapshotTask("task-b", 3_000),
+          snapshotTask("task-c", 2_000),
+          snapshotTask("task-d", 1_000),
+        ];
+        saveTaskRegistryStateToSqlite({
+          tasks: new Map(initialTasks.map((task) => [task.taskId, task])),
+          deliveryStates: new Map(),
+        });
+        reloadTaskRegistryFromStore();
+
+        const config = {
+          gateway: { auth: { mode: "token", token } },
+          plugins: { slots: { memory: "none" } },
+        } satisfies OpenClawConfig;
+        gateway = await startGatewayWithClient({
+          cfg: config,
+          configPath,
+          token,
+          clientDisplayName: "vitest-task-pagination",
+        });
+
+        const baseline = await listEveryTask(gateway.client, 2);
+        expect(new Set(baseline)).toEqual(new Set(["task-a", "task-b", "task-c", "task-d"]));
+        expect(new Set(baseline).size).toBe(baseline.length);
+
+        const page1 = await gateway.client.request<TasksListResult>("tasks.list", { limit: 2 });
+        expect(page1.tasks.map((task) => task.id)).toEqual(baseline.slice(0, 2));
+        expect(page1.nextCursor).toBeTypeOf("string");
+
+        const reorderedTaskId = baseline.at(-1);
+        if (!reorderedTaskId) {
+          throw new Error("expected a task outside the first page");
+        }
+        markTaskTerminalById({
+          taskId: reorderedTaskId,
+          status: "succeeded",
+          endedAt: Date.now(),
+          terminalSummary: "Task moved ahead of the first page",
+        });
+
+        await expect(
+          gateway.client.request<TasksListResult>("tasks.list", {
+            limit: 2,
+            cursor: page1.nextCursor,
+          }),
+        ).rejects.toMatchObject({
+          gatewayCode: "INVALID_REQUEST",
+          details: { code: "TASKS_LIST_CURSOR_STALE" },
+        });
+
+        const restarted = await listEveryTask(gateway.client, 2);
+        expect(new Set(restarted)).toEqual(new Set(["task-a", "task-b", "task-c", "task-d"]));
+        expect(new Set(restarted).size).toBe(restarted.length);
+      } finally {
+        try {
+          if (gateway) {
+            try {
+              await disconnectGatewayClient(gateway.client);
+            } finally {
+              await gateway.server.close({ reason: "task pagination E2E complete" });
+            }
+          }
+        } finally {
+          try {
+            resetGatewayState();
+          } finally {
+            envSnapshot.restore();
+          }
+        }
+      }
+    },
+  );
+});

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -1,4 +1,6 @@
+import { stableStringify } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { isActiveTaskStatus, ensureLinkedTaskFlowRegistryReady } from "./task-registry-common.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
@@ -72,7 +74,7 @@ export function listTaskRecordPage(params: {
   statuses?: readonly TaskStatus[];
   agentId?: string;
   sessionKey?: string;
-}): { tasks: TaskRecord[]; hasMore: boolean } {
+}): { tasks: TaskRecord[]; hasMore: boolean; revision: string } {
   ensureTaskRegistryReady();
   const statuses = params.statuses ? new Set(params.statuses) : null;
   const agentId = normalizeOptionalString(params.agentId);
@@ -97,6 +99,7 @@ export function listTaskRecordPage(params: {
   return {
     tasks: selected.map((task) => cloneTaskRecord(task)),
     hasMore: params.offset + selected.length < matching.length,
+    revision: `sha256:${sha256Base64Url(stableStringify(matching.map((task) => task.taskId)))}`,
   };
 }
 

--- a/ui/src/lib/gateway-errors.test.ts
+++ b/ui/src/lib/gateway-errors.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { GatewayRequestError } from "../api/gateway.ts";
-import { isMissingOperatorReadScopeError, isWizardNotFoundError } from "./gateway-errors.ts";
+import {
+  isMissingOperatorReadScopeError,
+  isTasksListCursorStaleError,
+  isWizardNotFoundError,
+} from "./gateway-errors.ts";
 
 function gatewayRequestError(params: { code: string; message: string; details?: unknown }): Error {
   return Object.assign(new Error(params.message), {
@@ -50,6 +54,23 @@ describe("gateway error helpers", () => {
     for (const details of [null, "WIZARD_NOT_FOUND", [], { code: 42 }]) {
       expect(isWizardNotFoundError({ gatewayCode: "INVALID_REQUEST", details })).toBe(false);
     }
+  });
+
+  it("classifies stale task cursors across Gateway error constructors", () => {
+    const error = gatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "stale tasks.list cursor",
+      details: { code: "TASKS_LIST_CURSOR_STALE" },
+    });
+
+    expect(error).not.toBeInstanceOf(GatewayRequestError);
+    expect(isTasksListCursorStaleError(error)).toBe(true);
+    expect(
+      isTasksListCursorStaleError({
+        gatewayCode: "INVALID_REQUEST",
+        details: { code: "UNKNOWN_AGENT_ID" },
+      }),
+    ).toBe(false);
   });
 
   it("classifies structured read-scope failures without message parsing", () => {

--- a/ui/src/lib/gateway-errors.ts
+++ b/ui/src/lib/gateway-errors.ts
@@ -8,6 +8,24 @@ import { asNullableRecord as asRecord } from "@openclaw/normalization-core/recor
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { resolveGatewayErrorDetailCode } from "../api/gateway.ts";
 
+/** Identifies a task-list continuation that must restart from page one. */
+export function isTasksListCursorStaleError(err: unknown): boolean {
+  const error = asRecord(err);
+  if (!error) {
+    return false;
+  }
+  const code =
+    typeof error.gatewayCode === "string"
+      ? error.gatewayCode
+      : typeof error.code === "string"
+        ? error.code
+        : null;
+  return (
+    code === ErrorCodes.INVALID_REQUEST &&
+    resolveGatewayErrorDetailCode(error) === GatewayErrorDetailCodes.TASKS_LIST_CURSOR_STALE
+  );
+}
+
 /** Identifies an expired process-local wizard session without parsing public copy. */
 export function isWizardNotFoundError(err: unknown): boolean {
   const error = asRecord(err);

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -28,6 +28,7 @@ import {
   type WorkboardTaskSummary,
 } from "./index.ts";
 import { normalizeExecution, normalizeMetadata } from "./metadata-normalization.ts";
+import { getWorkboardTaskPollBatch, listWorkboardTasks } from "./task-links.ts";
 import {
   createDeferred,
   createGatewaySession,
@@ -2142,6 +2143,110 @@ describe("workboard controller", () => {
       cursor: "page-2",
     });
     expect(getWorkboardState(host).cards[0]).toMatchObject({ taskId: "task-1" });
+  });
+
+  it("restarts paginated task loading after a stale cursor", async () => {
+    const linked = makeCard({
+      sessionKey: sampleTaskSessionKey,
+      runId: "run-1",
+    });
+    let taskListCalls = 0;
+    const client = createClient((method) => {
+      if (method === "workboard.cards.list") {
+        return listResult([linked], ["todo", "done"]);
+      }
+      if (method === "tasks.list") {
+        taskListCalls += 1;
+        if (taskListCalls === 1) {
+          return {
+            tasks: [{ ...sampleTask, id: "partial-task", taskId: "partial-task" }],
+            nextCursor: "stale-page",
+          };
+        }
+        if (taskListCalls === 2) {
+          throw new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message: "stale tasks.list cursor",
+            details: { code: "TASKS_LIST_CURSOR_STALE" },
+          });
+        }
+        return { tasks: [sampleTask] };
+      }
+      return {};
+    });
+
+    await loadBoard(client);
+
+    expect(taskListCalls).toBe(3);
+    expect(client.request).toHaveBeenNthCalledWith(2, "tasks.list", { limit: 500 });
+    expect(client.request).toHaveBeenNthCalledWith(3, "tasks.list", {
+      limit: 500,
+      cursor: "stale-page",
+    });
+    expect(client.request).toHaveBeenNthCalledWith(4, "tasks.list", { limit: 500 });
+    expect(getWorkboardState(host).cards[0]).toMatchObject({ taskId: "task-1" });
+  });
+
+  it("restarts a saved discovery cursor from the first page when stale", async () => {
+    const staleError = new GatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "stale tasks.list cursor",
+      details: { code: "TASKS_LIST_CURSOR_STALE" },
+    });
+    const client = createClient((method, params) => {
+      if (method !== "tasks.list") {
+        return {};
+      }
+      if ((params as { cursor?: string }).cursor) {
+        throw staleError;
+      }
+      return { tasks: [sampleTask], nextCursor: "fresh-page" };
+    });
+
+    const result = await getWorkboardTaskPollBatch(client, [], [{ cursor: "stale-page" }]);
+
+    expect(result).toMatchObject({
+      tasks: [sampleTask],
+      nextUnfilteredCursor: "fresh-page",
+      error: null,
+    });
+    expect(requestCalls(client, "tasks.list")).toEqual([
+      ["tasks.list", { cursor: "stale-page", limit: 500 }],
+      ["tasks.list", { limit: 500 }],
+    ]);
+  });
+
+  it("fails after bounded stale task pagination attempts", async () => {
+    let taskListCalls = 0;
+    const staleError = new GatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "stale tasks.list cursor",
+      details: { code: "TASKS_LIST_CURSOR_STALE" },
+    });
+    const client = createClient((method) => {
+      if (method !== "tasks.list") {
+        return {};
+      }
+      taskListCalls += 1;
+      if (taskListCalls % 2 === 1) {
+        return {
+          tasks: [{ ...sampleTask, id: `partial-${taskListCalls}` }],
+          nextCursor: `stale-${taskListCalls}`,
+        };
+      }
+      throw staleError;
+    });
+
+    await expect(listWorkboardTasks(client)).rejects.toBe(staleError);
+    expect(taskListCalls).toBe(6);
+    expect(requestCalls(client, "tasks.list")).toEqual([
+      ["tasks.list", { limit: 500 }],
+      ["tasks.list", { limit: 500, cursor: "stale-1" }],
+      ["tasks.list", { limit: 500 }],
+      ["tasks.list", { limit: 500, cursor: "stale-3" }],
+      ["tasks.list", { limit: 500 }],
+      ["tasks.list", { limit: 500, cursor: "stale-5" }],
+    ]);
   });
 
   it("summarizes parent dependency readiness from loaded cards", () => {

--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -28,6 +28,7 @@ import {
   type WorkboardTaskSummary,
 } from "./index.ts";
 import { normalizeExecution, normalizeMetadata } from "./metadata-normalization.ts";
+import { getWorkboardRuntime } from "./runtime.ts";
 import { getWorkboardTaskPollBatch, listWorkboardTasks } from "./task-links.ts";
 import {
   createDeferred,
@@ -60,6 +61,19 @@ function createSequencedClient(routes: Record<string, readonly unknown[]>, fallb
       throw reply;
     }
     return reply;
+  });
+}
+
+function createForeignGatewayRequestError(params: {
+  code: string;
+  message: string;
+  details?: unknown;
+}): Error {
+  return Object.assign(new Error(params.message), {
+    name: "GatewayRequestError",
+    code: params.code,
+    gatewayCode: params.code,
+    details: params.details,
   });
 }
 
@@ -2164,7 +2178,7 @@ describe("workboard controller", () => {
           };
         }
         if (taskListCalls === 2) {
-          throw new GatewayRequestError({
+          throw createForeignGatewayRequestError({
             code: "INVALID_REQUEST",
             message: "stale tasks.list cursor",
             details: { code: "TASKS_LIST_CURSOR_STALE" },
@@ -2187,33 +2201,50 @@ describe("workboard controller", () => {
     expect(getWorkboardState(host).cards[0]).toMatchObject({ taskId: "task-1" });
   });
 
-  it("restarts a saved discovery cursor from the first page when stale", async () => {
-    const staleError = new GatewayRequestError({
+  it("replaces a saved numeric discovery cursor after a foreign stale error", async () => {
+    const linkedCard = makeCard({
+      status: "running",
+      sessionKey: sampleTaskSessionKey,
+      runId: "run-1",
+    });
+    const staleError = createForeignGatewayRequestError({
       code: "INVALID_REQUEST",
       message: "stale tasks.list cursor",
       details: { code: "TASKS_LIST_CURSOR_STALE" },
     });
+    let firstPageRequests = 0;
     const client = createClient((method, params) => {
+      if (method === "workboard.cards.list") {
+        return listResult([linkedCard], ["todo", "running", "done"]);
+      }
       if (method !== "tasks.list") {
         return {};
       }
-      if ((params as { cursor?: string }).cursor) {
+      const cursor = (params as { cursor?: string }).cursor;
+      if (cursor === "500") {
         throw staleError;
       }
-      return { tasks: [sampleTask], nextCursor: "fresh-page" };
+      firstPageRequests += 1;
+      return firstPageRequests === 1
+        ? { tasks: [], nextCursor: "500" }
+        : {
+            tasks: [makeTask({ childSessionKey: `agent:main:${sampleTaskSessionKey}` })],
+            nextCursor: "fresh-page",
+          };
     });
 
-    const result = await getWorkboardTaskPollBatch(client, [], [{ cursor: "stale-page" }]);
+    await refreshBoard(client, "live");
+    expect(getWorkboardRuntime(host).defaultTaskDiscoveryCursor).toBe("500");
 
-    expect(result).toMatchObject({
-      tasks: [sampleTask],
-      nextUnfilteredCursor: "fresh-page",
-      error: null,
-    });
-    expect(requestCalls(client, "tasks.list")).toEqual([
-      ["tasks.list", { cursor: "stale-page", limit: 500 }],
-      ["tasks.list", { limit: 500 }],
+    await refreshBoard(client, "live");
+
+    expect(requestCalls(client, "tasks.list").map(([, params]) => params)).toEqual([
+      { limit: 500 },
+      { cursor: "500", limit: 500 },
+      { limit: 500 },
     ]);
+    expect(getWorkboardRuntime(host).defaultTaskDiscoveryCursor).toBe("fresh-page");
+    expect(getWorkboardState(host).cards[0]).toMatchObject({ taskId: sampleTask.taskId });
   });
 
   it("fails after bounded stale task pagination attempts", async () => {

--- a/ui/src/lib/workboard/task-links.ts
+++ b/ui/src/lib/workboard/task-links.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { isTasksListCursorStaleError } from "../gateway-errors.ts";
 import { normalizeTaskSummary } from "../tasks/task-summary.ts";
 import {
   isActiveWorkboardCard,
@@ -18,15 +19,6 @@ const WORKBOARD_TASKS_LIST_MAX_ATTEMPTS = 3;
 const WORKBOARD_TASK_POLL_BATCH_SIZE = 32;
 const WORKBOARD_TASK_DISCOVERY_BATCH_SIZE = 4;
 export const WORKBOARD_TASK_LOOKUP_RETRY_DELAYS_MS = [100, 250, 500] as const;
-
-function isStaleTasksListCursorError(error: unknown): boolean {
-  return (
-    error instanceof GatewayRequestError &&
-    error.gatewayCode === "INVALID_REQUEST" &&
-    isRecord(error.details) &&
-    error.details.code === "TASKS_LIST_CURSOR_STALE"
-  );
-}
 
 export async function listWorkboardTasks(
   client: GatewayBrowserClient,
@@ -50,7 +42,7 @@ export async function listWorkboardTasks(
         cursor = page.nextCursor;
       }
     } catch (error) {
-      if (!isStaleTasksListCursorError(error) || attempt + 1 >= WORKBOARD_TASKS_LIST_MAX_ATTEMPTS) {
+      if (!isTasksListCursorStaleError(error) || attempt + 1 >= WORKBOARD_TASKS_LIST_MAX_ATTEMPTS) {
         throw error;
       }
     }
@@ -283,7 +275,7 @@ export async function getWorkboardTaskPollBatch(
           limit: WORKBOARD_TASKS_LIST_LIMIT,
         });
       } catch (error) {
-        if (!query.cursor || !isStaleTasksListCursorError(error)) {
+        if (!query.cursor || !isTasksListCursorStaleError(error)) {
           throw error;
         }
         effectiveQuery = query.sessionKey ? { sessionKey: query.sessionKey } : {};

--- a/ui/src/lib/workboard/task-links.ts
+++ b/ui/src/lib/workboard/task-links.ts
@@ -14,29 +14,48 @@ import { getWorkboardRuntime, type WorkboardHost } from "./runtime.ts";
 import type { WorkboardCard, WorkboardTaskLinkState, WorkboardTaskSummary } from "./types.ts";
 
 const WORKBOARD_TASKS_LIST_LIMIT = 500;
+const WORKBOARD_TASKS_LIST_MAX_ATTEMPTS = 3;
 const WORKBOARD_TASK_POLL_BATCH_SIZE = 32;
 const WORKBOARD_TASK_DISCOVERY_BATCH_SIZE = 4;
 export const WORKBOARD_TASK_LOOKUP_RETRY_DELAYS_MS = [100, 250, 500] as const;
 
+function isStaleTasksListCursorError(error: unknown): boolean {
+  return (
+    error instanceof GatewayRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    isRecord(error.details) &&
+    error.details.code === "TASKS_LIST_CURSOR_STALE"
+  );
+}
+
 export async function listWorkboardTasks(
   client: GatewayBrowserClient,
 ): Promise<WorkboardTaskSummary[]> {
-  const tasks: WorkboardTaskSummary[] = [];
-  const seenCursors = new Set<string>();
-  let cursor: string | null = null;
-  while (true) {
-    const payload = await client.request("tasks.list", {
-      limit: WORKBOARD_TASKS_LIST_LIMIT,
-      ...(cursor ? { cursor } : {}),
-    });
-    const page = normalizeTasksPage(payload);
-    tasks.push(...page.tasks);
-    if (!page.nextCursor || seenCursors.has(page.nextCursor)) {
-      return tasks;
+  for (let attempt = 0; attempt < WORKBOARD_TASKS_LIST_MAX_ATTEMPTS; attempt++) {
+    const tasks: WorkboardTaskSummary[] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | null = null;
+    try {
+      while (true) {
+        const payload = await client.request("tasks.list", {
+          limit: WORKBOARD_TASKS_LIST_LIMIT,
+          ...(cursor ? { cursor } : {}),
+        });
+        const page = normalizeTasksPage(payload);
+        tasks.push(...page.tasks);
+        if (!page.nextCursor || seenCursors.has(page.nextCursor)) {
+          return tasks;
+        }
+        seenCursors.add(page.nextCursor);
+        cursor = page.nextCursor;
+      }
+    } catch (error) {
+      if (!isStaleTasksListCursorError(error) || attempt + 1 >= WORKBOARD_TASKS_LIST_MAX_ATTEMPTS) {
+        throw error;
+      }
     }
-    seenCursors.add(page.nextCursor);
-    cursor = page.nextCursor;
   }
+  return [];
 }
 
 export function taskUpdatedAtValue(task: WorkboardTaskSummary): number {
@@ -256,14 +275,27 @@ export async function getWorkboardTaskPollBatch(
       }
     }),
     ...discoveryQueries.map(async (query) => {
-      const payload = await client.request("tasks.list", {
-        ...query,
-        limit: WORKBOARD_TASKS_LIST_LIMIT,
-      });
+      let effectiveQuery = query;
+      let payload: unknown;
+      try {
+        payload = await client.request("tasks.list", {
+          ...effectiveQuery,
+          limit: WORKBOARD_TASKS_LIST_LIMIT,
+        });
+      } catch (error) {
+        if (!query.cursor || !isStaleTasksListCursorError(error)) {
+          throw error;
+        }
+        effectiveQuery = query.sessionKey ? { sessionKey: query.sessionKey } : {};
+        payload = await client.request("tasks.list", {
+          ...effectiveQuery,
+          limit: WORKBOARD_TASKS_LIST_LIMIT,
+        });
+      }
       const page = normalizeTasksPage(payload);
       return {
         tasks: page.tasks,
-        ...(query.sessionKey ? {} : { nextUnfilteredCursor: page.nextCursor ?? null }),
+        ...(effectiveQuery.sessionKey ? {} : { nextUnfilteredCursor: page.nextCursor ?? null }),
       };
     }),
   ]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clients that followed `tasks.list` pagination could silently receive duplicate tasks and miss another task when task activity changed between page requests. This affected Workboard task linking in particular because background tasks can complete, cancel, or report activity while Workboard is scanning multiple pages.

## Fix Classification

Root-cause fix.

## Root Cause

`tasks.list` sorted every request by mutable task activity but encoded only a numeric offset in its cursor. When a task moved across a page boundary between requests, the same offset addressed a different slice of the reordered collection. No page-level deduplication could recover the task that had moved behind the consumed offset, so the old cursor could silently produce both a duplicate and a permanent omission.

## Why This Fixes the Invariant

Task pages remain ordered by recent activity, but continuation cursors now bind their offset to both the normalized query and the complete filtered task order. The Gateway recomputes that order before applying an offset. If it changed, the continuation is rejected with a structured stale-cursor response instead of being applied to a different collection revision. Workboard then discards every partial page and restarts from page one with a bounded retry policy, so it either returns one coherent traversal or fails explicitly rather than presenting mixed pages as complete.

## Protocol and Compatibility Scope

The wire fields remain `cursor?: string` and `nextCursor?: string`; this change formally defines those string values as opaque cursors. It adds the structured `TASKS_LIST_CURSOR_STALE` protocol detail, documents the restart contract, exposes it through the canonical transport schema, and regenerates the Swift protocol model. Numeric cursors emitted by the previous Gateway are never resumed against mutable state, but are classified as stale so upgraded Workboard clients can discard saved cursor state and restart. Malformed cursor input remains a generic invalid request.

A repository-wide same-problem PR search found no open competing implementation before this change was prepared.

Out of scope: task persistence, task status semantics, activity ordering, permissions, page-size limits, and the bounded page-cloning behavior are unchanged. This does not add a server-side snapshot cache or change the task summary schema.

## User Impact

Workboard no longer treats a mixed task snapshot as a complete list: it discards partial pages and restarts from page one. SDK consumers receive a structured stale-cursor error and can apply the same restart contract. Active tasks are not silently skipped when another task changes activity across a page boundary; retrying the identical stale cursor is intentionally rejected.

## Evidence

- **Real Gateway + SQLite + WebSocket path:** restored four persisted tasks, traversed the unchanged list as a control, completed an existing task between page requests so it crossed the page boundary, observed `INVALID_REQUEST` with `TASKS_LIST_CURSOR_STALE`, then restarted and returned every task exactly once.
  - `1 passed` — `Gateway task pagination > restarts a traversal instead of returning mixed task order`
- **Gateway method regression:** `22 passed`
  - covers pure activity reordering with an unchanged task ID set
  - covers opaque cursor continuation, query binding, valid pre-upgrade numeric cursors entering the stale-restart path, malformed and oversized cursor rejection, stable tie-breaking, and page-only cloning
- **Control UI regressions:** `196 passed`
  - covers structural stale-error recognition across divergent Gateway error constructors, partial-result discard, bounded full traversal restart, saved pre-upgrade numeric discovery-cursor replacement, and retry exhaustion
- **Exact-head formatting:** the three files changed by the compatibility follow-up passed `oxfmt --check`.
- **Proof environment:** the exact-head checks above ran locally with Node 22.22.3 and no external service credentials. A sanitized remote proof runner is unavailable in this environment; hosted fork CI will provide the repository-controlled secretless result after the branch update.

