### PR TITLE
ci(release): tolerate async run-name evaluation when adopting validation children

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -481,31 +481,44 @@ jobs:
 
           validate_child_run() {
             local candidate_run_id="$1"
-            local candidate_run_json
+            local candidate_run_json attempt
             if [[ ! "$candidate_run_id" =~ ^[0-9]+$ ]]; then
               echo "::error::Refusing to adopt invalid ${workflow} run ID ${candidate_run_id}." >&2
               return 1
             fi
-            candidate_run_json="$(
-              gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}"
-            )"
-            if ! jq -e \
-              --argjson id "$candidate_run_id" \
-              --argjson workflow_id "$expected_workflow_id" \
-              --arg title "$dispatch_run_name" \
-              --arg branch "$CHILD_WORKFLOW_REF" \
-              '(.id == $id)
-                and (.workflow_id == $workflow_id)
-                and (.display_title == $title)
-                and (.head_branch == $branch)
-                and (.event == "workflow_dispatch")' \
-              <<< "$candidate_run_json" >/dev/null; then
-              echo "::error::Refusing to adopt unvalidated ${workflow} run ${candidate_run_id}." >&2
-              jq '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
-                <<< "$candidate_run_json" >&2
-              return 1
-            fi
-            printf '%s\n' "$candidate_run_json"
+            # GitHub evaluates run-name asynchronously: a run adopted from the dispatch
+            # response can briefly report its default display_title. Identity fields are
+            # immediate-refuse; a lone title mismatch retries until the template lands.
+            for attempt in $(seq 1 12); do
+              candidate_run_json="$(
+                gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_run_id}"
+              )"
+              if ! jq -e \
+                --argjson id "$candidate_run_id" \
+                --argjson workflow_id "$expected_workflow_id" \
+                --arg branch "$CHILD_WORKFLOW_REF" \
+                '(.id == $id)
+                  and (.workflow_id == $workflow_id)
+                  and (.head_branch == $branch)
+                  and (.event == "workflow_dispatch")' \
+                <<< "$candidate_run_json" >/dev/null; then
+                echo "::error::Refusing to adopt unvalidated ${workflow} run ${candidate_run_id}." >&2
+                jq '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
+                  <<< "$candidate_run_json" >&2
+                return 1
+              fi
+              if jq -e --arg title "$dispatch_run_name" '.display_title == $title' \
+                <<< "$candidate_run_json" >/dev/null; then
+                printf '%s\n' "$candidate_run_json"
+                return 0
+              fi
+              echo "Waiting for ${workflow} run ${candidate_run_id} display title (attempt ${attempt})." >&2
+              sleep 5
+            done
+            echo "::error::Refusing to adopt ${workflow} run ${candidate_run_id}: display title never matched ${dispatch_run_name}." >&2
+            jq '{id, workflow_id, path, display_title, head_branch, head_sha, event, html_url}' \
+              <<< "$candidate_run_json" >&2
+            return 1
           }
 
           fetch_child_jobs() {


### PR DESCRIPTION
## What Problem This Solves

Every Full Release Validation run since 2026-08-07 ~07:00 UTC fails with `Refusing to adopt unvalidated <workflow> run <id>` for all three children (CI, plugin prerelease, release checks), blocking 2026.8.1-beta.1. Example: run 31228444217 — the child run's `display_title` read as plain "CI" at validation time but shows the correct `CI full-release-validation-…` name now.

## Why This Change Was Made

GitHub evaluates `run-name` asynchronously: a freshly created run briefly reports its default title. The parent's fast adoption path (newer `gh` returns the run URL directly from the dispatch POST) validates the child ~1s after creation — before the template lands — so the strict five-field identity check fails on `display_title`. The Aug 5 validations passed only because dispatch output carried no URL, forcing the exact-name polling path that inherently waits for the title.

The fix keeps the security posture: id, workflow_id, head_branch, and event mismatches still refuse immediately (those prove the run is ours); only a lone `display_title` mismatch retries, bounded at 12×5s, then refuses with the same diagnostic dump. One edit in the shared `&full_release_child_dispatch` anchor covers all five dispatch jobs.

## User Impact

Release validation can adopt its children again; the beta.1 train unblocks at the harness layer (product-lane failures on the candidate are a separate, real signal now being investigated).

## Evidence

- All five extracted job scripts pass `bash -n`; `node scripts/check-workflows.mjs` (incl. zizmor) passes; YAML parses; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, high): clean — "preserves immediate rejection for mismatched run identity fields and bounds retries for the asynchronously populated display title" (0.98).
- Harness-only change: `.github/workflows/full-release-validation.yml`, +20/−8.
