### PR TITLE
test(qa): derive UX producer aggregate status

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -1847,8 +1847,11 @@ describe("qa test file scenario runner", () => {
     );
 
     expect(result.executionKind).toBe("script");
-    expect(result.results[0]).toMatchObject({ status: "blocked" });
-    expect(result.results[0]?.producerEvidence?.entries).toHaveLength(3);
+    const producerEntries = result.results[0]?.producerEvidence?.entries ?? [];
+    const producerStatuses = producerEntries.map((entry) => entry.result.status);
+    expect(producerEntries).toHaveLength(3);
+    expect(producerStatuses).toContain("blocked");
+    expect(result.results[0]?.status).toBe(producerStatuses.includes("pass") ? "pass" : "blocked");
     expect(evidence.entries.map((entry) => entry.test.id)).toEqual([
       "ux-matrix.qa-lab.producer-artifact-fixture",
       "ux-matrix.control-ui.screenshot-artifact",


### PR DESCRIPTION
## Summary

- derive the standalone UX Matrix scenario result from its imported producer statuses
- keep requiring three exact evidence entries, at least one blocked visual-proof cell, zero product coverage, and the expected artifacts

Fixes https://github.com/openclaw/openclaw/issues/120417

## Root cause

The integration fixture guarantees one blocked cell through `--skip-visual-proof`, but prepared builds can legitimately execute another producer cell. The test asserted `blocked` unconditionally even though the runner correctly returns `pass` when any allowed producer check succeeds.

## Verification

- deterministic current-main reproduction — unbuilt 45/45, then built 44/45 with expected `blocked` versus received `pass`
- fixed built environment — 45/45 passed
- built fresh-process stress — 10/10 runs, 450 assertions, zero failures
- changed gate — passed on Blacksmith Testbox `tbx_01kzfg0k6sqk2kyhhz4jjwe1z8`: https://github.com/openclaw/openclaw/actions/runs/31232897827
- AutoReview — clean at P2, confidence 0.99

## Risk

Very low. This is a five-line test assertion repair. It does not change the producer, runner, taxonomy, configuration, protocol, storage, dependencies, or runtime behavior.
