### PR TITLE
fix(agents): keep stalled turns visible after Responses streams settle

### DIFF
--- a/packages/ai/src/transports/openai-responses-stream-activity.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-activity.test.ts
@@ -1,0 +1,77 @@
+// Responses streams must report every SSE event as request activity so the
+// embedded-runner idle watchdog stays quiet while bookkeeping-only events
+// (in_progress, *.done echoes) arrive, matching the completions and anthropic
+// transports.
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantMessage, Model } from "../types.js";
+import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
+import {
+  processResponsesStream,
+  type OpenAIResponsesStreamEvent,
+} from "./openai-responses-stream-internal.js";
+
+const model = {
+  id: "gpt-5.6-luna",
+  name: "GPT-5.6 Luna",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-responses">;
+
+function createOutput(): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+async function* eventStream(
+  events: readonly Record<string, unknown>[],
+): AsyncGenerator<OpenAIResponsesStreamEvent> {
+  for (const event of events) {
+    yield event as OpenAIResponsesStreamEvent;
+  }
+}
+
+describe("processResponsesStream request activity", () => {
+  it("notifies request activity for every SSE event, including ignored ones", async () => {
+    const abortController = new AbortController();
+    const onActivity = vi.fn();
+    const unsubscribe = onLlmRequestActivity(abortController.signal, onActivity);
+    try {
+      const events: Record<string, unknown>[] = [
+        { type: "response.created", response: { id: "resp_activity" } },
+        // Ignored bookkeeping event: no consumer-visible event is pushed.
+        { type: "response.in_progress", response: { id: "resp_activity" } },
+        {
+          type: "response.completed",
+          response: { id: "resp_activity", status: "completed", output: [] },
+        },
+      ];
+      await processResponsesStream(eventStream(events), createOutput(), { push: () => {} }, model, {
+        signal: abortController.signal,
+      });
+      expect(onActivity).toHaveBeenCalledTimes(events.length);
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -20,6 +20,7 @@ import {
 } from "../providers/openai-responses-tool-call-tracker.js";
 import type { Api, AssistantMessage, Model, TextContent, ToolCall, Usage } from "../types.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import {
   type FirstStreamEventInternalOptions,
   withFirstStreamEventTimeout,
@@ -287,6 +288,10 @@ export async function processResponsesStream<TApi extends Api>(
   );
   try {
     for await (const event of guardedStream) {
+      // Bookkeeping-only SSE events (in_progress, *.done echoes) are still
+      // provider progress; keep the idle watchdog alive without exposing them,
+      // matching the completions and anthropic transports.
+      notifyLlmRequestActivity(options?.signal);
       if (event.type === "response.created") {
         output.responseId = event.response.id;
       } else if (event.type === "response.output_item.added") {

--- a/src/agents/embedded-agent-runner/run/abortable.test.ts
+++ b/src/agents/embedded-agent-runner/run/abortable.test.ts
@@ -1,6 +1,10 @@
 // Coverage for abort-aware promise wrapping in embedded attempts.
-import { describe, expect, it } from "vitest";
-import { abortable } from "./abortable.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  abortable,
+  joinWithRunLivenessDeadline,
+  RUN_LIVENESS_JOIN_TIMEOUT_MS,
+} from "./abortable.js";
 
 describe("abortable", () => {
   it("rejects with AbortError when signal aborts before inner settles", async () => {
@@ -28,5 +32,54 @@ describe("abortable", () => {
   it("resolves with inner value when inner settles before abort", async () => {
     const ac = new AbortController();
     await expect(abortable(ac.signal, Promise.resolve(42))).resolves.toBe(42);
+  });
+});
+
+describe("joinWithRunLivenessDeadline", () => {
+  it("resolves when the joined work settles, without firing onTimeout", async () => {
+    const ac = new AbortController();
+    const onTimeout = vi.fn();
+    await joinWithRunLivenessDeadline({
+      joinWork: () => Promise.resolve(),
+      runAbortSignal: ac.signal,
+      onTimeout,
+    });
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("resolves at the liveness deadline when the joined work hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      const ac = new AbortController();
+      const onTimeout = vi.fn();
+      const join = joinWithRunLivenessDeadline({
+        joinWork: () => new Promise<never>(() => {}),
+        runAbortSignal: ac.signal,
+        onTimeout,
+      });
+      await vi.advanceTimersByTimeAsync(RUN_LIVENESS_JOIN_TIMEOUT_MS);
+      await join;
+      expect(onTimeout).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resolves immediately on an aborted run signal and treats rejection as settled", async () => {
+    const aborted = new AbortController();
+    aborted.abort();
+    const onTimeout = vi.fn();
+    await joinWithRunLivenessDeadline({
+      joinWork: () => new Promise<never>(() => {}),
+      runAbortSignal: aborted.signal,
+      onTimeout,
+    });
+    const ac = new AbortController();
+    await joinWithRunLivenessDeadline({
+      joinWork: () => Promise.reject(new Error("delivery chain error already logged")),
+      runAbortSignal: ac.signal,
+      onTimeout,
+    });
+    expect(onTimeout).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/embedded-agent-runner/run/abortable.ts
+++ b/src/agents/embedded-agent-runner/run/abortable.ts
@@ -31,6 +31,60 @@ function makeAbortError(signal: AbortSignal): Error {
   return tagAsAbortableWrapper(err);
 }
 
+// Post-turn joins (pending subscription handlers, block-reply flush) ride
+// delivery chains that can wedge; the default run budget is 48h, so an
+// unbounded await there dead-ends the turn with no visible outcome. 120s
+// matches the cloud llm-idle class: anything quiet longer is a stuck lane,
+// not legitimate delivery work.
+export const RUN_LIVENESS_JOIN_TIMEOUT_MS = 120_000;
+
+/**
+ * Awaits post-turn work that must never dead-end the run: races the joined
+ * promise against the run-abort signal and a liveness deadline. Timeout and
+ * abort RESOLVE (timeout after `onTimeout`) instead of rejecting so settlement
+ * still produces a visible terminal outcome; rejections also resolve because
+ * the joined chains own their error logging.
+ */
+export function joinWithRunLivenessDeadline(input: {
+  joinWork: () => Promise<void> | void;
+  runAbortSignal: AbortSignal;
+  timeoutMs?: number;
+  onTimeout: () => void;
+}): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (reason: "settled" | "timeout" | "abort") => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      input.runAbortSignal.removeEventListener("abort", onAbort);
+      if (reason === "timeout") {
+        input.onTimeout();
+      }
+      resolve();
+    };
+    const onAbort = () => finish("abort");
+    const timer = setTimeout(
+      () => finish("timeout"),
+      input.timeoutMs ?? RUN_LIVENESS_JOIN_TIMEOUT_MS,
+    );
+    timer.unref?.();
+    if (input.runAbortSignal.aborted) {
+      finish("abort");
+      return;
+    }
+    input.runAbortSignal.addEventListener("abort", onAbort, { once: true });
+    Promise.resolve()
+      .then(() => input.joinWork())
+      .then(
+        () => finish("settled"),
+        () => finish("settled"),
+      );
+  });
+}
+
 /**
  * Races a promise against an AbortSignal while preserving normal promise
  * settlement. Abort wins immediately and rejected non-Error payloads are

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
@@ -246,6 +246,86 @@ describe("finalizeEmbeddedAttemptStreamPhase", () => {
     );
   });
 
+  it("proceeds to settlement when pending subscription events never settle", async () => {
+    vi.useFakeTimers();
+    try {
+      const fixture = createFixture();
+      // A hung delivery handler must not dead-end the turn until the run budget.
+      fixture.input.waitForPendingEvents = vi.fn(() => new Promise<never>(() => {}));
+      const settledStream = {
+        promptError: null,
+        promptErrorSource: null,
+        timedOutDuringCompaction: false,
+        compactionOccurredThisAttempt: false,
+        messagesSnapshot: [],
+        sessionIdUsed: "session-1",
+        lastAssistant: undefined,
+        currentAttemptAssistant: undefined,
+        currentAttemptCompletedAssistant: undefined,
+        attemptUsage: undefined,
+        cacheBreak: null,
+        lastCallUsage: undefined,
+        promptCache: undefined,
+      };
+      mocks.settleStream.mockResolvedValue(settledStream);
+      mocks.completeAfterTurn.mockResolvedValue({
+        sessionIdUsed: "session-1",
+        sessionFileUsed: "session.jsonl",
+      });
+
+      const finalize = finalizeEmbeddedAttemptStreamPhase(fixture.input);
+      await vi.advanceTimersByTimeAsync(119_999);
+      expect(mocks.settleStream).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(finalize).resolves.toEqual({
+        sessionIdUsed: "session-1",
+        sessionFileUsed: "session.jsonl",
+      });
+      expect(mocks.settleStream).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips the pending-events join once the run abort signal fires", async () => {
+    const abortController = new AbortController();
+    abortController.abort(new Error("operator cancel"));
+    const fixture = createFixture();
+    fixture.input.settle.runAbortSignal = abortController.signal;
+    fixture.input.waitForPendingEvents = vi.fn(() => new Promise<never>(() => {}));
+    fixture.input.settle.readLifecycleState = () => ({
+      aborted: true,
+      timedOut: false,
+      timedOutDuringCompaction: false,
+    });
+    const settledStream = {
+      promptError: null,
+      promptErrorSource: null,
+      timedOutDuringCompaction: false,
+      compactionOccurredThisAttempt: false,
+      messagesSnapshot: [],
+      sessionIdUsed: "session-1",
+      lastAssistant: undefined,
+      currentAttemptAssistant: undefined,
+      currentAttemptCompletedAssistant: undefined,
+      attemptUsage: undefined,
+      cacheBreak: null,
+      lastCallUsage: undefined,
+      promptCache: undefined,
+    };
+    mocks.settleStream.mockResolvedValue(settledStream);
+    mocks.completeAfterTurn.mockResolvedValue({
+      sessionIdUsed: "session-1",
+      sessionFileUsed: "session.jsonl",
+    });
+
+    await expect(finalizeEmbeddedAttemptStreamPhase(fixture.input)).resolves.toEqual({
+      sessionIdUsed: "session-1",
+      sessionFileUsed: "session.jsonl",
+    });
+    expect(mocks.settleStream).toHaveBeenCalledOnce();
+  });
+
   it("settles an aborted run when prompt release returns its recorded cancellation reason", async () => {
     const cancellationReason = new Error("cancelled by operator");
     const fixture = createFixture({

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
@@ -1,7 +1,55 @@
 /** Settles the provider stream and completes the post-turn lifecycle phase. */
 import { isRunnerAbortError } from "../abort.js";
+import { log } from "../logger.js";
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
+
+// Queued subscription handlers (block-reply delivery, tool events) are
+// fire-and-forget during the turn; the pending-events join below is the only
+// place the run waits for them. One hung handler (e.g. a stuck delivery
+// dispatch lane) must not dead-end the turn until the run budget — 48h by
+// default — so the join is bounded and settlement proceeds with a recorded
+// warning instead of producing no visible outcome at all.
+const PENDING_EVENT_JOIN_TIMEOUT_MS = 120_000;
+
+async function joinPendingEventsBounded(input: {
+  waitForPendingEvents: () => Promise<void>;
+  runAbortSignal: AbortSignal;
+  runId: string;
+}): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (reason: "settled" | "timeout" | "abort") => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      input.runAbortSignal.removeEventListener("abort", onAbort);
+      if (reason === "timeout") {
+        log.warn(
+          `pending subscription events did not settle within ${PENDING_EVENT_JOIN_TIMEOUT_MS}ms; ` +
+            `proceeding to stream settlement: runId=${input.runId}`,
+        );
+      }
+      resolve();
+    };
+    const onAbort = () => finish("abort");
+    const timer = setTimeout(() => finish("timeout"), PENDING_EVENT_JOIN_TIMEOUT_MS);
+    timer.unref?.();
+    if (input.runAbortSignal.aborted) {
+      finish("abort");
+      return;
+    }
+    input.runAbortSignal.addEventListener("abort", onAbort, { once: true });
+    // Handler failures are already swallowed and logged by the event chain;
+    // treat rejection as settled so finalize never re-fails on join.
+    input.waitForPendingEvents().then(
+      () => finish("settled"),
+      () => finish("settled"),
+    );
+  });
+}
 
 type StreamSettleInput = Parameters<typeof settleEmbeddedAttemptStream>[0];
 type StreamSettleResult = Awaited<ReturnType<typeof settleEmbeddedAttemptStream>>;
@@ -44,7 +92,11 @@ export async function finalizeEmbeddedAttemptStreamPhase(input: {
 }): Promise<{ sessionIdUsed: string; sessionFileUsed?: string }> {
   const { activeSession, sessionManager, sessionLockController, withOwnedSessionWriteLock } = input;
 
-  await input.waitForPendingEvents();
+  await joinPendingEventsBounded({
+    waitForPendingEvents: input.waitForPendingEvents,
+    runAbortSignal: input.settle.runAbortSignal,
+    runId: input.attempt.runId,
+  });
   const beforeAgentFinalizeRevisionReason = input.getBeforeAgentFinalizeRevisionReason();
   const beforeAgentFinalizeRevisionEntryId = input.getBeforeAgentFinalizeRevisionEntryId();
   let rewoundBeforeAgentFinalizeRevision = false;

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
@@ -1,55 +1,9 @@
 /** Settles the provider stream and completes the post-turn lifecycle phase. */
 import { isRunnerAbortError } from "../abort.js";
 import { log } from "../logger.js";
+import { joinWithRunLivenessDeadline, RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
-
-// Queued subscription handlers (block-reply delivery, tool events) are
-// fire-and-forget during the turn; the pending-events join below is the only
-// place the run waits for them. One hung handler (e.g. a stuck delivery
-// dispatch lane) must not dead-end the turn until the run budget — 48h by
-// default — so the join is bounded and settlement proceeds with a recorded
-// warning instead of producing no visible outcome at all.
-const PENDING_EVENT_JOIN_TIMEOUT_MS = 120_000;
-
-async function joinPendingEventsBounded(input: {
-  waitForPendingEvents: () => Promise<void>;
-  runAbortSignal: AbortSignal;
-  runId: string;
-}): Promise<void> {
-  await new Promise<void>((resolve) => {
-    let settled = false;
-    const finish = (reason: "settled" | "timeout" | "abort") => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      input.runAbortSignal.removeEventListener("abort", onAbort);
-      if (reason === "timeout") {
-        log.warn(
-          `pending subscription events did not settle within ${PENDING_EVENT_JOIN_TIMEOUT_MS}ms; ` +
-            `proceeding to stream settlement: runId=${input.runId}`,
-        );
-      }
-      resolve();
-    };
-    const onAbort = () => finish("abort");
-    const timer = setTimeout(() => finish("timeout"), PENDING_EVENT_JOIN_TIMEOUT_MS);
-    timer.unref?.();
-    if (input.runAbortSignal.aborted) {
-      finish("abort");
-      return;
-    }
-    input.runAbortSignal.addEventListener("abort", onAbort, { once: true });
-    // Handler failures are already swallowed and logged by the event chain;
-    // treat rejection as settled so finalize never re-fails on join.
-    input.waitForPendingEvents().then(
-      () => finish("settled"),
-      () => finish("settled"),
-    );
-  });
-}
 
 type StreamSettleInput = Parameters<typeof settleEmbeddedAttemptStream>[0];
 type StreamSettleResult = Awaited<ReturnType<typeof settleEmbeddedAttemptStream>>;
@@ -64,6 +18,13 @@ type SharedPhaseInputKeys =
   | "sessionManager"
   | "sessionLockController"
   | "withOwnedSessionWriteLock";
+
+// Queued subscription handlers (block-reply delivery, tool events) are
+// fire-and-forget during the turn; the pending-events join below is the only
+// place the run waits for them. One hung handler (e.g. a stuck delivery
+// dispatch lane) must not dead-end the turn until the run budget — 48h by
+// default — so the join is bounded and settlement proceeds with a recorded
+// warning instead of producing no visible outcome at all.
 
 export async function finalizeEmbeddedAttemptStreamPhase(input: {
   attempt: StreamSettleInput["attempt"];
@@ -92,10 +53,15 @@ export async function finalizeEmbeddedAttemptStreamPhase(input: {
 }): Promise<{ sessionIdUsed: string; sessionFileUsed?: string }> {
   const { activeSession, sessionManager, sessionLockController, withOwnedSessionWriteLock } = input;
 
-  await joinPendingEventsBounded({
-    waitForPendingEvents: input.waitForPendingEvents,
+  await joinWithRunLivenessDeadline({
+    joinWork: input.waitForPendingEvents,
     runAbortSignal: input.settle.runAbortSignal,
-    runId: input.attempt.runId,
+    onTimeout: () => {
+      log.warn(
+        `pending subscription events did not settle within ${RUN_LIVENESS_JOIN_TIMEOUT_MS}ms; ` +
+          `proceeding to stream settlement: runId=${input.attempt.runId}`,
+      );
+    },
   });
   const beforeAgentFinalizeRevisionReason = input.getBeforeAgentFinalizeRevisionReason();
   const beforeAgentFinalizeRevisionEntryId = input.getBeforeAgentFinalizeRevisionEntryId();

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -1,0 +1,102 @@
+// Settlement liveness: a wedged block-reply flush must not park the turn.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../sessions/index.js";
+import { RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
+import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
+
+type SettleInput = Parameters<typeof settleEmbeddedAttemptStream>[0];
+
+function createSettleFixture(overrides?: Partial<SettleInput>): SettleInput {
+  const sessionManager = SessionManager.inMemory();
+  return {
+    attempt: {
+      runId: "run-settle-1",
+      sessionId: "sess-settle-1",
+      sessionKey: "agent:main:test",
+      provider: "openai",
+      modelId: "gpt-5.6-luna",
+      model: { api: "openai-responses" },
+      config: {},
+      promptCacheKey: undefined,
+    },
+    activeSession: {
+      sessionId: "sess-settle-1",
+      isCompacting: false,
+      isStreaming: false,
+      messages: [],
+    },
+    sessionManager,
+    sessionLockController: {},
+    withOwnedSessionWriteLock: async (operation: () => unknown) => await operation(),
+    subscription: {
+      toolMetas: [],
+      waitForCompactionRetry: async () => {},
+      isCompactionInFlight: () => false,
+      getCompactionCount: () => 0,
+      getCurrentAttemptAssistant: () => undefined,
+      getUsageTotals: () => undefined,
+      getLastAssistantUsage: () => undefined,
+    },
+    state: {
+      promptError: null,
+      promptErrorSource: null,
+      yieldAborted: false,
+      sessionIdUsed: "sess-settle-1",
+    },
+    readLifecycleState: () => ({
+      aborted: false,
+      timedOut: false,
+      timedOutDuringCompaction: false,
+    }),
+    markTimedOutDuringCompaction: vi.fn(),
+    runAbortDeadlineAtMs: Date.now() + 600_000,
+    runAbortSignal: new AbortController().signal,
+    isProbeSession: true,
+    abortable: async <T>(promise: Promise<T>) => await promise,
+    prePromptMessageCount: 0,
+    toolSearchTargetTranscriptProjections: [],
+    cache: {
+      observabilityEnabled: false,
+      changesForTurn: null,
+      retention: undefined,
+    },
+    shouldFlushForContextEngine: false,
+    ...overrides,
+  } as unknown as SettleInput;
+}
+
+describe("settleEmbeddedAttemptStream liveness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("settles past a block-reply flush that never resolves", async () => {
+    vi.useFakeTimers();
+    // A wedged delivery lane (including the supported blockReplyTimeoutMs: 0
+    // path) previously parked settlement until the 48h run budget.
+    const input = createSettleFixture({
+      onBlockReplyFlush: () => new Promise<never>(() => {}),
+    } as Partial<SettleInput>);
+
+    const settle = settleEmbeddedAttemptStream(input);
+    let settled = false;
+    void settle.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(RUN_LIVENESS_JOIN_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await settle;
+    expect(result.sessionIdUsed).toBe("sess-settle-1");
+  });
+
+  it("settles normally when the flush resolves", async () => {
+    const flushed = vi.fn(async () => {});
+    const input = createSettleFixture({
+      onBlockReplyFlush: flushed,
+    } as Partial<SettleInput>);
+    const result = await settleEmbeddedAttemptStream(input);
+    expect(flushed).toHaveBeenCalledWith({ reason: "pre_compaction", attemptAccepted: false });
+    expect(result.sessionIdUsed).toBe("sess-settle-1");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -17,6 +17,7 @@ import {
   type PromptCacheBreak,
   type PromptCacheChange,
 } from "../prompt-cache-observability.js";
+import { joinWithRunLivenessDeadline, RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
 import {
   flushSessionManagerTranscript,
   normalizeCompactionRecoveryTranscriptTail,
@@ -191,7 +192,19 @@ export async function settleEmbeddedAttemptStream(input: {
         !input.readLifecycleState().timedOut &&
         !state.yieldAborted &&
         currentAssistant?.stopReason === "stop";
-      await input.onBlockReplyFlush({ reason: "pre_compaction", attemptAccepted });
+      // The flush rides the same delivery chain the finalize-phase join just
+      // bounded; a wedged lane (including the supported blockReplyTimeoutMs: 0
+      // path) must not park settlement until the 48h run budget either.
+      await joinWithRunLivenessDeadline({
+        joinWork: () => input.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted }),
+        runAbortSignal: input.runAbortSignal,
+        onTimeout: () => {
+          log.warn(
+            `block-reply flush did not settle within ${RUN_LIVENESS_JOIN_TIMEOUT_MS}ms; ` +
+              `proceeding with settlement: runId=${attempt.runId}`,
+          );
+        },
+      });
     }
 
     const compactionRetryWait = state.yieldAborted


### PR DESCRIPTION
## What Problem This Solves

Live QA (`goal-followthrough-live`, gpt-5.4 via openai-responses) caught a bare-continue turn that completed its SSE requests and then produced **no terminal result, delivery, timeout, or error for 6+ minutes** until the gateway was SIGTERMed — the worst bug class per Product Doctrine (action with no visible outcome and no recorded reason). This was the third failure signature from the same QA session, alongside #120344 and 0aaa77fc179.

## Why This Change Was Made

Root cause: turn liveness is enforced only while the agent loop awaits provider stream events (the llm-idle watchdog). Subscription event handlers (block-reply delivery, tool events) are fire-and-forget during the turn, serialized into a pending-event chain, and the runner's only join point — `waitForPendingEvents()` at the top of `attempt-stream-finalize.ts` — was unbounded and not abort-aware. One hung delivery handler (the bug class fixed in 0aaa77fc179, a leaked dispatch lane) parks the whole turn there, and the default run budget is **48 hours**, so nothing ever fires. The gateway log for the failing run shows the idle watchdog never aborted (an idle abort provably emits a `[responses] error` warn from the transport pump; none appeared), confirming the stall was post-stream.

Two repairs:

1. **Bounded pending-events join** (`src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts`): the join now races a 120s liveness deadline and the run-abort signal. On expiry it warns with the runId and proceeds to settlement, so the run always yields a visible terminal outcome; external aborts now unstick finalize immediately.
2. **Responses transport activity parity** (`packages/ai/src/transports/openai-responses-stream-internal.ts`): openai-responses transports never called `notifyLlmRequestActivity` (completions and anthropic do). `processResponsesStream` now notifies per SSE event — covering OpenAI, Azure, and chatgpt-responses paths — so bookkeeping-only events (`response.in_progress`, `*.done` echoes) keep the idle watchdog quiet instead of counting as network silence.

## User Impact

A turn whose delivery handlers hang now settles with a recorded warning within ~2 minutes instead of silently dead-ending until the 48h run budget or an operator restart. Responses streams that emit only bookkeeping SSE events during long hidden-reasoning phases no longer risk false idle-timeout aborts.

## Evidence

- Failure evidence: QA artifact `run-live-frontier-20260807/flow/isolated/scenarios/goal-followthrough-live/artifacts/gateway-runtime/gateway.stdout.log` — Responses fetches at 17:01:03/17:01:07, headers 17:01:08, then total silence until 17:07:08 SIGTERM; no idle-timeout abort, no `[responses] error` warn.
- New tests: `openai-responses-stream-activity.test.ts` (per-event activity incl. ignored bookkeeping events); `attempt-stream-finalize.test.ts` — hung handlers proceed to settlement after the 120s deadline (fake timers), pre-aborted run signal skips the join.
- Regression suites green: `llm-idle-timeout.test.ts`, `attempt.abort-race.test.ts`, `openai-responses-stream-parity.test.ts`, `openai-responses-stream-terminal-recovery.test.ts` (164 tests total).
- `tsgo` core + core-test lanes and oxlint clean. Codex autoreview (`gpt-5.6-sol`, high) on the diff: no actionable findings.

## Red-main repair included

`src/auto-reply/reply/reply-admission-ticket.ts` (landed on `main` via #120420) breaks the plugin-sdk boundary dts compile (`filter(Boolean)` does not narrow `string | undefined`) and oxlint `curly` / `no-promise-executor-return` / `unicorn(no-array-sort)` rules, turning `check-lint`, `check-prod-types`, `check-test-types`, and `check-additional-extension-package-boundary` red for every PR. Fixed here per landing policy (never land onto red): canonical `hasNonEmptyString` type guard, braced control flow, block-bodied promise executor, `toSorted()`. Behavior-neutral; `reply-turn-admission` + `followup-turn-admission` suites (80 tests) stay green.

Second round (b9eed1b4044): the first CI run surfaced three more main-breaking issues. `agent-runner-run.ts` exceeded the 700-line cap after #120420 — the always-returning active-run steer-injection block moved to `agent-runner-steer-injection.ts` (behavior-preserving), and `ParkedSteerReservation` switched to property-function syntax to clear the `unbound-method` lint. `queue/enqueue.ts` had further curly/promise-executor violations. `gateway-steer-fifo.e2e.test.ts` assigned readonly `as const` catalogs into `ModelProviderConfig` (mutable copies at the call site). The `package-acceptance-workflow` tooling test still asserted the pre-#120427 immediate wrong-title refusal; it now matches the shipped retry-then-refuse behavior. Proof: steer/queue suites (agent-runner runreplyagent, commands-steer, queue-policy, dedupe, drain-restart, in-flight, drain.identity-guard, state — 82 tests), full package-acceptance file (168), attempt.queue-message, tsgo core + core-test + test-root lanes, boundary dts compile, import-cycle check, oxlint. Codex autoreview clean.

Third round (c2cd4182f74): #120433 landed `src/cli/mcp-oauth-loopback.test.ts` with two `no-promise-executor-return` violations and pushed `mcp-cli.test.ts` over the 1000-counted-line test cap. Fixed with block-bodied close callbacks and by table-driving four structurally identical "clears stored OAuth credentials when …" tests into one `it.each` (repo test policy), preserving the `show --json` auth-removal assertion. Proof: both mcp test files green (37 tests), full `run-lint.mjs` lane clean locally, extensions test-types lane clean. Rebased onto 1f15bc92f90.

## ClawSweeper status at landing

Three ClawSweeper workers started on this PR (02:49Z on a superseded head, 03:48Z and 04:44Z on the exact landing head de4b02cd07e) without producing a durable review; no rank-up moves exist to apply. Landing proceeds on green exact-head CI, validated scripts/pr review artifacts, and three clean Codex autoreviews (gpt-5.6-sol, high) covering every commit — stated here per the never-merge-past-moves-silently policy.


## Final shape

Mainline PRs #120438, #120441, #120442, and #120477 independently landed equivalents of every red-main repair this PR had accumulated (admission-ticket typing, enqueue/mcp lint, agent-runner split, tooling-test alignment). The branch is now collapsed to the single original commit — the turn-liveness fix (bounded pending-events join + Responses activity parity) — rebased onto 733512b612e. All previously failing lanes verified green locally on this exact stack.

Additional red-main repair (ac9eebf5138): `check-plugin-sdk-api-baseline` fails closed on current `main` — the `module/session-catalog` hash drifted because `SessionCatalogEntrySummary`'s `SessionEntry` import re-pointed from `config/sessions.ts` to `plugin-sdk/session-store-runtime.ts` in tonight's landed commits without a manifest regen. Verified the declaration diff is the import path only (no export added/removed/reshaped, 0 additions/removals across the whole surface), regenerated via the generator, and committed the manifest.


## Final landing shape (0ff7018620b)

Rebased onto fb61ae15fcf, which independently repaired the lint/protocol/doctor/baseline breakage; my superseded interim commits were dropped. Two #120497 regressions remained red on main and are fixed here: (1) `attempt-normalization` carried `lastRunPromptUsage` outranked the session's unavailable-context sentinel, reviving a stale context-size fact across retries — the sentinel is now a barrier (fixes #120497's own shipped-red retry test, 8 direct + 47 usage tests green); (2) `commands-status` Codex context fixtures lacked the `totalTokensFresh`/`totalTokensVersion` provenance #120497 requires — hunks adopted from #120501 (45 tests green). ClawSweeper status at landing unchanged: no durable review across multiple worker attempts; landing on green exact-head CI, validated review artifacts, and clean Codex autoreviews per commit.


## ClawSweeper moves applied (head 895a90bbc1e)

- **P1 bound the block-reply flush**: applied. The bounded join is generalized into `joinWithRunLivenessDeadline` in `run/abortable.ts` and now guards both the finalize-phase pending-events join and settlement's `onBlockReplyFlush` await (the `blockReplyTimeoutMs: 0` path included). Covered by helper tests (hang/abort/rejection) plus a real-settle-path regression that holds the flush past the 120s deadline and verifies settlement completes.
- **P2 fence direct delivery after a timed-out join**: deferred as a named follow-up. The block-reply pipeline already suppresses late chunk inserts after the final text merge (`suppressBlockChunks` in embedded-agent-subscribe), which bounds the stale-delivery window; full delivery-lifecycle ownership (cancel/fence on join timeout) is a coherent refactor of the delivery owner and should not ride this liveness PR.
- **Integration fault test for the downstream flush path**: applied via the new `attempt-stream-settle.test.ts` real-path regression.
