### PR TITLE
fix(ui): make chat activity less visually noisy

### DIFF
--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -39,21 +39,29 @@ describe("renderChatAvatar", () => {
   it("renders assistant fallback, blob image, and text avatars", () => {
     const defaultAvatar = renderAvatar(["assistant"]);
     expect(defaultAvatar?.getAttribute("src")).toBe("/apple-touch-icon.png");
+    expect(defaultAvatar?.classList.contains("chat-avatar--logo")).toBe(true);
 
     const remoteAvatar = renderAvatar([
       "assistant",
       { avatar: "https://example.com/avatar.png", name: "Val" },
     ]);
     expect(remoteAvatar?.getAttribute("src")).toBe("/apple-touch-icon.png");
+    expect(remoteAvatar?.classList.contains("chat-avatar--logo")).toBe(true);
 
     const blobAvatar = renderAvatar(["assistant", { avatar: "blob:managed-image", name: "Val" }]);
     expect(blobAvatar?.tagName).toBe("IMG");
     expect(blobAvatar?.getAttribute("src")).toBe("blob:managed-image");
+    expect(blobAvatar?.classList.contains("chat-avatar--logo")).toBe(false);
 
     const textAvatar = renderAvatar(["assistant", { avatar: "VC", name: "Val" }]);
     expect(textAvatar?.tagName).toBe("DIV");
     expect(textAvatar?.textContent?.trim()).toBe("VC");
     expect(textAvatar?.getAttribute("aria-label")).toBe("Val");
+    expect(textAvatar?.classList.contains("chat-avatar--logo")).toBe(false);
+
+    const localAvatar = renderAvatar(["assistant", { avatar: "/avatar/main", name: "OpenClaw" }]);
+    expect(localAvatar?.getAttribute("src")).toBe("/avatar/main");
+    expect(localAvatar?.classList.contains("chat-avatar--logo")).toBe(false);
   });
 
   it("uses the assistant fallback while authenticated avatar routes are loading", () => {
@@ -66,16 +74,19 @@ describe("renderChatAvatar", () => {
     ]);
 
     expect(avatar?.getAttribute("src")).toBe("/apple-touch-icon.png");
+    expect(avatar?.classList.contains("chat-avatar--logo")).toBe(true);
   });
 
   it("renders local user image and text avatars", () => {
     const imageAvatar = renderAvatar(["user", undefined, { name: "Buns", avatar: "/avatar/user" }]);
     expect(imageAvatar?.getAttribute("src")).toBe("/avatar/user");
     expect(imageAvatar?.getAttribute("alt")).toBe("Buns");
+    expect(imageAvatar?.classList.contains("chat-avatar--logo")).toBe(false);
 
     const textAvatar = renderAvatar(["user", undefined, { name: "Buns", avatar: "AB" }]);
     expect(textAvatar?.tagName).toBe("DIV");
     expect(textAvatar?.textContent?.trim()).toBe("AB");
+    expect(textAvatar?.classList.contains("chat-avatar--logo")).toBe(false);
   });
 
   it("swaps a failing local user image to initials instead of a broken image", () => {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -906,6 +906,61 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("insets only the bundled logo inside the unchanged avatar box", async () => {
+    const page = await openBrowserPage(430, 720);
+    try {
+      await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+        <img class="chat-avatar assistant chat-avatar--logo" src="/apple-touch-icon.png" alt="Logo" />
+        <img class="chat-avatar assistant" src="/avatar/main" alt="Custom" />
+        <img class="chat-avatar user" src="/avatar/user" alt="User" />
+      </body></html>`);
+
+      const avatars = await page.evaluate(() =>
+        [...document.querySelectorAll<HTMLElement>(".chat-avatar")].map((avatar) => {
+          const style = getComputedStyle(avatar);
+          const bounds = avatar.getBoundingClientRect();
+          return {
+            width: bounds.width,
+            height: bounds.height,
+            boxSizing: style.boxSizing,
+            objectFit: style.objectFit,
+            padding: style.padding,
+            borderWidth: style.borderTopWidth,
+          };
+        }),
+      );
+
+      expect(avatars).toEqual([
+        {
+          width: 36,
+          height: 36,
+          boxSizing: "border-box",
+          objectFit: "contain",
+          padding: "2px",
+          borderWidth: "1px",
+        },
+        {
+          width: 36,
+          height: 36,
+          boxSizing: "border-box",
+          objectFit: "cover",
+          padding: "0px",
+          borderWidth: "1px",
+        },
+        {
+          width: 36,
+          height: 36,
+          boxSizing: "border-box",
+          objectFit: "cover",
+          padding: "0px",
+          borderWidth: "1px",
+        },
+      ]);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("applies configured chat width to tool rows and composer without changing defaults", async () => {
     const page = await openBrowserPage(1600, 900);
     const renderFixture = async (configured: boolean) => {

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -532,7 +532,7 @@ type WorkGroupRenderItem = {
   hasError: boolean;
 };
 
-export type ActivityRunRenderItem = {
+type ActivityRunRenderItem = {
   kind: "activity-run";
   key: string;
   groups: MessageGroup[];

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -532,6 +532,12 @@ type WorkGroupRenderItem = {
   hasError: boolean;
 };
 
+export type ActivityRunRenderItem = {
+  kind: "activity-run";
+  key: string;
+  groups: MessageGroup[];
+};
+
 type TurnRenderItem = RenderChatItem | StreamRunRenderItem;
 
 function isTurnBoundaryGroup(item: TurnRenderItem): boolean {
@@ -709,5 +715,39 @@ export function collapseCompletedTurnWork(
     });
     result.push(...turn.slice(segmentEnd + 1));
   }
+  return result;
+}
+
+type CompletedTurnRenderItem = TurnRenderItem | WorkGroupRenderItem;
+
+/** Presentation-only rollup for tool groups separated by projected turn boundaries. */
+export function coalesceActivityRuns(
+  items: CompletedTurnRenderItem[],
+  opts: { searchActive?: boolean } = {},
+): Array<CompletedTurnRenderItem | ActivityRunRenderItem> {
+  if (opts.searchActive) {
+    return items;
+  }
+  const result: Array<CompletedTurnRenderItem | ActivityRunRenderItem> = [];
+  let groups: MessageGroup[] = [];
+  const flush = () => {
+    const [first] = groups;
+    if (!first) {
+      return;
+    }
+    result.push(
+      groups.length === 1 ? first : { kind: "activity-run", key: `activity:${first.key}`, groups },
+    );
+    groups = [];
+  };
+  for (const item of items) {
+    if (item.kind === "group" && item.role.toLowerCase() === "tool") {
+      groups.push(item);
+      continue;
+    }
+    flush();
+    result.push(item);
+  }
+  flush();
   return result;
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -9,6 +9,7 @@ import * as toolCards from "../../lib/chat/tool-cards.ts";
 import {
   assistantGroupCanOwnActiveRunStatus,
   buildCachedChatItems,
+  coalesceActivityRuns,
   coalesceStreamRuns,
   collapseCompletedTurnWork,
   getExpansionStateVersion,
@@ -66,6 +67,10 @@ type ChatQueueItem = NonNullable<CachedChatItemsProps["queue"]>[number];
 type WorkGroupItem = Extract<
   ReturnType<typeof collapseCompletedTurnWork>[number],
   { kind: "work-group" }
+>;
+type ActivityRunItem = Extract<
+  ReturnType<typeof coalesceActivityRuns>[number],
+  { kind: "activity-run" }
 >;
 
 // Inbound context blocks are stamped with the provenance marker; strippers key
@@ -786,6 +791,108 @@ describe("collapseCompletedTurnWork", () => {
 
     expect(prependedWork.key).toBe(initialWork.key);
     expect(prependedWork.durationMs).toBeGreaterThan(initialWork.durationMs ?? 0);
+  });
+});
+
+describe("coalesceActivityRuns", () => {
+  const toolResult = (id: string, timestamp: number, overrides: Record<string, unknown> = {}) => ({
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "bash",
+    content: "ok",
+    timestamp,
+    ...overrides,
+  });
+
+  const projectedToolGroups = () =>
+    buildCachedChatItems(
+      createProps({
+        paneId: "activity-run-projection",
+        messages: [
+          toolResult("call-1", 1_000, {
+            __openclaw: { id: "tool-1", seq: 1, turnBoundary: true },
+          }),
+          toolResult("call-2", 2_000, {
+            __openclaw: { id: "tool-2", seq: 2, turnBoundary: true },
+          }),
+          toolResult("call-3", 3_000, {
+            __openclaw: { id: "tool-3", seq: 3, turnBoundary: true },
+          }),
+        ],
+      }),
+    ).filter((item): item is MessageGroup => item.kind === "group");
+
+  function requireActivityRun(value: unknown): ActivityRunItem {
+    expect(requireRecord(value).kind).toBe("activity-run");
+    return value as ActivityRunItem;
+  }
+
+  it("combines projected-turn tool groups without rewriting their order or messages", () => {
+    const groups = projectedToolGroups();
+    const projected = coalesceActivityRuns(groups.slice(0, 2));
+    const run = requireActivityRun(projected[0]);
+
+    expect(projected).toHaveLength(1);
+    expect(run.groups).toEqual([groups[0], groups[1]]);
+    expect(run.groups[0]).toBe(groups[0]);
+    expect(run.groups[1]).toBe(groups[1]);
+    expect(run.groups.flatMap((group) => group.messages.map((entry) => entry.key))).toEqual(
+      groups.slice(0, 2).flatMap((group) => group.messages.map((entry) => entry.key)),
+    );
+  });
+
+  it("keeps the first-group key stable when live tool groups append", () => {
+    const groups = projectedToolGroups();
+    const initial = requireActivityRun(coalesceActivityRuns(groups.slice(0, 2))[0]);
+    const appended = requireActivityRun(coalesceActivityRuns(groups)[0]);
+
+    expect(initial.key).toBe(`activity:${groups[0]?.key}`);
+    expect(appended.key).toBe(initial.key);
+  });
+
+  it("treats every non-tool item as a hard presentation boundary", () => {
+    const groups = projectedToolGroups();
+    const userBoundary: MessageGroup = {
+      kind: "group",
+      key: "group:user:boundary",
+      role: "user",
+      messages: [{ key: "user:boundary", message: userMessage("stop", 4_000) }],
+      timestamp: 4_000,
+      isStreaming: false,
+    };
+    const divider = {
+      kind: "divider" as const,
+      key: "divider:boundary",
+      label: "Boundary",
+      timestamp: 5_000,
+    };
+    const projected = coalesceActivityRuns([
+      groups[0]!,
+      userBoundary,
+      groups[1]!,
+      divider,
+      groups[2]!,
+    ]);
+
+    expect(projected).toEqual([groups[0], userBoundary, groups[1], divider, groups[2]]);
+  });
+
+  it("leaves a single tool group unchanged and disables projection during search", () => {
+    const groups = projectedToolGroups();
+    const singleton = coalesceActivityRuns([groups[0]!]);
+    const searchInput = groups.slice(0, 2);
+
+    expect(singleton[0]).toBe(groups[0]);
+    expect(coalesceActivityRuns(searchInput, { searchActive: true })).toBe(searchInput);
+  });
+
+  it("retains each member group's recovered or active error outcome", () => {
+    const groups = projectedToolGroups();
+    groups[0]!.turnSucceeded = true;
+    groups[1]!.turnSucceeded = false;
+    const run = requireActivityRun(coalesceActivityRuns(groups.slice(0, 2))[0]);
+
+    expect(run.groups.map((group) => group.turnSucceeded)).toEqual([true, false]);
   });
 });
 

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -23,9 +23,11 @@ import {
 export { isPendingSendMessage, persistedMessageEntryId } from "./chat-thread-items.ts";
 export {
   assistantGroupCanOwnActiveRunStatus,
+  coalesceActivityRuns,
   coalesceStreamRuns,
   collapseCompletedTurnWork,
 } from "./chat-thread-grouping.ts";
+export type { ActivityRunRenderItem } from "./chat-thread-grouping.ts";
 
 type CachedChatItems = {
   input: BuildChatItemsProps | null;

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -27,7 +27,6 @@ export {
   coalesceStreamRuns,
   collapseCompletedTurnWork,
 } from "./chat-thread-grouping.ts";
-export type { ActivityRunRenderItem } from "./chat-thread-grouping.ts";
 
 type CachedChatItems = {
   input: BuildChatItemsProps | null;

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -6073,7 +6073,7 @@ describe("right-click Reply", () => {
     expect(onCopy).toHaveBeenCalledOnce();
   });
 
-  it("confirms Hide from the context menu before hiding the message locally", () => {
+  it("confirms Hide before hiding every member of an aggregate activity row", () => {
     const storedValues = new Map<string, string>();
     vi.stubGlobal("localStorage", {
       clear: () => storedValues.clear(),
@@ -6090,7 +6090,8 @@ describe("right-click Reply", () => {
       { sessionKey: "context-hide-test", onRequestUpdate },
       { groupClass: "chat-group assistant" },
     );
-    group.dataset.chatRowKey = "group:assistant:persisted";
+    group.dataset.chatRowKey = "group:tool:first";
+    group.dataset.chatRowKeys = JSON.stringify(["group:tool:first", "group:tool:second"]);
 
     dispatchContextMenu(bubble);
     document.querySelector<HTMLButtonElement>('[aria-label="Hide message"]')!.click();
@@ -6098,7 +6099,7 @@ describe("right-click Reply", () => {
     document.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!.click();
 
     expect(storedValues.get("openclaw:deleted:context-hide-test")).toBe(
-      JSON.stringify(["group:assistant:persisted"]),
+      JSON.stringify(["group:tool:first", "group:tool:second"]),
     );
     expect(onRequestUpdate).toHaveBeenCalledOnce();
   });

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -10,6 +10,7 @@ import { formatSenderLabel } from "../../../lib/chat/sender-label.ts";
 import { summarizeToolGroup } from "../../../lib/chat/tool-call-grouping.ts";
 import { extractToolCardsCached, isToolCardError } from "../../../lib/chat/tool-cards.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
+import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import { resolveIdentityHue } from "../../../lib/identity-avatar.ts";
 import { renderChatAvatar } from "../chat-avatar.ts";
 import type { TurnRecap } from "../chat-progress.ts";
@@ -208,6 +209,126 @@ function shouldAnimateUserTurnEntry(messageKey: string, message: unknown): boole
   return freshSubmit;
 }
 
+export function renderActivityGroup(
+  groups: readonly MessageGroup[],
+  opts: RenderMessageGroupOptions,
+) {
+  const firstGroup = groups[0];
+  if (!firstGroup || opts.showToolCalls === false) {
+    return nothing;
+  }
+  const cards = groups.flatMap((group) =>
+    group.messages.flatMap((item) => extractToolCardsCached(item.message, item.key)),
+  );
+  const toolCount =
+    cards.length || groups.reduce((count, group) => count + group.messages.length, 0);
+  const hasError = groups.some(
+    (group) =>
+      group.turnSucceeded !== true &&
+      group.messages.some((item) =>
+        extractToolCardsCached(item.message, item.key).some(isToolCardError),
+      ),
+  );
+  // While a run is live, the newest still-running call names the group so
+  // the collapsed header reads like a status line; afterwards it aggregates.
+  const runningCard = opts.runActive
+    ? cards.findLast((card) => isRunningToolCard(card, opts.runActive))
+    : undefined;
+  const groupSummaryLabel = runningCard
+    ? `${resolveToolRowText(runningCard, opts.runActive)}…`
+    : summarizeToolGroup(
+        cards.map((card) => ({
+          name: card.name,
+          args: card.args,
+          isError: isToolCardError(card),
+        })),
+      );
+  const activityDisclosureId = `activity:${firstGroup.key}`;
+  const activityBodyId = `activity-body-${fnv1aUtf16(firstGroup.key).toString(16)}`;
+  const activityExpanded = opts.isToolMessageExpanded?.(activityDisclosureId) ?? hasError;
+  const showAvatarGutter = opts.showAvatarGutter !== false;
+  const assistantName = opts.assistantName ?? "Assistant";
+
+  return html`
+    <div
+      class="chat-group tool chat-group--activity chat-group--with-footer"
+      data-chat-row-key=${firstGroup.key}
+      data-chat-row-keys=${JSON.stringify(groups.map((group) => group.key))}
+    >
+      ${showAvatarGutter
+        ? renderChatAvatar(
+            firstGroup.role,
+            {
+              name: assistantName,
+              avatar: opts.assistantAvatar ?? null,
+            },
+            {
+              name: opts.userName ?? null,
+              avatar: opts.userAvatar ?? null,
+            },
+            opts.basePath,
+            opts.assistantAttachmentAuthToken,
+            firstGroup.sender,
+          )
+        : nothing}
+      <div class="chat-group-messages">
+        <div class="chat-activity-group ${activityExpanded ? "is-open" : ""}">
+          <button
+            class="chat-activity-group__summary ${hasError
+              ? "chat-activity-group__summary--error"
+              : ""}"
+            type="button"
+            aria-expanded=${String(activityExpanded)}
+            aria-controls=${activityBodyId}
+            aria-label=${hasError
+              ? t(
+                  toolCount === 1
+                    ? "chat.toolCards.group.activityErrorOne"
+                    : "chat.toolCards.group.activityErrorMany",
+                  { count: String(toolCount) },
+                )
+              : nothing}
+            @click=${(event: MouseEvent) => {
+              if (shouldToggleSelectableDisclosure(event)) {
+                opts.onToggleToolMessageExpanded?.(activityDisclosureId, activityExpanded);
+              }
+            }}
+          >
+            <span class="chat-activity-group__icon">${hasError ? icons.x : icons.activity}</span>
+            <span class="chat-activity-group__label" title=${groupSummaryLabel}
+              >${groupSummaryLabel}</span
+            >
+            <span
+              class="collapse-chevron ${activityExpanded ? "" : "collapse-chevron--collapsed"}"
+              aria-hidden="true"
+              >${icons.chevronDown}</span
+            >
+          </button>
+          <div class="chat-activity-group__body" id=${activityBodyId} ?hidden=${!activityExpanded}>
+            ${activityExpanded
+              ? groups.map((group) =>
+                  group.messages.map((item, index) =>
+                    renderGroupedMessage(
+                      item.message,
+                      item.key,
+                      buildGroupedMessageRenderOptions(group, item, index, opts),
+                      opts.onOpenSidebar,
+                    ),
+                  ),
+                )
+              : nothing}
+          </div>
+        </div>
+      </div>
+      <div class="chat-group-footer">
+        <span class="chat-sender-name">${t("chat.messages.activity")}</span>
+        ${renderChatTimestamp(firstGroup.timestamp)}
+        ${opts.onDelete ? renderDeleteButton(opts.onDelete, "right") : nothing}
+      </div>
+    </div>
+  `;
+}
+
 export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroupOptions) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
   const isWorkspaceConflict = group.messages.every((item) =>
@@ -259,102 +380,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
       : [];
 
   if (normalizedRole === "tool" && (group.messages.length > 1 || groupedToolCards.length > 1)) {
-    const cards = groupedToolCards;
-    const toolCount = cards.length || group.messages.length;
-    const hasError = cards.some(isToolCardError) && group.turnSucceeded !== true;
-    // While a run is live, the newest still-running call names the group so
-    // the collapsed header reads like a status line; afterwards it aggregates.
-    const runningCard = opts.runActive
-      ? cards.findLast((card) => isRunningToolCard(card, opts.runActive))
-      : undefined;
-    const groupSummaryLabel = runningCard
-      ? `${resolveToolRowText(runningCard, opts.runActive)}…`
-      : summarizeToolGroup(
-          cards.map((card) => ({
-            name: card.name,
-            args: card.args,
-            isError: isToolCardError(card),
-          })),
-        );
-    const activityDisclosureId = `activity:${group.key}`;
-    const activityExpanded = opts.isToolMessageExpanded?.(activityDisclosureId) ?? hasError;
-
-    return html`
-      <div
-        class="chat-group tool chat-group--activity chat-group--with-footer"
-        data-chat-row-key=${group.key}
-      >
-        ${showAvatarGutter
-          ? renderChatAvatar(
-              group.role,
-              {
-                name: assistantName,
-                avatar: opts.assistantAvatar ?? null,
-              },
-              {
-                name: opts.userName ?? null,
-                avatar: opts.userAvatar ?? null,
-              },
-              opts.basePath,
-              opts.assistantAttachmentAuthToken,
-              group.sender,
-            )
-          : nothing}
-        <div class="chat-group-messages">
-          <div class="chat-activity-group ${activityExpanded ? "is-open" : ""}">
-            <button
-              class="chat-activity-group__summary ${hasError
-                ? "chat-activity-group__summary--error"
-                : ""}"
-              type="button"
-              aria-expanded=${String(activityExpanded)}
-              aria-label=${hasError
-                ? t(
-                    toolCount === 1
-                      ? "chat.toolCards.group.activityErrorOne"
-                      : "chat.toolCards.group.activityErrorMany",
-                    { count: String(toolCount) },
-                  )
-                : nothing}
-              @click=${(event: MouseEvent) => {
-                if (shouldToggleSelectableDisclosure(event)) {
-                  opts.onToggleToolMessageExpanded?.(activityDisclosureId, activityExpanded);
-                }
-              }}
-            >
-              <span class="chat-activity-group__icon">${hasError ? icons.x : icons.activity}</span>
-              <span class="chat-activity-group__label" title=${groupSummaryLabel}
-                >${groupSummaryLabel}</span
-              >
-              <span
-                class="collapse-chevron ${activityExpanded ? "" : "collapse-chevron--collapsed"}"
-                aria-hidden="true"
-                >${icons.chevronDown}</span
-              >
-            </button>
-            ${activityExpanded
-              ? html`
-                  <div class="chat-activity-group__body">
-                    ${group.messages.map((item, index) =>
-                      renderGroupedMessage(
-                        item.message,
-                        item.key,
-                        buildGroupedMessageRenderOptions(group, item, index, opts),
-                        opts.onOpenSidebar,
-                      ),
-                    )}
-                  </div>
-                `
-              : nothing}
-          </div>
-        </div>
-        <div class="chat-group-footer">
-          <span class="chat-sender-name">${t("chat.messages.activity")}</span>
-          ${renderChatTimestamp(group.timestamp)}
-          ${opts.onDelete ? renderDeleteButton(opts.onDelete, "right") : nothing}
-        </div>
-      </div>
-    `;
+    return renderActivityGroup([group], opts);
   }
 
   const messageActionDetails = group.messages.map((item) =>

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -11,6 +11,7 @@ import { renderChatNotice } from "./chat-divider.ts";
 import {
   getAssistantAttachmentAvailabilityRenderVersion,
   dismissConfirmedActionPopovers,
+  renderActivityGroup,
   renderMessageGroup,
   renderStreamGroup,
 } from "./chat-message.ts";
@@ -2175,6 +2176,174 @@ describe("grouped chat rendering", () => {
     ).toBe("Read 2 files");
     expect(container.querySelectorAll(".chat-activity-group")).toHaveLength(1);
     expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
+  });
+
+  it("renders consecutive original tool groups behind one activity summary", () => {
+    const container = document.createElement("div");
+    const groups = [
+      createToolGroup("tool-group-1", [
+        createMessageEntry(
+          "tool-message-1",
+          createToolResultMessage("call-1", "run_command", "one"),
+        ),
+        createMessageEntry("tool-message-2", createToolResultMessage("call-2", "read_file", "two")),
+      ]),
+      createToolGroup("tool-group-2", [
+        createMessageEntry(
+          "tool-message-3",
+          createToolResultMessage("call-3", "write_file", "three"),
+        ),
+      ]),
+    ];
+
+    render(
+      renderActivityGroup(groups, {
+        showReasoning: true,
+        showToolCalls: true,
+        assistantName: "OpenClaw",
+        isToolMessageExpanded: (id) => id === "activity:tool-group-1",
+      }),
+      container,
+    );
+
+    expect(container.querySelectorAll(".chat-activity-group")).toHaveLength(1);
+    expect(container.querySelectorAll(".chat-activity-group__summary")).toHaveLength(1);
+    expect(container.querySelector(".chat-activity-group__label")?.textContent).toContain(
+      "Ran a command, read a file, created a file",
+    );
+    expect(container.querySelectorAll(".chat-activity-group__body > .chat-bubble")).toHaveLength(3);
+    expect(
+      container.querySelectorAll(".chat-activity-group__body .chat-activity-group"),
+    ).toHaveLength(0);
+    expect(
+      [...container.querySelectorAll<HTMLElement>("[data-message-id]")].map(
+        (row) => row.dataset.messageId,
+      ),
+    ).toEqual(["tool-message-1", "tool-message-2", "tool-message-3"]);
+  });
+
+  it("keeps aggregate expansion and accessibility ids stable when groups append", () => {
+    const container = document.createElement("div");
+    const groups = [
+      createToolGroup("stable-first", [
+        createMessageEntry("stable-1", createToolResultMessage("call-1", "read_file", "one")),
+      ]),
+      createToolGroup("stable-second", [
+        createMessageEntry("stable-2", createToolResultMessage("call-2", "read_file", "two")),
+      ]),
+      createToolGroup("stable-third", [
+        createMessageEntry("stable-3", createToolResultMessage("call-3", "read_file", "three")),
+      ]),
+    ];
+    const opts: RenderMessageGroupOptions = {
+      showReasoning: true,
+      showToolCalls: true,
+      isToolMessageExpanded: (id) => id === "activity:stable-first",
+    };
+
+    render(renderActivityGroup(groups.slice(0, 2), opts), container);
+    const initialSummary = expectElement(
+      container,
+      ".chat-activity-group__summary",
+      HTMLButtonElement,
+    );
+    const initialBodyId = initialSummary.getAttribute("aria-controls");
+    expect(initialSummary.getAttribute("aria-expanded")).toBe("true");
+    expect(initialBodyId).toMatch(/^activity-body-[0-9a-f]+$/);
+    expect(container.querySelector(`[id="${initialBodyId}"]`)).not.toBeNull();
+
+    render(renderActivityGroup(groups, opts), container);
+    const appendedSummary = expectElement(
+      container,
+      ".chat-activity-group__summary",
+      HTMLButtonElement,
+    );
+    expect(appendedSummary.getAttribute("aria-controls")).toBe(initialBodyId);
+    expect(appendedSummary.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelectorAll(".chat-activity-group__body > .chat-bubble")).toHaveLength(3);
+  });
+
+  it("uses the newest live card label before settling to the aggregate summary", () => {
+    const container = document.createElement("div");
+    const groups = [
+      createToolGroup("live-first", [
+        createMessageEntry("finished-read", createToolResultMessage("call-read", "read", "done")),
+      ]),
+      createToolGroup(
+        "live-second",
+        [
+          createMessageEntry("running-edit", {
+            role: "assistant",
+            __openclawToolStreamLive: true,
+            __openclawToolStreamResultReceived: false,
+            content: [
+              {
+                type: "tool_use",
+                id: "call-edit",
+                name: "edit",
+                input: { path: "/repo/src/a.ts", oldText: "old", newText: "new" },
+              },
+            ],
+          }),
+        ],
+        { isStreaming: true },
+      ),
+    ];
+    const opts = { showReasoning: true, showToolCalls: true, runActive: true };
+
+    render(renderActivityGroup(groups, opts), container);
+    expect(container.querySelector(".chat-activity-group__label")?.textContent).toBe(
+      "Editing a.ts…",
+    );
+
+    render(renderActivityGroup(groups, { ...opts, runActive: false }), container);
+    expect(container.querySelector(".chat-activity-group__label")?.textContent).toBe(
+      "Read a file, edited a file",
+    );
+  });
+
+  it("computes aggregate errors per owning group", () => {
+    const container = document.createElement("div");
+    const failedMessage = (id: string) =>
+      createToolResultMessage(id, "web_search", JSON.stringify({ error: "No matches" }), {
+        isError: true,
+      });
+    const recovered = createToolGroup(
+      "recovered",
+      [createMessageEntry("recovered-message", failedMessage("call-recovered"))],
+      { turnSucceeded: true },
+    );
+    const successful = createToolGroup("successful", [
+      createMessageEntry("successful-message", createToolResultMessage("call-ok", "read", "ok")),
+    ]);
+
+    render(
+      renderActivityGroup([recovered, successful], {
+        showReasoning: true,
+        showToolCalls: true,
+      }),
+      container,
+    );
+    expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
+    expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
+    expect(container.querySelector(".chat-activity-group__label")?.textContent).toContain(
+      "1 failed",
+    );
+
+    const unrecovered = createToolGroup(
+      "unrecovered",
+      [createMessageEntry("unrecovered-message", failedMessage("call-unrecovered"))],
+      { turnSucceeded: false },
+    );
+    render(
+      renderActivityGroup([recovered, unrecovered], {
+        showReasoning: true,
+        showToolCalls: true,
+      }),
+      container,
+    );
+    expect(container.querySelector(".chat-activity-group.is-open")).not.toBeNull();
+    expect(container.querySelector(".chat-activity-group__summary--error")).not.toBeNull();
   });
 
   it("uses the running mutation verb in an active group summary", () => {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -7,7 +7,7 @@ export {
   openChatHideConfirmation,
   openChatRewindConfirmation,
 } from "./chat-message-confirmation.ts";
-export { renderMessageGroup } from "./chat-message-group.ts";
+export { renderActivityGroup, renderMessageGroup } from "./chat-message-group.ts";
 export type { MessageReplyTarget } from "./chat-message-markdown.ts";
 export { renderStreamGroup, renderWorkGroupSummary } from "./chat-message-stream.ts";
 export type { StreamGroupOptions, StreamGroupPart } from "./chat-message-stream.ts";

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -55,6 +55,7 @@ import {
   assistantGroupCanOwnActiveRunStatus,
   assistantMessageExpansionSignature,
   buildCachedChatItems,
+  coalesceActivityRuns,
   coalesceStreamRuns,
   collapseCompletedTurnWork,
   deletedChatItemsSignature,
@@ -88,6 +89,7 @@ import {
   openChatHideConfirmation,
   openChatRewindConfirmation,
   renderMessageGroup,
+  renderActivityGroup,
   renderStreamGroup,
   renderWorkGroupSummary,
   type MessageReplyTarget,
@@ -192,7 +194,7 @@ type ChatPinnedMessagesProps = Pick<
   "paneId" | "sessionKey" | "messages" | "userName" | "userAvatar"
 >;
 
-type ChatRenderItem = ReturnType<typeof collapseCompletedTurnWork>[number];
+type ChatRenderItem = ReturnType<typeof coalesceActivityRuns>[number];
 
 type ChatTranscriptRow =
   | { kind: "item"; key: string; item: ChatRenderItem }
@@ -1107,6 +1109,22 @@ function selectionIntersectsElement(selection: Selection | null, element: Elemen
   return false;
 }
 
+function chatGroupRowKeys(group: HTMLElement): string[] {
+  const serialized = group.dataset.chatRowKeys;
+  if (serialized) {
+    try {
+      const keys = JSON.parse(serialized);
+      if (Array.isArray(keys) && keys.every((key) => typeof key === "string")) {
+        return keys;
+      }
+    } catch {
+      // Fall through to the canonical single-row key.
+    }
+  }
+  const key = group.dataset.chatRowKey?.trim();
+  return key ? [key] : [];
+}
+
 function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   if (event.composedPath().some((target) => target instanceof HTMLAnchorElement)) {
     return;
@@ -1115,7 +1133,7 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   if (!bubble) {
     return;
   }
-  const group = bubble.closest(".chat-group");
+  const group = bubble.closest<HTMLElement>(".chat-group");
   if (!group) {
     return;
   }
@@ -1130,7 +1148,7 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   const text = truncateUtf16Safe((bubble as HTMLElement).dataset.messageText?.trim() ?? "", 500);
   const entryId = (bubble as HTMLElement).dataset.entryId?.trim() ?? "";
   const messageId = (bubble as HTMLElement).dataset.messageId?.trim() ?? "";
-  const groupKey = (group as HTMLElement).dataset.chatRowKey?.trim() ?? "";
+  const groupKeys = chatGroupRowKeys(group);
   const isUserMessage = group.classList.contains("user") && Boolean(entryId);
   // Grouped rows can contain several bubbles. Match the clicked bubble to its
   // own action owner so copy never targets a sibling message.
@@ -1140,7 +1158,7 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   const copyButton = actionOwner?.querySelector<HTMLButtonElement>(".chat-copy-btn");
   const canReply = Boolean(text && props.onSetReply);
   const canRewind = isUserMessage && typeof props.onRewindMessage === "function";
-  const canHide = Boolean(groupKey);
+  const canHide = groupKeys.length > 0;
   const canCopy = Boolean(copyButton);
   const canFork = isUserMessage && typeof props.onForkMessage === "function";
   if (!canReply && !canRewind && !canHide && !canCopy && !canFork) {
@@ -1217,7 +1235,10 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
       onClick: () => {
         openChatHideConfirmation(action.button, () => {
           removeReplyContextMenu();
-          getDeletedMessages(props.sessionKey).delete(groupKey);
+          const deleted = getDeletedMessages(props.sessionKey);
+          for (const key of groupKeys) {
+            deleted.delete(key);
+          }
           props.onRequestUpdate?.();
         });
       },
@@ -1381,6 +1402,9 @@ function chatRenderItemGuardDependencies(item: ChatRenderItem): readonly unknown
   }
   if (item.kind === "work-group") {
     return [item.key, item.durationMs, item.hasError, ...item.groups];
+  }
+  if (item.kind === "activity-run") {
+    return [item.key, ...item.groups];
   }
   return [item];
 }
@@ -1578,16 +1602,13 @@ function renderChatThreadContents(
     { parts: StreamGroupPart[]; options: StreamGroupOptions }
   >();
   const turnRecapByGroupKey = new Map<string, TurnRecap>();
-  const renderGroupItem = (item: MessageGroup) => {
-    if (deleted.has(item.key)) {
-      return nothing;
-    }
+  const renderGroupOptions = (item: MessageGroup, onDelete: () => void) => {
     const lastMessage = item.messages.at(-1)?.message;
     const rewindEntryId =
       item.role.toLowerCase() === "user" && lastMessage
         ? persistedMessageEntryId(lastMessage)
         : null;
-    return renderMessageGroup(item, {
+    return {
       onOpenSidebar: props.onOpenSidebar,
       onOpenWorkspaceFile: props.onOpenWorkspaceFile,
       sessionKey: props.sessionKey,
@@ -1635,10 +1656,7 @@ function renderChatThreadContents(
       allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
       contextWindow: threadContextWindow,
       onReply: props.onSetReply,
-      onDelete: () => {
-        deleted.delete(item.key);
-        requestUpdate();
-      },
+      onDelete,
       onRewind:
         rewindEntryId && props.onRewindMessage
           ? () => {
@@ -1652,7 +1670,19 @@ function renderChatThreadContents(
       rewindDisabled: Boolean(props.runActive || props.runWorking),
       activeContinuation: activeContinuationByGroupKey.get(item.key),
       turnRecap: turnRecapByGroupKey.get(item.key),
-    });
+    } satisfies Parameters<typeof renderMessageGroup>[1];
+  };
+  const renderGroupItem = (item: MessageGroup) => {
+    if (deleted.has(item.key)) {
+      return nothing;
+    }
+    return renderMessageGroup(
+      item,
+      renderGroupOptions(item, () => {
+        deleted.delete(item.key);
+        requestUpdate();
+      }),
+    );
   };
   // Only the working indicator shows live usage, so rows without one keep
   // memoizing across usage patches.
@@ -1709,6 +1739,25 @@ function renderChatThreadContents(
         ${workExpanded ? item.groups.map((group) => renderGroupItem(group)) : nothing}
       `;
     }
+    if (item.kind === "activity-run") {
+      const visibleGroups = item.groups.filter((group) => !deleted.has(group.key));
+      const firstGroup = visibleGroups[0];
+      if (!firstGroup) {
+        return nothing;
+      }
+      if (visibleGroups.length === 1) {
+        return renderGroupItem(firstGroup);
+      }
+      return renderActivityGroup(
+        visibleGroups,
+        renderGroupOptions(firstGroup, () => {
+          for (const group of item.groups) {
+            deleted.delete(group.key);
+          }
+          requestUpdate();
+        }),
+      );
+    }
     if (item.kind === "group") {
       return renderGroupItem(item);
     }
@@ -1719,11 +1768,14 @@ function renderChatThreadContents(
     }
     return nothing;
   });
-  const collapsedItems = collapseCompletedTurnWork(coalesceStreamRuns(chatItems), {
-    sessionKey: props.sessionKey,
-    runWorking: Boolean(props.runWorking),
-    searchActive: searchFiltering,
-  });
+  const collapsedItems = coalesceActivityRuns(
+    collapseCompletedTurnWork(coalesceStreamRuns(chatItems), {
+      sessionKey: props.sessionKey,
+      runWorking: Boolean(props.runWorking),
+      searchActive: searchFiltering,
+    }),
+    { searchActive: searchFiltering },
+  );
   // Watch/settle on actual indicator visibility (not runWorking): queued
   // sends show the claw before the run starts, and the recap must never
   // stack under a visible working row.

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -501,6 +501,11 @@ img.chat-avatar {
   object-position: center;
 }
 
+img.chat-avatar.chat-avatar--logo {
+  object-fit: contain;
+  padding: 2px;
+}
+
 /* Minimal Bubble Design - dynamic width based on content */
 .chat-bubble {
   position: relative;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where chat transcripts could feel visually crowded because the bundled mascot nearly filled its bordered avatar tile and hidden/autonomous tool turns could appear as several repetitive activity rows.

## Why This Change Was Made

This keeps the existing 36×36 avatar layout while adding a small inset only to the bundled mascot fallback. It also adds a presentation-only rollup for consecutive tool activity groups after canonical turn, recovery, and completed-work semantics have already been resolved. The original tool groups and messages remain available when expanded.

AI-assisted: yes. The implementation and tests were reviewed with the repository autoreview workflow.

## User Impact

Chat identity chrome is less cramped, and consecutive machine activity reads as one quieter expandable row instead of several near-identical summaries. Live tool labels, error visibility, recovered-failure treatment, search results, per-call details, and custom avatars remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-avatar.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-responsive.browser.test.ts`
  - 5 files passed; 653 tests passed.
- `pnpm ui:build`
  - Vite production build, 704 precompressed sidecars, and Control UI performance budgets passed.
- `pnpm lint:ui:styles`
- `pnpm tsgo:ui`
- Targeted Oxfmt check and `git diff --check` passed.
- Local Control UI mock verified in the existing Chrome profile:
  - mascot tile remained 36×36 with a 1px border;
  - only the bundled mascot used 2px padding and `object-fit: contain`;
  - activity row stayed within a 430×932 viewport with no document overflow;
  - expanding the activity row revealed both original tool rows, with no nested activity summary;
  - no browser console errors were reported.
- Codex-backed autoreview completed with no accepted/actionable findings.

The repository changed-file gate could not acquire a remote Testbox because the local Crabbox broker authentication was unavailable. The permitted trusted-source local fallback above passed. No screenshot is attached because the original visual reference contains private operational content; the geometry and mock-browser observations above provide sanitized proof.
