### PR TITLE
fix(queue): deliver queued steers in arrival order across turn boundaries

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../../sessions/user-turn-transcript.test-support.js";
+import { setSteeringMessageIdentity } from "../../sessions/steering-message-identity.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "./attempt.queue-message.js";
 
 type EmbeddedAgentActiveSessionSteerTarget = Parameters<
@@ -12,10 +13,12 @@ function steerWithDeliveryWait(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
   deliveryTimeoutMs = 10_000,
+  options: { queueIdentity?: string; abortSignal?: AbortSignal } = {},
 ): ReturnType<typeof steerActiveSessionWithOptionalDeliveryWait> {
   return steerActiveSessionWithOptionalDeliveryWait(activeSession, text, {
     deliveryTimeoutMs,
     waitForTranscriptCommit: true,
+    ...options,
   });
 }
 
@@ -71,7 +74,14 @@ describe("embedded OpenClaw queued steering cancellation", () => {
       imageOrder: [...imageOrder],
     });
 
-    expect(steer).toHaveBeenCalledWith("inspect both", undefined, undefined, media, imageOrder);
+    expect(steer).toHaveBeenCalledWith(
+      "inspect both",
+      undefined,
+      undefined,
+      media,
+      imageOrder,
+      undefined,
+    );
   });
 
   it("waits for the queued user message_end transcript boundary", async () => {
@@ -169,7 +179,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     }
   });
 
-  it("rejects and removes the queued steering message when the session ends first", async () => {
+  it("returns an unconsumed terminal steer for normal-turn promotion", async () => {
     vi.useFakeTimers();
     let emit!: (event: unknown) => void;
     const targetMessage = {
@@ -202,6 +212,8 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     };
 
     const wait = steerWithDeliveryWait(activeSession, "completion after parent stopped");
+    // Removing it from the dying in-memory runtime lets the reply queue promote
+    // the same source turn instead of treating terminal completion as delivery.
     const rejection = expect(wait).rejects.toThrow(
       "active session ended before queued steering message was committed to the transcript",
     );
@@ -217,6 +229,69 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("matches identical steering text by stable queue identity", async () => {
+    let emit!: (event: unknown) => void;
+    const first = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "same text" }],
+      timestamp: 1,
+    };
+    const second = { ...first, content: [...first.content], timestamp: 2 };
+    setSteeringMessageIdentity(first, "steer-a");
+    setSteeringMessageIdentity(second, "steer-b");
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      agent: { steeringQueue: { messages: [first, second] } },
+      steer: async () => {},
+      subscribe: (listener) => {
+        emit = listener;
+        return () => {};
+      },
+    };
+    const wait = steerWithDeliveryWait(activeSession, "same text", 10_000, {
+      queueIdentity: "steer-a",
+    });
+    let settled = false;
+    void wait.then(() => {
+      settled = true;
+    });
+
+    emit({ type: "message_end", message: second });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    emit({ type: "message_end", message: first });
+    await expect(wait).resolves.toBeUndefined();
+  });
+
+  it("cancels the exact accepted steer when its source aborts", async () => {
+    const first = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "same text" }],
+      timestamp: 1,
+    };
+    const second = { ...first, content: [...first.content], timestamp: 2 };
+    setSteeringMessageIdentity(first, "steer-a");
+    setSteeringMessageIdentity(second, "steer-b");
+    const queueMessages = [first, second];
+    const steeringUiMessages = ["same text", "same text"];
+    const controller = new AbortController();
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      agent: { steeringQueue: { messages: queueMessages } },
+      getSteeringMessages: () => steeringUiMessages,
+      steer: async () => {},
+      subscribe: () => () => {},
+    };
+    const wait = steerWithDeliveryWait(activeSession, "same text", 10_000, {
+      queueIdentity: "steer-a",
+      abortSignal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(wait).rejects.toThrow("queued steering message was cancelled before delivery");
+    expect(queueMessages).toEqual([second]);
+    expect(steeringUiMessages).toEqual(["same text"]);
   });
 
   it("marks a missing queued message as accepted without transcript confirmation", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -10,6 +10,7 @@ import {
   cancelPendingAgentQuestionForSession,
   claimPendingAgentQuestionAnswer,
 } from "../../harness/gateway-question.js";
+import { getSteeringMessageIdentity } from "../../sessions/steering-message-identity.js";
 import { log } from "../logger.js";
 import type {
   EmbeddedAgentQueueMessageOptions,
@@ -29,6 +30,7 @@ type EmbeddedAgentActiveSessionSteerTarget = {
     userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
     media?: MediaFact[],
     imageOrder?: PromptImageOrderEntry[],
+    queueIdentity?: string,
   ): Promise<void>;
   subscribe(listener: (event: unknown) => void): () => void;
 };
@@ -50,9 +52,17 @@ function steerActiveSession(
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
   media?: MediaFact[],
   imageOrder?: PromptImageOrderEntry[],
+  queueIdentity?: string,
 ): Promise<void> {
-  if (media?.length) {
-    return activeSession.steer(text, images, userTurnTranscriptRecorder, media, imageOrder);
+  if (media?.length || queueIdentity) {
+    return activeSession.steer(
+      text,
+      images,
+      userTurnTranscriptRecorder,
+      media,
+      imageOrder,
+      queueIdentity,
+    );
   }
   return userTurnTranscriptRecorder
     ? activeSession.steer(text, images, userTurnTranscriptRecorder)
@@ -88,12 +98,17 @@ function extractQueuedUserMessageText(message: unknown): string | undefined {
   return text || undefined;
 }
 
-function isQueuedUserMessageEnd(event: unknown, text: string): boolean {
+function isQueuedUserMessageEnd(event: unknown, text: string, queueIdentity?: string): boolean {
   if (!event || typeof event !== "object") {
     return false;
   }
   const record = event as { message?: unknown; type?: unknown };
-  return record.type === "message_end" && extractQueuedUserMessageText(record.message) === text;
+  return (
+    record.type === "message_end" &&
+    (queueIdentity
+      ? getSteeringMessageIdentity(record.message) === queueIdentity
+      : extractQueuedUserMessageText(record.message) === text)
+  );
 }
 
 function isTerminalActiveSessionEvent(event: unknown): boolean {
@@ -134,6 +149,7 @@ function getAgentSteeringQueueMessages(agent: unknown): unknown[] | undefined {
 async function cancelQueuedSteeringMessage(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
+  queueIdentity?: string,
 ): Promise<boolean> {
   const queuedMessages = getAgentSteeringQueueMessages(activeSession.agent);
   if (!queuedMessages) {
@@ -141,16 +157,26 @@ async function cancelQueuedSteeringMessage(
   }
   // The session runtime exposes only all-queue clears publicly; mutate the exact pending message
   // so unrelated queued messages keep their full payloads.
-  const queueIndex = queuedMessages.findIndex(
-    (message) => extractQueuedUserMessageText(message) === text,
+  const queueIndex = queuedMessages.findIndex((message) =>
+    queueIdentity
+      ? getSteeringMessageIdentity(message) === queueIdentity
+      : extractQueuedUserMessageText(message) === text,
   );
   if (queueIndex === -1) {
     return false;
   }
+  const matchingOrdinal = queuedMessages
+    .slice(0, queueIndex)
+    .filter((message) => extractQueuedUserMessageText(message) === text).length;
   queuedMessages.splice(queueIndex, 1);
   const uiSteeringMessages = activeSession.getSteeringMessages?.();
   if (Array.isArray(uiSteeringMessages)) {
-    const uiIndex = uiSteeringMessages.indexOf(text);
+    const uiIndex = uiSteeringMessages.findIndex(
+      (candidate, index) =>
+        candidate === text &&
+        uiSteeringMessages.slice(0, index).filter((value) => value === text).length ===
+          matchingOrdinal,
+    );
     if (uiIndex !== -1) {
       uiSteeringMessages.splice(uiIndex, 1);
     }
@@ -171,10 +197,24 @@ async function steerAndWaitForTranscriptCommit(
   images?: ImageContent[],
   media?: MediaFact[],
   imageOrder?: PromptImageOrderEntry[],
+  queueIdentity?: string,
+  abortSignal?: AbortSignal,
+  onQueueAccepted?: (accepted: boolean) => void,
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
     let terminalTimer: ReturnType<typeof setTimeout> | undefined;
+    let accepted = false;
+    let abortRequested = abortSignal?.aborted === true;
+    let acceptanceReported = false;
+    let cancellation: Promise<void> | undefined;
+    const reportAcceptance = (value: boolean) => {
+      if (acceptanceReported) {
+        return;
+      }
+      acceptanceReported = true;
+      onQueueAccepted?.(value);
+    };
     const finish = (err?: unknown) => {
       if (settled) {
         return;
@@ -187,6 +227,7 @@ async function steerAndWaitForTranscriptCommit(
         clearTimeout(terminalTimer);
       }
       unsubscribe?.();
+      abortSignal?.removeEventListener("abort", onAbort);
       if (err) {
         reject(toErrorObject(err, "Non-Error rejection"));
         return;
@@ -196,25 +237,27 @@ async function steerAndWaitForTranscriptCommit(
     const rejectAfterCancellation = (message: string) => {
       // Cancellation is best-effort but must finish before rejecting so callers
       // do not return while a stale queued message can leak into the next turn.
-      void cancelQueuedSteeringMessage(activeSession, text)
-        .then((removed) => {
+      cancellation ??= cancelQueuedSteeringMessage(activeSession, text, queueIdentity).then(
+        (removed) => {
           if (!removed) {
             log.warn("failed to find queued steering message for cancellation");
             throw new EmbeddedSteeringAcceptedUnconfirmedError(message);
           }
-        })
-        .catch((err: unknown) => {
-          if (!(err instanceof EmbeddedSteeringAcceptedUnconfirmedError)) {
-            log.warn(`failed to cancel queued steering message: ${String(err)}`);
+        },
+      );
+      void cancellation.then(
+        () => finish(new Error(message)),
+        (error: unknown) => {
+          if (!(error instanceof EmbeddedSteeringAcceptedUnconfirmedError)) {
+            log.warn(`failed to cancel queued steering message: ${String(error)}`);
           }
-          throw err instanceof EmbeddedSteeringAcceptedUnconfirmedError
-            ? err
-            : new EmbeddedSteeringAcceptedUnconfirmedError(message, { cause: err });
-        })
-        .then(
-          () => finish(new Error(message)),
-          (error: unknown) => finish(error),
-        );
+          finish(
+            error instanceof EmbeddedSteeringAcceptedUnconfirmedError
+              ? error
+              : new EmbeddedSteeringAcceptedUnconfirmedError(message, { cause: error }),
+          );
+        },
+      );
     };
     const scheduleTerminalCancellation = () => {
       if (terminalTimer) {
@@ -247,7 +290,7 @@ async function steerAndWaitForTranscriptCommit(
         }
         return;
       }
-      if (isQueuedUserMessageEnd(event, text)) {
+      if (isQueuedUserMessageEnd(event, text, queueIdentity)) {
         finish();
         return;
       }
@@ -258,6 +301,11 @@ async function steerAndWaitForTranscriptCommit(
         scheduleTerminalCancellation();
       }
     });
+    if (abortRequested) {
+      reportAcceptance(false);
+      finish(new Error("queued steering message was cancelled before acceptance"));
+      return;
+    }
     const steer = steerActiveSession(
       activeSession,
       text,
@@ -265,10 +313,28 @@ async function steerAndWaitForTranscriptCommit(
       userTurnTranscriptRecorder,
       media,
       imageOrder,
+      queueIdentity,
     );
-    steer.catch((err: unknown) => {
-      finish(err);
-    });
+    void steer.then(
+      () => {
+        accepted = true;
+        reportAcceptance(true);
+        if (abortRequested) {
+          rejectAfterCancellation("queued steering message was cancelled before delivery");
+        }
+      },
+      (err: unknown) => {
+        reportAcceptance(false);
+        finish(err);
+      },
+    );
+    function onAbort() {
+      abortRequested = true;
+      if (accepted) {
+        rejectAfterCancellation("queued steering message was cancelled before delivery");
+      }
+    }
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 
@@ -304,17 +370,25 @@ export async function steerActiveSessionWithOptionalDeliveryWait(
         : undefined,
     }))
   ) {
+    options?.onQueueAccepted?.(true);
     return;
   }
   if (options?.waitForTranscriptCommit !== true) {
-    await steerActiveSession(
-      activeSession,
-      text,
-      options?.images,
-      options?.userTurnTranscriptRecorder,
-      options?.media,
-      options?.imageOrder,
-    );
+    try {
+      await steerActiveSession(
+        activeSession,
+        text,
+        options?.images,
+        options?.userTurnTranscriptRecorder,
+        options?.media,
+        options?.imageOrder,
+        options?.queueIdentity,
+      );
+      options?.onQueueAccepted?.(true);
+    } catch (error) {
+      options?.onQueueAccepted?.(false);
+      throw error;
+    }
     return;
   }
   try {
@@ -326,6 +400,9 @@ export async function steerActiveSessionWithOptionalDeliveryWait(
       options.images,
       options.media,
       options.imageOrder,
+      options.queueIdentity,
+      options.abortSignal,
+      options.onQueueAccepted,
     );
   } catch (error) {
     if (error instanceof EmbeddedSteeringAcceptedUnconfirmedError) {

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -16,6 +16,7 @@ import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth
 import type { CustomMessage } from "./messages.js";
 import { expandPromptTemplate } from "./prompt-templates.js";
 import type { ResourceLoader } from "./resource-loader.js";
+import { setSteeringMessageIdentity } from "./steering-message-identity.js";
 
 type PostAgentRunAction = "continue" | "settled" | "handoff";
 
@@ -336,6 +337,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
     media?: MediaFact[],
     imageOrder?: PromptImageOrderEntry[],
+    queueIdentity?: string,
   ): Promise<void> {
     // Check for extension commands (cannot be queued)
     if (text.startsWith("/")) {
@@ -355,6 +357,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
         : undefined,
       media,
       imageOrder,
+      queueIdentity,
     );
   }
 
@@ -390,6 +393,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     },
     media?: MediaFact[],
     imageOrder?: PromptImageOrderEntry[],
+    queueIdentity?: string,
   ): Promise<void> {
     this.steeringMessages.push(text);
     this.emitQueueUpdate();
@@ -397,6 +401,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     const promptMessage = media?.length
       ? attachRuntimePromptMediaFacts(runtimeMessage, media, imageOrder)
       : runtimeMessage;
+    setSteeringMessageIdentity(promptMessage, queueIdentity);
     this.agent.steer(
       transcriptContext
         ? attachRuntimeUserTurnTranscriptContext(promptMessage, transcriptContext)

--- a/src/agents/sessions/steering-message-identity.ts
+++ b/src/agents/sessions/steering-message-identity.ts
@@ -1,0 +1,21 @@
+import type { AgentMessage } from "../runtime/index.js";
+
+const STEERING_MESSAGE_IDENTITY = Symbol.for("openclaw.steeringMessageIdentity");
+
+export function setSteeringMessageIdentity(
+  message: AgentMessage,
+  identity: string | undefined,
+): void {
+  if (identity) {
+    Object.defineProperty(message, STEERING_MESSAGE_IDENTITY, {
+      configurable: true,
+      value: identity,
+    });
+  }
+}
+
+export function getSteeringMessageIdentity(message: unknown): string | undefined {
+  return message && typeof message === "object"
+    ? ((message as Record<PropertyKey, unknown>)[STEERING_MESSAGE_IDENTITY] as string | undefined)
+    : undefined;
+}

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -527,6 +527,7 @@ export type RunReplyAgentParams = {
   resolvedQueue: QueueSettings;
   shouldSteer: boolean;
   shouldFollowup: boolean;
+  queueAdmissionState?: "empty" | "steering" | "ready";
   isActive: boolean;
   isRunActive?: () => boolean;
   opts?: InternalGetReplyOptions;

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -1,3 +1,5 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
@@ -44,7 +46,14 @@ import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
-import { enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
+import {
+  admitFollowupRunLifecycle,
+  enqueueFollowupRun,
+  parkSteerCandidate,
+  resolveFollowupAbortSignal,
+  scheduleFollowupDrain,
+} from "./queue.js";
+import { REPLY_ADMISSION_TICKET } from "./reply-admission-ticket.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
 import * as replyRunState from "./reply-operation-run-state.js";
 import { type ReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
@@ -56,7 +65,7 @@ import {
   retireTerminalRestartRecoverySourceClaim,
 } from "./restart-recovery-claim.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
-import { readChannelSourceTurnId } from "./source-turn-id.js";
+import { buildChannelSourceTurnId, readChannelSourceTurnId } from "./source-turn-id.js";
 import { createTypingSignaler } from "./typing-mode.js";
 export async function runReplyAgent(
   params: RunReplyAgentParams,
@@ -69,6 +78,7 @@ export async function runReplyAgent(
     resolvedQueue,
     shouldSteer,
     shouldFollowup,
+    queueAdmissionState = "empty",
     isActive,
     isRunActive,
     opts,
@@ -95,6 +105,7 @@ export async function runReplyAgent(
   } = params;
   // One lifecycle for all adoption sites in this run.
   const turnAdoptionLifecycle = opts?.turnAdoptionLifecycle;
+  const releaseAdmissionTicket = () => opts?.[REPLY_ADMISSION_TICKET]?.release();
   let activeSessionEntry = sessionEntry;
   const activeSessionStore = sessionStore;
   let activeIsNewSession = isNewSession;
@@ -173,6 +184,7 @@ export async function runReplyAgent(
         }
       }
     }
+    releaseAdmissionTicket();
     typing.cleanup();
     return undefined;
   }
@@ -209,83 +221,6 @@ export async function runReplyAgent(
     }
   };
 
-  let shouldQueueAfterSteerRejection = false;
-  if (effectiveShouldSteer && isActive && opts?.messageInjectionAttempted !== true) {
-    // Steer against the operation that owns THIS session's run slot. A native
-    // command continuation whose slot adoption was skipped (#104844) still
-    // carries a source-keyed reservation; steering by its stale sessionId
-    // would miss the live target run.
-    const registeredReplyOperation = sessionKey ? replyRunRegistry.get(sessionKey) : undefined;
-    const activeReplyOperation =
-      providedReplyOperation?.key === sessionKey
-        ? providedReplyOperation
-        : (registeredReplyOperation ?? providedReplyOperation);
-    const steerSessionId = activeReplyOperation?.sessionId ?? followupRun.run.sessionId;
-    const steerOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
-      steerSessionId,
-      followupRun.prompt,
-      {
-        steeringMode: "all",
-        isInboundUserMessage: true,
-        ...(followupRun.images?.length ? { images: followupRun.images } : {}),
-        ...(followupRun.imageOrder?.length ? { imageOrder: followupRun.imageOrder } : {}),
-        ...(followupRun.media?.length ? { media: followupRun.media } : {}),
-        ...(turnAdoptionLifecycle ? { waitForTranscriptCommit: true } : {}),
-        ...(resolvedQueue.debounceMs !== undefined ? { debounceMs: resolvedQueue.debounceMs } : {}),
-        ...(followupRun.run.sourceReplyDeliveryMode
-          ? { sourceReplyDeliveryMode: followupRun.run.sourceReplyDeliveryMode }
-          : {}),
-        taskSuggestionDeliveryMode: followupRun.run.taskSuggestionDeliveryMode,
-        ...(followupRun.userTurnTranscriptRecorder
-          ? { userTurnTranscriptRecorder: followupRun.userTurnTranscriptRecorder }
-          : {}),
-      },
-    );
-    if (steerOutcome.queued) {
-      const adoptionDisposition = await finalizeAcceptedSteer({
-        activeReplyOperation,
-        abortKey: sessionKey ?? queueKey,
-        cleanupTyping: () => typing.cleanup(),
-        errorMessage: steerOutcome.errorMessage,
-        onAdopted: turnAdoptionLifecycle ? () => turnAdoptionLifecycle.onAdopted() : undefined,
-        replyOperationRunState,
-        steerSessionId,
-        transcriptCommit: steerOutcome.transcriptCommit,
-      });
-      if (adoptionDisposition === "stop") {
-        return undefined;
-      }
-      if (followupRun.currentInboundAudio === true) {
-        activeReplyOperation?.markAcceptedSteeredInboundAudio();
-      }
-      if (activeReplyOperation) {
-        // Steering joins the existing task; its dispatch-local controller is
-        // disposable, while the task-owned controller must keep its lifetime.
-        await refreshReplyOperationTyping(activeReplyOperation, {
-          startIfIdle: typingSignals.shouldStartImmediately,
-        });
-      }
-      await touchActiveSessionEntry();
-      typing.cleanup();
-      return undefined;
-    }
-    // A vanished/non-streaming owner can fall through; every rejection from a
-    // still-owning runtime must retain this exact turn as a follow-up.
-    shouldQueueAfterSteerRejection = !["no_active_run", "not_streaming", "stale_run"].includes(
-      steerOutcome.reason,
-    );
-    const summary = formatEmbeddedAgentQueueFailureSummary(steerOutcome);
-    logVerbose(`queue: active session ${steerSessionId} rejected steering injection: ${summary}`);
-  }
-
-  const activeRunQueueAction = resolveActiveRunQueueAction({
-    isActive,
-    isHeartbeat,
-    shouldFollowup: effectiveShouldFollowup || shouldQueueAfterSteerRejection,
-    queueMode: activeRunQueueMode,
-    resetTriggered: effectiveResetTriggered,
-  });
-
   const queuedRunFollowupTurn = createFollowupRunner({
     opts,
     typing,
@@ -298,10 +233,172 @@ export async function runReplyAgent(
     agentCfgContextTokens,
     toolProgressDetail,
   });
+
+  if (effectiveShouldSteer && isActive && opts?.messageInjectionAttempted !== true) {
+    // Steer against the operation that owns THIS session's run slot. A native
+    // command continuation whose slot adoption was skipped (#104844) still
+    // carries a source-keyed reservation; steering by its stale sessionId
+    // would miss the live target run.
+    const registeredReplyOperation = sessionKey ? replyRunRegistry.get(sessionKey) : undefined;
+    const activeReplyOperation =
+      providedReplyOperation?.key === sessionKey
+        ? providedReplyOperation
+        : (registeredReplyOperation ?? providedReplyOperation);
+    const steerSessionId = activeReplyOperation?.sessionId ?? followupRun.run.sessionId;
+    replyRunState.bindQueueDispositionToRunState(followupRun, replyOperationRunState);
+    const parked = parkSteerCandidate(queueKey, followupRun, resolvedQueue, queuedRunFollowupTurn);
+    if (!parked) {
+      releaseAdmissionTicket();
+      typing.cleanup();
+      return undefined;
+    }
+    const scheduleParkedFallback = () => {
+      const owner = replyRunRegistry.get(queueKey);
+      if (owner) {
+        scheduleFollowupDrainAfterReplyOperationClear({
+          operation: owner,
+          queueKey,
+          runFollowup: queuedRunFollowupTurn,
+        });
+      } else {
+        scheduleFollowupDrain(queueKey, queuedRunFollowupTurn);
+      }
+    };
+    scheduleParkedFallback();
+    releaseAdmissionTicket();
+    try {
+      const admission = await parked.admit();
+      if (admission === "cancelled") {
+        parked.consume();
+        typing.cleanup();
+        return undefined;
+      }
+      if (admission === "fallback") {
+        parked.fallback();
+        if (replyOperationRunState) {
+          replyOperationRunState.admission = { status: "accepted", mode: "followup" };
+        }
+        await touchActiveSessionEntry();
+        typing.cleanup();
+        return undefined;
+      }
+      // Channel dispatch normally stamps the route-scoped source id. Internal
+      // callers can derive the same per-message identity from the prepared turn.
+      const steerRunId = expectDefined(
+        restartRecoverySourceTurnId ??
+          buildChannelSourceTurnId({
+            provider:
+              followupRun.originatingChannel ??
+              followupRun.run.messageProvider ??
+              sessionCtx.Provider,
+            accountId:
+              followupRun.originatingAccountId ??
+              followupRun.run.agentAccountId ??
+              sessionCtx.AccountId,
+            conversationId:
+              followupRun.originatingTo ??
+              followupRun.originatingChatId ??
+              sessionKey ??
+              followupRun.run.sessionKey,
+            messageId: followupRun.messageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
+          }) ??
+          normalizeOptionalString(opts?.runId),
+        "steered turn id",
+      );
+      const steerOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
+        steerSessionId,
+        followupRun.prompt,
+        {
+          steeringMode: "all",
+          isInboundUserMessage: true,
+          ...(followupRun.images?.length ? { images: followupRun.images } : {}),
+          ...(followupRun.imageOrder?.length ? { imageOrder: followupRun.imageOrder } : {}),
+          ...(followupRun.media?.length ? { media: followupRun.media } : {}),
+          waitForTranscriptCommit: true,
+          queueIdentity: steerRunId,
+          abortSignal: resolveFollowupAbortSignal(followupRun),
+          onQueueAccepted: parked.accepted,
+          ...(resolvedQueue.debounceMs !== undefined
+            ? { debounceMs: resolvedQueue.debounceMs }
+            : {}),
+          ...(followupRun.run.sourceReplyDeliveryMode
+            ? { sourceReplyDeliveryMode: followupRun.run.sourceReplyDeliveryMode }
+            : {}),
+          taskSuggestionDeliveryMode: followupRun.run.taskSuggestionDeliveryMode,
+          ...(followupRun.userTurnTranscriptRecorder
+            ? { userTurnTranscriptRecorder: followupRun.userTurnTranscriptRecorder }
+            : {}),
+        },
+      );
+      if (!steerOutcome.queued) {
+        parked.fallback();
+        if (replyOperationRunState) {
+          replyOperationRunState.admission = { status: "accepted", mode: "followup" };
+        }
+        const summary = formatEmbeddedAgentQueueFailureSummary(steerOutcome);
+        logVerbose(
+          `queue: active session ${steerSessionId} rejected steering injection: ${summary}`,
+        );
+        await touchActiveSessionEntry();
+        typing.cleanup();
+        return undefined;
+      }
+      const adoptionDisposition = await finalizeAcceptedSteer({
+        activeReplyOperation,
+        abortKey: sessionKey ?? queueKey,
+        cleanupTyping: () => typing.cleanup(),
+        errorMessage: steerOutcome.errorMessage,
+        onAdopted: () => admitFollowupRunLifecycle(followupRun),
+        replyOperationRunState,
+        steerSessionId,
+        transcriptCommit: steerOutcome.transcriptCommit,
+      });
+      parked.consume();
+      if (adoptionDisposition === "stop") {
+        return undefined;
+      }
+      if (followupRun.currentInboundAudio === true) {
+        activeReplyOperation?.markAcceptedSteeredInboundAudio();
+      }
+      if (activeReplyOperation) {
+        await refreshReplyOperationTyping(activeReplyOperation, {
+          startIfIdle: typingSignals.shouldStartImmediately,
+        });
+      }
+      await touchActiveSessionEntry();
+      typing.cleanup();
+      return undefined;
+    } catch (error) {
+      if (resolveFollowupAbortSignal(followupRun)?.aborted) {
+        parked.consume();
+      } else {
+        parked.fallback();
+      }
+      throw error;
+    } finally {
+      if (followupRun.steerPending) {
+        if (resolveFollowupAbortSignal(followupRun)?.aborted) {
+          parked.consume();
+        } else {
+          parked.fallback();
+        }
+      }
+    }
+  }
+
+  const activeRunQueueAction = resolveActiveRunQueueAction({
+    queueAdmissionState,
+    isActive,
+    isHeartbeat,
+    shouldFollowup: effectiveShouldFollowup,
+    queueMode: activeRunQueueMode,
+    resetTriggered: effectiveResetTriggered,
+  });
   if (activeRunQueueAction === "drop") {
     if (replyOperationRunState) {
       replyOperationRunState.admission = { status: "skipped", reason: "active-run" };
     }
+    releaseAdmissionTicket();
     typing.cleanup();
     return undefined;
   }
@@ -317,6 +414,7 @@ export async function runReplyAgent(
       false,
     );
     if (!enqueued) {
+      releaseAdmissionTicket();
       typing.cleanup();
       return undefined;
     }
@@ -335,6 +433,7 @@ export async function runReplyAgent(
     } else {
       scheduleFollowupDrain(queueKey, queuedRunFollowupTurn);
     }
+    releaseAdmissionTicket();
     const queuedBehindActiveRun = isRunActive?.() === true;
     await touchActiveSessionEntry();
     if (queuedBehindActiveRun) {
@@ -426,6 +525,7 @@ export async function runReplyAgent(
     if (replyOperationRunState) {
       replyOperationRunState.admission = { status: "owned" };
     }
+    releaseAdmissionTicket();
   } else {
     const replyTurnKind = resolveReplyTurnKind(opts);
     const admission = await admitReplyTurn({
@@ -447,6 +547,7 @@ export async function runReplyAgent(
           : { status: "skipped", reason: admission.reason };
     }
     if (admission.status === "skipped") {
+      releaseAdmissionTicket();
       typing.cleanup();
       if (admission.reason !== "active-run" || replyTurnKind !== "visible") {
         return undefined;
@@ -456,6 +557,7 @@ export async function runReplyAgent(
       });
     }
     replyOperation = admission.operation;
+    releaseAdmissionTicket();
     const previousRunSessionId = followupRun.run.sessionId;
     followupRun.run.sessionId = replyOperation.sessionId;
     if (replyOperation.sessionId !== previousRunSessionId) {

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -26,8 +26,8 @@ export async function finalizeAcceptedSteer(params: {
     }
   };
   if (transcriptCommitUnconfirmed) {
-    // Work without a confirmed canonical transcript must stop, but the source
-    // remains adopted because harness acceptance is already irreversible.
+    // The runtime accepted this message, but exact cancellation could not find it.
+    // Preserve at-most-once delivery: abort the uncertain owner without replaying.
     abortActiveRun();
     logVerbose(
       `queue: active session ${params.steerSessionId} accepted steering without transcript confirmation; aborting active run without ingress replay (${params.errorMessage ?? "unknown receipt failure"})`,

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -34,11 +34,23 @@ const queueEmbeddedAgentMessageWithOutcomeAsyncMock = vi.fn(
 const resolveEmbeddedSessionLaneMock = vi.fn();
 const waitForEmbeddedAgentRunEndMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
+const parkedSteerAdmitMock = vi.fn(async () => "steer" as const);
+const parkedSteerAcceptedMock = vi.fn();
+const parkedSteerFallbackMock = vi.fn();
+const parkedSteerConsumeMock = vi.fn();
+const parkSteerCandidateMock = vi.fn(() => ({
+  admit: parkedSteerAdmitMock,
+  accepted: parkedSteerAcceptedMock,
+  fallback: parkedSteerFallbackMock,
+  consume: parkedSteerConsumeMock,
+}));
 const scheduleFollowupDrainMock = vi.fn();
 const refreshQueuedFollowupSessionMock = vi.fn();
 const resolveCommandSecretRefsViaGatewayMock = vi.fn();
 const resolveOutboundAttachmentFromUrlMock = vi.fn();
 const createReplyMediaContextRuntimeMock = vi.fn();
+const EXPECTED_STEER_QUEUE_IDENTITY =
+  "channel-user:v1:6f3f31084a7a2a6ff17176c0c16682e64d9f21301f64ff7e5bf1173b54fadc33";
 
 vi.mock("../../agents/model-fallback-runner.js", () => ({
   runWithModelFallback: (params: {
@@ -249,8 +261,11 @@ vi.mock("./agent-runner-memory.js", () => ({
 }));
 
 vi.mock("./queue.js", () => ({
+  admitFollowupRunLifecycle: vi.fn(async () => {}),
   enqueueFollowupRun: enqueueFollowupRunMock,
+  parkSteerCandidate: parkSteerCandidateMock,
   refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock,
+  resolveFollowupAbortSignal: vi.fn(() => undefined),
   scheduleFollowupDrain: scheduleFollowupDrainMock,
 }));
 
@@ -358,6 +373,18 @@ describe("runReplyAgent media path normalization", () => {
     resolveEmbeddedSessionLaneMock.mockReset();
     waitForEmbeddedAgentRunEndMock.mockReset();
     enqueueFollowupRunMock.mockReset();
+    parkedSteerAdmitMock.mockReset();
+    parkedSteerAdmitMock.mockResolvedValue("steer");
+    parkedSteerAcceptedMock.mockReset();
+    parkedSteerFallbackMock.mockReset();
+    parkedSteerConsumeMock.mockReset();
+    parkSteerCandidateMock.mockReset();
+    parkSteerCandidateMock.mockReturnValue({
+      admit: parkedSteerAdmitMock,
+      accepted: parkedSteerAcceptedMock,
+      fallback: parkedSteerFallbackMock,
+      consume: parkedSteerConsumeMock,
+    });
     scheduleFollowupDrainMock.mockReset();
     refreshQueuedFollowupSessionMock.mockReset();
     resolveCommandSecretRefsViaGatewayMock.mockReset();
@@ -452,12 +479,18 @@ describe("runReplyAgent media path normalization", () => {
       "session",
       "generate chart",
       {
+        abortSignal: undefined,
         steeringMode: "all",
         isInboundUserMessage: true,
+        waitForTranscriptCommit: true,
+        queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
+        onQueueAccepted: parkedSteerAcceptedMock,
         taskSuggestionDeliveryMode: "gateway",
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
+    expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
   });
 
   it("steers ordered current-turn images with the active prompt", async () => {
@@ -492,14 +525,20 @@ describe("runReplyAgent media path normalization", () => {
       "session",
       "compare these",
       {
+        abortSignal: undefined,
         steeringMode: "all",
         isInboundUserMessage: true,
+        waitForTranscriptCommit: true,
+        queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
+        onQueueAccepted: parkedSteerAcceptedMock,
         images,
         media: followupRun.media,
         taskSuggestionDeliveryMode: undefined,
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
+    expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
   });
 
   it("defers the complete image turn when the active runtime cannot preserve images", async () => {
@@ -523,8 +562,15 @@ describe("runReplyAgent media path normalization", () => {
       }),
     );
 
-    expect(enqueueFollowupRunMock).toHaveBeenCalledOnce();
-    expect(enqueueFollowupRunMock.mock.calls[0]?.[1]).toBe(followupRun);
+    expect(parkSteerCandidateMock).toHaveBeenCalledWith(
+      "main",
+      followupRun,
+      expect.objectContaining({ mode: "steer" }),
+      expect.any(Function),
+    );
+    expect(parkedSteerFallbackMock).toHaveBeenCalledOnce();
+    expect(parkedSteerConsumeMock).not.toHaveBeenCalled();
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
   });
 
   it("latches audio only after the active reply operation accepts the steer", async () => {
@@ -562,12 +608,18 @@ describe("runReplyAgent media path normalization", () => {
       "session",
       "summarize the audio",
       {
+        abortSignal: undefined,
         steeringMode: "all",
         isInboundUserMessage: true,
+        waitForTranscriptCommit: true,
+        queueIdentity: EXPECTED_STEER_QUEUE_IDENTITY,
+        onQueueAccepted: parkedSteerAcceptedMock,
         taskSuggestionDeliveryMode: undefined,
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
+    expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
   });
 
   it("queues active prompts in followup mode without steering", async () => {
@@ -582,6 +634,7 @@ describe("runReplyAgent media path normalization", () => {
     );
 
     expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).not.toHaveBeenCalled();
+    expect(parkSteerCandidateMock).not.toHaveBeenCalled();
     expect(enqueueFollowupRunMock).toHaveBeenCalledOnce();
     expect(enqueueFollowupRunMock.mock.calls[0]?.[1].prompt).toBe("generate chart");
   });
@@ -605,8 +658,15 @@ describe("runReplyAgent media path normalization", () => {
       }),
     );
 
-    expect(enqueueFollowupRunMock).toHaveBeenCalledOnce();
-    expect(enqueueFollowupRunMock.mock.calls[0]?.[1].prompt).toBe("generate chart");
+    expect(parkSteerCandidateMock).toHaveBeenCalledWith(
+      "main",
+      expect.objectContaining({ prompt: "generate chart" }),
+      expect.objectContaining({ mode: "steer" }),
+      expect.any(Function),
+    );
+    expect(parkedSteerFallbackMock).toHaveBeenCalledOnce();
+    expect(parkedSteerConsumeMock).not.toHaveBeenCalled();
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
   });
 
   it("shares one media cache between block accumulation and final payload delivery", async () => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -165,7 +165,15 @@ vi.mock("../../runtime.js", () => {
 
 vi.mock("./queue.js", () => {
   return {
+    admitFollowupRunLifecycle: vi.fn(async () => {}),
     enqueueFollowupRun: vi.fn(),
+    parkSteerCandidate: vi.fn(() => ({
+      admit: async () => "steer",
+      accepted: vi.fn(),
+      fallback: vi.fn(),
+      consume: vi.fn(),
+    })),
+    resolveFollowupAbortSignal: vi.fn(() => undefined),
     scheduleFollowupDrain: vi.fn(),
     clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
     refreshQueuedFollowupSession: (...args: unknown[]) => refreshQueuedFollowupSessionMock(...args),

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -30,6 +30,7 @@ import {
 } from "./agent-runner-failure-copy.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import {
+  clearSessionQueues,
   enqueueFollowupRun,
   refreshQueuedFollowupSession,
   scheduleFollowupDrain,
@@ -77,6 +78,19 @@ const state = vi.hoisted(() => ({
   queueEmbeddedAgentMessageMock: vi.fn(),
   runEmbeddedAgentMock: vi.fn(),
 }));
+const parkedSteer = vi.hoisted(() => {
+  const admit = vi.fn(async () => "steer" as const);
+  const accepted = vi.fn();
+  const fallback = vi.fn();
+  const consume = vi.fn();
+  return {
+    admit,
+    accepted,
+    fallback,
+    consume,
+    park: vi.fn(() => ({ admit, accepted, fallback, consume })),
+  };
+});
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -270,6 +284,7 @@ vi.mock("../../gateway/mcp-app-channel-action.js", () => ({
 vi.mock("./queue.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./queue.js")>()),
   enqueueFollowupRun: vi.fn(),
+  parkSteerCandidate: parkedSteer.park,
   refreshQueuedFollowupSession: vi.fn(),
   scheduleFollowupDrain: vi.fn(),
 }));
@@ -282,6 +297,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  clearSessionQueues(["main"]);
   replyRunTesting.resetReplyRunRegistry();
   state.compactEmbeddedAgentSessionMock.mockReset();
   state.compactEmbeddedAgentSessionMock.mockResolvedValue({
@@ -300,6 +316,17 @@ beforeEach(() => {
   state.queueEmbeddedAgentMessageMock.mockReturnValue(false);
   state.getChannelPluginMock.mockReset();
   state.materializeMcpAppChannelPresentationMock.mockReset();
+  parkedSteer.admit.mockReset().mockResolvedValue("steer");
+  parkedSteer.accepted.mockReset();
+  parkedSteer.fallback.mockReset();
+  parkedSteer.consume.mockReset();
+  parkedSteer.park.mockReset();
+  parkedSteer.park.mockReturnValue({
+    admit: parkedSteer.admit,
+    accepted: parkedSteer.accepted,
+    fallback: parkedSteer.fallback,
+    consume: parkedSteer.consume,
+  });
   vi.mocked(enqueueFollowupRun).mockReset().mockReturnValue(true);
   vi.mocked(refreshQueuedFollowupSession).mockReset();
   vi.mocked(scheduleFollowupDrain).mockReset();
@@ -350,6 +377,7 @@ function createMinimalRun(params?: {
     prompt: "hello",
     summaryLine: "hello",
     enqueuedAt: Date.now(),
+    turnAdoptionLifecycle: opts?.turnAdoptionLifecycle,
     currentInboundEventKind: params?.currentInboundEventKind,
     originatingChannel: sessionCtx.OriginatingChannel ?? sessionCtx.Provider,
     originatingTo: sessionCtx.OriginatingTo,
@@ -413,6 +441,15 @@ function createMinimalRun(params?: {
       });
     },
   };
+}
+
+function requireScheduledFollowupRunner(): (run: FollowupRun) => Promise<void> {
+  const scheduled = vi.mocked(scheduleFollowupDrain).mock.calls.at(-1);
+  if (!scheduled) {
+    throw new Error("expected a scheduled follow-up drain");
+  }
+  expect(scheduled[0]).toBe("main");
+  return scheduled[1];
 }
 
 async function runHookBackedEmbeddedAgent(params: {
@@ -598,14 +635,14 @@ describe("runReplyAgent active steering", () => {
     active.complete();
   });
 
-  it("does not dispatch again when a declined steer falls through to a new turn", async () => {
+  it("replays a declined steer without dispatching its hook twice", async () => {
     state.beforeAgentReplyHasHooksMock.mockImplementation(
       (hookName) => hookName === "before_agent_reply",
     );
     state.beforeAgentReplyRunMock.mockResolvedValue(undefined);
     state.queueEmbeddedAgentMessageMock.mockReturnValueOnce(false);
     state.runEmbeddedAgentMock.mockImplementationOnce(runHookBackedEmbeddedAgent);
-    const { run } = createMinimalRun({
+    const { followupRun, run } = createMinimalRun({
       isActive: true,
       shouldSteer: true,
       resolvedQueueMode: "steer",
@@ -618,11 +655,15 @@ describe("runReplyAgent active steering", () => {
       runOverrides: { agentId: "main", messageProvider: "discord" },
     });
 
-    await expect(run()).resolves.toEqual(expect.objectContaining({ text: "model reply" }));
+    await expect(run()).resolves.toBeUndefined();
 
     expect(state.beforeAgentReplyRunMock).toHaveBeenCalledOnce();
     expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledOnce();
+    expect(parkedSteer.fallback).toHaveBeenCalledOnce();
+    expect(parkedSteer.consume).not.toHaveBeenCalled();
+    await requireScheduledFollowupRunner()(followupRun);
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    expect(state.beforeAgentReplyRunMock).toHaveBeenCalledOnce();
   });
 
   it("runs normal reply hooks once after Gateway already attempted injection", async () => {
@@ -743,6 +784,8 @@ describe("runReplyAgent active steering", () => {
 
     expect(events).toEqual(["transcript-committed", "adoption-finalizer"]);
     expect(onAdopted).toHaveBeenCalledTimes(1);
+    expect(parkedSteer.consume).toHaveBeenCalledOnce();
+    expect(parkedSteer.fallback).not.toHaveBeenCalled();
     expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledTimes(1);
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
@@ -783,22 +826,18 @@ describe("runReplyAgent active steering", () => {
 
     await expect(run()).resolves.toBeUndefined();
 
-    expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
-    const enqueueArgs = mockCallArgs(vi.mocked(enqueueFollowupRun), "enqueue follow-up");
-    const queued = enqueueArgs[1] as FollowupRun;
-    const runFollowup = enqueueArgs[4];
-    if (typeof runFollowup !== "function") {
-      throw new Error("expected queued follow-up runner");
-    }
-    await runFollowup(queued);
-
+    expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
+    expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalled();
     expect(state.beforeAgentReplyRunMock).toHaveBeenCalledOnce();
-    expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
-    expect(onBlockReply).toHaveBeenCalledWith(expect.objectContaining({ text: "model reply" }));
+    expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
     expect(onAdopted).not.toHaveBeenCalled();
+    expect(parkedSteer.fallback).toHaveBeenCalledOnce();
+    expect(parkedSteer.consume).not.toHaveBeenCalled();
   });
 
-  it("adopts but never replays steering accepted without transcript confirmation", async () => {
+  it("adopts and consumes unconfirmed steering without replay", async () => {
+    const runState: ReplyOperationRunState = {};
     const cancel = vi.fn();
     const active = createReplyOperation({
       sessionKey: "main",
@@ -821,7 +860,10 @@ describe("runReplyAgent active steering", () => {
     });
     const onAdopted = vi.fn();
     const { run, typing } = createMinimalRun({
-      opts: { turnAdoptionLifecycle: { onAdopted } },
+      opts: {
+        [REPLY_OPERATION_RUN_STATE]: runState,
+        turnAdoptionLifecycle: { onAdopted },
+      },
       isActive: true,
       shouldSteer: true,
       shouldFollowup: true,
@@ -832,17 +874,25 @@ describe("runReplyAgent active steering", () => {
 
     expect(onAdopted).toHaveBeenCalledOnce();
     expect(cancel).toHaveBeenCalledOnce();
-    expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
+    expect(runState.admission).toEqual({ status: "accepted", mode: "steer" });
+    expect(parkedSteer.consume).toHaveBeenCalledOnce();
+    expect(parkedSteer.fallback).not.toHaveBeenCalled();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledOnce();
+    active.complete();
   });
 
   it("admits an ordinary rejected steering turn with durable recovery state", async () => {
     const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
-    const onAdopted = vi.fn(async () => {
+    const onAdopted = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
       expect((await readStoredMainSession(storePath)).restartRecoveryBeforeAgentReplyState).toBe(
         "admitted",
       );
+      return {
+        payloads: [{ text: "final" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
     });
     const { followupRun, run, sourceTurnId } = createMinimalRun({
       opts: { turnAdoptionLifecycle: { onAdopted } },
@@ -870,9 +920,12 @@ describe("runReplyAgent active steering", () => {
       text: "steering rejected before admission",
     });
 
-    await expect(run()).resolves.toEqual(expect.objectContaining({ text: "final" }));
+    await expect(run()).resolves.toBeUndefined();
 
     expect(state.beforeAgentReplyRunMock).not.toHaveBeenCalled();
+    expect(parkedSteer.fallback).toHaveBeenCalledOnce();
+    expect(parkedSteer.consume).not.toHaveBeenCalled();
+    await requireScheduledFollowupRunner()(followupRun);
     expect(onAdopted).toHaveBeenCalledOnce();
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
   });

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -657,7 +657,7 @@ describe("runReplyAgent active steering", () => {
 
     await expect(run()).resolves.toBeUndefined();
 
-    expect(state.beforeAgentReplyRunMock).toHaveBeenCalledOnce();
+    expect(state.beforeAgentReplyRunMock).not.toHaveBeenCalled();
     expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledOnce();
     expect(parkedSteer.fallback).toHaveBeenCalledOnce();
     expect(parkedSteer.consume).not.toHaveBeenCalled();
@@ -828,7 +828,7 @@ describe("runReplyAgent active steering", () => {
 
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
     expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalled();
-    expect(state.beforeAgentReplyRunMock).toHaveBeenCalledOnce();
+    expect(state.beforeAgentReplyRunMock).not.toHaveBeenCalled();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(onBlockReply).not.toHaveBeenCalled();
     expect(onAdopted).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/dispatch-from-config.prepare-operation.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-operation.ts
@@ -20,6 +20,7 @@ import {
   loadAbortRuntime,
   loadFastApproveRuntime,
 } from "./dispatch-from-config.runtime-loaders.js";
+import { REPLY_ADMISSION_TICKET } from "./reply-admission-ticket.js";
 import { extractShortModelName } from "./response-prefix-template.js";
 
 export async function prepareDispatchOperation(state: PrepareDispatchOperationContextReadyState) {
@@ -145,6 +146,10 @@ export async function prepareDispatchOperation(state: PrepareDispatchOperationCo
   }
   // Own the session before plugin-bound handlers or message hooks can perform
   // work. Fast abort, fast approval, and inbound dedupe remain ahead of this gate.
+  const admissionTicket = params.replyOptions?.[REPLY_ADMISSION_TICKET];
+  if (admissionTicket && !(await admissionTicket.wait(params.replyOptions?.abortSignal))) {
+    return { status: "complete" as const, result: finishReplyOperationAbortedDispatch() };
+  }
   const preDispatchAcquisition = await state.ensureDispatchReplyOperation("pre_dispatch");
   if (preDispatchAcquisition.status === "aborted") {
     return { status: "complete" as const, result: finishReplyOperationAbortedDispatch() };

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,4 +1,5 @@
 /** Main reply dispatch pipeline from finalized config/context to delivery payloads. */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { isDispatchReplyOperationAbortedError } from "./dispatch-from-config.abort.js";
 import { createInboundMessageAuditTerminal } from "./dispatch-from-config.audit.js";
@@ -15,6 +16,7 @@ import type {
   DispatchFromConfigResult,
 } from "./dispatch-from-config.types.js";
 import { commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
+import { REPLY_ADMISSION_TICKET, reserveReplyAdmissionTicket } from "./reply-admission-ticket.js";
 import "./dispatch-from-config.events.js";
 
 export type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
@@ -23,14 +25,26 @@ export type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
 export async function dispatchReplyFromConfig(
   params: DispatchFromConfigParams,
 ): Promise<DispatchFromConfigResult> {
+  const ticket = reserveReplyAdmissionTicket([
+    normalizeOptionalString(params.ctx.SessionKey),
+    normalizeOptionalString(params.ctx.CommandTargetSessionKey),
+  ]);
+  const ticketedParams = ticket
+    ? {
+        ...params,
+        replyOptions: { ...params.replyOptions, [REPLY_ADMISSION_TICKET]: ticket },
+      }
+    : params;
   const messageAuditTerminal = createInboundMessageAuditTerminal(params);
   try {
-    const result = await dispatchReplyFromConfigInner(params, messageAuditTerminal);
+    const result = await dispatchReplyFromConfigInner(ticketedParams, messageAuditTerminal);
     messageAuditTerminal?.finishSuccess(result);
     return result;
   } catch (error) {
     messageAuditTerminal?.finishError();
     throw error;
+  } finally {
+    ticket?.release();
   }
 }
 

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -34,6 +34,7 @@ import { resolvePreparedReplyQueueState } from "./get-reply-run-queue.js";
 import { buildReplyPromptEnvelope } from "./prompt-prelude.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
+import { getExistingFollowupQueue } from "./queue/state.js";
 import {
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   abortReplyRunBySessionId,
@@ -494,9 +495,18 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     }
   }
   const { activeSessionId, isActive } = resolveQueueBusyState();
+  const pendingQueue = getExistingFollowupQueue(queueKey);
+  const queueAdmissionState = !pendingQueue
+    ? "empty"
+    : pendingQueue.items.some((item) => !item.steerPending) ||
+        pendingQueue.inFlight.size > 0 ||
+        pendingQueue.droppedCount > 0
+      ? "ready"
+      : "steering";
   const activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   const shouldSteer =
     !isRoomEvent &&
+    queueAdmissionState !== "ready" &&
     activeRunAcceptsCurrentThread &&
     !context.isHeartbeat &&
     !effectiveResetTriggered &&
@@ -508,6 +518,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
       resolvedQueue.mode === "followup" ||
       resolvedQueue.mode === "collect");
   const activeRunQueueAction = resolveActiveRunQueueAction({
+    queueAdmissionState,
     isActive,
     isHeartbeat: context.isHeartbeat,
     shouldFollowup,
@@ -581,6 +592,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     queueKey,
     shouldSteer,
     shouldFollowup,
+    queueAdmissionState,
     isActive,
     authProfileId,
     authProfileIdSource,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -59,6 +59,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     queueKey,
     shouldSteer,
     shouldFollowup,
+    queueAdmissionState,
     isActive,
     authProfileId,
     authProfileIdSource,
@@ -452,6 +453,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     resolvedQueue,
     shouldSteer,
     shouldFollowup,
+    queueAdmissionState,
     isActive,
     isRunActive: () => {
       const latestSessionState = resolvePreparedSessionState();

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -7,6 +7,7 @@ import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import type { FollowupQueueDisposition } from "./queue/types.js";
+import type { ReplyOptionsWithAdmissionTicket } from "./reply-admission-ticket.js";
 import type { ReplyOptionsWithOperationRunState } from "./reply-operation-run-state.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 
@@ -40,7 +41,8 @@ type InternalReplySessionOptions = {
 export type InternalGetReplyOptions = GetReplyOptions &
   InternalReplySessionOptions &
   ReplyOptionsWithHeartbeatRunScope &
-  ReplyOptionsWithOperationRunState;
+  ReplyOptionsWithOperationRunState &
+  ReplyOptionsWithAdmissionTicket;
 
 export function shouldBridgeCliPreambleEvents(opts: InternalGetReplyOptions | undefined): boolean {
   return opts?.commentaryProgressEnabled === true || opts?.progressPreambleEnabled === true;

--- a/src/auto-reply/reply/queue-policy.ts
+++ b/src/auto-reply/reply/queue-policy.ts
@@ -6,13 +6,14 @@ export type ActiveRunQueueAction = "run-now" | "enqueue-followup" | "drop";
 
 /** Resolves whether an active session should run, queue, or drop a new inbound turn. */
 export function resolveActiveRunQueueAction(params: {
+  queueAdmissionState?: "empty" | "steering" | "ready";
   isActive: boolean;
   isHeartbeat: boolean;
   shouldFollowup: boolean;
   queueMode: QueueSettings["mode"];
   resetTriggered?: boolean;
 }): ActiveRunQueueAction {
-  if (!params.isActive) {
+  if (!params.isActive && (!params.queueAdmissionState || params.queueAdmissionState === "empty")) {
     return "run-now";
   }
   if (params.isHeartbeat) {
@@ -20,6 +21,9 @@ export function resolveActiveRunQueueAction(params: {
   }
   if (params.resetTriggered) {
     return "run-now";
+  }
+  if (params.queueAdmissionState && params.queueAdmissionState !== "empty") {
+    return "enqueue-followup";
   }
   // Follow-up queueing is only meaningful for non-heartbeat user turns.
   if (params.shouldFollowup) {

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -3,7 +3,7 @@
 export { clearSessionQueues } from "./queue/cleanup.js";
 export type { ClearSessionQueueResult } from "./queue/cleanup.js";
 export { scheduleFollowupDrain } from "./queue/drain.js";
-export { enqueueFollowupRun, getFollowupQueueDepth } from "./queue/enqueue.js";
+export { enqueueFollowupRun, getFollowupQueueDepth, parkSteerCandidate } from "./queue/enqueue.js";
 export { resolveQueueSettings } from "./queue/settings-runtime.js";
 export { refreshQueuedFollowupSession } from "./queue/state.js";
 export type { FollowupRun, QueueSettings } from "./queue/types.js";

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -1163,6 +1163,7 @@ export function scheduleFollowupDrain(
   // Give the detached chain its own root so inherited request admission cannot go stale.
   void runWithGatewayIndependentRootWorkContinuation(async () => {
     let retryDeferred = false;
+    let waitingForSteer = false;
     try {
       const collectState = { forceIndividualCollect: false };
       while (queue.items.length > 0 || queue.droppedCount > 0) {
@@ -1170,12 +1171,26 @@ export function scheduleFollowupDrain(
         if (queue.items.length === 0 && queue.droppedCount === 0) {
           break;
         }
+        if (queue.items.some((item) => item.steerPending)) {
+          waitingForSteer = true;
+          break;
+        }
         await waitForQueueDebounce(queue, queue.abortController.signal);
         await dropAbortedFollowups(queue.items, effectiveRunFollowup);
         if (queue.items.length === 0 && queue.droppedCount === 0) {
           break;
         }
+        if (queue.items.some((item) => item.steerPending)) {
+          waitingForSteer = true;
+          break;
+        }
         if (await drainProtectedPriorityFollowup(queue.items, effectiveRunFollowup)) {
+          continue;
+        }
+        if (queue.droppedCount > 0 && queue.items.some((item) => item.steerAnchor)) {
+          if (!(await drainNextQueueItem(queue.items, effectiveRunFollowup, reserveOptions))) {
+            break;
+          }
           continue;
         }
         if (
@@ -1386,7 +1401,11 @@ export function scheduleFollowupDrain(
     } finally {
       queue.draining = false;
       const hasPendingQueueWork = queue.items.length > 0 || queue.droppedCount > 0;
-      if (retryDeferred && hasPendingQueueWork) {
+      if (waitingForSteer && hasPendingQueueWork) {
+        if (!queue.items.some((item) => item.steerPending)) {
+          scheduleFollowupDrain(key, effectiveRunFollowup);
+        }
+      } else if (retryDeferred && hasPendingQueueWork) {
         scheduleFollowupDrain(key, effectiveRunFollowup);
       } else if (!hasPendingQueueWork) {
         // Only remove the map entry if it still points to this queue instance.

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,6 +1,7 @@
 // Enqueues follow-up reply runs and schedules queue drains.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../../channels/chat-type.js";
+import { logMessageQueuedWithBacklogPolicy } from "../../../logging/diagnostic-runtime.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
 import {
   applyQueueDropPolicy,
@@ -8,6 +9,7 @@ import {
   shouldSkipQueueItem,
 } from "../../../utils/queue-helpers.js";
 import {
+  clearFollowupDrainCallback,
   createOverflowSummaryRetrySource,
   kickFollowupDrainIfIdle,
   rememberFollowupDrainCallback,
@@ -19,7 +21,12 @@ import {
   recordRecentQueueMessageId,
   resetRecentQueuedMessageIdDedupe,
 } from "./recent-message-ids.js";
-import { getExistingFollowupQueue, getFollowupQueue, trimSummaryElisionsToCap } from "./state.js";
+import {
+  FOLLOWUP_QUEUES,
+  getExistingFollowupQueue,
+  getFollowupQueue,
+  trimSummaryElisionsToCap,
+} from "./state.js";
 import {
   completeFollowupRunLifecycle,
   isFollowupRunAborted,
@@ -89,6 +96,24 @@ function isRunAlreadyQueued(
   );
 }
 
+function appendQueueItem(params: {
+  key: string;
+  queue: ReturnType<typeof getFollowupQueue>;
+  run: FollowupRun;
+  recentMessageIdKey?: string;
+  runFollowup?: (run: FollowupRun) => Promise<void>;
+  restartIfIdle: boolean;
+  front: boolean;
+}): void {
+  params.queue.lastEnqueuedAt = Date.now();
+  params.queue.lastRun = params.run.run;
+  params.run.queueAbortSignal = params.queue.abortController.signal;
+  params.queue.items[params.front ? "unshift" : "push"](params.run);
+  if (params.recentMessageIdKey) recordRecentQueueMessageId(params.run, params.recentMessageIdKey);
+  if (params.runFollowup) rememberFollowupDrainCallback(params.key, params.runFollowup);
+  if (params.restartIfIdle && !params.queue.draining) kickFollowupDrainIfIdle(params.key);
+}
+
 export function enqueueFollowupRun(
   key: string,
   run: FollowupRun,
@@ -103,6 +128,9 @@ export function enqueueFollowupRun(
   }
   if (options.position === "front") {
     run.protectFromQueueOverflow = true;
+  }
+  if (options.steerCandidate) {
+    run.steerAnchor = true;
   }
   const queue = getFollowupQueue(key, settings);
   const recentMessageIdKey = dedupeMode !== "none" ? buildRecentMessageIdKey(run, key) : undefined;
@@ -120,10 +148,48 @@ export function enqueueFollowupRun(
   if (shouldSkipQueueItem({ item: run, items: queue.items, dedupe })) {
     return false;
   }
+  if (options.steerCandidate) {
+    if (!markFollowupRunEnqueued(run)) return false;
+    let settle = (_accepted: boolean) => {};
+    const acceptance = new Promise<boolean>((resolve) => (settle = resolve));
+    run.steerPending = { predecessor: queue.steerAcceptanceTail, settle };
+    queue.steerAcceptanceTail = acceptance;
+    appendQueueItem({
+      key,
+      queue,
+      run,
+      recentMessageIdKey,
+      runFollowup,
+      restartIfIdle,
+      front: options.position === "front",
+    });
+    return true;
+  }
+  // A later normal/interrupt prompt cannot be dropped while an older steer is
+  // deciding between same-turn delivery and fallback. Append it behind the
+  // anchor; ordinary overflow policy resumes as soon as the gate resolves.
+  if (queue.items.some((item) => item.steerPending)) {
+    if (!markFollowupRunEnqueued(run)) return false;
+    appendQueueItem({
+      key,
+      queue,
+      run,
+      recentMessageIdKey,
+      runFollowup,
+      restartIfIdle,
+      front: false,
+    });
+    return true;
+  }
   // drop:new rejects this source without mutating the existing queue. Do not
   // publish an external queued identity for work that will never be admitted.
   const pendingCount = countPendingQueueItems(queue.items, queue.inFlight);
-  if (queue.dropPolicy === "new" && queue.cap > 0 && pendingCount >= queue.cap) {
+  if (
+    !options.steerCandidate &&
+    queue.dropPolicy === "new" &&
+    queue.cap > 0 &&
+    pendingCount >= queue.cap
+  ) {
     run.onQueueDisposition?.("queue-cap-new");
     completeFollowupRunLifecycle(run);
     return false;
@@ -148,7 +214,7 @@ export function enqueueFollowupRun(
         completeFollowupRunLifecycle(item);
       }
     },
-    isProtected: (item) => item.protectFromQueueOverflow === true,
+    isProtected: (item) => item.protectFromQueueOverflow === true || item.steerAnchor === true,
   });
   if (queue.dropPolicy === "summarize") {
     const overflow = queue.summarySources.length - queue.summaryLines.length;
@@ -192,29 +258,15 @@ export function enqueueFollowupRun(
     completeFollowupRunLifecycle(run);
     return false;
   }
-  // Only admitted items refresh debounce; rejected overflow must not starve
-  // protected stranded-reply retries waiting for the quiet window.
-  queue.lastEnqueuedAt = Date.now();
-  queue.lastRun = run.run;
-
-  run.queueAbortSignal = queue.abortController.signal;
-  if (options.position === "front") {
-    queue.items.unshift(run);
-  } else {
-    queue.items.push(run);
-  }
-  if (recentMessageIdKey) {
-    recordRecentQueueMessageId(run, recentMessageIdKey);
-  }
-  if (runFollowup) {
-    rememberFollowupDrainCallback(key, runFollowup);
-  }
-  // If drain finished and deleted the queue before this item arrived, a new queue
-  // object was created (draining: false) but nobody scheduled a drain for it.
-  // Use the cached callback to restart the drain now.
-  if (restartIfIdle && !queue.draining) {
-    kickFollowupDrainIfIdle(key);
-  }
+  appendQueueItem({
+    key,
+    queue,
+    run,
+    recentMessageIdKey,
+    runFollowup,
+    restartIfIdle,
+    front: options.position === "front",
+  });
   return true;
 }
 
@@ -224,6 +276,116 @@ export function getFollowupQueueDepth(key: string): number {
     return 0;
   }
   return countPendingQueueItems(queue.items, queue.inFlight);
+}
+
+function settleParkedSteerAcceptance(key: string, run: FollowupRun, accepted: boolean): boolean {
+  const queue = getExistingFollowupQueue(key);
+  const pending = run.steerPending;
+  if (!queue?.items.includes(run) || !pending) {
+    return false;
+  }
+  pending.settle(accepted);
+  if (!accepted) {
+    delete run.steerPending;
+    reapplyDeferredOverflow(key);
+    kickFollowupDrainIfIdle(key);
+  }
+  return true;
+}
+
+function isParkedFollowupRunOwned(key: string, run: FollowupRun): boolean {
+  return getExistingFollowupQueue(key)?.items.includes(run) === true;
+}
+
+function reapplyDeferredOverflow(key: string): void {
+  const queue = getExistingFollowupQueue(key);
+  if (!queue || queue.items.some((item) => item.steerPending)) return;
+  const lastAnchor = queue.items.findLastIndex((item) => item.steerAnchor === true);
+  const suffix = queue.items.splice(lastAnchor + 1);
+  if (suffix.length === 0) return;
+  const originalCap = queue.cap;
+  const settings: QueueSettings = {
+    mode: queue.mode,
+    debounceMs: queue.debounceMs,
+    cap: originalCap + lastAnchor + 1,
+    dropPolicy: queue.dropPolicy,
+  };
+  for (const item of suffix) {
+    if (!enqueueFollowupRun(key, item, settings, "none", undefined, false)) {
+      completeFollowupRunLifecycle(item);
+    }
+  }
+  queue.cap = originalCap;
+}
+
+/** Remove an exactly committed steer while preserving every sibling's FIFO position. */
+function consumeParkedFollowupRun(key: string, run: FollowupRun): boolean {
+  const queue = getExistingFollowupQueue(key);
+  const index = queue?.items.indexOf(run) ?? -1;
+  if (!queue || index < 0) {
+    return false;
+  }
+  queue.items.splice(index, 1);
+  run.steerPending?.settle(true);
+  delete run.steerPending;
+  delete run.protectFromQueueOverflow;
+  delete run.steerAnchor;
+  reapplyDeferredOverflow(key);
+  completeFollowupRunLifecycle(run);
+  if (
+    !queue.draining &&
+    queue.items.length === 0 &&
+    queue.inFlight.size === 0 &&
+    queue.droppedCount === 0 &&
+    FOLLOWUP_QUEUES.get(key) === queue
+  ) {
+    FOLLOWUP_QUEUES.delete(key);
+    clearFollowupDrainCallback(key);
+  } else {
+    kickFollowupDrainIfIdle(key);
+  }
+  return true;
+}
+
+type ParkedSteerReservation = {
+  admit(): Promise<"steer" | "fallback" | "cancelled">;
+  accepted(accepted: boolean): void;
+  fallback(): void;
+  consume(): void;
+};
+
+export function parkSteerCandidate(
+  key: string,
+  run: FollowupRun,
+  settings: QueueSettings,
+  runFollowup: (run: FollowupRun) => Promise<void>,
+): ParkedSteerReservation | undefined {
+  if (
+    !enqueueFollowupRun(key, run, settings, "message-id", runFollowup, false, {
+      steerCandidate: true,
+    })
+  ) {
+    return undefined;
+  }
+  logMessageQueuedWithBacklogPolicy(
+    {
+      sessionId: run.run.sessionId,
+      sessionKey: key,
+      channel: run.originatingChannel ?? run.run.messageProvider,
+      source: "followup-queue-steer",
+    },
+    false,
+  );
+  return {
+    async admit() {
+      const predecessorAccepted = (await run.steerPending?.predecessor) ?? true;
+      if (isFollowupRunAborted(run) || !isParkedFollowupRunOwned(key, run)) return "cancelled";
+      return predecessorAccepted ? "steer" : "fallback";
+    },
+    accepted: (accepted) => settleParkedSteerAcceptance(key, run, accepted),
+    fallback: () => settleParkedSteerAcceptance(key, run, false),
+    consume: () => consumeParkedFollowupRun(key, run),
+  };
 }
 
 if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -31,6 +31,7 @@ type FollowupQueueState = {
   droppedCount: number;
   summaryLines: string[];
   summarySources: FollowupRun[];
+  steerAcceptanceTail: Promise<boolean>;
   /** Sources currently used by an async summary delivery cannot be evicted mid-run. */
   activeSummarySources: WeakSet<FollowupRun>;
   summaryElisions: Array<{
@@ -154,6 +155,7 @@ export function getFollowupQueue(key: string, settings: QueueSettings): Followup
     droppedCount: 0,
     summaryLines: [],
     summarySources: [],
+    steerAcceptanceTail: Promise.resolve(true),
     activeSummarySources: new WeakSet(),
     summaryElisions: [],
     evictedSummaryCount: 0,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -53,6 +53,7 @@ type QueueInsertPosition = "tail" | "front";
 
 export type EnqueueFollowupRunOptions = {
   position?: QueueInsertPosition;
+  steerCandidate?: boolean;
 };
 
 export type FollowupQueueDisposition = "queue-cap" | "queue-cap-old" | "queue-cap-new";
@@ -97,6 +98,14 @@ export type FollowupRun = {
   summaryLine?: string;
   /** Force individual drain; never merge this run into a collect batch. */
   disableCollectBatching?: boolean;
+  /** The current-turn hook already ran before this steer became a fallback. */
+  /** Pending same-turn acceptance while this item remains parked in FIFO order. */
+  steerPending?: {
+    predecessor: Promise<boolean>;
+    settle: (accepted: boolean) => void;
+  };
+  /** Preserves this candidate's position ahead of overflow summaries. */
+  steerAnchor?: true;
   /** Internal marker for the one-shot stranded final recovery retry. */
   strandedReplyRetry?: boolean;
   /** Preserve priority runs when old-item queue overflow eviction runs before drain. */
@@ -229,7 +238,7 @@ const retiredTurnAdoptionCancellationLifecycles = new WeakSet<TurnAdoptionLifecy
 const completedTurnAdoptionLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const completedTurnAdoptionLifecycleCallbacks = new WeakSet<TurnAdoptionLifecycle>();
 
-type FollowupLifecycleRun = Pick<FollowupRun, "turnAdoptionLifecycle">;
+type FollowupLifecycleRun = Pick<FollowupRun, "steerPending" | "turnAdoptionLifecycle">;
 
 export function markFollowupRunEnqueued(run: FollowupLifecycleRun): boolean {
   const lifecycle = run.turnAdoptionLifecycle;
@@ -281,6 +290,7 @@ export async function admitFollowupRunLifecycle(run: FollowupLifecycleRun): Prom
 }
 
 export function completeFollowupRunLifecycle(run: FollowupLifecycleRun): void {
+  run.steerPending?.settle(false);
   const lifecycle = run.turnAdoptionLifecycle;
 
   const finish = () => {

--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -1,0 +1,57 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveGlobalMap } from "../../shared/global-singleton.js";
+
+export const REPLY_ADMISSION_TICKET = Symbol("openclaw.replyAdmissionTicket");
+type ReplyAdmissionTicket = {
+  wait(signal?: AbortSignal): Promise<boolean>;
+  release(): void;
+};
+export type ReplyOptionsWithAdmissionTicket = {
+  [REPLY_ADMISSION_TICKET]?: ReplyAdmissionTicket;
+};
+
+const tails = resolveGlobalMap<string, Promise<void>>(Symbol.for("openclaw.replyAdmissionTickets"));
+
+/** Briefly orders queue publication across a command's source and target sessions. */
+export function reserveReplyAdmissionTicket(
+  sessionKeys: Iterable<string | undefined>,
+): ReplyAdmissionTicket | undefined {
+  const keys = [...new Set([...sessionKeys].map(normalizeOptionalString).filter(Boolean))].sort();
+  if (keys.length === 0) {
+    return undefined;
+  }
+  let finish = () => {};
+  const completed = new Promise<void>((resolve) => (finish = resolve));
+  const predecessors = keys.map((key) => tails.get(key) ?? Promise.resolve());
+  const owned = keys.map((key, index) => {
+    const tail = predecessors[index]!.then(() => completed);
+    tails.set(key, tail);
+    return { key, tail };
+  });
+  let released = false;
+  return {
+    async wait(signal) {
+      if (signal?.aborted) {
+        return false;
+      }
+      const ready = Promise.all(predecessors).then(() => true);
+      if (!signal) return await ready;
+      return await new Promise<boolean>((resolve) => {
+        const abort = () => resolve(false);
+        signal.addEventListener("abort", abort, { once: true });
+        void ready.then((value) => {
+          signal.removeEventListener("abort", abort);
+          resolve(value);
+        });
+      });
+    },
+    release() {
+      if (released) return;
+      released = true;
+      finish();
+      for (const { key, tail } of owned) {
+        void tail.then(() => tails.get(key) === tail && tails.delete(key));
+      }
+    },
+  };
+}

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -48,6 +48,11 @@ export type ReplyBackendQueueMessageOptions = {
   media?: MediaFact[];
   deliveryTimeoutMs?: number;
   waitForTranscriptCommit?: boolean;
+  /** Stable source identity for exact queued-message commit/cancellation matching. */
+  queueIdentity?: string;
+  abortSignal?: AbortSignal;
+  /** Releases arrival ordering once the runtime has actually accepted this queue item. */
+  onQueueAccepted?: (accepted: boolean) => void;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   taskSuggestionDeliveryMode?: TaskSuggestionDeliveryMode;
   /** Prepared channel turn to merge only at transcript persistence. */

--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -1,0 +1,633 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { GatewayClient, type GatewayClientOptions } from "../src/gateway/client.js";
+import { buildMockOpenAiResponsesProvider } from "../src/gateway/test-openai-responses-model.js";
+import { createDeferred } from "../src/test-utils/deferred.js";
+import { GatewayChatClient } from "../src/tui/gateway-chat.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../src/utils/message-channel.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+type FirstResponseKind = "final" | "tool";
+type ModelRequest = { body: Record<string, unknown> };
+type MockModelServer = {
+  baseUrl: string;
+  releaseFirst: (kind: FirstResponseKind) => void;
+  requests: ModelRequest[];
+  stop: () => Promise<void>;
+};
+type AgentEvent = {
+  runId?: string;
+  stream?: string;
+  data?: { phase?: string };
+};
+type GatewayFixture = {
+  client: GatewayChatClient;
+  diagnosticsClient: GatewayClient;
+  instance: OpenClawTestInstance;
+  modelServer: MockModelServer;
+  events: AgentEvent[];
+  chatErrors: Array<{ errorMessage?: string; runId?: string; state: "error" }>;
+  chatFinalRunIds: string[];
+  sessionKey: string;
+};
+
+const TEST_TIMEOUT_MS = 180_000;
+const WAIT_OPTS = { timeout: 30_000, interval: 20 } as const;
+const instances: OpenClawTestInstance[] = [];
+const clients: GatewayChatClient[] = [];
+const diagnosticsClients: GatewayClient[] = [];
+const cleanupDirs: string[] = [];
+const modelServers: MockModelServer[] = [];
+
+async function collectCleanupFailures(
+  tasks: Array<Promise<unknown>>,
+  failures: unknown[],
+): Promise<void> {
+  const results = await Promise.allSettled(tasks);
+  failures.push(
+    ...results.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
+  );
+}
+
+afterEach(async () => {
+  const failures: unknown[] = [];
+  await collectCleanupFailures(
+    clients.splice(0).map((client) => client.stop()),
+    failures,
+  );
+  await collectCleanupFailures(
+    diagnosticsClients.splice(0).map((client) => client.stopAndWait()),
+    failures,
+  );
+  await collectCleanupFailures(
+    instances.splice(0).map((instance) => instance.cleanup()),
+    failures,
+  );
+  await collectCleanupFailures(
+    modelServers.splice(0).map((server) => server.stop()),
+    failures,
+  );
+  await collectCleanupFailures(
+    cleanupDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    failures,
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Gateway steer FIFO cleanup failed");
+  }
+});
+
+async function readJsonRequest(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const body = Buffer.concat(chunks).toString("utf8");
+  return body ? (JSON.parse(body) as Record<string, unknown>) : {};
+}
+
+function writeSse(res: ServerResponse, events: Record<string, unknown>[]): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  res.end(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+  );
+}
+
+function writeTextResponse(res: ServerResponse, requestIndex: number): void {
+  const id = `msg_steer_fifo_${requestIndex}`;
+  const text = `TURN_${requestIndex}_COMPLETE`;
+  const message = {
+    type: "message",
+    id,
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+  writeSse(res, [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: id,
+      output_index: 0,
+      content_index: 0,
+      delta: text,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: id,
+      output_index: 0,
+      content_index: 0,
+      text,
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: `resp_steer_fifo_${requestIndex}`,
+        status: "completed",
+        output: [message],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      },
+    },
+  ]);
+}
+
+function writeToolResponse(res: ServerResponse): void {
+  const item = {
+    type: "function_call",
+    id: "fc_steer_fifo_status",
+    call_id: "call_steer_fifo_status",
+    name: "session_status",
+    arguments: "{}",
+    status: "completed",
+  };
+  writeSse(res, [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, status: "in_progress", arguments: "" },
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: item.id,
+      output_index: 0,
+      arguments: item.arguments,
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_steer_fifo_tool",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      },
+    },
+  ]);
+}
+
+async function startMockModelServer(): Promise<MockModelServer> {
+  const requests: ModelRequest[] = [];
+  const firstResponse = createDeferred<void>();
+  let firstResponseKind: FirstResponseKind = "final";
+  const server = createServer((req, res) => {
+    void (async () => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (req.method === "GET" && url.pathname === "/v1/models") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ data: [{ id: "steer-fifo", object: "model" }] }));
+        return;
+      }
+      if (req.method !== "POST" || url.pathname !== "/v1/responses") {
+        res.writeHead(404).end();
+        return;
+      }
+      requests.push({ body: await readJsonRequest(req) });
+      const requestIndex = requests.length;
+      if (requestIndex === 1) {
+        await firstResponse.promise;
+        if (res.destroyed) {
+          return;
+        }
+        if (firstResponseKind === "tool") {
+          writeToolResponse(res);
+          return;
+        }
+      }
+      writeTextResponse(res, requestIndex);
+    })().catch((error: unknown) => {
+      if (!res.destroyed) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { message: String(error) } }));
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock model server did not bind");
+  }
+  let stopped = false;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    releaseFirst: (kind) => {
+      firstResponseKind = kind;
+      firstResponse.resolve();
+    },
+    stop: async () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      firstResponse.resolve();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    },
+  };
+}
+
+function createConfig(params: {
+  fixtureDir: string;
+  modelServer: MockModelServer;
+}): OpenClawConfig {
+  const provider = buildMockOpenAiResponsesProvider(
+    `${params.modelServer.baseUrl}/v1`,
+    "steer-fifo",
+  );
+  return {
+    plugins: { slots: { memory: "none" } },
+    agents: {
+      defaults: {
+        workspace: path.join(params.fixtureDir, "workspace"),
+        model: { primary: provider.modelRef },
+        models: {
+          [provider.modelRef]: {
+            agentRuntime: { id: "openclaw" },
+            params: { transport: "sse", openaiWsWarmup: false },
+          },
+        },
+        skills: [],
+        skipBootstrap: true,
+      },
+      list: [{ id: "main", default: true, model: { primary: provider.modelRef }, skills: [] }],
+    },
+    tools: { profile: "minimal" },
+    models: {
+      mode: "replace",
+      providers: {
+        [provider.providerId]: {
+          ...provider.config,
+          request: { allowPrivateNetwork: true },
+        },
+      },
+    },
+    messages: { queue: { mode: "steer", debounceMsByChannel: { webchat: 0 } } },
+  };
+}
+
+async function connectDiagnosticsClient(instance: OpenClawTestInstance): Promise<GatewayClient> {
+  let resolveHello!: () => void;
+  let rejectHello!: (error: Error) => void;
+  const hello = new Promise<void>((resolve, reject) => {
+    resolveHello = resolve;
+    rejectHello = reject;
+  });
+  const gatewayUrl = new URL(instance.url);
+  gatewayUrl.protocol = gatewayUrl.protocol === "wss:" ? "https:" : "http:";
+  const options: GatewayClientOptions = {
+    url: instance.url,
+    origin: gatewayUrl.origin,
+    token: "steer-fifo-token",
+    clientName: GATEWAY_CLIENT_NAMES.TUI,
+    clientDisplayName: "steer-fifo-e2e-diagnostics",
+    mode: GATEWAY_CLIENT_MODES.UI,
+    role: "operator",
+    scopes: ["operator.admin", "operator.read", "operator.write"],
+    platform: process.platform,
+    requestTimeoutMs: 30_000,
+    onHelloOk: resolveHello,
+    onConnectError: rejectHello,
+    onClose: (code, reason) => rejectHello(new Error(`Gateway closed ${code}: ${reason}`)),
+  };
+  const client = new GatewayClient(options);
+  diagnosticsClients.push(client);
+  client.start();
+  await hello;
+  return client;
+}
+
+async function createGatewayFixture(name: string): Promise<GatewayFixture> {
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), `openclaw-${name}-`));
+  cleanupDirs.push(fixtureDir);
+  const modelServer = await startMockModelServer();
+  modelServers.push(modelServer);
+  const instance = await createOpenClawTestInstance({
+    name,
+    gatewayToken: "steer-fifo-token",
+    config: createConfig({ fixtureDir, modelServer }),
+    env: {
+      OPENCLAW_LOG_LEVEL: "debug",
+      OPENCLAW_SKIP_PROVIDERS: undefined,
+      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+    },
+  });
+  instances.push(instance);
+  await instance.startGateway();
+  const events: AgentEvent[] = [];
+  const chatErrors: Array<{ errorMessage?: string; runId?: string; state: "error" }> = [];
+  const chatFinalRunIds: string[] = [];
+  const client = new GatewayChatClient({
+    url: instance.url,
+    token: "steer-fifo-token",
+  });
+  clients.push(client);
+  client.onEvent = ({ event, payload }) => {
+    if (event === "agent" && payload && typeof payload === "object") {
+      const agentEvent = payload as AgentEvent;
+      events.push(agentEvent);
+    }
+    if (event === "chat" && payload && typeof payload === "object") {
+      const chat = payload as { errorMessage?: unknown; runId?: unknown; state?: unknown };
+      if (chat.state === "error") {
+        chatErrors.push({
+          state: "error",
+          ...(typeof chat.runId === "string" ? { runId: chat.runId } : {}),
+          ...(typeof chat.errorMessage === "string"
+            ? { errorMessage: chat.errorMessage.replaceAll("steer-fifo-token", "[REDACTED]") }
+            : {}),
+        });
+      } else if (chat.state === "final" && typeof chat.runId === "string") {
+        chatFinalRunIds.push(chat.runId);
+      }
+    }
+  };
+  client.start();
+  await client.waitForReady();
+  await client.subscribeSessionEvents();
+  const diagnosticsClient = await connectDiagnosticsClient(instance);
+  return {
+    client,
+    diagnosticsClient,
+    instance,
+    modelServer,
+    events,
+    chatErrors,
+    chatFinalRunIds,
+    sessionKey: `agent:main:${name}`,
+  };
+}
+
+async function sendChat(params: {
+  fixture: GatewayFixture;
+  message: string;
+  runId: string;
+}): Promise<{ runId: string; status?: string }> {
+  return await params.fixture.client.sendChat({
+    sessionKey: params.fixture.sessionKey,
+    message: params.message,
+    deliver: false,
+    runId: params.runId,
+  });
+}
+
+function redactedFixtureLogs(instance: OpenClawTestInstance): string {
+  return instance
+    .logs()
+    .replaceAll("steer-fifo-token", "[REDACTED]")
+    .replace(/Bearer\s+\S+/giu, "Bearer [REDACTED]")
+    .replace(/(["']?apiKey["']?\s*[:=]\s*)["'][^"']+["']/giu, "$1[REDACTED]")
+    .slice(-12_000);
+}
+
+async function sendHeldTurn(fixture: GatewayFixture) {
+  const first = await sendChat({
+    fixture,
+    message: "INITIAL_HELD_TURN",
+    runId: "initial-held-turn",
+  });
+  expect(first.status).toBe("started");
+  try {
+    await vi.waitFor(() => expect(fixture.modelServer.requests).toHaveLength(1), WAIT_OPTS);
+  } catch (error) {
+    throw new Error(
+      `initial chat turn did not reach the mock provider\n` +
+        `chat errors=${JSON.stringify(fixture.chatErrors)}\n` +
+        redactedFixtureLogs(fixture.instance),
+      { cause: error },
+    );
+  }
+  return first;
+}
+
+async function queueSteer(fixture: GatewayFixture, marker = "QUEUED_STEER_A") {
+  const baseline = await fixture.diagnosticsClient.request<{ lastSeq?: number }>(
+    "diagnostics.stability",
+    {
+      type: "message.queued",
+      limit: 1,
+    },
+  );
+  const result = await sendChat({
+    fixture,
+    message: marker,
+    runId: `run-${marker.toLowerCase()}`,
+  });
+  expect(result.status).toBe("started");
+  await vi.waitFor(async () => {
+    const snapshot = await fixture.diagnosticsClient.request<{
+      events?: Array<{
+        queueDepth?: number;
+        source?: string;
+        type?: string;
+      }>;
+    }>("diagnostics.stability", {
+      type: "message.queued",
+      sinceSeq: baseline.lastSeq ?? 0,
+      limit: 20,
+    });
+    const dispatchQueueEvents = (snapshot.events ?? []).filter(
+      (event) => event.type === "message.queued" && event.source === "followup-queue-steer",
+    );
+    expect(dispatchQueueEvents).not.toHaveLength(0);
+    expect(fixture.modelServer.requests).toHaveLength(1);
+  }, WAIT_OPTS);
+  return result;
+}
+
+async function queueOrdinaryFollowup(
+  fixture: GatewayFixture,
+  marker = "ORDINARY_MESSAGE_B",
+): Promise<void> {
+  const runId = `run-${marker.toLowerCase()}`;
+  const result = await fixture.diagnosticsClient.request<{ runId?: string; status?: string }>(
+    "chat.send",
+    {
+      sessionKey: fixture.sessionKey,
+      message: marker,
+      deliver: false,
+      queueMode: "followup",
+      idempotencyKey: runId,
+    },
+  );
+  expect(result).toMatchObject({ runId, status: "started" });
+  await vi.waitFor(() => {
+    expect(fixture.chatFinalRunIds).toContain(runId);
+    expect(fixture.modelServer.requests).toHaveLength(1);
+  }, WAIT_OPTS);
+}
+
+async function waitForRunTerminal(fixture: GatewayFixture, runId: string): Promise<void> {
+  await vi.waitFor(
+    () =>
+      expect(fixture.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            runId,
+            stream: "lifecycle",
+            data: expect.objectContaining({ phase: "end" }),
+          }),
+        ]),
+      ),
+    WAIT_OPTS,
+  );
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") {
+        return [];
+      }
+      const text = (part as { text?: unknown }).text;
+      return typeof text === "string" ? [text] : [];
+    })
+    .join("\n");
+}
+
+function userInputs(request: ModelRequest | undefined): string[] {
+  const input = request?.body.input;
+  if (typeof input === "string") {
+    return [input];
+  }
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return input.flatMap((item) =>
+    item && typeof item === "object" && (item as { role?: unknown }).role === "user"
+      ? [contentText((item as { content?: unknown }).content)]
+      : [],
+  );
+}
+
+function currentUserInput(request: ModelRequest | undefined): string {
+  return userInputs(request).at(-1) ?? "";
+}
+
+describe("Gateway steer FIFO", () => {
+  it(
+    "promotes a terminal steer into the next model turn",
+    async () => {
+      const fixture = await createGatewayFixture("steer-terminal-fallback");
+      const first = await sendHeldTurn(fixture);
+      await queueSteer(fixture);
+
+      fixture.modelServer.releaseFirst("final");
+
+      await vi.waitFor(() => expect(fixture.modelServer.requests).toHaveLength(2), WAIT_OPTS);
+      const currentA = currentUserInput(fixture.modelServer.requests[1]);
+      expect(currentA).toContain("QUEUED_STEER_A");
+      expect(currentA).not.toContain("ORDINARY_MESSAGE_B");
+      await waitForRunTerminal(fixture, first.runId);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "dispatches terminal A before a later ordinary B queued during the same turn",
+    async () => {
+      const fixture = await createGatewayFixture("steer-terminal-overtake");
+      const first = await sendHeldTurn(fixture);
+      await queueSteer(fixture);
+      await queueOrdinaryFollowup(fixture);
+      const idleBaseline = await fixture.diagnosticsClient.request<{ lastSeq?: number }>(
+        "diagnostics.stability",
+        { type: "session.state", limit: 1 },
+      );
+
+      fixture.modelServer.releaseFirst("final");
+
+      await vi.waitFor(() => expect(fixture.modelServer.requests).toHaveLength(3), WAIT_OPTS);
+      await waitForRunTerminal(fixture, first.runId);
+      await vi.waitFor(async () => {
+        const snapshot = await fixture.diagnosticsClient.request<{
+          events?: Array<{ outcome?: string; queueDepth?: number; type?: string }>;
+        }>("diagnostics.stability", {
+          type: "session.state",
+          sinceSeq: idleBaseline.lastSeq ?? 0,
+          limit: 20,
+        });
+        expect(
+          (snapshot.events ?? []).some(
+            (event) =>
+              event.type === "session.state" && event.outcome === "idle" && event.queueDepth === 0,
+          ),
+        ).toBe(true);
+      }, WAIT_OPTS);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const currentA = currentUserInput(fixture.modelServer.requests[1]);
+      const currentB = currentUserInput(fixture.modelServer.requests[2]);
+      expect(currentA).toContain("QUEUED_STEER_A");
+      expect(currentA).not.toContain("ORDINARY_MESSAGE_B");
+      expect(currentB).toContain("ORDINARY_MESSAGE_B");
+      expect(currentB).not.toContain("QUEUED_STEER_A");
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "consumes a steer at a tool control point without a fallback turn",
+    async () => {
+      const fixture = await createGatewayFixture("steer-tool-control-point");
+      const first = await sendHeldTurn(fixture);
+      await queueSteer(fixture);
+      const idleBaseline = await fixture.diagnosticsClient.request<{ lastSeq?: number }>(
+        "diagnostics.stability",
+        { type: "session.state", limit: 1 },
+      );
+
+      fixture.modelServer.releaseFirst("tool");
+
+      await vi.waitFor(() => expect(fixture.modelServer.requests).toHaveLength(2), WAIT_OPTS);
+      expect(currentUserInput(fixture.modelServer.requests[1])).toContain("QUEUED_STEER_A");
+      expect(JSON.stringify(fixture.modelServer.requests[1]?.body)).toContain(
+        "function_call_output",
+      );
+      await waitForRunTerminal(fixture, first.runId);
+      await vi.waitFor(async () => {
+        const snapshot = await fixture.diagnosticsClient.request<{
+          events?: Array<{ outcome?: string; queueDepth?: number; type?: string }>;
+        }>("diagnostics.stability", {
+          type: "session.state",
+          sinceSeq: idleBaseline.lastSeq ?? 0,
+          limit: 20,
+        });
+        expect(
+          (snapshot.events ?? []).some(
+            (event) =>
+              event.type === "session.state" && event.outcome === "idle" && event.queueDepth === 0,
+          ),
+        ).toBe(true);
+      }, WAIT_OPTS);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(fixture.modelServer.requests).toHaveLength(2);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

A message queued as a *steer* while the agent is mid-turn could be overtaken by a message sent later: if the turn ended before a control point consumed the steer, the later message claimed the idle session first. Strictly-later beat strictly-earlier — users experience "my queued messages don't reach the agent" (they do, late and out of order).

Fixes https://github.com/openclaw/openclaw/issues/119794 (reported by @Eprey27, with screenshot proof of the overtake).

## Why This Change Was Made

Maintainer-stated contract: a steer is a normal message with deferred delivery — inject at the next safe point mid-turn, or deliver as the next turn if the run ends first. Prompts are never dropped and never reordered.

Root cause was an ownership gap, not a sorting bug: the steer awaited asynchronous runtime injection while owning neither a followup-queue position nor a reply-lane reservation, so turn-end promotion raced fresh inbound admission. The fix records arrival where it happens: every inbound reserves an arrival-ordered admission ticket at dispatch entry (`reply-admission-ticket.ts`, per-session promise chain, released in `finally`); a steer is parked in the canonical followup FIFO *before* async injection (`queue/enqueue.ts` park/consume/settle lifecycle); safe-point delivery consumes the parked candidate, terminal rejection promotes it in place, and later admission fences behind pending work. Ambiguous already-absent runtime messages keep at-most-once behavior to avoid duplicate tool side effects.

Sibling modes share the repaired invariant: `followup` had the same overtake class (fixed by the shared pending-work admission), `collect` keeps batching, `interrupt` still aborts immediately but its prompt can no longer jump older queued work.

## User Impact

Messages are delivered in the order you sent them, in every queue mode. A steer that misses its turn becomes the next turn instead of being stranded behind newer messages.

## Evidence

- Process-level Gateway e2e (`test/gateway-steer-fifo.e2e.test.ts`, real gateway process, isolated state dir): terminal steer becomes the next turn; earlier steer executes before a later message; mid-turn control point still consumes steers. 3/3.
- Focused suites: 243/243 across queue-message, agent-runner, and dispatch paths — rerun green after rebasing onto current main (four conflicts resolved preserving main's pre-dispatch injection and protocol-owned QueueMode).
- `node scripts/check-deadcode-exports.mjs`: clean. `git diff --check`: clean.
- Codex autoreview (`gpt-5.6-sol`, high) run three times — worker closeout, independent coordinator pass on the frozen diff, and again on the final rebased branch: clean each time.
- Production +660/−184 (net +476): justified as a new ownership boundary — arrival-order publication tickets and the parked-steer lifecycle in the canonical queue — replacing an unowned async race; tests +854/−25 including the new gateway boundary suite.
