### PR TITLE
fix(gateway): refresh attributed message avatars

### DIFF
--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { isContextOverflowError } from "../agents/embedded-agent-helpers/context-overflow.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
@@ -22,13 +23,59 @@ import {
 } from "./chat-display-projection.sanitize.js";
 import { stripEnvelopeFromMessages } from "./chat-sanitize.js";
 import { isSuppressedControlReplyText } from "./control-reply-text.js";
+import type {
+  CurrentUserProfileDisplay,
+  CurrentUserProfileDisplayResolver,
+} from "./current-user-profile-display.js";
 
 type ChatDisplayProjectionOptions = {
   maxChars?: number;
+  resolveCurrentUserProfileDisplay?: CurrentUserProfileDisplayResolver;
   stripEnvelope?: boolean;
   turnBoundaryPending?: boolean;
   streamErrorFallbackPending?: boolean;
 };
+
+function projectCurrentUserProfileAvatars(
+  messages: Array<Record<string, unknown>>,
+  resolveDisplay: CurrentUserProfileDisplayResolver | undefined,
+): Array<Record<string, unknown>> {
+  if (!resolveDisplay) {
+    return messages;
+  }
+  const displayBySenderId = new Map<string, CurrentUserProfileDisplay>();
+  let changed = false;
+  const projected = messages.map((message) => {
+    if (message.role !== "user") {
+      return message;
+    }
+    const metadata = asOptionalRecord(message["__openclaw"]);
+    if (!metadata) {
+      return message;
+    }
+    const senderId = metadata.senderId;
+    if (typeof senderId !== "string" || !senderId) {
+      return message;
+    }
+    let display = displayBySenderId.get(senderId);
+    if (!display) {
+      display = resolveDisplay(senderId);
+      displayBySenderId.set(senderId, display);
+    }
+    if (display.kind === "unresolved") {
+      return message;
+    }
+    if (metadata.senderProfileAvatarUrl === display.avatarUrl) {
+      return message;
+    }
+    changed = true;
+    return {
+      ...message,
+      __openclaw: { ...metadata, senderProfileAvatarUrl: display.avatarUrl },
+    };
+  });
+  return changed ? projected : messages;
+}
 
 type ChatDisplayProjectionResult = {
   messages: Array<Record<string, unknown>>;
@@ -274,11 +321,15 @@ export function projectChatDisplayMessagesWithState(
     ),
     options?.turnBoundaryPending,
   );
+  const displayMessages = sanitizeChatHistoryMessages(
+    mergeTtsSupplementMessages(filtered.messages),
+    options?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  ) as Array<Record<string, unknown>>;
   return {
-    messages: sanitizeChatHistoryMessages(
-      mergeTtsSupplementMessages(filtered.messages),
-      options?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
-    ) as Array<Record<string, unknown>>,
+    messages: projectCurrentUserProfileAvatars(
+      displayMessages,
+      options?.resolveCurrentUserProfileDisplay,
+    ),
     turnBoundaryPending: filtered.turnBoundaryPending,
     streamErrorFallbackPending: repairedStreamErrors.pending,
     streamErrorFallbackRepaired: repairedStreamErrors.repaired,

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createNoisyPngBuffer } from "../../test/helpers/image-fixtures.js";
 import {
   projectChatDisplayMessages,
@@ -101,6 +101,187 @@ describe("private transcript metadata projection", () => {
         CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
       );
     }
+  });
+});
+
+describe("current user profile display projection", () => {
+  it("dedupes sender lookups per batch and enriches only resolved sender ids", () => {
+    const messages = [
+      {
+        role: "user",
+        content: "first",
+        __openclaw: {
+          senderId: "profile-ada",
+          senderName: "Historical Ada",
+          senderUsername: "ada",
+        },
+      },
+      {
+        role: "user",
+        content: "second",
+        __openclaw: { senderId: "profile-ada", senderName: "Earlier Ada" },
+      },
+      {
+        role: "user",
+        content: "third",
+        __openclaw: { senderId: "profile-bob" },
+      },
+      {
+        role: "user",
+        content: "unknown",
+        __openclaw: {
+          senderId: "channel-sender",
+          senderProfileAvatarUrl: "/channel/avatar",
+        },
+      },
+      { role: "user", content: "missing sender" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "hostile assistant metadata" }],
+        __openclaw: { senderId: "hostile-assistant" },
+      },
+      {
+        role: "toolResult",
+        toolCallId: "hostile-tool-call",
+        toolName: "read",
+        content: [{ type: "text", text: "hostile tool metadata" }],
+        __openclaw: { senderId: "hostile-tool" },
+      },
+    ];
+    const originalMessages = structuredClone(messages);
+    const resolveCurrentUserProfileDisplay = vi.fn((senderId: string) => {
+      if (senderId === "profile-ada") {
+        return {
+          kind: "resolved" as const,
+          profileId: "profile-ada",
+          label: "Current Ada",
+          avatarUrl: "/api/users/profile-ada/avatar?v=20",
+          hasUploadedAvatar: true,
+        };
+      }
+      if (senderId === "profile-bob") {
+        return {
+          kind: "resolved" as const,
+          profileId: "profile-bob",
+          avatarUrl: "/api/users/profile-bob/avatar?v=30",
+          hasUploadedAvatar: false,
+        };
+      }
+      return { kind: "unresolved" as const };
+    });
+
+    const projected = projectChatDisplayMessages(messages, {
+      resolveCurrentUserProfileDisplay,
+    });
+
+    expect(resolveCurrentUserProfileDisplay.mock.calls.map(([senderId]) => senderId)).toEqual([
+      "profile-ada",
+      "profile-bob",
+      "channel-sender",
+    ]);
+    expect(projected.map((message) => message["__openclaw"])).toEqual([
+      {
+        senderId: "profile-ada",
+        senderName: "Historical Ada",
+        senderUsername: "ada",
+        senderProfileAvatarUrl: "/api/users/profile-ada/avatar?v=20",
+      },
+      {
+        senderId: "profile-ada",
+        senderName: "Earlier Ada",
+        senderProfileAvatarUrl: "/api/users/profile-ada/avatar?v=20",
+      },
+      {
+        senderId: "profile-bob",
+        senderProfileAvatarUrl: "/api/users/profile-bob/avatar?v=30",
+      },
+      {
+        senderId: "channel-sender",
+        senderProfileAvatarUrl: "/channel/avatar",
+      },
+      undefined,
+      { senderId: "hostile-assistant" },
+      { senderId: "hostile-tool" },
+    ]);
+    expect(messages).toEqual(originalMessages);
+    expect(projected[0]).not.toBe(messages[0]);
+    expect(projected[3]).toBe(messages[3]);
+    expect(projected[4]).toBe(messages[4]);
+    expect(projected[5]).toBe(messages[5]);
+  });
+
+  it("overwrites stale and no-upload profile routes while preserving lookup failures", () => {
+    const staleAvatar = {
+      role: "user",
+      content: "stale avatar",
+      __openclaw: {
+        senderId: "with-avatar",
+        senderName: "Historical Name",
+        senderProfileAvatarUrl: "/api/users/with-avatar/avatar?v=10",
+      },
+    };
+    const noUploadAvatar = {
+      role: "user",
+      content: "removed avatar",
+      __openclaw: {
+        senderId: "without-avatar",
+        senderProfileAvatarUrl: "/api/users/without-avatar/avatar?v=10",
+      },
+    };
+    const failedLookup = {
+      role: "user",
+      content: "lookup failed",
+      __openclaw: {
+        senderId: "lookup-failed",
+        senderProfileAvatarUrl: "/existing/projected/avatar",
+      },
+    };
+    const projected = projectChatDisplayMessages([staleAvatar, noUploadAvatar, failedLookup], {
+      resolveCurrentUserProfileDisplay: (senderId) => {
+        if (senderId === "with-avatar") {
+          return {
+            kind: "resolved",
+            profileId: "with-avatar",
+            label: "Current Name",
+            avatarUrl: "/api/users/with-avatar/avatar?v=20",
+            hasUploadedAvatar: true,
+          };
+        }
+        if (senderId === "without-avatar") {
+          return {
+            kind: "resolved",
+            profileId: "without-avatar",
+            avatarUrl: "/api/users/without-avatar/avatar?v=20",
+            hasUploadedAvatar: false,
+          };
+        }
+        return { kind: "unresolved" };
+      },
+    });
+
+    expect(projected[0]?.["__openclaw"]).toEqual({
+      senderId: "with-avatar",
+      senderName: "Historical Name",
+      senderProfileAvatarUrl: "/api/users/with-avatar/avatar?v=20",
+    });
+    expect(projected[1]?.["__openclaw"]).toEqual({
+      senderId: "without-avatar",
+      senderProfileAvatarUrl: "/api/users/without-avatar/avatar?v=20",
+    });
+    expect(projected[2]).toBe(failedLookup);
+  });
+
+  it("keeps exact current behavior when no resolver is supplied", () => {
+    const message = {
+      role: "user",
+      content: "unchanged",
+      __openclaw: {
+        senderId: "profile-ada",
+        senderProfileAvatarUrl: "/api/users/profile-ada/avatar?v=old",
+      },
+    };
+    const projected = projectChatDisplayMessages([message]);
+    expect(projected[0]).toBe(message);
   });
 });
 

--- a/src/gateway/current-user-profile-display.ts
+++ b/src/gateway/current-user-profile-display.ts
@@ -1,5 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { getUserProfileListItem } from "../state/user-profiles.js";
+import { getUserProfileDisplay } from "../state/user-profiles.js";
 import { formatUserProfileAvatarPath } from "./user-profiles-http-path.js";
 
 export type CurrentUserProfileDisplay =
@@ -16,13 +16,13 @@ export type CurrentUserProfileDisplayResolver = (senderId: string) => CurrentUse
 
 export function resolveCurrentUserProfileDisplay(senderId: string): CurrentUserProfileDisplay {
   try {
-    const profile = getUserProfileListItem(senderId);
+    const profile = getUserProfileDisplay(senderId);
     const label = normalizeOptionalString(profile.displayName);
     return {
       kind: "resolved",
       profileId: profile.id,
       ...(label ? { label } : {}),
-      avatarUrl: formatUserProfileAvatarPath(profile.id, profile.updatedAt),
+      avatarUrl: formatUserProfileAvatarPath(profile.id, profile.avatarRevision),
       hasUploadedAvatar: profile.hasAvatar,
     };
   } catch {

--- a/src/gateway/current-user-profile-display.ts
+++ b/src/gateway/current-user-profile-display.ts
@@ -1,0 +1,32 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getUserProfileListItem } from "../state/user-profiles.js";
+import { formatUserProfileAvatarPath } from "./user-profiles-http-path.js";
+
+export type CurrentUserProfileDisplay =
+  | {
+      kind: "resolved";
+      profileId: string;
+      label?: string;
+      avatarUrl: string;
+      hasUploadedAvatar: boolean;
+    }
+  | { kind: "unresolved" };
+
+export type CurrentUserProfileDisplayResolver = (senderId: string) => CurrentUserProfileDisplay;
+
+export function resolveCurrentUserProfileDisplay(senderId: string): CurrentUserProfileDisplay {
+  try {
+    const profile = getUserProfileListItem(senderId);
+    const label = normalizeOptionalString(profile.displayName);
+    return {
+      kind: "resolved",
+      profileId: profile.id,
+      ...(label ? { label } : {}),
+      avatarUrl: formatUserProfileAvatarPath(profile.id, profile.updatedAt),
+      hasUploadedAvatar: profile.hasAvatar,
+    };
+  } catch {
+    // Durable ids can also be channel sender ids; only profile ids resolve here.
+    return { kind: "unresolved" };
+  }
+}

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -11,6 +11,7 @@ import {
   resolveChatHistoryWithCliSessionImports,
   resolveClaudeCliBindingSessionId,
 } from "../cli-session-history.js";
+import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import { resolveSessionHistoryTailReadOptions } from "../session-history-state.js";
 import { readSessionMessagesAroundIdWithStatsAsync } from "../session-transcript-anchor-reader.js";
 import {
@@ -320,10 +321,12 @@ export async function readChatHistoryPage(params: {
       ? projectRecentChatDisplayMessages(recencyFilteredMessages, {
           maxChars: effectiveMaxChars,
           maxMessages: max,
+          resolveCurrentUserProfileDisplay,
           turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
         })
       : projectChatDisplayMessages(recencyFilteredMessages, {
           maxChars: effectiveMaxChars,
+          resolveCurrentUserProfileDisplay,
           turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
         });
     const windowed = messageId
@@ -415,6 +418,7 @@ export async function readChatHistoryPage(params: {
     );
     const displayMessages = projectChatDisplayMessages(mergedMessages, {
       maxChars: effectiveMaxChars,
+      resolveCurrentUserProfileDisplay,
     });
     return {
       activeLeafEntryId,
@@ -440,6 +444,7 @@ export async function readChatHistoryPage(params: {
   const displayMessages = projectRecentChatDisplayMessages(recencyFilteredMessages, {
     maxChars: effectiveMaxChars,
     maxMessages: max,
+    resolveCurrentUserProfileDisplay,
     turnBoundaryPending,
   });
   return {

--- a/src/gateway/server-methods/chat-message-get-handler.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.ts
@@ -11,6 +11,7 @@ import {
   dropPreSessionStartAnnouncePairs,
   projectChatDisplayMessage,
 } from "../chat-display-projection.js";
+import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
 import {
   readSessionMessageByIdAsync,
@@ -134,6 +135,7 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
     const projectedMessage = resolved.message
       ? projectChatDisplayMessage(resolved.message, {
           maxChars: effectiveMaxChars,
+          resolveCurrentUserProfileDisplay,
         })
       : undefined;
     const projected = projectedMessage

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -16,6 +16,7 @@ import type { SessionLifecycleEvent } from "../sessions/session-lifecycle-events
 import type { InternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import { projectChatDisplayMessage } from "./chat-display-projection.js";
+import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 import type {
   SessionEventSubscriberRegistry,
@@ -363,7 +364,7 @@ async function handleTranscriptUpdateBroadcast(
     ...(idempotencyKey ? { idempotencyKey } : {}),
     ...(messageSeq !== undefined ? { seq: messageSeq } : {}),
   });
-  const message = projectChatDisplayMessage(rawMessage);
+  const message = projectChatDisplayMessage(rawMessage, { resolveCurrentUserProfileDisplay });
   if (message) {
     params.broadcastToConnIds(
       "session.message",

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -474,7 +474,10 @@ export async function attachAuthenticatedGatewayConnect(
       // gateway-side Gravatar proxy, so clients never need an email-hash URL.
       // The revision changes when the profile avatar changes, so reconnecting
       // viewers refetch instead of reusing a stale route response.
-      avatarUrl: `${formatUserProfileAvatarPath(authenticatedUserProfile.profileId)}?v=${authenticatedUserProfile.updatedAt}`,
+      avatarUrl: formatUserProfileAvatarPath(
+        authenticatedUserProfile.profileId,
+        authenticatedUserProfile.updatedAt,
+      ),
     };
   };
 

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -24,6 +24,7 @@ import {
   adoptTailscaleProfileAvatar,
   ensureProfileForEmail,
   ensureProfileForTailscaleIdentity,
+  getUserProfileDisplay,
 } from "../../../state/user-profiles.js";
 import {
   isBrowserCopilotClient,
@@ -63,6 +64,10 @@ type AuthenticatedNodePairingAdmission = {
   authenticated: { nodeId: string; publicKey: string; token: string };
   identity: NodePairingIdentity;
   generation?: NodePairingGeneration;
+};
+
+type AuthenticatedUserProfileDisplay = NonNullable<GatewayWsClient["authenticatedUserProfile"]> & {
+  avatarRevision: string;
 };
 
 function isReleasedVersion(version: string): boolean {
@@ -195,17 +200,19 @@ export async function attachAuthenticatedGatewayConnect(
     return;
   }
 
-  let authenticatedUserProfile: GatewayWsClient["authenticatedUserProfile"];
+  let authenticatedUserProfile: AuthenticatedUserProfileDisplay | undefined;
   if (authenticatedUserId) {
     try {
       const profile = authResult.tailscaleIdentity
         ? ensureProfileForTailscaleIdentity(authResult.tailscaleIdentity)
         : ensureProfileForEmail(authenticatedUserId);
+      const display = getUserProfileDisplay(profile.id);
       // User edits become visible after reconnect; detached provider-avatar adoption refreshes below.
       authenticatedUserProfile = {
-        profileId: profile.id,
-        displayName: profile.displayName,
-        hasAvatar: profile.avatarMime !== null,
+        profileId: display.id,
+        displayName: display.displayName,
+        avatarRevision: display.avatarRevision,
+        hasAvatar: display.hasAvatar,
         updatedAt: profile.updatedAt,
       };
     } catch (error) {
@@ -476,7 +483,7 @@ export async function attachAuthenticatedGatewayConnect(
       // viewers refetch instead of reusing a stale route response.
       avatarUrl: formatUserProfileAvatarPath(
         authenticatedUserProfile.profileId,
-        authenticatedUserProfile.updatedAt,
+        authenticatedUserProfile.avatarRevision,
       ),
     };
   };
@@ -584,10 +591,12 @@ export async function attachAuthenticatedGatewayConnect(
         if (!updated.avatarMime) {
           return;
         }
+        const display = getUserProfileDisplay(updated.id);
         authenticatedUserProfile = {
-          profileId: updated.id,
-          displayName: updated.displayName,
-          hasAvatar: true,
+          profileId: display.id,
+          displayName: display.displayName,
+          avatarRevision: display.avatarRevision,
+          hasAvatar: display.hasAvatar,
           updatedAt: updated.updatedAt,
         };
         nextClient.authenticatedUserProfile = authenticatedUserProfile;

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -668,62 +668,73 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
   });
 
   it("projects a stable durable profile into presence and refreshes avatar state on reconnect", async () => {
-    await withOpenClawTestState({ label: "gateway-profile-presence" }, async () => {
-      const connect = async (suffix: string) => {
-        const connId = `conn-trusted-proxy-user-${suffix}`;
-        const harness = connectTrustedProxyUser(connId);
-        await waitForFast(() => {
-          expect(upsertPresenceMock).toHaveBeenCalledWith(connId, expect.anything());
-        });
-        const presence = upsertPresenceMock.mock.calls.find(([key]) => key === connId)?.[1] as {
-          user?: { id: string; email?: string; name?: string; avatarUrl?: string };
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+    try {
+      await withOpenClawTestState({ label: "gateway-profile-presence" }, async () => {
+        const connect = async (suffix: string) => {
+          const connId = `conn-trusted-proxy-user-${suffix}`;
+          const harness = connectTrustedProxyUser(connId);
+          await waitForFast(() => {
+            expect(upsertPresenceMock).toHaveBeenCalledWith(connId, expect.anything());
+          });
+          const presence = upsertPresenceMock.mock.calls.find(([key]) => key === connId)?.[1] as {
+            user?: { id: string; email?: string; name?: string; avatarUrl?: string };
+          };
+          return { connId, harness, presence };
         };
-        return { connId, harness, presence };
-      };
 
-      const first = await connect("first");
-      const profileId = first.presence.user?.id;
-      expect(profileId).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
-      );
-      expect(first.presence.user).toEqual({
-        id: profileId,
-        email: "alice@example.com",
-        name: "alice",
-        // Published route carries the profile revision (?v=<updatedAt>) so a
-        // reconnecting viewer's <img> refetches after an avatar upload instead
-        // of reusing the stale cached image for an unchanged URL.
-        avatarUrl: expect.stringMatching(
-          new RegExp(`^/api/users/${profileId}/avatar\\?v=\\d+$`, "u"),
-        ),
-      });
-      expect(first.harness.client).toMatchObject({
-        authenticatedUserId: "alice@example.com",
-        authenticatedUserProfile: {
-          profileId,
-          displayName: "alice",
-          hasAvatar: false,
-        },
-      });
+        const first = await connect("first");
+        const profileId = first.presence.user?.id;
+        expect(profileId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+        );
+        expect(first.presence.user).toEqual({
+          id: profileId,
+          email: "alice@example.com",
+          name: "alice",
+          avatarUrl: expect.stringMatching(
+            new RegExp(`^/api/users/${profileId}/avatar\\?v=\\d+$`, "u"),
+          ),
+        });
+        expect(first.harness.client).toMatchObject({
+          authenticatedUserId: "alice@example.com",
+          authenticatedUserProfile: {
+            profileId,
+            displayName: "alice",
+            hasAvatar: false,
+          },
+        });
 
-      expect(setAvatar(profileId!, new Uint8Array([1, 2, 3]), "image/png").ok).toBe(true);
-      const second = await connect("second");
-      expect(second.presence.user).toEqual({
-        id: profileId,
-        email: "alice@example.com",
-        name: "alice",
-        avatarUrl: expect.stringMatching(
-          new RegExp(`^/api/users/${profileId}/avatar\\?v=\\d+$`, "u"),
-        ),
+        expect(setAvatar(profileId!, new Uint8Array([1, 2, 3]), "image/png").ok).toBe(true);
+        const second = await connect("second");
+        const secondAvatarUrl = second.presence.user?.avatarUrl;
+        expect(second.presence.user).toEqual({
+          id: profileId,
+          email: "alice@example.com",
+          name: "alice",
+          avatarUrl: expect.stringMatching(
+            new RegExp(`^/api/users/${profileId}/avatar\\?v=[0-9a-f]{64}-png$`, "u"),
+          ),
+        });
+        expect(second.harness.client).toMatchObject({
+          authenticatedUserProfile: { profileId, hasAvatar: true },
+        });
+
+        expect(setAvatar(profileId!, new Uint8Array([4, 5, 6]), "image/png").ok).toBe(true);
+        const third = await connect("third");
+        expect(third.presence.user?.avatarUrl).not.toBe(secondAvatarUrl);
+        expect(third.presence.user?.avatarUrl).toMatch(
+          new RegExp(`^/api/users/${profileId}/avatar\\?v=[0-9a-f]{64}-png$`, "u"),
+        );
+
+        expect(ensureProfileForEmailMock).toHaveBeenCalledTimes(3);
+        expect(first.harness.logWsControl.info).toHaveBeenCalledWith(
+          "authenticated user connected conn=conn-trusted-proxy-user-first user=alice@example.com",
+        );
       });
-      expect(second.harness.client).toMatchObject({
-        authenticatedUserProfile: { profileId, hasAvatar: true },
-      });
-      expect(ensureProfileForEmailMock).toHaveBeenCalledTimes(2);
-      expect(first.harness.logWsControl.info).toHaveBeenCalledWith(
-        "authenticated user connected conn=conn-trusted-proxy-user-first user=alice@example.com",
-      );
-    });
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it("registers a verified profile before detached Tailscale avatar adoption completes", async () => {
@@ -793,6 +804,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
           authenticatedUserProfile: { profileId: string; displayName: string; updatedAt: number };
         }
       ).authenticatedUserProfile;
+      expect(setAvatar(profile.profileId, new Uint8Array([7, 8, 9]), "image/png").ok).toBe(true);
       resolveAvatar?.({
         id: profile.profileId,
         displayName: profile.displayName,

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -6,6 +6,7 @@ import {
   projectChatDisplayMessages,
   projectChatDisplayMessagesWithState,
 } from "./chat-display-projection.js";
+import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import { resolveTranscriptPathForComparison } from "./session-transcript-path.js";
 import {
   attachOpenClawTranscriptMeta,
@@ -164,6 +165,7 @@ export function buildSessionHistorySnapshot(params: {
 }): SessionHistorySnapshot {
   const projected = projectChatDisplayMessagesWithState(params.rawMessages, {
     maxChars: params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+    resolveCurrentUserProfileDisplay,
   });
   const visibleMessages = toSessionHistoryMessages(projected.messages);
   const history = paginateSessionMessages(visibleMessages, params.limit, params.cursor);
@@ -317,6 +319,7 @@ export class SessionHistorySseState {
     const projectedMessages = toSessionHistoryMessages(
       projectChatDisplayMessages([...this.sentHistory.messages, nextMessage], {
         maxChars: this.maxChars,
+        resolveCurrentUserProfileDisplay,
       }),
     );
     if (projectedMessages.length > this.sentHistory.messages.length) {

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -1,5 +1,6 @@
 // Gateway session-history projection state.
 // Tracks transcript sequence windows for paginated chat-history SSE updates.
+import { isDeepStrictEqual } from "node:util";
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
@@ -322,6 +323,20 @@ export class SessionHistorySseState {
         resolveCurrentUserProfileDisplay,
       }),
     );
+    const projectedPrefix = projectedMessages.slice(0, this.sentHistory.messages.length);
+    if (
+      projectedMessages.length > this.sentHistory.messages.length &&
+      !isDeepStrictEqual(projectedPrefix, this.sentHistory.messages)
+    ) {
+      // A current-profile change can rewrite an already-emitted row while this
+      // append adds only one tail item. Refresh the full history so the client
+      // does not retain a stale prefix beside the newly revisioned message.
+      this.sentHistory = buildPaginatedSessionHistory({
+        messages: projectedMessages,
+        hasMore: false,
+      });
+      return { shouldRefresh: true };
+    }
     if (projectedMessages.length > this.sentHistory.messages.length) {
       const addedMessages = projectedMessages.slice(this.sentHistory.messages.length);
       if (hadPendingTurnBoundary && !this.turnBoundaryPending && addedMessages[0]) {

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -31,6 +31,7 @@ import * as transcriptEvents from "../sessions/transcript-events.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { persistUserTurnTranscript } from "../sessions/user-turn-transcript.test-support.js";
 import { ensureProfileForEmail, setAvatar, setDisplayName } from "../state/user-profiles.js";
+import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   connectOk,
@@ -198,6 +199,15 @@ function attributedMessageProjection(value: unknown) {
       senderProfileAvatarUrl: metadata.senderProfileAvatarUrl,
     },
   };
+}
+
+function currentProfileAvatarUrl(profileId: string): string {
+  const display = resolveCurrentUserProfileDisplay(profileId);
+  expect(display.kind).toBe("resolved");
+  if (display.kind !== "resolved") {
+    throw new Error("expected a resolved current profile display");
+  }
+  return display.avatarUrl;
 }
 
 describe("session.message websocket events", () => {
@@ -932,8 +942,7 @@ describe("session.message websocket events", () => {
   });
 
   test("projects current revisioned sender avatars consistently across live events and RPC reads", async () => {
-    const OLD_REV = 1_800_000_000_000;
-    const NEW_REV = 1_900_000_000_000;
+    const SHARED_REV = 1_800_000_000_000;
     const storePath = await createSessionStoreFile();
     const sessionId = "sess-current-profile-display";
     const sessionKey = "agent:main:current-profile-display";
@@ -943,12 +952,13 @@ describe("session.message websocket events", () => {
       storePath,
     });
 
-    const profile = withMockedDateNow(OLD_REV, () => {
+    const profile = withMockedDateNow(SHARED_REV, () => {
       const created = ensureProfileForEmail("current-profile-display@example.com");
       setDisplayName(created.id, "Old Display Name");
       expect(setAvatar(created.id, new Uint8Array([1, 2, 3]), "image/png").ok).toBe(true);
       return created;
     });
+    const firstAvatarUrl = currentProfileAvatarUrl(profile.id);
 
     const ws = await harness.openWs();
     try {
@@ -1007,14 +1017,14 @@ describe("session.message websocket events", () => {
         expect(response.payload?.ok).toBe(true);
         return response.payload?.message;
       };
-      const expectedProjection = (text: string, senderName: string, revision: number) => ({
+      const expectedProjection = (text: string, senderName: string, avatarUrl: string) => ({
         role: "user",
         content: text,
         __openclaw: {
           senderId: profile.id,
           senderName,
           senderUsername: "ada",
-          senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${revision}`,
+          senderProfileAvatarUrl: avatarUrl,
         },
       });
       const expectRpcParity = async (messageId: string, expected: unknown) => {
@@ -1038,26 +1048,36 @@ describe("session.message websocket events", () => {
         senderName: "Historical Ada",
         text: "first attributed turn",
       });
-      const firstExpected = expectedProjection("first attributed turn", "Historical Ada", OLD_REV);
+      const firstExpected = expectedProjection(
+        "first attributed turn",
+        "Historical Ada",
+        firstAvatarUrl,
+      );
       await expectEmitterParity(first, firstExpected);
 
-      withMockedDateNow(NEW_REV, () => {
+      withMockedDateNow(SHARED_REV, () => {
         setDisplayName(profile.id, "Current Ada");
         expect(setAvatar(profile.id, new Uint8Array([4, 5, 6]), "image/png").ok).toBe(true);
       });
+      const secondAvatarUrl = currentProfileAvatarUrl(profile.id);
+      expect(secondAvatarUrl).not.toBe(firstAvatarUrl);
 
       const second = await persistTurn({
         idempotencyKey: "current-profile-display:second",
         senderName: "Current Ada",
         text: "second attributed turn",
       });
-      const secondExpected = expectedProjection("second attributed turn", "Current Ada", NEW_REV);
+      const secondExpected = expectedProjection(
+        "second attributed turn",
+        "Current Ada",
+        secondAvatarUrl,
+      );
       await expectEmitterParity(second, secondExpected);
 
       const refreshedFirstExpected = expectedProjection(
         "first attributed turn",
         "Historical Ada",
-        NEW_REV,
+        secondAvatarUrl,
       );
       await expectRpcParity(first.persisted.messageId, refreshedFirstExpected);
     } finally {

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -29,6 +29,8 @@ import { rawDataToString } from "../infra/ws.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import * as transcriptEvents from "../sessions/transcript-events.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { persistUserTurnTranscript } from "../sessions/user-turn-transcript.test-support.js";
+import { ensureProfileForEmail, setAvatar, setDisplayName } from "../state/user-profiles.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   connectOk,
@@ -172,6 +174,30 @@ function expectRecordFields(value: unknown, expected: Record<string, unknown>): 
   for (const [key, expectedValue] of Object.entries(expected)) {
     expect(record[key]).toEqual(expectedValue);
   }
+}
+
+function withMockedDateNow<T>(now: number, run: () => T): T {
+  const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+  try {
+    return run();
+  } finally {
+    clock.mockRestore();
+  }
+}
+
+function attributedMessageProjection(value: unknown) {
+  const message = requireRecord(value, "attributed message");
+  const metadata = requireRecord(message["__openclaw"], "attributed message metadata");
+  return {
+    role: message.role,
+    content: message.content,
+    __openclaw: {
+      senderId: metadata.senderId,
+      senderName: metadata.senderName,
+      senderUsername: metadata.senderUsername,
+      senderProfileAvatarUrl: metadata.senderProfileAvatarUrl,
+    },
+  };
 }
 
 describe("session.message websocket events", () => {
@@ -902,6 +928,140 @@ describe("session.message websocket events", () => {
       webWs.close();
       tuiWs.close();
       reconnectedTuiWs?.close();
+    }
+  });
+
+  test("projects current revisioned sender avatars consistently across live events and RPC reads", async () => {
+    const OLD_REV = 1_800_000_000_000;
+    const NEW_REV = 1_900_000_000_000;
+    const storePath = await createSessionStoreFile();
+    const sessionId = "sess-current-profile-display";
+    const sessionKey = "agent:main:current-profile-display";
+    const sessionEntry = { sessionId, updatedAt: 1 };
+    await writeSessionStore({
+      entries: { "current-profile-display": sessionEntry },
+      storePath,
+    });
+
+    const profile = withMockedDateNow(OLD_REV, () => {
+      const created = ensureProfileForEmail("current-profile-display@example.com");
+      setDisplayName(created.id, "Old Display Name");
+      expect(setAvatar(created.id, new Uint8Array([1, 2, 3]), "image/png").ok).toBe(true);
+      return created;
+    });
+
+    const ws = await harness.openWs();
+    try {
+      await connectOk(ws, {
+        caps: [GATEWAY_CLIENT_CAPS.SESSION_SCOPED_EVENTS],
+        scopes: ["operator.read"],
+      });
+      const subscription = await rpcReq(ws, "sessions.messages.subscribe", { key: sessionKey });
+      expect(subscription.ok).toBe(true);
+
+      const persistTurn = async (params: {
+        idempotencyKey: string;
+        senderName: string;
+        text: string;
+      }) => {
+        const liveEvent = waitForSessionMessageEvent(ws, sessionKey);
+        const persisted = await persistUserTurnTranscript({
+          agentId: "main",
+          sessionEntry,
+          sessionId,
+          sessionKey,
+          storePath,
+          input: {
+            idempotencyKey: params.idempotencyKey,
+            sender: {
+              id: profile.id,
+              name: params.senderName,
+              username: "ada",
+            },
+            text: params.text,
+          },
+        });
+        expect(persisted).toBeDefined();
+        return { persisted: persisted!, liveEvent: await liveEvent };
+      };
+      const readHistoryMessage = async (messageId: string) => {
+        const response = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+          sessionKey,
+        });
+        expect(response.ok).toBe(true);
+        const messages = response.payload?.messages ?? [];
+        const message = messages.find((candidate) => {
+          const record = requireRecord(candidate, "history message");
+          const metadata = requireRecord(record["__openclaw"], "history message metadata");
+          return metadata.id === messageId;
+        });
+        expect(message).toBeDefined();
+        return message;
+      };
+      const readMessage = async (messageId: string) => {
+        const response = await rpcReq<{ ok?: boolean; message?: unknown }>(ws, "chat.message.get", {
+          sessionKey,
+          messageId,
+        });
+        expect(response.ok).toBe(true);
+        expect(response.payload?.ok).toBe(true);
+        return response.payload?.message;
+      };
+      const expectedProjection = (text: string, senderName: string, revision: number) => ({
+        role: "user",
+        content: text,
+        __openclaw: {
+          senderId: profile.id,
+          senderName,
+          senderUsername: "ada",
+          senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${revision}`,
+        },
+      });
+      const expectRpcParity = async (messageId: string, expected: unknown) => {
+        expect(attributedMessageProjection(await readHistoryMessage(messageId))).toEqual(expected);
+        expect(attributedMessageProjection(await readMessage(messageId))).toEqual(expected);
+      };
+      const expectEmitterParity = async (
+        turn: Awaited<ReturnType<typeof persistTurn>>,
+        expected: unknown,
+      ) => {
+        const liveMessage = requireRecord(
+          turn.liveEvent.payload,
+          "session.message payload",
+        ).message;
+        expect(attributedMessageProjection(liveMessage)).toEqual(expected);
+        await expectRpcParity(turn.persisted.messageId, expected);
+      };
+
+      const first = await persistTurn({
+        idempotencyKey: "current-profile-display:first",
+        senderName: "Historical Ada",
+        text: "first attributed turn",
+      });
+      const firstExpected = expectedProjection("first attributed turn", "Historical Ada", OLD_REV);
+      await expectEmitterParity(first, firstExpected);
+
+      withMockedDateNow(NEW_REV, () => {
+        setDisplayName(profile.id, "Current Ada");
+        expect(setAvatar(profile.id, new Uint8Array([4, 5, 6]), "image/png").ok).toBe(true);
+      });
+
+      const second = await persistTurn({
+        idempotencyKey: "current-profile-display:second",
+        senderName: "Current Ada",
+        text: "second attributed turn",
+      });
+      const secondExpected = expectedProjection("second attributed turn", "Current Ada", NEW_REV);
+      await expectEmitterParity(second, secondExpected);
+
+      const refreshedFirstExpected = expectedProjection(
+        "first attributed turn",
+        "Historical Ada",
+        NEW_REV,
+      );
+      await expectRpcParity(first.persisted.messageId, refreshedFirstExpected);
+    } finally {
+      ws.close();
     }
   });
 

--- a/src/gateway/session-utils-creators.test.ts
+++ b/src/gateway/session-utils-creators.test.ts
@@ -5,16 +5,16 @@ import { filterSessionStoreToConfiguredAgents } from "./server-methods/sessions-
 import type { GatewayClient } from "./server-methods/types.js";
 import { createSessionListEntryFilter } from "./session-sharing.js";
 
-const getUserProfileListItem = vi.hoisted(() =>
+const getUserProfileDisplay = vi.hoisted(() =>
   vi.fn((profileId: string) => ({
     id: profileId,
     displayName: profileId === "profile-ada" ? "Ada" : "Bob",
+    avatarRevision: profileId === "profile-ada" ? "ada-hash-png" : "42",
     hasAvatar: profileId === "profile-ada",
-    updatedAt: 42,
   })),
 );
 
-vi.mock("../state/user-profiles.js", () => ({ getUserProfileListItem }));
+vi.mock("../state/user-profiles.js", () => ({ getUserProfileDisplay }));
 vi.mock("./session-utils-row.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-utils-row.js")>();
   return {
@@ -44,7 +44,7 @@ import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-uti
 
 afterEach(() => {
   vi.restoreAllMocks();
-  getUserProfileListItem.mockClear();
+  getUserProfileDisplay.mockClear();
 });
 
 it("keeps creator labels and avatars stable across actor order", () => {
@@ -129,7 +129,7 @@ it("returns the complete deterministic creator facet independently of pagination
     {
       id: "profile-ada",
       label: "Ada",
-      avatarUrl: "/api/users/profile-ada/avatar?v=42",
+      avatarUrl: "/api/users/profile-ada/avatar?v=ada-hash-png",
     },
     { id: "profile-bob", label: "Bob" },
   ]);
@@ -137,14 +137,14 @@ it("returns the complete deterministic creator facet independently of pagination
     type: "human",
     id: "profile-ada",
     label: "Ada",
-    avatarUrl: "/api/users/profile-ada/avatar?v=42",
+    avatarUrl: "/api/users/profile-ada/avatar?v=ada-hash-png",
   });
   expect(result.sessions[0]?.archivedBy).toEqual({
     type: "human",
     id: "profile-bob",
     label: "Bob",
   });
-  expect(getUserProfileListItem).toHaveBeenCalledTimes(2);
+  expect(getUserProfileDisplay).toHaveBeenCalledTimes(2);
 
   const filtered = listSessionsFromStore({
     cfg: {} as OpenClawConfig,
@@ -159,12 +159,12 @@ it("returns the complete deterministic creator facet independently of pagination
 it("preserves legacy list output across visibility, scope, creator, and search filters", async () => {
   const now = 1_000_000;
   vi.spyOn(Date, "now").mockReturnValue(now);
-  getUserProfileListItem.mockImplementation((profileId: string) => ({
+  getUserProfileDisplay.mockImplementation((profileId: string) => ({
     id: profileId,
     displayName:
       profileId === "profile-ada" ? "Ada" : profileId === "profile-bob" ? "Bob" : "Carol",
+    avatarRevision: String(now),
     hasAvatar: false,
-    updatedAt: now,
   }));
   const cfg = {
     agents: {

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -29,9 +29,9 @@ import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.j
 import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import { resolveActiveSessionAgentStatus } from "../sessions/session-agent-status.js";
 import { resolveNonNegativeNumber } from "../shared/number-coercion.js";
-import { getUserProfileListItem } from "../state/user-profiles.js";
 import { projectSessionDeliveryFields } from "../utils/delivery-context.shared.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
+import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import { sessionHasAutomation } from "./session-automation-index.js";
 import { sessionClassificationForRow } from "./session-classification.js";
 import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
@@ -62,7 +62,6 @@ import {
 } from "./session-utils-projection.js";
 import { isGroupOrChannelDisplaySession, parseGroupKey } from "./session-utils-store.js";
 import type { GatewaySessionRow } from "./session-utils.types.js";
-import { formatUserProfileAvatarPath } from "./user-profiles-http-path.js";
 
 /** Adds current durable human profile display data without persisting rename-prone metadata. */
 export function projectSessionActor(
@@ -78,21 +77,14 @@ export function projectSessionActor(
   }
   let identity = userProfileIdentityById.get(id);
   if (!userProfileIdentityById.has(id)) {
-    try {
-      const profile = getUserProfileListItem(id);
-      const label = normalizeOptionalString(profile.displayName);
-      identity = {
-        ...(label ? { label } : {}),
-        ...(profile.hasAvatar
-          ? {
-              avatarUrl: `${formatUserProfileAvatarPath(profile.id)}?v=${profile.updatedAt}`,
-            }
-          : {}),
-      };
-    } catch {
-      // Human actors can also be channel sender ids; only profile ids resolve here.
-      identity = undefined;
-    }
+    const display = resolveCurrentUserProfileDisplay(id);
+    identity =
+      display.kind === "unresolved"
+        ? undefined
+        : {
+            ...(display.label ? { label: display.label } : {}),
+            ...(display.hasUploadedAvatar ? { avatarUrl: display.avatarUrl } : {}),
+          };
     userProfileIdentityById.set(id, identity);
   }
   return { type: actor.type, id, ...identity };

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { replaceTranscriptEvents } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
@@ -13,9 +14,11 @@ import {
 } from "../config/sessions/transcript.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { persistUserTurnTranscript } from "../sessions/user-turn-transcript.test-support.js";
 import { OPENCLAW_TRANSCRIPT_ARTIFACT_API } from "../shared/transcript-only-openclaw-assistant.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
+import { ensureProfileForEmail, setAvatar, setDisplayName } from "../state/user-profiles.js";
 import { SSE_CONTENT_TYPE } from "./http-common.js";
 import { hasExplicitAcceptableMediaRange } from "./http-media-range.js";
 import { SessionHistorySseState } from "./session-history-state.js";
@@ -34,6 +37,7 @@ installGatewayTestHooks();
 const AUTH_HEADER = { Authorization: "Bearer test-gateway-token-1234567890" };
 const READ_SCOPE_HEADER = { "x-openclaw-scopes": "operator.read" };
 const cleanupDirs: string[] = [];
+const requireRecord = createRequireRecord("object", "expected-label");
 
 afterEach(async () => {
   testState.sessionConfig = undefined;
@@ -300,6 +304,32 @@ async function readSessionHistoryBody(
   const res = await fetchSessionHistory(port, sessionKey, params);
   expect(res.status).toBe(200);
   return (await res.json()) as SessionHistoryBody;
+}
+
+function attributedHistoryMessageProjection(value: unknown) {
+  const message = requireRecord(value, "attributed history message");
+  const metadata = requireRecord(message["__openclaw"], "attributed history metadata");
+  return {
+    role: message.role,
+    content: message.content,
+    __openclaw: {
+      id: metadata.id,
+      seq: metadata.seq,
+      senderId: metadata.senderId,
+      senderName: metadata.senderName,
+      senderUsername: metadata.senderUsername,
+      senderProfileAvatarUrl: metadata.senderProfileAvatarUrl,
+    },
+  };
+}
+
+function withMockedDateNow<T>(now: number, run: () => T): T {
+  const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+  try {
+    return run();
+  } finally {
+    clock.mockRestore();
+  }
 }
 
 async function readSseEvent(
@@ -651,6 +681,111 @@ describe("session history HTTP endpoints", () => {
       expectOpenClawMetadata(body.messages?.[0]?.["__openclaw"], {
         seq: 1,
       });
+    });
+  });
+
+  test("shares revisioned current-profile projection across REST and initial and inline SSE", async () => {
+    const OLD_REV = 1_800_000_000_000;
+    const NEW_REV = 1_900_000_000_000;
+    const { storePath } = await seedSession();
+    const sessionId = "sess-main";
+    const sessionKey = "agent:main:main";
+    const sessionEntry = { sessionId, updatedAt: 1 };
+
+    const profile = withMockedDateNow(OLD_REV, () => {
+      const created = ensureProfileForEmail("session-history-profile@example.com");
+      setDisplayName(created.id, "Old Display Name");
+      expect(setAvatar(created.id, new Uint8Array([1, 2, 3]), "image/png").ok).toBe(true);
+      return created;
+    });
+    const persistAttributedTurn = async (id: string, senderName: string, text: string) => {
+      const turn = await persistUserTurnTranscript({
+        agentId: AGENT_ID,
+        sessionEntry,
+        sessionId,
+        sessionKey,
+        storePath,
+        input: {
+          idempotencyKey: `session-history-profile:${id}`,
+          sender: { id: profile.id, name: senderName, username: "ada" },
+          text,
+        },
+      });
+      expect(turn).toBeDefined();
+      return turn!;
+    };
+    const first = await persistAttributedTurn(
+      "first",
+      "Historical Ada",
+      "first attributed history turn",
+    );
+
+    await withGatewayHarness(async (harness) => {
+      const initialRest = await readSessionHistoryBody(harness.port, sessionKey);
+      const stream = await openSessionHistorySse(harness.port, sessionKey);
+      try {
+        const initialSse = await readSseEvent(stream.reader, stream.streamState);
+        expect(initialSse.event).toBe("history");
+        const oldExpected = {
+          role: "user",
+          content: "first attributed history turn",
+          __openclaw: {
+            id: first.messageId,
+            seq: 1,
+            senderId: profile.id,
+            senderName: "Historical Ada",
+            senderUsername: "ada",
+            senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${OLD_REV}`,
+          },
+        };
+        expect(attributedHistoryMessageProjection(initialRest.messages?.[0])).toEqual(oldExpected);
+        expect(
+          attributedHistoryMessageProjection((initialSse.data as SessionHistoryBody).messages?.[0]),
+        ).toEqual(oldExpected);
+
+        withMockedDateNow(NEW_REV, () => {
+          setDisplayName(profile.id, "Current Ada");
+          expect(setAvatar(profile.id, new Uint8Array([4, 5, 6]), "image/png").ok).toBe(true);
+        });
+
+        const inlineEventPromise = readSseEvent(stream.reader, stream.streamState);
+        const second = await persistAttributedTurn(
+          "second",
+          "Current Ada",
+          "second attributed history turn",
+        );
+        const inlineEvent = await inlineEventPromise;
+        expect(inlineEvent.event).toBe("message");
+        const inlineMessage = requireRecord(inlineEvent.data, "inline history SSE payload").message;
+        const newSecondExpected = {
+          role: "user",
+          content: "second attributed history turn",
+          __openclaw: {
+            id: second.messageId,
+            seq: 2,
+            senderId: profile.id,
+            senderName: "Current Ada",
+            senderUsername: "ada",
+            senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${NEW_REV}`,
+          },
+        };
+        expect(attributedHistoryMessageProjection(inlineMessage)).toEqual(newSecondExpected);
+
+        const refreshedRest = await readSessionHistoryBody(harness.port, sessionKey);
+        expect(refreshedRest.messages).toHaveLength(2);
+        expect(attributedHistoryMessageProjection(refreshedRest.messages?.[0])).toEqual({
+          ...oldExpected,
+          __openclaw: {
+            ...oldExpected["__openclaw"],
+            senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${NEW_REV}`,
+          },
+        });
+        expect(attributedHistoryMessageProjection(refreshedRest.messages?.[1])).toEqual(
+          newSecondExpected,
+        );
+      } finally {
+        await stream.reader.cancel();
+      }
     });
   });
 

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -767,9 +767,8 @@ describe("session history HTTP endpoints", () => {
           "Current Ada",
           "second attributed history turn",
         );
-        const inlineEvent = await inlineEventPromise;
-        expect(inlineEvent.event).toBe("message");
-        const inlineMessage = requireRecord(inlineEvent.data, "inline history SSE payload").message;
+        const refreshEvent = await inlineEventPromise;
+        expect(refreshEvent.event).toBe("history");
         const newSecondExpected = {
           role: "user",
           content: "second attributed history turn",
@@ -782,17 +781,27 @@ describe("session history HTTP endpoints", () => {
             senderProfileAvatarUrl: newAvatarUrl,
           },
         };
-        expect(attributedHistoryMessageProjection(inlineMessage)).toEqual(newSecondExpected);
-
-        const refreshedRest = await readSessionHistoryBody(harness.port, sessionKey);
-        expect(refreshedRest.messages).toHaveLength(2);
-        expect(attributedHistoryMessageProjection(refreshedRest.messages?.[0])).toEqual({
+        const newFirstExpected = {
           ...oldExpected,
           __openclaw: {
             ...oldExpected["__openclaw"],
             senderProfileAvatarUrl: newAvatarUrl,
           },
-        });
+        };
+        const refreshedSse = refreshEvent.data as SessionHistoryBody;
+        expect(refreshedSse.messages).toHaveLength(2);
+        expect(attributedHistoryMessageProjection(refreshedSse.messages?.[0])).toEqual(
+          newFirstExpected,
+        );
+        expect(attributedHistoryMessageProjection(refreshedSse.messages?.[1])).toEqual(
+          newSecondExpected,
+        );
+
+        const refreshedRest = await readSessionHistoryBody(harness.port, sessionKey);
+        expect(refreshedRest.messages).toHaveLength(2);
+        expect(attributedHistoryMessageProjection(refreshedRest.messages?.[0])).toEqual(
+          newFirstExpected,
+        );
         expect(attributedHistoryMessageProjection(refreshedRest.messages?.[1])).toEqual(
           newSecondExpected,
         );

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -19,6 +19,7 @@ import { OPENCLAW_TRANSCRIPT_ARTIFACT_API } from "../shared/transcript-only-open
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
 import { ensureProfileForEmail, setAvatar, setDisplayName } from "../state/user-profiles.js";
+import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import { SSE_CONTENT_TYPE } from "./http-common.js";
 import { hasExplicitAcceptableMediaRange } from "./http-media-range.js";
 import { SessionHistorySseState } from "./session-history-state.js";
@@ -330,6 +331,15 @@ function withMockedDateNow<T>(now: number, run: () => T): T {
   } finally {
     clock.mockRestore();
   }
+}
+
+function currentProfileAvatarUrl(profileId: string): string {
+  const display = resolveCurrentUserProfileDisplay(profileId);
+  expect(display.kind).toBe("resolved");
+  if (display.kind !== "resolved") {
+    throw new Error("expected a resolved current profile display");
+  }
+  return display.avatarUrl;
 }
 
 async function readSseEvent(
@@ -698,6 +708,7 @@ describe("session history HTTP endpoints", () => {
       expect(setAvatar(created.id, new Uint8Array([1, 2, 3]), "image/png").ok).toBe(true);
       return created;
     });
+    const oldAvatarUrl = currentProfileAvatarUrl(profile.id);
     const persistAttributedTurn = async (id: string, senderName: string, text: string) => {
       const turn = await persistUserTurnTranscript({
         agentId: AGENT_ID,
@@ -735,7 +746,7 @@ describe("session history HTTP endpoints", () => {
             senderId: profile.id,
             senderName: "Historical Ada",
             senderUsername: "ada",
-            senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${OLD_REV}`,
+            senderProfileAvatarUrl: oldAvatarUrl,
           },
         };
         expect(attributedHistoryMessageProjection(initialRest.messages?.[0])).toEqual(oldExpected);
@@ -747,6 +758,8 @@ describe("session history HTTP endpoints", () => {
           setDisplayName(profile.id, "Current Ada");
           expect(setAvatar(profile.id, new Uint8Array([4, 5, 6]), "image/png").ok).toBe(true);
         });
+        const newAvatarUrl = currentProfileAvatarUrl(profile.id);
+        expect(newAvatarUrl).not.toBe(oldAvatarUrl);
 
         const inlineEventPromise = readSseEvent(stream.reader, stream.streamState);
         const second = await persistAttributedTurn(
@@ -766,7 +779,7 @@ describe("session history HTTP endpoints", () => {
             senderId: profile.id,
             senderName: "Current Ada",
             senderUsername: "ada",
-            senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${NEW_REV}`,
+            senderProfileAvatarUrl: newAvatarUrl,
           },
         };
         expect(attributedHistoryMessageProjection(inlineMessage)).toEqual(newSecondExpected);
@@ -777,7 +790,7 @@ describe("session history HTTP endpoints", () => {
           ...oldExpected,
           __openclaw: {
             ...oldExpected["__openclaw"],
-            senderProfileAvatarUrl: `/api/users/${profile.id}/avatar?v=${NEW_REV}`,
+            senderProfileAvatarUrl: newAvatarUrl,
           },
         });
         expect(attributedHistoryMessageProjection(refreshedRest.messages?.[1])).toEqual(

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -235,17 +235,15 @@ export async function handleSessionHistoryHttpRequest(
     return true;
   }
   const rawSnapshot = boundedSnapshot?.messages ?? fullSnapshot?.messages ?? [];
-  const historySnapshot = buildSessionHistorySnapshot({
-    rawMessages: rawSnapshot,
-    maxChars: effectiveMaxChars,
-    limit,
-    cursor,
-    rawTranscriptSeq: boundedSnapshot?.totalMessages,
-    totalRawMessages: boundedSnapshot?.totalMessages,
-  });
-  const history = historySnapshot.history;
-
   if (!shouldStreamSse(req)) {
+    const history = buildSessionHistorySnapshot({
+      rawMessages: rawSnapshot,
+      maxChars: effectiveMaxChars,
+      limit,
+      cursor,
+      rawTranscriptSeq: boundedSnapshot?.totalMessages,
+      totalRawMessages: boundedSnapshot?.totalMessages,
+    }).history;
     sendJson(res, 200, {
       sessionKey: target.canonicalKey,
       ...history,
@@ -266,7 +264,6 @@ export async function handleSessionHistoryHttpRequest(
       )
     : new Set<string>();
 
-  let sentHistory = history;
   const sseState = SessionHistorySseState.fromRawSnapshot({
     target: {
       agentId: target.agentId,
@@ -283,7 +280,7 @@ export async function handleSessionHistoryHttpRequest(
     limit,
     cursor,
   });
-  sentHistory = sseState.snapshot();
+  let sentHistory = sseState.snapshot();
   let streamStopped = false;
   let streamQueue = Promise.resolve();
   const streamResources: {

--- a/src/gateway/user-profiles-http-path.test.ts
+++ b/src/gateway/user-profiles-http-path.test.ts
@@ -10,6 +10,9 @@ describe("formatUserProfileAvatarPath", () => {
     expect(formatUserProfileAvatarPath("profile/a b", 1_725_000_123_456)).toBe(
       "/api/users/profile%2Fa%20b/avatar?v=1725000123456",
     );
+    expect(formatUserProfileAvatarPath("profile/a b", "hash/image")).toBe(
+      "/api/users/profile%2Fa%20b/avatar?v=hash%2Fimage",
+    );
   });
 });
 

--- a/src/gateway/user-profiles-http-path.test.ts
+++ b/src/gateway/user-profiles-http-path.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { canonicalizeUserProfileAvatarPath } from "./user-profiles-http-path.js";
+import {
+  canonicalizeUserProfileAvatarPath,
+  formatUserProfileAvatarPath,
+} from "./user-profiles-http-path.js";
+
+describe("formatUserProfileAvatarPath", () => {
+  it("encodes the profile id and appends an optional revision", () => {
+    expect(formatUserProfileAvatarPath("profile/a b")).toBe("/api/users/profile%2Fa%20b/avatar");
+    expect(formatUserProfileAvatarPath("profile/a b", 1_725_000_123_456)).toBe(
+      "/api/users/profile%2Fa%20b/avatar?v=1725000123456",
+    );
+  });
+});
 
 describe("canonicalizeUserProfileAvatarPath", () => {
   it("preserves the root avatar route", () => {

--- a/src/gateway/user-profiles-http-path.ts
+++ b/src/gateway/user-profiles-http-path.ts
@@ -1,8 +1,8 @@
 const USER_PROFILE_AVATAR_PATH = /^\/api\/users\/([^/]+)\/avatar$/u;
 
-export function formatUserProfileAvatarPath(profileId: string, revision?: number): string {
+export function formatUserProfileAvatarPath(profileId: string, revision?: string | number): string {
   const path = `/api/users/${encodeURIComponent(profileId)}/avatar`;
-  return revision === undefined ? path : `${path}?v=${revision}`;
+  return revision === undefined ? path : `${path}?v=${encodeURIComponent(String(revision))}`;
 }
 
 export function matchUserProfileAvatarPath(pathname: string): string | undefined {

--- a/src/gateway/user-profiles-http-path.ts
+++ b/src/gateway/user-profiles-http-path.ts
@@ -1,7 +1,8 @@
 const USER_PROFILE_AVATAR_PATH = /^\/api\/users\/([^/]+)\/avatar$/u;
 
-export function formatUserProfileAvatarPath(profileId: string): string {
-  return `/api/users/${encodeURIComponent(profileId)}/avatar`;
+export function formatUserProfileAvatarPath(profileId: string, revision?: number): string {
+  const path = `/api/users/${encodeURIComponent(profileId)}/avatar`;
+  return revision === undefined ? path : `${path}?v=${revision}`;
 }
 
 export function matchUserProfileAvatarPath(pathname: string): string | undefined {

--- a/src/sessions/user-turn-transcript.persistence.test.ts
+++ b/src/sessions/user-turn-transcript.persistence.test.ts
@@ -151,40 +151,51 @@ describe("persistUserTurnTranscript", () => {
   it("persists sender metadata as __openclaw envelope", async () => {
     const dir = createTempDir("openclaw-user-turn-append-sender-");
     const target = createSqliteTranscriptTarget({ dir });
-
-    const appended = await persistUserTurnTranscript({
-      ...target,
-      input: {
-        text: "hello from group",
-        sender: {
-          id: "8489979671",
-          name: "Ram Shenoy",
-          username: "ram_s",
-        },
-      },
-      updateMode: "none",
-    });
-
-    expect(appended?.message).toMatchObject({
+    // Deliberately attach runtime-only profile fields to prove durable sender
+    // attribution is a whitelist, not a copy of the inbound sender object.
+    const runtimeOnlySenderFields = {
+      senderProfileAvatarUrl: "/api/users/8489979671/avatar?v=1989876543210",
+      profileRevision: 1_989_876_543_210,
+      avatarBytes: "volatile-avatar-bytes",
+      avatarHash: "volatile-avatar-hash",
+    };
+    const sender = {
+      id: "8489979671",
+      name: "Ram Shenoy",
+      username: "ram_s",
+      ...runtimeOnlySenderFields,
+    };
+    const expected = {
       role: "user",
       content: "hello from group",
+      timestamp: 1_700_000_000_000,
       __openclaw: {
         senderId: "8489979671",
         senderName: "Ram Shenoy",
         senderUsername: "ram_s",
       },
+    };
+
+    const appended = await persistUserTurnTranscript({
+      ...target,
+      input: {
+        text: "hello from group",
+        timestamp: expected.timestamp,
+        sender,
+      },
+      updateMode: "none",
     });
-    await expect(readTranscriptMessages(target)).resolves.toEqual([
-      expect.objectContaining({
-        role: "user",
-        content: "hello from group",
-        __openclaw: {
-          senderId: "8489979671",
-          senderName: "Ram Shenoy",
-          senderUsername: "ram_s",
-        },
-      }),
-    ]);
+
+    const reloaded = await readTranscriptMessages(target);
+    const durableMessages = [appended?.message, reloaded[0]];
+    expect(durableMessages).toEqual([expected, expected]);
+    for (const durableMessage of durableMessages) {
+      const serialized = JSON.stringify(durableMessage);
+      for (const [key, value] of Object.entries(runtimeOnlySenderFields)) {
+        expect(serialized).not.toContain(key);
+        expect(serialized).not.toContain(String(value));
+      }
+    }
   });
 
   it("omits __openclaw when no sender metadata is provided", async () => {

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -15,6 +15,7 @@ import {
   ensureProfileForTailscaleIdentity,
   formatUserProfileAvatarEtag,
   getProfileAvatar,
+  getUserProfileDisplay,
   linkEmail,
   listProfiles,
   resolveUserProfileId,
@@ -463,10 +464,13 @@ describe("user profiles", () => {
 
     expect(setAvatar(profile.id, new Uint8Array([1]), "image/png", options).ok).toBe(true);
     const first = getProfileAvatar(profile.id, options);
+    const firstDisplay = getUserProfileDisplay(profile.id, options);
     expect(setAvatar(profile.id, new Uint8Array([2]), "image/png", options).ok).toBe(true);
     const second = getProfileAvatar(profile.id, options);
+    const secondDisplay = getUserProfileDisplay(profile.id, options);
 
     expect(first?.updatedAt).toBe(second?.updatedAt);
+    expect(firstDisplay.avatarRevision).not.toBe(secondDisplay.avatarRevision);
     expect(formatUserProfileAvatarEtag(first?.sha256 ?? "", first?.mime ?? "image/png")).not.toBe(
       formatUserProfileAvatarEtag(second?.sha256 ?? "", second?.mime ?? "image/png"),
     );
@@ -479,9 +483,12 @@ describe("user profiles", () => {
 
     expect(setAvatar(profile.id, bytes, "image/png", options).ok).toBe(true);
     const png = getProfileAvatar(profile.id, options);
+    const pngDisplay = getUserProfileDisplay(profile.id, options);
     expect(setAvatar(profile.id, bytes, "image/webp", options).ok).toBe(true);
     const webp = getProfileAvatar(profile.id, options);
+    const webpDisplay = getUserProfileDisplay(profile.id, options);
 
+    expect(pngDisplay.avatarRevision).not.toBe(webpDisplay.avatarRevision);
     expect(formatUserProfileAvatarEtag(png?.sha256 ?? "", png?.mime ?? "image/png")).not.toBe(
       formatUserProfileAvatarEtag(webp?.sha256 ?? "", webp?.mime ?? "image/png"),
     );

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -49,6 +49,13 @@ type UserProfileAvatar = {
   updatedAt: number;
 };
 
+type UserProfileDisplay = {
+  id: string;
+  displayName: string | null;
+  avatarRevision: string;
+  hasAvatar: boolean;
+};
+
 type UserProfileAvatarError =
   | { code: "avatar_too_large"; maxBytes: number }
   | { code: "unsupported_avatar_mime"; mime: string };
@@ -247,6 +254,27 @@ export function getUserProfileListItem(
   ensureUserProfilesSchema(options);
   const { db } = openOpenClawStateDatabase(options);
   return selectUserProfileListItemById(db, requireResolvedProfileById(db, profileId).id);
+}
+
+/** Reads merge-aware display data without exposing avatar content through list/RPC shapes. */
+export function getUserProfileDisplay(
+  profileId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): UserProfileDisplay {
+  ensureUserProfilesSchema(options);
+  const { db } = openOpenClawStateDatabase(options);
+  const profile = requireResolvedProfileById(db, profileId);
+  const avatarMime = toAvatarMime(profile.avatar_mime);
+  const avatarRevision =
+    profile.avatar_sha256 && avatarMime
+      ? `${profile.avatar_sha256}-${avatarMime.slice("image/".length)}`
+      : String(profile.updated_at);
+  return {
+    id: profile.id,
+    displayName: profile.display_name,
+    avatarRevision,
+    hasAvatar: profile.avatar !== null,
+  };
 }
 
 function ensureProfileForEmailWithInitialName(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where attributed chat messages could keep showing an older sender avatar after that user changed their profile image. Stale URLs could persist in live `session.message` events, RPC/REST history, an already-open SSE history stream, and authenticated presence after reconnect.

Durable turns intentionally store only stable sender attribution (`senderId`, `senderName`, and `senderUsername`). Those display surfaces previously had no join to the current profile representation, so the UI derived an unversioned `/api/users/<id>/avatar` URL. Because the authenticated blob cache keys by the full URL, a previously successful response could keep serving old bytes.

## Why This Change Was Made

The Gateway now owns one merge-aware current-profile display projection. At every attributed-message output boundary it resolves the current profile and supplies a revisioned `/api/users/<resolved-id>/avatar?v=<revision>` route synchronously, while preserving the sender name captured with the historical turn and keeping avatar URLs out of SQLite transcripts.

Uploaded-avatar revisions come from SHA-256 plus MIME, matching the representation facts already used by the endpoint's ETag. This prevents different avatar writes in the same millisecond from sharing a blob-cache key. Authenticated presence uses that same canonical revision. Profiles without uploads retain the profile update revision on the Gateway-owned Gravatar/initials fallback route.

When an inline SSE append also reprojects a previously emitted row to a new avatar URL, the stream now emits a full refreshed history event instead of retaining the stale prefix and sending only the new tail.

Unknown channel sender IDs remain unchanged, only `role=user` messages are enriched, and session actor projection retains its uploaded-avatar-only semantics. The Control UI's local-viewer broken-image rerender behavior is intentionally outside this change.

The production delta is +183/-44 (net +139); that growth establishes the current-profile display owner, connects every live/history/presence boundary, and exposes collision-free representation identity from the profile state owner without changing profile list/RPC shapes. Tests are +651/-88 (net +563). No protocol, schema, configuration, dependency contract, or SQLite shape changes are involved.

## User Impact

Attributed chat avatars now refresh after profile changes across live and historical views, including active SSE streams and authenticated reconnects when distinct updates share one millisecond. Historical sender names stay historical, fallback avatars remain Gateway-owned, and non-profile channel senders keep their existing metadata.

Release-note context: attributed chat avatars now refresh after profile changes across live and historical views. No `CHANGELOG.md` edit is included because release generation owns changelog updates.

## Evidence

Initial focused suites passed for user-profile paths, display projection, live events, RPC reads, REST/SSE history, transcript persistence exclusion, session actor projection, reconnect presence, and UI identity/avatar behavior. The full changed-file `core`/`coreTests` gate also passed. Its initial hosted dispatch could not establish broker readiness, so the repository wrapper's documented trusted-source local fallback completed formatting, manifests/boundaries, dead exports, production/test typechecks, lint, native schema, database-first/runtime-sidecar guards, import cycles, and remaining guards.

ClawSweeper review findings were applied in two cycles:

- uploaded avatar URLs use content-plus-MIME revision identity, with same-millisecond and different-MIME regressions;
- authenticated presence reuses the canonical revision, with three same-millisecond reconnects proving distinct URLs;
- an active SSE stream refreshes its full history when an appended turn also changes an earlier projected avatar URL.

Fresh proof for the current head passed 4 files and 163 tests across unit, Gateway, and E2E Vitest shards. The E2E lane starts an ephemeral authenticated Gateway and exercises real HTTP/SSE delivery; the WebSocket lane exercises authenticated connect/presence projection. Fresh structured autoreview completed with no accepted or actionable findings. Targeted formatting and `git diff --check` passed.

Inspectible Gateway verdict:

```json
{
  "schema": "openclaw.gateway.avatar-refresh-proof/v1",
  "headSha": "acc198f20d46914ec5642abf3fbad9b4d7eb39fb",
  "environment": "ephemeral authenticated Gateway harness with HTTP, SSE, and WebSocket connect paths",
  "command": "node scripts/run-vitest.mjs session-history-state sessions-history-http message-handler.post-connect-health user-profiles",
  "result": "pass",
  "files": 4,
  "tests": 163,
  "observed": {
    "activeSseInitialEvent": "history",
    "activeSseAfterAvatarChange": "full history refresh with old and new rows on the new revision",
    "sameMillisecondUploadedRevisions": "distinct for different content and MIME",
    "sameMillisecondPresenceReconnects": "distinct authenticated avatar URLs",
    "rpcRestLiveHistoryParity": "pass",
    "sqliteTranscriptRuntimeFields": "excluded"
  }
}
```

The attempted focused Testbox rerun failed before code execution because the local wrapper could not find its Testbox CLI. The documented trusted-source local fallback used the existing canonical dependency install without reconciliation. There are no known local proof gaps after that fallback; exact-head CI, exact-head ClawSweeper re-review, and mandatory prepare/Testbox remain required landing gates.

