### PR TITLE
fix(ci): wait for release child metadata

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -481,31 +481,42 @@ jobs:
 
           validate_child_run() {
             local candidate_run_id="$1"
-            local candidate_run_json
+            local candidate_run_json candidate_attempt
             if [[ ! "$candidate_run_id" =~ ^[0-9]+$ ]]; then
               echo "::error::Refusing to adopt invalid ${workflow} run ID ${candidate_run_id}." >&2
               return 1
             fi
-            candidate_run_json="$(
-              gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}"
-            )"
-            if ! jq -e \
-              --argjson id "$candidate_run_id" \
-              --argjson workflow_id "$expected_workflow_id" \
-              --arg title "$dispatch_run_name" \
-              --arg branch "$CHILD_WORKFLOW_REF" \
-              '(.id == $id)
-                and (.workflow_id == $workflow_id)
-                and (.display_title == $title)
-                and (.head_branch == $branch)
-                and (.event == "workflow_dispatch")' \
-              <<< "$candidate_run_json" >/dev/null; then
-              echo "::error::Refusing to adopt unvalidated ${workflow} run ${candidate_run_id}." >&2
-              jq '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
-                <<< "$candidate_run_json" >&2
-              return 1
-            fi
-            printf '%s\n' "$candidate_run_json"
+            # GitHub can return a run URL before that run's identity metadata settles.
+            # Keep the candidate unowned until repeated reads prove its exact identity.
+            for candidate_attempt in $(seq 1 12); do
+              candidate_run_json="$(
+                gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}"
+              )"
+              if jq -e \
+                --argjson id "$candidate_run_id" \
+                --argjson workflow_id "$expected_workflow_id" \
+                --arg title "$dispatch_run_name" \
+                --arg branch "$CHILD_WORKFLOW_REF" \
+                '(.id == $id)
+                  and (.workflow_id == $workflow_id)
+                  and (.display_title == $title)
+                  and (.head_branch == $branch)
+                  and (.event == "workflow_dispatch")' \
+                <<< "$candidate_run_json" >/dev/null; then
+                printf '%s\n' "$candidate_run_json"
+                return 0
+              fi
+              if [[ "$candidate_attempt" != "12" ]]; then
+                echo "::warning::${workflow} run ${candidate_run_id} identity metadata has not settled (attempt ${candidate_attempt}/12); retrying in 5 seconds." >&2
+                jq -c '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
+                  <<< "$candidate_run_json" >&2
+                sleep 5
+              fi
+            done
+            echo "::error::Refusing to adopt unvalidated ${workflow} run ${candidate_run_id} after 12 metadata reads." >&2
+            jq -c '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
+              <<< "$candidate_run_json" >&2
+            return 1
           }
 
           fetch_child_jobs() {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -244,6 +244,7 @@ function runFullReleaseChildDispatch(
   const ghPath = resolve(workdir, "gh");
   const sleepPath = resolve(workdir, "sleep");
   const callsPath = resolve(workdir, "gh-calls.jsonl");
+  const metadataPath = resolve(workdir, "metadata-polls");
   const statusPath = resolve(workdir, "status-polls");
   writeFileSync(callsPath, "");
   writeFileSync(
@@ -266,6 +267,14 @@ function nextStatus() {
   try { index = Number(fs.readFileSync(env.MOCK_GH_STATUS_POLLS, "utf8")); } catch {}
   fs.writeFileSync(env.MOCK_GH_STATUS_POLLS, String(index + 1));
   return statuses[Math.min(index, statuses.length - 1)];
+}
+function nextRunMetadata() {
+  const metadata = JSON.parse(env.MOCK_GH_RUN_METADATA_SEQUENCE);
+  if (metadata.length === 0) return {};
+  let index = 0;
+  try { index = Number(fs.readFileSync(env.MOCK_GH_METADATA_POLLS, "utf8")); } catch {}
+  fs.writeFileSync(env.MOCK_GH_METADATA_POLLS, String(index + 1));
+  return metadata[Math.min(index, metadata.length - 1)];
 }
 if (args[0] === "workflow" && args[1] === "run") {
   if (env.MOCK_GH_DISPATCH_ERROR) {
@@ -290,17 +299,18 @@ if (args[0] === "workflow" && args[1] === "run") {
     console.error(env.MOCK_GH_STATUS_ERROR);
     process.exit(1);
   }
+  const runMetadata = nextRunMetadata();
   console.log(JSON.stringify({
     conclusion,
-    display_title: env.MOCK_GH_RUN_TITLE,
-    event: env.MOCK_GH_RUN_EVENT,
-    head_branch: env.MOCK_GH_RUN_HEAD_BRANCH,
-    head_sha: env.MOCK_GH_CHILD_SHA,
+    display_title: runMetadata.display_title ?? env.MOCK_GH_RUN_TITLE,
+    event: runMetadata.event ?? env.MOCK_GH_RUN_EVENT,
+    head_branch: runMetadata.head_branch ?? env.MOCK_GH_RUN_HEAD_BRANCH,
+    head_sha: runMetadata.head_sha ?? env.MOCK_GH_CHILD_SHA,
     html_url: url,
-    id: Number(env.MOCK_GH_RUN_ID),
-    path: env.MOCK_GH_RUN_PATH,
+    id: Number(runMetadata.id ?? env.MOCK_GH_RUN_ID),
+    path: runMetadata.path ?? env.MOCK_GH_RUN_PATH,
     status: nextStatus(),
-    workflow_id: Number(env.MOCK_GH_RUN_WORKFLOW_ID),
+    workflow_id: Number(runMetadata.workflow_id ?? env.MOCK_GH_RUN_WORKFLOW_ID),
   }));
 } else if (args[0] === "run" && args[1] === "view") {
   const field = args[args.indexOf("--json") + 1];
@@ -401,12 +411,14 @@ if (args[0] === "workflow" && args[1] === "run") {
       MOCK_GH_DISPATCH_OUTPUT: "Created workflow_dispatch event.",
       MOCK_GH_JOBS: JSON.stringify(defaultJobs),
       MOCK_GH_MATCHES: "[101]",
+      MOCK_GH_METADATA_POLLS: metadataPath,
       MOCK_GH_RUN_EVENT: "workflow_dispatch",
       MOCK_GH_RUN_HEAD_BRANCH:
         overrides.MOCK_GH_RUN_HEAD_BRANCH ??
         overrides.CHILD_WORKFLOW_REF ??
         stepEnv.CHILD_WORKFLOW_REF,
       MOCK_GH_RUN_ID: "101",
+      MOCK_GH_RUN_METADATA_SEQUENCE: "[]",
       MOCK_GH_RUN_PATH: `.github/workflows/${child.workflow}`,
       MOCK_GH_RUN_TITLE: `${child.runName} full-release-validation-77-2${child.nonceSuffix}`,
       MOCK_GH_RUN_WORKFLOW_ID: "789",
@@ -1950,6 +1962,27 @@ describe("package acceptance workflow", () => {
     },
   );
 
+  it("waits for returned child metadata to settle before adopting the run", () => {
+    const child = FULL_RELEASE_CHILD_DISPATCHES[4];
+    const { calls, result } = runFullReleaseChildDispatch(child, {
+      MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
+      MOCK_GH_RUN_METADATA_SEQUENCE: JSON.stringify([{ workflow_id: 790 }, {}]),
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stderr).toContain("identity metadata has not settled (attempt 1/12)");
+    expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
+    expect(
+      calls.filter(({ args }) => args.some((value) => value.endsWith("/actions/runs/101"))),
+    ).toHaveLength(2);
+    expect(
+      calls.filter(({ args }) =>
+        args.some((value) => value.endsWith(`/actions/workflows/${child.workflow}/runs`)),
+      ),
+    ).toHaveLength(0);
+    expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
+  });
+
   it("recovers by exact name when a successful dispatch returns no run URL", () => {
     const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
       MOCK_GH_DISPATCH_OUTPUT: "",
@@ -1969,14 +2002,20 @@ describe("package acceptance workflow", () => {
     ["title", { MOCK_GH_RUN_TITLE: "Unrelated workflow run" }],
     ["head branch", { MOCK_GH_RUN_HEAD_BRANCH: "other" }],
     ["event", { MOCK_GH_RUN_EVENT: "push" }],
-  ] as const)("refuses a returned run URL with the wrong %s", (_label, overrides) => {
+  ] as const)("refuses a returned run URL with persistently wrong %s", (_label, overrides) => {
     const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
       MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
       ...overrides,
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Refusing to adopt unvalidated ci.yml run 101");
+    expect(result.stderr).toContain(
+      "Refusing to adopt unvalidated ci.yml run 101 after 12 metadata reads",
+    );
+    expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
+    expect(
+      calls.filter(({ args }) => args.some((value) => value.endsWith("/actions/runs/101"))),
+    ).toHaveLength(12);
     expect(
       calls.some(({ args }) =>
         args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
@@ -1993,9 +2032,10 @@ describe("package acceptance workflow", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("Refusing to adopt invalid ci.yml run ID not-a-run-id");
-    expect(
-      calls.some(({ args }) => args.some((value) => value.endsWith("/actions/runs/not-a-run-id"))),
-    ).toBe(false);
+    expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
+    expect(calls.some(({ args }) => args.some((value) => value.includes("/actions/runs/")))).toBe(
+      false,
+    );
     expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
   });
 
@@ -2071,15 +2111,24 @@ describe("package acceptance workflow", () => {
   );
 
   it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "cancels exactly the identified $jobName child when its workflow SHA differs",
+    "cancels exactly the identified $jobName child when its workflow SHA differs after identity settlement",
     (child) => {
       const { calls, result } = runFullReleaseChildDispatch(child, {
         MOCK_GH_CHILD_SHA: "c".repeat(40),
         MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
+        MOCK_GH_RUN_METADATA_SEQUENCE: JSON.stringify([
+          { display_title: "Pending workflow metadata" },
+          {},
+        ]),
       });
 
       expect(result.status).toBe(1);
+      expect(result.stderr).toContain("identity metadata has not settled (attempt 1/12)");
       expect(result.stderr).toContain("expected parent workflow SHA");
+      expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
+      expect(
+        calls.filter(({ args }) => args.some((value) => value.endsWith("/actions/runs/101"))),
+      ).toHaveLength(2);
       expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toEqual([
         expect.objectContaining({ args: ["run", "cancel", "101"] }),
       ]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could dispatch the correct child workflows and then immediately reject them as unvalidated because GitHub's run metadata had not yet settled after the dispatch response.

The release-blocking parent run [31228444217](https://github.com/openclaw/openclaw/actions/runs/31228444217), using trusted workflow revision `b921139203eb`, dispatched all three authoritative children and then rejected them:

- CI [31228554929](https://github.com/openclaw/openclaw/actions/runs/31228554929)
- Plugin Prerelease [31229174697](https://github.com/openclaw/openclaw/actions/runs/31229174697)
- Release Checks [31229165502](https://github.com/openclaw/openclaw/actions/runs/31229165502)

Subsequent public Actions API reads showed that every child exactly matched the expected run ID, workflow ID, display title, `release-ci/b921139203eb-1786146712833` branch, `b921139203eb25aad35b3b9aa06c0969fc223dbf` head SHA, `workflow_dispatch` event, and workflow path. Local `jq` validation with those settled values succeeded. The initial GET was therefore too early to be authoritative.

## Why This Change Was Made

Known child run IDs, whether returned directly by the one-shot dispatch POST or recovered by the existing exact-name legacy/ambiguous fallback, now receive up to 12 metadata reads at 5-second intervals (55 seconds maximum sleep) before identity validation fails. Ownership is established only after the exact non-SHA identity fields match: run ID, workflow ID, display title, head branch, and event.

The head SHA remains a separate check after ownership is established. A settled identity with the wrong SHA is cancelled exactly once; a persistent workflow/title/branch/event mismatch remains unowned, is never cancelled, and fails after the bound. The dispatch POST remains one-shot, direct URL parsing and exact-name recovery are unchanged, and matching was not broadened.

Main independently fixed the unrelated max-lines regression with commit `644ad3bf41c67` (`test(agent): split run lifecycle coverage`). The now-obsolete PR commit `d3988b5eb19ed` (`test(agents): split embedded run steering tests`) was dropped wholesale during rebase; no test-file split or combined resolution remains in this PR.

The final diff is exactly two files:

- `.github/workflows/full-release-validation.yml`: `+32/-21`
- `test/scripts/package-acceptance-workflow.test.ts`: `+62/-13`

The metadata patch remained exact across the rebase: `git range-diff` reports equality and its stable patch ID remains `672574fb634b88ab7ce7aa16b9f3bbb3386a22ef`.

No release branch, including `release/2026.8.1`, was mutated. This PR does not dispatch workflows, generate a changelog, tag, publish, or land a release.

## User Impact

Release operators can run Full Release Validation without a correct child being falsely rejected during GitHub Actions metadata convergence, while the existing strict ownership and cancellation safety boundaries remain intact.

## Evidence

The real shell-execution harness proves transient metadata convergence and adoption, persistent identity mismatches remaining unowned and uncancelled for all guarded fields, invalid run IDs making no API call, post-settlement SHA mismatch cancelling exactly once, and the dispatch POST remaining one-shot. The mocked `sleep` keeps bounded-retry coverage fast.

- `node scripts/run-vitest.mjs test/scripts/release-no-push-workflow.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/ci-workflow-guards.test.ts` — 3 files passed; 287 tests passed, 2 skipped.
- `node scripts/check-workflows.mjs` — passed.
- `actionlint .github/workflows/full-release-validation.yml` — passed.
- Targeted `oxfmt --check` on the touched files — passed.
- `git diff --check` — passed.
- Targeted oxlint on current main's `src/agents/embedded-agent-runner/runs.test.ts` and `src/agents/embedded-agent-runner/runs.lifecycle.test.ts` — passed with no max-lines finding.
- Rebase equivalence — `git range-diff d6e88ebe2e414f1cf7d1ece3f23503e5946e6f09^! 5ea262610c0b891e366fb028dc4a2917041c8148^!` reports `=`; both stable patch IDs are `672574fb634b88ab7ce7aa16b9f3bbb3386a22ef`.

AI-assisted: yes.
