### PR TITLE
fix(types): narrow reply admission ticket session keys

### DIFF
--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -16,12 +16,18 @@ const tails = resolveGlobalMap<string, Promise<void>>(Symbol.for("openclaw.reply
 export function reserveReplyAdmissionTicket(
   sessionKeys: Iterable<string | undefined>,
 ): ReplyAdmissionTicket | undefined {
-  const keys = [...new Set([...sessionKeys].map(normalizeOptionalString).filter(Boolean))].sort();
+  const keys = [
+    ...new Set(
+      [...sessionKeys].map(normalizeOptionalString).filter((key): key is string => Boolean(key)),
+    ),
+  ].toSorted();
   if (keys.length === 0) {
     return undefined;
   }
   let finish = () => {};
-  const completed = new Promise<void>((resolve) => (finish = resolve));
+  const completed = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
   const predecessors = keys.map((key) => tails.get(key) ?? Promise.resolve());
   const owned = keys.map((key, index) => {
     const tail = predecessors[index]!.then(() => completed);
@@ -35,7 +41,9 @@ export function reserveReplyAdmissionTicket(
         return false;
       }
       const ready = Promise.all(predecessors).then(() => true);
-      if (!signal) return await ready;
+      if (!signal) {
+        return await ready;
+      }
       return await new Promise<boolean>((resolve) => {
         const abort = () => resolve(false);
         signal.addEventListener("abort", abort, { once: true });
@@ -46,7 +54,9 @@ export function reserveReplyAdmissionTicket(
       });
     },
     release() {
-      if (released) return;
+      if (released) {
+        return;
+      }
       released = true;
       finish();
       for (const { key, tail } of owned) {


### PR DESCRIPTION
## What Problem This Solves

`main` is currently red on the type and lint gates, and every open PR that runs those lanes inherits the failure.

`src/auto-reply/reply/reply-admission-ticket.ts`, added by #120420, builds its key list with:

```ts
const keys = [...new Set([...sessionKeys].map(normalizeOptionalString).filter(Boolean))].sort();
```

`normalizeOptionalString` returns `string | undefined`, and `.filter(Boolean)` does not narrow in TypeScript because `Boolean` is not a type predicate. So `keys` stays `(string | undefined)[]`, and every `tails.get`, `tails.set`, and `tails.delete` call on it fails against a `Map<string, ...>`:

```
src/auto-reply/reply/reply-admission-ticket.ts(25,52): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
```

Four of those, on both `tsconfig.core.json` and `test/tsconfig/tsconfig.core.test.json`. The same file also trips four oxlint rules: `unicorn(no-array-sort)`, `eslint(no-promise-executor-return)`, and `eslint(curly)` twice.

I confirmed all eight are pre-existing rather than mine by checking out pristine `upstream/main` at `2f1692c955` with no other changes and running the gates there; they reproduce identically. The reason `main`'s own check-runs look green is that the per-commit run on `main` does not include these lanes, so the breakage only surfaces on PRs.

## Why This Change Was Made

The narrowing uses the predicate form already used elsewhere in this codebase, so it matches local convention rather than introducing a new idiom:

```ts
.filter((key): key is string => Boolean(key))
```

`src/infra/provider-usage.fetch.deepseek.ts:94` and `src/infra/provider-usage.auth.ts:236` both do exactly this.

The four lint fixes are the mechanical form each rule asks for: `toSorted()` in place of `sort()` on an array that was already a fresh spread, a block body for the promise executor instead of returning the assignment, and braces on the two single-line `if` returns. No behaviour changes in any of them.

I kept this to the one file. It is an unbreak-main change, not a refactor, and widening it would make it harder to verify against the red gates.

## User Impact

None directly user-facing. It restores `check-prod-types`, `check-test-types`, and `check-lint` so PRs can be evaluated on their own merits again.

## Evidence

Before, on pristine `upstream/main` at `2f1692c955` with no local changes: four `TS2345` errors on both tsgo projects, and oxlint exits 1 with the four rule violations listed above.

After, on this branch: `tsgo -p tsconfig.core.json` and `tsgo -p test/tsconfig/tsconfig.core.test.json` both report zero errors, and `oxlint --config .oxlintrc.json` on the file exits 0.

Behaviour coverage: `src/auto-reply/reply/reply-turn-admission.test.ts` and `followup-turn-admission.test.ts` pass 80/80. `git diff --check` clean. One file, +14/-4.

Two limitations stated plainly. My usual checkout is on a machine whose `Documents` tree is returning `Interrupted system call` on every read, so this was validated in a fresh clone installed with `pnpm install --ignore-scripts`; that scratch install cannot build the Slack boundary d.ts artifacts, so I ran `oxlint` directly rather than through `scripts/run-oxlint.mjs`, whose prep step fails on unrelated `extensions/slack/**` files. And I did not complete a full `src/auto-reply/reply` suite run, which exceeded ten minutes locally; the two admission suites that own this module are green and CI will cover the rest.

AI-assisted: written with AI assistance. I reproduced the failure on pristine `main` before concluding it was not mine, and checked the existing filter-predicate convention before picking the fix shape.
