### PR TITLE
fix(reply): outbound content dedup for concurrent turn duplicate delivery

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import { _resetDeliveryDedupCacheForTests } from "./route-reply.js";
 
 const mocks = vi.hoisted(() => ({
   deliverOutboundPayloads: vi.fn(),
@@ -219,6 +220,7 @@ describe("routeReply", () => {
 
   afterEach(() => {
     setActivePluginRegistry(createTestRegistry());
+    _resetDeliveryDedupCacheForTests();
   });
 
   it("skips sends when abort signal is already aborted", async () => {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -18,6 +18,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
+import { getLogger } from "../../logging/logger.js";
 import { normalizeAccountId } from "../../routing/account-id.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
@@ -39,6 +40,54 @@ const messageRuntimeLoader = createLazyImportLoader(
 
 function loadDeliverRuntime() {
   return messageRuntimeLoader.load();
+}
+
+/**
+ * Short-term outbound content dedup cache.
+ *
+ * Prevents duplicate reply delivery when concurrent agent turns (e.g. compact
+ * continuation + new user message) produce identical reply text for the same
+ * route within a few seconds.
+ */
+const recentDeliveryCache = new Map<string, { text: string; mediaKey: string; ts: number }>();
+const DEDUP_WINDOW_MS = 15_000;
+const DEDUP_TTL_MS = 30_000;
+
+function buildDeliveryDedupKey(channel: string, to: string, accountId?: string): string {
+  return `${channel}:${to}:${accountId ?? ""}`;
+}
+
+function buildMediaKey(mediaUrls: string[]): string {
+  return mediaUrls.slice().sort().join(",");
+}
+
+/** Returns true if an identical reply was delivered to the same route recently. */
+function isDuplicateDelivery(routeKey: string, text: string, mediaKey: string): boolean {
+  const now = Date.now();
+  // TTL cleanup: sweep expired entries.
+  if (recentDeliveryCache.size > 0) {
+    for (const [key, entry] of recentDeliveryCache) {
+      if (now - entry.ts > DEDUP_TTL_MS) {
+        recentDeliveryCache.delete(key);
+      }
+    }
+  }
+  const existing = recentDeliveryCache.get(routeKey);
+  if (!existing) {
+    return false;
+  }
+  return (
+    now - existing.ts < DEDUP_WINDOW_MS && existing.text === text && existing.mediaKey === mediaKey
+  );
+}
+
+/** Clears the outbound content dedup cache. Intended for tests. */
+export function _resetDeliveryDedupCacheForTests(): void {
+  recentDeliveryCache.clear();
+}
+
+function recordDelivery(routeKey: string, text: string, mediaKey: string): void {
+  recentDeliveryCache.set(routeKey, { text, mediaKey, ts: Date.now() });
 }
 
 function replyDeliverySourceMatchesRoute(params: {
@@ -307,6 +356,23 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     replyToId: resolvedReplyToId,
   };
 
+  // Outbound content dedup: skip if an identical reply was already delivered
+  // to the same route within the dedup window. This catches concurrent agent
+  // turns (compact continuation + new user message) that produce identical text.
+  const dedupRouteKey = buildDeliveryDedupKey(channelId, to, accountId);
+  const dedupText = text;
+  const dedupMediaKey = buildMediaKey(mediaUrls);
+  if (dedupText && isDuplicateDelivery(dedupRouteKey, dedupText, dedupMediaKey)) {
+    getLogger().warn(
+      {
+        routeKey: dedupRouteKey,
+        textPreview: dedupText.slice(0, 80),
+      },
+      "reply-delivery-dedup: suppressed duplicate reply within dedup window",
+    );
+    return { ok: true, delivered: true, suppressed: true };
+  }
+
   try {
     // Provider docking: this is an execution boundary (we're about to send).
     // Keep the module cheap to import by loading outbound plumbing lazily.
@@ -398,6 +464,10 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     }
     const results = send.status === "sent" ? send.results : [];
     const delivery = summarizeVisibleRouteReplyDelivery(results);
+    // Record successful delivery for content dedup.
+    if (delivery.delivered && dedupText) {
+      recordDelivery(dedupRouteKey, dedupText, dedupMediaKey);
+    }
     return {
       ok: true,
       delivered: delivery.delivered,


### PR DESCRIPTION
## Problem

When compact continuation and a new user message (or subagent completion event) arrive near-simultaneously, each enqueues a followup run with a **different `messageId`**. The queue-level dedup in `enqueue.ts` (`isRunAlreadyQueued` → `buildRecentMessageIdKey`) only checks messageId, so **both runs drain independently**, produce identical reply text, and each delivers to the same channel route — the user receives 2–4 copies of the same message within seconds.

This is distinct from the four paths documented in #96242:
- **Path 1** (subagent-announce retry) — ✅ fixed in #92274
- **Path 2** (queue mid-batch replay) — ✅ fixed in #96247
- **Path 3** (turn-end delivery) — ⚠️ root cause unresolved
- **Path 4** (pendingFinalDelivery + SIGTERM) — ✅ primary trigger fixed in #98236

This PR addresses a **fifth path**: concurrent followup queue drains producing content-identical replies. It may explain some of the unidentified Path 3 reproductions.

## Root Cause

`enqueue.ts` dedup chain:
```
isRunAlreadyQueued → messageId equality
buildRecentMessageIdKey → ["queue", key, routeIdentity, messageId]
```

All checks are **ID-level**. Two runs triggered by different inbound events (compact continuation vs. new user message) have different messageIds and bypass all queue dedup. Each run independently produces a reply and calls `routeReply` → duplicate delivery.

Existing `reply-payloads-dedupe.ts` only covers `message()` tool sends, not normal source reply delivery.

## Fix

Add a short-term **content dedup cache** in `routeReply` (`route-reply.ts`):

- **Key**: `channel:to:accountId` (route identity)
- **Match**: same text + same media URLs within **15s window**
- **Action**: suppress duplicate + `warn` log (`reply-delivery-dedup`)
- **TTL**: entries auto-cleaned after 30s
- NO_REPLY / silent replies are unaffected (empty text is not cached)

This is a safety net — it does not replace queue-level or mirror-level dedup, but catches the case where those layers cannot detect duplication because the triggering messageIds differ.

## Verification

- `pnpm build` ✅
- Deployed on production gateway (pc2070, v2026.7.2) — triple-send bug eliminated, no false positives observed
- Test file updated to export `_resetDeliveryDedupCacheForTests`

## Files Changed

- `src/auto-reply/reply/route-reply.ts` — +82 lines (dedup cache + integration in routeReply)
- `src/auto-reply/reply/route-reply.test.ts` — test helper export

Related: #96242