### PR TITLE
fix: preserve no-clobber sources across Windows identity reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Filesystem publication ownership:** fence published file fingerprints before accepting no-clobber writes or removing moved sources, preventing Windows file-identity reuse from accepting a replacement pathname.
 - **Control UI debug diagnostics:** keep last-good status, health, model, and heartbeat snapshots visible when refreshes fail, show the failure inside Snapshots, isolate it from Manual RPC state, and prevent older manual calls from overwriting newer ones. Thanks @shakkernerd.
 - **Control UI read-only preferences:** keep personal preference edits browser-local without attempting unauthorized config writes or claiming server sync, preserve offline intent for a later authorized reconnect, and restore the current server value on local reset. Thanks @shakkernerd.
 - **Control UI owner handoff:** give browsers opened by host-issued dashboard and graphical onboarding links durable administrator access, including same-browser recovery from a limited credential, while keeping generic, Telegram, mobile, and ordinary scope-upgrade paths bounded. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Filesystem publication ownership:** fence published file fingerprints before accepting no-clobber writes or removing moved sources, preventing Windows file-identity reuse from accepting a replacement pathname.
 - **Control UI debug diagnostics:** keep last-good status, health, model, and heartbeat snapshots visible when refreshes fail, show the failure inside Snapshots, isolate it from Manual RPC state, and prevent older manual calls from overwriting newer ones. Thanks @shakkernerd.
 - **Control UI read-only preferences:** keep personal preference edits browser-local without attempting unauthorized config writes or claiming server sync, preserve offline intent for a later authorized reconnect, and restore the current server value on local reset. Thanks @shakkernerd.
 - **Control UI owner handoff:** give browsers opened by host-issued dashboard and graphical onboarding links durable administrator access, including same-browser recovery from a limited credential, while keeping generic, Telegram, mobile, and ordinary scope-upgrade paths bounded. Thanks @shakkernerd.

--- a/src/infra/directory-durability.test.ts
+++ b/src/infra/directory-durability.test.ts
@@ -9,7 +9,15 @@ import {
   syncDirectoryIfSupported,
 } from "./directory-durability.js";
 
+type PublishFileExclusive = typeof import("@openclaw/fs-safe/durability").publishFileExclusive;
+type PublishedFile = Awaited<ReturnType<PublishFileExclusive>>;
+type AfterPublish = (
+  params: Parameters<PublishFileExclusive>[0],
+  result: PublishedFile,
+) => Promise<PublishedFile>;
+
 const durabilityTestState = vi.hoisted(() => ({
+  afterPublish: undefined as AfterPublish | undefined,
   publishSyncOutcome: undefined as
     | { status: "synced" }
     | { status: "unsupported"; code?: string }
@@ -21,7 +29,10 @@ vi.mock("@openclaw/fs-safe/durability", async (importOriginal) => {
   return {
     ...actual,
     publishFileExclusive: async (...args: Parameters<typeof actual.publishFileExclusive>) => {
-      const result = await actual.publishFileExclusive(...args);
+      const published = await actual.publishFileExclusive(...args);
+      const result = durabilityTestState.afterPublish
+        ? await durabilityTestState.afterPublish(args[0], published)
+        : published;
       return durabilityTestState.publishSyncOutcome
         ? { ...result, directorySync: durabilityTestState.publishSyncOutcome }
         : result;
@@ -32,6 +43,7 @@ vi.mock("@openclaw/fs-safe/durability", async (importOriginal) => {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
+  durabilityTestState.afterPublish = undefined;
   durabilityTestState.publishSyncOutcome = undefined;
   vi.restoreAllMocks();
 });
@@ -58,27 +70,83 @@ describe("directory durability compatibility", () => {
     ).not.toThrow();
   });
 
-  it("preserves its target with a receipt when fail-closed durability rejects", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-    const directoryPath = tempDirs.make("openclaw-publish-cleanup-");
+  it.runIf(process.platform !== "win32")(
+    "preserves its target with a receipt when fail-closed durability rejects",
+    async () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      const directoryPath = tempDirs.make("openclaw-publish-cleanup-");
+      const sourcePath = path.join(directoryPath, "source.txt");
+      const targetPath = path.join(directoryPath, "target.txt");
+      await fs.writeFile(sourcePath, "complete publication");
+      durabilityTestState.publishSyncOutcome = { status: "unsupported", code: "ENOTSUP" };
+
+      const error = await publishFileNoClobber(sourcePath, targetPath, {
+        strategy: "link-or-copy",
+        durability: "fail-closed",
+      }).catch((caught: unknown) => caught);
+
+      expect(getPublishFileExclusiveFailureDetails(error)).toMatchObject({
+        phase: "directory-sync",
+        targetCreated: true,
+        cleanup: "preserved",
+      });
+      await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("complete publication");
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("complete publication");
+    },
+  );
+
+  it("removes a source only after its published target passes the ownership fence", async () => {
+    const directoryPath = tempDirs.make("openclaw-publish-move-");
     const sourcePath = path.join(directoryPath, "source.txt");
     const targetPath = path.join(directoryPath, "target.txt");
     await fs.writeFile(sourcePath, "complete publication");
-    durabilityTestState.publishSyncOutcome = { status: "unsupported", code: "ENOTSUP" };
 
-    const error = await publishFileNoClobber(sourcePath, targetPath, {
-      strategy: "link-or-copy",
-      durability: "fail-closed",
-    }).catch((caught: unknown) => caught);
-
-    expect(getPublishFileExclusiveFailureDetails(error)).toMatchObject({
-      phase: "directory-sync",
-      targetCreated: true,
-      cleanup: "preserved",
-    });
-    await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("complete publication");
+    await expect(
+      publishFileNoClobber(sourcePath, targetPath, {
+        strategy: "link-or-copy",
+        moveSource: true,
+        durability: "fail-closed",
+      }),
+    ).resolves.toMatchObject({ method: "hardlink" });
+    await expect(fs.access(sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("complete publication");
   });
+
+  it.each([false, true])(
+    "rejects a recycled publication identity without removing the source (moveSource=%s)",
+    async (moveSource) => {
+      const directoryPath = tempDirs.make("openclaw-publish-identity-reuse-");
+      const sourcePath = path.join(directoryPath, "source.txt");
+      const targetPath = path.join(directoryPath, "target.txt");
+      const displacedPath = path.join(directoryPath, "target.displaced.txt");
+      await fs.writeFile(sourcePath, "complete publication");
+      durabilityTestState.afterPublish = async (params, published) => {
+        if (path.resolve(params.targetPath) !== targetPath) {
+          return published;
+        }
+        await fs.rename(targetPath, displacedPath);
+        await fs.writeFile(targetPath, "racer");
+        // Reproduce the Windows failure mode where the dependency accepts a
+        // recycled identity and reports the replacement as its published file.
+        return { ...published, identity: await fs.lstat(targetPath) };
+      };
+
+      const error = await publishFileNoClobber(sourcePath, targetPath, {
+        strategy: "link-or-copy",
+        moveSource,
+        durability: "fail-closed",
+      }).catch((caught: unknown) => caught);
+
+      expect(getPublishFileExclusiveFailureDetails(error)).toMatchObject({
+        phase: "hardlink-verify",
+        targetCreated: true,
+        cleanup: "preserved",
+      });
+      await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("complete publication");
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("racer");
+      await expect(fs.readFile(displacedPath, "utf8")).resolves.toBe("complete publication");
+    },
+  );
 
   it.runIf(process.platform !== "win32")("reports a completed directory sync", async () => {
     const directoryPath = tempDirs.make("openclaw-directory-sync-");

--- a/src/infra/directory-durability.ts
+++ b/src/infra/directory-durability.ts
@@ -1,3 +1,4 @@
+import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import {
   publishFileExclusive,
@@ -90,6 +91,34 @@ function postPublicationFailure(params: {
   );
 }
 
+export function sameFileStatFingerprint(left: Stats, right: Stats): boolean {
+  // Hard-link creation/removal changes ctime. The remaining fields bind the
+  // pathname to the published bytes even when Windows recycles a file identity.
+  return (
+    sameFileIdentity(left, right) &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.birthtimeMs === right.birthtimeMs
+  );
+}
+
+function publicationVerificationPhase(
+  published: PublishFileExclusiveResult,
+): PublishFileExclusiveFailurePhase {
+  return published.method === "hardlink" ? "hardlink-verify" : "copy-verify";
+}
+
+function assertPublishedTargetFingerprint(
+  targetPath: string,
+  expectedIdentity: Stats,
+  message: string,
+): void {
+  const currentTarget = fsSync.lstatSync(targetPath);
+  if (!currentTarget.isFile() || !sameFileStatFingerprint(expectedIdentity, currentTarget)) {
+    throw new Error(`${message}: ${targetPath}`);
+  }
+}
+
 /** Publish one file without replacement under OpenClaw's durability policy. */
 export async function publishFileNoClobber(
   sourcePath: string,
@@ -107,6 +136,22 @@ export async function publishFileNoClobber(
     expectedSourceIdentity: sourceIdentity,
     strategy: options.strategy,
   });
+  const verificationPhase = publicationVerificationPhase(published);
+  try {
+    if (
+      published.method === "hardlink" &&
+      !sameFileStatFingerprint(sourceIdentity, published.identity)
+    ) {
+      throw new Error(`File publication target changed after hard-link creation: ${targetPath}`);
+    }
+    assertPublishedTargetFingerprint(
+      targetPath,
+      published.identity,
+      "File publication target changed after creation",
+    );
+  } catch (error) {
+    throw postPublicationFailure({ error, phase: verificationPhase, published });
+  }
   const degraded = published.directorySync.status === "unsupported";
   if (options.durability === "fail-closed") {
     try {
@@ -122,15 +167,27 @@ export async function publishFileNoClobber(
 
   if (options.moveSource) {
     try {
-      const currentSource = await fs.lstat(sourcePath);
-      if (!currentSource.isFile() || !sameFileIdentity(currentSource, sourceIdentity)) {
+      const currentSource = fsSync.lstatSync(sourcePath);
+      if (!currentSource.isFile() || !sameFileStatFingerprint(currentSource, sourceIdentity)) {
         throw new Error(`File publication source changed before removal: ${sourcePath}`);
       }
-      await fs.unlink(sourcePath);
+      assertPublishedTargetFingerprint(
+        targetPath,
+        published.identity,
+        "File publication target changed before source removal",
+      );
+      // Keep the final ownership fence and unlink in one synchronous section so
+      // another in-process publication cannot interleave between them.
+      fsSync.unlinkSync(sourcePath);
+      assertPublishedTargetFingerprint(
+        targetPath,
+        published.identity,
+        "File publication target changed after source removal",
+      );
     } catch (error) {
       throw postPublicationFailure({
         error,
-        phase: published.method === "hardlink" ? "hardlink-verify" : "copy-verify",
+        phase: verificationPhase,
         published,
       });
     }

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -12,6 +12,7 @@ import {
   pinDirectory,
   publishFileNoClobber,
   requireDirectorySync,
+  sameFileStatFingerprint,
   syncDirectory,
 } from "./directory-durability.js";
 import { formatErrorMessage } from "./errors.js";
@@ -383,17 +384,6 @@ function removePublishedTargetIfOwned(
   } catch {
     return false;
   }
-}
-
-function sameFileStatFingerprint(left: Stats, right: Stats): boolean {
-  // Creating the publication hard link changes source ctime, so compare the
-  // mutation fields that remain stable for the same bytes and pathname owner.
-  return (
-    sameFileIdentity(left, right) &&
-    left.size === right.size &&
-    left.mtimeMs === right.mtimeMs &&
-    left.birthtimeMs === right.birthtimeMs
-  );
 }
 
 function assertSynchronousCallbackResult(result: unknown, label: string): void {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows could accept a caller-replaced file as the result of a no-clobber publication when NTFS recycled the deleted file identity. SQLite publication still rejected the wrong bytes at its later content fence, but generic move-style callers could remove their source after the identity false-positive.

## Why This Change Was Made

The shared no-clobber publication boundary now verifies the stable file fingerprint (identity, size, mtime, and birthtime) after the dependency returns and immediately before source removal. The source-removal fence and unlink run synchronously so another in-process publication cannot interleave. SQLite reuses the same canonical fingerprint helper instead of maintaining duplicate policy.

Production LOC: +62/-15 (net +47) for the shared ownership boundary; tests: +84/-16.

## User Impact

Windows snapshot, backup, TLS, migration-archive, and repository publication paths reject replacement pathnames earlier. Move-style publication preserves the source instead of deleting it when target ownership cannot be proven.

## Evidence

- Before: exact-main SHA `e8da40010a330131aed83b96ca460e7192ef1345` failed native Windows CI in [run 31224436306, job 93017956061](https://github.com/openclaw/openclaw/actions/runs/31224436306/job/93017956061). `rejects a target replaced after atomic publication` observed replacement bytes (`expected 4096, got 5`) after the dependency accepted the recycled identity.
- After: native Windows AWS Crabbox `cbx_5597c3debaba` / run `run_62284038a606`, hydrated by [Actions run 31226607860](https://github.com/openclaw/openclaw/actions/runs/31226607860), ran `pnpm test src/infra/directory-durability.test.ts src/infra/sqlite-snapshot.test.ts`: 38 passed, 8 expected platform skips. The unchanged original SQLite assertion and both new `moveSource=false|true` identity-reuse regressions passed.
- Exact-head PR Windows CI also passed on `5c76359d5c60c4900e7567496768295a1e0fb005`: [run 31228750361, job 93028604032](https://github.com/openclaw/openclaw/actions/runs/31228750361/job/93028604032).
- `git diff --check`: passed.
- Autoreview: clean; no accepted or actionable findings on the final code and changelog patch.

The broader `check:changed` delegation was attempted, but its workload router selected Azure and the broker rejected the configured `azureImage` selector as admin-only. Exact-head PR CI remains the broad gate.
