### PR TITLE
fix(cli): bound unknown command diagnostics

### DIFF
--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2687,6 +2687,40 @@ describe("runCli exit behavior", () => {
     expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
   });
 
+  it("sanitizes control characters in unowned command diagnostics", async () => {
+    const primary = "bad\u001b[31m-red\u001b[0m\nforged\tline";
+
+    await expect(runCli(["node", "openclaw", primary])).rejects.toThrow(
+      'Unknown command: openclaw bad-red\\nforged\\tline. No built-in command or plugin CLI metadata owns "bad-red\\nforged\\tline".',
+    );
+
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(tryRouteCliMock).not.toHaveBeenCalled();
+    expect(buildProgramMock).not.toHaveBeenCalled();
+    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds long unowned command diagnostics without splitting Unicode", async () => {
+    const primary = "🦞".repeat(1_000);
+
+    let error: unknown;
+    try {
+      await runCli(["node", "openclaw", primary]);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain(`Unknown command: openclaw ${"🦞".repeat(64)}…`);
+    expect(message).not.toContain("�");
+    expect(message.length).toBeLessThan(500);
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(tryRouteCliMock).not.toHaveBeenCalled();
+    expect(buildProgramMock).not.toHaveBeenCalled();
+    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+  });
+
   it("keeps suggestions out of plugin-policy diagnostics", async () => {
     resolveManifestCommandAliasOwnerMock.mockReturnValueOnce({
       pluginId: "codex",

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2712,7 +2712,9 @@ describe("runCli exit behavior", () => {
 
     expect(error).toBeInstanceOf(Error);
     const message = (error as Error).message;
-    expect(message).toContain(`Unknown command: openclaw ${"🦞".repeat(64)}…`);
+    const displayPrimary = `${"🦞".repeat(63)}…`;
+    expect(displayPrimary.length).toBeLessThanOrEqual(128);
+    expect(message).toContain(`Unknown command: openclaw ${displayPrimary}`);
     expect(message).not.toContain("�");
     expect(message.length).toBeLessThan(500);
     expect(startProxyMock).not.toHaveBeenCalled();

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -3,7 +3,9 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Command as CommanderCommand, Option as CommanderOption } from "commander";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { isLoopbackAddress, isSecureWebSocketUrl } from "../gateway/net.js";
@@ -87,6 +89,7 @@ const CLI_PROXY_ENV_KEYS = [
   "https_proxy",
   "all_proxy",
 ] as const;
+const UNKNOWN_COMMAND_DISPLAY_LIMIT = 128;
 
 const loadRootHelpLiveConfigModule = async () => await import("./root-help-live-config.js");
 const loadRootHelpMetadataModule = async () => await import("./root-help-metadata.js");
@@ -1029,9 +1032,15 @@ async function resolveUnownedCliPrimaryMessage(params: {
   if (pluginPolicyMessage) {
     return pluginPolicyMessage;
   }
-  const suggestion = formatCliCommandSuggestions(params.primary);
+  const sanitizedPrimary = sanitizeTerminalText(params.primary);
+  const displayPrimary =
+    sanitizedPrimary.length <= UNKNOWN_COMMAND_DISPLAY_LIMIT
+      ? sanitizedPrimary
+      : `${truncateUtf16Safe(sanitizedPrimary, UNKNOWN_COMMAND_DISPLAY_LIMIT)}…`;
+  const suggestion =
+    displayPrimary === params.primary ? formatCliCommandSuggestions(params.primary) : "";
   return [
-    `Unknown command: openclaw ${params.primary}. No built-in command or plugin CLI metadata owns "${params.primary}".`,
+    `Unknown command: openclaw ${displayPrimary}. No built-in command or plugin CLI metadata owns "${displayPrimary}".`,
     suggestion,
   ]
     .filter(Boolean)

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1036,7 +1036,7 @@ async function resolveUnownedCliPrimaryMessage(params: {
   const displayPrimary =
     sanitizedPrimary.length <= UNKNOWN_COMMAND_DISPLAY_LIMIT
       ? sanitizedPrimary
-      : `${truncateUtf16Safe(sanitizedPrimary, UNKNOWN_COMMAND_DISPLAY_LIMIT)}…`;
+      : `${truncateUtf16Safe(sanitizedPrimary, UNKNOWN_COMMAND_DISPLAY_LIMIT - 1)}…`;
   const suggestion =
     displayPrimary === params.primary ? formatCliCommandSuggestions(params.primary) : "";
   return [


### PR DESCRIPTION
## Summary

- sanitize unknown root-command labels before rendering them in CLI failure output
- cap displayed labels at 128 UTF-16 units and mark truncation without splitting emoji
- preserve ordinary typo suggestions while skipping suggestion work for transformed or oversized input

Fixes https://github.com/openclaw/openclaw/issues/120379

## Root cause

The early unowned-command diagnostic interpolated the raw argv token twice. Control sequences and embedded line breaks therefore reached stderr unchanged, while oversized tokens amplified the error output.

## Verification

- `node scripts/run-vitest.mjs run src/cli/run-main.exit.test.ts` — 207 passed
- `pnpm build` — passed twice, including the packaged CLI and Control UI bundle
- source-blind built-CLI contract — ordinary typo suggestions preserved; hostile ANSI/newline/tab argv emitted zero ESC/tab control bytes and literal `\n`/`\t`; 1,000 emoji produced a bounded 776-byte diagnostic whose displayed label is 127 UTF-16 units including the ellipsis
- fresh-process hostile-input stress — 40/40 passed
- `node scripts/check-changed.mjs -- src/cli/run-main.ts src/cli/run-main.exit.test.ts` — passed on Blacksmith Testbox `tbx_01kzf8ab10337p41ms530ex4cb`: https://github.com/openclaw/openclaw/actions/runs/31226710750
- AutoReview — clean at P2, confidence 0.95
- fresh rebased/correction AutoReviews — clean at P2, confidence 0.99
- accepted ClawSweeper P2 — truncation now reserves marker space inside the 128-unit display cap

## Risk

Low. The change is limited to display formatting for unknown command roots. Command routing, plugin ownership, config, protocol, storage, dependencies, and normal command execution are unchanged.
