### PR TITLE
fix: restore reply admission checks on main

### DIFF
--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -57,7 +57,7 @@ export const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 const RESTART_LIFECYCLE_REPLY_TEXT =
   "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
 
-export function scheduleFollowupDrainAfterReplyOperationClear(params: {
+function scheduleFollowupDrainAfterReplyOperationClear(params: {
   operation: ReplyOperation;
   queueKey: string;
   runFollowup: (run: FollowupRun) => Promise<void>;

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -45,7 +45,11 @@ import {
 } from "./pending-final-delivery.js";
 import { type FollowupRun, type QueueSettings, scheduleFollowupDrain } from "./queue.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
-import { type ReplyOperation, runAfterReplyOperationClear } from "./reply-run-registry.js";
+import {
+  type ReplyOperation,
+  replyRunRegistry,
+  runAfterReplyOperationClear,
+} from "./reply-run-registry.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import type { TypingController } from "./typing.js";
 export const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
@@ -71,6 +75,19 @@ export function scheduleFollowupDrainAfterReplyOperationClear(params: {
             );
     scheduleFollowupDrain(params.queueKey, runFollowupAfterClear);
   });
+}
+
+/** Schedules a queued follow-up after the current owner clears, closing the enqueue/clear race. */
+export function scheduleFollowupDrainForCurrentOwner(params: {
+  queueKey: string;
+  runFollowup: (run: FollowupRun) => Promise<void>;
+}): void {
+  const operation = replyRunRegistry.get(params.queueKey);
+  if (operation) {
+    scheduleFollowupDrainAfterReplyOperationClear({ operation, ...params });
+  } else {
+    scheduleFollowupDrain(params.queueKey, params.runFollowup);
+  }
 }
 
 export function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -1,5 +1,3 @@
-import { expectDefined } from "@openclaw/normalization-core";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
@@ -21,7 +19,7 @@ import {
   refreshSessionEntryFromStore,
   resolveAdmittedRunSessionFile,
   type RunReplyAgentParams,
-  scheduleFollowupDrainAfterReplyOperationClear,
+  scheduleFollowupDrainForCurrentOwner,
 } from "./agent-runner-core.js";
 import {
   createReplyAgentRestartRecoveryController,
@@ -33,7 +31,7 @@ import {
   isAudioPayload,
 } from "./agent-runner-helpers.js";
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
-import { finalizeAcceptedSteer } from "./agent-runner-steer-adoption.js";
+import { finalizeAcceptedSteer, resolveSteeredTurnId } from "./agent-runner-steer-adoption.js";
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
@@ -51,7 +49,6 @@ import {
   enqueueFollowupRun,
   parkSteerCandidate,
   resolveFollowupAbortSignal,
-  scheduleFollowupDrain,
 } from "./queue.js";
 import { REPLY_ADMISSION_TICKET } from "./reply-admission-ticket.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
@@ -65,7 +62,7 @@ import {
   retireTerminalRestartRecoverySourceClaim,
 } from "./restart-recovery-claim.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
-import { buildChannelSourceTurnId, readChannelSourceTurnId } from "./source-turn-id.js";
+import { readChannelSourceTurnId } from "./source-turn-id.js";
 import { createTypingSignaler } from "./typing-mode.js";
 export async function runReplyAgent(
   params: RunReplyAgentParams,
@@ -252,19 +249,7 @@ export async function runReplyAgent(
       typing.cleanup();
       return undefined;
     }
-    const scheduleParkedFallback = () => {
-      const owner = replyRunRegistry.get(queueKey);
-      if (owner) {
-        scheduleFollowupDrainAfterReplyOperationClear({
-          operation: owner,
-          queueKey,
-          runFollowup: queuedRunFollowupTurn,
-        });
-      } else {
-        scheduleFollowupDrain(queueKey, queuedRunFollowupTurn);
-      }
-    };
-    scheduleParkedFallback();
+    scheduleFollowupDrainForCurrentOwner({ queueKey, runFollowup: queuedRunFollowupTurn });
     releaseAdmissionTicket();
     try {
       const admission = await parked.admit();
@@ -282,29 +267,13 @@ export async function runReplyAgent(
         typing.cleanup();
         return undefined;
       }
-      // Channel dispatch normally stamps the route-scoped source id. Internal
-      // callers can derive the same per-message identity from the prepared turn.
-      const steerRunId = expectDefined(
-        restartRecoverySourceTurnId ??
-          buildChannelSourceTurnId({
-            provider:
-              followupRun.originatingChannel ??
-              followupRun.run.messageProvider ??
-              sessionCtx.Provider,
-            accountId:
-              followupRun.originatingAccountId ??
-              followupRun.run.agentAccountId ??
-              sessionCtx.AccountId,
-            conversationId:
-              followupRun.originatingTo ??
-              followupRun.originatingChatId ??
-              sessionKey ??
-              followupRun.run.sessionKey,
-            messageId: followupRun.messageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
-          }) ??
-          normalizeOptionalString(opts?.runId),
-        "steered turn id",
-      );
+      const steerRunId = resolveSteeredTurnId({
+        followupRun,
+        restartRecoverySourceTurnId,
+        runId: opts?.runId,
+        sessionCtx,
+        sessionKey,
+      });
       const steerOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
         steerSessionId,
         followupRun.prompt,
@@ -421,18 +390,7 @@ export async function runReplyAgent(
     if (replyOperationRunState) {
       replyOperationRunState.admission = { status: "accepted", mode: "followup" };
     }
-    // The queue must stay dormant while the active owner can still collect
-    // messages. Registering after enqueue closes the owner-clear race.
-    const activeReplyOperation = replyRunRegistry.get(queueKey);
-    if (activeReplyOperation) {
-      scheduleFollowupDrainAfterReplyOperationClear({
-        operation: activeReplyOperation,
-        queueKey,
-        runFollowup: queuedRunFollowupTurn,
-      });
-    } else {
-      scheduleFollowupDrain(queueKey, queuedRunFollowupTurn);
-    }
+    scheduleFollowupDrainForCurrentOwner({ queueKey, runFollowup: queuedRunFollowupTurn });
     releaseAdmissionTicket();
     const queuedBehindActiveRun = isRunActive?.() === true;
     await touchActiveSessionEntry();

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -1,7 +1,46 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isIngressAdoptionLostError } from "../../channels/message/ingress-drain.js";
 import { logVerbose } from "../../globals.js";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun } from "./queue.js";
 import type { ReplyOperationRunState } from "./reply-operation-run-state.js";
 import { type ReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
+import { buildChannelSourceTurnId } from "./source-turn-id.js";
+
+/** Resolves the route-scoped source id, including prepared internal turns without a channel stamp. */
+export function resolveSteeredTurnId(params: {
+  followupRun: FollowupRun;
+  restartRecoverySourceTurnId: string | undefined;
+  runId: unknown;
+  sessionCtx: TemplateContext;
+  sessionKey: string | undefined;
+}): string {
+  return expectDefined(
+    params.restartRecoverySourceTurnId ??
+      buildChannelSourceTurnId({
+        provider:
+          params.followupRun.originatingChannel ??
+          params.followupRun.run.messageProvider ??
+          params.sessionCtx.Provider,
+        accountId:
+          params.followupRun.originatingAccountId ??
+          params.followupRun.run.agentAccountId ??
+          params.sessionCtx.AccountId,
+        conversationId:
+          params.followupRun.originatingTo ??
+          params.followupRun.originatingChatId ??
+          params.sessionKey ??
+          params.followupRun.run.sessionKey,
+        messageId:
+          params.followupRun.messageId ??
+          params.sessionCtx.MessageSidFull ??
+          params.sessionCtx.MessageSid,
+      }) ??
+      normalizeOptionalString(params.runId),
+    "steered turn id",
+  );
+}
 
 export async function finalizeAcceptedSteer(params: {
   activeReplyOperation: ReplyOperation | undefined;

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -109,9 +109,15 @@ function appendQueueItem(params: {
   params.queue.lastRun = params.run.run;
   params.run.queueAbortSignal = params.queue.abortController.signal;
   params.queue.items[params.front ? "unshift" : "push"](params.run);
-  if (params.recentMessageIdKey) recordRecentQueueMessageId(params.run, params.recentMessageIdKey);
-  if (params.runFollowup) rememberFollowupDrainCallback(params.key, params.runFollowup);
-  if (params.restartIfIdle && !params.queue.draining) kickFollowupDrainIfIdle(params.key);
+  if (params.recentMessageIdKey) {
+    recordRecentQueueMessageId(params.run, params.recentMessageIdKey);
+  }
+  if (params.runFollowup) {
+    rememberFollowupDrainCallback(params.key, params.runFollowup);
+  }
+  if (params.restartIfIdle && !params.queue.draining) {
+    kickFollowupDrainIfIdle(params.key);
+  }
 }
 
 export function enqueueFollowupRun(
@@ -149,9 +155,13 @@ export function enqueueFollowupRun(
     return false;
   }
   if (options.steerCandidate) {
-    if (!markFollowupRunEnqueued(run)) return false;
+    if (!markFollowupRunEnqueued(run)) {
+      return false;
+    }
     let settle = (_accepted: boolean) => {};
-    const acceptance = new Promise<boolean>((resolve) => (settle = resolve));
+    const acceptance = new Promise<boolean>((resolve) => {
+      settle = resolve;
+    });
     run.steerPending = { predecessor: queue.steerAcceptanceTail, settle };
     queue.steerAcceptanceTail = acceptance;
     appendQueueItem({
@@ -169,7 +179,9 @@ export function enqueueFollowupRun(
   // deciding between same-turn delivery and fallback. Append it behind the
   // anchor; ordinary overflow policy resumes as soon as the gate resolves.
   if (queue.items.some((item) => item.steerPending)) {
-    if (!markFollowupRunEnqueued(run)) return false;
+    if (!markFollowupRunEnqueued(run)) {
+      return false;
+    }
     appendQueueItem({
       key,
       queue,
@@ -299,10 +311,14 @@ function isParkedFollowupRunOwned(key: string, run: FollowupRun): boolean {
 
 function reapplyDeferredOverflow(key: string): void {
   const queue = getExistingFollowupQueue(key);
-  if (!queue || queue.items.some((item) => item.steerPending)) return;
+  if (!queue || queue.items.some((item) => item.steerPending)) {
+    return;
+  }
   const lastAnchor = queue.items.findLastIndex((item) => item.steerAnchor === true);
   const suffix = queue.items.splice(lastAnchor + 1);
-  if (suffix.length === 0) return;
+  if (suffix.length === 0) {
+    return;
+  }
   const originalCap = queue.cap;
   const settings: QueueSettings = {
     mode: queue.mode,
@@ -349,7 +365,7 @@ function consumeParkedFollowupRun(key: string, run: FollowupRun): boolean {
 
 type ParkedSteerReservation = {
   admit(): Promise<"steer" | "fallback" | "cancelled">;
-  accepted(accepted: boolean): void;
+  accepted: (accepted: boolean) => void;
   fallback(): void;
   consume(): void;
 };
@@ -379,7 +395,9 @@ export function parkSteerCandidate(
   return {
     async admit() {
       const predecessorAccepted = (await run.steerPending?.predecessor) ?? true;
-      if (isFollowupRunAborted(run) || !isParkedFollowupRunOwned(key, run)) return "cancelled";
+      if (isFollowupRunAborted(run) || !isParkedFollowupRunOwned(key, run)) {
+        return "cancelled";
+      }
       return predecessorAccepted ? "steer" : "fallback";
     },
     accepted: (accepted) => settleParkedSteerAcceptance(key, run, accepted),

--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -22,12 +22,14 @@ export function reserveReplyAdmissionTicket(
         .map(normalizeOptionalString)
         .filter((key): key is string => typeof key === "string"),
     ),
-  ].sort();
+  ].toSorted();
   if (keys.length === 0) {
     return undefined;
   }
   let finish = () => {};
-  const completed = new Promise<void>((resolve) => (finish = resolve));
+  const completed = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
   const predecessors = keys.map((key) => tails.get(key) ?? Promise.resolve());
   const owned = keys.map((key, index) => {
     const tail = predecessors[index]!.then(() => completed);
@@ -41,7 +43,9 @@ export function reserveReplyAdmissionTicket(
         return false;
       }
       const ready = Promise.all(predecessors).then(() => true);
-      if (!signal) return await ready;
+      if (!signal) {
+        return await ready;
+      }
       return await new Promise<boolean>((resolve) => {
         const abort = () => resolve(false);
         signal.addEventListener("abort", abort, { once: true });
@@ -52,7 +56,9 @@ export function reserveReplyAdmissionTicket(
       });
     },
     release() {
-      if (released) return;
+      if (released) {
+        return;
+      }
       released = true;
       finish();
       for (const { key, tail } of owned) {

--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -182,7 +182,7 @@ function writeToolResponse(res: ServerResponse): void {
 
 async function startMockModelServer(): Promise<MockModelServer> {
   const requests: ModelRequest[] = [];
-  const firstResponse = createDeferred<void>();
+  const firstResponse = createDeferred();
   let firstResponseKind: FirstResponseKind = "final";
   const server = createServer((req, res) => {
     void (async () => {
@@ -277,6 +277,9 @@ function createConfig(params: {
       providers: {
         [provider.providerId]: {
           ...provider.config,
+          models: provider.config.models.map((model) =>
+            Object.assign({}, model, { input: [...model.input] }),
+          ),
           request: { allowPrivateNetwork: true },
         },
       },
@@ -579,7 +582,9 @@ describe("Gateway steer FIFO", () => {
           ),
         ).toBe(true);
       }, WAIT_OPTS);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       const currentA = currentUserInput(fixture.modelServer.requests[1]);
       const currentB = currentUserInput(fixture.modelServer.requests[2]);
@@ -625,7 +630,9 @@ describe("Gateway steer FIFO", () => {
           ),
         ).toBe(true);
       }, WAIT_OPTS);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(fixture.modelServer.requests).toHaveLength(2);
     },
     TEST_TIMEOUT_MS,


### PR DESCRIPTION
## What Problem This Solves

Resolves the remaining repository-wide `main` CI failures introduced by #120420. Main run [31233869000](https://github.com/openclaw/openclaw/actions/runs/31233869000) first exposed reply admission ticket keys retaining `string | undefined`; after that declaration blocker was repaired, exact-head run [31234916273](https://github.com/openclaw/openclaw/actions/runs/31234916273) exposed the same commit's hidden lint and test-type fallout across queue admission, steer delivery, and its gateway fixture.

## Why This Change Was Made

The admission ticket file now satisfies the lint rules reached after #120441 landed the canonical key type guard. Queue publication uses lint-compliant control flow, follow-up drain scheduling has one internal shared owner instead of two inline copies, and route-scoped steer identity resolution lives in the existing steer-adoption owner so `agent-runner-run.ts` remains below the 700-line ratchet. The gateway test fixture copies readonly mock model data into the mutable config boundary. Queue ordering, admission, and delivery behavior are unchanged.

The unrelated package-acceptance assertion failure observed in the first PR run is not duplicated here: #120442 landed the same-or-better minimal alignment on `main`, and this branch is rebased on that fix. `packages/terminal-core/src/ansi.ts` also remains untouched: the lockfile and package manifest select `string-width@8.2.2`, whose published types accept the existing options argument; the local TS2554 came from this linked worktree resolving stale root `string-width@4.2.3` without its package-local install.

## User Impact

No runtime behavior changes. Maintainers and contributors regain green queue type, lint, test-type, dead-export, and plugin package-boundary checks on `main`.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` — 168/168 passed on #120442's delegated fix.
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-turn-admission.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts` — 56/56 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts test/gateway-steer-fifo.e2e.test.ts` — 145/145 passed twice, including the gateway steer FIFO path.
- Targeted `node scripts/run-oxlint.mjs` across all touched files — passed; `agent-runner-run.ts` is 696 lines.
- `node scripts/check-deadcode-exports.mjs` — production, full-tree, and script scans passed with zero unused exports.
- `git diff --check` — passed.
- Structured branch/local autoreview — clean, no accepted/actionable findings.
- `node scripts/check-changed.mjs` — attempted, but the configured remote proof backend was unavailable before execution because no authenticated Crabbox/Testbox provider was ready. Exact-head hosted CI and the native prepare Testbox are the broad validation sources.

Production LOC: +108/-70 (net +38) | Tests: +10/-3 (net +7). The production growth is lint-required control-flow expansion plus the shared scheduling/steer identity ownership split; it removes 42 lines from the oversized runner and deletes duplicate drain policy.

AI-assisted: yes. The patch and evidence were manually inspected against current source, #120420 history, dependency types, exact CI logs, current `main`, #120441, and #120442.
