### PR TITLE
fix(ci): honor env- and config-selected Windows targets

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -2504,15 +2504,13 @@ function envAssignmentInsertIndex(words) {
 }
 
 function isWindowsRemoteTarget(commandArgs) {
-  return (
-    optionValue(commandArgs, "--target") === "windows" || hasOption(commandArgs, "--windows-mode")
-  );
+  // Mirror Crabbox's arg/env/config resolution so indirect Windows targets never receive POSIX shell.
+  return effectiveTargetContext(commandArgs).target === "windows";
 }
 
 function isNativeWindowsRemoteTarget(commandArgs) {
-  return (
-    isWindowsRemoteTarget(commandArgs) && optionValue(commandArgs, "--windows-mode") !== "wsl2"
-  );
+  const targetContext = effectiveTargetContext(commandArgs);
+  return targetContext.target === "windows" && targetContext.windowsMode !== "wsl2";
 }
 
 function isAwsMacosRemoteTarget(commandArgs, providerName) {
@@ -2529,7 +2527,7 @@ function isBrokeredWsl2RemoteTarget(commandArgs, providerName) {
     commandArgs[0] === "run" &&
     (canonicalProvider === "aws" || canonicalProvider === "azure") &&
     isWindowsRemoteTarget(commandArgs) &&
-    optionValue(commandArgs, "--windows-mode") === "wsl2"
+    effectiveTargetContext(commandArgs).windowsMode === "wsl2"
   );
 }
 

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -348,6 +348,9 @@ function wrapperEnv(helpText: string, options: WrapperOptions): NodeJS.ProcessEn
       .filter(Boolean)
       .join(path.delimiter),
     CRABBOX_PROVIDER: "",
+    CRABBOX_TARGET: "",
+    CRABBOX_TARGET_OS: "",
+    CRABBOX_WINDOWS_MODE: "",
     OPENCLAW_CRABBOX_ALLOW_DIRECT_AWS: "",
     OPENCLAW_CRABBOX_SYNC_MIN_FREE_BYTES: "0",
     OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY: "1",
@@ -1872,7 +1875,17 @@ describe("scripts/crabbox-wrapper", () => {
   it("rejects Blacksmith Testbox for Windows-shaped proof", () => {
     for (const args of [
       ["run", "--provider", "blacksmith-testbox", "--target", "windows", "--", "echo ok"],
-      ["run", "--provider", "blacksmith-testbox", "--windows-mode", "wsl2", "--", "echo ok"],
+      [
+        "run",
+        "--provider",
+        "blacksmith-testbox",
+        "--target",
+        "windows",
+        "--windows-mode",
+        "wsl2",
+        "--",
+        "echo ok",
+      ],
     ]) {
       const result = runWrapper(azureProviderHelp, args);
 
@@ -2833,6 +2846,44 @@ describe("scripts/crabbox-wrapper", () => {
       runSuccessfulDefaultWrapper(["run", "--provider", "aws", "--", "echo", "ok"]),
       "echo ok",
     );
+  });
+
+  it("does not add POSIX shell bootstraps for env-selected native Windows", () => {
+    const { output, remoteCommand } = runSuccessfulDefaultWrapper(
+      ["run", "--provider", "aws", "--", "echo", "ok"],
+      { env: { CRABBOX_TARGET: "windows" } },
+    );
+
+    expect(output.args).not.toContain("--shell");
+    expect(remoteCommand).not.toContain(remotePosixHydratedModulesBootstrap);
+  });
+
+  it("keeps env-selected WSL2 runs on the POSIX bootstrap path", () => {
+    const { output } = runSuccessfulDefaultWrapper(
+      ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
+      {
+        env: {
+          CRABBOX_TARGET: "windows",
+          CRABBOX_WINDOWS_MODE: "wsl2",
+        },
+      },
+    );
+
+    expect(output.args).toContain("--script");
+    expect(output.args).not.toContain("--shell");
+    expect(output.scriptContent).toContain("openclaw_crabbox_bootstrap_wsl2_js");
+  });
+
+  it("does not add POSIX shell bootstraps for config-selected native Windows", () => {
+    const { output, remoteCommand } = runSuccessfulDefaultWrapper(["run", "--", "echo", "ok"], {
+      configJson: managedBrokerConfig("aws", {
+        target: "windows",
+        windowsMode: "normal",
+      }),
+    });
+
+    expect(output.args).not.toContain("--shell");
+    expect(remoteCommand).not.toContain(remotePosixHydratedModulesBootstrap);
   });
 
   const itWithPosixLinkedWorktreeFixture = process.platform === "win32" ? it.skip : it;


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #120365

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes ClawSweeper's exact-head P1 on merged PR #120365 (https://github.com/openclaw/openclaw/pull/120365#issuecomment-5223419830): the Windows-target predicates in `scripts/crabbox-wrapper.mjs` inspected raw arguments only, so native Windows runs selected via `CRABBOX_TARGET`, `CRABBOX_TARGET_OS`, or the configured `target:` were misclassified as POSIX. The new hydrated-modules bootstrap, along with the pre-existing changed-gate and junction gates, would inject POSIX shell into PowerShell commands.

## Why This Change Was Made

`isWindowsRemoteTarget` and `isNativeWindowsRemoteTarget` now consult `effectiveTargetContext`, mirroring Crabbox's own argument, environment, and configuration resolution order. Fixing the shared predicates heals all call sites uniformly, including WSL2's intentional POSIX path.

## User Impact

Maintainer CI tooling now preserves the correct PowerShell or POSIX command path when Windows targets are selected indirectly through environment or configuration. There is no end-user product-runtime impact.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  248 passed (248)`
  - `[test] passed 1 Vitest shard in 73.96s`
- `git diff --check origin/main...HEAD` passed with no output.

