### PR TITLE
fix(subagents): re-capture null-frozen completion results after false blocked ends

### DIFF
--- a/src/agents/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup.ts
@@ -68,10 +68,22 @@ export function createSubagentRegistryLifecycleCleanup(
     suspendPendingFinalDelivery,
   } = cleanupBase;
 
-  const shouldSuspendPendingFinalDelivery = (entry: SubagentRunRecord) =>
-    entry.expectsCompletionMessage === true &&
-    entry.endedReason === SUBAGENT_ENDED_REASON_COMPLETE &&
-    entry.execution.outcome?.status === "ok";
+  const shouldSuspendPendingFinalDelivery = (
+    entry: SubagentRunRecord,
+    reason: "expiry" | "permanent_failure",
+  ) => {
+    if (entry.expectsCompletionMessage !== true) {
+      return false;
+    }
+    // A false end (recoverable blocked/error) can still be superseded by a
+    // later real completion. Suspending an exhausted retry keeps the payload
+    // so that completion can re-capture and re-announce instead of stranding.
+    if (reason === "expiry" && entry.execution.outcome?.status === "error") {
+      return true;
+    }
+    return entry.endedReason === SUBAGENT_ENDED_REASON_COMPLETE &&
+      entry.execution.outcome?.status === "ok";
+  };
 
   const finalizeAnnounceGiveUp = async (giveUpParams: {
     runId: string;
@@ -84,7 +96,7 @@ export function createSubagentRegistryLifecycleCleanup(
   }) => {
     const { runId, entry, reason, cleanup, cleanupGeneration, retryCount, completedAt } =
       giveUpParams;
-    if (shouldSuspendPendingFinalDelivery(entry)) {
+    if (shouldSuspendPendingFinalDelivery(entry, reason)) {
       suspendPendingFinalDelivery({
         runId,
         entry,

--- a/src/agents/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagent-registry-lifecycle-delivery.ts
@@ -265,11 +265,21 @@ export function createSubagentRegistryLifecycleDelivery(
     entry: SubagentRunRecord,
     outcome: SubagentRunOutcome,
   ): Promise<boolean> => {
-    if (ensureCompletionState(entry).resultText !== undefined) {
+    const completion = ensureCompletionState(entry);
+    const existingResult = completion.resultText;
+    // An error settlement freezes `null` so a run that recovers and completes
+    // for real can re-capture its output. Any real text is final and must
+    // never be overwritten by later lifecycle noise; a terminalReply snapshot
+    // is authoritative even when it carries an empty result.
+    if (
+      existingResult !== undefined &&
+      (existingResult !== null ||
+        completion.terminalReply !== undefined ||
+        outcome.status === "error")
+    ) {
       return false;
     }
     if (outcome.status === "error") {
-      const completion = ensureCompletionState(entry);
       completion.resultText = null;
       completion.capturedAt = Date.now();
       return true;
@@ -317,12 +327,21 @@ export function createSubagentRegistryLifecycleDelivery(
     ) {
       return false;
     }
-    const completion = ensureCompletionState(entry);
-    if (completion.resultText !== undefined) {
+    const completionAfterCapture = ensureCompletionState(entry);
+    if (
+      completionAfterCapture.resultText !== undefined &&
+      completionAfterCapture.resultText !== null
+    ) {
       return false;
     }
-    completion.resultText = resultText;
-    completion.capturedAt = Date.now();
+    if (completionAfterCapture.terminalReply !== undefined) {
+      return false;
+    }
+    if (resultText === null && completionAfterCapture.resultText === null) {
+      return false;
+    }
+    completionAfterCapture.resultText = resultText;
+    completionAfterCapture.capturedAt = Date.now();
     return true;
   };
 

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -3316,11 +3316,6 @@ describe("subagent registry lifecycle hardening", () => {
       outcome: { status: "timeout" as const },
     },
     {
-      name: "error",
-      endedReason: SUBAGENT_ENDED_REASON_ERROR,
-      outcome: { status: "error" as const, error: "child failed" },
-    },
-    {
       name: "killed",
       endedReason: SUBAGENT_ENDED_REASON_KILLED,
       outcome: undefined,
@@ -3363,6 +3358,40 @@ describe("subagent registry lifecycle hardening", () => {
       expect(persistOrThrow).toHaveBeenCalled();
     },
   );
+
+  it("suspends error completion cleanup on retry exhaustion so a later real completion can deliver", async () => {
+    const persistOrThrow = vi.fn();
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      endedReason: SUBAGENT_ENDED_REASON_ERROR,
+      expectsCompletionMessage: true,
+      delivery: { status: "pending", lastError: "gateway request timeout for agent" },
+      outcome: { status: "error", error: "child failed" },
+      retainAttachmentsOnKeep: true,
+    });
+    const runs = new Map([[entry.runId, entry]]);
+
+    const controller = createLifecycleController({
+      entry,
+      runs,
+      persistOrThrow,
+      captureSubagentCompletionReply: vi.fn(async () => undefined),
+    });
+
+    await controller.finalizeResumedAnnounceGiveUp({
+      runId: entry.runId,
+      entry,
+      reason: "expiry",
+    });
+
+    expect(entry.delivery?.status).toBe("suspended");
+    expect(entry.delivery?.payload).toBeDefined();
+    expect(entry.delivery?.suspendedAt).toBeTypeOf("number");
+    expect(entry.delivery?.suspendedReason).toBe("expiry");
+    expect(entry.cleanupHandled).toBe(false);
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+    expect(persistOrThrow).toHaveBeenCalled();
+  });
 
   it("continues cleanup when delivery-status persistence throws after announce delivery", async () => {
     const persist = vi.fn();

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -18,6 +18,7 @@ type LifecycleData = {
   endedAt?: number;
   aborted?: boolean;
   error?: string;
+  livenessState?: string;
 };
 type LifecycleEvent = {
   stream?: string;
@@ -277,6 +278,45 @@ describe("subagent registry lifecycle error grace", () => {
         requesterSettleWake: lastRun?.requesterSettleWake,
       })}`,
     );
+  };
+
+  const waitForSuspendedDelivery = async (runId: string) => {
+    let lastRun: ReturnType<typeof mod.listSubagentRunsForRequester>[number] | undefined;
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      const run = mod
+        .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+        .find((candidate) => candidate.runId === runId);
+      lastRun = run;
+      if (run?.delivery?.status === "suspended") {
+        return run;
+      }
+      await vi.advanceTimersByTimeAsync(60_000);
+      await flushAsync();
+    }
+    throw new Error(
+      `run ${runId} did not reach suspended delivery in time: ${JSON.stringify({
+        delivery: lastRun?.delivery,
+        cleanupHandled: lastRun?.cleanupHandled,
+        cleanupCompletedAt: lastRun?.cleanupCompletedAt,
+        endedReason: lastRun?.endedReason,
+        outcome: lastRun?.execution.outcome,
+        agentCalls: getAgentCalls().length,
+      })}`,
+    );
+  };
+
+  const waitForDeliveredStatus = async (runId: string) => {
+    for (let attempt = 0; attempt < 80; attempt += 1) {
+      const run = mod
+        .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+        .find((candidate) => candidate.runId === runId);
+      if (run?.delivery?.status === "delivered" && typeof run.cleanupCompletedAt === "number") {
+        return run;
+      }
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flushAsync();
+    }
+    throw new Error(`run ${runId} did not reach delivered status in time`);
   };
 
   const waitForAgentCallCount = async (expectedCount: number) => {
@@ -557,6 +597,55 @@ describe("subagent registry lifecycle error grace", () => {
     await waitForAgentCallCount(1);
     expect(readFirstAnnounceOutcome()?.status).toBe("error");
     expect(readFirstAnnounceOutcome()?.error).toContain("fatal failure");
+  });
+
+  it("re-captures a null-frozen result after a false blocked end when the run completes for real", async () => {
+    // Regression for #120383: a recoverable context overflow is published as a
+    // blocked run end, freezing `resultText = null`. The exhausted announce must
+    // suspend (payload retained) instead of clearing, so the later real
+    // completion can re-capture and re-announce the answer.
+    registerCompletionRun("run-false-blocked", "false-blocked", "false blocked end test");
+    setAssistantOutput(
+      "agent:main:subagent:false-blocked",
+      "Context overflow: prompt too large for the model.",
+    );
+    agentCallPlan = Array(50).fill("throw");
+
+    // The announce retry budget is long past when the false end arrives, so the
+    // first deferred decision gives up (hard expiry) instead of scheduling
+    // resume timers. This keeps the test off the orphan-reconciliation path.
+    const falseEndedAt = Date.now() - 31 * 60_000;
+    emitLifecycleEvent("run-false-blocked", {
+      phase: "end",
+      endedAt: falseEndedAt,
+      livenessState: "blocked",
+      error: "Context overflow: prompt too large for the model.",
+    });
+    await flushAsync();
+
+    await waitForFrozenResultText("run-false-blocked", null);
+    const runAfterBlocked = mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((candidate) => candidate.runId === "run-false-blocked");
+    expect(runAfterBlocked?.execution.outcome?.status).toBe("error");
+    expect(runAfterBlocked?.completion?.resultText).toBeNull();
+
+    // Retries exhaust: give-up must suspend instead of wiping the payload.
+    const runSuspended = await waitForSuspendedDelivery("run-false-blocked");
+    expect(runSuspended?.delivery?.suspendedReason).toBe("expiry");
+    expect(runSuspended?.delivery?.payload).toBeDefined();
+    expect(runSuspended?.cleanupHandled).toBe(false);
+
+    // The run recovers and completes for real, long after the retry budget.
+    agentCallPlan = ["ok"];
+    setAssistantOutput("agent:main:subagent:false-blocked", "Final answer after recovery");
+    emitLifecycleEvent("run-false-blocked", { phase: "end", endedAt: falseEndedAt + 30_000 });
+    await flushAsync();
+
+    const runDelivered = await waitForDeliveredStatus("run-false-blocked");
+    expect(runDelivered?.completion?.resultText).toBe("Final answer after recovery");
+    const deliveredResults = getAgentResultsForChildSession("agent:main:subagent:false-blocked");
+    expect(deliveredResults[deliveredResults.length - 1]).toBe("Final answer after recovery");
   });
 
   it("freezes completion result at run termination across deferred announce retries", async () => {

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -330,7 +330,7 @@ describe("subagent registry lifecycle error grace", () => {
     throw new Error(`expected ${expectedCount} agent call(s), got ${getAgentCalls().length}`);
   };
 
-  const waitForFrozenResultText = async (runId: string, expectedText: string) => {
+  const waitForFrozenResultText = async (runId: string, expectedText: string | null) => {
     for (let attempt = 0; attempt < 80; attempt += 1) {
       const run = mod
         .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)

--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -16,12 +16,20 @@ const tails = resolveGlobalMap<string, Promise<void>>(Symbol.for("openclaw.reply
 export function reserveReplyAdmissionTicket(
   sessionKeys: Iterable<string | undefined>,
 ): ReplyAdmissionTicket | undefined {
-  const keys = [...new Set([...sessionKeys].map(normalizeOptionalString).filter(Boolean))].sort();
+  const keys = [
+    ...new Set(
+      [...sessionKeys]
+        .map(normalizeOptionalString)
+        .filter((key): key is string => Boolean(key)),
+    ),
+  ].toSorted();
   if (keys.length === 0) {
     return undefined;
   }
   let finish = () => {};
-  const completed = new Promise<void>((resolve) => (finish = resolve));
+  const completed = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
   const predecessors = keys.map((key) => tails.get(key) ?? Promise.resolve());
   const owned = keys.map((key, index) => {
     const tail = predecessors[index]!.then(() => completed);
@@ -35,7 +43,9 @@ export function reserveReplyAdmissionTicket(
         return false;
       }
       const ready = Promise.all(predecessors).then(() => true);
-      if (!signal) return await ready;
+      if (!signal) {
+        return await ready;
+      }
       return await new Promise<boolean>((resolve) => {
         const abort = () => resolve(false);
         signal.addEventListener("abort", abort, { once: true });
@@ -46,7 +56,9 @@ export function reserveReplyAdmissionTicket(
       });
     },
     release() {
-      if (released) return;
+      if (released) {
+        return;
+      }
       released = true;
       finish();
       for (const { key, tail } of owned) {


### PR DESCRIPTION
## What Problem This Solves

When a subagent hits a recoverable context overflow, the system can announce the run as ended and failed before it actually finishes; the final answer is then permanently frozen out of delivery and the user never receives it, even though the subagent completes successfully moments or minutes later. This change lets the system re-capture the real result and re-attempt delivery instead of dropping it.

- Problem: A recoverable blocked/error end settles the run, freezes `completion.resultText = null` permanently, and an exhausted announce clears the delivery payload — so a later real completion re-captures nothing and the answer is orphaned.
- Solution: Allow a later completion to re-capture output while the frozen result is still `null`, and route error-outcome expiry give-ups into the existing suspended-delivery lane (payload retained) instead of clearing it.
- What changed:
  - `src/agents/subagent-registry-lifecycle-delivery.ts` — `freezeRunResultAtCompletion` no longer treats an error-frozen `null` as final; a later non-error completion can overwrite it with the real output. Real text and authoritative `terminalReply` evidence remain final and are never overwritten.
  - `src/agents/subagent-registry-lifecycle-cleanup.ts` — `shouldSuspendPendingFinalDelivery` now also suspends (keeps payload) when an expected-completion run with an error outcome exhausts its announce retries (`expiry` give-up), instead of clearing the payload and marking delivery failed.
  - Tests: updated lifecycle unit coverage and added an e2e regression (`subagent-registry.lifecycle-retry-grace.e2e.test.ts`) that reproduces false blocked end → null freeze → give-up → later real completion → delivered.
- What did NOT change: The runner still publishes a blocked end for an overflow whose recovery budget is exhausted (the semantic "when has a run ended" decision from the issue is left to maintainers); timeout and killed-outcome give-ups still fail terminal; normal successful completion paths are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #120383 (registry-layer symptom fixed; runner-layer root fix intentionally left open per the issue's "when does a run end" decision)
- [x] This PR fixes a bug or regression

## Motivation

#82583 / #100426 / #109217 repeatedly reported stranded subagent completions. #120383 pinpoints the trigger: a recoverable context overflow is published as a `blocked` run end, `freezeRunResultAtCompletion` stores `resultText = null`, the guard (`resultText !== undefined`) makes that null permanent, and the announce give-up clears the delivery payload — so when the run later completes for real, its output is orphaned. The issue's production audit shows 0 of 28 retry-exhausted runs retained a frozen result (vs 403 of 435 normal runs), with recoveries arriving 26s–5m after give-up. This change makes the registry resilient to the false end regardless of how late the real completion arrives.

## Evidence

- **Behavior addressed**: A subagent completion stranded after a false blocked end is now re-captured and delivered when the run completes for real.
- **Real environment tested**: Linux (Ubuntu 24.04), Node 22, branch `fix/subagent-blocked-strand-120383` (openclaw @ 1510f1f0c29 on top of latest origin/main). The regression scenario runs the production registry lifecycle/delivery/cleanup code with only the gateway agent transport and session accessor stubbed.
- **Exact steps or command run after this patch**:

```console
$ node scripts/run-vitest.mjs src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts --run
$ node scripts/run-vitest.mjs src/agents/subagent-registry-lifecycle.test.ts --run
$ node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts --run
```

- **Evidence after fix**:

```console
$ node scripts/run-vitest.mjs src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts --run
 Test Files  1 passed (1)
      Tests  11 passed (11)
$ node scripts/run-vitest.mjs src/agents/subagent-registry-lifecycle.test.ts --run
 Test Files  1 passed (1)
      Tests  138 passed (138)

$ node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts --run
 Test Files  1 passed (1)
      Tests  143 passed (143)
```

Behavior matrix (regression e2e running the real registry lifecycle):

| Input sequence | Result |
|---|---|
| blocked end (error) → announce exhausted → later ok end (recovered answer) | delivery `suspended` (payload kept) → later completion re-captures text → `delivered` with the recovered answer |
| ok end → first announce throws → retry succeeds | frozen first answer delivered; later lifecycle noise never overwrites it |
| error end → remains terminal after grace | announced as error (unchanged) |
| timeout end → give-up at expiry | terminal `failed`, payload cleared (unchanged) |
| terminalReply `empty`/`visible` evidence | authoritative, never overwritten by transcript inference (unchanged) |

- **Observed result after fix**:
  1. A run settled as error with `resultText = null` and an exhausted announce now suspends (status `suspended`, payload retained, `cleanupHandled = false`) instead of failing terminal.
  2. When the run later completes for real (30s after the false end in the e2e), `freezeRunResultAtCompletion` re-captures the answer and the announce delivers it; `completion.resultText` and the final agent payload both contain the recovered answer.
  3. Existing guarantees preserved: a real frozen text is never overwritten by later lifecycle noise; `terminalReply`-derived empty/visible evidence stays authoritative; timeout/killed give-ups still fail terminal.
- **What was not tested**: A live model-provider context overflow end-to-end in a running OpenClaw gateway (`./scripts/dev.sh`) — the false-end/recovery race from #120383 is sporadic and could not be triggered deterministically here; the issue's own two-deployment production audit (0/28 retry-exhausted runs with frozen results vs 403/435 normal; recoveries at +26s/+3m22s/+5m08s) is the external baseline. Runner-layer change to stop publishing recoverable overflows as run ends was intentionally not implemented (maintainer semantic decision).

## Root Cause

What the user sees: a subagent finishes its work, but the result is never delivered, so the user has to ask again.

Why: the system treats a recoverable "context too long" situation as an immediate failure, permanently freezes "no result" as the final answer, and the notification channel gives up and clears the pending content; when the subagent actually finishes later, the system no longer reads the new answer, so the result is dropped.

Technical chain: `blocked` liveness end → immediate error settlement (no retry grace, `subagent-registry-listener.ts`) → `freezeRunResultAtCompletion` writes `resultText = null` (latch `resultText !== undefined` makes it permanent) → announce relays nothing and gives up → `clearPendingFinalDelivery` wipes the payload → a later ok end cannot re-capture (latch) or re-deliver (payload gone).

## Regression Test Plan

- e2e: false blocked end → null freeze → give-up suspends → later ok end re-captures and delivers (new test).
- Unit: error-outcome expiry give-up now suspends (new test); timeout/killed give-ups remain terminal (existing tests).
- Existing: frozen-result freeze/refresh, silent follow-up, 100KB cap, parallel children, lifecycle error/timeout grace — all pass.

## User-visible / Behavior Changes

Users receive subagent results that previously vanished after a false overflow end. Genuinely failed runs may remain pending up to the suspended-delivery TTL (7 days, hard cap 50) instead of failing immediately.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: No — the registry-layer defense is the minimal change that reliably fixes the reported stranding; the issue's preferred root fix (do not publish a recoverable overflow as a run end / give blocked ends a retry grace) is the better long-term fix but is a "when does a run end" semantic decision for maintainers. This PR intentionally scopes to the delivery-loss symptom, which is timing-independent.
- **Refactor needed**: No for this PR. Recommendation: unify error/timeout/blocked pending-terminal handling in `subagent-registry-pending-lifecycle.ts` so blocked ends also get a grace window.
- **Alternative considered**: 15s grace window for blocked ends — rejected because the issue's audited recoveries (+26s / +3m22s / +5m08s) all exceed it; raising the retry budget alone — rejected (retries relay the same frozen null); relaxing `refreshFrozenResultFromSession` alone — rejected (runId reuse makes it dead code, verified in issue).

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Codex <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Deep analysis of #120383 (provenance, main-freshness across freeze/give-up write points), Step 4 plan confirmation, Step 5 implementation with regression tests.

## Risks and Mitigations

**Highest-risk area**: Error-outcome runs whose announce retries exhaust now suspend (retained up to the 7-day suspended-delivery TTL, pressure-capped at 50) instead of failing terminal; the parent may see a pending completion longer than before.
**Mitigation**: Reuses the existing suspended-delivery lane with its TTL and hard cap; timeout and killed outcomes are unchanged; `permanent_failure` dispositions still fail terminal; a later real completion resumes and delivers, so suspension is bounded by the child's actual recovery.
**Compatibility impact**: No API/config/contract changes; announce idempotency keys and delivered/announcedAt gates unchanged.

Related to #120383
