### PR TITLE
fix(ui): keep missing profile avatars on initials after rerenders

### DIFF
--- a/ui/src/components/identity-avatar-view.ts
+++ b/ui/src/components/identity-avatar-view.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { guard } from "lit/directives/guard.js";
 import { live } from "lit/directives/live.js";
 import { until } from "lit/directives/until.js";
 import {
@@ -30,9 +31,11 @@ export function resolveIdentityAvatarView(identity: IdentityAvatarInput): Identi
   };
 }
 
-/** Reconcile image-event fallback mutations without replacing an existing image. */
+/** Reconcile changed images without overwriting event fallback on unchanged rerenders. */
 export function identityAvatarClass(className: string, view: IdentityAvatarView) {
-  return live(`${className}${view.pending ? " is-fallback" : ""}`);
+  return guard([className, view.imageUrl, view.pending], () =>
+    live(`${className}${view.pending ? " is-fallback" : ""}`),
+  );
 }
 
 function settleIdentityAvatarImage(event: Event, fallbackSelector: string, failed: boolean): void {

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -125,14 +125,25 @@ suite.define(() => {
     await context.close();
   });
 
-  it("keeps missing same-origin avatar initials through a live rerender", async () => {
-    const context = await suite.browser.newContext({ viewport: { height: 760, width: 1180 } });
+  it("keeps missing local-viewer avatar initials through a live rerender", async () => {
+    const artifactDir = resolveArtifactDir();
+    if (artifactDir) {
+      await fs.mkdir(artifactDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      viewport: { height: 760, width: 1180 },
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { height: 760, width: 1180 } } }
+        : {}),
+    });
     const page = await context.newPage();
-    const sender = {
+    const viewer = {
       id: "dd7c98e2-f51d-4590-b588-fa0682e165b7",
       name: "Hannah",
+      avatarUrl: "/api/users/dd7c98e2-f51d-4590-b588-fa0682e165b7/avatar?v=7",
     };
     let avatarRequestCount = 0;
+    const avatarRequests: Array<{ resourceType: string; url: string }> = [];
     let releaseRetry: () => void = () => undefined;
     const retryGate = new Promise<void>((resolve) => {
       releaseRetry = resolve;
@@ -145,7 +156,11 @@ suite.define(() => {
     const retrySettled = new Promise<void>((resolve) => {
       markRetrySettled = resolve;
     });
-    await page.route(`**/api/users/${sender.id}/avatar`, async (route) => {
+    await page.route(`**/api/users/${viewer.id}/avatar*`, async (route) => {
+      avatarRequests.push({
+        resourceType: route.request().resourceType(),
+        url: route.request().url(),
+      });
       const requestIndex = ++avatarRequestCount;
       if (requestIndex === 2) {
         markRetryStarted();
@@ -164,9 +179,8 @@ suite.define(() => {
       presenceUsers: [
         {
           self: true,
-          id: "viewer-profile",
-          name: "Viewer",
-          email: "viewer@example.test",
+          ...viewer,
+          email: "hannah@example.test",
           watchedSessions: ["agent:main:main"],
         },
       ],
@@ -174,13 +188,7 @@ suite.define(() => {
         {
           role: "user",
           content: "Please keep my fallback avatar readable.",
-          timestamp: Date.now(),
-          __openclaw: {
-            id: "missing-avatar-message",
-            senderId: sender.id,
-            senderName: sender.name,
-            seq: 1,
-          },
+          timestamp: Date.now() - 60_000,
         },
       ],
     });
@@ -197,11 +205,20 @@ suite.define(() => {
       const initials = slot.locator(".chat-avatar--sender-initials");
       await retryStarted;
       expect(avatarRequestCount).toBe(2);
+      expect(
+        avatarRequests.map((request) => ({
+          resourceType: request.resourceType,
+          url: new URL(request.url).pathname + new URL(request.url).search,
+        })),
+      ).toEqual([
+        { resourceType: "fetch", url: viewer.avatarUrl },
+        { resourceType: "fetch", url: viewer.avatarUrl },
+      ]);
       await expect(slot).toHaveClass(/\bis-fallback\b/u);
-      await expect.poll(() => image.getAttribute("src")).toBeNull();
+      await expect(slot.locator("img.chat-avatar.user[src]")).toHaveCount(0);
       await expect(initials).toBeVisible();
       await expect(initials).toHaveText("H");
-      await captureProof(page, "missing-avatar-after-404.png");
+      await captureProof(page, "missing-local-avatar-after-404.png");
 
       await userGroup.hover();
       await userGroup.getByRole("button", { name: "Reply to message" }).click();
@@ -219,10 +236,10 @@ suite.define(() => {
 
       expect(avatarRequestCount).toBe(2);
       await expect(slot).toHaveClass(/\bis-fallback\b/u);
-      await expect.poll(() => image.getAttribute("src")).toBeNull();
+      await expect(slot.locator("img.chat-avatar.user[src]")).toHaveCount(0);
       await expect(initials).toBeVisible();
       await expect(initials).toHaveText("H");
-      await captureProof(page, "missing-avatar-after-rerender.png");
+      await captureProof(page, "missing-local-avatar-after-rerender.png");
 
       releaseRetry();
       await retrySettled;

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -80,10 +80,12 @@ describe("renderChatAvatar", () => {
 
   it("swaps a failing local user image to initials instead of a broken image", () => {
     const container = document.createElement("div");
-    render(
-      renderChatAvatar("user", undefined, { name: "Buns", avatar: "/avatar/user" }),
-      container,
-    );
+    const renderUser = () =>
+      render(
+        renderChatAvatar("user", undefined, { name: "Buns", avatar: "/avatar/user" }),
+        container,
+      );
+    renderUser();
     const slot = container.querySelector<HTMLElement>(".chat-avatar-slot");
     const image = slot?.querySelector("img");
     expect(image?.getAttribute("src")).toBe("/avatar/user");
@@ -92,6 +94,41 @@ describe("renderChatAvatar", () => {
     image?.dispatchEvent(new Event("error"));
     expect(slot?.classList.contains("is-fallback")).toBe(true);
     expect(slot?.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("B");
+
+    renderUser();
+    expect(slot?.classList.contains("is-fallback")).toBe(true);
+    expect(slot?.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("B");
+  });
+
+  it("settles a missing local profile avatar to initials before rendering its URL", async () => {
+    const gatewayOrigin = globalThis.location.origin;
+    setAvatarGatewayOrigin(gatewayOrigin);
+    const fetchAvatar = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 404 }));
+    const container = document.createElement("div");
+    const avatarUrl = "/api/users/dd7c98e2-f51d-4590-b588-fa0682e165b7/avatar?v=7";
+    const renderUser = () =>
+      render(renderChatAvatar("user", undefined, { name: "Hannah", avatar: avatarUrl }), container);
+
+    renderUser();
+    const slot = container.querySelector<HTMLElement>(".chat-avatar-slot");
+    const image = slot?.querySelector("img");
+    expect(slot?.classList.contains("is-fallback")).toBe(true);
+    expect(image?.hasAttribute("src")).toBe(false);
+    expect(slot?.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("H");
+    await vi.waitFor(() => expect(fetchAvatar).toHaveBeenCalledOnce());
+    expect(fetchAvatar).toHaveBeenCalledWith(
+      `${gatewayOrigin}${avatarUrl}`,
+      expect.objectContaining({ credentials: "include", signal: expect.any(AbortSignal) }),
+    );
+    expect(image?.hasAttribute("src")).toBe(false);
+
+    renderUser();
+    await vi.waitFor(() => expect(fetchAvatar).toHaveBeenCalledTimes(2));
+    expect(slot?.classList.contains("is-fallback")).toBe(true);
+    expect(image?.hasAttribute("src")).toBe(false);
+    expect(slot?.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("H");
   });
 });
 

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -23,7 +23,7 @@ import {
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import type { SenderIdentity } from "../../lib/chat/sender-label.ts";
 import { formatSenderLabel } from "../../lib/chat/sender-label.ts";
-import { resolveAvatarInitials } from "../../lib/identity-avatar.ts";
+import { resolveAvatarImageUrl, resolveAvatarInitials } from "../../lib/identity-avatar.ts";
 import {
   DEFAULT_AGENT_ID,
   isUiGlobalSessionKey,
@@ -99,11 +99,12 @@ export function renderChatAvatar(
           : "other";
 
   if (normalized === "user" && userAvatarUrl) {
+    const imageUrl = resolveAvatarImageUrl(userAvatarUrl) ?? userAvatarUrl;
     return renderUserAvatarSlot(
       {
         fallback: resolveAvatarInitials({ name: userName }),
-        imageUrl: userAvatarUrl,
-        pending: false,
+        imageUrl,
+        pending: typeof imageUrl !== "string",
       },
       userName,
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a local user whose profile avatar endpoint returned the expected `404 not_found` could briefly fall back to initials, then show a broken-image glyph and colored alt text after an unrelated chat rerender.

This affected historical or otherwise unattributed local-user messages in the Control UI. Attributed sender avatars already used the authenticated identity-image loader and did not take this exact path.

## Why This Change Was Made

The shared avatar wrapper now preserves image-event fallback state across unchanged Lit rerenders while still reconciling when the image URL, revision, or pending state changes. Canonical local profile-avatar routes also use the shared authenticated image resolver before rendering, while direct data, blob, and configured same-origin avatar formats retain their existing behavior.

The Gateway remains unchanged: the profile route intentionally resolves uploaded avatar, then Gravatar, then returns 404 so the UI can display initials.

Production delta is +4 lines net. The added production code establishes one consistent avatar lifecycle across local chat and existing identity surfaces; the larger test delta covers the original browser-order failure.

## User Impact

Missing profile avatars now remain readable initials before and after chat UI updates. Users no longer see a broken thumbnail icon or their name rendered as image alt text when no upload or Gravatar exists.

## Evidence

- Focused unit proof:
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-avatar.test.ts ui/src/components/identity-avatar-view.test.ts`
  - 2 files passed, 23 tests passed.
- Browser boundary proof with a synthetic local viewer, revisioned avatar route, real JSON 404, and reply-preview rerender:
  - `OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR=.artifacts/control-ui-e2e/broken-local-viewer-avatar node scripts/run-vitest.mjs ui/src/e2e/chat-attributed-identity.e2e.test.ts`
  - 1 file passed, 2 tests passed.
  - Before rerender: initials visible; no `img.chat-avatar.user[src]` remains.
  - After reply-preview rerender: the same initials remain visible; no broken image or alt text appears.
- Source-blind behavior validation: all contract clauses passed, including the unrelated-rerender anti-cheat probe.
- Local fallback checks passed: targeted oxfmt, oxlint, UI production types, UI test types, and `git diff --check`.
- Autoreview: clean, with no accepted/actionable findings.
- The broader changed-file gate attempted normal Crabbox workload routing, but no configured remote provider was ready: Blacksmith Testbox doctor failed and managed brokers were unavailable. Per trusted-source policy, validation fell back to the local checks above.

AI-assisted: yes. I reviewed the implementation, live failure mechanism, tests, and generated synthetic visual proof.