### PR TITLE
fix(gateway): completed turns no longer stay stuck as active in session listings

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -90,9 +90,9 @@ function rememberCompletedSessionList(
 function resolveSessionListExpiration(result: SessionsListResult): number | null | undefined {
   let expiresAt: number | undefined;
   for (const session of result.sessions) {
-    // Running durations tick continuously, and a retained child can sit outside
-    // this page, leaving no authoritative child expiration to cache safely.
-    if (session.hasActiveSubagentRun || session.childSessions?.length) {
+    // Live work can settle without a session/index mutation, running durations tick,
+    // and a retained child can sit outside this page. None has a safe cache deadline.
+    if (session.hasActiveRun || session.hasActiveSubagentRun || session.childSessions?.length) {
       return null;
     }
     const statusExpiration = session.agentStatus?.expiresAt;

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -4,6 +4,7 @@ import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
 } from "../../agents/subagent-registry.test-helpers.js";
+import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
 import {
   loadSessionEntry,
   persistSessionTranscriptTurn,
@@ -590,8 +591,11 @@ describe("sessions.list single-flight", () => {
         hasActiveRun: true,
       });
       const activeCached = await listSessions({ client, context, request });
-      expect(activeCached).toBe(active);
-      expect(loader.calls).toHaveBeenCalledTimes(1);
+      expect(activeCached).not.toBe(active);
+      expect(
+        activeCached.sessions.find((session) => session.key === "agent:main:active"),
+      ).toMatchObject({ hasActiveRun: true });
+      expect(loader.calls).toHaveBeenCalledTimes(2);
 
       clearAgentRunContext(runId);
       const settled = await listSessions({ client, context, request });
@@ -600,11 +604,41 @@ describe("sessions.list single-flight", () => {
           hasActiveRun: false,
         },
       );
-      expect(loader.calls).toHaveBeenCalledTimes(2);
+      expect(loader.calls).toHaveBeenCalledTimes(3);
 
       const settledCached = await listSessions({ client, context, request });
       expect(settledCached).toBe(settled);
-      expect(loader.calls).toHaveBeenCalledTimes(2);
+      expect(loader.calls).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("does not cache a reply-owned active projection past turn completion", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { agentId: "main", archived: "all" as const, limit: 100 };
+      const operation = createReplyOperation({
+        sessionId: "main-active",
+        sessionKey: "agent:main:active",
+        resetTriggered: false,
+      });
+
+      try {
+        const active = await listSessions({ client, context, request });
+        expect(
+          active.sessions.find((session) => session.key === "agent:main:active"),
+        ).toMatchObject({ hasActiveRun: true });
+
+        operation.complete();
+        const settled = await listSessions({ client, context, request });
+        expect(
+          settled.sessions.find((session) => session.key === "agent:main:active"),
+        ).toMatchObject({ hasActiveRun: false });
+        expect(loader.calls).toHaveBeenCalledTimes(2);
+      } finally {
+        operation.complete();
+      }
     });
   });
 


### PR DESCRIPTION
# What Problem This Solves

Live QA (`goal-followthrough-live`, qa-channel + `openai/gpt-5.4`) failed ~3 of 5 runs with a silent hang: the goal-start turn completed and delivered its reply, yet `sessions.list` kept reporting the session as `hasActiveRun: true` indefinitely, so any client waiting for the session to settle (session pickers, QA waits, automation polling for idle) waited forever. Instrumented captures show the stuck terminal state directly: session `status: "done"`, goal present and active, `hasActiveRun: true` minutes after the turn finished — an action ending with no visible outcome, the worst failure class in the product doctrine.

# Why This Change Was Made

Two stacked defects, found by evidence rather than plausibility:

1. **Dispatch ownership leak** (`fix(auto-reply): always finalize dispatch operations`): a successful early-return path in `dispatchReplyFromConfigInner` could finish the turn without completing the admitted `ReplyOperation`, leaving the reply lane retained. The pipeline now finalizes every operation it admits in a `finally`; completion stays idempotent via the reply-run registry.
2. **Stale sessions-list cache row** (`fix(gateway): refresh active session listings`): the root cause of the observed stuck state. `sessions.list` results are cached with a monotonic fence (store mutations, agent-run index, identity, title projection). A poll landing inside the short window where the reply operation is still `running` captured `hasActiveRun: true` into the completed-listing cache — and reply/embedded cleanup bumps **no** fence, so every later poll returned the stale cached row without re-entering the resolver. The expiration policy now refuses to cache any completed listing containing an active-run row (same treatment as active subagent runs and retained children, which the guard already covered). Concurrent requests still share in-flight work; fully idle listings stay cached.

The intermittency matched the mechanism: failure required the first poll to land inside the narrow finalization window. (The recent `sessions.list` performance fix, #120344, made polls fast enough to hit that window more often.)

# User Impact

- A completed channel turn can no longer leave its session permanently marked active: session lists, TUI/Control-UI session pickers, and automations polling for idle observe settling correctly.
- Reply-lane ownership is released on every dispatch path, including successful early returns.

# Evidence

- Ground-truth capture of the stuck state (instrumented wait dumping `sessions.list` per poll): final poll shows `status:"done"`, goal active, `hasActiveRun:true` on the failing run; healthy runs show `hasActiveRun:false` immediately.
- Deterministic regression test `src/gateway/server-methods/sessions-read-cache.test.ts` ("second listing must rebuild"): fails without the cache fix (`Expected hasActiveRun: false / Received: true`), passes with it. Dispatch-finalization regression test `src/auto-reply/reply/dispatch-from-config.owner-finalization.test.ts` covers the ownership leak.
- Focused suites: gateway cache/active-run tests 31/31; both regression tests re-verified independently.
- Live proof: 4 consecutive full passes of `goal-followthrough-live` on `openai/gpt-5.4` post-fix (24.4s / 24.5s / 25.0s / independent verifier run), versus ~60% failure before.
- Autoreview (codex, gpt-5.6-sol, high) over the full branch: clean, no actionable findings, overall 0.98.
- Production LOC: +3/-0 (finalization) and +3/-3 (cache guard, net zero); tests +96/-4.
- Known separate follow-up (not in this PR): a live turn can stall silently mid-SSE with no idle-watchdog abort (`attempt-stream-finalize.ts` pending-event wait); tracked as its own task.
