### PR TITLE
fix(ui): show 1M context for million-token models

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6275,7 +6275,6 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-functions-list@3.3.3:
     resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6275,6 +6275,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-functions-list@3.3.3:
     resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -7,6 +7,7 @@ import {
   formatDateTimeMs,
   formatDateMs,
   formatCompactTokenCount,
+  formatContextTokenCapacity,
   formatDurationCompact,
   formatDurationHuman,
   formatMs,
@@ -209,6 +210,7 @@ describe("formatCompactTokenCount", () => {
 
   it("formats millions with one decimal, trimming a trailing .0", () => {
     expect(formatCompactTokenCount(1_000_000)).toBe("1M");
+    expect(formatCompactTokenCount(1_050_000)).toBe("1.1M");
     expect(formatCompactTokenCount(1_500_000)).toBe("1.5M");
   });
 
@@ -232,6 +234,21 @@ describe("formatCompactTokenCount", () => {
       "1.0K",
     );
     expect(formatCompactTokenCount(1_000_000, { trimTrailingZero: false })).toBe("1.0M");
+  });
+});
+
+describe("formatContextTokenCapacity", () => {
+  it("truncates million-scale capacity to at most one decimal", () => {
+    expect(formatContextTokenCapacity(1_000_000)).toBe("1M");
+    expect(formatContextTokenCapacity(1_050_000)).toBe("1M");
+    expect(formatContextTokenCapacity(1_100_000)).toBe("1.1M");
+  });
+
+  it("preserves shared compact formatting below one million", () => {
+    expect(formatContextTokenCapacity(999)).toBe("999");
+    expect(formatContextTokenCapacity(1_000)).toBe("1k");
+    expect(formatContextTokenCapacity(32_768)).toBe("32.8k");
+    expect(formatContextTokenCapacity(999_999)).toBe("1M");
   });
 });
 

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -325,3 +325,10 @@ export function formatCompactTokenCount(
   }
   return String(tokens);
 }
+
+export function formatContextTokenCapacity(tokens: number): string {
+  if (tokens < 1_000_000) {
+    return formatCompactTokenCount(tokens);
+  }
+  return `${Math.floor(tokens / 100_000) / 10}M`;
+}

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5106,7 +5106,7 @@ describe("chat model controls", () => {
     );
 
     expect(modelOption?.querySelector(".chat-controls__model-option-meta")?.textContent).toBe(
-      "1.1M context",
+      "1M context",
     );
     expect(modelOption?.closest("openclaw-tooltip")).toBeNull();
   });

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -26,7 +26,7 @@ import {
   formatThinkingOverrideLabel,
   resolveChatThinkingSelectState,
 } from "../../../lib/chat/thinking.ts";
-import { formatCompactTokenCount } from "../../../lib/format.ts";
+import { formatContextTokenCapacity } from "../../../lib/format.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { moveChatModelProviderFocus, selectChatModelProvider } from "./chat-model-provider-menu.ts";
 
@@ -658,7 +658,7 @@ function renderChatModelReasoningSelect(params: {
     const modelMeta = [
       entry.contextWindow
         ? t("chat.modelControls.contextWindow", {
-            count: formatCompactTokenCount(entry.contextWindow),
+            count: formatContextTokenCapacity(entry.contextWindow),
           })
         : "",
       entry.supportsTools === false ? t("chat.modelControls.chatOnly") : "",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the model picker would see `1.1M context` for models with a 1,050,000-token provider window, conflicting with their nominal 1M context labeling.

## Why This Change Was Made

The picker now uses a context-capacity formatter instead of the shared general token-count formatter. Million-scale capacity labels truncate to one decimal, so 1,050,000 displays as `1M`, while exact runtime metadata and existing sub-million formatting remain unchanged.

## User Impact

Million-token models now show `1M context` in the picker. This is presentation-only: provider capacity, active runtime budgets, compaction, and request behavior do not change.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/format.test.ts ui/src/pages/chat/chat-view.test.ts` — 272 tests passed.
- Local changed-file gates passed, including UI/core-test typechecks, i18n verification, dead-export scan, dependency guards, formatting, and lint. The remote Crabbox/Testbox router was unavailable, so trusted-source validation used the documented local fallback.
- Live mock Control UI verified the same model metadata before and after: `1.1M context` before, `1M context` after.
- Codex autoreview: clean, no accepted/actionable findings.
- Production: +9/-2 (net +7); tests: +18/-1 (net +17).

### Visual proof

| Before | After |
| --- | --- |
| <img width="900" alt="Model picker showing 1.1M context before the fix" src="https://github.com/user-attachments/assets/e8914f86-ba52-4a8a-82f0-9ef8d215c5e2" /> | <img width="900" alt="Model picker showing 1M context after the fix" src="https://github.com/user-attachments/assets/1177031d-9194-4774-ac31-7ea917284d83" /> |

AI-assisted: yes. The implementation and review were agent-assisted and maintainer-verified.
