### PR TITLE
fix(cli): avoid missing-facing camera snap failures

### DIFF
--- a/docs/nodes/camera.md
+++ b/docs/nodes/camera.md
@@ -52,13 +52,14 @@ Like `canvas.*`, the iOS node only allows `camera.*` commands in the **foregroun
 The easiest way to get media files is via the CLI helper, which writes decoded media to a temp file and prints the saved path.
 
 ```bash
-openclaw nodes camera snap --node <id>                 # default: both front + back (2 MEDIA lines)
+openclaw nodes camera snap --node <id>                 # default: one node-selected photo
 openclaw nodes camera snap --node <id> --facing front
+openclaw nodes camera snap --node <id> --facing both   # front then back (2 saved paths)
 openclaw nodes camera clip --node <id> --duration 3000
 openclaw nodes camera clip --node <id> --no-audio
 ```
 
-`nodes camera snap` defaults to `--facing both`, capturing both front and back to give the agent both views; pass `--device-id` with a single explicit facing (`both` is rejected when `--device-id` is set). Output files are temporary (in the OS temp directory) unless you build your own wrapper.
+Without `--facing`, `nodes camera snap` captures one photo using the node's default camera and labels the saved artifact `unknown`. On non-Linux nodes, `--facing both` captures front then back and prints two saved paths. `--device-id` is valid without `--facing`; on non-Linux nodes, it cannot be combined with `--facing both`. Linux always sends one facing-less request and labels the artifact `unknown`, regardless of `--facing`. Output files are temporary (in the OS temp directory) unless you build your own wrapper.
 
 ## Android node
 

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -582,8 +582,9 @@ Photos (`jpg`):
 
 ```bash
 openclaw nodes camera list --node <idOrNameOrIp>
-openclaw nodes camera snap --node <idOrNameOrIp>            # default: both facings (2 MEDIA lines)
+openclaw nodes camera snap --node <idOrNameOrIp>            # default: one node-selected photo
 openclaw nodes camera snap --node <idOrNameOrIp> --facing front
+openclaw nodes camera snap --node <idOrNameOrIp> --facing both # front then back (2 saved paths)
 openclaw nodes camera snap --node <idOrNameOrIp> --device-id <id> --max-width 1200 --quality 0.9 --delay-ms 2000
 ```
 

--- a/src/cli/claws-cli.test-helpers.ts
+++ b/src/cli/claws-cli.test-helpers.ts
@@ -1,4 +1,4 @@
-import { realpath, writeFile } from "node:fs/promises";
+import { mkdir, realpath, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
 export const minimalManifest = {
@@ -31,4 +31,41 @@ export async function writeManifestFile(
   const path = join(dir, "openclaw.claw.json");
   await writeFile(path, JSON.stringify(value), "utf8");
   return path;
+}
+
+export async function writePackageFixture(tempDirs: {
+  make(prefix: string): string;
+}): Promise<{ root: string; workspace: string }> {
+  const root = tempDirs.make("openclaw-claws-cli-package-");
+  await mkdir(join(root, "workspace"));
+  await writeFile(join(root, "workspace", "AGENTS.md"), "# Demo\n", "utf8");
+  await writeFile(
+    join(root, "package.json"),
+    JSON.stringify({
+      name: "@acme/demo-agent",
+      version: "1.2.3",
+      openclaw: { claw: "openclaw.claw.json" },
+    }),
+    "utf8",
+  );
+  await writeFile(
+    join(root, "openclaw.claw.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      agent: { id: "demo-agent", name: "Demo Agent" },
+      workspace: {
+        bootstrapFiles: { "AGENTS.md": { source: "workspace/AGENTS.md" } },
+      },
+      packages: [
+        {
+          kind: "skill",
+          source: "clawhub",
+          ref: "@acme/demo-skill",
+          version: "1.0.0",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  return { root, workspace: join(root, "target-workspace") };
 }

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => {
     exportClawAgent: vi.fn(),
     callGatewayFromCli: vi.fn(),
     sleep: vi.fn(),
+    preflightClawPackage: vi.fn(),
   };
 });
 
@@ -66,6 +67,11 @@ vi.mock("./gateway-rpc.js", () => ({
 
 vi.mock("../utils/sleep.js", () => ({
   sleep: mocks.sleep,
+}));
+
+vi.mock("../claws/packages.js", async () => ({
+  ...(await vi.importActual<typeof import("../claws/packages.js")>("../claws/packages.js")),
+  preflightClawPackage: mocks.preflightClawPackage,
 }));
 
 vi.mock("../state/openclaw-state-db.js", async () => ({
@@ -183,6 +189,12 @@ describe("claws cli", () => {
     mocks.callGatewayFromCli.mockReset();
     mocks.sleep.mockReset();
     mocks.sleep.mockResolvedValue(undefined);
+    mocks.preflightClawPackage.mockReset();
+    mocks.preflightClawPackage.mockResolvedValue({
+      ok: false,
+      code: "package_install_unavailable",
+      message: "Package preflight is unavailable.",
+    });
     mocks.closeReadOnlyDatabase.mockReset();
     mocks.stateTableGet.mockReset();
     mocks.stateTableGet.mockReturnValue({ 1: 1 });

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -120,41 +120,6 @@ async function writeManifest(value: unknown = cliTestHelpers.minimalManifest): P
   return await cliTestHelpers.writeManifestFile(tempDirs, value);
 }
 
-async function writePackage(): Promise<{ root: string; workspace: string }> {
-  const root = tempDirs.make("openclaw-claws-cli-package-");
-  await mkdir(join(root, "workspace"));
-  await writeFile(join(root, "workspace", "AGENTS.md"), "# Demo\n", "utf8");
-  await writeFile(
-    join(root, "package.json"),
-    JSON.stringify({
-      name: "@acme/demo-agent",
-      version: "1.2.3",
-      openclaw: { claw: "openclaw.claw.json" },
-    }),
-    "utf8",
-  );
-  await writeFile(
-    join(root, "openclaw.claw.json"),
-    JSON.stringify({
-      schemaVersion: 1,
-      agent: { id: "demo-agent", name: "Demo Agent" },
-      workspace: {
-        bootstrapFiles: { "AGENTS.md": { source: "workspace/AGENTS.md" } },
-      },
-      packages: [
-        {
-          kind: "skill",
-          source: "clawhub",
-          ref: "@acme/demo-skill",
-          version: "1.0.0",
-        },
-      ],
-    }),
-    "utf8",
-  );
-  return { root, workspace: join(root, "target-workspace") };
-}
-
 async function runCli(args: string[]) {
   const program = new Command();
   program.exitOverride();
@@ -424,7 +389,7 @@ describe("claws cli", () => {
   });
 
   it("takes identity from package.json and plans one new agent", async () => {
-    const { root, workspace } = await writePackage();
+    const { root, workspace } = await cliTestHelpers.writePackageFixture(tempDirs);
     const expectedWorkspace = await cliTestHelpers.canonicalFuturePath(workspace);
 
     await runCli(["claws", "add", root, "--dry-run", "--workspace", workspace, "--json"]);
@@ -462,7 +427,7 @@ describe("claws cli", () => {
   });
 
   it("blocks adding into an existing agent instead of merging", async () => {
-    const { root, workspace } = await writePackage();
+    const { root, workspace } = await cliTestHelpers.writePackageFixture(tempDirs);
     mocks.loadConfig.mockReturnValue({ agents: { entries: { "demo-agent": {} } } });
 
     await runCli(["claws", "add", root, "--dry-run", "--workspace", workspace, "--json"]);
@@ -475,7 +440,7 @@ describe("claws cli", () => {
   });
 
   it("honors an explicit unused agent id in the plan", async () => {
-    const { root, workspace } = await writePackage();
+    const { root, workspace } = await cliTestHelpers.writePackageFixture(tempDirs);
     mocks.loadConfig.mockReturnValue({ agents: { entries: { "demo-agent": {} } } });
 
     await runCli([
@@ -807,7 +772,7 @@ describe("claws cli", () => {
   });
 
   it("prints a read-only grouped update plan", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
 
     await runCli(["claws", "update", "demo-agent", "--from", root, "--dry-run", "--json"]);
 
@@ -831,7 +796,7 @@ describe("claws cli", () => {
   });
 
   it("prints capability escalation details in human update previews", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
 
     await runCli(["claws", "update", "demo-agent", "--from", root, "--dry-run"]);
 
@@ -848,7 +813,7 @@ describe("claws cli", () => {
   });
 
   it("returns failure when an update plan contains blocked actions", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
     mocks.buildClawUpdatePlan.mockResolvedValueOnce({
       schemaVersion: "openclaw.clawUpdatePlan.v1",
       stability: "experimental",
@@ -891,7 +856,7 @@ describe("claws cli", () => {
   });
 
   it("uses the source recorded by the installed Claw when --from is omitted", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
     mocks.readClawStatus.mockResolvedValue({
       schemaVersion: "openclaw.clawStatus.v1",
       records: [
@@ -945,7 +910,7 @@ describe("claws cli", () => {
   });
 
   it("fails closed when update is invoked without dry-run", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
 
     await runCli(["claws", "update", "demo-agent", "--from", root, "--json"]);
 
@@ -958,7 +923,7 @@ describe("claws cli", () => {
   });
 
   it("requires exact plan integrity with update consent", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
 
     await runCli(["claws", "update", "demo-agent", "--from", root, "--yes", "--json"]);
 
@@ -970,7 +935,7 @@ describe("claws cli", () => {
   });
 
   it("applies a supported update only after explicit consent", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
 
     await runCli([
       "claws",
@@ -1011,7 +976,7 @@ describe("claws cli", () => {
   });
 
   it("reports uncertain update mutations as partial JSON", async () => {
-    const { root } = await writePackage();
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
     mocks.applyClawUpdatePlan.mockRejectedValueOnce(
       new ClawUpdateMutationError("update_partial", "artifact outcome requires reconciliation"),
     );

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -139,23 +139,47 @@ describe("nodes camera helpers", () => {
     );
   });
 
-  it("collapses Linux facing requests into one unknown-position capture", () => {
-    expect(resolveCameraSnapTargets({ facing: "both", platform: "linux" })).toEqual([
-      { artifactFacing: "unknown" },
-    ]);
-    expect(resolveCameraSnapTargets({ facing: "back", platform: "linux" })).toEqual([
-      { artifactFacing: "unknown" },
-    ]);
+  it.each([undefined, "front", "back", "both"] as const)(
+    "collapses Linux facing=%s into one unknown-position capture",
+    (facing) => {
+      expect(resolveCameraSnapTargets({ facing, platform: "linux" })).toEqual([
+        { artifactFacing: "unknown" },
+      ]);
+    },
+  );
+
+  it("keeps Linux device selection facing-less", () => {
     expect(
       resolveCameraSnapTargets({ facing: "front", platform: "linux", deviceId: "/dev/video2" }),
     ).toEqual([{ artifactFacing: "unknown" }]);
+    expect(
+      resolveCameraSnapTargets({ facing: "both", platform: "linux", deviceId: "/dev/video2" }),
+    ).toEqual([{ artifactFacing: "unknown" }]);
   });
 
-  it("keeps front and back requests for positioned camera platforms", () => {
+  it("uses one unknown target when facing is omitted on a positioned camera platform", () => {
+    expect(resolveCameraSnapTargets({ platform: "macos" })).toEqual([
+      { artifactFacing: "unknown" },
+    ]);
+    expect(resolveCameraSnapTargets({ platform: "macos", deviceId: "camera-device" })).toEqual([
+      { artifactFacing: "unknown" },
+    ]);
+  });
+
+  it("keeps explicit facing requests for positioned camera platforms", () => {
+    expect(resolveCameraSnapTargets({ facing: "front", platform: "macos" })).toEqual([
+      { requestFacing: "front", artifactFacing: "front" },
+    ]);
+    expect(resolveCameraSnapTargets({ facing: "back", platform: "macos" })).toEqual([
+      { requestFacing: "back", artifactFacing: "back" },
+    ]);
     expect(resolveCameraSnapTargets({ facing: "both", platform: "macos" })).toEqual([
       { requestFacing: "front", artifactFacing: "front" },
       { requestFacing: "back", artifactFacing: "back" },
     ]);
+    expect(() =>
+      resolveCameraSnapTargets({ facing: "both", platform: "macos", deviceId: "camera-device" }),
+    ).toThrow("facing=both is not allowed when deviceId is set");
   });
 
   it("labels Linux clips as unknown without sending unsupported facing", () => {

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -34,13 +34,16 @@ type CameraSnapTarget = {
 
 type CameraClipTarget = CameraSnapTarget;
 
-/** Resolve one or two snap requests without inventing a facing for Linux V4L2 devices. */
+/** Resolve snap requests without inventing a facing when the CLI or node cannot select one. */
 export function resolveCameraSnapTargets(params: {
-  facing: CameraFacing | "both";
+  facing?: CameraFacing | "both";
   platform?: string;
   deviceId?: string;
 }): CameraSnapTarget[] {
   if (params.platform?.toLowerCase() === "linux") {
+    return [{ artifactFacing: "unknown" }];
+  }
+  if (!params.facing) {
     return [{ artifactFacing: "unknown" }];
   }
   const facings: CameraFacing[] = params.facing === "both" ? ["front", "back"] : [params.facing];

--- a/src/cli/nodes-cli/register.camera.test.ts
+++ b/src/cli/nodes-cli/register.camera.test.ts
@@ -80,6 +80,7 @@ describe("nodes camera snap CLI option forwarding", () => {
       throw new Error("expected camera snap command");
     }
 
+    expect(snap.options.find((option) => option.long === "--facing")?.defaultValue).toBeUndefined();
     expect(snap.options.find((option) => option.long === "--quality")?.description).toBe(
       "JPEG quality (optional; platform-specific default)",
     );
@@ -88,20 +89,21 @@ describe("nodes camera snap CLI option forwarding", () => {
     );
   });
 
-  it("omits quality and delayMs from RPC params when flags are not provided", async () => {
+  it("makes one facing-less request and forwards deviceId when --facing is omitted", async () => {
     const nodes = buildRootCommand();
-    await nodes.parseAsync(cameraSnapArgs(["--node", "test-node"]));
+    await nodes.parseAsync(cameraSnapArgs(["--node", "test-node", "--device-id", "camera-device"]));
 
-    // Default facing="both" may invoke camera.snap for more than one target.
-    expect(rpc.callGatewayCli).toHaveBeenCalled();
-    for (const invokeParams of capturedInvokeParams) {
-      expect(invokeParams).toMatchObject({
-        command: "camera.snap",
-        nodeId: "node-abc123",
-      });
-      expect((invokeParams.params as Record<string, unknown>).quality).toBeUndefined();
-      expect((invokeParams.params as Record<string, unknown>).delayMs).toBeUndefined();
-    }
+    expect(rpc.callGatewayCli).toHaveBeenCalledTimes(1);
+    expect(capturedInvokeParams).toHaveLength(1);
+    expect(capturedInvokeParams[0]).toMatchObject({
+      command: "camera.snap",
+      nodeId: "node-abc123",
+    });
+    const forwardedParams = capturedInvokeParams[0]?.params as Record<string, unknown>;
+    expect(forwardedParams).not.toHaveProperty("facing");
+    expect(forwardedParams.deviceId).toBe("camera-device");
+    expect(forwardedParams.quality).toBeUndefined();
+    expect(forwardedParams.delayMs).toBeUndefined();
   });
 
   it("forwards explicit --quality and --delay-ms values in RPC params", async () => {

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -120,7 +120,7 @@ export function registerNodesCameraCommands(nodes: Command) {
       .command("snap")
       .description("Capture a photo from a node camera (prints the saved path)")
       .requiredOption("--node <idOrNameOrIp>", "Node id, name, or IP")
-      .option("--facing <front|back|both>", "Camera facing", "both")
+      .option("--facing <front|back|both>", "Camera facing")
       .option("--device-id <id>", "Camera device id (from nodes camera list)")
       .option("--max-width <px>", "Max width in px (optional)")
       .option("--quality <0-1>", "JPEG quality (optional; platform-specific default)")
@@ -131,16 +131,18 @@ export function registerNodesCameraCommands(nodes: Command) {
           const node = await resolveNode(opts, normalizeOptionalString(opts.node) ?? "");
           const nodeId = node.nodeId;
           const facingOpt = normalizeLowercaseStringOrEmpty(
-            normalizeOptionalString(opts.facing) ?? "both",
+            normalizeOptionalString(opts.facing) ?? "",
           );
           const facing =
-            facingOpt === "both" || facingOpt === "front" || facingOpt === "back"
-              ? facingOpt
-              : (() => {
-                  throw new Error(
-                    `invalid facing: ${String(opts.facing)} (expected front|back|both)`,
-                  );
-                })();
+            facingOpt === ""
+              ? undefined
+              : facingOpt === "both" || facingOpt === "front" || facingOpt === "back"
+                ? facingOpt
+                : (() => {
+                    throw new Error(
+                      `invalid facing: ${String(opts.facing)} (expected front|back|both)`,
+                    );
+                  })();
 
           const maxWidth = parseOptionalNodePositiveInteger(opts.maxWidth, "--max-width");
           const quality = parseOptionalNodeFiniteNumber(opts.quality, "--quality", {
@@ -174,7 +176,7 @@ export function registerNodesCameraCommands(nodes: Command) {
               nodeId,
               command: "camera.snap",
               params: {
-                facing: target.requestFacing,
+                ...(target.requestFacing ? { facing: target.requestFacing } : {}),
                 maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,
                 quality: Number.isFinite(quality) ? quality : undefined,
                 format: "jpg",

--- a/src/cli/program.nodes-media.e2e.test.ts
+++ b/src/cli/program.nodes-media.e2e.test.ts
@@ -154,10 +154,20 @@ describe("cli program (nodes media)", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("No cameras reported."));
   });
 
-  it("runs nodes camera snap and prints two MEDIA paths", async () => {
+  it("runs one default snap and two explicitly requested facing snaps", async () => {
     mockNodeGateway("camera.snap", { format: "jpg", base64: "aGk=", width: 1, height: 1 });
 
     await runNodesCommand(["nodes", "camera", "snap", "--node", "ios-node"]);
+
+    const defaultInvokeCalls = nodeInvokeCalls();
+    expect(defaultInvokeCalls).toHaveLength(1);
+    expect(defaultInvokeCalls[0]?.commandParams).not.toHaveProperty("facing");
+    await expectLoggedSingleMediaFile({
+      expectedPathPattern: /openclaw-camera-snap-unknown-.*\.jpg$/,
+    });
+
+    callGateway.mockClear();
+    await runNodesCommand(["nodes", "camera", "snap", "--node", "ios-node", "--facing", "both"]);
 
     const invokeCalls = nodeInvokeCalls();
     const facings = invokeCalls


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw nodes camera snap` against a node with only one front- or back-facing camera could receive one photo followed by a guaranteed failure because the CLI implicitly requested both facings.

## Why This Change Was Made

When `--facing` is omitted, the CLI now sends one facing-less request and lets the node choose its default camera. Explicit `--facing front`, `back`, and `both` keep their existing semantics, including Linux's single unknown-facing capture and the existing `deviceId` rules. The camera docs now distinguish the one-photo default from explicit two-photo capture.

The final exact-head run also exposed a pre-existing Claws CLI test leak to the live ClawHub API. The test now partially mocks only `preflightClawPackage`, preserving the existing unavailable-package planning contract while making the suite deterministic and network-free. Production preflight behavior is unchanged.

## User Impact

The default camera snap command now succeeds on single-camera nodes such as ESP-based camera nodes instead of attempting an unavailable second facing. Operators who explicitly request `--facing both` still receive front-then-back captures.

## Evidence

- `node scripts/run-vitest.mjs src/cli/nodes-camera.test.ts src/cli/nodes-cli/register.camera.test.ts src/cli/program.nodes-media.e2e.test.ts` — 60 tests passed across unit and full CLI e2e shards.
- Source-blind CLI behavior validation under an isolated home — 19 tests passed, covering omitted facing, explicit `both`, `deviceId`, non-Linux rejection, Linux collapse, and invalid-facing handling.
- `node scripts/run-vitest.mjs src/cli/claws-cli.test.ts src/cli/nodes-camera.test.ts src/cli/nodes-cli/register.camera.test.ts src/cli/program.nodes-media.e2e.test.ts` — 96 tests passed with ClawHub preflight isolated from external network.
- `git diff --check` — passed.
- Codex autoreview (`--mode branch --base origin/main`) — clean, no accepted/actionable findings.

AI-assisted change; implementation and behavior were independently reviewed and verified.
