### PR TITLE
fix(deps): update nanoid past denial-of-service advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7828,8 +7828,8 @@ packages:
     resolution: {integrity: sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==}
     engines: {node: '>=18'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -15310,7 +15310,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -15786,7 +15786,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ minimumReleaseAgeExclude:
   - "hono"
   - "libopus-wasm@0.2.0"
   - "libsignal@6.0.0"
+  - "nanoid@3.3.18"
   - "openclaw"
   - "protobufjs"
   - "vite"


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where required CI and downstream exact-head deployments were blocked by the newly updated HIGH NanoID advisory [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8). The production lock graph resolved `nanoid@3.3.16`, whose custom generators can loop indefinitely for nonpositive sizes.

The reachable graph is `@openclaw/qa-lab` → `@copilotkit/aimock@1.37.4` → optional peer `vitest@4.1.10` → `vite@8.1.5` → `postcss@8.5.23` → `nanoid@3.3.16`. `node-llama-cpp` is unaffected here; it resolves the already-safe NanoID 5.x line.

## Why This Change Was Made

The committed product lock now resolves PostCSS's declared `nanoid@^3.3.16` range to `3.3.18`. This version completes the advisory repair for the React Native async entrypoint that `3.3.17` missed, while retaining the same Node engine contract.

Because `3.3.18` is intentionally fresh, its exact reviewed version is admitted through `minimumReleaseAgeExclude`; the global 48-hour policy remains unchanged. This does not suppress the audit, reclassify runtime dependencies, or add a long-lived override.

## User Impact

Required security CI can pass again, and supported NanoID 3.x generator entrypoints terminate for zero or negative sizes. There is no OpenClaw API or configuration change.

## Evidence

- Before: exact-main CI `fb0812c857ffe409947296eebd30677fef4ec211` failed `security-fast` on NanoID 3.3.16: https://github.com/openclaw/openclaw/actions/runs/31221372962/job/93007745550
- After: `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` reports no HIGH-or-higher production advisories.
- After: `pnpm audit --prod --audit-level=high` exits 0 (remaining findings are below HIGH).
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts` accepts the lock unchanged and passes all 1,611 supply-chain policy entries.
- `pnpm deps:npm-lock:check` validates all 95 transient npm package locks.
- `node scripts/run-vitest.mjs test/package-manager-config.test.ts test/scripts/pnpm-audit-prod.test.ts` — 31/31 passed.
- `node scripts/run-vitest.mjs test/scripts/transitive-manifest-risk-report.test.ts` — 10/10 passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- pnpm-lock.yaml pnpm-workspace.yaml` and `git diff --check` pass.
- Final structured autoreview: clean, no accepted/actionable findings (`patch is correct`, confidence 0.99).
- Registry integrity: `sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==`.
- Registry `gitHead` is `9ad98052b316c5e707f8098ace509d2ae165e54d`, matching the inspected upstream release commit: https://github.com/ai/nanoid/commit/9ad98052b316c5e707f8098ace509d2ae165e54d
- The inspected 3.3.17 → 3.3.18 package delta is limited to the missing `async/index.native.js` nonpositive-size guard plus README/release metadata.

AI-assisted: yes (Codex). I understand and reviewed the dependency graph, upstream contract, and exact lock/config changes.
