### PR TITLE
chore(release): prepare 2026.8.1

### DIFF
--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2026.7.2</string>
+    <string>2026.8.1</string>
     <key>CFBundleVersion</key>
-    <string>2026070200</string>
+    <string>2026080100</string>
     <key>CFBundleIconFile</key>
     <string>OpenClaw</string>
     <key>CFBundleURLTypes</key>

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -303,7 +303,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[slack](/plugins/reference/slack)** (`@openclaw/slack`) - npm; ClawHub. OpenClaw Slack channel plugin for channels, DMs, commands, and app events.
 
-- **[sms](/plugins/reference/sms)** (`@openclaw/sms`) - npm; ClawHub: `clawhub:@openclaw/sms`. Twilio SMS channel plugin for OpenClaw text messages.
+- **[sms](/plugins/reference/sms)** (`@openclaw/sms`) - npm; ClawHub: `clawhub:@openclaw/sms`. Twilio SMS/MMS channel plugin for OpenClaw messages.
 
 - **[stepfun](/plugins/reference/stepfun)** (`@openclaw/stepfun-provider`) - npm; ClawHub: `clawhub:@openclaw/stepfun-provider`. Adds StepFun, StepFun Plan model provider support to OpenClaw.
 

--- a/docs/plugins/reference/cua-computer.md
+++ b/docs/plugins/reference/cua-computer.md
@@ -7,9 +7,7 @@ title: "Cua Computer plugin"
 
 # Cua Computer plugin
 
-Experimental CUA Driver SDK computer control for Windows and Linux node hosts. It preserves
-the node `screen.snapshot` and `computer.act` contract while using a configured, trusted
-CUA Driver 0.14.1 SDK session directly; it does not run a CUA daemon or MCP proxy.
+Experimental CUA Driver SDK computer control for Windows and Linux node hosts.
 
 ## Distribution
 

--- a/docs/plugins/reference/google.md
+++ b/docs/plugins/reference/google.md
@@ -16,7 +16,7 @@ Adds Google, Google Gemini CLI, Google Vertex model provider support to OpenClaw
 
 ## Surface
 
-providers: `google`, `google-gemini-cli`, `google-vertex`; contracts: `imageGenerationProviders`, `mediaUnderstandingProviders`, `memoryEmbeddingProviders`, `musicGenerationProviders`, `realtimeVoiceProviders`, `speechProviders`, `usageProviders`, `videoGenerationProviders`, `webSearchProviders`
+providers: `google`, `google-gemini-cli`, `google-vertex`; contracts: `imageGenerationProviders`, `mediaUnderstandingProviders`, `memoryEmbeddingProviders`, `musicGenerationProviders`, `realtimeVoiceProviders`, `speechProviders`, `videoGenerationProviders`, `webSearchProviders`
 
 ## Related docs
 

--- a/docs/plugins/reference/sms.md
+++ b/docs/plugins/reference/sms.md
@@ -1,5 +1,5 @@
 ---
-summary: "Twilio SMS channel plugin for OpenClaw text messages."
+summary: "Twilio SMS/MMS channel plugin for OpenClaw messages."
 read_when:
   - You are installing, configuring, or auditing the sms plugin
 title: "Sms plugin"
@@ -7,7 +7,7 @@ title: "Sms plugin"
 
 # Sms plugin
 
-Twilio SMS channel plugin for OpenClaw text messages.
+Twilio SMS/MMS channel plugin for OpenClaw messages.
 
 ## Distribution
 

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/acpx",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw ACP runtime backend with plugin-owned session and transport management.",
   "repository": {
     "type": "git",
@@ -43,10 +43,10 @@
       ]
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "staticAssets": [
         {
           "source": "./src/runtime-internals/mcp-proxy.mjs",

--- a/extensions/admin-http-rpc/package.json
+++ b/extensions/admin-http-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/admin-http-rpc",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw admin HTTP RPC endpoint",
   "type": "module",

--- a/extensions/alibaba/package.json
+++ b/extensions/alibaba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/alibaba-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Alibaba Model Studio video provider plugin",
   "type": "module",

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Amazon Bedrock Mantle provider plugin for OpenAI-compatible model routing.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/amazon-bedrock/package.json
+++ b/extensions/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Amazon Bedrock provider plugin with model discovery, embeddings, and guardrail support.",
   "repository": {
     "type": "git",
@@ -28,10 +28,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.",
   "repository": {
     "type": "git",
@@ -25,10 +25,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/anthropic/package.json
+++ b/extensions/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Anthropic provider, Claude CLI, and native session catalog plugin",
   "type": "module",

--- a/extensions/arcee/package.json
+++ b/extensions/arcee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/arcee-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Arcee provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/azure-speech/package.json
+++ b/extensions/azure-speech/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/azure-speech",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Azure Speech plugin",
   "type": "module",

--- a/extensions/baseten/package.json
+++ b/extensions/baseten/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/baseten-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Baseten provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/beam/package.json
+++ b/extensions/beam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/beam",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "Read-only coding-session Beam receiver",
   "type": "module",

--- a/extensions/bonjour/package.json
+++ b/extensions/bonjour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/bonjour",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Bonjour/mDNS gateway discovery",
   "type": "module",
   "dependencies": {

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/brave-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Brave Search provider plugin for web search.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/browser-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw browser tool plugin",
   "type": "module",

--- a/extensions/buzz/package.json
+++ b/extensions/buzz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/buzz",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "Connect OpenClaw agents to Buzz rooms",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -24,13 +24,18 @@
     }
   },
   "openclaw": {
-    "extensions": ["./index.ts"],
+    "extensions": [
+      "./index.ts"
+    ],
     "setupEntry": "./setup-entry.ts",
     "channel": {
       "id": "buzz",
       "configuredState": {
         "env": {
-          "allOf": ["BUZZ_RELAY_URL", "BUZZ_PRIVATE_KEY"]
+          "allOf": [
+            "BUZZ_RELAY_URL",
+            "BUZZ_PRIVATE_KEY"
+          ]
         }
       },
       "label": "Buzz",
@@ -42,9 +47,31 @@
       "order": 56,
       "setup": {
         "fields": [
-          { "key": "relayUrl", "kind": "string", "cli": { "flags": "--relay-url <url>", "description": "Buzz relay WebSocket URL" } },
-          { "key": "privateKey", "kind": "string", "sensitive": true, "cli": { "flags": "--private-key <key>", "description": "Buzz bot Nostr private key" } },
-          { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use BUZZ_PRIVATE_KEY with the supplied relay URL" } }
+          {
+            "key": "relayUrl",
+            "kind": "string",
+            "cli": {
+              "flags": "--relay-url <url>",
+              "description": "Buzz relay WebSocket URL"
+            }
+          },
+          {
+            "key": "privateKey",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--private-key <key>",
+              "description": "Buzz bot Nostr private key"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use BUZZ_PRIVATE_KEY with the supplied relay URL"
+            }
+          }
         ]
       }
     },
@@ -55,10 +82,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/byteplus/package.json
+++ b/extensions/byteplus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/byteplus-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw BytePlus provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/canvas/package.json
+++ b/extensions/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/canvas-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Canvas plugin",
   "type": "module",

--- a/extensions/cerebras/package.json
+++ b/extensions/cerebras/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cerebras-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Cerebras provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/chutes/package.json
+++ b/extensions/chutes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/chutes-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Chutes.ai provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/clawrouter/package.json
+++ b/extensions/clawrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clawrouter",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw ClawRouter plugin",
   "type": "module",

--- a/extensions/clickclack/package.json
+++ b/extensions/clickclack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clickclack",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw ClickClack channel plugin",
   "type": "module",
   "exports": {
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -54,15 +54,81 @@
       },
       "setup": {
         "fields": [
-          { "key": "code", "kind": "string", "sensitive": true, "cli": { "flags": "--code <code>", "description": "ClickClack one-time setup code or setup URL" } },
-          { "key": "token", "kind": "string", "sensitive": true, "cli": { "flags": "--token <token>", "description": "ClickClack bot token" } },
-          { "key": "tokenFile", "kind": "string", "sensitive": true, "cli": { "flags": "--token-file <path>", "description": "ClickClack bot token file" } },
-          { "key": "baseUrl", "kind": "string", "cli": { "flags": "--base-url <url>", "description": "ClickClack API base URL" } },
-          { "key": "workspace", "kind": "string", "cli": { "flags": "--workspace <workspace>", "description": "ClickClack workspace id, slug, or name" } },
-          { "key": "defaultTo", "kind": "string", "cli": { "flags": "--default-to <target>", "description": "Default ClickClack target" } },
-          { "key": "allowFrom", "kind": "string-list", "cli": { "flags": "--allow-from <ids>", "description": "Allowed ClickClack senders" } },
-          { "key": "agentActivity", "kind": "boolean", "cli": { "flags": "--agent-activity", "description": "Enable ClickClack agent activity" } },
-          { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use CLICKCLACK_BOT_TOKEN" } }
+          {
+            "key": "code",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--code <code>",
+              "description": "ClickClack one-time setup code or setup URL"
+            }
+          },
+          {
+            "key": "token",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token <token>",
+              "description": "ClickClack bot token"
+            }
+          },
+          {
+            "key": "tokenFile",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token-file <path>",
+              "description": "ClickClack bot token file"
+            }
+          },
+          {
+            "key": "baseUrl",
+            "kind": "string",
+            "cli": {
+              "flags": "--base-url <url>",
+              "description": "ClickClack API base URL"
+            }
+          },
+          {
+            "key": "workspace",
+            "kind": "string",
+            "cli": {
+              "flags": "--workspace <workspace>",
+              "description": "ClickClack workspace id, slug, or name"
+            }
+          },
+          {
+            "key": "defaultTo",
+            "kind": "string",
+            "cli": {
+              "flags": "--default-to <target>",
+              "description": "Default ClickClack target"
+            }
+          },
+          {
+            "key": "allowFrom",
+            "kind": "string-list",
+            "cli": {
+              "flags": "--allow-from <ids>",
+              "description": "Allowed ClickClack senders"
+            }
+          },
+          {
+            "key": "agentActivity",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--agent-activity",
+              "description": "Enable ClickClack agent activity"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use CLICKCLACK_BOT_TOKEN"
+            }
+          }
         ]
       }
     },
@@ -74,10 +140,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/cloudflare-ai-gateway/package.json
+++ b/extensions/cloudflare-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cloudflare-ai-gateway-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Cloudflare AI Gateway provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/codex",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Codex app-server harness and native session supervision plugin.",
   "repository": {
     "type": "git",
@@ -35,10 +35,10 @@
       ]
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/cohere/package.json
+++ b/extensions/cohere/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cohere-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Cohere provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/comfy/package.json
+++ b/extensions/comfy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/comfy-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw ComfyUI provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot-proxy",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw GitHub Copilot agent runtime plugin (registers a `github-copilot` AgentHarness backed by @github/copilot-sdk over JSON-RPC to the GitHub Copilot CLI)",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/crabbox/package.json
+++ b/extensions/crabbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw cloud worker provider backed by the Crabbox CLI",
   "type": "module",

--- a/extensions/cua-computer/package.json
+++ b/extensions/cua-computer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cua-computer",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "Experimental CUA Driver SDK computer control for Windows and Linux node hosts",
   "type": "module",
   "dependencies": {

--- a/extensions/deepgram/package.json
+++ b/extensions/deepgram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepgram-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Deepgram media-understanding provider",
   "type": "module",

--- a/extensions/deepinfra/package.json
+++ b/extensions/deepinfra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepinfra-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw DeepInfra provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/deepseek/package.json
+++ b/extensions/deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepseek-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw DeepSeek provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw diagnostics OpenTelemetry exporter for metrics, traces, and logs.",
   "repository": {
     "type": "git",
@@ -37,10 +37,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diagnostics-prometheus/package.json
+++ b/extensions/diagnostics-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-prometheus",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw diagnostics Prometheus exporter for runtime metrics.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diffs-language-pack/package.json
+++ b/extensions/diffs-language-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs-language-pack",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw diffs viewer syntax highlighting language pack",
   "repository": {
     "type": "git",
@@ -22,13 +22,13 @@
       "minHostVersion": ">=2026.5.27"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "assetScripts": {
       "build": "node ../../scripts/build-diffs-viewer-runtime.mjs full"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw read-only diff viewer plugin and file renderer for agents.",
   "repository": {
     "type": "git",
@@ -28,13 +28,13 @@
       "minHostVersion": ">=2026.4.30"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "assetScripts": {
       "build": "node ../../scripts/build-diffs-viewer-runtime.mjs curated"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "staticAssets": [
         {
           "source": "./assets/viewer-runtime.js",

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -66,12 +66,18 @@
             "key": "token",
             "kind": "string",
             "sensitive": true,
-            "cli": { "flags": "--token <token>", "description": "Discord bot token" }
+            "cli": {
+              "flags": "--token <token>",
+              "description": "Discord bot token"
+            }
           },
           {
             "key": "useEnv",
             "kind": "boolean",
-            "cli": { "flags": "--use-env", "description": "Use DISCORD_BOT_TOKEN" }
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use DISCORD_BOT_TOKEN"
+            }
           }
         ]
       },
@@ -93,10 +99,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "staticAssets": [
         {
           "source": "./assets/embedded-app-sdk.mjs",

--- a/extensions/document-extract/package.json
+++ b/extensions/document-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/document-extract-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw local document extraction plugin",
   "type": "module",

--- a/extensions/duckduckgo/package.json
+++ b/extensions/duckduckgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/duckduckgo-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw DuckDuckGo plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/elevenlabs/package.json
+++ b/extensions/elevenlabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/elevenlabs-speech",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw ElevenLabs speech plugin",
   "type": "module",

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/exa-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Exa plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/fal/package.json
+++ b/extensions/fal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fal-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw fal provider plugin",
   "type": "module",

--- a/extensions/featherless/package.json
+++ b/extensions/featherless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/featherless-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Featherless AI provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.11"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -54,7 +54,9 @@
       ],
       "order": 35,
       "quickstartAllowFrom": true,
-      "setup": { "fields": [] }
+      "setup": {
+        "fields": []
+      }
     },
     "install": {
       "npmSpec": "@openclaw/feishu",
@@ -62,10 +64,10 @@
       "minHostVersion": ">=2026.5.29"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/file-transfer/package.json
+++ b/extensions/file-transfer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/file-transfer",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw file transfer plugin (file_fetch, dir_list, dir_fetch, file_write)",
   "type": "module",
   "dependencies": {

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/firecrawl-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Firecrawl plugin.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/fireworks/package.json
+++ b/extensions/fireworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fireworks-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Fireworks provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/fish-audio/package.json
+++ b/extensions/fish-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fish-audio-speech",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Fish Audio speech plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/github-copilot/package.json
+++ b/extensions/github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/github-copilot-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw GitHub Copilot provider plugin",
   "type": "module",

--- a/extensions/gmi/package.json
+++ b/extensions/gmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gmi-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw GMI Cloud provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-meet",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Google Meet participant plugin for joining calls through Chrome or Twilio transports.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -34,10 +34,10 @@
       "minHostVersion": ">=2026.4.20"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/google/package.json
+++ b/extensions/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Google plugin",
   "type": "module",

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -66,39 +66,63 @@
             "key": "token",
             "kind": "string",
             "sensitive": true,
-            "cli": { "flags": "--token <json>", "description": "Google Chat service account JSON" }
+            "cli": {
+              "flags": "--token <json>",
+              "description": "Google Chat service account JSON"
+            }
           },
           {
             "key": "tokenFile",
             "kind": "string",
             "sensitive": true,
-            "cli": { "flags": "--token-file <path>", "description": "Google Chat service account file" }
+            "cli": {
+              "flags": "--token-file <path>",
+              "description": "Google Chat service account file"
+            }
           },
           {
             "key": "audienceType",
             "kind": "choice",
-            "choices": ["app-url", "project-number"],
-            "cli": { "flags": "--audience-type <type>", "description": "Google Chat audience type" }
+            "choices": [
+              "app-url",
+              "project-number"
+            ],
+            "cli": {
+              "flags": "--audience-type <type>",
+              "description": "Google Chat audience type"
+            }
           },
           {
             "key": "audience",
             "kind": "string",
-            "cli": { "flags": "--audience <value>", "description": "Google Chat audience value" }
+            "cli": {
+              "flags": "--audience <value>",
+              "description": "Google Chat audience value"
+            }
           },
           {
             "key": "webhookPath",
             "kind": "string",
-            "cli": { "flags": "--webhook-path <path>", "description": "Google Chat webhook path" }
+            "cli": {
+              "flags": "--webhook-path <path>",
+              "description": "Google Chat webhook path"
+            }
           },
           {
             "key": "webhookUrl",
             "kind": "string",
-            "cli": { "flags": "--webhook-url <url>", "description": "Google Chat webhook URL" }
+            "cli": {
+              "flags": "--webhook-url <url>",
+              "description": "Google Chat webhook URL"
+            }
           },
           {
             "key": "useEnv",
             "kind": "boolean",
-            "cli": { "flags": "--use-env", "description": "Use Google Chat environment credentials" }
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use Google Chat environment credentials"
+            }
           }
         ]
       }
@@ -109,10 +133,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/gradium/package.json
+++ b/extensions/gradium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gradium-speech",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Gradium speech plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/groq-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Groq media-understanding provider.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/huggingface/package.json
+++ b/extensions/huggingface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/huggingface-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Hugging Face provider plugin",
   "type": "module",

--- a/extensions/image-generation-core/package.json
+++ b/extensions/image-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/image-generation-core",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw image generation runtime package",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/imessage",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -52,23 +52,39 @@
           {
             "key": "cliPath",
             "kind": "string",
-            "cli": { "flags": "--cli-path <path>", "description": "iMessage CLI path" }
+            "cli": {
+              "flags": "--cli-path <path>",
+              "description": "iMessage CLI path"
+            }
           },
           {
             "key": "dbPath",
             "kind": "string",
-            "cli": { "flags": "--db-path <path>", "description": "iMessage database path" }
+            "cli": {
+              "flags": "--db-path <path>",
+              "description": "iMessage database path"
+            }
           },
           {
             "key": "service",
             "kind": "choice",
-            "choices": ["imessage", "sms", "auto"],
-            "cli": { "flags": "--service <service>", "description": "iMessage service" }
+            "choices": [
+              "imessage",
+              "sms",
+              "auto"
+            ],
+            "cli": {
+              "flags": "--service <service>",
+              "description": "iMessage service"
+            }
           },
           {
             "key": "region",
             "kind": "string",
-            "cli": { "flags": "--region <region>", "description": "SMS region" }
+            "cli": {
+              "flags": "--region <region>",
+              "description": "SMS region"
+            }
           }
         ]
       }
@@ -81,10 +97,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/inworld/package.json
+++ b/extensions/inworld/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/inworld-speech",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Inworld speech plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/irc",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw IRC channel plugin",
   "type": "module",
   "devDependencies": {
@@ -41,23 +41,89 @@
         "internet-relay-chat"
       ],
       "systemImage": "network",
-      "setup": { "fields": [
-        { "key": "host", "kind": "string", "cli": { "flags": "--host <host>", "description": "IRC server host" } },
-        { "key": "port", "kind": "string", "cli": { "flags": "--port <port>", "description": "IRC server port" } },
-        { "key": "tls", "kind": "boolean", "cli": { "flags": "--tls", "description": "Use TLS for IRC" } },
-        { "key": "nick", "kind": "string", "cli": { "flags": "--nick <nick>", "description": "IRC nickname" } },
-        { "key": "username", "kind": "string", "cli": { "flags": "--username <name>", "description": "IRC username" } },
-        { "key": "realname", "kind": "string", "cli": { "flags": "--realname <name>", "description": "IRC real name" } },
-        { "key": "channels", "kind": "string-list", "cli": { "flags": "--channels <names>", "description": "IRC channels" } },
-        { "key": "password", "kind": "string", "sensitive": true, "cli": { "flags": "--password <password>", "description": "IRC server password" } },
-        { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use IRC environment configuration" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "host",
+            "kind": "string",
+            "cli": {
+              "flags": "--host <host>",
+              "description": "IRC server host"
+            }
+          },
+          {
+            "key": "port",
+            "kind": "string",
+            "cli": {
+              "flags": "--port <port>",
+              "description": "IRC server port"
+            }
+          },
+          {
+            "key": "tls",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--tls",
+              "description": "Use TLS for IRC"
+            }
+          },
+          {
+            "key": "nick",
+            "kind": "string",
+            "cli": {
+              "flags": "--nick <nick>",
+              "description": "IRC nickname"
+            }
+          },
+          {
+            "key": "username",
+            "kind": "string",
+            "cli": {
+              "flags": "--username <name>",
+              "description": "IRC username"
+            }
+          },
+          {
+            "key": "realname",
+            "kind": "string",
+            "cli": {
+              "flags": "--realname <name>",
+              "description": "IRC real name"
+            }
+          },
+          {
+            "key": "channels",
+            "kind": "string-list",
+            "cli": {
+              "flags": "--channels <names>",
+              "description": "IRC channels"
+            }
+          },
+          {
+            "key": "password",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--password <password>",
+              "description": "IRC server password"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use IRC environment configuration"
+            }
+          }
+        ]
+      }
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/kilocode/package.json
+++ b/extensions/kilocode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kilocode-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Kilo Gateway provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/kimi-coding/package.json
+++ b/extensions/kimi-coding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kimi-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Kimi provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -47,14 +47,63 @@
       "systemImage": "message",
       "order": 75,
       "quickstartAllowFrom": true,
-      "setup": { "fields": [
-        { "key": "channelAccessToken", "kind": "string", "sensitive": true, "cli": { "flags": "--channel-access-token <token>", "description": "LINE channel access token" } },
-        { "key": "token", "kind": "string", "sensitive": true, "cli": { "flags": "--token <token>", "description": "LINE channel access token (alias)" } },
-        { "key": "channelSecret", "kind": "string", "sensitive": true, "cli": { "flags": "--channel-secret <secret>", "description": "LINE channel secret" } },
-        { "key": "tokenFile", "kind": "string", "sensitive": true, "cli": { "flags": "--token-file <path>", "description": "LINE access token file" } },
-        { "key": "secretFile", "kind": "string", "sensitive": true, "cli": { "flags": "--secret-file <path>", "description": "LINE channel secret file" } },
-        { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use LINE environment credentials" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "channelAccessToken",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--channel-access-token <token>",
+              "description": "LINE channel access token"
+            }
+          },
+          {
+            "key": "token",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token <token>",
+              "description": "LINE channel access token (alias)"
+            }
+          },
+          {
+            "key": "channelSecret",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--channel-secret <secret>",
+              "description": "LINE channel secret"
+            }
+          },
+          {
+            "key": "tokenFile",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token-file <path>",
+              "description": "LINE access token file"
+            }
+          },
+          {
+            "key": "secretFile",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--secret-file <path>",
+              "description": "LINE channel secret file"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use LINE environment credentials"
+            }
+          }
+        ]
+      }
     },
     "install": {
       "npmSpec": "@openclaw/line",
@@ -62,10 +111,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/linux-canvas/package.json
+++ b/extensions/linux-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/linux-canvas",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Linux desktop canvas bridge",
   "type": "module",
   "dependencies": {

--- a/extensions/linux-node/package.json
+++ b/extensions/linux-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/linux-node",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Linux node device capabilities",
   "type": "module",
   "dependencies": {

--- a/extensions/litellm/package.json
+++ b/extensions/litellm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/litellm-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw LiteLLM provider plugin",
   "type": "module",

--- a/extensions/llama-cpp/package.json
+++ b/extensions/llama-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llama-cpp-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw llama.cpp text inference and embedding provider plugin",
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
       "minHostVersion": ">=2026.6.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llm-task",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",

--- a/extensions/lmstudio/package.json
+++ b/extensions/lmstudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lmstudio-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw LM Studio provider plugin",
   "type": "module",

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "Lobster workflow tool plugin for typed pipelines and resumable approvals.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/logbook/package.json
+++ b/extensions/logbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/logbook",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw automatic work journal plugin",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/longcat/package.json
+++ b/extensions/longcat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/longcat-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw LongCat provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.8.1
+
+### Changes
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.7.2
 
 ### Changes

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -74,16 +74,88 @@
       },
       "setup": {
         "fields": [
-          { "key": "homeserver", "kind": "string", "cli": { "flags": "--homeserver <url>", "description": "Matrix homeserver URL" } },
-          { "key": "userId", "kind": "string", "cli": { "flags": "--user-id <id>", "description": "Matrix user id" } },
-          { "key": "accessToken", "kind": "string", "sensitive": true, "cli": { "flags": "--access-token <token>", "description": "Matrix access token" } },
-          { "key": "password", "kind": "string", "sensitive": true, "cli": { "flags": "--password <password>", "description": "Matrix password" } },
-          { "key": "deviceName", "kind": "string", "cli": { "flags": "--device-name <name>", "description": "Matrix device name" } },
-          { "key": "avatarUrl", "kind": "string", "cli": { "flags": "--avatar-url <url>", "description": "Matrix avatar URL" } },
-          { "key": "initialSyncLimit", "kind": "integer", "cli": { "flags": "--initial-sync-limit <n>", "description": "Matrix initial sync room limit" } },
-          { "key": "proxy", "kind": "string", "cli": { "flags": "--proxy <url>", "description": "Matrix proxy URL" } },
-          { "key": "dangerouslyAllowPrivateNetwork", "kind": "boolean", "cli": { "flags": "--dangerously-allow-private-network", "description": "Allow private-network Matrix homeservers" } },
-          { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use Matrix environment credentials" } }
+          {
+            "key": "homeserver",
+            "kind": "string",
+            "cli": {
+              "flags": "--homeserver <url>",
+              "description": "Matrix homeserver URL"
+            }
+          },
+          {
+            "key": "userId",
+            "kind": "string",
+            "cli": {
+              "flags": "--user-id <id>",
+              "description": "Matrix user id"
+            }
+          },
+          {
+            "key": "accessToken",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--access-token <token>",
+              "description": "Matrix access token"
+            }
+          },
+          {
+            "key": "password",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--password <password>",
+              "description": "Matrix password"
+            }
+          },
+          {
+            "key": "deviceName",
+            "kind": "string",
+            "cli": {
+              "flags": "--device-name <name>",
+              "description": "Matrix device name"
+            }
+          },
+          {
+            "key": "avatarUrl",
+            "kind": "string",
+            "cli": {
+              "flags": "--avatar-url <url>",
+              "description": "Matrix avatar URL"
+            }
+          },
+          {
+            "key": "initialSyncLimit",
+            "kind": "integer",
+            "cli": {
+              "flags": "--initial-sync-limit <n>",
+              "description": "Matrix initial sync room limit"
+            }
+          },
+          {
+            "key": "proxy",
+            "kind": "string",
+            "cli": {
+              "flags": "--proxy <url>",
+              "description": "Matrix proxy URL"
+            }
+          },
+          {
+            "key": "dangerouslyAllowPrivateNetwork",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--dangerously-allow-private-network",
+              "description": "Allow private-network Matrix homeservers"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use Matrix environment credentials"
+            }
+          }
         ]
       },
       "persistedAuthState": {
@@ -99,10 +171,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mattermost",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Mattermost channel plugin",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -44,12 +44,44 @@
       "docsLabel": "mattermost",
       "blurb": "self-hosted Slack-style chat; install the plugin to enable.",
       "order": 65,
-      "setup": { "fields": [
-        { "key": "token", "kind": "string", "sensitive": true, "cli": { "flags": "--token <token>", "description": "Mattermost bot token" } },
-        { "key": "botToken", "kind": "string", "sensitive": true, "cli": { "flags": "--bot-token <token>", "description": "Mattermost bot token" } },
-        { "key": "httpUrl", "kind": "string", "cli": { "flags": "--http-url <url>", "description": "Mattermost server URL" } },
-        { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use Mattermost environment credentials" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "token",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token <token>",
+              "description": "Mattermost bot token"
+            }
+          },
+          {
+            "key": "botToken",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--bot-token <token>",
+              "description": "Mattermost bot token"
+            }
+          },
+          {
+            "key": "httpUrl",
+            "kind": "string",
+            "cli": {
+              "flags": "--http-url <url>",
+              "description": "Mattermost server URL"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use Mattermost environment credentials"
+            }
+          }
+        ]
+      }
     },
     "install": {
       "clawhubSpec": "clawhub:@openclaw/mattermost",
@@ -59,10 +91,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/media-understanding-core/package.json
+++ b/extensions/media-understanding-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/media-understanding-core",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw media understanding runtime package",
   "type": "module",

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-core",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",
@@ -18,7 +18,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, and vector search.",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
       "minHostVersion": ">=2026.5.31"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-wiki",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw persistent wiki plugin",
   "type": "module",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/meta/package.json
+++ b/extensions/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/meta-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Meta provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.11"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/microsoft-foundry/package.json
+++ b/extensions/microsoft-foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-foundry",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Microsoft Foundry provider plugin",
   "type": "module",

--- a/extensions/microsoft/package.json
+++ b/extensions/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-speech",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Microsoft speech plugin",
   "type": "module",

--- a/extensions/migrate-claude/package.json
+++ b/extensions/migrate-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-claude",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "Claude to OpenClaw migration provider",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/migrate-hermes/package.json
+++ b/extensions/migrate-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/migrate-hermes",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "Hermes to OpenClaw migration provider",
   "type": "module",
@@ -13,7 +13,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/minimax/package.json
+++ b/extensions/minimax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/minimax-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw MiniMax provider and OAuth plugin",
   "type": "module",

--- a/extensions/mistral/package.json
+++ b/extensions/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mistral-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Mistral provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/moonshot/package.json
+++ b/extensions/moonshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/moonshot-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Moonshot provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -60,7 +60,9 @@
         "groupAllowFromFallbackToAllowFrom": true,
         "warnOnEmptyGroupSenderAllowlist": true
       },
-      "setup": { "fields": [] }
+      "setup": {
+        "fields": []
+      }
     },
     "install": {
       "npmSpec": "@openclaw/msteams",
@@ -68,10 +70,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "runtimeFormat": "cjs"
     },
     "release": {

--- a/extensions/mxc/package.json
+++ b/extensions/mxc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mxc-sandbox",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw MXC sandbox execution plugin for MXC-capable hosts",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.6.11"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false,
       "staticAssets": [
         {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -48,16 +48,79 @@
       ],
       "order": 65,
       "quickstartAllowFrom": true,
-      "setup": { "fields": [
-        { "key": "baseUrl", "kind": "string", "cli": { "flags": "--base-url <url>", "description": "Nextcloud base URL" } },
-        { "key": "url", "kind": "string", "cli": { "flags": "--url <url>", "description": "Legacy Nextcloud base URL alias" } },
-        { "key": "secret", "kind": "string", "sensitive": true, "cli": { "flags": "--secret <secret>", "description": "Nextcloud Talk bot secret" } },
-        { "key": "token", "kind": "string", "sensitive": true, "cli": { "flags": "--token <secret>", "description": "Legacy Nextcloud bot secret alias" } },
-        { "key": "password", "kind": "string", "sensitive": true, "cli": { "flags": "--password <secret>", "description": "Legacy Nextcloud bot secret alias" } },
-        { "key": "secretFile", "kind": "string", "sensitive": true, "cli": { "flags": "--secret-file <path>", "description": "Nextcloud Talk bot secret file" } },
-        { "key": "tokenFile", "kind": "string", "sensitive": true, "cli": { "flags": "--token-file <path>", "description": "Legacy Nextcloud bot secret file alias" } },
-        { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use Nextcloud Talk environment credentials" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "baseUrl",
+            "kind": "string",
+            "cli": {
+              "flags": "--base-url <url>",
+              "description": "Nextcloud base URL"
+            }
+          },
+          {
+            "key": "url",
+            "kind": "string",
+            "cli": {
+              "flags": "--url <url>",
+              "description": "Legacy Nextcloud base URL alias"
+            }
+          },
+          {
+            "key": "secret",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--secret <secret>",
+              "description": "Nextcloud Talk bot secret"
+            }
+          },
+          {
+            "key": "token",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token <secret>",
+              "description": "Legacy Nextcloud bot secret alias"
+            }
+          },
+          {
+            "key": "password",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--password <secret>",
+              "description": "Legacy Nextcloud bot secret alias"
+            }
+          },
+          {
+            "key": "secretFile",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--secret-file <path>",
+              "description": "Nextcloud Talk bot secret file"
+            }
+          },
+          {
+            "key": "tokenFile",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token-file <path>",
+              "description": "Legacy Nextcloud bot secret file alias"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use Nextcloud Talk environment credentials"
+            }
+          }
+        ]
+      }
     },
     "install": {
       "npmSpec": "@openclaw/nextcloud-talk",
@@ -65,10 +128,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -46,9 +46,31 @@
       "quickstartAllowFrom": true,
       "setup": {
         "fields": [
-          { "key": "privateKey", "kind": "string", "sensitive": true, "cli": { "flags": "--private-key <key>", "description": "Nostr private key" } },
-          { "key": "relayUrls", "kind": "string", "cli": { "flags": "--relay-urls <urls>", "description": "Nostr relay URLs" } },
-          { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use NOSTR_PRIVATE_KEY" } }
+          {
+            "key": "privateKey",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--private-key <key>",
+              "description": "Nostr private key"
+            }
+          },
+          {
+            "key": "relayUrls",
+            "kind": "string",
+            "cli": {
+              "flags": "--relay-urls <urls>",
+              "description": "Nostr relay URLs"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use NOSTR_PRIVATE_KEY"
+            }
+          }
         ]
       }
     },
@@ -58,10 +80,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/novita/package.json
+++ b/extensions/novita/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/novita-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw NovitaAI provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/nvidia/package.json
+++ b/extensions/nvidia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nvidia-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw NVIDIA provider plugin",
   "type": "module",

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/oc-path",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
@@ -14,7 +14,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/ollama/package.json
+++ b/extensions/ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/ollama-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Ollama provider plugin",
   "type": "module",

--- a/extensions/onepassword/package.json
+++ b/extensions/onepassword/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/onepassword",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "1Password SecretRef resolver and audited agent secrets broker for OpenClaw",
   "type": "module",

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/open-prose",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",

--- a/extensions/openai/package.json
+++ b/extensions/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openai-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw OpenAI provider plugins",
   "type": "module",

--- a/extensions/opencode-go/package.json
+++ b/extensions/opencode-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-go-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw OpenCode Go provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw OpenCode Zen provider plugin",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/openrouter/package.json
+++ b/extensions/openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openrouter-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw OpenRouter provider plugin",
   "type": "module",

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openshell-sandbox",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
       "minHostVersion": ">=2026.5.12-beta.1"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/parallel/package.json
+++ b/extensions/parallel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/parallel-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Parallel web search plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/perplexity/package.json
+++ b/extensions/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/perplexity-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Perplexity plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/pixverse/package.json
+++ b/extensions/pixverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/pixverse-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw PixVerse video generation provider plugin.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.5.26"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/policy/package.json
+++ b/extensions/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/policy",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw policy doctor checks for workspace conformance",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-channel",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw QA synthetic channel plugin",
   "type": "module",
@@ -19,7 +19,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -46,11 +46,34 @@
         "setup": false,
         "docs": false
       },
-      "setup": { "fields": [
-        { "key": "baseUrl", "kind": "string", "cli": { "flags": "--base-url <url>", "description": "QA channel base URL" } },
-        { "key": "botUserId", "kind": "string", "cli": { "flags": "--bot-user-id <id>", "description": "QA channel bot user id" } },
-        { "key": "botDisplayName", "kind": "string", "cli": { "flags": "--bot-display-name <name>", "description": "QA channel bot display name" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "baseUrl",
+            "kind": "string",
+            "cli": {
+              "flags": "--base-url <url>",
+              "description": "QA channel base URL"
+            }
+          },
+          {
+            "key": "botUserId",
+            "kind": "string",
+            "cli": {
+              "flags": "--bot-user-id <id>",
+              "description": "QA channel bot user id"
+            }
+          },
+          {
+            "key": "botDisplayName",
+            "kind": "string",
+            "cli": {
+              "flags": "--bot-display-name <name>",
+              "description": "QA channel bot display name"
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-lab",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner",
   "type": "module",
@@ -27,7 +27,7 @@
     "vite": "8.1.5"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -39,7 +39,7 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     }
   }
 }

--- a/extensions/qianfan/package.json
+++ b/extensions/qianfan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qianfan-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Qianfan provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qqbot",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": false,
   "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
   "repository": {
@@ -23,7 +23,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -55,11 +55,36 @@
       "docsLabel": "qqbot",
       "blurb": "connect to QQ via official QQ Bot API with group chat and direct message support.",
       "systemImage": "bubble.left.and.bubble.right",
-      "setup": { "fields": [
-        { "key": "token", "kind": "string", "sensitive": true, "cli": { "flags": "--token <appId:secret>", "description": "QQBot app id and client secret" } },
-        { "key": "tokenFile", "kind": "string", "sensitive": true, "cli": { "flags": "--token-file <path>", "description": "QQBot client secret file" } },
-        { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use QQBOT environment credentials" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "token",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token <appId:secret>",
+              "description": "QQBot app id and client secret"
+            }
+          },
+          {
+            "key": "tokenFile",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token-file <path>",
+              "description": "QQBot client secret file"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use QQBOT environment credentials"
+            }
+          }
+        ]
+      }
     },
     "install": {
       "npmSpec": "@openclaw/qqbot",
@@ -68,10 +93,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/qwen/package.json
+++ b/extensions/qwen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qwen-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Qwen Cloud provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/raft/package.json
+++ b/extensions/raft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/raft",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Raft channel plugin for Raft CLI wake bridges.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.6.8"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "channel": {
       "id": "raft",
@@ -58,7 +58,10 @@
           {
             "key": "profile",
             "kind": "string",
-            "cli": { "flags": "--profile <profile>", "description": "Raft CLI profile" }
+            "cli": {
+              "flags": "--profile <profile>",
+              "description": "Raft CLI profile"
+            }
           }
         ]
       }

--- a/extensions/reef/package.json
+++ b/extensions/reef/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/reef",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Reef channel plugin — guarded end-to-end encrypted claw-to-claw messaging",
   "type": "module",
   "dependencies": {
@@ -27,7 +27,9 @@
       "docsLabel": "reef",
       "blurb": "Guarded end-to-end encrypted claw messaging.",
       "systemImage": "message.badge",
-      "setup": { "fields": [] }
+      "setup": {
+        "fields": []
+      }
     }
   },
   "devDependencies": {

--- a/extensions/runway/package.json
+++ b/extensions/runway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/runway-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Runway video provider plugin",
   "type": "module",

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/searxng-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw SearXNG plugin",
   "type": "module",
   "devDependencies": {
@@ -18,10 +18,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/senseaudio/package.json
+++ b/extensions/senseaudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/senseaudio-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw SenseAudio media-understanding provider",
   "type": "module",

--- a/extensions/sglang/package.json
+++ b/extensions/sglang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sglang-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw SGLang provider plugin",
   "type": "module",

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/signal",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Signal channel plugin",
   "type": "module",
   "dependencies": {
@@ -44,7 +44,10 @@
           {
             "key": "signalTransport",
             "kind": "choice",
-            "choices": ["external-native", "container"],
+            "choices": [
+              "external-native",
+              "container"
+            ],
             "cli": {
               "flags": "--signal-transport <kind>",
               "description": "Signal HTTP transport (external-native or container)"
@@ -93,10 +96,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -71,15 +71,78 @@
         "nativeCommandsAutoEnabled": false,
         "nativeSkillsAutoEnabled": false
       },
-      "setup": { "fields": [
-        { "key": "botToken", "kind": "string", "sensitive": true, "cli": { "flags": "--bot-token <token>", "description": "Slack bot token" } },
-        { "key": "appToken", "kind": "string", "sensitive": true, "cli": { "flags": "--app-token <token>", "description": "Slack app token" } },
-        { "key": "userToken", "kind": "string", "sensitive": true, "cli": { "flags": "--user-token <token>", "description": "Slack user token" } },
-        { "key": "signingSecret", "kind": "string", "sensitive": true, "cli": { "flags": "--signing-secret <secret>", "description": "Slack signing secret" } },
-        { "key": "identity", "kind": "choice", "choices": ["bot", "user"], "cli": { "flags": "--identity <kind>", "description": "Slack identity" } },
-        { "key": "mode", "kind": "choice", "choices": ["socket", "http"], "cli": { "flags": "--mode <mode>", "description": "Slack connection mode" } },
-        { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use Slack environment credentials" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "botToken",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--bot-token <token>",
+              "description": "Slack bot token"
+            }
+          },
+          {
+            "key": "appToken",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--app-token <token>",
+              "description": "Slack app token"
+            }
+          },
+          {
+            "key": "userToken",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--user-token <token>",
+              "description": "Slack user token"
+            }
+          },
+          {
+            "key": "signingSecret",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--signing-secret <secret>",
+              "description": "Slack signing secret"
+            }
+          },
+          {
+            "key": "identity",
+            "kind": "choice",
+            "choices": [
+              "bot",
+              "user"
+            ],
+            "cli": {
+              "flags": "--identity <kind>",
+              "description": "Slack identity"
+            }
+          },
+          {
+            "key": "mode",
+            "kind": "choice",
+            "choices": [
+              "socket",
+              "http"
+            ],
+            "cli": {
+              "flags": "--mode <mode>",
+              "description": "Slack connection mode"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use Slack environment credentials"
+            }
+          }
+        ]
+      }
     },
     "install": {
       "npmSpec": "@openclaw/slack",
@@ -88,10 +151,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/sms/package.json
+++ b/extensions/sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sms",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw SMS/MMS channel plugin for Twilio messages.",
   "repository": {
     "type": "git",
@@ -41,23 +41,96 @@
       "blurb": "Twilio-backed SMS/MMS with inbound webhooks and outbound replies.",
       "order": 88,
       "quickstartAllowFrom": true,
-      "setup": { "fields": [
-        { "key": "accountSid", "kind": "string", "sensitive": true, "cli": { "flags": "--account-sid <sid>", "description": "Twilio account SID" } },
-        { "key": "authToken", "kind": "string", "sensitive": true, "cli": { "flags": "--auth-token <token>", "description": "Twilio auth token" } },
-        { "key": "fromNumber", "kind": "string", "cli": { "flags": "--from-number <e164>", "description": "Twilio sender phone number" } },
-        { "key": "messagingServiceSid", "kind": "string", "cli": { "flags": "--messaging-service-sid <sid>", "description": "Twilio Messaging Service SID" } },
-        { "key": "defaultTo", "kind": "string", "cli": { "flags": "--default-to <e164>", "description": "Default SMS recipient" } },
-        { "key": "webhookPath", "kind": "string", "cli": { "flags": "--webhook-path <path>", "description": "SMS webhook path" } },
-        { "key": "publicWebhookUrl", "kind": "string", "cli": { "flags": "--public-webhook-url <url>", "description": "Public SMS webhook URL" } },
-        { "key": "dmPolicy", "kind": "choice", "choices": ["pairing", "allowlist", "open", "disabled"], "cli": { "flags": "--dm-policy <policy>", "description": "SMS DM policy" } },
-        { "key": "allowFrom", "kind": "string-list", "cli": { "flags": "--allow-from <numbers>", "description": "Allowed SMS senders" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "accountSid",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--account-sid <sid>",
+              "description": "Twilio account SID"
+            }
+          },
+          {
+            "key": "authToken",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--auth-token <token>",
+              "description": "Twilio auth token"
+            }
+          },
+          {
+            "key": "fromNumber",
+            "kind": "string",
+            "cli": {
+              "flags": "--from-number <e164>",
+              "description": "Twilio sender phone number"
+            }
+          },
+          {
+            "key": "messagingServiceSid",
+            "kind": "string",
+            "cli": {
+              "flags": "--messaging-service-sid <sid>",
+              "description": "Twilio Messaging Service SID"
+            }
+          },
+          {
+            "key": "defaultTo",
+            "kind": "string",
+            "cli": {
+              "flags": "--default-to <e164>",
+              "description": "Default SMS recipient"
+            }
+          },
+          {
+            "key": "webhookPath",
+            "kind": "string",
+            "cli": {
+              "flags": "--webhook-path <path>",
+              "description": "SMS webhook path"
+            }
+          },
+          {
+            "key": "publicWebhookUrl",
+            "kind": "string",
+            "cli": {
+              "flags": "--public-webhook-url <url>",
+              "description": "Public SMS webhook URL"
+            }
+          },
+          {
+            "key": "dmPolicy",
+            "kind": "choice",
+            "choices": [
+              "pairing",
+              "allowlist",
+              "open",
+              "disabled"
+            ],
+            "cli": {
+              "flags": "--dm-policy <policy>",
+              "description": "SMS DM policy"
+            }
+          },
+          {
+            "key": "allowFrom",
+            "kind": "string-list",
+            "cli": {
+              "flags": "--allow-from <numbers>",
+              "description": "Allowed SMS senders"
+            }
+          }
+        ]
+      }
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "install": {

--- a/extensions/stepfun/package.json
+++ b/extensions/stepfun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/stepfun-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw StepFun provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
   "repository": {
     "type": "git",
@@ -35,12 +35,43 @@
       "docsLabel": "synology-chat",
       "blurb": "Connect your Synology NAS Chat to OpenClaw with full agent capabilities.",
       "order": 90,
-      "setup": { "fields": [
-        { "key": "token", "kind": "string", "sensitive": true, "cli": { "flags": "--token <token>", "description": "Synology Chat token" } },
-        { "key": "url", "kind": "string", "cli": { "flags": "--url <url>", "description": "Synology Chat webhook URL" } },
-        { "key": "webhookPath", "kind": "string", "cli": { "flags": "--webhook-path <path>", "description": "Synology Chat webhook path" } },
-        { "key": "useEnv", "kind": "boolean", "cli": { "flags": "--use-env", "description": "Use Synology Chat environment credentials" } }
-      ] }
+      "setup": {
+        "fields": [
+          {
+            "key": "token",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--token <token>",
+              "description": "Synology Chat token"
+            }
+          },
+          {
+            "key": "url",
+            "kind": "string",
+            "cli": {
+              "flags": "--url <url>",
+              "description": "Synology Chat webhook URL"
+            }
+          },
+          {
+            "key": "webhookPath",
+            "kind": "string",
+            "cli": {
+              "flags": "--webhook-path <path>",
+              "description": "Synology Chat webhook path"
+            }
+          },
+          {
+            "key": "useEnv",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use Synology Chat environment credentials"
+            }
+          }
+        ]
+      }
     },
     "install": {
       "npmSpec": "@openclaw/synology-chat",
@@ -48,10 +79,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/synthetic/package.json
+++ b/extensions/synthetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synthetic-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Synthetic provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tavily-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Tavily plugin",
   "type": "module",
   "dependencies": {
@@ -21,10 +21,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/teams-meetings/package.json
+++ b/extensions/teams-meetings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/teams-meetings",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Microsoft Teams browser meeting participant plugin.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/telegram",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",
@@ -55,18 +55,27 @@
             "key": "token",
             "kind": "string",
             "sensitive": true,
-            "cli": { "flags": "--token <token>", "description": "Telegram bot token" }
+            "cli": {
+              "flags": "--token <token>",
+              "description": "Telegram bot token"
+            }
           },
           {
             "key": "tokenFile",
             "kind": "string",
             "sensitive": true,
-            "cli": { "flags": "--token-file <path>", "description": "Telegram bot token file" }
+            "cli": {
+              "flags": "--token-file <path>",
+              "description": "Telegram bot token file"
+            }
           },
           {
             "key": "useEnv",
             "kind": "boolean",
-            "cli": { "flags": "--use-env", "description": "Use TELEGRAM_BOT_TOKEN" }
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use TELEGRAM_BOT_TOKEN"
+            }
           }
         ]
       },

--- a/extensions/tencent/package.json
+++ b/extensions/tencent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tencent-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Tencent Cloud provider plugin (TokenHub + Token Plan)",
   "type": "module",
   "devDependencies": {
@@ -18,10 +18,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -45,14 +45,72 @@
       "quickstartAllowFrom": true,
       "setup": {
         "fields": [
-          { "key": "ship", "kind": "string", "cli": { "flags": "--ship <ship>", "description": "Tlon ship" } },
-          { "key": "url", "kind": "string", "cli": { "flags": "--url <url>", "description": "Tlon URL" } },
-          { "key": "code", "kind": "string", "sensitive": true, "cli": { "flags": "--code <code>", "description": "Tlon login code" } },
-          { "key": "dangerouslyAllowPrivateNetwork", "kind": "boolean", "cli": { "flags": "--dangerously-allow-private-network", "description": "Allow private-network Tlon URLs" } },
-          { "key": "groupChannels", "kind": "string-list", "cli": { "flags": "--group-channels <list>", "description": "Tlon group channels" } },
-          { "key": "dmAllowlist", "kind": "string-list", "cli": { "flags": "--dm-allowlist <list>", "description": "Tlon DM allowlist" } },
-          { "key": "autoDiscoverChannels", "kind": "boolean", "cli": { "flags": "--auto-discover-channels", "negatedFlags": "--no-auto-discover-channels", "description": "Auto-discover Tlon group channels" } },
-          { "key": "ownerShip", "kind": "string", "cli": { "flags": "--owner-ship <ship>", "description": "Tlon owner ship" } }
+          {
+            "key": "ship",
+            "kind": "string",
+            "cli": {
+              "flags": "--ship <ship>",
+              "description": "Tlon ship"
+            }
+          },
+          {
+            "key": "url",
+            "kind": "string",
+            "cli": {
+              "flags": "--url <url>",
+              "description": "Tlon URL"
+            }
+          },
+          {
+            "key": "code",
+            "kind": "string",
+            "sensitive": true,
+            "cli": {
+              "flags": "--code <code>",
+              "description": "Tlon login code"
+            }
+          },
+          {
+            "key": "dangerouslyAllowPrivateNetwork",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--dangerously-allow-private-network",
+              "description": "Allow private-network Tlon URLs"
+            }
+          },
+          {
+            "key": "groupChannels",
+            "kind": "string-list",
+            "cli": {
+              "flags": "--group-channels <list>",
+              "description": "Tlon group channels"
+            }
+          },
+          {
+            "key": "dmAllowlist",
+            "kind": "string-list",
+            "cli": {
+              "flags": "--dm-allowlist <list>",
+              "description": "Tlon DM allowlist"
+            }
+          },
+          {
+            "key": "autoDiscoverChannels",
+            "kind": "boolean",
+            "cli": {
+              "flags": "--auto-discover-channels",
+              "negatedFlags": "--no-auto-discover-channels",
+              "description": "Auto-discover Tlon group channels"
+            }
+          },
+          {
+            "key": "ownerShip",
+            "kind": "string",
+            "cli": {
+              "flags": "--owner-ship <ship>",
+              "description": "Tlon owner ship"
+            }
+          }
         ]
       }
     },
@@ -62,10 +120,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/together/package.json
+++ b/extensions/together/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/together-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw Together provider plugin",
   "type": "module",

--- a/extensions/tokenjuice/package.json
+++ b/extensions/tokenjuice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tokenjuice",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw tokenjuice exec output compaction plugin",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
     "tokenjuice": "0.8.1"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.5.28"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/tts-local-cli/package.json
+++ b/extensions/tts-local-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tts-local-cli",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw local CLI TTS plugin",
   "type": "module",

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "channel": {
       "id": "twitch",
@@ -51,7 +51,9 @@
       "aliases": [
         "twitch-chat"
       ],
-      "setup": { "fields": [] }
+      "setup": {
+        "fields": []
+      }
     },
     "release": {
       "bundleRuntimeDependencies": false,

--- a/extensions/vault/package.json
+++ b/extensions/vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vault",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "HashiCorp Vault SecretRef provider integration for OpenClaw",
   "type": "module",

--- a/extensions/venice/package.json
+++ b/extensions/venice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/venice-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Venice provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/vercel-ai-gateway/package.json
+++ b/extensions/vercel-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vercel-ai-gateway-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Vercel AI Gateway provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/video-generation-core/package.json
+++ b/extensions/video-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/video-generation-core",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw video generation runtime package",
   "type": "module",

--- a/extensions/vllm/package.json
+++ b/extensions/vllm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vllm-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw vLLM provider plugin",
   "type": "module",

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -34,10 +34,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/volcengine/package.json
+++ b/extensions/volcengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/volcengine-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Volcengine provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/voyage/package.json
+++ b/extensions/voyage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voyage-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Voyage embedding provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/vydra/package.json
+++ b/extensions/vydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vydra-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Vydra media provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/web-readability/package.json
+++ b/extensions/web-readability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/web-readability-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw local Readability web extraction plugin",
   "type": "module",

--- a/extensions/webhooks/package.json
+++ b/extensions/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/webhooks",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw webhook bridge plugin",
   "type": "module",

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -70,10 +70,10 @@
       "minHostVersion": ">=2026.4.25"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/workboard/package.json
+++ b/extensions/workboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/workboard",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw dashboard workboard plugin",
   "type": "module",
@@ -13,7 +13,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xai-plugin",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "private": true,
   "description": "OpenClaw xAI plugin",
   "type": "module",

--- a/extensions/xiaomi/package.json
+++ b/extensions/xiaomi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xiaomi-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Xiaomi provider plugin.",
   "repository": {
     "type": "git",
@@ -21,10 +21,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/zai/package.json
+++ b/extensions/zai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zai-provider",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Z.AI provider plugin",
   "type": "module",
   "devDependencies": {
@@ -17,10 +17,10 @@
       "minHostVersion": ">=2026.6.9"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -53,18 +53,27 @@
             "key": "token",
             "kind": "string",
             "sensitive": true,
-            "cli": { "flags": "--token <token>", "description": "Zalo bot token" }
+            "cli": {
+              "flags": "--token <token>",
+              "description": "Zalo bot token"
+            }
           },
           {
             "key": "tokenFile",
             "kind": "string",
             "sensitive": true,
-            "cli": { "flags": "--token-file <path>", "description": "Zalo bot token file" }
+            "cli": {
+              "flags": "--token-file <path>",
+              "description": "Zalo bot token file"
+            }
           },
           {
             "key": "useEnv",
             "kind": "boolean",
-            "cli": { "flags": "--use-env", "description": "Use ZALO_BOT_TOKEN" }
+            "cli": {
+              "flags": "--use-env",
+              "description": "Use ZALO_BOT_TOKEN"
+            }
           }
         ]
       }
@@ -75,10 +84,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -55,7 +55,9 @@
         "groupAllowFromFallbackToAllowFrom": false,
         "warnOnEmptyGroupSenderAllowlist": false
       },
-      "setup": { "fields": [] }
+      "setup": {
+        "fields": []
+      }
     },
     "install": {
       "npmSpec": "@openclaw/zalouser",
@@ -63,10 +65,10 @@
       "minHostVersion": ">=2026.4.10"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.8.1"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/zoom-meetings/package.json
+++ b/extensions/zoom-meetings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zoom-meetings",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "OpenClaw Zoom browser meeting participant plugin.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -33,10 +33,10 @@
       "minHostVersion": ">=2026.7.2"
     },
     "compat": {
-      "pluginApi": ">=2026.7.2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.2",
+      "openclawVersion": "2026.8.1",
       "bundledDist": false
     },
     "release": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "openclaw": {
     "schemaVersions": {
       "state": 6,

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/ai",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "Reusable model provider adapters and streaming runtime from OpenClaw",
   "keywords": [
     "ai",

--- a/packages/gateway-client/package.json
+++ b/packages/gateway-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gateway-client",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "Reference WebSocket client for the OpenClaw Gateway protocol",
   "keywords": [
     "client",

--- a/packages/gateway-protocol/package.json
+++ b/packages/gateway-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/gateway-protocol",
-  "version": "2026.7.2",
+  "version": "2026.8.1",
   "description": "Typed schemas and runtime validators for the OpenClaw Gateway WebSocket protocol",
   "keywords": [
     "gateway",

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -2,7 +2,7 @@
   "entries": [
     {
       "name": "@openclaw/buzz",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "Connect OpenClaw agents to Buzz rooms",
       "source": "official",
       "kind": "channel",
@@ -313,7 +313,7 @@
     },
     {
       "name": "@openclaw/clickclack",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw ClickClack channel plugin",
       "source": "official",
       "kind": "channel",
@@ -512,7 +512,7 @@
     },
     {
       "name": "@openclaw/discord",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
       "source": "official",
       "kind": "channel",
@@ -589,7 +589,7 @@
     },
     {
       "name": "@openclaw/feishu",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).",
       "source": "official",
       "kind": "channel",
@@ -647,7 +647,7 @@
     },
     {
       "name": "@openclaw/googlechat",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Google Chat channel plugin for spaces and direct messages.",
       "source": "official",
       "kind": "channel",
@@ -760,7 +760,7 @@
     },
     {
       "name": "@openclaw/imessage",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac",
       "source": "official",
       "kind": "channel",
@@ -833,7 +833,7 @@
     },
     {
       "name": "@openclaw/irc",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw IRC channel plugin",
       "source": "official",
       "kind": "channel",
@@ -947,7 +947,7 @@
     },
     {
       "name": "@openclaw/line",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw LINE channel plugin for LINE Bot API chats.",
       "source": "official",
       "kind": "channel",
@@ -1038,7 +1038,7 @@
     },
     {
       "name": "@openclaw/matrix",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Matrix channel plugin for rooms and direct messages.",
       "source": "official",
       "kind": "channel",
@@ -1180,7 +1180,7 @@
     },
     {
       "name": "@openclaw/mattermost",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Mattermost channel plugin",
       "source": "official",
       "kind": "channel",
@@ -1251,7 +1251,7 @@
     },
     {
       "name": "@openclaw/msteams",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Microsoft Teams channel plugin for bot conversations.",
       "source": "official",
       "kind": "channel",
@@ -1295,7 +1295,7 @@
     },
     {
       "name": "@openclaw/nextcloud-talk",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Nextcloud Talk channel plugin for conversations.",
       "source": "official",
       "kind": "channel",
@@ -1404,7 +1404,7 @@
     },
     {
       "name": "@openclaw/nostr",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted direct messages.",
       "source": "official",
       "kind": "channel",
@@ -1549,7 +1549,7 @@
     },
     {
       "name": "@openclaw/qqbot",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw QQ Bot channel plugin for group and direct-message workflows.",
       "source": "official",
       "kind": "channel",
@@ -1620,7 +1620,7 @@
     },
     {
       "name": "@openclaw/raft",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Raft channel plugin for Raft CLI wake bridges.",
       "source": "official",
       "kind": "channel",
@@ -1706,7 +1706,7 @@
     },
     {
       "name": "@openclaw/signal",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Signal channel plugin",
       "source": "official",
       "kind": "channel",
@@ -1792,7 +1792,7 @@
     },
     {
       "name": "@openclaw/slack",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Slack channel plugin for channels, DMs, commands, and app events.",
       "source": "official",
       "kind": "channel",
@@ -1922,7 +1922,7 @@
     },
     {
       "name": "@openclaw/sms",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw SMS/MMS channel plugin for Twilio messages.",
       "source": "official",
       "kind": "channel",
@@ -2047,7 +2047,7 @@
     },
     {
       "name": "@openclaw/synology-chat",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "Synology Chat channel plugin for OpenClaw channels and direct messages.",
       "source": "official",
       "kind": "channel",
@@ -2119,7 +2119,7 @@
     },
     {
       "name": "@openclaw/tlon",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Tlon/Urbit channel plugin for chat workflows.",
       "source": "official",
       "kind": "channel",
@@ -2213,7 +2213,7 @@
     },
     {
       "name": "@openclaw/twitch",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Twitch channel plugin for chat and moderation workflows.",
       "source": "official",
       "kind": "channel",
@@ -2294,7 +2294,7 @@
     },
     {
       "name": "@openclaw/whatsapp",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw WhatsApp channel plugin for WhatsApp Web chats.",
       "source": "official",
       "kind": "channel",
@@ -2393,7 +2393,7 @@
     },
     {
       "name": "@openclaw/zalo",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Zalo channel plugin for bot and webhook chats.",
       "source": "official",
       "kind": "channel",
@@ -2458,7 +2458,7 @@
     },
     {
       "name": "@openclaw/zalouser",
-      "version": "2026.7.2",
+      "version": "2026.8.1",
       "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration.",
       "source": "official",
       "kind": "channel",


### PR DESCRIPTION
Related: #120068
Related: #120352

## What Problem This Solves

Prepares `main` for the 2026.8.1 release train. The root, macOS, package, and plugin metadata still reported 2026.7.2.

## Why This Change Was Made

Runs the canonical version and release-preflight generators to align the root package, macOS bundle, version-coupled packages/plugins, catalogs, and inventory at 2026.8.1. The required generated Control UI and native locale refreshes landed separately in #120068 and #120352 so their automation-owned artifacts remain isolated. Android remains on its independently pinned release train.

This PR does not publish npm packages, create a tag, or create a GitHub Release. It was AI-assisted and reviewed with the repository's required autoreview workflow.

## User Impact

There is no immediate published release. Once merged, source builds and release automation on `main` consistently identify the next release as 2026.8.1.

## Evidence

- `node --import tsx scripts/release-version.ts --version 2026.8.1 --check`
- `node scripts/release-preflight.mjs --check --scope version`
- `node scripts/run-vitest.mjs test/scripts/release-version.test.ts` — 8 tests passed
- `git diff --check`
- Codex autoreview: clean on the final version/package diff
- Generated prerequisites: exact-head autoreview clean for #120068 and #120352 before landing
