### PR TITLE
fix(ui): settle stale hasActiveRun rows when terminal status arrives

### DIFF
--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -902,7 +902,10 @@ describe("createSessionCapability", () => {
     sessions.dispose();
   });
 
-  it("preserves registry-active terminal rows without matching run identity", () => {
+  it("settles stale terminal rows even without a matching run identity", () => {
+    // A row that already carries an explicit terminal status together with a
+    // stale hasActiveRun: true must be settled by the terminal event. The
+    // overlap guard only applies while the row is genuinely active.
     const result = sessionsResult(
       [
         {
@@ -923,7 +926,17 @@ describe("createSessionCapability", () => {
         status: "done",
         endedAt: 160,
       }),
-    ).toBe(result);
+    ).toEqual({
+      ...result,
+      sessions: [
+        {
+          ...result.sessions[0],
+          hasActiveRun: false,
+          status: "done",
+          endedAt: 160,
+        },
+      ],
+    });
   });
 
   it("refreshes instead of inserting hidden sessions after configured-only lists", async () => {

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -557,7 +557,7 @@ export function reconcileSessionRunTerminal(
     if (!keys.some((key) => areUiSessionKeysEquivalent(row.key, key))) {
       return row;
     }
-    if (row.hasActiveRun === true || isSessionRunActive(row)) {
+    if (isSessionRunActive(row)) {
       // Active identity belongs to the originating model run, not a newer overlap.
       if (!runId || !row.activeRunIds?.includes(runId)) {
         return row;

--- a/ui/src/lib/sessions/run-terminal.test.ts
+++ b/ui/src/lib/sessions/run-terminal.test.ts
@@ -81,4 +81,39 @@ describe("reconcileSessionRunTerminal yielded parent", () => {
       ],
     });
   });
+
+  it("clears a stale hasActiveRun when the row already carries a terminal status", () => {
+    // Regression: the row shows a terminal status (run finished) yet keeps a
+    // stale hasActiveRun: true and no tracked run ids. The terminal event must
+    // win over the stale flag instead of being skipped by the overlap guard.
+    const result = sessionsResult([
+      {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 1,
+        hasActiveRun: true,
+        status: "done",
+        endedAt: 100,
+      },
+    ]);
+
+    expect(
+      reconcileSessionRunTerminal(result, {
+        sessionKeys: ["main"],
+        runId: "run-1",
+        status: "done",
+        endedAt: 160,
+      }),
+    ).toEqual({
+      ...result,
+      sessions: [
+        {
+          ...result.sessions[0],
+          hasActiveRun: false,
+          status: "done",
+          endedAt: 100,
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## What Problem

After a chat run completes, the **New Session** button in the Control UI sidebar can stay disabled indefinitely. The session row keeps `hasActiveRun: true` alongside a terminal status (`done`), and the state never reconciles on its own — the button only re-enables after clicking a different session. Reported in #120321 as a regression of the v2026.7.1 spinner fix (#101293).

## Why

`reconcileSessionRunTerminal` (ui/src/lib/sessions/reconcile.ts) guarded settlement with:

```ts
if (row.hasActiveRun === true || isSessionRunActive(row)) {
  // Active identity belongs to the originating model run, not a newer overlap.
  if (!runId || !row.activeRunIds?.includes(runId)) {
    return row;
  }
}
```

The raw `row.hasActiveRun === true` disjunct re-enters the overlap guard even when the row already carries an explicit terminal status. If the ended `runId` is not tracked in the row's `activeRunIds` (or the list is absent), the row is skipped and the stale `hasActiveRun: true` is never cleared. `isSessionRunActive` (ui/src/lib/session-run-state.ts) already implements the intended precedence — an explicit terminal status wins over a stale `hasActiveRun` flag — so the raw-flag disjunct is both redundant and harmful.

## User Impact

- New Session button unlocks immediately when a run ends, with no session switch or refresh.
- Sidebar spinner / running class / Stop control and the button now clear together, in the current session.
- The overlap guard still protects genuinely active rows (e.g. overlapping subagent runs), so no active-run protection is lost.

## Evidence

- **Inline verification:** focused unit tests pass — `pnpm vitest run src/lib/sessions/run-terminal.test.ts src/lib/sessions/index.test.ts src/lib/session-run-state.test.ts` → 37/37 passed.
- **New regression test** `run-terminal.test.ts` "clears a stale hasActiveRun when the row already carries a terminal status": row `{ hasActiveRun: true, status: "done", endedAt: 100 }` + terminal event → settled to `{ hasActiveRun: false, status: "done", endedAt: 100 }` (previously skipped by the guard).
- **Updated existing test** `index.test.ts` "settles stale terminal rows even without a matching run identity" — previously asserted the buggy skip (`toBe(result)`), now asserts settlement.
- **Diff:** 1 production line changed (`ui/src/lib/sessions/reconcile.ts`), remainder is tests.

- [x] 4-part PR body
- [x] Real evidence (unit test runs + before/after assertion diff)
- [x] [AI-assisted]

Fixes #120321
