### PR TITLE
fix(reply): normalize admission ticket keys

### DIFF
--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -1,4 +1,4 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeSortedUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { resolveGlobalMap } from "../../shared/global-singleton.js";
 
 export const REPLY_ADMISSION_TICKET = Symbol("openclaw.replyAdmissionTicket");
@@ -16,7 +16,7 @@ const tails = resolveGlobalMap<string, Promise<void>>(Symbol.for("openclaw.reply
 export function reserveReplyAdmissionTicket(
   sessionKeys: Iterable<string | undefined>,
 ): ReplyAdmissionTicket | undefined {
-  const keys = [...new Set([...sessionKeys].map(normalizeOptionalString).filter(Boolean))].sort();
+  const keys = normalizeSortedUniqueTrimmedStringList([...sessionKeys]);
   if (keys.length === 0) {
     return undefined;
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes a release merge-tree TypeScript declaration gate failure where the reply admission ticket's local map/filter normalization pipeline produced `(string | undefined)[]` instead of the required `string[]`.

## Why This Change Was Made

Uses the canonical normalization-core string-list helper to restore `string[]` while preserving trimming, empty-value removal, deduplication, and sorting. This is an owner-local declaration repair with no behavior expansion.

## User Impact

There is no runtime behavior change. The reply admission path retains its existing key normalization semantics while remaining compatible with the declaration gate.

## Evidence

- Production: +2/-2, net 0. Tests: 0. Changelog: none.
- Local formatting and `git diff --check` passed.
- Structured autoreview completed cleanly with no accepted or actionable findings.
- Independent review verdict: GO.
- The local declaration rerun was invalid because the stale shared install resolved `string-width` 4.2.3 instead of the locked 8.2.2. Exact clean hosted declaration proof remains required.
- Commit attestation: `att_01KZFM9E0H1XY39AE3H78P4DE5`.

Punchcard-Session: golden-valley-workshop-br
