### PR TITLE
[AI-assisted] docs(gateway): lead secrets guide with safe-migration quick path

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -18,6 +18,34 @@ Plaintext still works. SecretRefs are opt-in per credential.
 Plaintext credentials remain agent-readable when they sit in files the agent can inspect, including `openclaw.json`, `.env`, retired auth-profile JSON archives, or generated `agents/*/agent/models.json` files. SecretRefs reduce that local blast radius once every supported credential is migrated and `openclaw secrets audit --check` reports no plaintext residue.
 </Warning>
 
+## Safe migration quick path
+
+To move supported credentials out of plaintext, follow this three-step workflow:
+
+<Steps>
+  <Step title="Audit current state">
+    ```bash
+    openclaw secrets audit --check
+    ```
+  </Step>
+  <Step title="Configure and apply SecretRefs">
+    ```bash
+    openclaw secrets configure --apply
+    ```
+  </Step>
+  <Step title="Re-audit">
+    ```bash
+    openclaw secrets audit --check
+    ```
+  </Step>
+</Steps>
+
+Do not treat the migration as complete until the re-audit is clean. If the audit still reports plaintext values at rest, the agent-access risk remains even when runtime APIs return redacted values.
+
+If you save a plan instead of applying during `configure`, apply that saved plan with `openclaw secrets apply --from <plan-path>` before the re-audit.
+
+For supported credential fields, see [SecretRef Credential Surface](/reference/secretref-credential-surface). For command details, see [Audit and configure workflow](#audit-and-configure-workflow) below.
+
 ## Runtime model
 
 - Secrets resolve into an in-memory runtime snapshot, eagerly during activation, not lazily on request paths.
@@ -653,29 +681,7 @@ Other notes:
 
 ## Audit and configure workflow
 
-Default operator flow:
-
-<Steps>
-  <Step title="Audit current state">
-    ```bash
-    openclaw secrets audit --check
-    ```
-  </Step>
-  <Step title="Configure and apply SecretRefs">
-    ```bash
-    openclaw secrets configure --apply
-    ```
-  </Step>
-  <Step title="Re-audit">
-    ```bash
-    openclaw secrets audit --check
-    ```
-  </Step>
-</Steps>
-
-Do not treat the migration as complete until the re-audit is clean. If the audit still reports plaintext values at rest, the agent-access risk remains even when runtime APIs return redacted values.
-
-If you save a plan instead of applying during `configure`, apply that saved plan with `openclaw secrets apply --from <plan-path>` before the re-audit.
+For the high-level safe-migration flow, see [Safe migration quick path](#safe-migration-quick-path). The sections below detail each `secrets` command used in the workflow.
 
 <AccordionGroup>
   <Accordion title="secrets audit">

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -44,6 +44,8 @@ Do not treat the migration as complete until the re-audit is clean. If the audit
 
 If you save a plan instead of applying during `configure`, apply that saved plan with `openclaw secrets apply --from <plan-path>` before the re-audit.
 
+If your plan includes exec SecretRef providers, add `--allow-exec` to the `configure` or `apply` step. Without it, write mode rejects plans containing exec SecretRefs/providers.
+
 For supported credential fields, see [SecretRef Credential Surface](/reference/secretref-credential-surface). For command details, see [Audit and configure workflow](#audit-and-configure-workflow) below.
 
 ## Runtime model

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -46,6 +46,14 @@ If you save a plan instead of applying during `configure`, apply that saved plan
 
 If your plan includes exec SecretRef providers, add `--allow-exec` to the `configure` or `apply` step. Without it, write mode rejects plans containing exec SecretRefs/providers.
 
+For exec plans, also re-audit with exec resolution enabled. By default, `openclaw secrets audit --check` skips exec SecretRef resolvability checks to avoid command side effects, so it can report a clean result without verifying exec providers. Run the conditional re-audit after the standard re-audit:
+
+```bash
+openclaw secrets audit --check --allow-exec
+```
+
+`--allow-exec` executes exec provider commands during the audit, so a clean result confirms exec SecretRefs resolve as well as plaintext residue is gone.
+
 For supported credential fields, see [SecretRef Credential Surface](/reference/secretref-credential-surface). For command details, see [Audit and configure workflow](#audit-and-configure-workflow) below.
 
 ## Runtime model


### PR DESCRIPTION
Closes #120355

## What Problem This Solves

The `docs/gateway/secrets.md` English source page leads with dense runtime reference material (runtime model, sentinels, active-surface filtering, etc.) before the "Default operator flow" appears at line 654. The German localized page inherits that order, and a reader reported that the page is too difficult for non-experts.

## Why This Change Was Made

Added a plain-language **Safe migration quick path** section at the top of the English source with the three-step audit/configure/apply workflow, while retaining the existing warning and keeping the detailed command reference later under the existing `## Audit and configure workflow` heading. This preserves the verified CLI contract and lets the i18n publish pipeline regenerate the German route from the reordered source.

## User Impact

Operators reading the secrets guide now see the recommended migration steps first, before the runtime/provider/protocol details, making the page approachable for non-experts.

## Evidence

- `pnpm docs:list` — passed
- `pnpm docs:check-mdx` — passed (768 files)
- `pnpm docs:check-links` — passed (6403 internal links, 0 broken)
- `pnpm docs:check-i18n-glossary` — passed
- `pnpm format:docs:check` — passed (752 files, docs formatting clean)
- `python3 /home/ubuntu/Projects/open-source/scripts/preflight_ship.py --repo openclaw/openclaw --local openclaw --branch main --issue 120355 --file docs/gateway/secrets.md --must-contain "## Audit and configure workflow"` — PREFLIGHT CLEAR
- Local diff is a focused docs-only reorder in `docs/gateway/secrets.md` (29 insertions, 23 deletions).