### PR TITLE
fix(codex): surface install prompts in source channels

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -113,6 +113,7 @@ type StartCodexAttemptThreadResult = {
   turnRoute: CodexThreadRouteReservation;
   thread: CodexAppServerThreadLifecycleBinding;
   pluginAppServer: CodexAppServerRuntimeOptions;
+  pluginAppCacheKey: string;
   sandboxEnvironment: CodexSandboxExecEnvironment | undefined;
   environmentSelection: CodexTurnEnvironmentParams[] | undefined;
   executionCwd: string;
@@ -528,6 +529,7 @@ export async function startCodexAttemptThread(params: {
               startupAttemptSucceeded = true;
               return {
                 client: activeStartupClient,
+                pluginAppCacheKey,
                 turnRouter,
                 turnRoute: startupRoute,
                 thread: startupThread,

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -76,6 +76,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
   turnId: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
   appServerRequest?: CodexPluginRuntimeRequest;
+  pluginAppCacheKey?: string;
   computerUseMcpServerName?: string;
   signal?: AbortSignal;
 }): Promise<JsonValue | undefined> {
@@ -92,6 +93,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
     paramsForRun: params.paramsForRun,
     activeTurnId: params.turnId,
     appServerRequest: params.appServerRequest,
+    pluginAppCacheKey: params.pluginAppCacheKey,
     signal: params.signal,
   });
   if (toolSuggestionResponse) {

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -6,21 +6,20 @@ import {
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
 import {
-  approvalRequestExplicitlyUnavailable,
-  mapExecDecisionToOutcome,
-  requestPluginApproval,
+  requestPluginApprovalOutcome,
   sanitizeCodexApprovalVisibleText,
   truncateCodexApprovalDisplayText as truncateDisplayText,
   type AppServerApprovalOutcome,
   type ExecApprovalDecision,
-  waitForPluginApprovalDecision,
 } from "./plugin-approval-roundtrip.js";
+import type { CodexPluginRuntimeRequest } from "./plugin-inventory.js";
 import type {
   CodexAppPolicyContextEntry,
   PluginAppPolicyContext,
   PluginAppPolicyContextEntry,
 } from "./plugin-thread-config.js";
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
+import { handleCodexAppServerToolSuggestion } from "./tool-suggestion-bridge.js";
 
 type ApprovalPropertyContext = {
   name: string;
@@ -76,6 +75,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
   threadId: string;
   turnId: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
+  appServerRequest?: CodexPluginRuntimeRequest;
   computerUseMcpServerName?: string;
   signal?: AbortSignal;
 }): Promise<JsonValue | undefined> {
@@ -86,6 +86,16 @@ export async function handleCodexAppServerElicitationRequest(params: {
   const requestTurnId = requestParams.turnId;
   if (requestTurnId !== null && requestTurnId !== undefined && requestTurnId !== params.turnId) {
     return undefined;
+  }
+  const toolSuggestionResponse = await handleCodexAppServerToolSuggestion({
+    requestParams,
+    paramsForRun: params.paramsForRun,
+    activeTurnId: params.turnId,
+    appServerRequest: params.appServerRequest,
+    signal: params.signal,
+  });
+  if (toolSuggestionResponse) {
+    return toolSuggestionResponse;
   }
   const pluginResolution = resolvePluginElicitation({
     requestParams,
@@ -119,6 +129,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
     paramsForRun: params.paramsForRun,
     title: approvalPrompt.title,
     description: approvalPrompt.description,
+    toolName: "codex_mcp_tool_approval",
     allowedDecisions: approvalPrompt.allowedDecisions,
     signal: params.signal,
   });
@@ -299,6 +310,7 @@ async function buildPluginPolicyElicitationResponse(params: {
       paramsForRun: params.paramsForRun,
       title: approvalPrompt.title,
       description: approvalPrompt.description,
+      toolName: "codex_mcp_tool_approval",
       allowedDecisions: allowedPluginPolicyApprovalDecisions(mode, approvalPrompt),
       signal: params.signal,
     });
@@ -637,37 +649,6 @@ function sanitizeDisplayText(value: string): string {
   });
   const escaped = sanitized ? formatCodexDisplayText(sanitized) : "";
   return clipped && escaped ? `${escaped}...` : escaped;
-}
-
-async function requestPluginApprovalOutcome(params: {
-  paramsForRun: EmbeddedRunAttemptParams;
-  title: string;
-  description: string;
-  allowedDecisions?: ExecApprovalDecision[];
-  signal?: AbortSignal;
-}): Promise<AppServerApprovalOutcome> {
-  try {
-    const requestResult = await requestPluginApproval({
-      paramsForRun: params.paramsForRun,
-      title: params.title,
-      description: params.description,
-      severity: "warning",
-      toolName: "codex_mcp_tool_approval",
-      allowedDecisions: params.allowedDecisions,
-    });
-
-    const approvalId = requestResult?.id;
-    if (!approvalId) {
-      return "unavailable";
-    }
-
-    const decision = approvalRequestExplicitlyUnavailable(requestResult)
-      ? null
-      : await waitForPluginApprovalDecision({ approvalId, signal: params.signal });
-    return mapExecDecisionToOutcome(decision);
-  } catch {
-    return params.signal?.aborted ? "cancelled" : "denied";
-  }
 }
 
 function buildElicitationResponse(

--- a/extensions/codex/src/app-server/elicitation-tool-suggestion.test.ts
+++ b/extensions/codex/src/app-server/elicitation-tool-suggestion.test.ts
@@ -430,6 +430,88 @@ describe("Codex app-server tool-suggestion elicitations", () => {
     expect(appServerRequest.mock.calls.filter(([method]) => method === "app/list")).toHaveLength(2);
   });
 
+  it("declines after the bounded app inventory page limit with unique cursors", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:install-bounded", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:install-bounded", decision: "allow-once" })
+      .mockResolvedValueOnce({ id: "plugin:authorize-bounded", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:authorize-bounded", decision: "allow-once" });
+    let appListCalls = 0;
+    const appServerRequest = vi.fn(async (method: string, requestParams?: unknown) => {
+      if (method === "plugin/list") {
+        if ((requestParams as { forceRefetch?: boolean } | undefined)?.forceRefetch) {
+          return { marketplaces: [], marketplaceLoadErrors: [], featuredPluginIds: [] };
+        }
+        return {
+          marketplaces: [
+            {
+              name: "openai-curated-remote",
+              path: null,
+              plugins: [
+                {
+                  id: "google-calendar@openai-curated-remote",
+                  remotePluginId: "plugin_connector_google_calendar",
+                  name: "Google Calendar",
+                  installed: false,
+                  enabled: false,
+                },
+              ],
+            },
+          ],
+          marketplaceLoadErrors: [],
+          featuredPluginIds: [],
+        };
+      }
+      if (method === "plugin/install") {
+        return {
+          authPolicy: "ON_INSTALL",
+          appsNeedingAuth: [
+            {
+              id: "connector_google_calendar",
+              name: "Google Calendar",
+              description: null,
+              installUrl: "https://chatgpt.com/apps/google-calendar/authorize",
+              category: null,
+            },
+          ],
+        };
+      }
+      if (method === "skills/list" || method === "hooks/list") {
+        return { data: [] };
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
+      }
+      if (method === "app/list") {
+        appListCalls += 1;
+        if (appListCalls > 100) {
+          throw new Error("app/list exceeded the expected bounded page limit");
+        }
+        const cursor = (requestParams as { cursor?: string } | undefined)?.cursor;
+        const page = cursor ? Number(cursor.slice("page-".length)) : 1;
+        return { data: [], nextCursor: `page-${page + 1}` };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion(),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(appServerRequest.mock.calls.filter(([method]) => method === "app/list")).toHaveLength(
+      100,
+    );
+    expect(appServerRequest).toHaveBeenLastCalledWith("app/list", {
+      threadId: codexTestTurnIds().threadId,
+      forceRefetch: true,
+      cursor: "page-100",
+    });
+  });
+
   it("surfaces but cannot accept a connector suggestion with an unsafe install URL", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "connector:unsafe", status: "accepted" })

--- a/extensions/codex/src/app-server/elicitation-tool-suggestion.test.ts
+++ b/extensions/codex/src/app-server/elicitation-tool-suggestion.test.ts
@@ -56,8 +56,15 @@ describe("Codex app-server tool-suggestion elicitations", () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:install-1", status: "accepted" })
       .mockResolvedValueOnce({ id: "plugin:install-1", decision: "allow-once" });
-    const appServerRequest = vi.fn(async (method: string) => {
+    const appServerRequest = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "plugin/list") {
+        if ((requestParams as { forceRefetch?: boolean } | undefined)?.forceRefetch) {
+          return {
+            marketplaces: [],
+            marketplaceLoadErrors: [],
+            featuredPluginIds: [],
+          };
+        }
         return {
           marketplaces: [
             {
@@ -80,6 +87,12 @@ describe("Codex app-server tool-suggestion elicitations", () => {
       }
       if (method === "plugin/install") {
         return { authPolicy: "none", appsNeedingAuth: [] };
+      }
+      if (method === "skills/list" || method === "hooks/list") {
+        return { data: [] };
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
       }
       throw new Error(`unexpected method: ${method}`);
     });
@@ -108,6 +121,13 @@ describe("Codex app-server tool-suggestion elicitations", () => {
       remoteMarketplaceName: "openai-curated-remote",
       pluginName: "plugin_connector_google_calendar",
     });
+    expect(appServerRequest).toHaveBeenNthCalledWith(3, "plugin/list", { forceRefetch: true });
+    expect(appServerRequest).toHaveBeenNthCalledWith(4, "skills/list", {
+      cwds: [],
+      forceReload: true,
+    });
+    expect(appServerRequest).toHaveBeenNthCalledWith(5, "hooks/list", { cwds: [] });
+    expect(appServerRequest).toHaveBeenNthCalledWith(6, "config/mcpServer/reload", undefined);
   });
 
   it("relays a connector install URL and waits for explicit channel confirmation", async () => {
@@ -177,6 +197,52 @@ describe("Codex app-server tool-suggestion elicitations", () => {
     expect(appServerRequest).not.toHaveBeenCalled();
   });
 
+  it("does not refresh plugin runtime state when installation fails", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:install-failed", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:install-failed", decision: "allow-once" });
+    const appServerRequest = vi.fn(async (method: string) => {
+      if (method === "plugin/list") {
+        return {
+          marketplaces: [
+            {
+              name: "openai-curated-remote",
+              path: null,
+              plugins: [
+                {
+                  id: "google-calendar@openai-curated-remote",
+                  remotePluginId: "plugin_connector_google_calendar",
+                  name: "Google Calendar",
+                  installed: false,
+                  enabled: false,
+                },
+              ],
+            },
+          ],
+          marketplaceLoadErrors: [],
+          featuredPluginIds: [],
+        };
+      }
+      if (method === "plugin/install") {
+        throw new Error("install failed");
+      }
+      throw new Error(`unexpected refresh after failed install: ${method}`);
+    });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion(),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(appServerRequest.mock.calls.map(([method]) => method)).toEqual([
+      "plugin/list",
+      "plugin/install",
+    ]);
+  });
+
   it("does not install when the gateway returns a decision the prompt did not advertise", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:install-unadvertised", status: "accepted" })
@@ -204,8 +270,15 @@ describe("Codex app-server tool-suggestion elicitations", () => {
       .mockResolvedValueOnce({ id: "plugin:authorize-app", status: "accepted" })
       .mockResolvedValueOnce({ id: "plugin:authorize-app", decision: "allow-once" });
     const authorizationUrl = "https://chatgpt.com/apps/google-calendar/authorize";
-    const appServerRequest = vi.fn(async (method: string) => {
+    const appServerRequest = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "plugin/list") {
+        if ((requestParams as { forceRefetch?: boolean } | undefined)?.forceRefetch) {
+          return {
+            marketplaces: [],
+            marketplaceLoadErrors: [],
+            featuredPluginIds: [],
+          };
+        }
         return {
           marketplaces: [
             {
@@ -240,7 +313,19 @@ describe("Codex app-server tool-suggestion elicitations", () => {
           ],
         };
       }
+      if (method === "skills/list" || method === "hooks/list") {
+        return { data: [] };
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
+      }
       if (method === "app/list") {
+        if (!(requestParams as { cursor?: string } | undefined)?.cursor) {
+          return {
+            data: [{ id: "some_other_app", isAccessible: true }],
+            nextCursor: "page-2",
+          };
+        }
         return {
           data: [{ id: "connector_google_calendar", isAccessible: true }],
           nextCursor: null,
@@ -263,10 +348,86 @@ describe("Codex app-server tool-suggestion elicitations", () => {
       turnSourceChannel: "discord",
       turnSourceTo: "channel:123456789",
     });
-    expect(appServerRequest).toHaveBeenLastCalledWith("app/list", {
+    expect(appServerRequest).toHaveBeenNthCalledWith(7, "app/list", {
       threadId: codexTestTurnIds().threadId,
       forceRefetch: true,
     });
+    expect(appServerRequest).toHaveBeenLastCalledWith("app/list", {
+      threadId: codexTestTurnIds().threadId,
+      forceRefetch: true,
+      cursor: "page-2",
+    });
+  });
+
+  it("declines when app inventory repeats a pagination cursor", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:install-loop", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:install-loop", decision: "allow-once" })
+      .mockResolvedValueOnce({ id: "plugin:authorize-loop", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:authorize-loop", decision: "allow-once" });
+    const appServerRequest = vi.fn(async (method: string, requestParams?: unknown) => {
+      if (method === "plugin/list") {
+        if ((requestParams as { forceRefetch?: boolean } | undefined)?.forceRefetch) {
+          return { marketplaces: [], marketplaceLoadErrors: [], featuredPluginIds: [] };
+        }
+        return {
+          marketplaces: [
+            {
+              name: "openai-curated-remote",
+              path: null,
+              plugins: [
+                {
+                  id: "google-calendar@openai-curated-remote",
+                  remotePluginId: "plugin_connector_google_calendar",
+                  name: "Google Calendar",
+                  installed: false,
+                  enabled: false,
+                },
+              ],
+            },
+          ],
+          marketplaceLoadErrors: [],
+          featuredPluginIds: [],
+        };
+      }
+      if (method === "plugin/install") {
+        return {
+          authPolicy: "ON_INSTALL",
+          appsNeedingAuth: [
+            {
+              id: "connector_google_calendar",
+              name: "Google Calendar",
+              description: null,
+              installUrl: "https://chatgpt.com/apps/google-calendar/authorize",
+              category: null,
+            },
+          ],
+        };
+      }
+      if (method === "skills/list" || method === "hooks/list") {
+        return { data: [] };
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
+      }
+      if (method === "app/list") {
+        return {
+          data: [],
+          nextCursor: (requestParams as { cursor?: string } | undefined)?.cursor ?? "same-cursor",
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion(),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(appServerRequest.mock.calls.filter(([method]) => method === "app/list")).toHaveLength(2);
   });
 
   it("surfaces but cannot accept a connector suggestion with an unsafe install URL", async () => {

--- a/extensions/codex/src/app-server/elicitation-tool-suggestion.test.ts
+++ b/extensions/codex/src/app-server/elicitation-tool-suggestion.test.ts
@@ -1,0 +1,333 @@
+import {
+  callGatewayTool,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { codexTestTurnIds } from "./codex-app-server.test-fixtures.js";
+import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
+
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>()),
+  callGatewayTool: vi.fn(),
+}));
+
+const mockCallGatewayTool = vi.mocked(callGatewayTool);
+
+function createDiscordParams(): EmbeddedRunAttemptParams {
+  return {
+    sessionKey: "agent:main:discord:channel:123456789",
+    agentId: "main",
+    messageChannel: "discord",
+    currentChannelId: "channel:123456789",
+    agentAccountId: "default",
+    currentThreadTs: "777888999",
+  } as unknown as EmbeddedRunAttemptParams;
+}
+
+function buildToolSuggestion(overrides: Record<string, unknown> = {}) {
+  return {
+    ...codexTestTurnIds(),
+    serverName: "codex_apps",
+    mode: "form",
+    message: "Google Calendar can create the requested event.",
+    _meta: {
+      codex_approval_kind: "tool_suggestion",
+      persist: "always",
+      tool_type: "plugin",
+      suggest_type: "install",
+      suggest_reason: "Google Calendar can create the requested event.",
+      tool_id: "google-calendar@openai-curated-remote",
+      tool_name: "Google Calendar",
+    },
+    requestedSchema: {
+      type: "object",
+      properties: {},
+    },
+    ...overrides,
+  };
+}
+
+describe("Codex app-server tool-suggestion elicitations", () => {
+  beforeEach(() => {
+    mockCallGatewayTool.mockReset();
+  });
+
+  it("routes a remote plugin install prompt to the originating Discord session before installing", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:install-1", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:install-1", decision: "allow-once" });
+    const appServerRequest = vi.fn(async (method: string) => {
+      if (method === "plugin/list") {
+        return {
+          marketplaces: [
+            {
+              name: "openai-curated-remote",
+              path: null,
+              plugins: [
+                {
+                  id: "google-calendar@openai-curated-remote",
+                  remotePluginId: "plugin_connector_google_calendar",
+                  name: "Google Calendar",
+                  installed: false,
+                  enabled: false,
+                },
+              ],
+            },
+          ],
+          marketplaceLoadErrors: [],
+          featuredPluginIds: [],
+        };
+      }
+      if (method === "plugin/install") {
+        return { authPolicy: "none", appsNeedingAuth: [] };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion(),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "accept", content: null, _meta: null });
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+    expect(mockCallGatewayTool.mock.calls[0]?.[2]).toMatchObject({
+      toolName: "codex_plugin_install",
+      turnSourceChannel: "discord",
+      turnSourceTo: "channel:123456789",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "777888999",
+    });
+    expect(appServerRequest).toHaveBeenNthCalledWith(1, "plugin/list", {});
+    expect(appServerRequest).toHaveBeenNthCalledWith(2, "plugin/install", {
+      remoteMarketplaceName: "openai-curated-remote",
+      pluginName: "plugin_connector_google_calendar",
+    });
+  });
+
+  it("relays a connector install URL and waits for explicit channel confirmation", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "connector:install-1", status: "accepted" })
+      .mockResolvedValueOnce({ id: "connector:install-1", decision: "allow-once" });
+    const installUrl =
+      "https://chatgpt.com/apps/google-calendar/connector_2128aebfecb84f64a069897515042a44";
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion({
+        _meta: {
+          codex_approval_kind: "tool_suggestion",
+          persist: "always",
+          tool_type: "connector",
+          suggest_type: "install",
+          suggest_reason: "Google Calendar can create the requested event.",
+          tool_id: "connector_2128aebfecb84f64a069897515042a44",
+          tool_name: "Google Calendar",
+          install_url: installUrl,
+        },
+      }),
+      paramsForRun: createDiscordParams(),
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "accept", content: null, _meta: null });
+    expect(mockCallGatewayTool.mock.calls[0]?.[2]).toMatchObject({
+      toolName: "codex_connector_install",
+      turnSourceChannel: "discord",
+      turnSourceTo: "channel:123456789",
+    });
+    expect(mockCallGatewayTool.mock.calls[0]?.[2]).toMatchObject({
+      description: expect.stringContaining(installUrl),
+    });
+  });
+
+  it("does not prompt or install for another active turn", async () => {
+    const appServerRequest = vi.fn();
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion({ turnId: "turn-other" }),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toBeUndefined();
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(appServerRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not install a plugin when the channel approval is denied", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:install-denied", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:install-denied", decision: "deny" });
+    const appServerRequest = vi.fn();
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion(),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(appServerRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not install when the gateway returns a decision the prompt did not advertise", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:install-unadvertised", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:install-unadvertised",
+        decision: "allow-always",
+      });
+    const appServerRequest = vi.fn();
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion(),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(appServerRequest).not.toHaveBeenCalled();
+  });
+
+  it("relays plugin app authorization and verifies accessibility before accepting", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:install-auth", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:install-auth", decision: "allow-once" })
+      .mockResolvedValueOnce({ id: "plugin:authorize-app", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:authorize-app", decision: "allow-once" });
+    const authorizationUrl = "https://chatgpt.com/apps/google-calendar/authorize";
+    const appServerRequest = vi.fn(async (method: string) => {
+      if (method === "plugin/list") {
+        return {
+          marketplaces: [
+            {
+              name: "openai-curated-remote",
+              path: null,
+              plugins: [
+                {
+                  id: "google-calendar@openai-curated-remote",
+                  remotePluginId: "plugin_connector_google_calendar",
+                  name: "Google Calendar",
+                  installed: false,
+                  enabled: false,
+                },
+              ],
+            },
+          ],
+          marketplaceLoadErrors: [],
+          featuredPluginIds: [],
+        };
+      }
+      if (method === "plugin/install") {
+        return {
+          authPolicy: "ON_INSTALL",
+          appsNeedingAuth: [
+            {
+              id: "connector_google_calendar",
+              name: "Google Calendar",
+              description: null,
+              installUrl: authorizationUrl,
+              category: null,
+            },
+          ],
+        };
+      }
+      if (method === "app/list") {
+        return {
+          data: [{ id: "connector_google_calendar", isAccessible: true }],
+          nextCursor: null,
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion(),
+      paramsForRun: createDiscordParams(),
+      appServerRequest,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "accept", content: null, _meta: null });
+    expect(mockCallGatewayTool.mock.calls[2]?.[2]).toMatchObject({
+      toolName: "codex_app_authorization",
+      description: expect.stringContaining(authorizationUrl),
+      turnSourceChannel: "discord",
+      turnSourceTo: "channel:123456789",
+    });
+    expect(appServerRequest).toHaveBeenLastCalledWith("app/list", {
+      threadId: codexTestTurnIds().threadId,
+      forceRefetch: true,
+    });
+  });
+
+  it("surfaces but cannot accept a connector suggestion with an unsafe install URL", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "connector:unsafe", status: "accepted" })
+      .mockResolvedValueOnce({ id: "connector:unsafe", decision: "allow-once" });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion({
+        _meta: {
+          codex_approval_kind: "tool_suggestion",
+          persist: "always",
+          tool_type: "connector",
+          suggest_type: "install",
+          suggest_reason: "Google Calendar can create the requested event.",
+          tool_id: "connector_unsafe",
+          tool_name: "Google Calendar",
+          install_url: "javascript:alert(1)",
+        },
+      }),
+      paramsForRun: createDiscordParams(),
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(mockCallGatewayTool.mock.calls[0]?.[2]).toMatchObject({
+      description: expect.stringContaining("did not provide a safe install link"),
+      allowedDecisions: ["deny"],
+    });
+  });
+
+  it("uses the originating messaging target when a direct channel has no channel id", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "connector:direct", status: "accepted" })
+      .mockResolvedValueOnce({ id: "connector:direct", decision: "allow-once" });
+    const paramsForRun = createDiscordParams();
+    paramsForRun.messageChannel = "whatsapp";
+    paramsForRun.currentChannelId = undefined;
+    paramsForRun.currentMessagingTarget = "+15555550123";
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildToolSuggestion({
+        _meta: {
+          codex_approval_kind: "tool_suggestion",
+          persist: "always",
+          tool_type: "connector",
+          suggest_type: "install",
+          suggest_reason: "Google Calendar can create the requested event.",
+          tool_id: "connector_direct",
+          tool_name: "Google Calendar",
+          install_url: "https://chatgpt.com/apps/google-calendar/connector_direct",
+        },
+      }),
+      paramsForRun,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ action: "accept", content: null, _meta: null });
+    expect(mockCallGatewayTool.mock.calls[0]?.[2]).toMatchObject({
+      turnSourceChannel: "whatsapp",
+      turnSourceTo: "+15555550123",
+    });
+  });
+});

--- a/extensions/codex/src/app-server/plugin-activation.test.ts
+++ b/extensions/codex/src/app-server/plugin-activation.test.ts
@@ -6,7 +6,10 @@ import {
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
   type ResolvedCodexPluginPolicy,
 } from "./config.js";
-import { ensureCodexPluginActivation } from "./plugin-activation.js";
+import {
+  ensureCodexPluginActivation,
+  refreshCodexPluginAppInventoryState,
+} from "./plugin-activation.js";
 import { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import type { v2 } from "./protocol.js";
 
@@ -200,6 +203,49 @@ describe("Codex plugin activation", () => {
       },
     ]);
     expect(appCache.getRevision()).toBeGreaterThan(0);
+  });
+
+  it("can defer app inventory refresh until plugin app authorization completes", async () => {
+    const calls: string[] = [];
+    const appCache = new CodexAppInventoryCache();
+    const request = vi.fn(async (method: string) => {
+      calls.push(method);
+      if (method === "plugin/list") {
+        return pluginList([pluginSummary("google-calendar", { installed: false, enabled: false })]);
+      }
+      if (method === "plugin/install") {
+        return { authPolicy: "ON_INSTALL", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
+      }
+      if (method === "skills/list") {
+        return { data: [] } satisfies v2.SkillsListResponse;
+      }
+      if (method === "hooks/list") {
+        return { data: [] } satisfies v2.HooksListResponse;
+      }
+      if (method === "config/mcpServer/reload") {
+        return {};
+      }
+      if (method === "app/installed") {
+        return { apps: [] } satisfies v2.AppsInstalledResponse;
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    await ensureCodexPluginActivation({
+      identity: identity("google-calendar"),
+      appCache,
+      appCacheKey: "runtime",
+      deferAppInventoryRefresh: true,
+      request,
+    });
+
+    expect(calls).not.toContain("app/installed");
+    await refreshCodexPluginAppInventoryState({
+      request,
+      appCache,
+      appCacheKey: "runtime",
+    });
+    expect(calls.at(-1)).toBe("app/installed");
   });
 
   it("reports post-install runtime refresh failures without hiding the install attempt", async () => {

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -113,9 +113,6 @@ export async function ensureCodexPluginActivation(
         : params.identity.pluginName,
     ) satisfies v2.PluginInstallParams,
   )) as v2.PluginInstallResponse;
-  if (params.metadataCache && params.appCacheKey) {
-    params.metadataCache.invalidate(params.appCacheKey);
-  }
   const refreshDiagnostics: CodexPluginActivationDiagnostic[] = [];
   let refreshFailed = false;
   try {
@@ -160,7 +157,7 @@ export async function ensureCodexPluginActivation(
 }
 
 /** Forces Codex plugin, skill, hook, MCP, and app inventory refreshes after activation. */
-async function refreshCodexPluginRuntimeState(params: {
+export async function refreshCodexPluginRuntimeState(params: {
   request: CodexPluginRuntimeRequest;
   appCache?: CodexAppInventoryCache;
   appCacheKey?: string;
@@ -169,6 +166,9 @@ async function refreshCodexPluginRuntimeState(params: {
   targetAppIds?: readonly string[];
 }): Promise<CodexPluginRuntimeRefreshResult> {
   const diagnostics: CodexPluginActivationDiagnostic[] = [];
+  if (params.metadataCache && params.appCacheKey) {
+    params.metadataCache.invalidate(params.appCacheKey);
+  }
   await listCuratedCodexPluginMetadata(params, { forceRefetch: true });
   await (params.request("skills/list", {
     cwds: [],
@@ -197,24 +197,39 @@ async function refreshCodexPluginRuntimeState(params: {
     if (params.deferAppInventoryRefresh) {
       return { diagnostics };
     }
-    const request: CodexAppInventoryRequest = async (method, requestParams) =>
-      (await params.request(method, requestParams)) as CodexAppServerRequestResult<typeof method>;
-    try {
-      await params.appCache.refreshNow({
-        key: params.appCacheKey,
-        request,
-        forceRefetch: true,
-        targetAppIds: params.targetAppIds,
-      });
-    } catch (error) {
-      diagnostics.push({
-        message: `Codex app inventory refresh skipped: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      });
-    }
+    diagnostics.push(...(await refreshCodexPluginAppInventoryState(params)).diagnostics);
   }
 
+  return { diagnostics };
+}
+
+/** Refreshes only the OpenClaw app inventory after deferred plugin app authorization. */
+export async function refreshCodexPluginAppInventoryState(params: {
+  request: CodexPluginRuntimeRequest;
+  appCache?: CodexAppInventoryCache;
+  appCacheKey?: string;
+  targetAppIds?: readonly string[];
+}): Promise<CodexPluginRuntimeRefreshResult> {
+  const diagnostics: CodexPluginActivationDiagnostic[] = [];
+  if (!params.appCache || !params.appCacheKey) {
+    return { diagnostics };
+  }
+  const request: CodexAppInventoryRequest = async (method, requestParams) =>
+    (await params.request(method, requestParams)) as CodexAppServerRequestResult<typeof method>;
+  try {
+    await params.appCache.refreshNow({
+      key: params.appCacheKey,
+      request,
+      forceRefetch: true,
+      targetAppIds: params.targetAppIds,
+    });
+  } catch (error) {
+    diagnostics.push({
+      message: `Codex app inventory refresh skipped: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    });
+  }
   return { diagnostics };
 }
 

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -72,7 +72,8 @@ export async function requestPluginApproval(params: {
       agentId: params.paramsForRun.agentId,
       sessionKey: params.paramsForRun.sessionKey,
       turnSourceChannel: params.paramsForRun.messageChannel ?? params.paramsForRun.messageProvider,
-      turnSourceTo: params.paramsForRun.currentChannelId,
+      turnSourceTo:
+        params.paramsForRun.currentMessagingTarget ?? params.paramsForRun.currentChannelId,
       turnSourceAccountId: params.paramsForRun.agentAccountId,
       turnSourceThreadId: params.paramsForRun.currentThreadTs,
       timeoutMs,
@@ -154,6 +155,42 @@ export function mapExecDecisionToOutcome(
     return "unavailable";
   }
   return "denied";
+}
+
+/** Runs a complete channel-bound approval round trip and fails closed on routing errors. */
+export async function requestPluginApprovalOutcome(params: {
+  paramsForRun: EmbeddedRunAttemptParams;
+  title: string;
+  description: string;
+  toolName: string;
+  allowedDecisions?: ExecApprovalDecision[];
+  signal?: AbortSignal;
+}): Promise<AppServerApprovalOutcome> {
+  try {
+    const requestResult = await requestPluginApproval({
+      paramsForRun: params.paramsForRun,
+      title: params.title,
+      description: params.description,
+      severity: "warning",
+      toolName: params.toolName,
+      allowedDecisions: params.allowedDecisions,
+    });
+
+    const approvalId = requestResult?.id;
+    if (!approvalId) {
+      return "unavailable";
+    }
+
+    const decision = approvalRequestExplicitlyUnavailable(requestResult)
+      ? null
+      : await waitForPluginApprovalDecision({ approvalId, signal: params.signal });
+    if (decision && params.allowedDecisions && !params.allowedDecisions.includes(decision)) {
+      return "denied";
+    }
+    return mapExecDecisionToOutcome(decision);
+  } catch {
+    return params.signal?.aborted ? "cancelled" : "denied";
+  }
 }
 
 export function truncateCodexApprovalDisplayText(value: string, maxLength: number): string {

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -184,9 +184,6 @@ export async function requestPluginApprovalOutcome(params: {
     const decision = approvalRequestExplicitlyUnavailable(requestResult)
       ? null
       : await waitForPluginApprovalDecision({ approvalId, signal: params.signal });
-    if (decision && params.allowedDecisions && !params.allowedDecisions.includes(decision)) {
-      return "denied";
-    }
     return mapExecDecisionToOutcome(decision);
   } catch {
     return params.signal?.aborted ? "cancelled" : "denied";

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -59,6 +59,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
   });
   const state = {
     client: undefined as unknown as CodexAppServerClient,
+    pluginAppCacheKey: undefined as string | undefined,
     thread: undefined as unknown as CodexAppServerThreadLifecycleBinding,
     runtimeArtifact: undefined as AgentHarnessRuntimeArtifactBinding | undefined,
     turnRouter: undefined as unknown as CodexAppServerTurnRouter,

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -103,6 +103,8 @@ export function createCodexAttemptServerRequestController(
           threadId: resourceState.thread.threadId,
           turnId,
           pluginAppPolicyContext: resourceState.thread.pluginAppPolicyContext,
+          appServerRequest: (method, requestParams) =>
+            resourceState.client.request(method, requestParams, { signal }),
           ...(computerUseConfig.enabled
             ? { computerUseMcpServerName: computerUseConfig.mcpServerName }
             : {}),

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -105,6 +105,7 @@ export function createCodexAttemptServerRequestController(
           pluginAppPolicyContext: resourceState.thread.pluginAppPolicyContext,
           appServerRequest: (method, requestParams) =>
             resourceState.client.request(method, requestParams, { signal }),
+          pluginAppCacheKey: resourceState.pluginAppCacheKey,
           ...(computerUseConfig.enabled
             ? { computerUseMcpServerName: computerUseConfig.mcpServerName }
             : {}),

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -108,6 +108,7 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
       spawnedBy: params.spawnedBy,
     });
     state.client = startupResult.client;
+    state.pluginAppCacheKey = startupResult.pluginAppCacheKey;
     toolBridge.setRemoteWorkspaceFileReader?.(
       ({ path, maxBytes, workspaceRoot, signal, timeoutMs }) =>
         readBoundedCodexRemoteWorkspaceFile({

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4513,14 +4513,12 @@ describe("runCodexAppServerAttempt", () => {
     const appServer = resolveCodexAppServerRuntimeOptions({
       pluginConfig: readCodexPluginConfig(pluginConfig),
     });
-    await primeGoogleCalendarAppInventory(
-      buildCodexPluginAppCacheKey({
-        appServer,
-        agentDir,
-        runtimeIdentity: getMockRuntimeIdentity(),
-      }),
-      true,
-    );
+    const pluginAppCacheKey = buildCodexPluginAppCacheKey({
+      appServer,
+      agentDir,
+      runtimeIdentity: getMockRuntimeIdentity(),
+    });
+    await primeGoogleCalendarAppInventory(pluginAppCacheKey, true);
     const bridgeSpy = vi
       .spyOn(elicitationBridge, "handleCodexAppServerElicitationRequest")
       .mockResolvedValue({
@@ -4558,12 +4556,16 @@ describe("runCodexAppServerAttempt", () => {
         pluginAppPolicyContext?: {
           apps?: Record<string, { mcpServerNames?: string[]; pluginName?: string }>;
         };
+        appServerRequest?: unknown;
+        pluginAppCacheKey?: string;
         threadId?: string;
         turnId?: string;
       },
     ];
     expect(bridgeCall.threadId).toBe("thread-1");
     expect(bridgeCall.turnId).toBe("turn-1");
+    expect(bridgeCall.appServerRequest).toBeTypeOf("function");
+    expect(bridgeCall.pluginAppCacheKey).toBe(pluginAppCacheKey);
     const calendarPolicy = bridgeCall.pluginAppPolicyContext?.apps?.["google-calendar-app"];
     expect(calendarPolicy?.pluginName).toBe("google-calendar");
     expect(calendarPolicy?.mcpServerNames).toEqual(["google-calendar"]);

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1,5 +1,6 @@
 // Codex tests cover side question plugin behavior.
 import {
+  callGatewayTool,
   nativeHookRelayTesting,
   type NativeHookRelayRegistrationHandle,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -20,6 +21,7 @@ import {
 } from "./codex-app-server.test-fixtures.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
+import { requestPluginApproval } from "./plugin-approval-roundtrip.js";
 import type { CodexServerNotification, JsonObject, JsonValue } from "./protocol.js";
 import {
   createCodexTestBindingStore,
@@ -67,6 +69,11 @@ vi.mock("./session-binding.js", async (importOriginal) => ({
     isCodexAppServerNativeAuthProfileMock(...args),
 }));
 
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>()),
+  callGatewayTool: vi.fn(),
+}));
+
 vi.mock("./shared-client.js", () => ({
   getSharedCodexAppServerClient: (...args: unknown[]) => getSharedCodexAppServerClientMock(...args),
   getLeasedSharedCodexAppServerClient: (...args: unknown[]) =>
@@ -107,6 +114,7 @@ vi.mock("openclaw/plugin-sdk/agent-harness", () => ({
 
 const { runCodexAppServerSideQuestion: runCodexAppServerSideQuestionImpl } =
   await import("./side-question.js");
+const mockCallGatewayTool = vi.mocked(callGatewayTool);
 const baseBindingStore = createCodexTestBindingStore();
 const bindingStore: CodexAppServerBindingStore = {
   ...baseBindingStore,
@@ -488,6 +496,7 @@ describe("runCodexAppServerSideQuestion", () => {
       content: null,
       _meta: null,
     });
+    mockCallGatewayTool.mockReset();
     resolveCodexProviderWebSearchSupportForClientMock.mockReset();
     withLeasedCodexAppServerClientStartSelectionRetryMock.mockReset();
     withLeasedCodexAppServerClientStartSelectionRetryMock.mockImplementation(
@@ -743,14 +752,25 @@ describe("runCodexAppServerSideQuestion", () => {
     });
     getSharedCodexAppServerClientMock.mockResolvedValue(client);
 
-    await expect(runCodexAppServerSideQuestion(sideParams())).resolves.toEqual({
-      text: "Side answer.",
-    });
+    await expect(
+      runCodexAppServerSideQuestion(
+        sideParams({
+          messageChannel: "discord",
+          messageProvider: "discord",
+          chatType: "direct",
+          sessionKey: "agent:main:discord:direct:user-1",
+          agentAccountId: "discord-account-1",
+          messageTo: "user:user-1",
+          messageThreadId: "thread-42",
+        }),
+      ),
+    ).resolves.toEqual({ text: "Side answer." });
 
     expect(elicitationResponse).toEqual({ action: "decline", content: null, _meta: null });
     const bridgeParams = handleCodexAppServerElicitationRequestMock.mock.calls[0]?.[0] as
       | {
           appServerRequest?: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+          paramsForRun?: Parameters<typeof requestPluginApproval>[0]["paramsForRun"];
           pluginAppCacheKey?: string;
         }
       | undefined;
@@ -761,6 +781,28 @@ describe("runCodexAppServerSideQuestion", () => {
       "plugin/list",
       { forceRefetch: true },
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    mockCallGatewayTool.mockResolvedValueOnce({ id: "plugin:side-question-route" });
+    await requestPluginApproval({
+      paramsForRun: bridgeParams!.paramsForRun!,
+      title: "Install calendar connector",
+      description: "Install the suggested connector",
+      severity: "warning",
+      toolName: "request_plugin_install",
+    });
+    expect(mockCallGatewayTool).toHaveBeenCalledWith(
+      "plugin.approval.request",
+      expect.any(Object),
+      expect.objectContaining({
+        sessionKey: "agent:main:discord:direct:user-1",
+        turnSourceChannel: "discord",
+        turnSourceTo: "user:user-1",
+        turnSourceAccountId: "discord-account-1",
+        turnSourceThreadId: "thread-42",
+        twoPhase: true,
+      }),
+      { expectFinal: false },
     );
   });
 

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -34,6 +34,7 @@ const refreshCodexAppServerAuthTokensMock = vi.fn();
 const createOpenClawCodingToolsMock = vi.fn();
 const toolExecuteMock = vi.fn();
 const handleCodexAppServerApprovalRequestMock = vi.fn();
+const handleCodexAppServerElicitationRequestMock = vi.fn();
 const resolveCodexProviderWebSearchSupportForClientMock = vi.fn();
 type SelectionRetryParams = {
   lease: { client?: unknown };
@@ -88,6 +89,11 @@ vi.mock("./auth-bridge.js", async (importOriginal) => ({
 vi.mock("./approval-bridge.js", () => ({
   handleCodexAppServerApprovalRequest: (...args: unknown[]) =>
     handleCodexAppServerApprovalRequestMock(...args),
+}));
+
+vi.mock("./elicitation-bridge.js", () => ({
+  handleCodexAppServerElicitationRequest: (...args: unknown[]) =>
+    handleCodexAppServerElicitationRequestMock(...args),
 }));
 
 vi.mock("./provider-capabilities.js", () => ({
@@ -476,6 +482,12 @@ describe("runCodexAppServerSideQuestion", () => {
     createOpenClawCodingToolsMock.mockReset();
     toolExecuteMock.mockReset();
     handleCodexAppServerApprovalRequestMock.mockReset();
+    handleCodexAppServerElicitationRequestMock.mockReset();
+    handleCodexAppServerElicitationRequestMock.mockResolvedValue({
+      action: "decline",
+      content: null,
+      _meta: null,
+    });
     resolveCodexProviderWebSearchSupportForClientMock.mockReset();
     withLeasedCodexAppServerClientStartSelectionRetryMock.mockReset();
     withLeasedCodexAppServerClientStartSelectionRetryMock.mockImplementation(
@@ -691,6 +703,65 @@ describe("runCodexAppServerSideQuestion", () => {
       messageActionTurnCapability: "turn-capability-1",
     });
     expect(toolOptions).toHaveProperty("requireExplicitMessageTarget", true);
+  });
+
+  it("gives side-thread tool suggestions a signal-bound app-server request adapter", async () => {
+    const client = createFakeClient();
+    let elicitationResponse: unknown;
+    client.request.mockImplementation(async (method: string, requestParams: unknown) => {
+      if (method === "thread/fork") {
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        setTimeout(() => {
+          void (async () => {
+            elicitationResponse = await client.handleRequest({
+              id: 43,
+              method: "mcpServer/elicitation/request",
+              params: {
+                ...codexTestTurnIds("side-thread"),
+                serverName: "codex_apps",
+                mode: "form",
+                requestedSchema: { type: "object", properties: {} },
+              },
+            });
+            client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
+          })();
+        }, 0);
+        return turnStartResult("turn-1");
+      }
+      if (method === "plugin/list") {
+        return { marketplaces: [], marketplaceLoadErrors: [], featuredPluginIds: [] };
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method} ${JSON.stringify(requestParams)}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(runCodexAppServerSideQuestion(sideParams())).resolves.toEqual({
+      text: "Side answer.",
+    });
+
+    expect(elicitationResponse).toEqual({ action: "decline", content: null, _meta: null });
+    const bridgeParams = handleCodexAppServerElicitationRequestMock.mock.calls[0]?.[0] as
+      | {
+          appServerRequest?: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+          pluginAppCacheKey?: string;
+        }
+      | undefined;
+    expect(bridgeParams?.appServerRequest).toBeTypeOf("function");
+    expect(bridgeParams?.pluginAppCacheKey).toBeTypeOf("string");
+    await bridgeParams?.appServerRequest?.("plugin/list", { forceRefetch: true });
+    expect(client.request).toHaveBeenCalledWith(
+      "plugin/list",
+      { forceRefetch: true },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("rebinds side-question handlers when selection retry replaces the client", async () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -913,8 +913,15 @@ function buildSideRunAttemptParams(
     ...(params.messageProvider ? { messageProvider: params.messageProvider } : {}),
     ...(params.chatType ? { chatType: params.chatType } : {}),
     ...(params.agentAccountId ? { agentAccountId: params.agentAccountId } : {}),
-    ...(params.messageTo ? { messageTo: params.messageTo } : {}),
-    ...(params.messageThreadId !== undefined ? { messageThreadId: params.messageThreadId } : {}),
+    ...(params.messageTo
+      ? { messageTo: params.messageTo, currentMessagingTarget: params.messageTo }
+      : {}),
+    ...(params.messageThreadId !== undefined
+      ? {
+          messageThreadId: params.messageThreadId,
+          currentThreadTs: String(params.messageThreadId),
+        }
+      : {}),
     ...(params.chatId ? { chatId: params.chatId } : {}),
     ...(params.messageActionTurnCapability
       ? { messageActionTurnCapability: params.messageActionTurnCapability }

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -25,7 +25,12 @@ import {
   retireUnsafeCodexTurnClientBestEffort,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
-import { resolveCodexAppServerPreparedAuthHandoff } from "./auth-bridge.js";
+import {
+  resolveCodexAppServerAuthAccountCacheKey,
+  resolveCodexAppServerFallbackApiKeyCacheKey,
+  resolveCodexAppServerPreparedApiKeyCacheKey,
+  resolveCodexAppServerPreparedAuthHandoff,
+} from "./auth-bridge.js";
 import {
   requireCodexSupervisionModelSelection,
   resolveCodexBindingAppServerConnection,
@@ -77,6 +82,7 @@ import {
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
 } from "./notification-correlation.js";
+import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   mergeCodexThreadConfigs,
@@ -307,7 +313,36 @@ export async function runCodexAppServerSideQuestion(
     config: params.cfg,
     ...(params.opts?.abortSignal ? { abandonSignal: params.opts.abortSignal } : {}),
   } satisfies CodexAppServerClientOptions;
+  const pluginAuthAccountCacheKey = usesSupervisionConnection
+    ? undefined
+    : startupPreparedAuth?.kind === "api-key"
+      ? resolveCodexAppServerPreparedApiKeyCacheKey(startupPreparedAuth.apiKey)
+      : startupPreparedAuth?.kind === "profile"
+        ? startupPreparedAuth.snapshot?.secretFreeCacheKey
+        : await resolveCodexAppServerAuthAccountCacheKey({
+            authProfileId: connection.requestAuthProfileId,
+            authProfileStore: preparedRuntimeAuth.authProfileStore,
+            agentDir: params.agentDir,
+            config: params.cfg,
+          });
+  const pluginEnvApiKeyCacheKey =
+    usesSupervisionConnection || startupPreparedAuth || connection.requestAuthProfileId
+      ? undefined
+      : resolveCodexAppServerFallbackApiKeyCacheKey({ startOptions: appServer.start });
   let client = await getLeasedSharedCodexAppServerClient(clientOptions);
+  const buildPluginAppCacheKey = (targetClient: CodexAppServerClient) =>
+    buildCodexPluginAppCacheKey({
+      appServer,
+      agentDir: params.agentDir,
+      authProfileId:
+        startupPreparedAuth?.kind === "profile"
+          ? startupPreparedAuth.profileId
+          : connection.requestAuthProfileId,
+      accountId: pluginAuthAccountCacheKey,
+      envApiKeyFingerprint: pluginEnvApiKeyCacheKey,
+      appServerVersion: targetClient.getServerVersion(),
+      runtimeIdentity: targetClient.getRuntimeIdentity(),
+    });
   const clientLease: CodexAppServerClientLease = { client };
   const collector = new CodexSideQuestionCollector(params, () => readRecentCodexRateLimits(client));
   const runAbortController = new AbortController();
@@ -450,6 +485,9 @@ export async function runCodexAppServerSideQuestion(
             threadId: childThreadId,
             turnId,
             pluginAppPolicyContext: binding.pluginAppPolicyContext,
+            appServerRequest: (method, requestParams) =>
+              targetClient.request(method, requestParams, { signal: runAbortController.signal }),
+            pluginAppCacheKey: buildPluginAppCacheKey(targetClient),
             signal: runAbortController.signal,
           });
         }

--- a/extensions/codex/src/app-server/tool-suggestion-bridge.ts
+++ b/extensions/codex/src/app-server/tool-suggestion-bridge.ts
@@ -23,6 +23,9 @@ const CODEX_APPS_SERVER_NAME = "codex_apps";
 const TOOL_SUGGESTION_KIND = "tool_suggestion";
 const INSTALL_SUGGESTION_TYPE = "install";
 const INSTALL_ALLOWED_DECISIONS = ["allow-once", "deny"] as const;
+// Match the extension's other Codex inventory scans: tolerate large catalogs while bounding
+// a malformed or adversarial stream of endlessly unique continuation cursors.
+const APP_LIST_MAX_PAGES = 100;
 
 type ToolSuggestion = {
   toolType: "plugin" | "connector";
@@ -230,7 +233,7 @@ async function verifyPluginAppsAccessible(params: {
   const accessibleIds = new Set<string>();
   const seenCursors = new Set<string>();
   let cursor: string | undefined;
-  while (true) {
+  for (let page = 0; page < APP_LIST_MAX_PAGES; page += 1) {
     const inventory = (await params.request("app/list", {
       threadId: params.threadId,
       forceRefetch: true,
@@ -251,6 +254,7 @@ async function verifyPluginAppsAccessible(params: {
     seenCursors.add(nextCursor);
     cursor = nextCursor;
   }
+  return false;
 }
 
 function pluginNameFromToolId(toolId: string): string | undefined {

--- a/extensions/codex/src/app-server/tool-suggestion-bridge.ts
+++ b/extensions/codex/src/app-server/tool-suggestion-bridge.ts
@@ -1,0 +1,245 @@
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  requestPluginApprovalOutcome,
+  sanitizeCodexApprovalVisibleText,
+} from "./plugin-approval-roundtrip.js";
+import {
+  findOpenAiCuratedPluginSummary,
+  pluginReadParams,
+  type CodexPluginRuntimeRequest,
+} from "./plugin-inventory.js";
+import { isJsonObject, type JsonObject, type JsonValue, type v2 } from "./protocol.js";
+
+const CODEX_APPS_SERVER_NAME = "codex_apps";
+const TOOL_SUGGESTION_KIND = "tool_suggestion";
+const INSTALL_SUGGESTION_TYPE = "install";
+const INSTALL_ALLOWED_DECISIONS = ["allow-once", "deny"] as const;
+
+type ToolSuggestion = {
+  toolType: "plugin" | "connector";
+  threadId: string;
+  toolId: string;
+  toolName: string;
+  reason: string;
+  installUrl?: string;
+};
+
+export async function handleCodexAppServerToolSuggestion(params: {
+  requestParams: JsonObject;
+  paramsForRun: EmbeddedRunAttemptParams;
+  activeTurnId: string;
+  appServerRequest?: CodexPluginRuntimeRequest;
+  signal?: AbortSignal;
+}): Promise<JsonValue | undefined> {
+  const suggestion = readToolSuggestion(params.requestParams, params.activeTurnId);
+  if (!suggestion) {
+    return undefined;
+  }
+
+  if (suggestion.toolType === "connector" && !suggestion.installUrl) {
+    const outcome = await requestPluginApprovalOutcome({
+      paramsForRun: params.paramsForRun,
+      title: `Cannot install ${suggestion.toolName}`,
+      description: "Codex did not provide a safe install link. Complete this setup in a Codex UI.",
+      toolName: "codex_connector_install",
+      allowedDecisions: ["deny"],
+      signal: params.signal,
+    });
+    return outcome === "cancelled" ? cancelResponse() : declineResponse();
+  }
+
+  const outcome = await requestPluginApprovalOutcome({
+    paramsForRun: params.paramsForRun,
+    title: `Install ${suggestion.toolName}`,
+    description: buildInstallDescription(suggestion),
+    toolName: suggestion.toolType === "plugin" ? "codex_plugin_install" : "codex_connector_install",
+    allowedDecisions: [...INSTALL_ALLOWED_DECISIONS],
+    signal: params.signal,
+  });
+  if (outcome === "cancelled") {
+    return cancelResponse();
+  }
+  if (outcome !== "approved-once" && outcome !== "approved-session") {
+    return declineResponse();
+  }
+  if (suggestion.toolType === "connector") {
+    return acceptResponse();
+  }
+  if (!params.appServerRequest) {
+    return declineResponse();
+  }
+
+  try {
+    const installed = await installSuggestedPlugin(params.appServerRequest, suggestion.toolId);
+    const authorized = await authorizePluginApps({
+      apps: installed.appsNeedingAuth,
+      paramsForRun: params.paramsForRun,
+      request: params.appServerRequest,
+      threadId: suggestion.threadId,
+      signal: params.signal,
+    });
+    return authorized ? acceptResponse() : declineResponse();
+  } catch (error) {
+    embeddedAgentLog.warn("codex suggested plugin install failed", {
+      toolId: suggestion.toolId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return declineResponse();
+  }
+}
+
+function readToolSuggestion(
+  requestParams: JsonObject,
+  activeTurnId: string,
+): ToolSuggestion | undefined {
+  if (
+    requestParams.serverName !== CODEX_APPS_SERVER_NAME ||
+    requestParams.mode !== "form" ||
+    requestParams.turnId !== activeTurnId
+  ) {
+    return undefined;
+  }
+  const meta = isJsonObject(requestParams._meta) ? requestParams._meta : undefined;
+  const requestedSchema = isJsonObject(requestParams.requestedSchema)
+    ? requestParams.requestedSchema
+    : undefined;
+  const properties = isJsonObject(requestedSchema?.properties)
+    ? requestedSchema.properties
+    : undefined;
+  if (
+    !meta ||
+    meta.codex_approval_kind !== TOOL_SUGGESTION_KIND ||
+    meta.suggest_type !== INSTALL_SUGGESTION_TYPE ||
+    requestedSchema?.type !== "object" ||
+    !properties ||
+    Object.keys(properties).length !== 0
+  ) {
+    return undefined;
+  }
+  const toolType = meta.tool_type;
+  const threadId = readVisibleString(requestParams.threadId);
+  const toolId = readVisibleString(meta.tool_id);
+  const toolName = readVisibleString(meta.tool_name);
+  const reason = readVisibleString(meta.suggest_reason);
+  if (
+    (toolType !== "plugin" && toolType !== "connector") ||
+    !threadId ||
+    !toolId ||
+    !toolName ||
+    !reason
+  ) {
+    return undefined;
+  }
+  const installUrl = toolType === "connector" ? readSafeHttpsUrl(meta.install_url) : undefined;
+  return { toolType, threadId, toolId, toolName, reason, ...(installUrl ? { installUrl } : {}) };
+}
+
+function buildInstallDescription(suggestion: ToolSuggestion): string {
+  if (suggestion.toolType === "connector") {
+    return suggestion.installUrl
+      ? `Open this Codex install link, finish setup, then approve:\n${suggestion.installUrl}`
+      : "Codex did not provide a safe install link. Complete setup in a Codex UI, then approve.";
+  }
+  return `${suggestion.reason} Approve to install it in Codex.`;
+}
+
+async function installSuggestedPlugin(
+  request: CodexPluginRuntimeRequest,
+  toolId: string,
+): Promise<v2.PluginInstallResponse> {
+  const listed = (await request("plugin/list", {})) as v2.PluginListResponse;
+  const resolved = findOpenAiCuratedPluginSummary(listed, toolId);
+  if (!resolved) {
+    throw new Error("suggested plugin was not found in the curated Codex catalog");
+  }
+  const installName = resolved.marketplace.remoteMarketplaceName
+    ? resolved.summary.remotePluginId
+    : pluginNameFromToolId(toolId);
+  if (!installName) {
+    throw new Error("suggested plugin did not have an installable catalog id");
+  }
+  return (await request(
+    "plugin/install",
+    pluginReadParams(resolved.marketplace, installName),
+  )) as v2.PluginInstallResponse;
+}
+
+async function authorizePluginApps(params: {
+  apps: v2.AppSummary[];
+  paramsForRun: EmbeddedRunAttemptParams;
+  request: CodexPluginRuntimeRequest;
+  threadId: string;
+  signal?: AbortSignal;
+}): Promise<boolean> {
+  if (params.apps.length === 0) {
+    return true;
+  }
+  for (const app of params.apps) {
+    const installUrl = readSafeHttpsUrl(app.installUrl);
+    const outcome = await requestPluginApprovalOutcome({
+      paramsForRun: params.paramsForRun,
+      title: `Authorize ${readVisibleString(app.name) ?? "Codex app"}`,
+      description: installUrl
+        ? `Open this Codex authorization link, finish setup, then approve:\n${installUrl}`
+        : "Codex did not provide a safe authorization link. Complete setup in a Codex UI, then approve.",
+      toolName: "codex_app_authorization",
+      allowedDecisions: [...INSTALL_ALLOWED_DECISIONS],
+      signal: params.signal,
+    });
+    if (outcome !== "approved-once" && outcome !== "approved-session") {
+      return false;
+    }
+  }
+  const inventory = (await params.request("app/list", {
+    threadId: params.threadId,
+    forceRefetch: true,
+  })) as { data?: v2.AppInfo[] };
+  const accessibleIds = new Set(
+    inventory.data?.filter((app) => app.isAccessible).map((app) => app.id) ?? [],
+  );
+  return params.apps.every((app) => accessibleIds.has(app.id));
+}
+
+function pluginNameFromToolId(toolId: string): string | undefined {
+  const at = toolId.lastIndexOf("@");
+  const name = (at > 0 ? toolId.slice(0, at) : toolId).trim();
+  return name || undefined;
+}
+
+function readVisibleString(value: JsonValue | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return (
+    sanitizeCodexApprovalVisibleText(value, { stripDanglingTerminalSequence: true }) || undefined
+  );
+}
+
+function readSafeHttpsUrl(value: JsonValue | undefined): string | undefined {
+  if (typeof value !== "string" || value.length > 190) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" && !parsed.username && !parsed.password
+      ? parsed.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function acceptResponse(): JsonValue {
+  return { action: "accept", content: null, _meta: null };
+}
+
+function declineResponse(): JsonValue {
+  return { action: "decline", content: null, _meta: null };
+}
+
+function cancelResponse(): JsonValue {
+  return { action: "cancel", content: null, _meta: null };
+}

--- a/extensions/codex/src/app-server/tool-suggestion-bridge.ts
+++ b/extensions/codex/src/app-server/tool-suggestion-bridge.ts
@@ -2,6 +2,11 @@ import {
   embeddedAgentLog,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
+import {
+  refreshCodexPluginAppInventoryState,
+  refreshCodexPluginRuntimeState,
+} from "./plugin-activation.js";
 import {
   requestPluginApprovalOutcome,
   sanitizeCodexApprovalVisibleText,
@@ -11,6 +16,7 @@ import {
   pluginReadParams,
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
+import { defaultCodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import { isJsonObject, type JsonObject, type JsonValue, type v2 } from "./protocol.js";
 
 const CODEX_APPS_SERVER_NAME = "codex_apps";
@@ -32,6 +38,7 @@ export async function handleCodexAppServerToolSuggestion(params: {
   paramsForRun: EmbeddedRunAttemptParams;
   activeTurnId: string;
   appServerRequest?: CodexPluginRuntimeRequest;
+  pluginAppCacheKey?: string;
   signal?: AbortSignal;
 }): Promise<JsonValue | undefined> {
   const suggestion = readToolSuggestion(params.requestParams, params.activeTurnId);
@@ -74,6 +81,13 @@ export async function handleCodexAppServerToolSuggestion(params: {
 
   try {
     const installed = await installSuggestedPlugin(params.appServerRequest, suggestion.toolId);
+    await refreshCodexPluginRuntimeState({
+      request: params.appServerRequest,
+      appCache: defaultCodexAppInventoryCache,
+      appCacheKey: params.pluginAppCacheKey,
+      metadataCache: defaultCodexPluginMetadataCache,
+      deferAppInventoryRefresh: installed.appsNeedingAuth.length > 0,
+    });
     const authorized = await authorizePluginApps({
       apps: installed.appsNeedingAuth,
       paramsForRun: params.paramsForRun,
@@ -81,6 +95,13 @@ export async function handleCodexAppServerToolSuggestion(params: {
       threadId: suggestion.threadId,
       signal: params.signal,
     });
+    if (authorized && installed.appsNeedingAuth.length > 0) {
+      await refreshCodexPluginAppInventoryState({
+        request: params.appServerRequest,
+        appCache: defaultCodexAppInventoryCache,
+        appCacheKey: params.pluginAppCacheKey,
+      });
+    }
     return authorized ? acceptResponse() : declineResponse();
   } catch (error) {
     embeddedAgentLog.warn("codex suggested plugin install failed", {
@@ -193,14 +214,43 @@ async function authorizePluginApps(params: {
       return false;
     }
   }
-  const inventory = (await params.request("app/list", {
+  return await verifyPluginAppsAccessible({
+    apps: params.apps,
+    request: params.request,
     threadId: params.threadId,
-    forceRefetch: true,
-  })) as { data?: v2.AppInfo[] };
-  const accessibleIds = new Set(
-    inventory.data?.filter((app) => app.isAccessible).map((app) => app.id) ?? [],
-  );
-  return params.apps.every((app) => accessibleIds.has(app.id));
+  });
+}
+
+async function verifyPluginAppsAccessible(params: {
+  apps: readonly v2.AppSummary[];
+  request: CodexPluginRuntimeRequest;
+  threadId: string;
+}): Promise<boolean> {
+  const expectedIds = new Set(params.apps.map((app) => app.id));
+  const accessibleIds = new Set<string>();
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  while (true) {
+    const inventory = (await params.request("app/list", {
+      threadId: params.threadId,
+      forceRefetch: true,
+      ...(cursor ? { cursor } : {}),
+    })) as { data?: v2.AppInfo[]; nextCursor?: string | null };
+    for (const app of inventory.data ?? []) {
+      if (app.isAccessible && expectedIds.has(app.id)) {
+        accessibleIds.add(app.id);
+      }
+    }
+    if (accessibleIds.size === expectedIds.size) {
+      return true;
+    }
+    const nextCursor = inventory.nextCursor?.trim();
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      return false;
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
 }
 
 function pluginNameFromToolId(toolId: string): string | undefined {

--- a/extensions/codex/src/app-server/tool-suggestion-bridge.ts
+++ b/extensions/codex/src/app-server/tool-suggestion-bridge.ts
@@ -72,7 +72,7 @@ export async function handleCodexAppServerToolSuggestion(params: {
   if (outcome === "cancelled") {
     return cancelResponse();
   }
-  if (outcome !== "approved-once" && outcome !== "approved-session") {
+  if (outcome !== "approved-once") {
     return declineResponse();
   }
   if (suggestion.toolType === "connector") {
@@ -213,7 +213,7 @@ async function authorizePluginApps(params: {
       allowedDecisions: [...INSTALL_ALLOWED_DECISIONS],
       signal: params.signal,
     });
-    if (outcome !== "approved-once" && outcome !== "approved-session") {
+    if (outcome !== "approved-once") {
       return false;
     }
   }

--- a/extensions/discord/src/approval-native.test.ts
+++ b/extensions/discord/src/approval-native.test.ts
@@ -206,6 +206,101 @@ describe("createDiscordNativeApprovalAdapter", () => {
     expect(target).toBeNull();
   });
 
+  it("routes an authorized owner DM back to that owner's approver DM", async () => {
+    const adapter = createDiscordNativeApprovalAdapter();
+    const request = {
+      id: "plugin:owner-dm",
+      request: {
+        title: "Plugin approval",
+        description: "Install the requested plugin",
+        sessionKey: "agent:main:discord:direct:555555555",
+        turnSourceChannel: "discord",
+        turnSourceTo: "user:555555555",
+        turnSourceAccountId: "main",
+      },
+      createdAtMs: 1,
+      expiresAtMs: 2,
+    };
+
+    const originTarget = await adapter.native?.resolveOriginTarget?.({
+      cfg: NATIVE_DELIVERY_CFG as never,
+      accountId: "main",
+      approvalKind: "plugin",
+      request,
+    });
+    const approverDmTargets = await adapter.native?.resolveApproverDmTargets?.({
+      cfg: NATIVE_DELIVERY_CFG as never,
+      accountId: "main",
+      approvalKind: "plugin",
+      request,
+    });
+
+    expect(originTarget).toBeNull();
+    expect(approverDmTargets).toEqual([{ to: "555555555" }]);
+    expect(
+      adapter.auth?.authorizeActorAction?.({
+        cfg: NATIVE_DELIVERY_CFG as never,
+        accountId: "main",
+        senderId: "555555555",
+        action: "approve",
+        approvalKind: "plugin",
+      }),
+    ).toEqual({ authorized: true });
+  });
+
+  it("routes a non-approver DM source only to configured approver DMs", async () => {
+    const adapter = createDiscordNativeApprovalAdapter();
+    const cfg = {
+      channels: {
+        discord: {
+          execApprovals: {
+            enabled: true,
+            approvers: ["discord:555555555", "user:666666666"],
+          },
+        },
+      },
+    } as const;
+    const request = {
+      id: "plugin:non-approver-dm",
+      request: {
+        title: "Plugin approval",
+        description: "Install the requested plugin",
+        sessionKey: "agent:main:discord:direct:999999999",
+        turnSourceChannel: "discord",
+        turnSourceTo: "user:999999999",
+        turnSourceAccountId: "main",
+      },
+      createdAtMs: 1,
+      expiresAtMs: 2,
+    };
+
+    const originTarget = await adapter.native?.resolveOriginTarget?.({
+      cfg: cfg as never,
+      accountId: "main",
+      approvalKind: "plugin",
+      request,
+    });
+    const approverDmTargets = await adapter.native?.resolveApproverDmTargets?.({
+      cfg: cfg as never,
+      accountId: "main",
+      approvalKind: "plugin",
+      request,
+    });
+
+    expect(originTarget).toBeNull();
+    expect(approverDmTargets).toEqual([{ to: "555555555" }, { to: "666666666" }]);
+    expect(approverDmTargets).not.toContainEqual({ to: "999999999" });
+    expect(
+      adapter.auth?.authorizeActorAction?.({
+        cfg: cfg as never,
+        accountId: "main",
+        senderId: "999999999",
+        action: "approve",
+        approvalKind: "plugin",
+      }),
+    ).toMatchObject({ authorized: false });
+  });
+
   it("falls back to approver DMs for account-scoped Discord direct sessions", async () => {
     const adapter = createDiscordNativeApprovalAdapter();
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users asking Codex to use an uninstalled plugin or connector from an OpenClaw channel could not receive Codex's install prompt through the channel-bound approval flow.

## Why This Change Was Made

The Codex app-server adapter recognizes typed `tool_suggestion` elicitations and routes them through OpenClaw's existing two-phase approval broker. Plugin installs happen only after an explicit one-shot decision and use Codex's catalog identifiers; connector and app authorization links are relayed only when they are safe HTTPS URLs. Foreign turns, unavailable delivery, unsupported decisions, denial, timeout, malformed metadata, and unsafe links fail closed.

Normal and side-question turns supply the same signal-bound app-server request capability and runtime-scoped cache identity. Side questions translate their explicit recipient and thread into the canonical approval-route fields, preserving server-channel and thread delivery. Discord direct sessions intentionally retain the existing approver boundary: an owner or configured approver receives the prompt in the same DM through approver-DM fallback, while a non-approver source does not receive an actionable prompt and delivery falls back only to configured approver DMs.

Successful plugin installs reuse the canonical activation owner for plugin metadata invalidation plus plugin, skills, hooks, MCP, and app-inventory refresh. App authorization verification follows `app/list` cursors until the expected apps are accessible, inventory ends, a cursor repeats, or the established 100-page Codex inventory ceiling is reached.

Native Codex UI behavior is unchanged. Channel delivery continues to use the existing source session, account, target, and thread binding, including persisted-session fallback when the immediate target is unavailable.

## User Impact

Users can receive and answer Codex install prompts through the channel-bound approval route. For example, a Google Calendar request from a Discord server thread can surface the setup prompt in that thread, wait for explicit confirmation, install and refresh the plugin runtime, verify authorization across bounded paginated app inventory, and resume the exact waiting Codex interaction. For a Discord DM, the same-DM experience applies when the initiator is an owner/configured approver; otherwise only configured approver DMs receive the prompt.

## Evidence

- Initial TDD red: focused extension test failed the previously unhandled plugin and connector paths ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31218701313)).
- Lifecycle-finding TDD red: 4 intended failures / 69 passes proved missing side-question capability, missing post-install refresh, second-page authorization failure, and cursor traversal absence ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31222305560)).
- Unique-cursor cap TDD red: the new regression observed 101 `app/list` calls instead of the required 100 ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31225505492)).
- Side-question route TDD red: a Discord direct-message/thread fixture reached the real approval payload with `turnSourceTo` and `turnSourceThreadId` both `undefined` ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31228521881)).
- Focused route green: the same regression passed 1/1 after canonical target/thread translation ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31228736535)).
- Previous exact head `6c87f55ef49ce2a9324d92116b9788120d99a1b9`: side-question, approval bridge, elicitation bridge, and tool-suggestion suites passed 214/214 tests ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31230087183)).
- Discord DM security-boundary TDD red: mutating the approver mapping made exactly the two new delivery assertions fail while the existing 14 Discord adapter tests passed ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31250485331)).
- Restored-source green: the shared delivery planner and Discord adapter suites passed 20/20 tests, including same-DM delivery for a configured owner and configured-approver-only fallback for a non-approver source ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31250638573)).
- Invalidated `extensionTests` static lane passed formatting, extension test typecheck, exact-file lint with 0 warnings/errors, plugin boundaries, dead-export scans, and shared ratchet/guard checks ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/31250823106)).
- Fresh `autoreview --mode branch --base 480e0c006067b72ea63cae2e667a54fac659a85c`: clean TruffleHog scan, one complete 66,668-byte review pass, no accepted/actionable findings, patch-correct confidence 0.99.
- Exact pushed head: `560b19b8ffff389863a009467cf06dbcbdc0314e`.
- The closeout fetch observed `upstream/main` at `c5d00cb47ddb7236980de8e0fbc938b23fdeaae0`; the existing PR lineage remains rooted at `480e0c006067b72ea63cae2e667a54fac659a85c`, and no contributor-history rewrite was performed for unrelated drift.
- Blacksmith owns one-shot Testbox lifecycle teardown, so successful delegated commands can leave their backing Actions wrapper cancelled; the terminal Crabbox receipts above exited 0.
- Source-blind live behavior validation remains blocked because no public channel-connected, authenticated Codex fixture can deterministically emit these install, pagination, and failure scenarios without repository source. Typed owner-boundary RPC and real native-delivery regressions are not represented as black-box validation.
