### PR TITLE
fix(types): narrow admission ticket session keys with a type guard

### DIFF
--- a/src/auto-reply/reply/reply-admission-ticket.ts
+++ b/src/auto-reply/reply/reply-admission-ticket.ts
@@ -16,7 +16,13 @@ const tails = resolveGlobalMap<string, Promise<void>>(Symbol.for("openclaw.reply
 export function reserveReplyAdmissionTicket(
   sessionKeys: Iterable<string | undefined>,
 ): ReplyAdmissionTicket | undefined {
-  const keys = [...new Set([...sessionKeys].map(normalizeOptionalString).filter(Boolean))].sort();
+  const keys = [
+    ...new Set(
+      [...sessionKeys]
+        .map(normalizeOptionalString)
+        .filter((key): key is string => typeof key === "string"),
+    ),
+  ].sort();
   if (keys.length === 0) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

`main` is red on the tsgo typecheck lane: four TS2345 errors in `src/auto-reply/reply/reply-admission-ticket.ts` (25, 28, 53×2), introduced by the steer-FIFO landing (#120420). `.filter(Boolean)` does not narrow `string | undefined`, so the keys array kept its optional element type.

## Why This Change Was Made

Replace the `Boolean` filter with a typed predicate (`(key): key is string => typeof key === "string"`) — semantics identical (normalizeOptionalString never returns empty strings), type now provably `string[]`. No behavior change.

## User Impact

Unbreaks the typecheck lane for every PR gate diffing against main.

## Evidence

- `pnpm tsgo:core`: passes (was 4 errors).
- Steer FIFO suites re-run green: attempt.queue-message + gateway-steer-fifo e2e (2 shards, incl. the 3 process-level ordering proofs).
- Root cause of the gap: the steer PR's proof ran Vitest/deadcode but not tsgo; the coordinator pipeline now adds a typecheck step to every worker gate.
