### PR TITLE
fix(ui): restore terminal button in chat header

### DIFF
--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -24,7 +24,6 @@ import { ChatPaneContext } from "./chat-pane-context.ts";
 import { headerPlatformByClient } from "./chat-pane-shared.ts";
 import { readChatSessionActionAccess } from "./chat-session-action-access.ts";
 import { patchChatSessionLabel } from "./chat-state-route.ts";
-import { renderCatalogTerminalButton } from "./components/catalog-terminal-button.ts";
 import { renderBackgroundTasksToggle } from "./components/chat-background-tasks-render.ts";
 import type { BackgroundTasksProps } from "./components/chat-background-tasks.types.ts";
 import { isChatRunWorking } from "./components/chat-composer.ts";
@@ -40,6 +39,7 @@ import {
   renderSessionWorkspaceToggle,
   type SessionWorkspaceProps,
 } from "./components/chat-session-workspace.ts";
+import { renderChatTerminalButton } from "./components/chat-terminal-button.ts";
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
 import {
@@ -166,7 +166,11 @@ export abstract class ChatPaneHeader extends ChatPaneContext {
       canReveal,
       copiedAction: this.headerCopiedAction,
       renameDisabledReason,
-      terminalAction: renderCatalogTerminalButton(this.state, this.catalogSession),
+      terminalAction: renderChatTerminalButton(
+        this.state,
+        this.catalogSession,
+        sessionWorkspace.onToggleTerminal,
+      ),
       discussionAction: this.renderSessionDiscussionAction(),
       diffAction: renderSessionDiffToggle(sessionWorkspace),
       backgroundTasksAction: renderBackgroundTasksToggle(backgroundTasks),

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -1,0 +1,57 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import {
+  TERMINAL_PANEL_TOGGLE_EVENT,
+  type TerminalPanelToggleDetail,
+} from "../../components/panel-toggle-contract.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { createTestChatPane } from "./chat-pane.test-support.ts";
+import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
+import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
+
+describe("chat pane terminal action", () => {
+  it("renders only when available and opens the terminal dock", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const session = {
+      key: state.sessionKey,
+      kind: "direct",
+      updatedAt: 0,
+    } satisfies GatewaySessionRow;
+    state.terminalAvailable = true;
+    const container = document.createElement("div");
+    const renderHeader = () =>
+      render(
+        pane.renderPaneHeader(
+          createSessionWorkspaceProps(state),
+          createBackgroundTasksProps(state, { onOpenSession: () => {} }),
+          session,
+          false,
+          undefined,
+          false,
+        ),
+        container,
+      );
+    const events: CustomEvent<TerminalPanelToggleDetail>[] = [];
+    const listener = (event: Event) => events.push(event as CustomEvent<TerminalPanelToggleDetail>);
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, listener);
+    try {
+      renderHeader();
+      const button = container.querySelector<HTMLButtonElement>('[aria-label="Toggle terminal"]');
+      expect(button).not.toBeNull();
+      button?.click();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.detail).toEqual({ dock: "right", open: true });
+
+      state.terminalAvailable = false;
+      renderHeader();
+      expect(container.querySelector('[aria-label="Toggle terminal"]')).toBeNull();
+    } finally {
+      window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, listener);
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -28,7 +28,7 @@ describe("chat pane terminal action", () => {
       render(
         pane.renderPaneHeader(
           createSessionWorkspaceProps(state),
-          createBackgroundTasksProps(state, { onOpenSession: () => {} }),
+          createBackgroundTasksProps(state),
           session,
           false,
           undefined,

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -15,6 +15,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
+import { TERMINAL_PANEL_TOGGLE_EVENT } from "../../components/panel-toggle-contract.ts";
 import { buildCatalogSessionKey, type CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
@@ -720,11 +721,11 @@ describe("chat pane catalog session lifecycle", () => {
     const listener = (event: Event) => {
       detail = (event as CustomEvent).detail;
     };
-    window.addEventListener("openclaw:terminal-toggle", listener);
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, listener);
     try {
       (container.querySelector('[aria-label="Open in terminal"]') as HTMLElement).click();
     } finally {
-      window.removeEventListener("openclaw:terminal-toggle", listener);
+      window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, listener);
     }
     expect(detail).toEqual({ open: true, catalog: key });
   });

--- a/ui/src/pages/chat/components/chat-terminal-button.ts
+++ b/ui/src/pages/chat/components/chat-terminal-button.ts
@@ -1,4 +1,4 @@
-// Catalog viewer header action for opening an eligible native session in a terminal.
+// Chat header action for toggling the native terminal or resuming an eligible catalog session.
 import { html, nothing } from "lit";
 import type { SessionCatalogSession } from "../../../../../packages/gateway-protocol/src/index.js";
 import { icons } from "../../../components/icons.ts";
@@ -7,21 +7,27 @@ import { t } from "../../../i18n/index.ts";
 import { parseCatalogSessionKey } from "../../../lib/sessions/catalog-key.ts";
 import { openCatalogSessionInTerminal } from "../../../lib/sessions/catalog-terminal.ts";
 
-export function renderCatalogTerminalButton(
+export function renderChatTerminalButton(
   state: { sessionKey: string; terminalAvailable?: boolean } | null | undefined,
   session: SessionCatalogSession | null,
+  onToggleTerminal: (() => void) | undefined,
 ) {
   const catalogKey = state ? parseCatalogSessionKey(state.sessionKey) : null;
-  if (!catalogKey || !session?.canOpenTerminal || !state?.terminalAvailable) {
+  if (
+    (catalogKey && (!state?.terminalAvailable || !session?.canOpenTerminal)) ||
+    (!catalogKey && !onToggleTerminal)
+  ) {
     return nothing;
   }
+  const label = catalogKey ? t("chat.catalog.openInTerminal") : t("terminal.toggle");
   return html`
-    <openclaw-tooltip .content=${t("chat.catalog.openInTerminal")}>
+    <openclaw-tooltip .content=${label}>
       <button
         class="btn btn--ghost btn--icon chat-icon-btn"
         type="button"
-        aria-label=${t("chat.catalog.openInTerminal")}
-        @click=${() => openCatalogSessionInTerminal(catalogKey)}
+        aria-label=${label}
+        @click=${() =>
+          catalogKey ? openCatalogSessionInTerminal(catalogKey) : onToggleTerminal?.()}
       >
         ${icons.terminal}
       </button>


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted: Yes. The implementation and PR preparation were AI-assisted, and the final UI-only branch autoreview was clean.

## What Problem This Solves

Ordinary chat users lost the always-visible terminal action after collapsed workspace chrome was removed. The terminal became discoverable only after opening the workspace rail or using a shortcut.

## Why This Change Was Made

This uses one shared chat-header terminal renderer. Ordinary sessions consume the existing availability-gated toggle callback, while catalog sessions retain their targeted eligibility checks.

## User Impact

Terminal-capable sessions again show an accessible **Toggle terminal** button in the chat header. Unavailable sessions remain unchanged.

## Evidence

- Final branch scope remains UI-only at `91efbbec7efa859f118147da2f6af07d8031ff4b`: four rename-aware diff records across five Control UI path names, counting both sides of the 59% component rename.
- Focused UI terminal tests passed: 41/41. The Control UI test-type project passes on current main. Type-aware oxlint, oxfmt, `git diff --check`, and final branch autoreview are clean.
- #120438, #120481, #120514, and #120463 fixed the earlier main-branch blockers and retired test-helper callback upstream. The auxiliary baseline and Doctor commits were dropped from this branch; this branch contains only the UI repair and its current-main test API follow-up.
- The browser unavailable-state was verified, and the terminal-capable positive path was integration-tested.
- Visual proof remains a gap: the original screenshot was withheld because it contained private browser chrome.
