### PR TITLE
fix(state): converge v15 schema additions before canonical index repair

### DIFF
--- a/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
@@ -1,0 +1,47 @@
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
+
+function removeSchemaRange(sql: string, startMarker: string, endMarker: string): string {
+  const start = sql.indexOf(startMarker);
+  const end = sql.indexOf(endMarker, start);
+  if (start === -1 || end === -1) {
+    throw new Error(`Historical agent schema marker is missing: ${startMarker}`);
+  }
+  return sql.slice(0, start) + sql.slice(end);
+}
+
+/** Exact schema bytes from 509a5f0373764, derived from current SQL with later additions removed. */
+export function historicalV15AgentSchemaSql(): string {
+  let sql = OPENCLAW_AGENT_SCHEMA_SQL.replace(
+    "  entry_valid INTEGER NOT NULL DEFAULT 0 CHECK (entry_valid IN (-1, 0, 1)),\n",
+    "",
+  );
+  sql = removeSchemaRange(
+    sql,
+    "CREATE INDEX IF NOT EXISTS idx_agent_session_nodes_entry_valid_pending",
+    "CREATE TABLE IF NOT EXISTS session_windows (",
+  );
+  sql = removeSchemaRange(
+    sql,
+    "CREATE TABLE IF NOT EXISTS context_engine_turn_outbox (",
+    "CREATE TABLE IF NOT EXISTS cache_entries (",
+  );
+  sql = removeSchemaRange(
+    sql,
+    "CREATE TABLE IF NOT EXISTS memory_index_chunk_recall_metadata (",
+    "CREATE TABLE IF NOT EXISTS memory_embedding_cache (",
+  );
+  return removeSchemaRange(
+    sql,
+    "CREATE TABLE IF NOT EXISTS standing_intents (",
+    "CREATE TABLE IF NOT EXISTS session_transcript_index_state (",
+  );
+}
+
+/** Exact schema bytes from v2026.7.2-beta.4, the first tagged agent schema v14. */
+export function historicalV14AgentSchemaSql(): string {
+  return removeSchemaRange(
+    historicalV15AgentSchemaSql(),
+    "\nCREATE TABLE IF NOT EXISTS session_suggestions (",
+    "CREATE TABLE IF NOT EXISTS board_tabs (",
+  );
+}

--- a/src/infra/state-migrations.media-persistence.historical-v14.test.ts
+++ b/src/infra/state-migrations.media-persistence.historical-v14.test.ts
@@ -1,0 +1,154 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { historicalV14AgentSchemaSql } from "./state-migrations.media-persistence.historical-schema.test-support.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("legacy media persistence Doctor migration from historical v14", () => {
+  it("migrates a copy of the exact v2026.7.2-beta.4 schema without losing its session", () => {
+    const historicalSchema = historicalV14AgentSchemaSql();
+    expect(createHash("sha256").update(historicalSchema).digest("hex")).toBe(
+      "955889668707fbccab70b80b5058af5a1587fd35ae32a80f8605179a68fb5117",
+    );
+
+    const stateDir = makeTempDir(tempDirs, "media-persistence-historical-v14-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const pristinePath = path.join(stateDir, "historical", "v14-pristine.sqlite");
+    const databasePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    fs.mkdirSync(path.dirname(pristinePath), { recursive: true });
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const pristine = new DatabaseSync(pristinePath);
+    try {
+      pristine.exec(historicalSchema);
+      pristine.exec("PRAGMA user_version = 14;");
+      pristine
+        .prepare(
+          `INSERT INTO schema_meta (
+             meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
+           ) VALUES ('primary', 'agent', 14, 'main', '2026.7.2-beta.4', 1000, 1000)`,
+        )
+        .run();
+      const entry = JSON.stringify({
+        sessionId: "historical-v14",
+        status: "done",
+        updatedAt: 1000,
+      });
+      pristine
+        .prepare(
+          `INSERT INTO session_nodes (
+             session_key, current_session_id, entry_json, updated_at, status, created_at, created_via
+           ) VALUES (?, ?, ?, ?, 'done', ?, 'operator')`,
+        )
+        .run("agent:main:historical-v14", "historical-v14", entry, 1000, 1000);
+      pristine
+        .prepare(
+          `INSERT INTO session_windows (
+             session_id, session_key, session_scope, created_at, updated_at, status, display_name
+           ) VALUES (?, ?, 'conversation', ?, ?, 'done', 'historical v14')`,
+        )
+        .run("historical-v14", "agent:main:historical-v14", 1000, 1000);
+      const event = {
+        id: "event-v14",
+        message: { MediaPath: "/media/v14.png", content: "historical", role: "user" },
+        parentId: null,
+        timestamp: 1000,
+        type: "message",
+      };
+      pristine
+        .prepare(
+          "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, 0, ?, ?)",
+        )
+        .run("historical-v14", JSON.stringify(event), 1100);
+      pristine
+        .prepare(
+          `INSERT INTO transcript_event_identities (
+             session_id, event_id, seq, event_type, parent_id, message_idempotency_key, created_at
+           ) VALUES (?, ?, 0, 'message', NULL, NULL, ?)`,
+        )
+        .run("historical-v14", "event-v14", 1100);
+    } finally {
+      pristine.close();
+    }
+    const pristineHash = createHash("sha256").update(fs.readFileSync(pristinePath)).digest("hex");
+    fs.copyFileSync(pristinePath, databasePath);
+    registerOpenClawAgentDatabase({ agentId: "main", env, path: databasePath, schemaVersion: 14 });
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    expect(
+      listSessionEntries({ agentId: "main", env }).map(({ entry, sessionKey }) => ({
+        sessionId: entry.sessionId,
+        sessionKey,
+      })),
+    ).toContainEqual({
+      sessionId: "historical-v14",
+      sessionKey: "agent:main:historical-v14",
+    });
+    closeOpenClawAgentDatabasesForTest();
+
+    const migrated = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(migrated.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        migrated.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+      ).toEqual({ schema_version: OPENCLAW_AGENT_SCHEMA_VERSION });
+      expect(
+        migrated
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get("agent:main:historical-v14"),
+      ).toEqual({ entry_valid: 1 });
+      expect(
+        migrated.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
+      ).toEqual({ main_key: "main" });
+      const row = migrated
+        .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
+        .get("historical-v14") as { event_json: string };
+      const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
+      expect(message).not.toHaveProperty("MediaPath");
+      expect(message["__openclaw"]).toMatchObject({
+        media: [expect.objectContaining({ path: "/media/v14.png" })],
+      });
+      expect(migrated.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+      expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    } finally {
+      migrated.close();
+    }
+
+    expect(createHash("sha256").update(fs.readFileSync(pristinePath)).digest("hex")).toBe(
+      pristineHash,
+    );
+    const original = new DatabaseSync(pristinePath, { readOnly: true });
+    try {
+      expect(original.prepare("PRAGMA user_version").get()).toEqual({ user_version: 14 });
+      expect(
+        original
+          .prepare("SELECT name FROM pragma_table_info('session_nodes') WHERE name = 'entry_valid'")
+          .get(),
+      ).toBeUndefined();
+    } finally {
+      original.close();
+    }
+  });
+});

--- a/src/infra/state-migrations.media-persistence.historical-v15.test.ts
+++ b/src/infra/state-migrations.media-persistence.historical-v15.test.ts
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { historicalV15AgentSchemaSql } from "./state-migrations.media-persistence.historical-schema.test-support.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("legacy media persistence Doctor migration from historical v15", () => {
+  it("converges the exact 509a5f0373764 schema before current-index repair", () => {
+    const historicalSchema = historicalV15AgentSchemaSql();
+    expect(createHash("sha256").update(historicalSchema).digest("hex")).toBe(
+      "75953ef97a738251822fc5aaf283bbe55fbcabe8702ad771892cdafc85d8e6b9",
+    );
+
+    const stateDir = makeTempDir(tempDirs, "media-persistence-historical-v15-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const historical = new DatabaseSync(databasePath);
+    try {
+      historical.exec(historicalSchema);
+      historical.exec("PRAGMA user_version = 15;");
+      historical
+        .prepare(
+          `INSERT INTO schema_meta (
+             meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
+           ) VALUES ('primary', 'agent', 15, 'main', '2026.7.2', 1000, 1000)`,
+        )
+        .run();
+      const entry = JSON.stringify({
+        sessionId: "historical-v15",
+        status: "done",
+        updatedAt: 1000,
+      });
+      historical
+        .prepare(
+          `INSERT INTO session_nodes (
+             session_key, current_session_id, entry_json, updated_at, status, created_at, created_via
+           ) VALUES (?, ?, ?, ?, 'done', ?, 'operator')`,
+        )
+        .run("agent:main:historical-v15", "historical-v15", entry, 1000, 1000);
+      historical
+        .prepare(
+          `INSERT INTO session_windows (
+             session_id, session_key, session_scope, created_at, updated_at, status, display_name
+           ) VALUES (?, ?, 'conversation', ?, ?, 'done', 'historical v15')`,
+        )
+        .run("historical-v15", "agent:main:historical-v15", 1000, 1000);
+      const event = {
+        id: "event-v15",
+        message: { MediaPath: "/media/v15.png", content: "historical", role: "user" },
+        parentId: null,
+        timestamp: 1000,
+        type: "message",
+      };
+      historical
+        .prepare(
+          "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, 0, ?, ?)",
+        )
+        .run("historical-v15", JSON.stringify(event), 1100);
+      historical
+        .prepare(
+          `INSERT INTO transcript_event_identities (
+             session_id, event_id, seq, event_type, parent_id, message_idempotency_key, created_at
+           ) VALUES (?, ?, 0, 'message', NULL, NULL, ?)`,
+        )
+        .run("historical-v15", "event-v15", 1100);
+    } finally {
+      historical.close();
+    }
+    registerOpenClawAgentDatabase({ agentId: "main", env, path: databasePath, schemaVersion: 15 });
+
+    const result = migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    expect(
+      listSessionEntries({ agentId: "main", env }).map(({ entry, sessionKey }) => ({
+        sessionId: entry.sessionId,
+        sessionKey,
+      })),
+    ).toContainEqual({
+      sessionId: "historical-v15",
+      sessionKey: "agent:main:historical-v15",
+    });
+    closeOpenClawAgentDatabasesForTest();
+
+    const migrated = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(migrated.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        migrated.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+      ).toEqual({ schema_version: OPENCLAW_AGENT_SCHEMA_VERSION });
+      expect(
+        migrated
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get("agent:main:historical-v15"),
+      ).toEqual({ entry_valid: 1 });
+      expect(
+        migrated.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
+      ).toEqual({ main_key: "main" });
+      const row = migrated
+        .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
+        .get("historical-v15") as { event_json: string };
+      const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
+      expect(message).not.toHaveProperty("MediaPath");
+      expect(message["__openclaw"]).toMatchObject({
+        media: [expect.objectContaining({ path: "/media/v15.png" })],
+      });
+      expect(migrated.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+      expect(migrated.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    } finally {
+      migrated.close();
+    }
+  });
+});

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -321,7 +321,7 @@ function migrateRegisteredDatabase(params: {
       pathname: params.pathname,
     });
     let userVersion = readSqliteUserVersion(database);
-    if (userVersion < PREVIOUS_MEDIA_SCHEMA_VERSION) {
+    if (userVersion <= PREVIOUS_MEDIA_SCHEMA_VERSION) {
       migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema(database, {
         agentId: params.agentId,
         path: params.pathname,

--- a/src/state/openclaw-agent-db-maintenance.ts
+++ b/src/state/openclaw-agent-db-maintenance.ts
@@ -1,12 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
-import { ensureMemoryChunkProvenance } from "../../packages/memory-host-sdk/src/host/memory-schema-provenance.js";
-import {
-  ensureMemoryRecallMetadataSchema,
-  hasLegacyMemoryRecallMetadataColumns,
-} from "../../packages/memory-host-sdk/src/host/memory-schema-recall.js";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { repairCanonicalSqliteIndexes } from "../infra/sqlite-index-schema.js";
 import {
   createNewerSqliteSchemaVersionError,
   readSqliteUserVersion,
@@ -103,40 +97,13 @@ export function migrateOpenClawAgentDatabaseForMaintenance(options: {
     if (!hasCurrentVersion && !hasSupportedOlderVersion) {
       return;
     }
-    if (hasCurrentVersion) {
-      const hadLegacyRecallMetadata = hasLegacyMemoryRecallMetadataColumns(database);
-      const hadLegacyProvenanceTrigger = Boolean(
-        database
-          .prepare(
-            "SELECT 1 FROM sqlite_schema WHERE type = 'trigger' AND name = 'memory_index_chunk_provenance_after_insert'",
-          )
-          .get(),
-      );
-      if (hadLegacyRecallMetadata || hadLegacyProvenanceTrigger) {
-        ensureMemoryRecallMetadataSchema(database);
-        ensureMemoryChunkProvenance(database);
-        database.exec(OPENCLAW_AGENT_SCHEMA_SQL);
-      }
-      repairCanonicalSqliteIndexes(database, options.pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
-        // The maintenance contract is the runtime owner/schema contract plus
-        // an exact user_version gate, so table drift rolls this savepoint back.
-        validateAfterRepair: () =>
-          assertOpenClawAgentDatabaseForMaintenance(database, {
-            agentId,
-            pathname: options.pathname,
-          }),
-      });
-      ensureMemoryRecallMetadataSchema(database);
-      ensureMemoryChunkProvenance(database);
-      assertOpenClawAgentDatabaseForMaintenance(database, {
-        agentId,
-        pathname: options.pathname,
-      });
-      return;
-    }
     ensureOpenClawAgentDatabaseSchema(database, {
       agentId,
       path: options.pathname,
+    });
+    assertOpenClawAgentDatabaseForMaintenance(database, {
+      agentId,
+      pathname: options.pathname,
     });
   } finally {
     clearNodeSqliteKyselyCacheForDatabase(database);

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -24,6 +24,7 @@ import {
 import { CONTEXT_ENGINE_TURN_OUTBOX_TABLE } from "./openclaw-agent-context-engine-turn-outbox-schema.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
+import { ensureSessionEntryValidityProjection } from "./openclaw-agent-db-session-migrations.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import {
   AGENT_V14_ADDITIVE_SCHEMA_SQL,
@@ -116,6 +117,19 @@ function repairAndAssertAgentSchemaGroup(
   assertOpenClawAgentSchemaContains(database, pathname, schemaSql);
 }
 
+const SESSION_KEY_CONTRACT_SCHEMA_START = "CREATE TABLE IF NOT EXISTS session_key_contract (";
+const SESSION_KEY_CONTRACT_SCHEMA_END = "CREATE TABLE IF NOT EXISTS session_windows (";
+
+/** Ensure the additive session-key contract table inside the caller's transaction. */
+export function ensureSessionKeyContractSchemaInTransaction(db: DatabaseSync): void {
+  const start = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(SESSION_KEY_CONTRACT_SCHEMA_START);
+  const end = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(SESSION_KEY_CONTRACT_SCHEMA_END, start);
+  if (start === -1 || end === -1) {
+    throw new Error("OpenClaw agent session-key contract schema markers are missing.");
+  }
+  db.exec(OPENCLAW_AGENT_SCHEMA_SQL.slice(start, end)); // sqlite-allow-raw -- Idempotent additive lazy ensure.
+}
+
 export function repairAndAssertOpenClawAgentV14SchemaForMigration(
   database: DatabaseSync,
   options: { agentId: string; pathname: string },
@@ -140,8 +154,13 @@ export function repairAndAssertOpenClawAgentV14SchemaForMigration(
     );
   }
 
+  ensureSessionEntryValidityProjection(database);
+  ensureSessionKeyContractSchemaInTransaction(database);
+
   // v14 always owned the core schema. Board and collaboration groups were
   // lazy, but a partially present group still has to be complete and canonical.
+  // Keep this preflight before full CREATE IF NOT EXISTS convergence: otherwise
+  // a missing stable v14 table could be recreated empty and hide data loss.
   repairAndAssertAgentSchemaGroup(database, options.pathname, AGENT_V14_CORE_SCHEMA_SQL);
   if (hasAnyCanonicalTable(database, AGENT_V14_SESSION_SHARING_SCHEMA_SQL)) {
     repairAndAssertAgentSchemaGroup(

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -31,6 +31,7 @@ import {
   assertOpenClawAgentSchemaContains,
   assertOpenClawAgentCurrentRuntimeSchema,
   assertSupportedAgentSchemaVersion,
+  ensureSessionKeyContractSchemaInTransaction,
   readExistingAgentSchemaMeta,
   repairAndAssertOpenClawAgentV14SchemaForMigration,
 } from "./openclaw-agent-db-schema-helpers.js";
@@ -54,19 +55,8 @@ import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
 
 type OpenClawAgentMetadataDatabase = Pick<OpenClawAgentKyselyDatabase, "schema_meta">;
 type MigratedSessionEntry = Record<string, unknown>;
-const SESSION_KEY_CONTRACT_SCHEMA_START = "CREATE TABLE IF NOT EXISTS session_key_contract (";
-const SESSION_KEY_CONTRACT_SCHEMA_END = "CREATE TABLE IF NOT EXISTS session_windows (";
 
 const agentDbLog = createSubsystemLogger("state/agent-db");
-
-function ensureSessionKeyContractSchemaInTransaction(db: DatabaseSync): void {
-  const start = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(SESSION_KEY_CONTRACT_SCHEMA_START);
-  const end = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(SESSION_KEY_CONTRACT_SCHEMA_END, start);
-  if (start === -1 || end === -1) {
-    throw new Error("OpenClaw agent session-key contract schema markers are missing.");
-  }
-  db.exec(OPENCLAW_AGENT_SCHEMA_SQL.slice(start, end)); // sqlite-allow-raw -- Idempotent additive lazy ensure.
-}
 
 function migratedSessionColumn(
   columns: ReadonlySet<string>,
@@ -587,6 +577,7 @@ function ensureAgentSchema(
       }
       if (previousVersion === targetVersion) {
         ensureSessionEntryValidityProjection(db);
+        ensureSessionKeyContractSchemaInTransaction(db);
         if (hasPendingMemoryChunkMetadataMigration(db)) {
           migrateMemoryChunkMetadataSchema(db);
           db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
@@ -596,7 +587,6 @@ function ensureAgentSchema(
         repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
           verifyPhysicalIntegrity: false,
         });
-        ensureSessionKeyContractSchemaInTransaction(db);
         assertAgentSchemaVersion(db, { agentId, pathname, version: targetVersion });
         return;
       } else if (previousVersion === 14) {
@@ -698,7 +688,7 @@ export function migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema(
 ): void {
   const targetVersion = OPENCLAW_AGENT_SCHEMA_VERSION - 1;
   const userVersion = readSqliteUserVersion(db);
-  if (userVersion >= targetVersion) {
+  if (userVersion > targetVersion) {
     return;
   }
   const agentId = normalizeAgentId(options.agentId);

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3189,6 +3189,62 @@ describe("openclaw agent database", () => {
     ).toEqual({ main_key: "main" });
   });
 
+  it("installs same-version session additions before maintenance index repair", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const drifted = new DatabaseSync(databasePath);
+    try {
+      drifted
+        .prepare(
+          `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run(
+          "agent:worker-1:maintenance",
+          "maintenance-session",
+          JSON.stringify({ sessionId: "maintenance-session", updatedAt: 1000 }),
+          1000,
+        );
+      drifted.exec(`
+        DROP TRIGGER session_nodes_entry_valid_after_insert;
+        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
+        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
+        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+        DROP TABLE session_key_contract;
+        ALTER TABLE session_nodes DROP COLUMN entry_valid;
+      `);
+    } finally {
+      drifted.close();
+    }
+
+    migrateOpenClawAgentDatabaseForMaintenance({
+      agentId: "worker-1",
+      pathname: databasePath,
+    });
+
+    const repaired = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        repaired
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get("agent:worker-1:maintenance"),
+      ).toEqual({ entry_valid: 1 });
+      expect(
+        repaired.prepare("SELECT main_key FROM session_key_contract WHERE id = 1").get(),
+      ).toEqual({ main_key: "main" });
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(repaired, {
+          agentId: "worker-1",
+          pathname: databasePath,
+        }),
+      ).not.toThrow();
+    } finally {
+      repaired.close();
+    }
+  });
+
   it("rejects a missing current-schema table instead of recreating it empty", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };


### PR DESCRIPTION
## What Problem This Solves

Upgrading an agent database from schema v14 (2026.7.2-beta.4 era) fails in `doctor --fix`: canonical index repair references `entry_valid` before the column exists, the transaction rolls back, the gateway refuses to start, and users see their session list reset (a fresh empty v16 DB gets created). Genuine v15 databases fail identically — the repair-before-convergence hazard existed for both versions.

Fixes https://github.com/openclaw/openclaw/issues/119263 (reported by @Wwhin-88). Supersedes and completes https://github.com/openclaw/openclaw/pull/119271 by @wangmiao0668000666, whose v14 analysis and helper ordering are preserved with Co-authored-by credit.

## Why This Change Was Made

Root cause (provenance): 509a5f0373764 (#113473) introduced the latent pre-convergence repair; cd8a96491e267 (#116703) made it executable by adding the `entry_valid` partial index and `session_key_contract` table at v16. The contributor PR fixed v14 but left authentic v15 databases failing the same way, and the current-version maintenance path carried a duplicate of the hazardous sequence.

The complete repair converges schema additions before any current-schema index repair, at the owning boundaries:

- `migrateRegisteredDatabase` routes v15 (not just <v15) into prerequisite convergence; `migrateOpenClawAgentDatabaseToMediaPrerequisiteSchema` runs its same-version path instead of early-returning.
- The v14 preflight installs the validity projection and key-contract table first, and keeps structural preflight before broad `CREATE IF NOT EXISTS` convergence (otherwise a missing stable v14 table could be recreated empty and hide data loss — rationale now documented inline).
- `ensureAgentSchema`'s same-version path installs additions before `repairCanonicalSqliteIndexes`, not after.
- The maintenance path's duplicated sequence is deleted; it delegates to the canonical schema owner (−37 lines of duplicate policy).

No schema-version bump (stays 16). Synchronous transactions; raw SQL only at documented DDL boundaries.

## User Impact

2026.7.2-beta.4/beta-era databases and genuine v15 databases migrate cleanly to v16; sessions remain visible; the gateway starts. Crash-loop release blocker cleared.

## Evidence

- Hash-pinned historical fixtures: exact `v2026.7.2-beta.4` v14 schema and exact `509a5f0373764` v15 schema, migrated on copies — both version stores reach v16, `entry_valid=1`, contract row seeded, the real `listSessionEntries` API returns the preserved session, media canonicalized, `PRAGMA integrity_check` ok, FK check empty, pristine source byte-identical.
- Migration-chain suites: 13 files, 256 tests passed (worker) + independent rerun of the 7 core files green after review.
- `node scripts/check-deadcode-exports.mjs` clean; `git diff --check` clean; oxfmt clean.
- Codex autoreview (`gpt-5.6-sol`, high), worker closeout + independent coordinator pass: clean both times (0.96).
- Production +27/−51 (net −24); tests +392 including the historical-schema test support.
