### PR TITLE
fix(qa): enforce native provider modes

### DIFF
--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -57,6 +57,19 @@ async function writeEvidence(pathLocal: string, writeFile = true) {
   return evidence;
 }
 
+function createMockLab() {
+  return {
+    baseUrl: "http://127.0.0.1:43124",
+    listenUrl: "http://127.0.0.1:43124",
+    runSelfCheck: vi.fn(),
+    setControlUi: vi.fn(),
+    setLatestReport: vi.fn(),
+    setScenarioRun: vi.fn(),
+    state: {} as QaLabServerHandle["state"],
+    stop: vi.fn(),
+  } satisfies QaLabServerHandle;
+}
+
 function trackMaxActiveFlowRuns() {
   const run = runQaFlowSuite.getMockImplementation();
   if (!run) {
@@ -1087,6 +1100,118 @@ describe("qa suite runtime launcher", () => {
         ],
       }),
     );
+  });
+
+  it("adopts an implicit native live-frontier requirement", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-native-live-provider-");
+
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/native-live-provider",
+      scenarioIds: ["openai-realtime-talk-live"],
+    });
+
+    expect(runQaFlowSuite).not.toHaveBeenCalled();
+    expect(runQaTestFileScenarios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerMode: "live-frontier",
+        primaryModel: expect.stringMatching(/^openai\//),
+        scenarios: [expect.objectContaining({ id: "openai-realtime-talk-live" })],
+      }),
+    );
+  });
+
+  it("rejects an incompatible explicit native provider mode before progress or runners", async () => {
+    const lab = createMockLab();
+
+    await expect(
+      runQaSuite({
+        lab,
+        repoRoot: process.cwd(),
+        providerMode: "mock-openai",
+        scenarioIds: ["openai-realtime-talk-live"],
+      }),
+    ).rejects.toThrow(
+      "selected QA scenario(s) do not match the current QA lane: openai-realtime-talk-live (providerMode=live-frontier)",
+    );
+
+    expect(lab.setScenarioRun).not.toHaveBeenCalled();
+    expect(runQaFlowSuite).not.toHaveBeenCalled();
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+  });
+
+  it("rejects conflicting native provider requirements before progress or runners", async () => {
+    const lab = createMockLab();
+
+    await expect(
+      runQaSuite({
+        lab,
+        repoRoot: process.cwd(),
+        scenarioIds: ["diagnostic-events-boundary", "openai-realtime-talk-live"],
+      }),
+    ).rejects.toThrow(
+      "selected native QA scenarios require conflicting provider modes: live-frontier (openai-realtime-talk-live), mock-openai (diagnostic-events-boundary)",
+    );
+
+    expect(lab.setScenarioRun).not.toHaveBeenCalled();
+    expect(runQaFlowSuite).not.toHaveBeenCalled();
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
+  });
+
+  it("runs a native scenario under a compatible explicit provider override", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-native-live-override-");
+
+    await runQaSuite({
+      repoRoot,
+      providerMode: "live-frontier",
+      scenarioIds: ["openai-realtime-talk-live"],
+    });
+
+    expect(runQaFlowSuite).not.toHaveBeenCalled();
+    expect(runQaTestFileScenarios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerMode: "live-frontier",
+        scenarios: [expect.objectContaining({ id: "openai-realtime-talk-live" })],
+      }),
+    );
+  });
+
+  it("keeps unconstrained native scenarios lane-agnostic during provider adoption", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-native-lane-agnostic-");
+
+    await runQaSuite({
+      repoRoot,
+      scenarioIds: ["gateway-smoke", "openai-realtime-talk-live"],
+    });
+
+    expect(runQaFlowSuite).not.toHaveBeenCalled();
+    expect(runQaTestFileScenarios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerMode: "live-frontier",
+        scenarios: [
+          expect.objectContaining({ id: "gateway-smoke" }),
+          expect.objectContaining({ id: "openai-realtime-talk-live" }),
+        ],
+      }),
+    );
+  });
+
+  it("rejects a mixed native and flow provider conflict before progress or runners", async () => {
+    const lab = createMockLab();
+
+    await expect(
+      runQaSuite({
+        lab,
+        repoRoot: process.cwd(),
+        scenarioIds: ["openai-realtime-talk-live", "goal-context-next-turn"],
+      }),
+    ).rejects.toThrow(
+      "selected QA scenario(s) do not match the current QA lane: goal-context-next-turn (providerMode=mock-openai)",
+    );
+
+    expect(lab.setScenarioRun).not.toHaveBeenCalled();
+    expect(runQaFlowSuite).not.toHaveBeenCalled();
+    expect(runQaTestFileScenarios).not.toHaveBeenCalled();
   });
 
   it("serializes test-file runner partitions in one checkout", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -12,7 +12,7 @@ import {
   validateQaEvidenceSummaryJson,
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
-import { isQaFastModeEnabled } from "./model-selection.js";
+import { isQaFastModeEnabled, type QaProviderMode } from "./model-selection.js";
 import { DEFAULT_QA_PROVIDER_MODE } from "./providers/index.js";
 import {
   defaultQaSuiteConcurrencyForTransport,
@@ -26,7 +26,11 @@ import {
   resolveQaScenarioRequiredProviderMode,
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
-import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
+import {
+  describeQaProviderLaneMismatches,
+  expandQaScenarioExecutionCells,
+  type QaScenarioExecutionCell,
+} from "./scenario-lane.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
@@ -745,6 +749,21 @@ async function runUnifiedQaSuite(params: {
   const startedAt = new Date();
   const repoRoot = path.resolve(params.runParams?.repoRoot ?? process.cwd());
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, params.runParams?.outputDir);
+  const nativeModeScenarios = new Map<QaProviderMode, string[]>();
+  for (const scenario of [...params.plan.testFileScenariosByKind.values()].flat()) {
+    const mode = resolveQaScenarioRequiredProviderMode(scenario);
+    if (mode) {
+      nativeModeScenarios.set(mode, [...(nativeModeScenarios.get(mode) ?? []), scenario.id]);
+    }
+  }
+  const nativeProviderModes = [...nativeModeScenarios.keys()].toSorted();
+  if (nativeProviderModes.length > 1) {
+    throw new Error(
+      `selected native QA scenarios require conflicting provider modes: ${nativeProviderModes
+        .map((mode) => `${mode} (${nativeModeScenarios.get(mode)?.toSorted().join(", ")})`)
+        .join(", ")}`,
+    );
+  }
   // Only an explicitly selected single flow may replace the unified suite's mock default.
   const [selectedScenario] = params.plan.scenarios;
   const selectedProviderMode =
@@ -755,8 +774,26 @@ async function runUnifiedQaSuite(params: {
       ? resolveQaScenarioRequiredProviderMode(selectedScenario)
       : undefined;
   const providerMode = normalizeQaProviderMode(
-    params.runParams?.providerMode ?? selectedProviderMode ?? DEFAULT_QA_PROVIDER_MODE,
+    params.runParams?.providerMode ??
+      nativeProviderModes[0] ??
+      selectedProviderMode ??
+      DEFAULT_QA_PROVIDER_MODE,
   );
+  const primaryModel =
+    params.runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
+  const providerModeMismatches =
+    params.plan.testFileScenariosByKind.size === 0
+      ? []
+      : params.plan.scenarios.flatMap((scenario) =>
+          describeQaProviderLaneMismatches({ scenario, providerMode, primaryModel })
+            .filter((reason) => reason.startsWith("providerMode="))
+            .map((reason) => `${scenario.id} (${reason})`),
+        );
+  if (providerModeMismatches.length > 0) {
+    throw new Error(
+      `selected QA scenario(s) do not match the current QA lane: ${providerModeMismatches.join(", ")}`,
+    );
+  }
   const progress = params.runParams?.lab
     ? createQaSuiteProgressController({
         lab: params.runParams.lab,
@@ -765,8 +802,6 @@ async function runUnifiedQaSuite(params: {
       })
     : undefined;
   progress?.start();
-  const primaryModel =
-    params.runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   const alternateModel =
     params.runParams?.alternateModel?.trim() || defaultQaModelForMode(providerMode, true);
   const fastMode =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native test files that required provider modes bypassed unified flow lane adoption and validation, allowing mock execution to be labeled live.

## Why This Change Was Made

The canonical fix adds unified-suite preflight at suite selection and launch ownership, reusing the canonical provider-lane mismatch helper.

- Implicit native provider modes are adopted.
- Explicit provider-mode mismatches are rejected before any runner invocation.
- Conflicting selected native requirements are rejected before any runner invocation.
- Compatible explicit overrides succeed.

Production LOC: +40/-5 (net +35). Tests: +125.

No changelog entry.

## User Impact

QA authors can rely on native test requirements selecting the correct provider lane, while contradictory selections fail before execution instead of producing mislabeled results.

Merge remains blocked on exact-head hosted QA/release proof, automatic ClawSweeper, and the current-main release merge-tree max-lines declaration blocker exposed by https://github.com/openclaw/openclaw/pull/120421. Its release run https://github.com/openclaw/openclaw/actions/runs/31233994017 remains in progress, with `checks-fast-max-lines-ratchet` failed at `Run max-lines-ratchet (node)`.

## Evidence

- 84 focused tests: 53 launcher tests and 31 sibling tests.
- Accepted invocations: 83 launcher/lane/provider-selection tests plus one targeted provider-metadata catalog test.
- Format, Oxlint, diff, privacy, and autoreview: clean.

Punchcard-Session: golden-valley-workshop-br
