### PR TITLE
fix(agents): memory-flush append-only write returns outputSchema-conforming details

### DIFF
--- a/src/agents/agent-tools.memory-flush-append-write.test.ts
+++ b/src/agents/agent-tools.memory-flush-append-write.test.ts
@@ -11,7 +11,7 @@ const RELATIVE_PATH = "memory/2026-08-08.md";
 
 // Mirror the catalog path: declared schemas are JSON-serialized before the
 // bridge validates results against them.
-const declaredWriteOutputSchema = JSON.parse(JSON.stringify(WriteToolOutputSchema)) as Parameters<
+const declaredWriteOutputSchema = structuredClone(WriteToolOutputSchema) as Parameters<
   typeof validateJsonSchemaValue
 >[0]["schema"];
 
@@ -63,7 +63,7 @@ describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
 
   it("returns write-schema-conforming details when creating the memory file", async () => {
     const details = await runAppend();
-    expect(details).toEqual({ changed: true, created: true });
+    expect(details).toEqual({ changed: true });
     expect(validateAgainstDeclaredSchema(details).ok).toBe(true);
   });
 
@@ -72,7 +72,7 @@ describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
     await fs.mkdir(path.dirname(absolute), { recursive: true });
     await fs.writeFile(absolute, "seed\n", "utf-8");
     const details = await runAppend();
-    expect(details).toEqual({ changed: true, created: false });
+    expect(details).toEqual({ changed: true });
     expect(validateAgainstDeclaredSchema(details).ok).toBe(true);
     expect(await fs.readFile(absolute, "utf-8")).toBe("seed\nhello");
   });

--- a/src/agents/agent-tools.memory-flush-append-write.test.ts
+++ b/src/agents/agent-tools.memory-flush-append-write.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
+import { wrapToolMemoryFlushAppendOnlyWrite } from "./agent-tools.read.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+import { WriteToolOutputSchema } from "./sessions/tools/write.js";
+
+const RELATIVE_PATH = "memory/2026-08-08.md";
+
+// Mirror the catalog path: declared schemas are JSON-serialized before the
+// bridge validates results against them.
+const declaredWriteOutputSchema = JSON.parse(JSON.stringify(WriteToolOutputSchema)) as Parameters<
+  typeof validateJsonSchemaValue
+>[0]["schema"];
+
+function baseWriteTool(): AnyAgentTool {
+  return {
+    name: "write",
+    description: "Write a file.",
+    parameters: { type: "object", properties: {} },
+    outputSchema: declaredWriteOutputSchema,
+    execute: async () => {
+      throw new Error("append-only wrapper should not delegate for append params");
+    },
+  } as unknown as AnyAgentTool;
+}
+
+function validateAgainstDeclaredSchema(value: unknown) {
+  return validateJsonSchemaValue({
+    schema: declaredWriteOutputSchema,
+    cacheKey: "test:memory-flush-write-output",
+    value,
+    cache: false,
+  });
+}
+
+describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "memory-flush-write-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function runAppend(): Promise<unknown> {
+    const wrapped = wrapToolMemoryFlushAppendOnlyWrite(baseWriteTool(), {
+      root,
+      relativePath: RELATIVE_PATH,
+    });
+    const result = await wrapped.execute(
+      "call-1",
+      { path: RELATIVE_PATH, content: "hello" },
+      new AbortController().signal,
+      undefined,
+    );
+    return (result as { details?: unknown }).details;
+  }
+
+  it("returns write-schema-conforming details when creating the memory file", async () => {
+    const details = await runAppend();
+    expect(details).toEqual({ changed: true, created: true });
+    expect(validateAgainstDeclaredSchema(details).ok).toBe(true);
+  });
+
+  it("returns write-schema-conforming details when appending to an existing file", async () => {
+    const absolute = path.join(root, RELATIVE_PATH);
+    await fs.mkdir(path.dirname(absolute), { recursive: true });
+    await fs.writeFile(absolute, "seed\n", "utf-8");
+    const details = await runAppend();
+    expect(details).toEqual({ changed: true, created: false });
+    expect(validateAgainstDeclaredSchema(details).ok).toBe(true);
+    expect(await fs.readFile(absolute, "utf-8")).toBe("seed\nhello");
+  });
+
+  it("documents the pre-fix regression: append-only metadata violates the declared schema", () => {
+    const validation = validateAgainstDeclaredSchema({ path: RELATIVE_PATH, appendOnly: true });
+    expect(validation.ok).toBe(false);
+  });
+});

--- a/src/agents/agent-tools.memory-flush-append-write.test.ts
+++ b/src/agents/agent-tools.memory-flush-append-write.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import { wrapToolMemoryFlushAppendOnlyWrite } from "./agent-tools.read.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
-import { createWriteTool } from "./sessions/index.js";
+import { createWriteTool } from "./sessions/tools/index.js";
 
 const RELATIVE_PATH = "memory/2026-08-08.md";
 

--- a/src/agents/agent-tools.memory-flush-append-write.test.ts
+++ b/src/agents/agent-tools.memory-flush-append-write.test.ts
@@ -5,15 +5,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import { wrapToolMemoryFlushAppendOnlyWrite } from "./agent-tools.read.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
-import { WriteToolOutputSchema } from "./sessions/tools/write.js";
+import { createWriteTool } from "./sessions/index.js";
 
 const RELATIVE_PATH = "memory/2026-08-08.md";
 
-// Mirror the catalog path: declared schemas are JSON-serialized before the
-// bridge validates results against them.
-const declaredWriteOutputSchema = structuredClone(WriteToolOutputSchema) as Parameters<
-  typeof validateJsonSchemaValue
->[0]["schema"];
+let declaredWriteOutputSchema: Parameters<typeof validateJsonSchemaValue>[0]["schema"];
 
 function baseWriteTool(): AnyAgentTool {
   return {
@@ -41,6 +37,13 @@ describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), "memory-flush-write-"));
+    // Mirror the catalog path: declared schemas are JSON-serialized before the
+    // bridge validates results against them. Read the schema from the public
+    // tool factory so production internals do not need a test-only export.
+    const writeTool = createWriteTool(root) as unknown as AnyAgentTool;
+    declaredWriteOutputSchema = structuredClone(writeTool.outputSchema) as unknown as Parameters<
+      typeof validateJsonSchemaValue
+    >[0]["schema"];
   });
 
   afterEach(async () => {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -662,27 +662,6 @@ async function readOptionalUtf8File(params: {
   }
 }
 
-/**
- * Best-effort pre-append existence probe so the append-only memory-flush write
- * can report `created` truthfully. Sandbox-bridged appends resolve inside the
- * bridge, so existence is unknown there; callers omit `created` instead of
- * guessing.
- */
-async function memoryFlushAppendTargetExists(params: {
-  absolutePath: string;
-  sandbox?: MemoryFlushAppendOnlyWriteOptions["sandbox"];
-}): Promise<boolean | undefined> {
-  if (params.sandbox) {
-    return undefined;
-  }
-  try {
-    await fs.stat(params.absolutePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function appendMemoryFlushContent(params: {
   absolutePath: string;
   root: string;
@@ -766,10 +745,6 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         );
       }
 
-      const existedBeforeAppend = await memoryFlushAppendTargetExists({
-        absolutePath: allowedAbsolutePath,
-        sandbox: options.sandbox,
-      });
       await appendMemoryFlushContent({
         absolutePath: allowedAbsolutePath,
         root: options.root,
@@ -782,12 +757,15 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
       // `{ ...tool }`, so the details it returns must satisfy that same
       // contract. Append-only metadata here made the code-mode bridge reject
       // the result after a successful append (openclaw/openclaw#120385).
+      //
+      // `created` is deliberately omitted: any pre-append existence probe is a
+      // TOCTOU guess (another writer can create or remove the target between the
+      // probe and the append), and the append path cannot report creation
+      // authoritatively. The declared schema permits the bare `{ changed: true }`
+      // shape, so report only what this call actually knows.
       return {
         content: [{ type: "text", text: `Appended content to ${options.relativePath}.` }],
-        details:
-          existedBeforeAppend === undefined
-            ? { changed: true }
-            : { changed: true, created: !existedBeforeAppend },
+        details: { changed: true },
       };
     },
   };

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -753,16 +753,8 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         sandbox: options.sandbox,
         signal,
       });
-      // The wrapper inherits the base write tool's declared outputSchema via
-      // `{ ...tool }`, so the details it returns must satisfy that same
-      // contract. Append-only metadata here made the code-mode bridge reject
-      // the result after a successful append (openclaw/openclaw#120385).
-      //
-      // `created` is deliberately omitted: any pre-append existence probe is a
-      // TOCTOU guess (another writer can create or remove the target between the
-      // probe and the append), and the append path cannot report creation
-      // authoritatively. The declared schema permits the bare `{ changed: true }`
-      // shape, so report only what this call actually knows.
+      // This wrapper inherits the write tool's output schema, so report only
+      // the authoritative `changed`; deriving `created` before append is racy.
       return {
         content: [{ type: "text", text: `Appended content to ${options.relativePath}.` }],
         details: { changed: true },

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -662,6 +662,27 @@ async function readOptionalUtf8File(params: {
   }
 }
 
+/**
+ * Best-effort pre-append existence probe so the append-only memory-flush write
+ * can report `created` truthfully. Sandbox-bridged appends resolve inside the
+ * bridge, so existence is unknown there; callers omit `created` instead of
+ * guessing.
+ */
+async function memoryFlushAppendTargetExists(params: {
+  absolutePath: string;
+  sandbox?: MemoryFlushAppendOnlyWriteOptions["sandbox"];
+}): Promise<boolean | undefined> {
+  if (params.sandbox) {
+    return undefined;
+  }
+  try {
+    await fs.stat(params.absolutePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function appendMemoryFlushContent(params: {
   absolutePath: string;
   root: string;
@@ -745,6 +766,10 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         );
       }
 
+      const existedBeforeAppend = await memoryFlushAppendTargetExists({
+        absolutePath: allowedAbsolutePath,
+        sandbox: options.sandbox,
+      });
       await appendMemoryFlushContent({
         absolutePath: allowedAbsolutePath,
         root: options.root,
@@ -753,12 +778,16 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         sandbox: options.sandbox,
         signal,
       });
+      // The wrapper inherits the base write tool's declared outputSchema via
+      // `{ ...tool }`, so the details it returns must satisfy that same
+      // contract. Append-only metadata here made the code-mode bridge reject
+      // the result after a successful append (openclaw/openclaw#120385).
       return {
         content: [{ type: "text", text: `Appended content to ${options.relativePath}.` }],
-        details: {
-          path: options.relativePath,
-          appendOnly: true,
-        },
+        details:
+          existedBeforeAppend === undefined
+            ? { changed: true }
+            : { changed: true, created: !existedBeforeAppend },
       };
     },
   };

--- a/src/agents/agent-tools.workspace-paths.test.ts
+++ b/src/agents/agent-tools.workspace-paths.test.ts
@@ -1062,10 +1062,7 @@ describe("FS tools with workspaceOnly=false", () => {
     expect(hasToolError(result)).toBe(false);
     expect(result).toStrictEqual({
       content: [{ type: "text", text: "Appended content to memory/2026-03-07.md." }],
-      details: {
-        path: "memory/2026-03-07.md",
-        appendOnly: true,
-      },
+      details: { changed: true },
     });
     await expect(fs.readFile(allowedAbsolutePath, "utf-8")).resolves.toBe("seed\nnew note");
   });
@@ -1090,10 +1087,7 @@ describe("FS tools with workspaceOnly=false", () => {
     expect(hasToolError(result)).toBe(false);
     expect(result).toStrictEqual({
       content: [{ type: "text", text: "Appended content to memory/2026-03-08.md." }],
-      details: {
-        path: "memory/2026-03-08.md",
-        appendOnly: true,
-      },
+      details: { changed: true },
     });
     await expect(fs.readFile(allowedAbsolutePath, "utf-8")).resolves.toBe("new note");
   });

--- a/src/agents/embedded-agent-runner/run/attempt.memory-flush-forwarding.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.memory-flush-forwarding.test.ts
@@ -94,8 +94,8 @@ describe("runEmbeddedAttempt memory flush tool forwarding", () => {
         { type: "text", text: `Appended content to ${MEMORY_RELATIVE_PATH}.` },
       ]);
       expect(result.details).toEqual({
-        path: MEMORY_RELATIVE_PATH,
-        appendOnly: true,
+        changed: true,
+        created: false,
       });
       await expect(fs.readFile(memoryFile, "utf-8")).resolves.toBe("seed\nnew durable note");
       await expect(

--- a/src/agents/embedded-agent-runner/run/attempt.memory-flush-forwarding.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.memory-flush-forwarding.test.ts
@@ -93,10 +93,7 @@ describe("runEmbeddedAttempt memory flush tool forwarding", () => {
       expect(result.content).toEqual([
         { type: "text", text: `Appended content to ${MEMORY_RELATIVE_PATH}.` },
       ]);
-      expect(result.details).toEqual({
-        changed: true,
-        created: false,
-      });
+      expect(result.details).toEqual({ changed: true });
       await expect(fs.readFile(memoryFile, "utf-8")).resolves.toBe("seed\nnew durable note");
       await expect(
         wrapped.execute("call-memory-flush-deny", {

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -40,7 +40,7 @@ const writeSchema = Type.Object({
   content: Type.String({ description: "File content." }),
 });
 
-const WriteToolOutputSchema = Type.Union([
+export const WriteToolOutputSchema = Type.Union([
   Type.Object({ changed: Type.Literal(false) }, { additionalProperties: false }),
   Type.Object(
     {

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -40,7 +40,7 @@ const writeSchema = Type.Object({
   content: Type.String({ description: "File content." }),
 });
 
-export const WriteToolOutputSchema = Type.Union([
+const WriteToolOutputSchema = Type.Union([
   Type.Object({ changed: Type.Literal(false) }, { additionalProperties: false }),
   Type.Object(
     {


### PR DESCRIPTION
## What Problem This Solves

During pre-compaction memory flushes, `wrapToolMemoryFlushAppendOnlyWrite()` inherits the base write tool's `outputSchema`, but previously returned:

```ts
details: { path: options.relativePath, appendOnly: true }
```

Every write-schema arm is closed and requires `changed`, so the Code Mode bridge rejected the result **after the append had already landed**. The caller saw a terminal bridge failure and could not tell that the side effect succeeded.

## Fix

The append-only wrapper now returns the minimal truthful write result:

```ts
details: { changed: true }
```

It does not report `created`: a pre-append existence probe would be a TOCTOU guess and sandbox/non-sandbox paths cannot report it consistently. Human-readable output is unchanged.

## Regression coverage

`src/agents/agent-tools.memory-flush-append-write.test.ts` obtains the declared schema from the public `createWriteTool()` factory, JSON-serializes it like the catalog bridge, and validates results with the same `validateJsonSchemaValue` engine.

Coverage proves:

- a fresh memory file returns `{ changed: true }` and validates;
- an existing file appends content, returns `{ changed: true }`, and validates;
- the pre-fix `{ path, appendOnly: true }` shape is rejected;
- workspace-path and embedded-attempt expectations use the new contract.

## Evidence

### Exact-head evidence

Head: `032fb728150`.

```text
pnpm exec vitest run \
  src/agents/agent-tools.memory-flush-append-write.test.ts \
  src/agents/agent-tools.workspace-paths.test.ts \
  src/agents/embedded-agent-runner/run/attempt.memory-flush-forwarding.test.ts

Test Files  7 passed (7)
Tests       85 passed | 2 skipped (87)

pnpm tsgo:test:root        # exit 0
pnpm deadcode:full         # exit 0
pnpm exec oxlint <touched> # exit 0
pnpm exec oxfmt --check <touched> # clean
```

The previous exact runtime source (`d75d3a5b476`) was deployed on the production gateway `pink`: memory-flush appends completed without the pre-fix `outputSchema` bridge rejection and persisted successfully. From that deployed head to `032fb728150`, the executable append/result statements remain unchanged; the follow-up only routes tests through the public factory, removes the test-only export, and condenses the inline contract comment to two lines.

### CI failure triage

The prior run had two branch-owned failures, both fixed in `bc09a46499e`:

- `check-dependencies`: `WriteToolOutputSchema` was exported only for the new test. The test now reads the schema through `createWriteTool()`, and the production constant is private again.
- `check-test-types`: the test's direct TypeBox-to-JSON-schema cast triggered TS2352. The serialization boundary now uses an explicit `unknown` conversion.

The other two failures were unrelated suite flakes outside this PR's files:

- `session-message-events.test.ts`: sender-ID redaction/avatar projection mismatch;
- `state-migrations.worktree-paths.test.ts`: 240-second timeout.

New exact-head CI is the final authority for those global jobs.

Closes the memory-flush output-schema symptom discussed in #120385; it does not change explicit tool-allowlist policy or the separate cron diagnostic-loss issue.



### Follow-up exact-head validation

Head: `4a90d1111dea8d1c5039ead72fa40d24dfa68075`.

- Replaced the new schema test's broad `./sessions/index.js` import with the public narrow `./sessions/tools/index.js` barrel, resolving ClawSweeper's concrete P3 finding.
- `pnpm exec vitest run src/agents/agent-tools.memory-flush-append-write.test.ts`, `pnpm tsgo:test:root`, `pnpm deadcode:full`, targeted `oxlint`, and `oxfmt --check` all passed on this exact head.


## Real behavior proof — exact head `4a90d1111de` (added 2026-08-17)

After-fix runtime trace of a real pre-compaction memory flush, proving both the persisted append and the accepted bridge validation. Environment: this exact head built (`pnpm build`) and run as a dist-backed Gateway with an isolated `OPENCLAW_STATE_DIR`; per-agent `tools.codeMode: true`; bundled memory-core defaults; real `deepseek/deepseek-v4-pro` turns driven through the real webchat channel entry (`chat.send` gateway RPC — the same path the dashboard uses), which is the auto-reply pipeline that owns the flush preflight. `agents.defaults.contextTokens: 50000` shrinks the window so the flush threshold is reachable in minutes; everything else is stock.

**Flush trigger (gateway debug log):**

```text
memoryFlush check: sessionKey=agent:main:main tokenCount=41084 contextWindow=50000 threshold=26000 isHeartbeat=false isCli=false memoryFlushWritable=true …
memoryFlush triggered: sessionKey=agent:main:main tokenCount=41084 threshold=26000
```

**The flush turn's write, verbatim from the persisted session transcript** — the model appends to `memory/2026-08-17.md` via the Code Mode bridge (`tools.callValue("openclaw:core:write", { path, content })`, i.e. the write tool wrapped by `wrapToolMemoryFlushAppendOnlyWrite`), and the bridge validates and accepts the wrapper's result:

```json
{
  "role": "toolResult",
  "toolName": "exec",
  "details": {
    "status": "completed",
    "value": { "changed": true },
    "telemetry": { "visibleTools": ["exec", "wait"], "callCount": 2 }
  }
}
```

**Persisted append:** the memory file on disk gained exactly the flush turn's appended entry (before/after SHA-256 recorded; the appended line records the new durable facts), and the pre-existing daily-note content above it is intact — append semantics held.

**Bridge validation accepted:** zero occurrences of `does not match its declared outputSchema` across the full session transcript and gateway debug log for the run. On pre-fix code this exact write returns `{ path, appendOnly: true }`, which the bridge rejects after the append lands — the failure this PR removes.
