### PR TITLE
fix(release): supply exact Codex companions to cross-OS checks and repair legacy node-host metadata

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -101,6 +101,11 @@ on:
         required: false
         default: ""
         type: string
+      candidate_artifact_json:
+        description: Optional immutable full-release candidate tuple with companion plugins
+        required: false
+        default: ""
+        type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
         required: false
@@ -205,6 +210,11 @@ on:
         required: false
         default: ""
         type: string
+      candidate_artifact_json:
+        description: Optional immutable full-release candidate tuple with companion plugins
+        required: false
+        default: ""
+        type: string
       openai_model:
         description: OpenAI model for release cross-OS agent-turn smoke
         required: false
@@ -255,7 +265,15 @@ jobs:
       candidate_file_name: ${{ steps.candidate_metadata.outputs.file_name }}
       candidate_sha256: ${{ steps.candidate_metadata.outputs.sha256 }}
       candidate_version: ${{ steps.candidate_metadata.outputs.version }}
+      codex_plugin_file_name: ${{ steps.codex_plugin_metadata.outputs.file_name }}
+      codex_plugin_sha256: ${{ steps.codex_plugin_metadata.outputs.sha256 }}
       matrix: ${{ steps.matrix.outputs.value }}
+      prepublish_plugin_registry_artifact_digest: ${{ steps.upload_generated_plugin_registry.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+      prepublish_plugin_registry_artifact_id: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+      prepublish_plugin_registry_artifact_name: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id && format('openclaw-cross-os-release-checks-plugins-{0}-{1}', github.run_id, github.run_attempt) || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
+      prepublish_plugin_registry_artifact_run_attempt: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+      prepublish_plugin_registry_artifact_run_id: ${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+      prepublish_plugin_registry_manifest_sha256: ${{ steps.create_codex_plugin_registry.outputs.manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       source_sha: ${{ steps.candidate_metadata.outputs.source_sha }}
       workflow_ref: ${{ steps.workflow_ref.outputs.value }}
     steps:
@@ -457,12 +475,34 @@ jobs:
               exit 1
             }
 
+      - name: Validate prerelease plugin registry artifact binding
+        if: fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId != ''
+        env:
+          ARTIFACT_DIGEST: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+          ARTIFACT_ID: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+          ARTIFACT_NAME: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
+          ARTIFACT_RUN_ATTEMPT: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+          ARTIFACT_RUN_ID: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_SHA256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Prerelease plugin registry manifest SHA-256 is missing or invalid." >&2
+            exit 1
+          }
+          bash workflow/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Prerelease plugin registry" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
       - name: Checkout public source ref
-        if: inputs.candidate_artifact_name == ''
+        if: inputs.candidate_artifact_name == '' || (inputs.provider == 'openai' && fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId == '')
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ env.OPENCLAW_REPOSITORY }}
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.candidate_artifact_name != '' && inputs.candidate_source_sha || inputs.ref }}
           path: source
           fetch-depth: 0
           filter: blob:none
@@ -492,6 +532,13 @@ jobs:
           CI: "true"
         run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
+      - name: Install companion plugin build dependencies
+        if: inputs.candidate_artifact_name != '' && inputs.provider == 'openai' && fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId == ''
+        working-directory: source
+        env:
+          CI: "true"
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Build candidate artifact once
         if: inputs.candidate_artifact_name == ''
         env:
@@ -509,6 +556,26 @@ jobs:
           artifact-ids: ${{ inputs.candidate_artifact_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/input
           run-id: ${{ inputs.candidate_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download prerelease plugin registry artifact
+        if: fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId != ''
+        id: download_prepublish_plugin_registry
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
+          run-id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+          github-token: ${{ github.token }}
+
+      - name: Retry prerelease plugin registry artifact download
+        if: fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
+          run-id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
           github-token: ${{ github.token }}
 
       - name: Resolve provided candidate package
@@ -635,6 +702,80 @@ jobs:
           process.stdout.write(`source_sha=${sourceSha}\n`);
           NODE
 
+      - name: Pack exact Codex companion plugin
+        id: create_codex_plugin_registry
+        if: inputs.provider == 'openai' && fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId == ''
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
+          CANDIDATE_VERSION: ${{ steps.candidate_metadata.outputs.version }}
+          SOURCE_SHA: ${{ steps.candidate_metadata.outputs.source_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$ARTIFACT_DIR"
+          result="$(
+            node workflow/scripts/prepublish-plugin-registry-artifact.mjs create \
+              --repo-root source \
+              --artifact-dir "$ARTIFACT_DIR" \
+              --source-sha "$SOURCE_SHA" \
+              --candidate-version "$CANDIDATE_VERSION" \
+              --required-packages-json '["@openclaw/codex"]'
+          )"
+          manifest_sha256="$(jq -er '.manifestSha256' <<< "$result")"
+          echo "manifest_sha256=$manifest_sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve exact Codex companion plugin
+        id: codex_plugin_metadata
+        if: inputs.provider == 'openai'
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins
+          CANDIDATE_VERSION: ${{ steps.candidate_metadata.outputs.version }}
+          EXPECTED_MANIFEST_SHA256: ${{ steps.create_codex_plugin_registry.outputs.manifest_sha256 || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
+          SOURCE_SHA: ${{ steps.candidate_metadata.outputs.source_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest="$ARTIFACT_DIR/prepublish-plugin-registry.json"
+          required_packages="$(jq -c '[.packages[].name]' "$manifest")"
+          jq -e '.packages | any(.name == "@openclaw/codex")' "$manifest" >/dev/null || {
+            echo "Prerelease plugin registry does not contain @openclaw/codex." >&2
+            exit 1
+          }
+          node workflow/scripts/prepublish-plugin-registry-artifact.mjs verify \
+            --artifact-dir "$ARTIFACT_DIR" \
+            --source-sha "$SOURCE_SHA" \
+            --candidate-version "$CANDIDATE_VERSION" \
+            --manifest-sha256 "$EXPECTED_MANIFEST_SHA256" \
+            --required-packages-json "$required_packages"
+          node <<'NODE' >>"$GITHUB_OUTPUT"
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const manifest = JSON.parse(
+            fs.readFileSync(path.join(process.env.ARTIFACT_DIR, "prepublish-plugin-registry.json"), "utf8"),
+          );
+          const entry = manifest.packages.find((candidate) => candidate.name === "@openclaw/codex");
+          if (
+            typeof entry?.tarball !== "string" ||
+            !entry.tarball.endsWith(".tgz") ||
+            entry.tarball !== path.basename(entry.tarball) ||
+            entry.tarball !== path.win32.basename(entry.tarball) ||
+            !/^[a-f0-9]{64}$/u.test(entry.sha256 ?? "")
+          ) {
+            throw new Error("Codex companion plugin manifest entry is invalid.");
+          }
+          process.stdout.write(`file_name=${entry.tarball}\n`);
+          process.stdout.write(`sha256=${entry.sha256}\n`);
+          NODE
+
+      - name: Upload generated prerelease plugin registry artifact
+        id: upload_generated_plugin_registry
+        if: inputs.provider == 'openai' && steps.create_codex_plugin_registry.outputs.manifest_sha256 != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-cross-os-release-checks-plugins-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/plugins/
+          if-no-files-found: error
+
       - name: Capture baseline metadata
         if: ${{ inputs.mode != 'fresh' }}
         id: baseline_metadata
@@ -758,7 +899,13 @@ jobs:
           CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
           CANDIDATE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           CANDIDATE_VERSION: ${{ needs.prepare.outputs.candidate_version }}
+          CODEX_PLUGIN_FILE_NAME: ${{ needs.prepare.outputs.codex_plugin_file_name }}
           GH_TOKEN: ${{ github.token }}
+          PLUGIN_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_digest }}
+          PLUGIN_ARTIFACT_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
+          PLUGIN_ARTIFACT_NAME: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_name }}
+          PLUGIN_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_attempt }}
+          PLUGIN_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}
           SUITE: ${{ matrix.suite }}
         shell: bash
         run: |
@@ -811,6 +958,16 @@ jobs:
               name: process.env.BASELINE_ARTIFACT_NAME,
               runAttempt: process.env.BASELINE_ARTIFACT_RUN_ATTEMPT,
               runId: process.env.BASELINE_ARTIFACT_RUN_ID,
+            });
+          }
+          if (process.env.CODEX_PLUGIN_FILE_NAME) {
+            tuples.push({
+              digest: process.env.PLUGIN_ARTIFACT_DIGEST,
+              id: process.env.PLUGIN_ARTIFACT_ID,
+              label: "prerelease plugin registry",
+              name: process.env.PLUGIN_ARTIFACT_NAME,
+              runAttempt: process.env.PLUGIN_ARTIFACT_RUN_ATTEMPT,
+              runId: process.env.PLUGIN_ARTIFACT_RUN_ID,
             });
           }
 
@@ -897,6 +1054,26 @@ jobs:
           run-id: ${{ needs.prepare.outputs.baseline_artifact_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Download prerelease plugin registry artifact
+        if: needs.prepare.outputs.codex_plugin_file_name != ''
+        id: download_prepublish_plugin_registry
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
+          run-id: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Retry prerelease plugin registry artifact download
+        if: needs.prepare.outputs.codex_plugin_file_name != '' && steps.download_prepublish_plugin_registry.outcome == 'failure'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins
+          run-id: ${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}
+          github-token: ${{ github.token }}
+
       - name: Verify release-check inputs
         shell: bash
         env:
@@ -904,6 +1081,8 @@ jobs:
           EXPECTED_CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
           BASELINE_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/baseline/${{ needs.prepare.outputs.baseline_file_name }}
           EXPECTED_BASELINE_SHA256: ${{ needs.prepare.outputs.baseline_sha256 }}
+          CODEX_PLUGIN_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins/${{ needs.prepare.outputs.codex_plugin_file_name }}
+          EXPECTED_CODEX_PLUGIN_SHA256: ${{ needs.prepare.outputs.codex_plugin_sha256 }}
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
           SUITE: ${{ matrix.suite }}
         run: |
@@ -946,6 +1125,26 @@ jobs:
               exit 1
             fi
           fi
+          if [[ -n "$EXPECTED_CODEX_PLUGIN_SHA256" ]]; then
+            [[ -f "$CODEX_PLUGIN_TGZ" ]] || {
+              echo "::error::Codex companion plugin artifact missing: ${CODEX_PLUGIN_TGZ}"
+              exit 1
+            }
+            actual_codex_sha256="$(
+              node -e '
+                const crypto = require("node:crypto");
+                const fs = require("node:fs");
+                process.stdout.write(
+                  crypto.createHash("sha256").update(fs.readFileSync(process.env.CODEX_PLUGIN_TGZ)).digest("hex"),
+                );
+              '
+            )"
+            if [[ ! "$EXPECTED_CODEX_PLUGIN_SHA256" =~ ^[a-f0-9]{64}$ ||
+                  "$actual_codex_sha256" != "$EXPECTED_CODEX_PLUGIN_SHA256" ]]; then
+              echo "::error::Codex companion plugin SHA-256 does not match the prepared identity"
+              exit 1
+            fi
+          fi
 
       - name: Run cross-OS release checks
         shell: bash
@@ -969,7 +1168,15 @@ jobs:
           SUITE: ${{ matrix.suite }}
           REF: ${{ inputs.ref }}
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
+          CODEX_PLUGIN_FILE_NAME: ${{ needs.prepare.outputs.codex_plugin_file_name }}
+          CODEX_PLUGIN_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/plugins/${{ needs.prepare.outputs.codex_plugin_file_name }}
         run: |
+          if [[ -n "$CODEX_PLUGIN_FILE_NAME" ]]; then
+            export OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES=1
+            export OPENCLAW_PLUGIN_INSTALL_OVERRIDES="$(
+              node -e 'process.stdout.write(JSON.stringify({ codex: `npm-pack:${process.env.CODEX_PLUGIN_TGZ}` }))'
+            )"
+          fi
           DISCORD_ARGS=()
           if [[ -n "${OPENCLAW_DISCORD_SMOKE_BOT_TOKEN}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_GUILD_ID}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_CHANNEL_ID}" ]]; then
             DISCORD_ARGS+=(--run-discord-roundtrip true)

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -814,6 +814,7 @@ jobs:
       candidate_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
       candidate_version: ${{ needs.prepare_release_package.outputs.package_version }}
       candidate_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
+      candidate_artifact_json: ${{ inputs.candidate_artifact_json }}
       openai_model: openai/gpt-5.6-luna
       ubuntu_runner: ubuntu-24.04
       windows_runner: windows-2025

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -16,7 +16,10 @@ import {
   resolveNodeCommandAllowlist,
   resolveNodePairingCommandAllowlist,
 } from "./node-command-policy.js";
-import { filterLegacyNodeProtocolFeatures } from "./node-legacy-protocol-filter.js";
+import {
+  filterLegacyNodeProtocolFeatures,
+  normalizeLegacyNodeHostClientMetadata,
+} from "./node-legacy-protocol-filter.js";
 
 describe("gateway/node-command-policy", () => {
   afterEach(() => {
@@ -171,6 +174,39 @@ describe("gateway/node-command-policy", () => {
         "device.info",
       ],
     });
+  });
+
+  it.each([
+    ["darwin", "macos", "Mac"],
+    ["linux", "linux", "Linux"],
+    ["win32", "windows", "Windows"],
+  ])("normalizes shipped protocol-v3 node-host metadata for %s", (platform, expected, family) => {
+    expect(
+      normalizeLegacyNodeHostClientMetadata({
+        id: GATEWAY_CLIENT_IDS.NODE_HOST,
+        version: "2026.5.7",
+        platform,
+        mode: GATEWAY_CLIENT_MODES.NODE,
+      }),
+    ).toMatchObject({ platform: expected, deviceFamily: family });
+  });
+
+  it("does not normalize non-node-host or conflicting legacy metadata", () => {
+    const conflicting = {
+      id: GATEWAY_CLIENT_IDS.NODE_HOST,
+      version: "2026.5.7",
+      platform: "linux",
+      deviceFamily: "iPhone",
+      mode: GATEWAY_CLIENT_MODES.NODE,
+    } as const;
+    expect(normalizeLegacyNodeHostClientMetadata(conflicting)).toBe(conflicting);
+
+    const otherClient = {
+      ...conflicting,
+      id: GATEWAY_CLIENT_IDS.LINUX_APP,
+      deviceFamily: undefined,
+    };
+    expect(normalizeLegacyNodeHostClientMetadata(otherClient)).toBe(otherClient);
   });
 
   it("adds explicitly defaulted plugin node-host agent tools from the active registry", () => {

--- a/src/gateway/node-legacy-protocol-filter.ts
+++ b/src/gateway/node-legacy-protocol-filter.ts
@@ -1,5 +1,10 @@
 // N-1 (legacy protocol) node feature filtering, kept out of the oversized
 // node-command-policy.ts file.
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../packages/gateway-protocol/src/client-info.js";
+import type { ConnectParams } from "../../packages/gateway-protocol/src/index.js";
 import { getActivePluginGatewayNodePolicyRegistry } from "../plugins/runtime.js";
 import {
   DEFAULT_DANGEROUS_NODE_COMMANDS,
@@ -17,6 +22,29 @@ const BUILT_IN_NODE_COMMANDS = new Set<string>([
   ...TALK_PTT_COMMANDS,
   ...IOS_WATCH_RELAY_COMMANDS,
 ]);
+
+const LEGACY_NODE_HOST_DESKTOP_METADATA: Readonly<
+  Record<string, { platform: string; deviceFamily: string }>
+> = {
+  darwin: { platform: "macos", deviceFamily: "Mac" },
+  linux: { platform: "linux", deviceFamily: "Linux" },
+  win32: { platform: "windows", deviceFamily: "Windows" },
+};
+
+/** Normalizes the desktop metadata emitted by the shipped protocol-v3 node host. */
+export function normalizeLegacyNodeHostClientMetadata(
+  client: ConnectParams["client"],
+): ConnectParams["client"] {
+  if (
+    client.id !== GATEWAY_CLIENT_IDS.NODE_HOST ||
+    client.mode !== GATEWAY_CLIENT_MODES.NODE ||
+    client.deviceFamily?.trim()
+  ) {
+    return client;
+  }
+  const metadata = LEGACY_NODE_HOST_DESKTOP_METADATA[client.platform];
+  return metadata ? { ...client, ...metadata } : client;
+}
 
 export function filterLegacyNodeProtocolFeatures(params: {
   caps: readonly string[];

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -502,7 +502,7 @@ export function registerDefaultAuthTokenSuite(): void {
       ws.close();
     });
 
-    test("allows authenticated previous-protocol nodes to register for maintenance", async () => {
+    test("retains authenticated previous-protocol node-host maintenance commands", async () => {
       const nodeWs = await openWs(port);
       const operatorWs = await openWs(port);
       try {
@@ -511,23 +511,35 @@ export function registerDefaultAuthTokenSuite(): void {
           minProtocol: MIN_NODE_PROTOCOL_VERSION,
           maxProtocol: MIN_NODE_PROTOCOL_VERSION,
           role: "node",
-          client: { ...NODE_CLIENT, version: legacyVersion },
+          client: { ...NODE_CLIENT, version: legacyVersion, platform: "linux" },
+          caps: ["system"],
+          commands: ["system.which"],
         });
         expect(nodeRes.ok).toBe(true);
 
         const operatorRes = await connectReq(operatorWs);
         expect(operatorRes.ok).toBe(true);
-        const listRes = await rpcReq<{ nodes?: Array<{ connected?: boolean; version?: string }> }>(
-          operatorWs,
-          "node.list",
-          {},
+        type LegacyNodeStatus = {
+          commands?: string[];
+          connected?: boolean;
+          deviceFamily?: string;
+          pendingDeclaredCommands?: string[];
+          pendingRequestId?: string;
+          platform?: string;
+          version?: string;
+        };
+        const pendingList = await rpcReq<{
+          nodes?: LegacyNodeStatus[];
+        }>(operatorWs, "node.list", {});
+        const pendingNode = pendingList.payload?.nodes?.find(
+          (node) => node.connected === true && node.version === legacyVersion,
         );
-        expect(listRes.ok).toBe(true);
-        expect(
-          listRes.payload?.nodes?.some(
-            (node) => node.connected === true && node.version === legacyVersion,
-          ),
-        ).toBe(true);
+        expect(pendingNode).toMatchObject({
+          deviceFamily: "Linux",
+          pendingDeclaredCommands: ["system.which"],
+          platform: "linux",
+        });
+        expect(pendingNode?.pendingRequestId).toBeTypeOf("string");
       } finally {
         nodeWs.close();
         operatorWs.close();

--- a/src/gateway/server/ws-connection/connect-node-session.ts
+++ b/src/gateway/server/ws-connection/connect-node-session.ts
@@ -10,7 +10,10 @@ import {
 import { AUTH_RATE_LIMIT_SCOPE_NODE_PAIRING } from "../../auth-rate-limit.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../../method-scopes.js";
 import { reconcileNodePairingOnConnect } from "../../node-connect-reconcile.js";
-import { filterLegacyNodeProtocolFeatures } from "../../node-legacy-protocol-filter.js";
+import {
+  filterLegacyNodeProtocolFeatures,
+  normalizeLegacyNodeHostClientMetadata,
+} from "../../node-legacy-protocol-filter.js";
 import { withSerializedRateLimitAttempt } from "../../rate-limit-attempt-serialization.js";
 import type {
   DeviceAuthorizedGatewayConnect,
@@ -83,6 +86,11 @@ export async function prepareGatewayNodeConnect(
     broadcastNodePairingResult,
   } = context;
   const { device, devicePublicKey, usesLegacyNodeProtocol, rejectUnauthorized } = state;
+  if (usesLegacyNodeProtocol) {
+    // Protocol-v3 node hosts predate canonical desktop family metadata. Repair
+    // that exact shipped envelope before policy reconciliation or exec vanishes.
+    connectParams.client = normalizeLegacyNodeHostClientMetadata(connectParams.client);
+  }
   const nodeId = connectParams.device?.id ?? connectParams.client.id;
   const nodePairingSnapshot = await beginNodePairingConnect(nodeId);
   const pairedNode = nodePairingSnapshot.pairedNode;

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -175,6 +175,7 @@ describe("cross-OS release checks workflow", () => {
       candidate_sha256: "${{ needs.prepare_release_package.outputs.package_sha256 }}",
       candidate_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
       candidate_version: "${{ needs.prepare_release_package.outputs.package_version }}",
+      candidate_artifact_json: "${{ inputs.candidate_artifact_json }}",
     });
 
     expect(job(release, "docker_e2e_release_checks").with).toMatchObject({
@@ -214,6 +215,7 @@ describe("cross-OS release checks workflow", () => {
       "candidate_sha256",
       "candidate_source_sha",
       "candidate_version",
+      "candidate_artifact_json",
     ]) {
       expect(workflow.on?.workflow_dispatch?.inputs?.[inputName], inputName).toMatchObject({
         default: "",
@@ -238,6 +240,14 @@ describe("cross-OS release checks workflow", () => {
       candidate_artifact_run_id: "${{ github.run_id }}",
       candidate_sha256: "${{ steps.candidate_metadata.outputs.sha256 }}",
       candidate_version: "${{ steps.candidate_metadata.outputs.version }}",
+      codex_plugin_file_name: "${{ steps.codex_plugin_metadata.outputs.file_name }}",
+      codex_plugin_sha256: "${{ steps.codex_plugin_metadata.outputs.sha256 }}",
+      prepublish_plugin_registry_artifact_id:
+        "${{ steps.upload_generated_plugin_registry.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
+      prepublish_plugin_registry_artifact_run_attempt:
+        "${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}",
+      prepublish_plugin_registry_artifact_run_id:
+        "${{ steps.upload_generated_plugin_registry.outputs.artifact-id && github.run_id || fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
       source_sha: "${{ steps.candidate_metadata.outputs.source_sha }}",
     });
     for (const [jobName, workflowJob] of Object.entries(workflow.jobs)) {
@@ -369,6 +379,65 @@ describe("cross-OS release checks workflow", () => {
       "${{ needs.prepare.outputs.baseline_sha256 }}",
     );
     expect(verify.run).toContain('"$actual_baseline_sha256" != "$EXPECTED_BASELINE_SHA256"');
+  });
+
+  it("binds OpenAI onboarding to the exact prerelease Codex companion", () => {
+    const workflow = readWorkflow(WORKFLOW_PATH);
+    const prepare = job(workflow, "prepare");
+    const binding = step(prepare, "Validate prerelease plugin registry artifact binding");
+    expect(binding.run).toContain('verify-upload "Prerelease plugin registry"');
+    expect(binding.env).toMatchObject({
+      ARTIFACT_ID:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}",
+      ARTIFACT_RUN_ID:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}",
+      MANIFEST_SHA256:
+        "${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}",
+    });
+
+    const sourceCheckout = step(prepare, "Checkout public source ref");
+    expect(sourceCheckout.if).toContain("inputs.provider == 'openai'");
+    expect(sourceCheckout.with?.ref).toBe(
+      "${{ inputs.candidate_artifact_name != '' && inputs.candidate_source_sha || inputs.ref }}",
+    );
+    expect(step(prepare, "Install companion plugin build dependencies").run).toBe(
+      "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
+    );
+    const pack = step(prepare, "Pack exact Codex companion plugin");
+    expect(pack.run).toContain("prepublish-plugin-registry-artifact.mjs create");
+    expect(pack.run).toContain("--repo-root source");
+    expect(pack.run).toContain(`--required-packages-json '["@openclaw/codex"]'`);
+
+    const metadata = step(prepare, "Resolve exact Codex companion plugin");
+    expect(metadata.run).toContain('any(.name == "@openclaw/codex")');
+    expect(metadata.run).toContain("prepublish-plugin-registry-artifact.mjs verify");
+    expect(metadata.run).toContain('--source-sha "$SOURCE_SHA"');
+    expect(metadata.run).toContain('--candidate-version "$CANDIDATE_VERSION"');
+    expect(metadata.run).toContain("entry.tarball !== path.win32.basename(entry.tarball)");
+    expect(
+      step(prepare, "Upload generated prerelease plugin registry artifact").with,
+    ).toMatchObject({
+      name: "openclaw-cross-os-release-checks-plugins-${{ github.run_id }}-${{ github.run_attempt }}",
+      "if-no-files-found": "error",
+    });
+
+    const consumer = job(workflow, "cross_os_release_checks");
+    const download = step(consumer, "Download prerelease plugin registry artifact");
+    expect(download.with).toMatchObject({
+      "artifact-ids": "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_id }}",
+      "run-id": "${{ needs.prepare.outputs.prepublish_plugin_registry_artifact_run_id }}",
+    });
+    const verify = step(consumer, "Verify release-check inputs");
+    expect(verify.run).toContain('"$actual_codex_sha256" != "$EXPECTED_CODEX_PLUGIN_SHA256"');
+
+    const run = step(consumer, "Run cross-OS release checks");
+    expect(run.env?.CODEX_PLUGIN_FILE_NAME).toBe(
+      "${{ needs.prepare.outputs.codex_plugin_file_name }}",
+    );
+    expect(run.run).toContain("OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES=1");
+    expect(run.run).toContain(
+      "JSON.stringify({ codex: `npm-pack:${process.env.CODEX_PLUGIN_TGZ}` })",
+    );
   });
 
   it("executes the release harness directly with Node", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1969,14 +1969,18 @@ describe("package acceptance workflow", () => {
     ["title", { MOCK_GH_RUN_TITLE: "Unrelated workflow run" }],
     ["head branch", { MOCK_GH_RUN_HEAD_BRANCH: "other" }],
     ["event", { MOCK_GH_RUN_EVENT: "push" }],
-  ] as const)("refuses a returned run URL with the wrong %s", (_label, overrides) => {
+  ] as const)("refuses a returned run URL with the wrong %s", (label, overrides) => {
     const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
       MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
       ...overrides,
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Refusing to adopt unvalidated ci.yml run 101");
+    expect(result.stderr).toContain(
+      label === "title"
+        ? "Refusing to adopt ci.yml run 101: display title never matched"
+        : "Refusing to adopt unvalidated ci.yml run 101",
+    );
     expect(
       calls.some(({ args }) =>
         args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),


### PR DESCRIPTION
## What Problem This Solves

Every cross-OS release-check lane fails, blocking 2026.8.1-beta.1. Two independent regressions:

1. **All fresh/upgrade packaged+installer lanes (3 OSes)**: OpenAI onboarding installed the *published* Codex companion plugin instead of the exact candidate companion — e.g. core `2026.8.1-beta.1` paired with npm's `@openclaw/codex@2026.7.2-beta.7`. The plugin identity fence (`doctor-config-preflight.ts`) correctly exits after repair changes the fingerprint, but the stale repair repeats on every restart, so `wait-gateway` times out forever.
2. **Gateway/node packaged-compatibility lanes**: a shipped protocol-v3 node host (v2026.5.7) reports `platform=linux` with no `deviceFamily`; strict canonical metadata (d656087b3156) classifies it unknown and policy reconciliation strips `system.which` — the harness case times out (the 1006 close is teardown, not cause).

Provenance: e4aab26d017e (correct identity fence), cc1a09fbc437 (candidate bumped beyond published companions), a0deb8edae1a (immutable companion artifacts added for package/Docker QA but never plumbed into cross-OS), d656087b3156 (strict metadata), 912af0a56f67 (N−1 compat tested connection/listing only).

## Why This Change Was Made

- Cross-OS now reuses the immutable exact-source Codex companion artifact — or packs one from the candidate SHA when absent — validates artifact/run/manifest/version/SHA identity, and supplies it via the gated `npm-pack:` override (`openclaw-cross-os-release-checks-reusable.yml`); Release Checks forwards the full candidate tuple.
- Authenticated protocol-v3 node hosts get exactly the three shipped desktop metadata normalizations (darwin/linux/win32 → canonical platform+family) before policy reconciliation, scoped to the exact node-host client id/mode with absent family only (`node-legacy-protocol-filter.ts`, `connect-node-session.ts`). Current-protocol, other-client, unknown-platform, and conflicting-family metadata remain strict.

## User Impact

Release validation lanes can pass again; shipped v2026.5.7 nodes keep `system.which` (exec) when connecting to new gateways instead of silently losing capability.

## Evidence

- Historical repro before fix: `wait-gateway: failed in 36s` with stale Codex repair loop; after supplying the exact companion: migration restart, `[gateway] ready`, `wait-gateway: done in 23s` (remaining failure only the intentionally fake provider token).
- Standalone fallback packs and verifies the exact Codex registry artifact. Direct `../codex` source inspection confirms version-bound npm package/app-server schemas (`codex-cli/package.json`, `codex-rs/app-server/README.md`).
- Post-rebase gates: `tsgo:core` pass; 365 focused tests; deadcode 0; workflow checks/zizmor pass; `git diff --check` clean; Codex autoreview clean twice (0.98 coordinator pass, 0.99 final).
- Remaining verification is exactly what Full Release Validation provides: the cross-OS group re-run on Linux/Windows/macOS (dispatched next against the release candidate).
- Production/tooling +247/−3 (immutable cross-workflow artifact lifecycle + the shipped N−1 protocol boundary); tests +130/−13.
