### PR TITLE
fix(ci): harden hydrated dead-export scans

### DIFF
--- a/scripts/check-deadcode-exports.d.mts
+++ b/scripts/check-deadcode-exports.d.mts
@@ -11,3 +11,12 @@ export function checkUnusedExports(output: string): {
   entries: string[];
   message: string;
 };
+/** Classifies Knip export output, rejecting findings after resolution failures. */
+export function checkExportScan(
+  scanName: string,
+  output: string,
+): {
+  ok: boolean;
+  entries: string[];
+  message: string;
+};

--- a/scripts/check-deadcode-exports.mjs
+++ b/scripts/check-deadcode-exports.mjs
@@ -99,7 +99,7 @@ export function checkUnusedExports(output) {
 export function checkExportScan(scanName, output) {
   const resolutionErrors = output
     .split(/\r?\n/u)
-    .filter((line) => /^ERROR: Error loading /u.test(line));
+    .filter((line) => line.startsWith("ERROR: Error loading "));
   if (resolutionErrors.length > 0) {
     return {
       ok: false,

--- a/scripts/check-deadcode-exports.mjs
+++ b/scripts/check-deadcode-exports.mjs
@@ -95,6 +95,30 @@ export function checkUnusedExports(output) {
   };
 }
 
+/** Classifies Knip export output, rejecting findings after resolution failures. */
+export function checkExportScan(scanName, output) {
+  const resolutionErrors = output
+    .split(/\r?\n/u)
+    .filter((line) => /^ERROR: Error loading /u.test(line));
+  if (resolutionErrors.length > 0) {
+    return {
+      ok: false,
+      entries: [],
+      message: [
+        `deadcode ${scanName} could not resolve workspace modules; export findings would be unreliable and are discarded.`,
+        ...resolutionErrors,
+        "Install workspace dependencies in-tree (pnpm install) — on delegated boxes the crabbox wrapper links the hydrated modules dir into the workdir — and rerun.",
+      ].join("\n"),
+    };
+  }
+
+  const check = checkUnusedExports(output);
+  return {
+    ...check,
+    message: check.ok ? "" : `${scanName}:\n${check.message}`,
+  };
+}
+
 async function main() {
   // The scans are independent Knip child processes over separate configs;
   // running them concurrently cuts the lane's serial wall clock roughly 2x.
@@ -128,6 +152,12 @@ function reportUnusedExportScan(scan, result) {
     return false;
   }
 
+  const check = checkExportScan(scan.name, result.output);
+  if (!check.ok) {
+    console.error(check.message);
+    return false;
+  }
+
   const parsed = parseKnipCompactUnusedExportsResult(result.output);
   // Knip's compact reporter omits empty sections, so a clean scan (exit 0)
   // legitimately prints no export sections; sectionless output is only a
@@ -140,11 +170,6 @@ function reportUnusedExportScan(scan, result) {
     return false;
   }
 
-  const check = checkUnusedExports(result.output);
-  if (!check.ok) {
-    console.error(`${scan.name}:\n${check.message}`);
-    return false;
-  }
   if (result.status !== 0) {
     console.error(`deadcode ${scan.name} exited with status ${result.status}.`);
     if (result.output) {

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -2550,6 +2550,12 @@ function remoteWindowsHydratedNodeModulesBootstrap() {
   ].join("; ");
 }
 
+function remotePosixHydratedNodeModulesBootstrap() {
+  // Knip and other non-pnpm tools walk node_modules, while hydrated boxes keep it external.
+  // Without this link, dead-code scans silently lose consumer edges and report false positives.
+  return 'if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ] && [ -d "$PNPM_CONFIG_MODULES_DIR" ] && [ ! -e node_modules ]; then ln -s "$PNPM_CONFIG_MODULES_DIR" node_modules; fi;';
+}
+
 function injectRemoteWindowsHydratedNodeModulesBootstrap(invocation, facts, providerName) {
   if (
     invocation.args[0] !== "run" ||
@@ -2568,6 +2574,23 @@ function injectRemoteWindowsHydratedNodeModulesBootstrap(invocation, facts, prov
   return replaceRunCommandWithShell(
     invocation,
     `${remoteWindowsHydratedNodeModulesBootstrap()}; ${renderRunShellCommand(invocation, powershellJoin)}`,
+  );
+}
+
+function injectRemotePosixHydratedNodeModulesBootstrap(invocation) {
+  if (
+    invocation.args[0] !== "run" ||
+    isWindowsRemoteTarget(invocation.args) ||
+    invocation.options.has("script") ||
+    invocation.options.has("script-stdin") ||
+    invocation.start < 0
+  ) {
+    return invocation.args;
+  }
+
+  return replaceRunCommandWithShell(
+    invocation,
+    `${remotePosixHydratedNodeModulesBootstrap()} ${renderRunShellCommand(invocation)}`,
   );
 }
 
@@ -3636,6 +3659,8 @@ function applyRunTransforms(initialInvocation, initialFacts, options) {
       options.changedGateAlias,
     );
   }
+  invocation = parseRunInvocation(help.text, transformedArgs);
+  transformedArgs = injectRemotePosixHydratedNodeModulesBootstrap(invocation);
   return {
     args: injectRemoteTestboxCi(transformedArgs, options.provider),
     wsl2ScriptBootstrap,

--- a/test/scripts/check-deadcode-exports.test.ts
+++ b/test/scripts/check-deadcode-exports.test.ts
@@ -7,6 +7,7 @@ import allExportsKnipConfig from "../../config/knip.all-exports.config.ts";
 import knipConfig from "../../config/knip.config.ts";
 import scriptExportsKnipConfig from "../../config/knip.scripts-exports.config.ts";
 import {
+  checkExportScan,
   checkUnusedExports,
   parseKnipCompactUnusedExports,
   parseKnipCompactUnusedExportsResult,
@@ -386,6 +387,43 @@ src/a.ts: alpha
   src/a.ts: alpha
   src/z.ts: zebra
 Delete the exports or model their real production consumers in Knip.`,
+    });
+  });
+
+  it("discards export findings after workspace module resolution failures", () => {
+    const output = `ERROR: Error loading vitest.config.ts (Cannot find module 'vitest/config')
+ERROR: Error loading ui/vite.config.ts (Cannot find module 'vite')
+Unused exports (1)
+src/config/types.ts: TelegramConfig
+`;
+
+    const result = checkExportScan("production unused-export scan", output);
+    expect(result.ok).toBe(false);
+    expect(result.entries).toEqual([]);
+    expect(result.message).toContain(
+      "deadcode production unused-export scan could not resolve workspace modules; export findings would be unreliable and are discarded.",
+    );
+    expect(result.message).toContain("ERROR: Error loading vitest.config.ts");
+    expect(result.message).toContain("ERROR: Error loading ui/vite.config.ts");
+    expect(result.message).toContain("Install workspace dependencies in-tree (pnpm install)");
+    expect(result.message).not.toContain("Unused exports are not allowed");
+    expect(result.message).not.toContain("src/config/types.ts: TelegramConfig");
+  });
+
+  it("accepts clean export scan output unchanged", () => {
+    expect(checkExportScan("clean scan", "")).toEqual({ entries: [], message: "", ok: true });
+  });
+
+  it("reports genuine export findings unchanged", () => {
+    expect(
+      checkExportScan("finding scan", "Unused exports (1)\nsrc/config/types.ts: TelegramConfig\n"),
+    ).toEqual({
+      entries: ["src/config/types.ts: TelegramConfig"],
+      message: `finding scan:
+Unused exports are not allowed:
+  src/config/types.ts: TelegramConfig
+Delete the exports or model their real production consumers in Knip.`,
+      ok: false,
     });
   });
 });

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -468,7 +468,10 @@ function expectHydratedWindowsShell(run: ParsedWrapperRun, command: string): voi
 const remotePosixHydratedModulesBootstrap =
   'if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ] && [ -d "$PNPM_CONFIG_MODULES_DIR" ] && [ ! -e node_modules ]; then ln -s "$PNPM_CONFIG_MODULES_DIR" node_modules; fi;';
 
-function expectHydratedPosixShell(run: ParsedWrapperRun, command: string): void {
+function expectHydratedPosixShell(
+  run: Pick<ParsedWrapperRun, "output" | "remoteCommand">,
+  command: string,
+): void {
   expect(run.output.args).toContain("--shell");
   expect(run.remoteCommand).toContain(remotePosixHydratedModulesBootstrap);
   expect(run.remoteCommand).toContain(command);

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -465,6 +465,15 @@ function expectHydratedWindowsShell(run: ParsedWrapperRun, command: string): voi
   expect(run.remoteCommand).toContain(command);
 }
 
+const remotePosixHydratedModulesBootstrap =
+  'if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ] && [ -d "$PNPM_CONFIG_MODULES_DIR" ] && [ ! -e node_modules ]; then ln -s "$PNPM_CONFIG_MODULES_DIR" node_modules; fi;';
+
+function expectHydratedPosixShell(run: ParsedWrapperRun, command: string): void {
+  expect(run.output.args).toContain("--shell");
+  expect(run.remoteCommand).toContain(remotePosixHydratedModulesBootstrap);
+  expect(run.remoteCommand).toContain(command);
+}
+
 function normalizeShellLineEndings(value: string): string {
   return value.replace(/\r\n/g, "\n");
 }
@@ -822,14 +831,14 @@ describe("scripts/crabbox-wrapper", () => {
       "name=proof",
       "--provider",
       "local-container",
+      "--shell",
       "--",
-      "echo",
-      "ok",
+      `${remotePosixHydratedModulesBootstrap} echo ok`,
     ]);
   });
 
   it("routes the provider-neutral changed gate without consuming its run option values", () => {
-    const { output, result } = runSuccessfulBrokerWrapper(
+    const { output, remoteCommand, result } = runSuccessfulBrokerWrapper(
       [
         "run",
         "--workload",
@@ -856,7 +865,7 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).not.toContain("blacksmith-testbox");
     expect(output.args).toContain("90m");
     expect(output.args).toContain("240m");
-    expect(output.args.slice(-3)).toEqual(["corepack", "pnpm", "check:changed"]);
+    expectHydratedPosixShell({ output, remoteCommand }, "corepack pnpm check:changed");
     expect(result.stderr).toContain("route workload=ci-fast selected=daytona");
   });
 
@@ -1403,10 +1412,9 @@ describe("scripts/crabbox-wrapper", () => {
       "blacksmith-testbox",
       "--id",
       "tbx_owned",
+      "--shell",
       "--",
-      "env",
-      "CI=true",
-      "echo ok",
+      `export CI=true; ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
     ]);
   });
 
@@ -1621,10 +1629,9 @@ describe("scripts/crabbox-wrapper", () => {
       "blacksmith-testbox",
       "--id",
       "blue-hermit",
+      "--shell",
       "--",
-      "env",
-      "CI=true",
-      "echo ok",
+      `export CI=true; ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
     ]);
   });
 
@@ -1644,7 +1651,7 @@ describe("scripts/crabbox-wrapper", () => {
       "blacksmith-testbox",
       "--shell",
       "--",
-      "export CI=true; cd packages && pnpm install && pnpm build",
+      `export CI=true; ${remotePosixHydratedModulesBootstrap} cd packages && pnpm install && pnpm build`,
     ]);
   });
 
@@ -1676,8 +1683,9 @@ describe("scripts/crabbox-wrapper", () => {
       "macos",
       "--market",
       "on-demand",
+      "--shell",
       "--",
-      "echo ok",
+      `${remotePosixHydratedModulesBootstrap} 'echo ok'`,
     ]);
   });
 
@@ -1955,8 +1963,9 @@ describe("scripts/crabbox-wrapper", () => {
       "--target=macos",
       "--market",
       "spot",
+      "--shell",
       "--",
-      "echo ok",
+      `${remotePosixHydratedModulesBootstrap} 'echo ok'`,
     ]);
     expect(existingLease.status).toBe(0);
     expect(parseFakeCrabboxOutput(existingLease).args).toEqual([
@@ -1967,8 +1976,9 @@ describe("scripts/crabbox-wrapper", () => {
       "macos",
       "--id",
       "cbx_existing",
+      "--shell",
       "--",
-      "echo ok",
+      `${remotePosixHydratedModulesBootstrap} 'echo ok'`,
     ]);
   });
 
@@ -2073,7 +2083,9 @@ describe("scripts/crabbox-wrapper", () => {
       "bash -lc 'env -i PATH=/usr/bin:/bin pnpm --version'",
     );
     expect(remoteCommand).not.toContain("openclaw_crabbox_bootstrap_macos_js");
-    expect(remoteCommand).toBe("bash -lc 'env -i PATH=/usr/bin:/bin pnpm --version'");
+    expect(remoteCommand).toBe(
+      `${remotePosixHydratedModulesBootstrap} bash -lc 'env -i PATH=/usr/bin:/bin pnpm --version'`,
+    );
   });
 
   it("preserves sanitized env shell package scripts when JS tooling is needed", () => {
@@ -2224,8 +2236,11 @@ describe("scripts/crabbox-wrapper", () => {
   });
 
   it("does not preflight Swift for raw AWS macOS commands that only mention package scripts", () => {
-    const { output } = runSuccessfulMacosCommand(["echo", "scripts/package-mac-app.sh"]);
-    expect(output.args).not.toContain("--shell");
+    const { output, remoteCommand } = runSuccessfulMacosCommand([
+      "echo",
+      "scripts/package-mac-app.sh",
+    ]);
+    expect(remoteCommand).not.toContain("openclaw_crabbox_require_macos_swift_62");
     expect(output.args).toEqual([
       "run",
       "--provider",
@@ -2234,9 +2249,9 @@ describe("scripts/crabbox-wrapper", () => {
       "macos",
       "--market",
       "on-demand",
+      "--shell",
       "--",
-      "echo",
-      "scripts/package-mac-app.sh",
+      `${remotePosixHydratedModulesBootstrap} echo scripts/package-mac-app.sh`,
     ]);
   });
 
@@ -2391,7 +2406,7 @@ describe("scripts/crabbox-wrapper", () => {
       "--version",
     ]);
     expect(remoteCommand).not.toContain("openclaw_crabbox_bootstrap_macos_js");
-    expect(output.args).not.toContain("--shell");
+    expectHydratedPosixShell({ output, remoteCommand }, "./tools/env -i pnpm --version");
   });
 
   it("does not bootstrap env ignore-environment commands that bypass shell functions", () => {
@@ -2405,7 +2420,10 @@ describe("scripts/crabbox-wrapper", () => {
         "--version",
       ]);
       expect(remoteCommand).not.toContain("openclaw_crabbox_bootstrap_macos_js");
-      expect(output.args).not.toContain("--shell");
+      expectHydratedPosixShell(
+        { output, remoteCommand },
+        `${prefix} env -i PATH=/usr/bin:/bin pnpm --version`,
+      );
     }
   });
 
@@ -2439,7 +2457,7 @@ describe("scripts/crabbox-wrapper", () => {
       "pnpm --version",
     ]);
     expect(remoteCommand).not.toContain("openclaw_crabbox_bootstrap_macos_js");
-    expect(output.args).not.toContain("--shell");
+    expectHydratedPosixShell({ output, remoteCommand }, "env -i -S 'pnpm --version'");
   });
 
   it("bootstraps Corepack for raw AWS macOS env split-string pnpm commands", () => {
@@ -2759,7 +2777,7 @@ describe("scripts/crabbox-wrapper", () => {
   });
 
   it("does not bootstrap non-macOS AWS JavaScript commands", () => {
-    const { output } = runSuccessfulDefaultWrapper([
+    const { output, remoteCommand } = runSuccessfulDefaultWrapper([
       "run",
       "--provider",
       "aws",
@@ -2769,23 +2787,23 @@ describe("scripts/crabbox-wrapper", () => {
       "pnpm",
       "--version",
     ]);
+    expect(remoteCommand).not.toContain("openclaw_crabbox_bootstrap_macos_js");
     expect(output.args).toEqual([
       "run",
       "--provider",
       "aws",
       "--target",
       "linux",
+      "--shell",
       "--",
-      "pnpm",
-      "--version",
+      `${remotePosixHydratedModulesBootstrap} pnpm --version`,
     ]);
   });
 
   it("restores hydrated node_modules before AWS native Windows shell commands", () => {
-    expectHydratedWindowsShell(
-      runSuccessfulNativeWindows("aws", ["corepack pnpm check:changed"], true),
-      "corepack pnpm check:changed",
-    );
+    const run = runSuccessfulNativeWindows("aws", ["corepack pnpm check:changed"], true);
+    expectHydratedWindowsShell(run, "corepack pnpm check:changed");
+    expect(run.remoteCommand).not.toContain('ln -s "$PNPM_CONFIG_MODULES_DIR" node_modules');
   });
 
   it("restores hydrated node_modules before Azure native Windows shell commands", () => {
@@ -2805,6 +2823,13 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain("--shell");
     expect(remoteCommand).toContain("$openclawModulesDir = $env:PNPM_CONFIG_MODULES_DIR");
     expect(remoteCommand).toContain("pnpm --filter '@openclaw/discord' test");
+  });
+
+  it("restores hydrated node_modules before POSIX run commands", () => {
+    expectHydratedPosixShell(
+      runSuccessfulDefaultWrapper(["run", "--provider", "aws", "--", "echo", "ok"]),
+      "echo ok",
+    );
   });
 
   const itWithPosixLinkedWorktreeFixture = process.platform === "win32" ? it.skip : it;
@@ -3065,6 +3090,7 @@ describe("scripts/crabbox-wrapper", () => {
     );
     expect(output.args).toContain("--shell");
     expectChangedGateGitBootstrap(remoteCommand);
+    expectHydratedPosixShell({ output, remoteCommand }, "corepack pnpm check:changed");
     expect(remoteCommand).toContain("refs/heads/openclaw-changed-gate-head");
     expect(remoteCommand).toMatch(
       /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,


### PR DESCRIPTION
## What Problem This Solves

The `check:changed` dead-export lane produced false positives when delegated to AWS-hydrated
Crabbox boxes. On 2026-08-06, three independent small branches (PRs #120041, #120046, #120047)
each failed the remote lane, flagging dozens of existing exports under `src/config/**`
(types.slack/telegram/tools/whatsapp, validation) whose consumers exist in the tree, while the
full-tree local scan (`node scripts/check-deadcode-exports.mjs`) passed clean on the same trees.
Reference repro runs: run_b38d4f1d8dac, run_b71c0e4e0035 (AWS Crabbox, c7a.8xlarge).

## Why This Change Was Made

Root cause is the delegated box environment, not scan scoping: AWS hydration
(`.github/workflows/crabbox-hydrate.yml`) installs pnpm dependencies to an external directory
(`PNPM_CONFIG_MODULES_DIR=/var/tmp/openclaw-pnpm/node_modules`) and leaves no `node_modules`
in the repo workdir. pnpm-run lanes honor that env var, but knip resolves modules by filesystem
walking: it silently loses every consumer edge that resolves through node_modules (printing
`ERROR: Error loading vitest.config.ts (Cannot find module 'vitest/config')` and continuing),
so exports consumed by extensions/UI get reported unused. The crabbox wrapper already repairs
exactly this on native Windows via a junction link; POSIX never got the equivalent. Blacksmith
Testbox is unaffected (sticky-disk binds a stock in-tree node_modules).

Fix, at the owner boundary:
- `scripts/crabbox-wrapper.mjs`: POSIX hydrated-modules bootstrap — every non-Windows remote
  run is prefixed with a remote-side guard that symlinks `$PNPM_CONFIG_MODULES_DIR` into the
  workdir when set and no `node_modules` exists. Composes with the changed-gate git bootstrap
  (the link is gitignored, so `git clean -fd` keeps it); `--script`/`--script-stdin` invocations
  are excluded because their trailing tokens are script arguments. Deliberate tradeoff to call
  out: this converts POSIX remote runs to `--shell` form, using the same rendering path the
  changed-gate and Windows bootstraps already use.
- `scripts/check-deadcode-exports.mjs`: fail-closed guard — when knip output contains
  `ERROR: Error loading` resolution failures, the lane discards findings and fails with an
  actionable diagnostic instead of reporting unreliable findings.

## User Impact

Maintainer/CI tooling only. Delegated `check:changed` dead-export results now match full-tree
truth on hydrated POSIX boxes, and a broken environment fails loudly with a next step instead
of gating on false findings.

## Evidence

Reproduced in a synthetic changed-gate checkout of PR #120041 (shallow merge-base fetch named
`origin/main`, parentless head-tree carrier, `reset --hard` + `clean -fd`):

| Environment | Lane result |
|---|---|
| real in-tree node_modules | pass (0 entries) |
| no node_modules (AWS box state) | false positives — exact reported `src/config/**` class |
| symlink to external dir not named `node_modules` | fail (transitive resolution walks up from real paths) |
| symlink to external `.../node_modules` (this fix's layout) | pass (0 entries) |
| patched lane, no node_modules | exit 1 with the new environment diagnostic, findings discarded |

Focused tests: `node scripts/run-vitest.mjs test/scripts/check-deadcode-exports.test.ts`
(26 passed) and `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts` (245 passed).
`pnpm check:script-declarations` contracts pass (253). Fresh autoreview (Codex gpt-5.6-sol,
high) clean: "patch is correct (0.98)". Production LOC +64/−5; tests +93/−29.

`security-fast` was red on `main` from HIGH GHSA-2v37-7h3g-55p8 while this PR was in flight; `main` fixed it independently in #120368 (nanoid 3.3.18) and this branch was rebased onto that, so this PR no longer carries a lockfile change.

