### PR TITLE
fix(matrix): ignore out-of-range hex escapes in env account tokens

### DIFF
--- a/extensions/matrix/src/env-vars.test.ts
+++ b/extensions/matrix/src/env-vars.test.ts
@@ -1,0 +1,34 @@
+// Matrix tests cover scoped env var account token behavior.
+import { describe, expect, it } from "vitest";
+import { listMatrixEnvAccountIds, resolveMatrixEnvAccountToken } from "./env-vars.js";
+
+describe("listMatrixEnvAccountIds", () => {
+  it("discovers accounts whose ids need hex-escaped env tokens", () => {
+    const token = resolveMatrixEnvAccountToken("team.ops");
+    const env = {
+      [`MATRIX_${token}_HOMESERVER`]: "https://matrix.example.org",
+    } satisfies NodeJS.ProcessEnv;
+
+    expect(listMatrixEnvAccountIds(env)).toEqual(["team-ops"]);
+  });
+
+  it("ignores scoped env vars whose account token is malformed", () => {
+    const env = {
+      MATRIX_TEAM_XZZ_OPS_HOMESERVER: "https://matrix.example.org",
+      "MATRIX_!_HOMESERVER": "https://matrix.example.org",
+    } satisfies NodeJS.ProcessEnv;
+
+    expect(listMatrixEnvAccountIds(env)).toEqual([]);
+  });
+
+  it("ignores hex escapes above the Unicode range instead of throwing", () => {
+    // String.fromCodePoint throws a RangeError for code points above 0x10FFFF;
+    // a malformed MATRIX_* env var must not crash account discovery.
+    const env = {
+      MATRIX_A_X110000_B_HOMESERVER: "https://matrix.example.org",
+      MATRIX_A_XFFFFFFFF_B_HOMESERVER: "https://matrix.example.org",
+    } satisfies NodeJS.ProcessEnv;
+
+    expect(listMatrixEnvAccountIds(env)).toEqual([]);
+  });
+});

--- a/extensions/matrix/src/env-vars.ts
+++ b/extensions/matrix/src/env-vars.ts
@@ -49,8 +49,7 @@ function decodeMatrixEnvAccountToken(token: string): string | undefined {
     if (hexEscape) {
       const hex = hexEscape[1];
       const codePoint = hex ? Number.parseInt(hex, 16) : Number.NaN;
-      // Guard String.fromCodePoint's Unicode range so one malformed env token
-      // cannot abort discovery of every Matrix account.
+      // Reject invalid code points so one malformed env token cannot abort Matrix discovery.
       if (!Number.isInteger(codePoint) || codePoint > 0x10ffff) {
         return undefined;
       }

--- a/extensions/matrix/src/env-vars.ts
+++ b/extensions/matrix/src/env-vars.ts
@@ -49,7 +49,11 @@ function decodeMatrixEnvAccountToken(token: string): string | undefined {
     if (hexEscape) {
       const hex = hexEscape[1];
       const codePoint = hex ? Number.parseInt(hex, 16) : Number.NaN;
-      if (!Number.isFinite(codePoint)) {
+      // String.fromCodePoint throws a RangeError above the Unicode max, so a
+      // finiteness check alone is not enough: an env var whose _X<hex>_ escape
+      // exceeds 0x10FFFF must be rejected like any other malformed token
+      // instead of crashing account discovery.
+      if (!Number.isInteger(codePoint) || codePoint > 0x10ffff) {
         return undefined;
       }
       const char = String.fromCodePoint(codePoint);

--- a/extensions/matrix/src/env-vars.ts
+++ b/extensions/matrix/src/env-vars.ts
@@ -49,10 +49,8 @@ function decodeMatrixEnvAccountToken(token: string): string | undefined {
     if (hexEscape) {
       const hex = hexEscape[1];
       const codePoint = hex ? Number.parseInt(hex, 16) : Number.NaN;
-      // String.fromCodePoint throws a RangeError above the Unicode max, so a
-      // finiteness check alone is not enough: an env var whose _X<hex>_ escape
-      // exceeds 0x10FFFF must be rejected like any other malformed token
-      // instead of crashing account discovery.
+      // Guard String.fromCodePoint's Unicode range so one malformed env token
+      // cannot abort discovery of every Matrix account.
       if (!Number.isInteger(codePoint) || codePoint > 0x10ffff) {
         return undefined;
       }


### PR DESCRIPTION
## Summary

`fix(matrix): reject out-of-range Unicode escapes in MATRIX_* env account tokens so one malformed env var cannot crash account discovery`

## What Problem This Solves

Matrix accounts can be configured through scoped environment variables (`MATRIX_<ACCOUNT>_HOMESERVER`, ...), where characters outside `[A-Z0-9]` in the account id are encoded as `_X<hex>_` escapes. During startup and doctor checks, `listMatrixEnvAccountIds` scans the process environment and decodes every candidate token. A single environment variable whose hex escape exceeds the Unicode range (e.g. `MATRIX_A_X110000_B_HOMESERVER`, or one with a very long hex run like `_XFFFFFFFF_`) does not get ignored like other malformed tokens -- it throws an uncaught `RangeError: Invalid code point` out of the scan, taking down discovery of **every** env-backed Matrix account, valid ones included.

When does this bite? The environment is operator-controlled but not curated for Matrix: a leftover/mistyped variable, a deployment tool that exports similarly-shaped names, or a copied value with an over-long hex run is enough. Everything else malformed in the token (non-hex characters, invalid account characters, non-canonical round-trip) is already rejected gracefully -- this one path crashes instead.

**Code evidence**: in `extensions/matrix/src/env-vars.ts` (main, before this fix):

- `extensions/matrix/src/env-vars.ts:52-55` -- the escape is guarded by `Number.isFinite(codePoint)` and then passed to `String.fromCodePoint(codePoint)`. `Number.isFinite` is not the valid domain of `String.fromCodePoint`: any finite value above `0x10FFFF` (e.g. `0x110000` = 1114112, `0xFFFFFFFF` = 4294967295) throws `RangeError`.
- `extensions/matrix/src/env-vars.ts:82-94` -- `listMatrixEnvAccountIds` calls the decoder inside the scan loop with no try/catch, so the throw escapes the entire listing; the caller chain (`resolveConfiguredMatrixAccountIds`, `account-selection.ts:173`) has no guard either.

Minimal reproduction: run `listMatrixEnvAccountIds({ MATRIX_A_X110000_B_HOMESERVER: "https://x" })` -- it throws `RangeError: Invalid code point 1114112` instead of returning `[]`. See the Evidence section below.

## Root Cause

- The guard predates the current history root (`2436a13d835`, the file arrives unchanged at the boundary).
- Violated invariant: malformed env tokens must make `decodeMatrixEnvAccountToken` return `undefined` (the function's own contract -- it does exactly that for every other malformed case), never throw. `Number.isFinite` was used as a proxy for "safe to pass to `String.fromCodePoint`", but the actual precondition is `Number.isInteger(v) && 0 <= v <= 0x10FFFF`.
- Trigger condition: any environment variable matching `^MATRIX_(.+)_<SUFFIX>$` whose `_X<hex>_` escape parses to a value above `0x10FFFF`.

## Why This Fix

- Option A (chosen): tighten the existing guard to `!Number.isInteger(codePoint) || codePoint > 0x10FFFF` and keep the `return undefined` rejection path -- one condition changed, behavior for every valid token and every other malformed token is unchanged, and it reuses the function's established failure mode.
- Option B: wrap the `String.fromCodePoint` call (or the scan loop) in try/catch -- rejected: it handles the throw instead of the cause, splits the rejection logic across two places, and a try/catch in the hot scan loop hides future invariant breaks.
- Option C: cap the hex length in the regex (e.g. `[0-9A-F]{1,6}`) -- rejected: it fixes the crash but changes the grammar in a second place that must stay in sync with the encoder; the domain check at the decode site is the single source of truth.

## User Impact

- Affected scenario: any deployment whose process environment contains a Matrix-shaped variable with an out-of-range `_X<hex>_` escape.
- Before: Matrix account discovery throws `RangeError: Invalid code point` and every env-backed Matrix account (including valid ones) fails to enumerate during startup/doctor.
- After: the malformed variable is ignored like any other invalid token; valid accounts are discovered normally.
- Behavior change: none for valid configurations -- the fix only converts a crash into the function's documented `undefined` rejection.

## Evidence

No mocks: the proof runs the real `listMatrixEnvAccountIds` / `resolveMatrixEnvAccountToken` from `extensions/matrix/src/env-vars.ts` directly (tsx) against crafted process-env maps. S1: the out-of-range escape alone; S2: the malformed var next to a **valid** env-backed account (discovery of the valid account must survive); S3 control: valid escaped token + global default vars (behavior must be unchanged). `extensions/matrix/src/env-vars.ts` is byte-identical between the main checkout used below and the current PR base, so the Before run exercises the exact code under review.

### Before (on main)

```bash
$ node --import tsx proof-matrix-env-token.mjs   # main: Number.isFinite guard lets 0x110000/0xFFFFFFFF through
S1 out-of-range escape alone: THREW Invalid code point 1114112
BAD  S1: one malformed MATRIX_* env var crashed account discovery
S2 malformed var + valid account: THREW Invalid code point 4294967295
BAD  S2: one malformed MATRIX_* env var crashed discovery of ALL accounts
S3 control (valid token + global default): returned ["default","team-ops"]
BEHAVIOR: FAIL - malformed MATRIX_* env token crashes Matrix account discovery
exit=1
```

### After (with fix)

```bash
$ node --import tsx proof-matrix-env-token.mjs   # HEAD: escapes above 0x10FFFF rejected like other malformed tokens
S1 out-of-range escape alone: returned [] (no crash)
S2 malformed var + valid account: returned ["team-ops"]
S3 control (valid token + global default): returned ["default","team-ops"]
BEHAVIOR: PASS - malformed MATRIX_* env tokens are ignored; valid accounts still discovered
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run extensions/matrix/src/env-vars.test.ts extensions/matrix/src/account-selection.test.ts` -- 11/11 tests passed, including the new regression tests `ignores hex escapes above the Unicode range instead of throwing` (`MATRIX_A_X110000_B_...`, `MATRIX_A_XFFFFFFFF_B_...`) and `ignores scoped env vars whose account token is malformed`, alongside the existing account-selection suite.
- Manual verification (the proof above):
  1. On main, one malformed env var throws `RangeError` out of the scan and kills discovery of all accounts -- FAIL.
  2. With the fix, the malformed vars are ignored, the neighboring valid account is still discovered, and the valid-token control is unchanged -- PASS.

Note: proof and tests were run with Node 24.19.0; the module graph requires a recent Node (the repo toolchain's vitest workers do too).
