### PR TITLE
fix(queue): restore admission ticket type safety

### DIFF
--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -1,10 +1,4 @@
-import { expectDefined } from "@openclaw/normalization-core";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
-import {
-  formatEmbeddedAgentQueueFailureSummary,
-  queueEmbeddedAgentMessageWithOutcomeAsync,
-} from "../../agents/embedded-agent-runner/runs.js";
 import { settleProgressVisibilityCallbackResult } from "../../channels/progress-visibility.js";
 import { hasRestartRecoverySourceClaim } from "../../config/sessions/restart-recovery-state.js";
 import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -33,7 +27,7 @@ import {
   isAudioPayload,
 } from "./agent-runner-helpers.js";
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
-import { finalizeAcceptedSteer } from "./agent-runner-steer-adoption.js";
+import { runActiveReplySteer } from "./agent-runner-steer-adoption.js";
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
@@ -46,18 +40,12 @@ import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
-import {
-  admitFollowupRunLifecycle,
-  enqueueFollowupRun,
-  parkSteerCandidate,
-  resolveFollowupAbortSignal,
-  scheduleFollowupDrain,
-} from "./queue.js";
+import { enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
 import { REPLY_ADMISSION_TICKET } from "./reply-admission-ticket.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
 import * as replyRunState from "./reply-operation-run-state.js";
 import { type ReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
-import { bindReplyOperationTyping, refreshReplyOperationTyping } from "./reply-run-typing.js";
+import { bindReplyOperationTyping } from "./reply-run-typing.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
 import {
@@ -65,7 +53,7 @@ import {
   retireTerminalRestartRecoverySourceClaim,
 } from "./restart-recovery-claim.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
-import { buildChannelSourceTurnId, readChannelSourceTurnId } from "./source-turn-id.js";
+import { readChannelSourceTurnId } from "./source-turn-id.js";
 import { createTypingSignaler } from "./typing-mode.js";
 export async function runReplyAgent(
   params: RunReplyAgentParams,
@@ -235,155 +223,24 @@ export async function runReplyAgent(
   });
 
   if (effectiveShouldSteer && isActive && opts?.messageInjectionAttempted !== true) {
-    // Steer against the operation that owns THIS session's run slot. A native
-    // command continuation whose slot adoption was skipped (#104844) still
-    // carries a source-keyed reservation; steering by its stale sessionId
-    // would miss the live target run.
-    const registeredReplyOperation = sessionKey ? replyRunRegistry.get(sessionKey) : undefined;
-    const activeReplyOperation =
-      providedReplyOperation?.key === sessionKey
-        ? providedReplyOperation
-        : (registeredReplyOperation ?? providedReplyOperation);
-    const steerSessionId = activeReplyOperation?.sessionId ?? followupRun.run.sessionId;
     replyRunState.bindQueueDispositionToRunState(followupRun, replyOperationRunState);
-    const parked = parkSteerCandidate(queueKey, followupRun, resolvedQueue, queuedRunFollowupTurn);
-    if (!parked) {
-      releaseAdmissionTicket();
-      typing.cleanup();
-      return undefined;
-    }
-    const scheduleParkedFallback = () => {
-      const owner = replyRunRegistry.get(queueKey);
-      if (owner) {
-        scheduleFollowupDrainAfterReplyOperationClear({
-          operation: owner,
-          queueKey,
-          runFollowup: queuedRunFollowupTurn,
-        });
-      } else {
-        scheduleFollowupDrain(queueKey, queuedRunFollowupTurn);
-      }
-    };
-    scheduleParkedFallback();
-    releaseAdmissionTicket();
-    try {
-      const admission = await parked.admit();
-      if (admission === "cancelled") {
-        parked.consume();
-        typing.cleanup();
-        return undefined;
-      }
-      if (admission === "fallback") {
-        parked.fallback();
-        if (replyOperationRunState) {
-          replyOperationRunState.admission = { status: "accepted", mode: "followup" };
-        }
-        await touchActiveSessionEntry();
-        typing.cleanup();
-        return undefined;
-      }
-      // Channel dispatch normally stamps the route-scoped source id. Internal
-      // callers can derive the same per-message identity from the prepared turn.
-      const steerRunId = expectDefined(
-        restartRecoverySourceTurnId ??
-          buildChannelSourceTurnId({
-            provider:
-              followupRun.originatingChannel ??
-              followupRun.run.messageProvider ??
-              sessionCtx.Provider,
-            accountId:
-              followupRun.originatingAccountId ??
-              followupRun.run.agentAccountId ??
-              sessionCtx.AccountId,
-            conversationId:
-              followupRun.originatingTo ??
-              followupRun.originatingChatId ??
-              sessionKey ??
-              followupRun.run.sessionKey,
-            messageId: followupRun.messageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
-          }) ??
-          normalizeOptionalString(opts?.runId),
-        "steered turn id",
-      );
-      const steerOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
-        steerSessionId,
-        followupRun.prompt,
-        {
-          steeringMode: "all",
-          isInboundUserMessage: true,
-          ...(followupRun.images?.length ? { images: followupRun.images } : {}),
-          ...(followupRun.imageOrder?.length ? { imageOrder: followupRun.imageOrder } : {}),
-          ...(followupRun.media?.length ? { media: followupRun.media } : {}),
-          waitForTranscriptCommit: true,
-          queueIdentity: steerRunId,
-          abortSignal: resolveFollowupAbortSignal(followupRun),
-          onQueueAccepted: parked.accepted,
-          ...(resolvedQueue.debounceMs !== undefined
-            ? { debounceMs: resolvedQueue.debounceMs }
-            : {}),
-          ...(followupRun.run.sourceReplyDeliveryMode
-            ? { sourceReplyDeliveryMode: followupRun.run.sourceReplyDeliveryMode }
-            : {}),
-          taskSuggestionDeliveryMode: followupRun.run.taskSuggestionDeliveryMode,
-          ...(followupRun.userTurnTranscriptRecorder
-            ? { userTurnTranscriptRecorder: followupRun.userTurnTranscriptRecorder }
-            : {}),
-        },
-      );
-      if (!steerOutcome.queued) {
-        parked.fallback();
-        if (replyOperationRunState) {
-          replyOperationRunState.admission = { status: "accepted", mode: "followup" };
-        }
-        const summary = formatEmbeddedAgentQueueFailureSummary(steerOutcome);
-        logVerbose(
-          `queue: active session ${steerSessionId} rejected steering injection: ${summary}`,
-        );
-        await touchActiveSessionEntry();
-        typing.cleanup();
-        return undefined;
-      }
-      const adoptionDisposition = await finalizeAcceptedSteer({
-        activeReplyOperation,
-        abortKey: sessionKey ?? queueKey,
-        cleanupTyping: () => typing.cleanup(),
-        errorMessage: steerOutcome.errorMessage,
-        onAdopted: () => admitFollowupRunLifecycle(followupRun),
-        replyOperationRunState,
-        steerSessionId,
-        transcriptCommit: steerOutcome.transcriptCommit,
-      });
-      parked.consume();
-      if (adoptionDisposition === "stop") {
-        return undefined;
-      }
-      if (followupRun.currentInboundAudio === true) {
-        activeReplyOperation?.markAcceptedSteeredInboundAudio();
-      }
-      if (activeReplyOperation) {
-        await refreshReplyOperationTyping(activeReplyOperation, {
-          startIfIdle: typingSignals.shouldStartImmediately,
-        });
-      }
-      await touchActiveSessionEntry();
-      typing.cleanup();
-      return undefined;
-    } catch (error) {
-      if (resolveFollowupAbortSignal(followupRun)?.aborted) {
-        parked.consume();
-      } else {
-        parked.fallback();
-      }
-      throw error;
-    } finally {
-      if (followupRun.steerPending) {
-        if (resolveFollowupAbortSignal(followupRun)?.aborted) {
-          parked.consume();
-        } else {
-          parked.fallback();
-        }
-      }
-    }
+    await runActiveReplySteer({
+      followupRun,
+      opts,
+      providedReplyOperation,
+      queueKey,
+      releaseAdmissionTicket,
+      replyOperationRunState,
+      resolvedQueue,
+      restartRecoverySourceTurnId,
+      runFollowup: queuedRunFollowupTurn,
+      sessionCtx,
+      sessionKey,
+      touchActiveSessionEntry,
+      typing,
+      typingSignals,
+    });
+    return undefined;
   }
 
   const activeRunQueueAction = resolveActiveRunQueueAction({

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -116,9 +116,7 @@ async function finalizeAcceptedSteer(params: {
   return "continue";
 }
 
-export async function runActiveReplySteer(
-  params: ActiveReplySteerParams,
-): Promise<"handled"> {
+export async function runActiveReplySteer(params: ActiveReplySteerParams): Promise<"handled"> {
   const {
     followupRun,
     queueKey,
@@ -192,9 +190,7 @@ export async function runActiveReplySteer(
         queueIdentity: resolveAcceptedSteerRunId(params),
         abortSignal: resolveFollowupAbortSignal(followupRun),
         onQueueAccepted: parked.accepted,
-        ...(resolvedQueue.debounceMs !== undefined
-          ? { debounceMs: resolvedQueue.debounceMs }
-          : {}),
+        ...(resolvedQueue.debounceMs !== undefined ? { debounceMs: resolvedQueue.debounceMs } : {}),
         ...(followupRun.run.sourceReplyDeliveryMode
           ? { sourceReplyDeliveryMode: followupRun.run.sourceReplyDeliveryMode }
           : {}),
@@ -210,9 +206,7 @@ export async function runActiveReplySteer(
         replyOperationRunState.admission = { status: "accepted", mode: "followup" };
       }
       const summary = formatEmbeddedAgentQueueFailureSummary(steerOutcome);
-      logVerbose(
-        `queue: active session ${steerSessionId} rejected steering injection: ${summary}`,
-      );
+      logVerbose(`queue: active session ${steerSessionId} rejected steering injection: ${summary}`);
       await touchActiveSessionEntry();
       typing.cleanup();
       return "handled";

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -63,7 +63,7 @@ function resolveAcceptedSteerRunId(params: ActiveReplySteerParams): string {
   );
 }
 
-export async function finalizeAcceptedSteer(params: {
+async function finalizeAcceptedSteer(params: {
   activeReplyOperation: ReplyOperation | undefined;
   abortKey: string | undefined;
   cleanupTyping: () => void;

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -1,7 +1,67 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  formatEmbeddedAgentQueueFailureSummary,
+  queueEmbeddedAgentMessageWithOutcomeAsync,
+} from "../../agents/embedded-agent-runner/runs.js";
 import { isIngressAdoptionLostError } from "../../channels/message/ingress-drain.js";
 import { logVerbose } from "../../globals.js";
+import {
+  scheduleFollowupDrainAfterReplyOperationClear,
+  type RunReplyAgentParams,
+} from "./agent-runner-core.js";
+import {
+  admitFollowupRunLifecycle,
+  parkSteerCandidate,
+  resolveFollowupAbortSignal,
+  scheduleFollowupDrain,
+  type FollowupRun,
+} from "./queue.js";
 import type { ReplyOperationRunState } from "./reply-operation-run-state.js";
 import { type ReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
+import { refreshReplyOperationTyping } from "./reply-run-typing.js";
+import { buildChannelSourceTurnId } from "./source-turn-id.js";
+import type { TypingSignaler } from "./typing-mode.js";
+
+type ActiveReplySteerParams = {
+  followupRun: RunReplyAgentParams["followupRun"];
+  opts: RunReplyAgentParams["opts"];
+  providedReplyOperation: ReplyOperation | undefined;
+  queueKey: string;
+  releaseAdmissionTicket: () => void;
+  replyOperationRunState: ReplyOperationRunState | undefined;
+  resolvedQueue: RunReplyAgentParams["resolvedQueue"];
+  restartRecoverySourceTurnId: string | undefined;
+  runFollowup: (run: FollowupRun) => Promise<void>;
+  sessionCtx: RunReplyAgentParams["sessionCtx"];
+  sessionKey: string | undefined;
+  touchActiveSessionEntry: () => Promise<void>;
+  typing: RunReplyAgentParams["typing"];
+  typingSignals: TypingSignaler;
+};
+
+function resolveAcceptedSteerRunId(params: ActiveReplySteerParams): string {
+  const { followupRun, sessionCtx } = params;
+  return expectDefined(
+    params.restartRecoverySourceTurnId ??
+      buildChannelSourceTurnId({
+        provider:
+          followupRun.originatingChannel ?? followupRun.run.messageProvider ?? sessionCtx.Provider,
+        accountId:
+          followupRun.originatingAccountId ??
+          followupRun.run.agentAccountId ??
+          sessionCtx.AccountId,
+        conversationId:
+          followupRun.originatingTo ??
+          followupRun.originatingChatId ??
+          params.sessionKey ??
+          followupRun.run.sessionKey,
+        messageId: followupRun.messageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
+      }) ??
+      normalizeOptionalString(params.opts?.runId),
+    "steered turn id",
+  );
+}
 
 export async function finalizeAcceptedSteer(params: {
   activeReplyOperation: ReplyOperation | undefined;
@@ -54,4 +114,148 @@ export async function finalizeAcceptedSteer(params: {
     return "stop";
   }
   return "continue";
+}
+
+export async function runActiveReplySteer(
+  params: ActiveReplySteerParams,
+): Promise<"handled"> {
+  const {
+    followupRun,
+    queueKey,
+    releaseAdmissionTicket,
+    replyOperationRunState,
+    resolvedQueue,
+    runFollowup,
+    sessionKey,
+    touchActiveSessionEntry,
+    typing,
+    typingSignals,
+  } = params;
+  // Steer against the operation that owns THIS session's run slot. A native
+  // command continuation whose slot adoption was skipped (#104844) still
+  // carries a source-keyed reservation; steering by its stale sessionId
+  // would miss the live target run.
+  const registeredReplyOperation = sessionKey ? replyRunRegistry.get(sessionKey) : undefined;
+  const activeReplyOperation =
+    params.providedReplyOperation?.key === sessionKey
+      ? params.providedReplyOperation
+      : (registeredReplyOperation ?? params.providedReplyOperation);
+  const steerSessionId = activeReplyOperation?.sessionId ?? followupRun.run.sessionId;
+  const parked = parkSteerCandidate(queueKey, followupRun, resolvedQueue, runFollowup);
+  if (!parked) {
+    releaseAdmissionTicket();
+    typing.cleanup();
+    return "handled";
+  }
+  const scheduleParkedFallback = () => {
+    const owner = replyRunRegistry.get(queueKey);
+    if (owner) {
+      scheduleFollowupDrainAfterReplyOperationClear({
+        operation: owner,
+        queueKey,
+        runFollowup,
+      });
+    } else {
+      scheduleFollowupDrain(queueKey, runFollowup);
+    }
+  };
+  scheduleParkedFallback();
+  releaseAdmissionTicket();
+  try {
+    const admission = await parked.admit();
+    if (admission === "cancelled") {
+      parked.consume();
+      typing.cleanup();
+      return "handled";
+    }
+    if (admission === "fallback") {
+      parked.fallback();
+      if (replyOperationRunState) {
+        replyOperationRunState.admission = { status: "accepted", mode: "followup" };
+      }
+      await touchActiveSessionEntry();
+      typing.cleanup();
+      return "handled";
+    }
+    // Channel dispatch normally stamps the route-scoped source id. Internal
+    // callers can derive the same per-message identity from the prepared turn.
+    const steerOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
+      steerSessionId,
+      followupRun.prompt,
+      {
+        steeringMode: "all",
+        isInboundUserMessage: true,
+        ...(followupRun.images?.length ? { images: followupRun.images } : {}),
+        ...(followupRun.imageOrder?.length ? { imageOrder: followupRun.imageOrder } : {}),
+        ...(followupRun.media?.length ? { media: followupRun.media } : {}),
+        waitForTranscriptCommit: true,
+        queueIdentity: resolveAcceptedSteerRunId(params),
+        abortSignal: resolveFollowupAbortSignal(followupRun),
+        onQueueAccepted: parked.accepted,
+        ...(resolvedQueue.debounceMs !== undefined
+          ? { debounceMs: resolvedQueue.debounceMs }
+          : {}),
+        ...(followupRun.run.sourceReplyDeliveryMode
+          ? { sourceReplyDeliveryMode: followupRun.run.sourceReplyDeliveryMode }
+          : {}),
+        taskSuggestionDeliveryMode: followupRun.run.taskSuggestionDeliveryMode,
+        ...(followupRun.userTurnTranscriptRecorder
+          ? { userTurnTranscriptRecorder: followupRun.userTurnTranscriptRecorder }
+          : {}),
+      },
+    );
+    if (!steerOutcome.queued) {
+      parked.fallback();
+      if (replyOperationRunState) {
+        replyOperationRunState.admission = { status: "accepted", mode: "followup" };
+      }
+      const summary = formatEmbeddedAgentQueueFailureSummary(steerOutcome);
+      logVerbose(
+        `queue: active session ${steerSessionId} rejected steering injection: ${summary}`,
+      );
+      await touchActiveSessionEntry();
+      typing.cleanup();
+      return "handled";
+    }
+    const adoptionDisposition = await finalizeAcceptedSteer({
+      activeReplyOperation,
+      abortKey: sessionKey ?? queueKey,
+      cleanupTyping: () => typing.cleanup(),
+      errorMessage: steerOutcome.errorMessage,
+      onAdopted: () => admitFollowupRunLifecycle(followupRun),
+      replyOperationRunState,
+      steerSessionId,
+      transcriptCommit: steerOutcome.transcriptCommit,
+    });
+    parked.consume();
+    if (adoptionDisposition === "stop") {
+      return "handled";
+    }
+    if (followupRun.currentInboundAudio === true) {
+      activeReplyOperation?.markAcceptedSteeredInboundAudio();
+    }
+    if (activeReplyOperation) {
+      await refreshReplyOperationTyping(activeReplyOperation, {
+        startIfIdle: typingSignals.shouldStartImmediately,
+      });
+    }
+    await touchActiveSessionEntry();
+    typing.cleanup();
+    return "handled";
+  } catch (error) {
+    if (resolveFollowupAbortSignal(followupRun)?.aborted) {
+      parked.consume();
+    } else {
+      parked.fallback();
+    }
+    throw error;
+  } finally {
+    if (followupRun.steerPending) {
+      if (resolveFollowupAbortSignal(followupRun)?.aborted) {
+        parked.consume();
+      } else {
+        parked.fallback();
+      }
+    }
+  }
 }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,5 +1,4 @@
 /** Main reply dispatch pipeline from finalized config/context to delivery payloads. */
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { isDispatchReplyOperationAbortedError } from "./dispatch-from-config.abort.js";
 import { createInboundMessageAuditTerminal } from "./dispatch-from-config.audit.js";
@@ -26,8 +25,8 @@ export async function dispatchReplyFromConfig(
   params: DispatchFromConfigParams,
 ): Promise<DispatchFromConfigResult> {
   const ticket = reserveReplyAdmissionTicket([
-    normalizeOptionalString(params.ctx.SessionKey),
-    normalizeOptionalString(params.ctx.CommandTargetSessionKey),
+    params.ctx.SessionKey,
+    params.ctx.CommandTargetSessionKey,
   ]);
   const ticketedParams = ticket
     ? {

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -109,9 +109,15 @@ function appendQueueItem(params: {
   params.queue.lastRun = params.run.run;
   params.run.queueAbortSignal = params.queue.abortController.signal;
   params.queue.items[params.front ? "unshift" : "push"](params.run);
-  if (params.recentMessageIdKey) recordRecentQueueMessageId(params.run, params.recentMessageIdKey);
-  if (params.runFollowup) rememberFollowupDrainCallback(params.key, params.runFollowup);
-  if (params.restartIfIdle && !params.queue.draining) kickFollowupDrainIfIdle(params.key);
+  if (params.recentMessageIdKey) {
+    recordRecentQueueMessageId(params.run, params.recentMessageIdKey);
+  }
+  if (params.runFollowup) {
+    rememberFollowupDrainCallback(params.key, params.runFollowup);
+  }
+  if (params.restartIfIdle && !params.queue.draining) {
+    kickFollowupDrainIfIdle(params.key);
+  }
 }
 
 export function enqueueFollowupRun(

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -149,9 +149,13 @@ export function enqueueFollowupRun(
     return false;
   }
   if (options.steerCandidate) {
-    if (!markFollowupRunEnqueued(run)) return false;
+    if (!markFollowupRunEnqueued(run)) {
+      return false;
+    }
     let settle = (_accepted: boolean) => {};
-    const acceptance = new Promise<boolean>((resolve) => (settle = resolve));
+    const acceptance = new Promise<boolean>((resolve) => {
+      settle = resolve;
+    });
     run.steerPending = { predecessor: queue.steerAcceptanceTail, settle };
     queue.steerAcceptanceTail = acceptance;
     appendQueueItem({
@@ -169,7 +173,9 @@ export function enqueueFollowupRun(
   // deciding between same-turn delivery and fallback. Append it behind the
   // anchor; ordinary overflow policy resumes as soon as the gate resolves.
   if (queue.items.some((item) => item.steerPending)) {
-    if (!markFollowupRunEnqueued(run)) return false;
+    if (!markFollowupRunEnqueued(run)) {
+      return false;
+    }
     appendQueueItem({
       key,
       queue,
@@ -299,10 +305,14 @@ function isParkedFollowupRunOwned(key: string, run: FollowupRun): boolean {
 
 function reapplyDeferredOverflow(key: string): void {
   const queue = getExistingFollowupQueue(key);
-  if (!queue || queue.items.some((item) => item.steerPending)) return;
+  if (!queue || queue.items.some((item) => item.steerPending)) {
+    return;
+  }
   const lastAnchor = queue.items.findLastIndex((item) => item.steerAnchor === true);
   const suffix = queue.items.splice(lastAnchor + 1);
-  if (suffix.length === 0) return;
+  if (suffix.length === 0) {
+    return;
+  }
   const originalCap = queue.cap;
   const settings: QueueSettings = {
     mode: queue.mode,
@@ -349,7 +359,7 @@ function consumeParkedFollowupRun(key: string, run: FollowupRun): boolean {
 
 type ParkedSteerReservation = {
   admit(): Promise<"steer" | "fallback" | "cancelled">;
-  accepted(accepted: boolean): void;
+  accepted: (accepted: boolean) => void;
   fallback(): void;
   consume(): void;
 };
@@ -379,7 +389,9 @@ export function parkSteerCandidate(
   return {
     async admit() {
       const predecessorAccepted = (await run.steerPending?.predecessor) ?? true;
-      if (isFollowupRunAborted(run) || !isParkedFollowupRunOwned(key, run)) return "cancelled";
+      if (isFollowupRunAborted(run) || !isParkedFollowupRunOwned(key, run)) {
+        return "cancelled";
+      }
       return predecessorAccepted ? "steer" : "fallback";
     },
     accepted: (accepted) => settleParkedSteerAcceptance(key, run, accepted),

--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -1,4 +1,4 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeStringifiedEntries } from "@openclaw/normalization-core/string-coerce";
 import { resolveGlobalMap } from "../../shared/global-singleton.js";
 
 export const REPLY_ADMISSION_TICKET = Symbol("openclaw.replyAdmissionTicket");
@@ -14,15 +14,9 @@ const tails = resolveGlobalMap<string, Promise<void>>(Symbol.for("openclaw.reply
 
 /** Briefly orders queue publication across a command's source and target sessions. */
 export function reserveReplyAdmissionTicket(
-  sessionKeys: Iterable<string | undefined>,
+  sessionKeys: ReadonlyArray<string | undefined>,
 ): ReplyAdmissionTicket | undefined {
-  const keys = [
-    ...new Set(
-      [...sessionKeys]
-        .map(normalizeOptionalString)
-        .filter((key): key is string => typeof key === "string"),
-    ),
-  ].sort();
+  const keys = [...new Set(normalizeStringifiedEntries(sessionKeys))].sort();
   if (keys.length === 0) {
     return undefined;
   }

--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -16,12 +16,14 @@ const tails = resolveGlobalMap<string, Promise<void>>(Symbol.for("openclaw.reply
 export function reserveReplyAdmissionTicket(
   sessionKeys: ReadonlyArray<string | undefined>,
 ): ReplyAdmissionTicket | undefined {
-  const keys = [...new Set(normalizeStringifiedEntries(sessionKeys))].sort();
+  const keys = [...new Set(normalizeStringifiedEntries(sessionKeys))].toSorted();
   if (keys.length === 0) {
     return undefined;
   }
   let finish = () => {};
-  const completed = new Promise<void>((resolve) => (finish = resolve));
+  const completed = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
   const predecessors = keys.map((key) => tails.get(key) ?? Promise.resolve());
   const owned = keys.map((key, index) => {
     const tail = predecessors[index]!.then(() => completed);
@@ -35,7 +37,9 @@ export function reserveReplyAdmissionTicket(
         return false;
       }
       const ready = Promise.all(predecessors).then(() => true);
-      if (!signal) return await ready;
+      if (!signal) {
+        return await ready;
+      }
       return await new Promise<boolean>((resolve) => {
         const abort = () => resolve(false);
         signal.addEventListener("abort", abort, { once: true });
@@ -46,7 +50,9 @@ export function reserveReplyAdmissionTicket(
       });
     },
     release() {
-      if (released) return;
+      if (released) {
+        return;
+      }
       released = true;
       finish();
       for (const { key, tail } of owned) {

--- a/src/cli/mcp-cli.test-support.ts
+++ b/src/cli/mcp-cli.test-support.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+
+export async function writeProbeMcpServer(filePath: string): Promise<void> {
+  await fs.writeFile(
+    filePath,
+    `let buffer = "";
+const mode = process.env.MCP_MODE ?? "normal";
+if (mode === "crash") {
+  process.exit(1);
+}
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+function handle(message) {
+  if (message.method === "initialize") {
+    if (mode === "hang-start") {
+      return;
+    }
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "cli-probe-test", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+  if (message.method === "tools/list") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { tools: [{ name: "ping", inputSchema: { type: "object" } }] },
+    });
+  }
+}
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      handle(JSON.parse(line));
+    }
+  }
+});
+process.stdin.on("end", () => process.exit(0));
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));
+`,
+    "utf8",
+  );
+}

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -9,6 +9,7 @@ import { withTempHome } from "../config/home-env.test-harness.js";
 import { createDeferred } from "../shared/deferred.js";
 import { getFreePort } from "../test-utils/ports.js";
 import { registerMcpCli } from "./mcp-cli.js";
+import { writeProbeMcpServer } from "./mcp-cli.test-support.js";
 
 type CreateSessionMcpRuntime =
   typeof import("../agents/agent-bundle-mcp-runtime.js").createSessionMcpRuntime;
@@ -72,64 +73,6 @@ async function createWorkspace(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-mcp-"));
   tempDirs.push(dir);
   return dir;
-}
-
-async function writeProbeMcpServer(filePath: string): Promise<void> {
-  await fs.writeFile(
-    filePath,
-    `let buffer = "";
-const mode = process.env.MCP_MODE ?? "normal";
-if (mode === "crash") {
-  process.exit(1);
-}
-function send(message) {
-  process.stdout.write(JSON.stringify(message) + "\\n");
-}
-function handle(message) {
-  if (message.method === "initialize") {
-    if (mode === "hang-start") {
-      return;
-    }
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
-        capabilities: { tools: {} },
-        serverInfo: { name: "cli-probe-test", version: "1.0.0" },
-      },
-    });
-    return;
-  }
-  if (message.method === "tools/list") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { tools: [{ name: "ping", inputSchema: { type: "object" } }] },
-    });
-  }
-}
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => {
-  buffer += chunk;
-  while (true) {
-    const newline = buffer.indexOf("\\n");
-    if (newline < 0) {
-      return;
-    }
-    const line = buffer.slice(0, newline).replace(/\\r$/, "");
-    buffer = buffer.slice(newline + 1);
-    if (line.trim()) {
-      handle(JSON.parse(line));
-    }
-  }
-});
-process.stdin.on("end", () => process.exit(0));
-process.on("SIGTERM", () => process.exit(0));
-process.on("SIGINT", () => process.exit(0));
-`,
-    "utf8",
-  );
 }
 
 let sharedProgram: Command;

--- a/src/cli/mcp-oauth-loopback.test.ts
+++ b/src/cli/mcp-oauth-loopback.test.ts
@@ -21,7 +21,9 @@ async function getFreeIpv6Port(): Promise<number> {
     server.listen(0, "::1", resolve);
   });
   const port = (server.address() as AddressInfo).port;
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
   return port;
 }
 
@@ -139,7 +141,9 @@ describe("MCP OAuth loopback callback", () => {
       );
       expect(onReady).toHaveBeenCalledOnce();
     } finally {
-      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        blocker.close(() => resolve());
+      });
     }
   });
 

--- a/src/gateway/test-openai-responses-model.ts
+++ b/src/gateway/test-openai-responses-model.ts
@@ -4,6 +4,9 @@
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 
 const MOCK_OPENAI_RESPONSES_PROVIDER_ID = "mock-openai";
+type MockOpenAiResponsesProviderConfig = Omit<ModelProviderConfig, "models"> & {
+  models: [ModelDefinitionConfig];
+};
 
 function buildOpenAiResponsesTestModel(id = "gpt-5.4"): ModelDefinitionConfig {
   return {
@@ -21,7 +24,7 @@ function buildOpenAiResponsesTestModel(id = "gpt-5.4"): ModelDefinitionConfig {
 function buildOpenAiResponsesProviderConfig(
   baseUrl: string,
   modelId = "gpt-5.4",
-): ModelProviderConfig {
+): MockOpenAiResponsesProviderConfig {
   return {
     baseUrl,
     apiKey: "test",

--- a/src/gateway/test-openai-responses-model.ts
+++ b/src/gateway/test-openai-responses-model.ts
@@ -1,9 +1,11 @@
 /**
  * Mock OpenAI Responses provider used by gateway compatibility tests.
  */
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
+
 const MOCK_OPENAI_RESPONSES_PROVIDER_ID = "mock-openai";
 
-function buildOpenAiResponsesTestModel(id = "gpt-5.4") {
+function buildOpenAiResponsesTestModel(id = "gpt-5.4"): ModelDefinitionConfig {
   return {
     id,
     name: id,
@@ -13,16 +15,19 @@ function buildOpenAiResponsesTestModel(id = "gpt-5.4") {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128_000,
     maxTokens: 4096,
-  } as const;
+  };
 }
 
-function buildOpenAiResponsesProviderConfig(baseUrl: string, modelId = "gpt-5.4") {
+function buildOpenAiResponsesProviderConfig(
+  baseUrl: string,
+  modelId = "gpt-5.4",
+): ModelProviderConfig {
   return {
     baseUrl,
     apiKey: "test",
     api: "openai-responses",
     models: [buildOpenAiResponsesTestModel(modelId)],
-  } as const;
+  };
 }
 
 /** Builds provider config and model refs for local OpenAI-compatible HTTP tests. */


### PR DESCRIPTION
<!-- AI-assisted maintainer repair. -->

Related: #120420
Related: #120441

## What Problem This Solves

Resolves the cluster of CI regressions left after the queued-steer ordering work in #120420 and the MCP OAuth loopback change in #120433. `main` first failed type and package-boundary checks on optional admission-ticket keys, then the full PR graph exposed lint, max-lines, dead-export, formatter, and test-support typing failures in the same newly changed surfaces.

## Why This Change Was Made

The admission-ticket owner now normalizes optional session keys into canonical strings with the shared `normalizeStringifiedEntries` helper, while the dispatch caller passes raw optional keys directly. This replaces the narrower type-predicate fix from #120441 with the canonical owner-boundary invariant and retains #120441 in branch ancestry.

The complete parked-steer transaction moved out of the oversized `agent-runner-run.ts` orchestration file into its existing steer-adoption owner. Queue logic now satisfies the repository's explicit-branch and Promise-executor rules without suppressions. MCP CLI probe source moved into focused test support, OAuth loopback executors no longer return server handles, and the mock OpenAI provider records its real one-model tuple contract so all consumers receive mutable, defined model config.

This is the best fix because it removes duplicated normalization, records each invariant at its producer, and gives the active-steer transaction one owner. Consumer casts, lint suppressions, or isolated downstream guards would only hide the same failures.

Provenance is clear: #120420 introduced the admission-ticket and queued-steer lint/type failures in squash commit dba9fb8509191834a26f5f57a271f9479f15c966 on 2026-08-07. Peter Steinberger authored the PR and commit; GitHub is the squash commit's committer, and the live PR records Peter as the merger. #120433 introduced the MCP test lint/max-lines failures.

## User Impact

There is no intended runtime behavior change. This restores the type, lint, dependency, package-boundary, and test-type gates for the queued-steer work while retaining the same trimmed, deduplicated, sorted session keys and steer ordering.

Production LOC: +262/-190 (net +72). The positive delta is the explicit owner-boundary extraction of the complete parked-steer transaction plus required branch blocks. Tests/support: +78/-64 (net +14).

## Evidence

- Original type failure: https://github.com/openclaw/openclaw/actions/runs/31233869000 — four selected jobs reported TS2345 errors from optional session keys reaching string-keyed map operations.
- Exact changed-file formatting passes with repository-pinned `oxfmt@0.60.0`.
- `git diff --check origin/main...HEAD` passes.
- Structured autoreview passed on the complete post-rebase branch and after every follow-up edit, with no accepted/actionable findings.
- Exact-head PR CI: https://github.com/openclaw/openclaw/actions/runs/31237459063 is green on head `f5817e62655867319a8fc1d9834a1bfa0856c220`. One unrelated `EnvironmentTeardownError` in `system-agent-reset-boundary.test.ts` occurred on attempt 1; the isolated failed-job rerun passed, along with the aggregate gate.
- AWS Crabbox run `run_35a570eaa556` installed dependencies and identified the single formatter target before the broker session expired. Earlier runs `run_d096f341e3b0` and `run_94f302e44dd6` did not complete the changed gate, so they are recorded only as infrastructure proof gaps.
- No new behavior regression test was added because the repair preserves queue behavior and corrects compiler/linter ownership. Existing queue, MCP, gateway, and exact-head CI suites exercise the affected paths.
